### PR TITLE
fix(query): preserve multipass contributor counts

### DIFF
--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -7,9 +7,32 @@
 #define HGBC_PARTIAL_FLAG (1U << 31)
 #define HGBC_COUNT_MASK   (~HGBC_PARTIAL_FLAG)
 
-void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
-                                         RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
-                                         STORAGE_POINT *query_points, size_t pass __maybe_unused) {
+static bool group_by_pass_propagates_raw_contributor_counts(const QUERY_TARGET *qt, size_t pass) {
+    // Raw count is an Agent-Cloud contract and needs an explicit capability before it can change.
+    if(query_target_aggregatable(qt))
+        return false;
+
+    for(size_t p = 0; p <= pass; p++) {
+        RRDR_GROUP_BY_FUNCTION aggregation = qt->request.group_by[p].aggregation;
+        if(aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE ||
+           aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE ||
+           (qt->request.group_by[p].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE))
+            return false;
+    }
+
+    return true;
+}
+
+static bool group_by_pass_calculates_percentage(const QUERY_TARGET *qt, size_t pass) {
+    return qt->request.group_by[pass].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE ||
+           (qt->request.group_by[pass].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE);
+}
+
+static ALWAYS_INLINE void rrd2rrdr_group_by_add_metric_internal(
+    RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
+    RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
+    STORAGE_POINT *query_points, bool propagate_raw_contributor_counts,
+    bool track_raw_anomaly_contributors, const uint32_t *source_anomaly_contributors) {
     if(!r_tmp || r_dst == r_tmp || !(r_tmp->od[d_tmp] & RRDR_DIMENSION_QUERIED))
         return;
 
@@ -75,7 +98,9 @@ void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t
             *co &= ~RRDR_VALUE_EMPTY;
             *co |= (o_tmp & (RRDR_VALUE_RESET | RRDR_VALUE_PARTIAL));
             *ar += ar_tmp;
-            (*gbc)++;
+            *gbc += propagate_raw_contributor_counts ? r_tmp->gbc[idx_tmp] : 1;
+            if(track_raw_anomaly_contributors)
+                r_dst->arc[idx_dst] += source_anomaly_contributors[idx_tmp];
         }
         else if(r_dst->hgbc) {
             // count the hidden (denominator) contributions too, so that
@@ -88,6 +113,30 @@ void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t
                 r_dst->hgbc[idx_dst] |= HGBC_PARTIAL_FLAG;
         }
     }
+}
+
+void rrd2rrdr_group_by_add_metric(RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
+                                  RRDR_GROUP_BY_FUNCTION group_by_aggregate_function,
+                                  STORAGE_POINT *query_points, size_t pass __maybe_unused) {
+    rrd2rrdr_group_by_add_metric_internal(
+        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points, false, false, NULL);
+}
+
+NEVER_INLINE
+static void rrd2rrdr_group_by_add_metric_with_raw_contributor_counts(
+    RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
+    RRDR_GROUP_BY_FUNCTION group_by_aggregate_function, STORAGE_POINT *query_points) {
+    rrd2rrdr_group_by_add_metric_internal(
+        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points, true, false, NULL);
+}
+
+NEVER_INLINE
+static void rrd2rrdr_group_by_add_metric_with_raw_anomaly_contributors(
+    RRDR *r_dst, size_t d_dst, RRDR *r_tmp, size_t d_tmp,
+    RRDR_GROUP_BY_FUNCTION group_by_aggregate_function, STORAGE_POINT *query_points) {
+    rrd2rrdr_group_by_add_metric_internal(
+        r_dst, d_dst, r_tmp, d_tmp, group_by_aggregate_function, query_points,
+        false, true, r_tmp->gbc);
 }
 
 // stamp RRDR_VALUE_PARTIAL on every point that received fewer contributions
@@ -295,11 +344,12 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     RRDR *last_r = r_tmp->group_by.r;
 
     // how many sources are expected to contribute to every point of each
-    // dimension, in the units gbc counts at each pass: metrics at the first
-    // pass, prior-pass groups at later passes; dgbc cannot be this comparand
-    // - it counts metrics at every pass, including the hidden ones - so
-    // complete data would flag PARTIAL; the split between expected_gbc and
-    // expected_hgbc mirrors the routing rule of
+    // dimension, in the units gbc uses at that pass: metrics at the first
+    // pass; raw metrics in eligible later passes; prior-pass groups at held
+    // boundaries and on the raw wire. dgbc is used only by the eligible
+    // non-raw result path; the predicate rejects both the raw wire and paths
+    // with hidden percentage contributors.
+    // The split between expected_gbc and expected_hgbc mirrors the routing rule of
     // rrd2rrdr_group_by_add_metric(): hidden sources feed the percentage
     // denominator (vh) and are counted by hgbc, never by gbc
     ONEWAYALLOC *owa = last_r->internal.owa;
@@ -317,12 +367,14 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     }
     rrd2rrdr_group_by_stamp_partial(last_r, expected_gbc, expected_hgbc);
 
-    rrdr2rrdr_group_by_calculate_percentage_of_group(last_r);
+    if(group_by_pass_calculates_percentage(qt, 0))
+        rrdr2rrdr_group_by_calculate_percentage_of_group(last_r);
 
     RRDR *r = last_r->group_by.r;
     size_t pass = 0;
     while(r) {
         pass++;
+        bool propagate_raw_contributor_counts = group_by_pass_propagates_raw_contributor_counts(qt, pass);
         onewayalloc_freez(owa, expected_gbc);
         onewayalloc_freez(owa, expected_hgbc);
         expected_gbc = onewayalloc_callocz(owa, r->d, sizeof(*expected_gbc));
@@ -332,14 +384,24 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             if((last_r->od[d] & RRDR_DIMENSION_HIDDEN) && r->vh)
                 expected_hgbc[last_r->dgbs[d]]++;
             else
-                expected_gbc[last_r->dgbs[d]]++;
+                expected_gbc[last_r->dgbs[d]] += propagate_raw_contributor_counts ? last_r->dgbc[d] : 1;
 
-            rrd2rrdr_group_by_add_metric(r, last_r->dgbs[d], last_r, d,
-                                         qt->request.group_by[pass].aggregation,
-                                         &last_r->dqp[d], pass);
+            if(r->arc)
+                rrd2rrdr_group_by_add_metric_with_raw_anomaly_contributors(
+                    r, last_r->dgbs[d], last_r, d,
+                    qt->request.group_by[pass].aggregation, &last_r->dqp[d]);
+            else if(propagate_raw_contributor_counts)
+                rrd2rrdr_group_by_add_metric_with_raw_contributor_counts(
+                    r, last_r->dgbs[d], last_r, d,
+                    qt->request.group_by[pass].aggregation, &last_r->dqp[d]);
+            else
+                rrd2rrdr_group_by_add_metric(
+                    r, last_r->dgbs[d], last_r, d,
+                    qt->request.group_by[pass].aggregation, &last_r->dqp[d], pass);
         }
         rrd2rrdr_group_by_stamp_partial(r, expected_gbc, expected_hgbc);
-        rrdr2rrdr_group_by_calculate_percentage_of_group(r);
+        if(group_by_pass_calculates_percentage(qt, pass))
+            rrdr2rrdr_group_by_calculate_percentage_of_group(r);
 
         last_r = r;
         r = last_r->group_by.r;
@@ -364,9 +426,16 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
 
     // find the final aggregation
     RRDR_GROUP_BY_FUNCTION aggregation = qt->request.group_by[0].aggregation;
+    size_t final_pass = 0;
     for(size_t g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++)
-        if(qt->request.group_by[g].group_by != RRDR_GROUP_BY_NONE)
+        if(qt->request.group_by[g].group_by != RRDR_GROUP_BY_NONE) {
             aggregation = qt->request.group_by[g].aggregation;
+            final_pass = g;
+        }
+
+    bool final_percentage = group_by_pass_calculates_percentage(qt, final_pass);
+    uint32_t *anomaly_contributor_counts =
+        (aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE || final_percentage) && r->arc ? r->arc : r->gbc;
 
     if(!query_target_aggregatable(qt) && r->partial_data_trimming.expected_after < qt->window.before)
         rrdr2rrdr_group_by_partial_trimming(r);
@@ -400,6 +469,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             RRDR_VALUE_FLAGS *co = &r->o[ idx ];
             NETDATA_DOUBLE *ar = &r->ar[ idx ];
             uint32_t gbc = r->gbc[ idx ];
+            uint32_t anomaly_contributors = anomaly_contributor_counts[idx];
 
             if(likely(gbc)) {
                 *co &= ~RRDR_VALUE_EMPTY;
@@ -410,7 +480,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
 
                 // when the sts pair is per-row, the anomaly rate must also be
                 // accumulated per-row (the row mean), not per-contribution
-                ars += stats_by_rows ? (*ar / (NETDATA_DOUBLE)gbc) : *ar;
+                ars += stats_by_rows ? (*ar / (NETDATA_DOUBLE)anomaly_contributors) : *ar;
 
                 if(aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE && !query_target_aggregatable(qt))
                     n = (*cn /= gbc);
@@ -418,7 +488,7 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
                     n = *cn;
 
                 if(!query_target_aggregatable(qt))
-                    *ar /= gbc;
+                    *ar /= anomaly_contributors;
 
                 if(islessgreater(n, 0.0))
                     points_nonzero++;
@@ -460,6 +530,10 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             .anomaly_count = (size_t)(ars * RRDR_DVIEW_ANOMALY_COUNT_MULTIPLIER / 100.0),
         };
     }
+
+    // Anomaly contributor counts are only needed while finalizing group-by.
+    onewayalloc_freez(owa, r->arc);
+    r->arc = NULL;
 
     r->view.min = global_min;
     r->view.max = global_max;

--- a/src/web/api/queries/query-group-by-finalize.c
+++ b/src/web/api/queries/query-group-by-finalize.c
@@ -469,6 +469,8 @@ RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             RRDR_VALUE_FLAGS *co = &r->o[ idx ];
             NETDATA_DOUBLE *ar = &r->ar[ idx ];
             uint32_t gbc = r->gbc[ idx ];
+            // Keep this load here to preserve the optimized hot-path code shape.
+            // cppcheck-suppress variableScope
             uint32_t anomaly_contributors = anomaly_contributor_counts[idx];
 
             if(likely(gbc)) {

--- a/src/web/api/queries/query-group-by-init.c
+++ b/src/web/api/queries/query-group-by-init.c
@@ -314,16 +314,25 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     // so a percentage aggregation on a NONE pass resolves to NORMAL mode
     // everywhere - the same behavior such a query had before this scan
     ssize_t percentage_of_group_pass = -1;
+    size_t final_group_by_pass = 0;
     for(size_t g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++) {
         if(qt->request.group_by[g].group_by == RRDR_GROUP_BY_NONE)
             break;
 
-        if((qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) ||
-            qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE) {
+        final_group_by_pass = g;
+
+        if(percentage_of_group_pass < 0 &&
+           ((qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) ||
+            qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE)) {
             percentage_of_group_pass = (ssize_t)g;
-            break;
         }
     }
+
+    bool final_pass_needs_raw_anomaly_contributors =
+        !query_target_aggregatable(qt) && final_group_by_pass > 0 &&
+        (qt->request.group_by[final_group_by_pass].aggregation == RRDR_GROUP_BY_FUNCTION_AVERAGE ||
+         qt->request.group_by[final_group_by_pass].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE ||
+         (qt->request.group_by[final_group_by_pass].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE));
 
     size_t added = 0;
     RRDR *first_r = NULL, *last_r = NULL;
@@ -509,6 +518,10 @@ RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             if(r->n) {
                 r->gbc = onewayalloc_callocz(
                     owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR group-by counts"), sizeof(*r->gbc));
+
+                if(final_grouping && final_pass_needs_raw_anomaly_contributors)
+                    r->arc = onewayalloc_callocz(
+                        owa, onewayalloc_mul_or_fatal(r->n, r->d, "RRDR anomaly-rate contributors"), sizeof(*r->arc));
 
                 if(hidden_dimensions && ((group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE) || (aggregation_method == RRDR_GROUP_BY_FUNCTION_PERCENTAGE))) {
                     // this is where we are going to group the hidden dimensions

--- a/src/web/api/queries/rrdr.c
+++ b/src/web/api/queries/rrdr.c
@@ -82,6 +82,7 @@ inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
     onewayalloc_freez(owa, r->dqp);
     onewayalloc_freez(owa, r->ar);
     onewayalloc_freez(owa, r->gbc);
+    onewayalloc_freez(owa, r->arc);
     onewayalloc_freez(owa, r->hgbc);
     onewayalloc_freez(owa, r->dgbc);
     onewayalloc_freez(owa, r->dgbs);

--- a/src/web/api/queries/rrdr.h
+++ b/src/web/api/queries/rrdr.h
@@ -75,6 +75,7 @@ typedef struct rrdresult {
     RRDR_VALUE_FLAGS *o;      // array n x d options for each value returned
     NETDATA_DOUBLE *ar;       // array n x d of anomaly rates (0 - 100)
     uint32_t *gbc;            // array n x d of group by count - NOT ALLOCATED when RRDR is created
+    uint32_t *arc;            // array n x d of anomaly-rate contributors, internal to group-by - NOT ALLOCATED when RRDR is created
     uint32_t *hgbc;           // array n x d of hidden (vh) group by count, internal to group-by - NOT ALLOCATED when RRDR is created
 
     struct {


### PR DESCRIPTION
## Summary

Fix anomaly-rate contributor accounting across two group-by passes without changing the Agent-to-Cloud raw contributor
contract.

This extracts one complete root-cause fix from #23283 into an independently reviewable PR. It also narrows the internal
bookkeeping to the final average/percentage pass, so ordinary one-pass queries retain their existing hot path.

## Root cause

`gbc` counts contributors to a result cell. After a first average or percentage pass, its unit becomes prior-pass groups
rather than original series. Reusing that count as the final anomaly-rate denominator therefore weights grouped results
incorrectly.

The fix preserves a separate raw anomaly-contributor count only on the final RRDR when a two-pass average or percentage
needs it. Raw Agent output continues to propagate the established `gbc` contract; the separate array is internal and is
released after finalization.

## Test contract

The focused regression contracts are in #23130:

- Layer 6 two-pass grouping, grid, values, point/view anomaly rates, partial/empty evidence, and raw schema;
- Layer 6 average and percentage boundaries, including held Agent/Cloud contract boundaries;
- Layer 6 live-edge trimming, values, and annotations;
- Layer 5 group-by matrix as the unchanged-path control.

`CASE-018` average-of-node-averages remains intentionally deferred because changing that behavior also requires a Cloud
contract change; this PR does not silently alter that wire contract.

## Verification

- Current master fails the focused two-pass anomaly/contributor contracts.
- This branch passes the complete focused Layer 5/6 matrix and the full native unit suite.
- The full query corpus has the same expected red set as before this extraction: no added or removed red contract.
- Twelve reverse mutations fail the intended contracts, including final-array allocation, raw contributor propagation,
  final anomaly denominator selection, PARTIAL stamping, and raw-schema boundaries.
- Focused crossed performance keeps the one-pass SUM path neutral (`+0.255%`, 95% CI `[-0.894%, +1.418%]`); measured
  two-pass deltas remain below the 3% material-regression gate.
- The same optimized production shape is present in combined PR #23283 at commit `06b235bbc7`.

The corpus PR should merge before this fix so the regression contracts become part of the normal CI surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves raw contributor counts across multi-pass group-by so anomaly-rate denominators use raw metrics, not prior-pass group counts. Previously the final pass reused `gbc` (group units); now the final pass uses tracked raw anomaly contributors, keeping the Agent→Cloud `gbc` contract and the one-pass hot path unchanged.

- Allocates `arc` only on the final RRDR when the final pass is AVG or PERCENTAGE (incl. percentage-of-instance) to track anomaly contributors; frees `arc` after finalize and in `rrdr_free`.
- Propagates raw `gbc` across passes only on eligible non-aggregatable, non-percentage paths; otherwise counts 1 per prior-pass group. Updates `expected_gbc` to use `dgbc` when propagating.
- Gates percentage-of-group calculation per pass; final anomaly denominator divides by `arc` when present, else by `gbc`.
- Introduces internal helpers to preserve the optimized hot-path code shape for multi-pass processing. No wire/schema changes.

<sup>Written for commit 2632dc4b9d3aed68e01806d44255929341d7808d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy for group-by queries using averages, percentages, and percentage-of-instance calculations.
  - Anomaly-related statistics now use the correct contributing values, improving results for non-aggregatable data.
  - Enhanced handling of raw counts and anomaly contributors across multi-pass group-by calculations.
  - Improved final statistics for anomaly-based calculations.
  - Improved resource cleanup after query processing to reduce unnecessary memory retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->