### PR TITLE
fix(query): keep API timestamps independent of retention

### DIFF
--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -70,8 +70,8 @@ typedef struct query_engine_ops {
     size_t db_total_points_read;
     size_t db_points_read_per_tier[RRD_STORAGE_TIERS];
 
-    // the LATEST grouping with a single output point covering the metric's
-    // last stored sample is answered from the collector's cached value,
+    // the LATEST grouping with a single output point reached by the metric's
+    // latest collection interval is answered from the collector's cached value,
     // without querying the storage engine (no query plan is built)
     bool latest_fast_path;
     NETDATA_DOUBLE latest_fast_path_value;

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -512,10 +512,10 @@ static QUERY_ENGINE_OPS *rrd2rrdr_query_ops_get(RRDR *r, QUERY_ENGINE_OPS_CACHE 
 }
 
 // the LATEST grouping asks for the most recent collected value; when the
-// query wants a single point and its window covers the metric's last stored
-// sample, the answer is the collector's cached last_stored_value - serve it
-// without building a query plan, so the storage engine is never touched.
-// options that change the value semantics (anomaly-bit, natural points,
+// query wants a single point and the metric's latest collection interval
+// reaches its window, the answer is the collector's cached last_stored_value -
+// serve it without building a query plan, so storage is never touched.
+// options that change the value semantics (anomaly-bit, resampling,
 // a pinned tier) fall back to the normal execution path.
 static bool query_latest_fast_path(RRDR *r, QUERY_ENGINE_OPS *ops) {
     QUERY_TARGET *qt = r->internal.qt;
@@ -529,9 +529,13 @@ static bool query_latest_fast_path(RRDR *r, QUERY_ENGINE_OPS *ops) {
         (qt->window.options & (RRDR_OPTION_SELECTED_TIER|RRDR_OPTION_ANOMALY_BIT)))
         return false;
 
-    // the single output bucket spans (after, before]
+    // The single output bucket spans (after, before]. LATEST may use the live
+    // last observation until its next expected collection interval reaches
+    // the window, even when the stored endpoint itself precedes `after`.
     time_t db_last = ops->qm->tiers[0].db_last_time_s;
-    if(db_last <= qt->window.after || db_last > qt->window.before)
+    time_t db_update_every = ops->qm->tiers[0].db_update_every_s;
+    if(db_last > qt->window.before ||
+       nd_time_t_add_compare(db_last, db_update_every, qt->window.after) < 0)
         return false;
 
     // NAN when there is no live dimension (archived metric), or when the

--- a/src/web/api/queries/query-window.c
+++ b/src/web/api/queries/query-window.c
@@ -147,8 +147,7 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
     }
 
     // convert our before_wanted and after_wanted to absolute
-    time_t query_now_s = 0;
-    rrdr_relative_window_to_absolute_query(&after_wanted, &before_wanted, &query_now_s, unittest_running);
+    rrdr_relative_window_to_absolute_query(&after_wanted, &before_wanted, NULL, unittest_running);
     query_debug_log(":relative2absolute after %ld, before %ld", after_wanted, before_wanted);
 
     if (natural_points && (options & RRDR_OPTION_SELECTED_TIER) &&
@@ -307,32 +306,20 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
         query_debug_log(":resampling divisor " NETDATA_DOUBLE_FORMAT, resampling_divisor);
     }
 
-    // the LATEST grouping with a single point asking for the hot edge
-    // (the requested before resolves to zero or to within one
-    // update_every of now) anchors the window end at the newest stored
-    // sample - the clamp to now-1 above would exclude an end-stamped
-    // sample that already exists, making the hot edge a race against
-    // the collector. The anchored end needs no re-alignment: collectors
-    // end-stamp samples on update_every boundaries.
-    bool latest_hot_edge = false;
-    if (group_method == RRDR_GROUPING_LATEST && points_requested == 1 && qt->db.last_time_s > 0) {
-        // resolve the requested before against the SAME now snapshot the
-        // conversion above used, so the hot-edge classification and the
-        // window math cannot disagree on a boundary request
-        time_t before_resolved = before_requested;
-        if (rrdr_relative_window_value_is_relative(before_requested))
-            before_resolved = query_now_s + ((before_requested > 0) ? -before_requested : before_requested);
-
-        if (before_requested == 0 || before_resolved >= query_now_s - update_every) {
-            latest_hot_edge = true;
-            before_wanted = qt->db.last_time_s;
-            query_debug_log(":latest hot edge before_wanted %ld", before_wanted);
-        }
+    // before=0 explicitly asks for the database end. Restore that exact end
+    // after granularity rounding and keep it unaligned; explicit and relative
+    // windows must never derive their result grid from stored timestamps.
+    bool latest_database_end = group_method == RRDR_GROUPING_LATEST &&
+                               points_requested == 1 && before_requested == 0 &&
+                               qt->db.last_time_s > 0;
+    if (latest_database_end) {
+        before_wanted = qt->db.last_time_s;
+        query_debug_log(":latest database end before_wanted %ld", before_wanted);
     }
 
     // now that we have group, align the requested timeframe to fit it.
     // The product is proven representable above; retain the original conversions for negative timestamps.
-    bool alignment_needed = aligned && !latest_hot_edge && before_wanted % (group * query_granularity);
+    bool alignment_needed = aligned && !latest_database_end && before_wanted % (group * query_granularity);
     time_t alignment = aligned ? before_wanted % view_update_every : 0;
     if (alignment_needed) {
         if (before_is_aligned_to_db_end) {


### PR DESCRIPTION
## Summary

- keep explicit and relative one-point `LATEST` query grids derived from the requested time window
- preserve the established literal `before=0` database-end behavior, including off-cadence endpoints
- keep an active sparse metric's cached latest value eligible while its latest collection interval reaches the window
- leave ordinary AVERAGE/chart carry-forward, storage traversal, and near-live partial-data trimming unchanged

## Root cause

The one-point `LATEST` window planner treated every request ending near now like the literal `before=0` sentinel. It
replaced the requested end with each Agent's newest stored timestamp and skipped normal alignment. Two Agents answering
the same explicit or relative request could therefore return different public row timestamps when their retention ends
differed.

Only literal `before=0` means “query the database end.” Explicit absolute and relative windows must retain their
request-derived geometry.

That correction exposed a coupled regression for sparse active metrics: the LATEST cache selector required the stored
endpoint itself inside the corrected window. It now keeps the live numeric cached value eligible when
`db_last <= before` and the overflow-safe interval endpoint `db_last + update_every >= after`. Equality is included;
one second after the interval is excluded. Archived/nonnumeric, selected-tier, anomaly-bit, and resampling requests still
fall back to the normal path.

## Verification

The tests are supplied by #23130:

- `CASE-034/api-timestamp-grid-is-immutable/hot-edge-data-independence`
  - explicit aligned and unaligned v1/v3 requests
  - relative unaligned v1/v3 requests
  - two Agents with newest stored timestamps 60 seconds apart
  - zero storage reads on the collector-cache paths
- `CASE-022/latest-before-zero-v3`
- `CASE-022/latest-before-zero-v1`, including an off-grid natural-points endpoint
- `CASE-039/sparse-active-latest-table`
  - update_every 60/600/3600/86400 over one-minute and fifteen-minute windows
  - exact value and request-derived timestamp with zero tier reads
  - inclusive interval endpoint and one-second expiry
- `CASE-039/sparse-active-chart` remains a separate honest red for ordinary AVERAGE carry-forward

Results on the exact split:

- current master: focused CASE-034 component fails
- split: focused and complete CASE-034 pass
- split: both CASE-022 database-end controls pass
- two independent `before=0` reverse mutations fail the corresponding control
- strict-overlap and exclusive-interval selector mutations independently fail CASE-039
- full native unit suite passes twice
- `git diff --check`, stable patch identity, reference search, and generated-code checks pass
- focused crossed timing found no statistically established regression:
  - historical LATEST: -0.644%, 95% CI [-12.583%, +12.925%]
  - corrected hot edge: +1.329%, 95% CI [-3.015%, +5.868%]
  - same-binary controls showed wider/comparable noise

## Split lineage

This is the bug-focused extraction from #23283. Its original `query-window.c` timestamp correction retains the same
stable patch identity, and its coupled LATEST selector plus state comment are byte-identical to the combined implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes single-point LATEST so public timestamps are derived from the requested window, not from each Agent’s newest stored sample, unless the request uses before=0. Also retains sparse active latest values by treating the latest collection interval as reaching the window, preventing drop-outs when the stored endpoint precedes after.

- Only before=0 anchors the end to the database end; absolute and relative windows keep their request-derived geometry and align normally.
- Refines the LATEST fast path: return the cached value when the latest collection interval reaches the window; still bypassed by anomaly-bit and selected-tier options; no storage reads.
- Preserves off-cadence endpoints and established before=0 semantics; value selection, storage traversal, and near-live partial-data trimming are unchanged.
- Client action: if you relied on near-now single-point LATEST anchoring, send before=0.

<sup>Written for commit 094206beaec6ee620e72be7cb8d9f4300f39f759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for latest single-point queries.
  * Preserved the database’s exact end timestamp in eligible latest-value queries.
  * Prevented unnecessary timeframe alignment for exact-end queries.
  * Improved retrieval of the latest value when the collection interval reaches the query window.
  * Removed inconsistent handling of relative or near-current query boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
