### PR TITLE
fix(storage): preserve gap evidence across backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1386,6 +1386,8 @@ set(DAEMON_FILES
         src/daemon/pipename.h
         src/daemon/unit_test.c
         src/daemon/unit_test.h
+        src/daemon/unit_test_bridge.c
+        src/daemon/unit_test_bridge.h
         src/daemon/dyncfg/dyncfg.c
         src/daemon/dyncfg/dyncfg.h
         src/daemon/dyncfg/dyncfg-files.c
@@ -1874,6 +1876,8 @@ if(ENABLE_DBENGINE)
             src/database/engine/pagecache.c
             src/database/engine/pagecache.h
             src/database/engine/page_test.cc
+            src/database/engine/page_test_bridge.cc
+            src/database/engine/page_test_bridge.h
             src/database/engine/page.c
             src/database/engine/page.h
             src/database/engine/cache.c
@@ -3166,6 +3170,14 @@ add_executable(stream-replay-endpoints-test EXCLUDE_FROM_ALL
 target_link_libraries(stream-replay-endpoints-test libnetdata)
 
 if(OS_LINUX)
+        add_executable(rrddim-collection-test EXCLUDE_FROM_ALL
+                src/database/tests/rrddim-collection-test.c)
+        target_compile_options(rrddim-collection-test PRIVATE -ffunction-sections -fdata-sections)
+        target_link_options(rrddim-collection-test PRIVATE -Wl,--no-export-dynamic -Wl,--gc-sections)
+        target_link_libraries(rrddim-collection-test libnetdata)
+endif()
+
+if(OS_LINUX)
         add_executable(http-auth-bearer-test EXCLUDE_FROM_ALL
                 src/web/api/tests/http-auth-bearer-test.c)
         target_compile_options(http-auth-bearer-test PRIVATE -ffunction-sections -fdata-sections)
@@ -3585,6 +3597,28 @@ if(OS_WINDOWS)
         configure_file(packaging/windows/Top.bmp Top.bmp COPYONLY)
         configure_file(packaging/windows/BackGround.bmp BackGround.bmp COPYONLY)
         configure_file(src/collectors/windows.plugin/driver/netdata_driver.inf netdata_driver.inf COPYONLY)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$" AND
+   NOT CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+        set_property(
+                SOURCE src/daemon/unit_test_bridge.c
+                APPEND PROPERTY COMPILE_OPTIONS "-fno-lto" "-fvisibility=hidden")
+elseif(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        message(WARNING
+                "Netdata test bridge cannot disable IPO for unsupported C compiler '${CMAKE_C_COMPILER_ID}'")
+endif()
+
+if(ENABLE_DBENGINE)
+        if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$" AND
+           NOT CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+                set_property(
+                        SOURCE src/database/engine/page_test_bridge.cc
+                        APPEND PROPERTY COMPILE_OPTIONS "-fno-lto" "-fvisibility=hidden")
+        elseif(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+                message(WARNING
+                        "Netdata page-test bridge cannot disable IPO for unsupported C++ compiler '${CMAKE_CXX_COMPILER_ID}'")
+        endif()
 endif()
 
 add_executable(netdata

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "common.h"
+#include "unit_test_bridge.h"
 #include "web/api/formatters/rrd2json.h"
 #include "web/api/queries/query-internal.h"
 #include "database/contexts/rrdcontext-internal.h"
@@ -403,8 +404,247 @@ static int check_storage_number_exists() {
     return 0;
 }
 
+#define STORAGE_POINT_EXPECT(condition) do {                                                                           \
+    if(!(condition)) {                                                                                                  \
+        fprintf(stderr, "Storage-point unittest failed at %s:%d: %s\n", __FILE__, __LINE__, #condition);              \
+        errors++;                                                                                                       \
+    }                                                                                                                   \
+} while(0)
+
+static STORAGE_POINT unittest_numeric_storage_point(
+    time_t start_time_s, time_t end_time_s,
+    NETDATA_DOUBLE min, NETDATA_DOUBLE max, NETDATA_DOUBLE sum,
+    uint32_t count, uint32_t gap_count, uint32_t anomaly_count, SN_FLAGS flags) {
+    return (STORAGE_POINT) {
+        .min = min,
+        .max = max,
+        .sum = sum,
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .count = count,
+        .anomaly_count = anomaly_count,
+        .flags = flags,
+        .gap_count = gap_count,
+    };
+}
+
+static size_t test_storage_point_contract(void) {
+    size_t errors = 0;
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    STORAGE_POINT_EXPECT(storage_point_is_unset(sp));
+    STORAGE_POINT_EXPECT(!storage_point_has_value(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_gap(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_complete(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_partial(sp));
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 0);
+    STORAGE_POINT_EXPECT(storage_point_is_zero(sp));
+    STORAGE_POINT_EXPECT(storage_point_average_value(sp) == 0);
+    STORAGE_POINT_EXPECT(storage_point_anomaly_rate(sp) == 0);
+    STORAGE_POINT_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+                         !netdata_double_isnumber(sp.sum));
+    STORAGE_POINT_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 0);
+    STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    STORAGE_POINT_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp = unittest_numeric_storage_point(10, 20, 1, 2, 3, 2, 3, 1, SN_FLAG_RESET);
+    storage_point_unset(sp);
+    STORAGE_POINT_EXPECT(storage_point_is_unset(sp));
+    STORAGE_POINT_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+                         !netdata_double_isnumber(sp.sum));
+    STORAGE_POINT_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 0);
+    STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    STORAGE_POINT_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    storage_point_empty_slots(sp, 10, 20, 0);
+    STORAGE_POINT_EXPECT(!storage_point_is_unset(sp));
+    STORAGE_POINT_EXPECT(storage_point_is_gap(sp));
+    STORAGE_POINT_EXPECT(!storage_point_has_value(sp));
+    STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 1);
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 1);
+    STORAGE_POINT_EXPECT(!netdata_double_isnumber(storage_point_average_value(sp)));
+    STORAGE_POINT_EXPECT(storage_point_anomaly_rate(sp) == 0);
+
+    storage_point_empty_slots(sp, 20, 30, 65536);
+    STORAGE_POINT_EXPECT(storage_point_is_gap(sp));
+    STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 65536);
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 65536);
+
+    sp.count = UINT32_MAX;
+    sp.gap_count = UINT32_MAX;
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 2ULL * UINT32_MAX);
+
+    sp = unittest_numeric_storage_point(10, 20, 1, 2, 3, 2, 0, 1, SN_FLAG_NONE);
+    STORAGE_POINT_EXPECT(storage_point_has_value(sp));
+    STORAGE_POINT_EXPECT(storage_point_is_complete(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_partial(sp));
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 2);
+    STORAGE_POINT_EXPECT(storage_point_average_value(sp) == 1.5);
+    STORAGE_POINT_EXPECT(storage_point_anomaly_rate(sp) == 50);
+
+    sp.gap_count = 3;
+    STORAGE_POINT_EXPECT(storage_point_has_value(sp));
+    STORAGE_POINT_EXPECT(!storage_point_is_complete(sp));
+    STORAGE_POINT_EXPECT(storage_point_is_partial(sp));
+    STORAGE_POINT_EXPECT(storage_point_slots(sp) == 5);
+    STORAGE_POINT_EXPECT(storage_point_average_value(sp) == 1.5);
+
+    sp = unittest_numeric_storage_point(0, 1, 0, 0, 0, 1, 0, 0, SN_DEFAULT_FLAGS);
+    STORAGE_POINT_EXPECT(storage_point_is_zero(sp));
+    sp.anomaly_count = 1;
+    STORAGE_POINT_EXPECT(!storage_point_is_zero(sp));
+
+    STORAGE_POINT numeric = unittest_numeric_storage_point(10, 20, 2, 5, 7, 2, 1, 1, SN_FLAG_RESET);
+    STORAGE_POINT merged = STORAGE_POINT_UNSET;
+    storage_point_merge_to(merged, numeric);
+    STORAGE_POINT_EXPECT(merged.min == 2 && merged.max == 5 && merged.sum == 7);
+    STORAGE_POINT_EXPECT(merged.start_time_s == 10 && merged.end_time_s == 20);
+    STORAGE_POINT_EXPECT(merged.count == 2 && merged.gap_count == 1 && merged.anomaly_count == 1);
+    STORAGE_POINT_EXPECT(merged.flags & SN_FLAG_RESET);
+
+    STORAGE_POINT unset = STORAGE_POINT_UNSET;
+    storage_point_merge_to(merged, unset);
+    STORAGE_POINT_EXPECT(merged.min == 2 && merged.max == 5 && merged.sum == 7);
+    STORAGE_POINT_EXPECT(merged.count == 2 && merged.gap_count == 1 && merged.anomaly_count == 1);
+
+    STORAGE_POINT gap;
+    storage_point_empty(gap, 0, 10);
+    STORAGE_POINT gap_first = gap;
+    storage_point_merge_to(gap_first, numeric);
+    STORAGE_POINT_EXPECT(gap_first.start_time_s == 0 && gap_first.end_time_s == 20);
+    STORAGE_POINT_EXPECT(gap_first.min == 2 && gap_first.max == 5 && gap_first.sum == 7);
+    STORAGE_POINT_EXPECT(gap_first.count == 2 && gap_first.gap_count == 2 && gap_first.anomaly_count == 1);
+    STORAGE_POINT_EXPECT(storage_point_is_partial(gap_first));
+
+    STORAGE_POINT numeric_first = numeric;
+    storage_point_merge_to(numeric_first, gap);
+    STORAGE_POINT_EXPECT(numeric_first.start_time_s == gap_first.start_time_s &&
+                         numeric_first.end_time_s == gap_first.end_time_s);
+    STORAGE_POINT_EXPECT(numeric_first.min == gap_first.min && numeric_first.max == gap_first.max &&
+                         numeric_first.sum == gap_first.sum);
+    STORAGE_POINT_EXPECT(numeric_first.count == gap_first.count &&
+                         numeric_first.gap_count == gap_first.gap_count &&
+                         numeric_first.anomaly_count == gap_first.anomaly_count &&
+                         numeric_first.flags == gap_first.flags);
+
+    STORAGE_POINT second_gap;
+    storage_point_empty(second_gap, 20, 30);
+    storage_point_merge_to(gap, second_gap);
+    STORAGE_POINT_EXPECT(storage_point_is_gap(gap));
+    STORAGE_POINT_EXPECT(gap.start_time_s == 0 && gap.end_time_s == 30 && gap.gap_count == 2);
+
+    STORAGE_POINT second_numeric =
+        unittest_numeric_storage_point(20, 30, 1, 7, 11, 3, 2, 2, SN_FLAG_NONE);
+    storage_point_merge_to(numeric, second_numeric);
+    STORAGE_POINT_EXPECT(numeric.start_time_s == 10 && numeric.end_time_s == 30);
+    STORAGE_POINT_EXPECT(numeric.min == 1 && numeric.max == 7 && numeric.sum == 18);
+    STORAGE_POINT_EXPECT(numeric.count == 5 && numeric.gap_count == 3 && numeric.anomaly_count == 3);
+    STORAGE_POINT_EXPECT(numeric.flags & SN_FLAG_RESET);
+
+    STORAGE_POINT added = unittest_numeric_storage_point(0, 10, 2, 5, 7, 2, 1, 1, SN_FLAG_NONE);
+    second_numeric = unittest_numeric_storage_point(10, 20, 3, 7, 11, 3, 2, 2, SN_FLAG_RESET);
+    storage_point_add_to(added, second_numeric);
+    STORAGE_POINT_EXPECT(added.start_time_s == 0 && added.end_time_s == 20);
+    STORAGE_POINT_EXPECT(added.min == 5 && added.max == 12 && added.sum == 18);
+    STORAGE_POINT_EXPECT(added.count == 5 && added.gap_count == 3 && added.anomaly_count == 3);
+    STORAGE_POINT_EXPECT(added.flags & SN_FLAG_RESET);
+    storage_point_empty(gap, 20, 30);
+    storage_point_add_to(added, gap);
+    STORAGE_POINT_EXPECT(added.sum == 18 && added.count == 5 && added.gap_count == 4);
+
+    storage_point_empty(gap, 0, 10);
+    STORAGE_POINT gap_added = gap;
+    storage_point_add_to(gap_added, added);
+    STORAGE_POINT_EXPECT(gap_added.start_time_s == 0 && gap_added.end_time_s == 30);
+    STORAGE_POINT_EXPECT(gap_added.min == 5 && gap_added.max == 12 && gap_added.sum == 18);
+    STORAGE_POINT_EXPECT(gap_added.count == 5 && gap_added.gap_count == 5 && gap_added.anomaly_count == 3);
+    STORAGE_POINT_EXPECT(gap_added.flags & SN_FLAG_RESET);
+
+    STORAGE_POINT absolute =
+        unittest_numeric_storage_point(10, 20, -5, -2, -7, 2, 1, 1, SN_FLAG_RESET);
+    storage_point_make_positive(absolute);
+    STORAGE_POINT_EXPECT(absolute.min == 2 && absolute.max == 5 && absolute.sum == 7);
+    STORAGE_POINT_EXPECT(absolute.start_time_s == 10 && absolute.end_time_s == 20);
+    STORAGE_POINT_EXPECT(absolute.count == 2 && absolute.gap_count == 1 && absolute.anomaly_count == 1);
+    STORAGE_POINT_EXPECT(absolute.flags & SN_FLAG_RESET);
+    storage_point_empty(gap, 20, 30);
+    storage_point_make_positive(gap);
+    STORAGE_POINT_EXPECT(storage_point_is_gap(gap) && gap.gap_count == 1);
+
+    fprintf(stderr, "Storage-point contract unittests: %s\n", errors ? "FAILED" : "PASSED");
+    return errors;
+}
+
+static size_t test_rrddim_storage_point_contract_mode(RRD_DB_MODE mode, const char *id) {
+    size_t errors = 0;
+
+    RRDSET *st = rrdset_create_custom(
+        localhost, "unittest-storage", id, id, "unittest", "unittest.storage",
+        "Storage Point Unit Testing", "value", "unittest", id,
+        1, 1, RRDSET_TYPE_LINE, mode, 8);
+    RRDDIM *rd = rrddim_add(st, "dim", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    STORAGE_POINT_EXPECT(rd->rrd_memory_mode == mode);
+    STORAGE_POINT_EXPECT(rd->tiers[0].seb == STORAGE_ENGINE_BACKEND_RRDDIM);
+
+    const time_t t = 1700000000;
+    unittest_storage_engine_store_metric(rd->tiers[0].sch, (usec_t)t * USEC_PER_SEC,
+                                         10, 10, 10, 1, 0, SN_DEFAULT_FLAGS);
+    unittest_storage_engine_store_metric(rd->tiers[0].sch, (usec_t)(t + 1) * USEC_PER_SEC,
+                                         NAN, NAN, NAN, 0, 0, SN_EMPTY_SLOT);
+    unittest_storage_engine_store_metric(rd->tiers[0].sch, (usec_t)(t + 2) * USEC_PER_SEC,
+                                         -20, -20, -20, 1, 1, SN_FLAG_RESET);
+
+    struct storage_engine_query_handle seqh = { 0 };
+    unittest_storage_engine_query_init(rd->tiers[0].seb, rd->tiers[0].smh, &seqh,
+                                       t - 1, t + 3, STORAGE_PRIORITY_SYNCHRONOUS);
+
+    for(time_t end_time_s = t - 1; end_time_s <= t + 3; end_time_s++) {
+        STORAGE_POINT sp = unittest_storage_engine_query_next_metric(&seqh);
+        STORAGE_POINT_EXPECT(sp.start_time_s == end_time_s - 1);
+        STORAGE_POINT_EXPECT(sp.end_time_s == end_time_s);
+
+        if(end_time_s == t) {
+            STORAGE_POINT_EXPECT(storage_point_is_complete(sp));
+            STORAGE_POINT_EXPECT(sp.min == 10 && sp.max == 10 && sp.sum == 10);
+            STORAGE_POINT_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 0);
+            STORAGE_POINT_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+        }
+        else if(end_time_s == t + 2) {
+            STORAGE_POINT_EXPECT(storage_point_is_complete(sp));
+            STORAGE_POINT_EXPECT(sp.min == -20 && sp.max == -20 && sp.sum == -20);
+            STORAGE_POINT_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 1);
+            STORAGE_POINT_EXPECT((sp.flags & SN_FLAG_RESET) && !(sp.flags & SN_FLAG_NOT_ANOMALOUS));
+        }
+        else {
+            STORAGE_POINT_EXPECT(storage_point_is_gap(sp));
+            STORAGE_POINT_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+                                 !netdata_double_isnumber(sp.sum));
+            STORAGE_POINT_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
+            STORAGE_POINT_EXPECT(sp.flags == SN_FLAG_NONE);
+        }
+    }
+
+    STORAGE_POINT_EXPECT(unittest_storage_engine_query_is_finished(&seqh));
+    unittest_storage_engine_query_finalize(&seqh);
+    rrdset_free(st);
+    return errors;
+}
+
+static size_t test_rrddim_storage_point_contract(void) {
+    size_t errors = 0;
+    errors += test_rrddim_storage_point_contract_mode(RRD_DB_MODE_RAM, "storage-point-ram");
+    errors += test_rrddim_storage_point_contract_mode(RRD_DB_MODE_ALLOC, "storage-point-alloc");
+    fprintf(stderr, "RAM/ALLOC storage-point unittests: %s\n", errors ? "FAILED" : "PASSED");
+    return errors;
+}
+
+#undef STORAGE_POINT_EXPECT
+
 int unit_test_storage() {
-    if(check_storage_number_exists()) return 0;
+    if(test_storage_point_contract()) return 1;
+    if(test_rrddim_storage_point_contract()) return 1;
+    if(check_storage_number_exists()) return 1;
 
     NETDATA_DOUBLE storage_number_positive_min = unpack_storage_number(STORAGE_NUMBER_POSITIVE_MIN_RAW);
     NETDATA_DOUBLE storage_number_negative_max = unpack_storage_number(STORAGE_NUMBER_NEGATIVE_MAX_RAW);

--- a/src/daemon/unit_test_bridge.c
+++ b/src/daemon/unit_test_bridge.c
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "unit_test_bridge.h"
+
+NOINLINE void unittest_storage_engine_store_metric(
+    STORAGE_COLLECT_HANDLE *sch,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    storage_engine_store_metric(
+        sch, point_in_time_ut, n, min_value, max_value, count, anomaly_count, flags);
+}
+
+NOINLINE void unittest_storage_engine_query_init(
+    STORAGE_ENGINE_BACKEND seb,
+    STORAGE_METRIC_HANDLE *smh,
+    struct storage_engine_query_handle *seqh,
+    time_t start_time_s,
+    time_t end_time_s,
+    STORAGE_PRIORITY priority) {
+    storage_engine_query_init(seb, smh, seqh, start_time_s, end_time_s, priority);
+}
+
+NOINLINE STORAGE_POINT unittest_storage_engine_query_next_metric(
+    struct storage_engine_query_handle *seqh) {
+    return storage_engine_query_next_metric(seqh);
+}
+
+NOINLINE int unittest_storage_engine_query_is_finished(
+    struct storage_engine_query_handle *seqh) {
+    return storage_engine_query_is_finished(seqh);
+}
+
+NOINLINE void unittest_storage_engine_query_finalize(
+    struct storage_engine_query_handle *seqh) {
+    storage_engine_query_finalize(seqh);
+}

--- a/src/daemon/unit_test_bridge.h
+++ b/src/daemon/unit_test_bridge.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_UNIT_TEST_BRIDGE_H
+#define NETDATA_UNIT_TEST_BRIDGE_H
+
+#include "common.h"
+
+void unittest_storage_engine_store_metric(
+    STORAGE_COLLECT_HANDLE *sch,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags);
+
+void unittest_storage_engine_query_init(
+    STORAGE_ENGINE_BACKEND seb,
+    STORAGE_METRIC_HANDLE *smh,
+    struct storage_engine_query_handle *seqh,
+    time_t start_time_s,
+    time_t end_time_s,
+    STORAGE_PRIORITY priority);
+
+STORAGE_POINT unittest_storage_engine_query_next_metric(struct storage_engine_query_handle *seqh);
+int unittest_storage_engine_query_is_finished(struct storage_engine_query_handle *seqh);
+void unittest_storage_engine_query_finalize(struct storage_engine_query_handle *seqh);
+
+#endif // NETDATA_UNIT_TEST_BRIDGE_H

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -2,6 +2,7 @@
 
 #include "database/rrd.h"
 #include "database/rrddim-collection.h"
+#include "page_test.h"
 
 #ifdef ENABLE_DBENGINE
 
@@ -327,11 +328,17 @@ static size_t dbengine_test_rrdr_single_region(
                 RRDR_VALUE_FLAGS *co = &r->o[ p * r->d ];
                 NETDATA_DOUBLE *cn = &r->v[ p * r->d ];
 
+                time_t end_time_s = r->t[p];
+                time_t start_time_s = end_time_s - r->view.update_every;
                 STORAGE_POINT sp = STORAGE_POINT_UNSET;
-                sp.min = sp.max = sp.sum = (co[d] & RRDR_VALUE_EMPTY) ? NAN :cn[d];
-                sp.count = 1;
-                sp.end_time_s = r->t[p];
-                sp.start_time_s = sp.end_time_s - r->view.update_every;
+                if(co[d] & RRDR_VALUE_EMPTY)
+                    storage_point_empty(sp, start_time_s, end_time_s);
+                else {
+                    sp.min = sp.max = sp.sum = cn[d];
+                    sp.count = 1;
+                    sp.start_time_s = start_time_s;
+                    sp.end_time_s = end_time_s;
+                }
 
                 storage_point_check(current_region, c, d, p, time_now, update_every, sp, &value_errors, &time_errors, &update_every_errors);
                 d++;
@@ -470,6 +477,7 @@ int test_dbengine(void) {
     if(!host)
         fatal("Failed to initialize host");
 
+    errors += (size_t)pgd_storage_point_unittest();
     errors += test_dbengine_burst_retention(host);
 
     RRDSET *st[CHARTS] = { 0 };

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -1036,12 +1036,13 @@ static void pgdc_seek(PGDC *pgdc, uint32_t position)
     }
 }
 
-void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position)
+void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point)
 {
     // pgd might be null and position equal to UINT32_MAX
 
     pgdc->pgd = pgd;
     pgdc->position = position;
+    pgdc->slots_per_point = slots_per_point ? slots_per_point : 1;
 
     if (!pgd)
         return;
@@ -1060,7 +1061,7 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
 {
     if (!pgdc->pgd || pgdc->pgd == PGD_EMPTY || pgdc->position >= pgdc->slots)
     {
-        storage_point_empty(*sp, sp->start_time_s, sp->end_time_s);
+        storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
         return false;
     }
 
@@ -1074,14 +1075,14 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             uint32_t n = 666666666;
             bool ok = gorilla_reader_read(&pgdc->gr, &n);
 
-            if (ok) {
+            if (ok && likely(does_storage_number_exist(n))) {
                 sp->min = sp->max = sp->sum = unpack_storage_number(n);
                 sp->flags = (SN_FLAGS)(n & SN_USER_FLAGS);
                 sp->count = 1;
+                sp->gap_count = 0;
                 sp->anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
-            } else {
-                storage_point_empty(*sp, sp->start_time_s, sp->end_time_s);
-            }
+            } else
+                storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
 
             return ok;
         }
@@ -1089,12 +1090,18 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             storage_number_tier1_t *array = (storage_number_tier1_t *) pgdc->pgd->raw.data;
             storage_number_tier1_t n = array[pgdc->position++];
 
-            sp->flags = n.anomaly_count ? SN_FLAG_NONE : SN_FLAG_NOT_ANOMALOUS;
-            sp->count = n.count;
-            sp->anomaly_count = n.anomaly_count;
-            sp->min = n.min_value;
-            sp->max = n.max_value;
-            sp->sum = n.sum_value;
+            if(likely(n.count && netdata_double_isnumber(n.sum_value))) {
+                sp->flags = n.anomaly_count ? SN_FLAG_NONE : SN_FLAG_NOT_ANOMALOUS;
+                sp->count = n.count;
+                sp->anomaly_count = n.anomaly_count;
+                sp->min = n.min_value;
+                sp->max = n.max_value;
+                sp->sum = n.sum_value;
+                // V1 records omit gaps; the active grouping is the best available estimate.
+                sp->gap_count = pgdc->slots_per_point > n.count ? pgdc->slots_per_point - n.count : 0;
+            }
+            else
+                storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
 
             return true;
         }
@@ -1102,10 +1109,14 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             storage_number *array = (storage_number *) pgdc->pgd->raw.data;
             storage_number n = array[pgdc->position++];
 
-            sp->min = sp->max = sp->sum = unpack_storage_number(n);
-            sp->flags = (SN_FLAGS)(n & SN_USER_FLAGS);
-            sp->count = 1;
-            sp->anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
+            if(likely(does_storage_number_exist(n))) {
+                sp->min = sp->max = sp->sum = unpack_storage_number(n);
+                sp->flags = (SN_FLAGS)(n & SN_USER_FLAGS);
+                sp->count = 1;
+                sp->gap_count = 0;
+                sp->anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
+            } else
+                storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
 
             return true;
         }
@@ -1118,7 +1129,7 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
                 logged = true;
             }
 
-            storage_point_empty(*sp, sp->start_time_s, sp->end_time_s);
+            storage_point_empty_slots(*sp, sp->start_time_s, sp->end_time_s, pgdc->slots_per_point);
             return false;
         }
     }

--- a/src/database/engine/page.h
+++ b/src/database/engine/page.h
@@ -13,6 +13,7 @@ typedef struct pgd_cursor {
     struct pgd *pgd;
     uint32_t position;
     uint32_t slots;
+    uint32_t slots_per_point;
 
     gorilla_reader_t gr;
 } PGDC;
@@ -53,7 +54,7 @@ size_t pgd_append_point(PGD *pg,
                       SN_FLAGS flags,
                       uint32_t expected_slot);
 
-void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position);
+void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point);
 bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position, STORAGE_POINT *sp);
 
 void *dbengine_extent_alloc(size_t size);

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -1,5 +1,239 @@
-#include "page.h"
+#include "page_test_bridge.h"
 #include "page_test.h"
+
+static size_t pgd_unittest_tier0(uint8_t page_type) {
+    size_t errors = 0;
+
+#define PGD_EXPECT(condition) do {                                                                                       \
+    if(!(condition)) {                                                                                                  \
+        fprintf(stderr, "PGD storage-point unittest failed at %s:%d: %s\n", __FILE__, __LINE__, #condition);           \
+        errors++;                                                                                                       \
+    }                                                                                                                   \
+} while(0)
+
+    PGD *pg = pgd_unittest_create(page_type, 4);
+    pgd_unittest_append_point(pg, 1, 42, 42, 42, 1, 0, SN_DEFAULT_FLAGS, 0);
+    pgd_unittest_append_point(pg, 2, NAN, NAN, NAN, 0, 0, SN_EMPTY_SLOT, 1);
+    pgd_unittest_append_point(pg, 3, -7, -7, -7, 1, 0, SN_FLAG_RESET, 2);
+
+    PGDC cursor = {};
+    pgd_unittest_cursor_reset(&cursor, pg, 0, 1);
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.start_time_s = 0;
+    sp.end_time_s = 1;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 0, &sp));
+    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 1);
+    PGD_EXPECT(storage_point_is_complete(sp));
+    PGD_EXPECT(sp.min == 42 && sp.max == 42 && sp.sum == 42);
+    PGD_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+
+    sp.start_time_s = 1;
+    sp.end_time_s = 2;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 1, &sp));
+    PGD_EXPECT(sp.start_time_s == 1 && sp.end_time_s == 2);
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp.start_time_s = 2;
+    sp.end_time_s = 3;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 2, &sp));
+    PGD_EXPECT(sp.start_time_s == 2 && sp.end_time_s == 3);
+    PGD_EXPECT(storage_point_is_complete(sp));
+    PGD_EXPECT(sp.min == -7 && sp.max == -7 && sp.sum == -7);
+    PGD_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 1);
+    PGD_EXPECT((sp.flags & SN_FLAG_RESET) && !(sp.flags & SN_FLAG_NOT_ANOMALOUS));
+
+    sp.start_time_s = 3;
+    sp.end_time_s = 4;
+    PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 3, &sp));
+    PGD_EXPECT(sp.start_time_s == 3 && sp.end_time_s == 4);
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    pgd_unittest_free(pg);
+    return errors;
+}
+
+static size_t pgd_unittest_tier1(void) {
+    size_t errors = 0;
+
+    PGD *gap_pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 2);
+    pgd_unittest_append_point(gap_pg, 60, NAN, NAN, NAN, 0, 0, SN_FLAG_NONE, 0);
+    PGD_EXPECT(pgd_unittest_slots_used(gap_pg) == 1);
+    PGD_EXPECT(pgd_unittest_is_empty(gap_pg));
+    pgd_unittest_free(gap_pg);
+
+    PGD *pg = pgd_unittest_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 6);
+    pgd_unittest_append_point(pg, 60, 400, 9, 11, 40, 4, SN_DEFAULT_FLAGS, 0);
+    pgd_unittest_append_point(pg, 120, 800, 9, 11, 80, 0, SN_DEFAULT_FLAGS, 1);
+    pgd_unittest_append_point(pg, 180, 300, 9, 11, 0, 0, SN_DEFAULT_FLAGS, 2);
+    pgd_unittest_append_point(pg, 240, NAN, NAN, NAN, 7, 1, SN_DEFAULT_FLAGS, 3);
+    pgd_unittest_append_point(pg, 300, INFINITY, 9, 11, 7, 1, SN_DEFAULT_FLAGS, 4);
+
+    PGDC cursor = {};
+    pgd_unittest_cursor_reset(&cursor, pg, 0, 60);
+
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.start_time_s = 0;
+    sp.end_time_s = 60;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 0, &sp));
+    PGD_EXPECT(storage_point_is_partial(sp));
+    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 60);
+    PGD_EXPECT(sp.min == 9 && sp.max == 11 && sp.sum == 400);
+    PGD_EXPECT(sp.count == 40 && sp.gap_count == 20 && sp.anomaly_count == 4);
+    PGD_EXPECT(!(sp.flags & SN_FLAG_NOT_ANOMALOUS));
+
+    sp.start_time_s = 60;
+    sp.end_time_s = 120;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 1, &sp));
+    PGD_EXPECT(storage_point_is_complete(sp));
+    PGD_EXPECT(sp.start_time_s == 60 && sp.end_time_s == 120);
+    PGD_EXPECT(sp.min == 9 && sp.max == 11 && sp.sum == 800);
+    PGD_EXPECT(sp.count == 80 && sp.gap_count == 0 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+
+    sp.start_time_s = 120;
+    sp.end_time_s = 180;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 2, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 120 && sp.end_time_s == 180);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp.start_time_s = 180;
+    sp.end_time_s = 240;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 3, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 180 && sp.end_time_s == 240);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp.start_time_s = 240;
+    sp.end_time_s = 300;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 4, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 240 && sp.end_time_s == 300);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    sp.start_time_s = 300;
+    sp.end_time_s = 360;
+    PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 5, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 300 && sp.end_time_s == 360);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 60 && sp.anomaly_count == 0);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    pgd_unittest_cursor_reset(&cursor, pg, 2, 65536);
+    sp.start_time_s = 0;
+    sp.end_time_s = 65536;
+    PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 2, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp));
+    PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 65536);
+    PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+               !netdata_double_isnumber(sp.sum));
+    PGD_EXPECT(sp.count == 0 && sp.gap_count == 65536);
+    PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+    pgd_unittest_free(pg);
+    return errors;
+}
+
+static size_t pgd_unittest_corrupt_gorilla_entries(void) {
+    size_t errors = 0;
+
+    PGD *pg_collector = pgd_unittest_create(RRDENG_PAGE_TYPE_GORILLA_32BIT, 2);
+    pgd_unittest_append_point(pg_collector, 1, 666, 666, 666, 1, 0, SN_DEFAULT_FLAGS, 0);
+
+    uint32_t size_in_bytes = pgd_unittest_disk_footprint(pg_collector);
+    auto *disk_buffer = static_cast<uint32_t *>(mallocz(size_in_bytes));
+    pgd_unittest_copy_to_extent(pg_collector, reinterpret_cast<uint8_t *>(disk_buffer), size_in_bytes);
+
+    auto *gbuf = reinterpret_cast<gorilla_buffer_t *>(disk_buffer);
+    gbuf->header.entries++;
+
+    PGD *pg_disk = pgd_unittest_create_from_disk_data(
+        RRDENG_PAGE_TYPE_GORILLA_32BIT, disk_buffer, size_in_bytes);
+    PGD_EXPECT(pg_disk != PGD_EMPTY);
+    PGD_EXPECT(pgd_unittest_slots_used(pg_disk) == 2);
+
+    if(pg_disk != PGD_EMPTY) {
+        PGDC cursor = {};
+        pgd_unittest_cursor_reset(&cursor, pg_disk, 0, 1);
+
+        STORAGE_POINT sp = STORAGE_POINT_UNSET;
+        sp.start_time_s = 0;
+        sp.end_time_s = 1;
+        PGD_EXPECT(pgd_unittest_cursor_next(&cursor, 0, &sp));
+        PGD_EXPECT(sp.start_time_s == 0 && sp.end_time_s == 1);
+        PGD_EXPECT(storage_point_is_complete(sp));
+        PGD_EXPECT(sp.min == 666 && sp.max == 666 && sp.sum == 666);
+        PGD_EXPECT(sp.count == 1 && sp.gap_count == 0 && sp.anomaly_count == 0);
+        PGD_EXPECT(sp.flags & SN_FLAG_NOT_ANOMALOUS);
+
+        sp.start_time_s = 1;
+        sp.end_time_s = 2;
+        PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 1, &sp));
+        PGD_EXPECT(sp.start_time_s == 1 && sp.end_time_s == 2);
+        PGD_EXPECT(storage_point_is_gap(sp));
+        PGD_EXPECT(!netdata_double_isnumber(sp.min) && !netdata_double_isnumber(sp.max) &&
+                   !netdata_double_isnumber(sp.sum));
+        PGD_EXPECT(sp.count == 0 && sp.gap_count == 1 && sp.anomaly_count == 0);
+        PGD_EXPECT(sp.flags == SN_FLAG_NONE);
+
+        pgd_unittest_free(pg_disk);
+    }
+
+    pgd_unittest_free(pg_collector);
+    freez(disk_buffer);
+    return errors;
+}
+
+int pgd_storage_point_unittest(void) {
+    size_t errors = 0;
+
+    PGDC cursor = {};
+    STORAGE_POINT sp = STORAGE_POINT_UNSET;
+    sp.start_time_s = 10;
+    sp.end_time_s = 11;
+    pgd_unittest_cursor_reset(&cursor, nullptr, UINT32_MAX, 0);
+    PGD_EXPECT(cursor.slots_per_point == 1);
+    PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 0, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp) && sp.gap_count == 1);
+
+    sp.start_time_s = 10;
+    sp.end_time_s = 65546;
+    pgd_unittest_cursor_reset(&cursor, nullptr, UINT32_MAX, 65536);
+    PGD_EXPECT(cursor.slots_per_point == 65536);
+    PGD_EXPECT(!pgd_unittest_cursor_next(&cursor, 0, &sp));
+    PGD_EXPECT(storage_point_is_gap(sp) && sp.gap_count == 65536);
+
+    errors += pgd_unittest_tier0(RRDENG_PAGE_TYPE_GORILLA_32BIT);
+    errors += pgd_unittest_tier0(RRDENG_PAGE_TYPE_ARRAY_32BIT);
+    errors += pgd_unittest_tier1();
+    errors += pgd_unittest_corrupt_gorilla_entries();
+
+    fprintf(stderr, "PGD storage-point unittests: %s\n", errors ? "FAILED" : "PASSED");
+    return (int)errors;
+}
+
+#undef PGD_EXPECT
 
 #ifdef HAVE_GTEST
 
@@ -24,6 +258,12 @@ bool operator==(const STORAGE_POINT lhs, const STORAGE_POINT rhs) {
         return false;
 
     if (lhs.count != rhs.count)
+        return false;
+
+    if (lhs.gap_count != rhs.gap_count)
+        return false;
+
+    if (lhs.anomaly_count != rhs.anomaly_count)
         return false;
 
     if (lhs.flags != rhs.flags)
@@ -54,65 +294,65 @@ TEST(PGD, EmptyOrNull) {
     STORAGE_POINT sp;
 
     EXPECT_TRUE(pgd_is_empty(pg));
-    EXPECT_EQ(pgd_slots_used(pg), 0);
+    EXPECT_EQ(pgd_unittest_slots_used(pg), 0);
     EXPECT_EQ(pgd_memory_footprint(pg), 0);
-    EXPECT_EQ(pgd_disk_footprint(pg), 0);
+    EXPECT_EQ(pgd_unittest_disk_footprint(pg), 0);
 
-    pgdc_reset(&cursor, pg, 0);
-    EXPECT_FALSE(pgdc_get_next_point(&cursor, 0, &sp));
+    pgd_unittest_cursor_reset(&cursor, pg, 0, 1);
+    EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, 0, &sp));
 
-    pgd_free(pg);
+    pgd_unittest_free(pg);
 
     pg = PGD_EMPTY;
 
     EXPECT_TRUE(pgd_is_empty(pg));
-    EXPECT_EQ(pgd_slots_used(pg), 0);
+    EXPECT_EQ(pgd_unittest_slots_used(pg), 0);
     EXPECT_EQ(pgd_memory_footprint(pg), 0);
-    EXPECT_EQ(pgd_disk_footprint(pg), 0);
-    EXPECT_FALSE(pgdc_get_next_point(&cursor, 0, &sp));
+    EXPECT_EQ(pgd_unittest_disk_footprint(pg), 0);
+    EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, 0, &sp));
 
-    pgdc_reset(&cursor, pg, 0);
-    EXPECT_FALSE(pgdc_get_next_point(&cursor, 0, &sp));
+    pgd_unittest_cursor_reset(&cursor, pg, 0, 1);
+    EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, 0, &sp));
 
-    pgd_free(pg);
+    pgd_unittest_free(pg);
 }
 
 TEST(PGD, Create) {
     size_t slots = slots_for_page(1024 * 1024);
-    PGD *pg = pgd_create(page_type, slots);
+    PGD *pg = pgd_unittest_create(page_type, slots);
 
     EXPECT_EQ(pgd_type(pg), page_type);
     EXPECT_TRUE(pgd_is_empty(pg));
-    EXPECT_EQ(pgd_slots_used(pg), 0);
+    EXPECT_EQ(pgd_unittest_slots_used(pg), 0);
 
     for (size_t i = 0; i != slots; i++) {
-        pgd_append_point(pg, i, i, 0, 0, 1, 1, SN_DEFAULT_FLAGS, i);
+        pgd_unittest_append_point(pg, i, i, 0, 0, 1, 1, SN_DEFAULT_FLAGS, i);
         EXPECT_FALSE(pgd_is_empty(pg));
     }
-    EXPECT_EQ(pgd_slots_used(pg), slots);
+    EXPECT_EQ(pgd_unittest_slots_used(pg), slots);
 
     EXPECT_DEATH(
-        pgd_append_point(pg, slots, slots, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slots),
+        pgd_unittest_append_point(pg, slots, slots, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slots),
         ".*"
     );
 
-    pgd_free(pg);
+    pgd_unittest_free(pg);
 }
 
 TEST(PGD, CursorFullPage) {
     size_t slots = slots_for_page(1024 * 1024);
-    PGD *pg = pgd_create(page_type, slots);
+    PGD *pg = pgd_unittest_create(page_type, slots);
 
     for (size_t slot = 0; slot != slots; slot++)
-        pgd_append_point(pg, slot, slot, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
+        pgd_unittest_append_point(pg, slot, slot, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
 
     for (size_t i = 0; i != 2; i++) {
         PGDC cursor;
-        pgdc_reset(&cursor, pg, 0);
+        pgd_unittest_cursor_reset(&cursor, pg, 0, 1);
 
         STORAGE_POINT sp;
         for (size_t slot = 0; slot != slots; slot++) {
-            EXPECT_TRUE(pgdc_get_next_point(&cursor, slot, &sp));
+            EXPECT_TRUE(pgd_unittest_cursor_next(&cursor, slot, &sp));
 
             EXPECT_EQ(slot, static_cast<size_t>(sp.min));
             EXPECT_EQ(sp.min, sp.max);
@@ -121,16 +361,16 @@ TEST(PGD, CursorFullPage) {
             EXPECT_EQ(sp.anomaly_count, 0);
         }
 
-        EXPECT_FALSE(pgdc_get_next_point(&cursor, slots, &sp));
+        EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, slots, &sp));
     }
 
     for (size_t i = 0; i != 2; i++) {
         PGDC cursor;
-        pgdc_reset(&cursor, pg, slots / 2);
+        pgd_unittest_cursor_reset(&cursor, pg, slots / 2, 1);
 
         STORAGE_POINT sp;
         for (size_t slot = slots / 2; slot != slots; slot++) {
-            EXPECT_TRUE(pgdc_get_next_point(&cursor, slot, &sp));
+            EXPECT_TRUE(pgd_unittest_cursor_next(&cursor, slot, &sp));
 
             EXPECT_EQ(slot, static_cast<size_t>(sp.min));
             EXPECT_EQ(sp.min, sp.max);
@@ -139,36 +379,36 @@ TEST(PGD, CursorFullPage) {
             EXPECT_EQ(sp.anomaly_count, 0);
         }
 
-        EXPECT_FALSE(pgdc_get_next_point(&cursor, slots, &sp));
+        EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, slots, &sp));
     }
 
     // out of bounds seek
     {
         PGDC cursor;
-        pgdc_reset(&cursor, pg, 2 * slots);
+        pgd_unittest_cursor_reset(&cursor, pg, 2 * slots, 1);
 
         STORAGE_POINT sp;
-        EXPECT_FALSE(pgdc_get_next_point(&cursor, 2 * slots, &sp));
+        EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, 2 * slots, &sp));
     }
 
-    pgd_free(pg);
+    pgd_unittest_free(pg);
 }
 
 TEST(PGD, CursorHalfPage) {
     size_t slots = slots_for_page(1024 * 1024);
-    PGD *pg = pgd_create(page_type, slots);
+    PGD *pg = pgd_unittest_create(page_type, slots);
 
     PGDC cursor;
     STORAGE_POINT sp;
 
     // fill the 1st half of the page
     for (size_t slot = 0; slot != slots / 2; slot++)
-        pgd_append_point(pg, slot, slot, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
+        pgd_unittest_append_point(pg, slot, slot, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
 
-    pgdc_reset(&cursor, pg, 0);
+    pgd_unittest_cursor_reset(&cursor, pg, 0, 1);
 
     for (size_t slot = 0; slot != slots / 2; slot++) {
-        EXPECT_TRUE(pgdc_get_next_point(&cursor, slot, &sp));
+        EXPECT_TRUE(pgd_unittest_cursor_next(&cursor, slot, &sp));
 
         EXPECT_EQ(slot, static_cast<size_t>(sp.min));
         EXPECT_EQ(sp.min, sp.max);
@@ -176,27 +416,27 @@ TEST(PGD, CursorHalfPage) {
         EXPECT_EQ(sp.count, 1);
         EXPECT_EQ(sp.anomaly_count, 0);
     }
-    EXPECT_FALSE(pgdc_get_next_point(&cursor, slots / 2, &sp));
+    EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, slots / 2, &sp));
 
     // reset pgdc to the end of the page, we should not be getting more
     // points even if the page has grown in between.
 
-    pgdc_reset(&cursor, pg, slots / 2);
+    pgd_unittest_cursor_reset(&cursor, pg, slots / 2, 1);
 
     for (size_t slot = slots / 2; slot != slots; slot++)
-        pgd_append_point(pg, slot, slot, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
+        pgd_unittest_append_point(pg, slot, slot, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
 
     for (size_t slot = slots / 2; slot != slots; slot++)
-        EXPECT_FALSE(pgdc_get_next_point(&cursor, slot, &sp));
+        EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, slot, &sp));
 
-    EXPECT_FALSE(pgdc_get_next_point(&cursor, slots, &sp));
+    EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, slots, &sp));
 
-    pgd_free(pg);
+    pgd_unittest_free(pg);
 }
 
 TEST(PGD, MemoryFootprint) {
     size_t slots = slots_for_page(1024 * 1024);
-    PGD *pg = pgd_create(page_type, slots);
+    PGD *pg = pgd_unittest_create(page_type, slots);
 
     uint32_t footprint = 0;
     switch (pgd_type(pg)) {
@@ -218,7 +458,7 @@ TEST(PGD, MemoryFootprint) {
 
     for (size_t slot = 0; slot != slots; slot++) {
         uint32_t n = distr(gen);
-        pgd_append_point(pg, slot, n, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
+        pgd_unittest_append_point(pg, slot, n, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
     }
 
     footprint = slots * sizeof(uint32_t);
@@ -240,7 +480,7 @@ TEST(PGD, MemoryFootprint) {
 
 TEST(PGD, DiskFootprint) {
     size_t slots = slots_for_page(1024 * 1024);
-    PGD *pg = pgd_create(page_type, slots);
+    PGD *pg = pgd_unittest_create(page_type, slots);
 
     std::random_device rand_dev;
     std::mt19937 gen(rand_dev());
@@ -251,7 +491,7 @@ TEST(PGD, DiskFootprint) {
 
     for (size_t slot = 0; slot != used_slots; slot++) {
         uint32_t n = distr(gen);
-        pgd_append_point(pg, slot, n, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
+        pgd_unittest_append_point(pg, slot, n, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
     }
 
     uint32_t footprint = 0;
@@ -265,17 +505,17 @@ TEST(PGD, DiskFootprint) {
         default:
             fatal("Uknown page type: %uc", pgd_type(pg));
     }
-    EXPECT_EQ(pgd_disk_footprint(pg), footprint);
+    EXPECT_EQ(pgd_unittest_disk_footprint(pg), footprint);
 
-    pgd_free(pg);
+    pgd_unittest_free(pg);
 
-    pg = pgd_create(page_type, slots);
+    pg = pgd_unittest_create(page_type, slots);
 
     used_slots = 128 + 64;
 
     for (size_t slot = 0; slot != used_slots; slot++) {
         uint32_t n = distr(gen);
-        pgd_append_point(pg, slot, n, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
+        pgd_unittest_append_point(pg, slot, n, 0, 0, 1, 1, SN_DEFAULT_FLAGS, slot);
     }
 
     switch (pgd_type(pg)) {
@@ -288,19 +528,19 @@ TEST(PGD, DiskFootprint) {
         default:
             fatal("Uknown page type: %uc", pgd_type(pg));
     }
-    EXPECT_EQ(pgd_disk_footprint(pg), footprint);
+    EXPECT_EQ(pgd_unittest_disk_footprint(pg), footprint);
 
-    pgd_free(pg);
+    pgd_unittest_free(pg);
 }
 
 TEST(PGD, CopyToExtent) {
     size_t slots = slots_for_page(1024 * 1024);
-    PGD *pg_collector = pgd_create(page_type, slots);
+    PGD *pg_collector = pgd_unittest_create(page_type, slots);
 
     uint32_t value = 666;
-    pgd_append_point(pg_collector, 0, value, 0, 0, 1, 0, SN_DEFAULT_FLAGS, 0);
+    pgd_unittest_append_point(pg_collector, 0, value, 0, 0, 1, 0, SN_DEFAULT_FLAGS, 0);
 
-    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_bytes = pgd_unittest_disk_footprint(pg_collector);
     EXPECT_EQ(size_in_bytes, 512);
 
     uint32_t size_in_words = size_in_bytes / sizeof(uint32_t);
@@ -310,7 +550,7 @@ TEST(PGD, CopyToExtent) {
         disk_buffer[i] = std::numeric_limits<uint32_t>::max();
     }
 
-    pgd_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
+    pgd_unittest_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
 
     EXPECT_EQ(disk_buffer[0], NULL);
     EXPECT_EQ(disk_buffer[1], NULL);
@@ -323,130 +563,130 @@ TEST(PGD, CopyToExtent) {
     for (size_t i = 5; i != size_in_words; i++)
         EXPECT_EQ(disk_buffer[i], 0);
 
-    pgd_free(pg_collector);
+    pgd_unittest_free(pg_collector);
 }
 
 TEST(PGD, Roundtrip) {
     size_t slots = slots_for_page(1024 * 1024);
-    PGD *pg_collector = pgd_create(page_type, slots);
+    PGD *pg_collector = pgd_unittest_create(page_type, slots);
 
     for (size_t i = 0; i != slots; i++)
-        pgd_append_point(pg_collector, i, i, 0, 0, 1, 1, SN_DEFAULT_FLAGS, i);
+        pgd_unittest_append_point(pg_collector, i, i, 0, 0, 1, 1, SN_DEFAULT_FLAGS, i);
 
-    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_bytes = pgd_unittest_disk_footprint(pg_collector);
     uint32_t size_in_words = size_in_bytes / sizeof(uint32_t);
 
     alignas(sizeof(uintptr_t)) uint32_t disk_buffer[size_in_words];
     for (size_t i = 0; i != size_in_words; i++)
         disk_buffer[i] = std::numeric_limits<uint32_t>::max();
 
-    pgd_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
+    pgd_unittest_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
 
-    PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
-    EXPECT_EQ(pgd_slots_used(pg_disk), slots);
+    PGD *pg_disk = pgd_unittest_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
+    EXPECT_EQ(pgd_unittest_slots_used(pg_disk), slots);
 
     // Expected memory footprint is equal to the disk footprint + a couple
     // bytes for the PGD metadata.
     EXPECT_NEAR(pgd_memory_footprint(pg_disk), size_in_bytes, 128);
 
     // Do not allow calling disk footprint for pages created from disk.
-    EXPECT_DEATH(pgd_disk_footprint(pg_disk), ".*");
+    EXPECT_DEATH(pgd_unittest_disk_footprint(pg_disk), ".*");
 
     for (size_t i = 0; i != 10; i++) {
         PGDC cursor_collector;
         PGDC cursor_disk;
 
-        pgdc_reset(&cursor_collector, pg_collector, i * 1024);
-        pgdc_reset(&cursor_disk, pg_disk, i * 1024);
+        pgd_unittest_cursor_reset(&cursor_collector, pg_collector, i * 1024, 1);
+        pgd_unittest_cursor_reset(&cursor_disk, pg_disk, i * 1024, 1);
 
         STORAGE_POINT sp_collector = {};
         STORAGE_POINT sp_disk = {};
 
         for (size_t slot = i * 1024; slot != slots; slot++) {
-            EXPECT_TRUE(pgdc_get_next_point(&cursor_collector, slot, &sp_collector));
-            EXPECT_TRUE(pgdc_get_next_point(&cursor_disk, slot, &sp_disk));
+            EXPECT_TRUE(pgd_unittest_cursor_next(&cursor_collector, slot, &sp_collector));
+            EXPECT_TRUE(pgd_unittest_cursor_next(&cursor_disk, slot, &sp_disk));
 
             EXPECT_EQ(sp_collector, sp_disk);
         }
 
-        EXPECT_FALSE(pgdc_get_next_point(&cursor_collector, slots, &sp_collector));
-        EXPECT_FALSE(pgdc_get_next_point(&cursor_disk, slots, &sp_disk));
+        EXPECT_FALSE(pgd_unittest_cursor_next(&cursor_collector, slots, &sp_collector));
+        EXPECT_FALSE(pgd_unittest_cursor_next(&cursor_disk, slots, &sp_disk));
     }
 
-    pgd_free(pg_disk);
-    pgd_free(pg_collector);
+    pgd_unittest_free(pg_disk);
+    pgd_unittest_free(pg_collector);
 }
 
 TEST(PGD, RejectCorruptGorillaDiskChain) {
     size_t slots = slots_for_page(16);
-    PGD *pg_collector = pgd_create(page_type, slots);
+    PGD *pg_collector = pgd_unittest_create(page_type, slots);
 
     for (size_t i = 0; i != slots; i++)
-        pgd_append_point(pg_collector, i, i, 0, 0, 1, 1, SN_DEFAULT_FLAGS, i);
+        pgd_unittest_append_point(pg_collector, i, i, 0, 0, 1, 1, SN_DEFAULT_FLAGS, i);
 
-    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_bytes = pgd_unittest_disk_footprint(pg_collector);
     uint32_t size_in_words = size_in_bytes / sizeof(uint32_t);
 
     alignas(sizeof(uintptr_t)) uint32_t disk_buffer[size_in_words];
-    pgd_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
+    pgd_unittest_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
 
     void *last_gbuf = &disk_buffer[size_in_words - RRDENG_GORILLA_32BIT_BUFFER_SLOTS];
     memcpy(last_gbuf, &last_gbuf, sizeof(last_gbuf));
 
-    PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
+    PGD *pg_disk = pgd_unittest_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
     EXPECT_EQ(pg_disk, PGD_EMPTY);
 
-    pgd_free(pg_collector);
+    pgd_unittest_free(pg_collector);
 }
 
 TEST(PGD, StopCorruptGorillaDiskEntriesAtEncodedBits) {
-    PGD *pg_collector = pgd_create(page_type, slots_for_page(1));
+    PGD *pg_collector = pgd_unittest_create(page_type, slots_for_page(1));
 
     uint32_t value = 666;
-    pgd_append_point(pg_collector, 0, value, 0, 0, 1, 1, SN_DEFAULT_FLAGS, 0);
+    pgd_unittest_append_point(pg_collector, 0, value, 0, 0, 1, 1, SN_DEFAULT_FLAGS, 0);
 
-    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_bytes = pgd_unittest_disk_footprint(pg_collector);
     uint32_t size_in_words = size_in_bytes / sizeof(uint32_t);
 
     alignas(sizeof(uintptr_t)) uint32_t disk_buffer[size_in_words];
-    pgd_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
+    pgd_unittest_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
 
     auto *gbuf = static_cast<gorilla_buffer_t *>(static_cast<void *>(&disk_buffer[0]));
     gbuf->header.entries++;
 
-    PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
-    EXPECT_EQ(pgd_slots_used(pg_disk), 2);
+    PGD *pg_disk = pgd_unittest_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
+    EXPECT_EQ(pgd_unittest_slots_used(pg_disk), 2);
 
     PGDC cursor;
-    pgdc_reset(&cursor, pg_disk, 0);
+    pgd_unittest_cursor_reset(&cursor, pg_disk, 0, 1);
 
     STORAGE_POINT sp = {};
-    EXPECT_TRUE(pgdc_get_next_point(&cursor, 0, &sp));
+    EXPECT_TRUE(pgd_unittest_cursor_next(&cursor, 0, &sp));
     EXPECT_EQ(value, static_cast<uint32_t>(sp.min));
-    EXPECT_FALSE(pgdc_get_next_point(&cursor, 1, &sp));
+    EXPECT_FALSE(pgd_unittest_cursor_next(&cursor, 1, &sp));
 
-    pgd_free(pg_disk);
-    pgd_free(pg_collector);
+    pgd_unittest_free(pg_disk);
+    pgd_unittest_free(pg_collector);
 }
 
 TEST(PGD, RejectCorruptGorillaDiskNbits) {
-    PGD *pg_collector = pgd_create(page_type, slots_for_page(1));
+    PGD *pg_collector = pgd_unittest_create(page_type, slots_for_page(1));
 
-    pgd_append_point(pg_collector, 0, 666, 0, 0, 1, 1, SN_DEFAULT_FLAGS, 0);
+    pgd_unittest_append_point(pg_collector, 0, 666, 0, 0, 1, 1, SN_DEFAULT_FLAGS, 0);
 
-    uint32_t size_in_bytes = pgd_disk_footprint(pg_collector);
+    uint32_t size_in_bytes = pgd_unittest_disk_footprint(pg_collector);
     uint32_t size_in_words = size_in_bytes / sizeof(uint32_t);
 
     alignas(sizeof(uintptr_t)) uint32_t disk_buffer[size_in_words];
-    pgd_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
+    pgd_unittest_copy_to_extent(pg_collector, (uint8_t *) &disk_buffer[0], size_in_bytes);
 
     auto *gbuf = static_cast<gorilla_buffer_t *>(static_cast<void *>(&disk_buffer[0]));
     gbuf->header.nbits = RRDENG_GORILLA_32BIT_BUFFER_SIZE * CHAR_BIT;
 
-    PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
+    PGD *pg_disk = pgd_unittest_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
     EXPECT_EQ(pg_disk, PGD_EMPTY);
 
-    pgd_free(pg_collector);
+    pgd_unittest_free(pg_collector);
 }
 
 int pgd_test(int argc, char *argv[])

--- a/src/database/engine/page_test.h
+++ b/src/database/engine/page_test.h
@@ -6,6 +6,10 @@ extern "C" {
 #endif
 
 int pgd_test(int argc, char *argv[]);
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+int pgd_storage_point_unittest(void);
 
 #ifdef __cplusplus
 }

--- a/src/database/engine/page_test_bridge.cc
+++ b/src/database/engine/page_test_bridge.cc
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "page_test_bridge.h"
+
+NOINLINE PGD *pgd_unittest_create(uint8_t type, uint32_t slots) {
+    return pgd_create(type, slots);
+}
+
+NOINLINE PGD *pgd_unittest_create_from_disk_data(uint8_t type, void *base, uint32_t size) {
+    return pgd_create_from_disk_data(type, base, size);
+}
+
+NOINLINE void pgd_unittest_free(PGD *pg) {
+    pgd_free(pg);
+}
+
+NOINLINE uint32_t pgd_unittest_slots_used(PGD *pg) {
+    return pgd_slots_used(pg);
+}
+
+NOINLINE bool pgd_unittest_is_empty(PGD *pg) {
+    return pgd_is_empty(pg);
+}
+
+NOINLINE uint32_t pgd_unittest_disk_footprint(PGD *pg) {
+    return pgd_disk_footprint(pg);
+}
+
+NOINLINE void pgd_unittest_copy_to_extent(PGD *pg, uint8_t *dst, uint32_t dst_size) {
+    pgd_copy_to_extent(pg, dst, dst_size);
+}
+
+NOINLINE size_t pgd_unittest_append_point(
+    PGD *pg,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags,
+    uint32_t expected_slot) {
+    return pgd_append_point(
+        pg, point_in_time_ut, n, min_value, max_value, count, anomaly_count, flags, expected_slot);
+}
+
+NOINLINE void pgd_unittest_cursor_reset(
+    PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point) {
+    pgdc_reset(pgdc, pgd, position, slots_per_point);
+}
+
+NOINLINE bool pgd_unittest_cursor_next(
+    PGDC *pgdc, uint32_t expected_position, STORAGE_POINT *sp) {
+    return pgdc_get_next_point(pgdc, expected_position, sp);
+}

--- a/src/database/engine/page_test_bridge.h
+++ b/src/database/engine/page_test_bridge.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_DBENGINE_PAGE_TEST_BRIDGE_H
+#define NETDATA_DBENGINE_PAGE_TEST_BRIDGE_H
+
+#include "page.h"
+
+PGD *pgd_unittest_create(uint8_t type, uint32_t slots);
+PGD *pgd_unittest_create_from_disk_data(uint8_t type, void *base, uint32_t size);
+void pgd_unittest_free(PGD *pg);
+uint32_t pgd_unittest_slots_used(PGD *pg);
+bool pgd_unittest_is_empty(PGD *pg);
+uint32_t pgd_unittest_disk_footprint(PGD *pg);
+void pgd_unittest_copy_to_extent(PGD *pg, uint8_t *dst, uint32_t dst_size);
+
+size_t pgd_unittest_append_point(
+    PGD *pg,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags,
+    uint32_t expected_slot);
+
+void pgd_unittest_cursor_reset(PGDC *pgdc, PGD *pgd, uint32_t position, uint32_t slots_per_point);
+bool pgd_unittest_cursor_next(PGDC *pgdc, uint32_t expected_position, STORAGE_POINT *sp);
+
+#endif // NETDATA_DBENGINE_PAGE_TEST_BRIDGE_H

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -785,6 +785,8 @@ ALWAYS_INLINE_HOT void rrdeng_load_metric_init(
     handle->ctx = ctx;
     handle->metric = metric;
     handle->priority = priority;
+    size_t tier_grouping = get_tier_grouping(ctx->config.tier);
+    handle->pgdc.slots_per_point = tier_grouping > UINT32_MAX ? UINT32_MAX : (uint32_t)tier_grouping;
 
     // IMPORTANT!
     // It is crucial not to exceed the db boundaries, because dbengine
@@ -839,7 +841,7 @@ static ALWAYS_INLINE_HOT bool rrdeng_load_page_next(struct storage_engine_query_
         // we have a page to release
         pgc_page_release(main_cache, handle->page);
         handle->page = NULL;
-        pgdc_reset(&handle->pgdc, NULL, UINT32_MAX);
+        pgdc_reset(&handle->pgdc, NULL, UINT32_MAX, handle->pgdc.slots_per_point);
     }
 
     if (unlikely(handle->now_s > seqh->end_time_s))
@@ -894,7 +896,8 @@ static ALWAYS_INLINE_HOT bool rrdeng_load_page_next(struct storage_engine_query_
     handle->position = position;
     handle->dt_s = page_update_every_s;
 
-    pgdc_reset(&handle->pgdc, pgc_page_data(handle->page), handle->position);
+    pgdc_reset(
+        &handle->pgdc, pgc_page_data(handle->page), handle->position, handle->pgdc.slots_per_point);
 
     return true;
 }
@@ -907,7 +910,8 @@ ALWAYS_INLINE_HOT STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_qu
     STORAGE_POINT sp;
 
     if (unlikely(handle->now_s > seqh->end_time_s)) {
-        storage_point_empty(sp, handle->now_s - handle->dt_s, handle->now_s);
+        storage_point_empty_slots(
+            sp, handle->now_s - handle->dt_s, handle->now_s, handle->pgdc.slots_per_point);
         goto prepare_for_next_iteration;
     }
 
@@ -916,7 +920,8 @@ ALWAYS_INLINE_HOT STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_qu
 
         if (!rrdeng_load_page_next(seqh, false)) {
             handle->now_s = seqh->end_time_s;
-            storage_point_empty(sp, handle->now_s - handle->dt_s, handle->now_s);
+            storage_point_empty_slots(
+                sp, handle->now_s - handle->dt_s, handle->now_s, handle->pgdc.slots_per_point);
             goto prepare_for_next_iteration;
         }
     }
@@ -950,7 +955,7 @@ ALWAYS_INLINE void rrdeng_load_metric_finalize(struct storage_engine_query_handl
 
     if (handle->page) {
         pgc_page_release(main_cache, handle->page);
-        pgdc_reset(&handle->pgdc, NULL, UINT32_MAX);
+        pgdc_reset(&handle->pgdc, NULL, UINT32_MAX, handle->pgdc.slots_per_point);
     }
 
     if(handle->pdc) {

--- a/src/database/ram/rrddim_mem.c
+++ b/src/database/ram/rrddim_mem.c
@@ -592,7 +592,6 @@ ALWAYS_INLINE STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query
     size_t slot = h->slot;
 
     STORAGE_POINT sp;
-    sp.count = 1;
 
     time_t this_timestamp = h->next_timestamp;
     h->next_timestamp += h->dt;
@@ -617,9 +616,12 @@ ALWAYS_INLINE STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query
     h->slot = slot;
     h->slot_timestamp += h->dt;
 
-    sp.anomaly_count = is_storage_number_anomalous(n) ? 1 : 0;
     sp.flags = (n & SN_USER_FLAGS);
     sp.min = sp.max = sp.sum = unpack_storage_number(n);
+    bool exists = does_storage_number_exist(n);
+    sp.count = exists ? 1 : 0;
+    sp.anomaly_count = exists && is_storage_number_anomalous(n) ? 1 : 0;
+    sp.gap_count = exists ? 0 : 1;
 
     return sp;
 }

--- a/src/database/rrddim-collection.c
+++ b/src/database/rrddim-collection.c
@@ -19,7 +19,7 @@ void store_metric_at_tier_flush_last_completed(RRDDIM *rd __maybe_unused, size_t
     if(!LAST_COMPLETED_POINT_EXISTS(t)) return;
 
     STORAGE_POINT *sp = &t->last_completed_point;
-    if(likely(!storage_point_is_unset(t->last_completed_point))) {
+    if(likely(storage_point_has_value(t->last_completed_point))) {
         storage_engine_store_metric(
             t->sch,
             sp->end_time_s * USEC_PER_SEC,
@@ -43,9 +43,7 @@ void store_metric_at_tier_flush_last_completed(RRDDIM *rd __maybe_unused, size_t
 
     rrdset_done_statistics_points_stored_per_tier[tier]++;
 
-    // make the point unset
-    t->last_completed_point.count = 0;      // make it unset
-    t->last_completed_point.end_time_s = 0; // make it not saved
+    storage_point_unset(t->last_completed_point);
 }
 
 ALWAYS_INLINE_HOT
@@ -76,35 +74,11 @@ void store_metric_at_tier(RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAG
         else
             store_metric_at_tier_save_last_completed(rd, tier, t, STORAGE_POINT_UNSET);
 
-        t->virtual_point.count = 0; // make the point unset
+        storage_point_unset(t->virtual_point);
         t->next_point_end_time_s = tier_next_point_time_s(rd, t, sp.end_time_s);
     }
 
-    // merge the dates into our virtual point
-    if (unlikely(sp.start_time_s < t->virtual_point.start_time_s))
-        t->virtual_point.start_time_s = sp.start_time_s;
-
-    if (likely(sp.end_time_s > t->virtual_point.end_time_s))
-        t->virtual_point.end_time_s = sp.end_time_s;
-
-    // merge the values into our virtual point
-    if (likely(!storage_point_is_gap(sp))) {
-        // we aggregate only non NULLs into higher tiers
-
-        if (likely(!storage_point_is_unset(t->virtual_point))) {
-            // merge the collected point to our virtual one
-            t->virtual_point.sum += sp.sum;
-            t->virtual_point.min = MIN(t->virtual_point.min, sp.min);
-            t->virtual_point.max = MAX(t->virtual_point.max, sp.max);
-            t->virtual_point.count += sp.count;
-            t->virtual_point.anomaly_count += sp.anomaly_count;
-            t->virtual_point.flags |= sp.flags;
-        }
-        else {
-            // reset our virtual point to this one
-            t->virtual_point = sp;
-        }
-    }
+    storage_point_merge_to(t->virtual_point, sp);
 }
 
 NOT_INLINE_HOT
@@ -153,31 +127,41 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
 
     rrdset_done_statistics_points_stored_per_tier[0]++;
 
-    time_t now_s = (time_t)(point_end_time_ut / USEC_PER_SEC);
+    if(likely(nd_profile.storage_tiers > 1)) {
+        time_t now_s = (time_t)(point_end_time_ut / USEC_PER_SEC);
 
-    STORAGE_POINT sp = {
-        .start_time_s = now_s - rd->rrdset->update_every,
-        .end_time_s = now_s,
-        .min = n,
-        .max = n,
-        .sum = n,
-        .count = 1,
-        .anomaly_count = (flags & SN_FLAG_NOT_ANOMALOUS) ? 0 : 1,
-        .flags = flags
-    };
-
-    for(size_t tier = 1; tier < nd_profile.storage_tiers;tier++) {
-        if(unlikely(!rd->tiers[tier].smh)) continue;
-
-        struct rrddim_tier *t = &rd->tiers[tier];
-
-        if(!rrddim_option_check(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS)) {
-            // we have not collected this tier before
-            // let's fill any gap that may exist
-            backfill_tier_from_smaller_tiers(rd, tier, now_s);
+        time_t start_time_s = now_s - rd->rrdset->update_every;
+        STORAGE_POINT sp;
+        if(likely(netdata_double_isnumber(n))) {
+            sp = (STORAGE_POINT){
+                .start_time_s = start_time_s,
+                .end_time_s = now_s,
+                .min = n,
+                .max = n,
+                .sum = n,
+                .count = 1,
+                .anomaly_count = !(flags & SN_FLAG_NOT_ANOMALOUS) ? 1 : 0,
+                .flags = flags,
+                .gap_count = 0,
+            };
         }
+        else
+            storage_point_empty(sp, start_time_s, now_s);
 
-        store_metric_at_tier(rd, tier, t, sp, point_end_time_ut);
+        size_t tier = 1;
+        do {
+            if(unlikely(!rd->tiers[tier].smh)) continue;
+
+            struct rrddim_tier *t = &rd->tiers[tier];
+
+            if(!rrddim_option_check(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS)) {
+                // we have not collected this tier before
+                // let's fill any gap that may exist
+                backfill_tier_from_smaller_tiers(rd, tier, now_s);
+            }
+
+            store_metric_at_tier(rd, tier, t, sp, point_end_time_ut);
+        } while(++tier < nd_profile.storage_tiers);
     }
     rrddim_option_set(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS);
 

--- a/src/database/tests/rrddim-collection-test.c
+++ b/src/database/tests/rrddim-collection-test.c
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#define rrdeng_store_metric_next collection_test_dbengine_store
+#define rrddim_collect_store_metric collection_test_ram_store
+#define rrdeng_metric_oldest_time collection_test_oldest_time
+#define rrddim_query_oldest_time_s collection_test_oldest_time
+#define rrdeng_metric_latest_time collection_test_latest_time
+#define rrddim_query_latest_time_s collection_test_latest_time
+#define rrdeng_load_metric_init collection_test_query_init
+#define rrddim_query_init collection_test_query_init
+#define rrdeng_load_metric_next collection_test_query_next
+#define rrddim_query_next_metric collection_test_query_next
+#define rrdeng_load_metric_is_finished collection_test_query_is_finished
+#define rrddim_query_is_finished collection_test_query_is_finished
+#define rrdeng_load_metric_finalize collection_test_query_finalize
+#define rrddim_query_finalize collection_test_query_finalize
+#define rrdcontext_collected_rrddim collection_test_context_collected
+#include "../rrddim-collection.c"
+#include "../rrddim-backfill.c"
+#undef rrdcontext_collected_rrddim
+#undef rrddim_query_finalize
+#undef rrdeng_load_metric_finalize
+#undef rrddim_query_is_finished
+#undef rrdeng_load_metric_is_finished
+#undef rrddim_query_next_metric
+#undef rrdeng_load_metric_next
+#undef rrddim_query_init
+#undef rrdeng_load_metric_init
+#undef rrddim_query_latest_time_s
+#undef rrdeng_metric_latest_time
+#undef rrddim_query_oldest_time_s
+#undef rrdeng_metric_oldest_time
+#undef rrddim_collect_store_metric
+#undef rrdeng_store_metric_next
+
+#define TEST_EXPECT(condition) do { \
+    if(!(condition)) { \
+        fprintf(stderr, "%s:%d: %s\n", __FUNCTION__, __LINE__, #condition); \
+        errors++; \
+    } \
+} while(0)
+
+struct nd_profile_t nd_profile = { 0 };
+RRD_BACKFILL default_backfill = RRD_BACKFILL_FULL;
+__thread size_t rrdset_done_statistics_points_stored_per_tier[RRD_STORAGE_TIERS];
+
+struct captured_store {
+    usec_t point_in_time_ut;
+    NETDATA_DOUBLE n;
+    NETDATA_DOUBLE min;
+    NETDATA_DOUBLE max;
+    uint16_t count;
+    uint16_t anomaly_count;
+    SN_FLAGS flags;
+};
+
+static struct captured_store captured_stores[16];
+static size_t captured_store_count;
+static size_t context_collected_count;
+static size_t backfill_started_count;
+static size_t backfill_finished_count;
+static size_t backfill_completed_count;
+static size_t backfill_points_read;
+static size_t collection_completed_count;
+
+static void capture_store(
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    if(captured_store_count >= _countof(captured_stores))
+        fatal("too many captured stores");
+
+    captured_stores[captured_store_count++] = (struct captured_store){
+        .point_in_time_ut = point_in_time_ut,
+        .n = n,
+        .min = min,
+        .max = max,
+        .count = count,
+        .anomaly_count = anomaly_count,
+        .flags = flags,
+    };
+}
+
+void collection_test_dbengine_store(
+    STORAGE_COLLECT_HANDLE *sch __maybe_unused,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    capture_store(point_in_time_ut, n, min, max, count, anomaly_count, flags);
+}
+
+void collection_test_ram_store(
+    STORAGE_COLLECT_HANDLE *sch __maybe_unused,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    capture_store(point_in_time_ut, n, min, max, count, anomaly_count, flags);
+}
+
+void collection_test_context_collected(RRDDIM *rd __maybe_unused) {
+    context_collected_count++;
+}
+
+void stream_control_backfill_query_started(void) {
+    backfill_started_count++;
+}
+
+void stream_control_backfill_query_finished(void) {
+    backfill_finished_count++;
+}
+
+void pulse_queries_backfill_query_completed(size_t points_read) {
+    backfill_completed_count++;
+    backfill_points_read += points_read;
+}
+
+void pulse_queries_rrdset_collection_completed(size_t *points_read_per_tier_array __maybe_unused) {
+    collection_completed_count++;
+}
+
+struct collection_test_metric {
+    const STORAGE_POINT *points;
+    size_t points_count;
+    size_t next_point;
+    time_t oldest_time_s;
+    time_t latest_time_s;
+};
+
+time_t collection_test_oldest_time(STORAGE_METRIC_HANDLE *smh) {
+    return ((struct collection_test_metric *)smh)->oldest_time_s;
+}
+
+time_t collection_test_latest_time(STORAGE_METRIC_HANDLE *smh) {
+    return ((struct collection_test_metric *)smh)->latest_time_s;
+}
+
+void collection_test_query_init(
+    STORAGE_METRIC_HANDLE *smh,
+    struct storage_engine_query_handle *seqh,
+    time_t start_time_s,
+    time_t end_time_s,
+    STORAGE_PRIORITY priority) {
+    struct collection_test_metric *metric = (struct collection_test_metric *)smh;
+    metric->next_point = 0;
+    *seqh = (struct storage_engine_query_handle){
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .priority = priority,
+#ifdef ENABLE_DBENGINE
+        .seb = STORAGE_ENGINE_BACKEND_DBENGINE,
+#else
+        .seb = STORAGE_ENGINE_BACKEND_RRDDIM,
+#endif
+        .handle = (STORAGE_QUERY_HANDLE *)metric,
+    };
+}
+
+STORAGE_POINT collection_test_query_next(struct storage_engine_query_handle *seqh) {
+    struct collection_test_metric *metric = (struct collection_test_metric *)seqh->handle;
+    if(metric->next_point >= metric->points_count)
+        return STORAGE_POINT_UNSET;
+
+    return metric->points[metric->next_point++];
+}
+
+int collection_test_query_is_finished(struct storage_engine_query_handle *seqh) {
+    struct collection_test_metric *metric = (struct collection_test_metric *)seqh->handle;
+    return metric->next_point >= metric->points_count;
+}
+
+void collection_test_query_finalize(struct storage_engine_query_handle *seqh __maybe_unused) {
+    // The mock query borrows fixture storage and owns no resources.
+}
+
+static STORAGE_POINT numeric_point(
+    time_t start_time_s,
+    time_t end_time_s,
+    NETDATA_DOUBLE min,
+    NETDATA_DOUBLE max,
+    NETDATA_DOUBLE sum,
+    uint32_t count,
+    uint32_t gap_count,
+    uint32_t anomaly_count,
+    SN_FLAGS flags) {
+    return (STORAGE_POINT){
+        .min = min,
+        .max = max,
+        .sum = sum,
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .count = count,
+        .anomaly_count = anomaly_count,
+        .flags = flags,
+        .gap_count = gap_count,
+    };
+}
+
+static STORAGE_POINT gap_point(time_t start_time_s, time_t end_time_s, NETDATA_DOUBLE payload, uint32_t gaps) {
+    return (STORAGE_POINT){
+        .min = payload,
+        .max = payload,
+        .sum = payload,
+        .start_time_s = start_time_s,
+        .end_time_s = end_time_s,
+        .count = 0,
+        .anomaly_count = 0,
+        .flags = SN_FLAG_RESET,
+        .gap_count = gaps,
+    };
+}
+
+static bool point_is_fully_unset(STORAGE_POINT sp) {
+    return storage_point_is_unset(sp) &&
+        isnan(sp.min) && isnan(sp.max) && isnan(sp.sum) &&
+        sp.start_time_s == 0 && sp.end_time_s == 0 &&
+        sp.count == 0 && sp.gap_count == 0 && sp.anomaly_count == 0 &&
+        sp.flags == SN_FLAG_NONE;
+}
+
+static size_t test_completed_point_persistence(void) {
+    size_t errors = 0;
+    STORAGE_COLLECT_HANDLE sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    struct rrddim_tier tier = { .sch = &sch };
+
+    const STORAGE_POINT cases[] = {
+        numeric_point(100, 160, 1, 3, 6, 3, 0, 1, SN_FLAG_RESET),
+        numeric_point(160, 220, 2, 4, 6, 2, 3, 1, SN_DEFAULT_FLAGS),
+        gap_point(220, 280, NAN, 60),
+        gap_point(280, 340, INFINITY, 60),
+        gap_point(340, 400, -INFINITY, 60),
+    };
+
+    captured_store_count = 0;
+    memset(rrdset_done_statistics_points_stored_per_tier, 0,
+           sizeof(rrdset_done_statistics_points_stored_per_tier));
+
+    for(size_t i = 0; i < _countof(cases); i++) {
+        tier.last_completed_point = cases[i];
+        store_metric_at_tier_flush_last_completed(NULL, 1, &tier);
+        TEST_EXPECT(point_is_fully_unset(tier.last_completed_point));
+    }
+
+    TEST_EXPECT(captured_store_count == _countof(cases));
+    TEST_EXPECT(rrdset_done_statistics_points_stored_per_tier[1] == _countof(cases));
+
+    for(size_t i = 0; i < 2 && i < captured_store_count; i++) {
+        TEST_EXPECT(captured_stores[i].point_in_time_ut == (usec_t)cases[i].end_time_s * USEC_PER_SEC);
+        TEST_EXPECT(captured_stores[i].n == cases[i].sum);
+        TEST_EXPECT(captured_stores[i].min == cases[i].min);
+        TEST_EXPECT(captured_stores[i].max == cases[i].max);
+        TEST_EXPECT(captured_stores[i].count == cases[i].count);
+        TEST_EXPECT(captured_stores[i].anomaly_count == cases[i].anomaly_count);
+        TEST_EXPECT(captured_stores[i].flags == cases[i].flags);
+    }
+
+    for(size_t i = 2; i < _countof(cases) && i < captured_store_count; i++) {
+        TEST_EXPECT(captured_stores[i].point_in_time_ut == (usec_t)cases[i].end_time_s * USEC_PER_SEC);
+        TEST_EXPECT(isnan(captured_stores[i].n));
+        TEST_EXPECT(isnan(captured_stores[i].min));
+        TEST_EXPECT(isnan(captured_stores[i].max));
+        TEST_EXPECT(captured_stores[i].count == 0);
+        TEST_EXPECT(captured_stores[i].anomaly_count == 0);
+        TEST_EXPECT(captured_stores[i].flags == SN_FLAG_NONE);
+    }
+
+    return errors;
+}
+
+static size_t test_one_tier_fast_path(void) {
+    size_t errors = 0;
+    STORAGE_COLLECT_HANDLE tier0_sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    STORAGE_COLLECT_HANDLE tier1_sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    RRDSET st = { .update_every = 1 };
+    RRDDIM *rd = callocz(1, sizeof(*rd) + 2 * sizeof(struct rrddim_tier));
+    rd->id = string_strdupz("collection-one-tier");
+    rd->rrdset = &st;
+    rd->tiers[0].sch = &tier0_sch;
+    rd->tiers[1].sch = &tier1_sch;
+    rd->tiers[1].smh = (STORAGE_METRIC_HANDLE *)(uintptr_t)1;
+    rd->tiers[1].tier_grouping = 60;
+    rd->tiers[1].last_completed_point_flush_modulo = 1;
+    storage_point_unset(rd->tiers[1].virtual_point);
+    storage_point_unset(rd->tiers[1].last_completed_point);
+    rrddim_option_set(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS);
+
+    nd_profile.storage_tiers = 1;
+    captured_store_count = 0;
+    context_collected_count = 0;
+    rrddim_store_metric(rd, 200 * USEC_PER_SEC, 42, SN_DEFAULT_FLAGS);
+
+    TEST_EXPECT(captured_store_count == 1);
+    if(captured_store_count == 1) {
+        TEST_EXPECT(captured_stores[0].point_in_time_ut == 200 * USEC_PER_SEC);
+        TEST_EXPECT(captured_stores[0].n == 42);
+        TEST_EXPECT(captured_stores[0].count == 1);
+    }
+    TEST_EXPECT(context_collected_count == 1);
+    TEST_EXPECT(point_is_fully_unset(rd->tiers[1].virtual_point));
+    TEST_EXPECT(point_is_fully_unset(rd->tiers[1].last_completed_point));
+    TEST_EXPECT(rd->tiers[1].next_point_end_time_s == 0);
+
+    string_freez(rd->id);
+    freez(rd);
+    return errors;
+}
+
+static size_t test_ordinary_higher_tier_rollup(void) {
+    size_t errors = 0;
+    STORAGE_COLLECT_HANDLE tier0_sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    STORAGE_COLLECT_HANDLE tier1_sch = { .seb = STORAGE_ENGINE_BACKEND_RRDDIM };
+    RRDSET st = { .update_every = 10 };
+    RRDDIM *rd = callocz(1, sizeof(*rd) + 2 * sizeof(struct rrddim_tier));
+    rd->id = string_strdupz("collection-higher-tier");
+    rd->rrdset = &st;
+    rd->tiers[0].sch = &tier0_sch;
+    rd->tiers[1].sch = &tier1_sch;
+    rd->tiers[1].smh = (STORAGE_METRIC_HANDLE *)(uintptr_t)1;
+    rd->tiers[1].tier_grouping = 3;
+    rd->tiers[1].last_completed_point_flush_modulo = 1;
+    storage_point_unset(rd->tiers[1].virtual_point);
+    storage_point_unset(rd->tiers[1].last_completed_point);
+    rrddim_option_set(rd, RRDDIM_OPTION_BACKFILLED_HIGH_TIERS);
+
+    nd_profile.storage_tiers = 2;
+    captured_store_count = 0;
+    context_collected_count = 0;
+
+    rrddim_store_metric(rd, 70 * USEC_PER_SEC, INFINITY, SN_FLAG_RESET);
+    TEST_EXPECT(storage_point_is_gap(rd->tiers[1].virtual_point));
+    TEST_EXPECT(isnan(rd->tiers[1].virtual_point.min));
+    TEST_EXPECT(isnan(rd->tiers[1].virtual_point.max));
+    TEST_EXPECT(isnan(rd->tiers[1].virtual_point.sum));
+    TEST_EXPECT(rd->tiers[1].virtual_point.flags == SN_FLAG_NONE);
+    rrddim_store_metric(rd, 80 * USEC_PER_SEC, NAN, SN_FLAG_NONE);
+    rrddim_store_metric(rd, 90 * USEC_PER_SEC, -INFINITY, SN_FLAG_NONE);
+
+    struct rrddim_tier *t = &rd->tiers[1];
+    TEST_EXPECT(t->next_point_end_time_s == 90);
+    TEST_EXPECT(storage_point_is_gap(t->virtual_point));
+    TEST_EXPECT(t->virtual_point.start_time_s == 60 && t->virtual_point.end_time_s == 90);
+    TEST_EXPECT(isnan(t->virtual_point.min));
+    TEST_EXPECT(isnan(t->virtual_point.max));
+    TEST_EXPECT(isnan(t->virtual_point.sum));
+    TEST_EXPECT(t->virtual_point.count == 0 && t->virtual_point.gap_count == 3);
+    TEST_EXPECT(t->virtual_point.anomaly_count == 0 && t->virtual_point.flags == SN_FLAG_NONE);
+
+    rrddim_store_metric(rd, 100 * USEC_PER_SEC, 4, SN_DEFAULT_FLAGS);
+    TEST_EXPECT(t->next_point_end_time_s == 120);
+    TEST_EXPECT(storage_point_is_gap(t->last_completed_point));
+    TEST_EXPECT(t->last_completed_point.start_time_s == 60 && t->last_completed_point.end_time_s == 90);
+    TEST_EXPECT(isnan(t->last_completed_point.min));
+    TEST_EXPECT(isnan(t->last_completed_point.max));
+    TEST_EXPECT(isnan(t->last_completed_point.sum));
+    TEST_EXPECT(t->last_completed_point.count == 0 && t->last_completed_point.gap_count == 3);
+    TEST_EXPECT(t->last_completed_point.anomaly_count == 0 && t->last_completed_point.flags == SN_FLAG_NONE);
+    TEST_EXPECT(storage_point_is_complete(t->virtual_point));
+    TEST_EXPECT(t->virtual_point.start_time_s == 90 && t->virtual_point.end_time_s == 100);
+    TEST_EXPECT(t->virtual_point.min == 4 && t->virtual_point.max == 4 && t->virtual_point.sum == 4);
+    TEST_EXPECT(t->virtual_point.count == 1 && t->virtual_point.gap_count == 0);
+    TEST_EXPECT(t->virtual_point.anomaly_count == 0 && t->virtual_point.flags == SN_DEFAULT_FLAGS);
+
+    store_metric_at_tier_flush_last_completed(rd, 1, t);
+    TEST_EXPECT(captured_store_count == 5);
+    if(captured_store_count == 5) {
+        const struct captured_store *gap = &captured_stores[4];
+        TEST_EXPECT(gap->point_in_time_ut == 90 * USEC_PER_SEC);
+        TEST_EXPECT(isnan(gap->n) && isnan(gap->min) && isnan(gap->max));
+        TEST_EXPECT(gap->count == 0 && gap->anomaly_count == 0 && gap->flags == SN_FLAG_NONE);
+    }
+    TEST_EXPECT(point_is_fully_unset(t->last_completed_point));
+
+    rrddim_store_metric(rd, 110 * USEC_PER_SEC, 6, SN_FLAG_RESET);
+    rrddim_store_metric(rd, 120 * USEC_PER_SEC, NAN, SN_FLAG_NONE);
+    rrddim_store_metric(rd, 130 * USEC_PER_SEC, 8, SN_DEFAULT_FLAGS);
+
+    TEST_EXPECT(t->next_point_end_time_s == 150);
+    TEST_EXPECT(storage_point_is_partial(t->last_completed_point));
+    TEST_EXPECT(t->last_completed_point.start_time_s == 90 && t->last_completed_point.end_time_s == 120);
+    TEST_EXPECT(t->last_completed_point.min == 4 && t->last_completed_point.max == 6 &&
+                t->last_completed_point.sum == 10);
+    TEST_EXPECT(t->last_completed_point.count == 2 && t->last_completed_point.gap_count == 1);
+    TEST_EXPECT(t->last_completed_point.anomaly_count == 1 &&
+                t->last_completed_point.flags == (SN_DEFAULT_FLAGS | SN_FLAG_RESET));
+    TEST_EXPECT(storage_point_is_complete(t->virtual_point));
+    TEST_EXPECT(t->virtual_point.start_time_s == 120 && t->virtual_point.end_time_s == 130);
+    TEST_EXPECT(t->virtual_point.min == 8 && t->virtual_point.max == 8 && t->virtual_point.sum == 8);
+    TEST_EXPECT(t->virtual_point.count == 1 && t->virtual_point.gap_count == 0);
+    TEST_EXPECT(t->virtual_point.anomaly_count == 0 && t->virtual_point.flags == SN_DEFAULT_FLAGS);
+
+    store_metric_at_tier_flush_last_completed(rd, 1, t);
+    TEST_EXPECT(captured_store_count == 9);
+    if(captured_store_count == 9) {
+        const struct captured_store *partial = &captured_stores[8];
+        TEST_EXPECT(partial->point_in_time_ut == 120 * USEC_PER_SEC);
+        TEST_EXPECT(partial->n == 10 && partial->min == 4 && partial->max == 6);
+        TEST_EXPECT(partial->count == 2 && partial->anomaly_count == 1 &&
+                    partial->flags == (SN_DEFAULT_FLAGS | SN_FLAG_RESET));
+    }
+    TEST_EXPECT(point_is_fully_unset(t->last_completed_point));
+    TEST_EXPECT(context_collected_count == 7);
+
+    string_freez(rd->id);
+    freez(rd);
+    return errors;
+}
+
+#ifdef ENABLE_DBENGINE
+static size_t test_backfill_gap_composition(void) {
+    size_t errors = 0;
+    const time_t t = 600;
+    const STORAGE_POINT source_points[] = {
+        numeric_point(t, t + 10, 1, 1, 1, 1, 0, 0, SN_DEFAULT_FLAGS),
+        numeric_point(t + 10, t + 20, 2, 2, 2, 1, 0, 0, SN_DEFAULT_FLAGS),
+        numeric_point(t + 20, t + 21, 3, 3, 3, 1, 0, 0, SN_DEFAULT_FLAGS),
+        gap_point(t + 21, t + 22, NAN, 1),
+        numeric_point(t + 22, t + 23, 4, 4, 4, 1, 0, 0, SN_DEFAULT_FLAGS),
+    };
+    struct collection_test_metric source = {
+        .points = source_points,
+        .points_count = _countof(source_points),
+        .oldest_time_s = t + 10,
+        .latest_time_s = t + 23,
+    };
+    struct collection_test_metric target = { .oldest_time_s = 0, .latest_time_s = 0 };
+    RRDSET st = { .update_every = 1 };
+    RRDDIM *rd = callocz(1, sizeof(*rd) + 2 * sizeof(struct rrddim_tier));
+    rd->rrdset = &st;
+    rd->tiers[0].seb = STORAGE_ENGINE_BACKEND_DBENGINE;
+    rd->tiers[0].smh = (STORAGE_METRIC_HANDLE *)&source;
+    rd->tiers[1].seb = STORAGE_ENGINE_BACKEND_DBENGINE;
+    rd->tiers[1].smh = (STORAGE_METRIC_HANDLE *)&target;
+    rd->tiers[1].tier_grouping = 60;
+    rd->tiers[1].last_completed_point_flush_modulo = 1;
+    storage_point_unset(rd->tiers[1].virtual_point);
+    storage_point_unset(rd->tiers[1].last_completed_point);
+
+    nd_profile.storage_tiers = 2;
+    default_backfill = RRD_BACKFILL_FULL;
+    backfill_started_count = 0;
+    backfill_finished_count = 0;
+    backfill_completed_count = 0;
+    backfill_points_read = 0;
+    collection_completed_count = 0;
+
+    bool backfilled = backfill_tier_from_smaller_tiers(rd, 1, t + 120);
+    STORAGE_POINT sp = rd->tiers[1].virtual_point;
+    TEST_EXPECT(backfilled);
+    TEST_EXPECT(sp.start_time_s == t && sp.end_time_s == t + 23);
+    TEST_EXPECT(sp.min == 1 && sp.max == 4 && sp.sum == 10);
+    TEST_EXPECT(sp.count == 4 && sp.gap_count == 1 && sp.anomaly_count == 0);
+    TEST_EXPECT(sp.flags == SN_DEFAULT_FLAGS);
+    TEST_EXPECT(storage_point_is_partial(sp));
+    TEST_EXPECT(storage_point_slots(sp) == 5);
+    TEST_EXPECT(rd->tiers[1].next_point_end_time_s == t + 60);
+    TEST_EXPECT(backfill_started_count == 1 && backfill_finished_count == 1);
+    TEST_EXPECT(backfill_completed_count == 1 && backfill_points_read == _countof(source_points));
+    TEST_EXPECT(collection_completed_count == 1);
+
+    freez(rd);
+    return errors;
+}
+#endif
+
+int main(void) {
+    size_t errors = 0;
+    errors += test_completed_point_persistence();
+    errors += test_one_tier_fast_path();
+    errors += test_ordinary_higher_tier_rollup();
+#ifdef ENABLE_DBENGINE
+    errors += test_backfill_gap_composition();
+#endif
+    return errors ? 1 : 0;
+}

--- a/src/database/tests/rrddim-collection-test.c
+++ b/src/database/tests/rrddim-collection-test.c
@@ -448,6 +448,7 @@ static size_t test_backfill_gap_composition(void) {
 
     nd_profile.storage_tiers = 2;
     default_backfill = RRD_BACKFILL_FULL;
+    captured_store_count = 0;
     backfill_started_count = 0;
     backfill_finished_count = 0;
     backfill_completed_count = 0;

--- a/src/libnetdata/storage-point.h
+++ b/src/libnetdata/storage-point.h
@@ -18,6 +18,7 @@ typedef struct storage_point {
     uint32_t anomaly_count; // the number of original points found anomalous
 
     SN_FLAGS flags;         // flags stored with the point
+    uint32_t gap_count;     // the number of missing original points
 } STORAGE_POINT;
 
 #define storage_point_unset(x)                     do { \
@@ -25,31 +26,57 @@ typedef struct storage_point {
     (x).count = 0;                                      \
     (x).anomaly_count = 0;                              \
     (x).flags = SN_FLAG_NONE;                           \
+    (x).gap_count = 0;                                  \
     (x).start_time_s = 0;                               \
     (x).end_time_s = 0;                                 \
     } while(0)
 
 #define storage_point_empty(x, start_s, end_s)     do { \
     (x).min = (x).max = (x).sum = NAN;                  \
-    (x).count = 1;                                      \
+    (x).count = 0;                                      \
     (x).anomaly_count = 0;                              \
     (x).flags = SN_FLAG_NONE;                           \
+    (x).gap_count = 1;                                  \
     (x).start_time_s = start_s;                         \
     (x).end_time_s = end_s;                             \
     } while(0)
 
-#define STORAGE_POINT_UNSET (STORAGE_POINT){ .min = NAN, .max = NAN, .sum = NAN, .count = 0, .anomaly_count = 0, .flags = SN_FLAG_NONE, .start_time_s = 0, .end_time_s = 0 }
+#define storage_point_empty_slots(x, start_s, end_s, slots) do { \
+    uint32_t _storage_point_slots = (uint32_t)(slots);         \
+    storage_point_empty(x, start_s, end_s);                    \
+    (x).gap_count = _storage_point_slots ?                     \
+        _storage_point_slots : 1;                              \
+} while(0)
 
-#define storage_point_is_unset(x) (!(x).count)
-#define storage_point_is_gap(x) (!netdata_double_isnumber((x).sum))
-#define storage_point_is_zero(x) (!(x).count || (netdata_double_is_zero((x).min) && netdata_double_is_zero((x).max) && netdata_double_is_zero((x).sum) && (x).anomaly_count == 0))
+#define STORAGE_POINT_UNSET (STORAGE_POINT){ .min = NAN, .max = NAN, .sum = NAN, .start_time_s = 0, .end_time_s = 0, .count = 0, .anomaly_count = 0, .flags = SN_FLAG_NONE, .gap_count = 0 }
 
-#define storage_point_merge_to(dst, src) do {           \
+#define storage_point_has_value(x) ((x).count != 0)
+#define storage_point_is_unset(x) (!(x).count && !(x).gap_count)
+#define storage_point_is_gap(x) (!(x).count && (x).gap_count)
+#define storage_point_is_complete(x) ((x).count && !(x).gap_count)
+#define storage_point_is_partial(x) ((x).count && (x).gap_count)
+#define storage_point_slots(x) ((uint64_t)(x).count + (uint64_t)(x).gap_count)
+#define storage_point_is_zero(x) (!storage_point_has_value(x) || \
+    (netdata_double_is_zero((x).min) && netdata_double_is_zero((x).max) && \
+     netdata_double_is_zero((x).sum) && (x).anomaly_count == 0))
+
+#define storage_point_merge_values(dst, src) do {       \
+        if((src).min < (dst).min)                       \
+            (dst).min = (src).min;                      \
+        if((src).max > (dst).max)                       \
+            (dst).max = (src).max;                      \
+} while(0)
+
+#define storage_point_add_values(dst, src) do {         \
+        (dst).min += (src).min;                         \
+        (dst).max += (src).max;                         \
+} while(0)
+
+#define storage_point_accumulate_to(dst, src, values) do { \
         if(storage_point_is_unset(dst))                 \
             (dst) = (src);                              \
                                                         \
-        else if(!storage_point_is_unset(src) &&         \
-                !storage_point_is_gap(src)) {           \
+        else if(!storage_point_is_unset(src)) {         \
                                                         \
             if((src).start_time_s < (dst).start_time_s) \
                 (dst).start_time_s = (src).start_time_s;\
@@ -57,48 +84,37 @@ typedef struct storage_point {
             if((src).end_time_s > (dst).end_time_s)     \
                 (dst).end_time_s = (src).end_time_s;    \
                                                         \
-            if((src).min < (dst).min)                   \
-                (dst).min = (src).min;                  \
-                                                        \
-            if((src).max > (dst).max)                   \
-                (dst).max = (src).max;                  \
-                                                        \
-            (dst).sum += (src).sum;                     \
-                                                        \
-            (dst).count += (src).count;                 \
-            (dst).anomaly_count += (src).anomaly_count; \
-                                                        \
-            (dst).flags |= (src).flags & SN_FLAG_RESET; \
+            if(storage_point_has_value(src)) {          \
+                if(storage_point_has_value(dst)) {      \
+                    values(dst, src);                   \
+                    (dst).sum += (src).sum;             \
+                    (dst).count += (src).count;         \
+                    (dst).anomaly_count +=              \
+                        (src).anomaly_count;             \
+                }                                       \
+                else {                                  \
+                    (dst).min = (src).min;              \
+                    (dst).max = (src).max;              \
+                    (dst).sum = (src).sum;              \
+                    (dst).count = (src).count;          \
+                    (dst).anomaly_count =               \
+                        (src).anomaly_count;             \
+                }                                       \
+                (dst).flags |=                          \
+                    (src).flags & SN_FLAG_RESET;         \
+            }                                           \
+            (dst).gap_count += (src).gap_count;         \
         }                                               \
 } while(0)
 
-#define storage_point_add_to(dst, src) do {             \
-        if(storage_point_is_unset(dst))                 \
-            (dst) = (src);                              \
-                                                        \
-        else if(!storage_point_is_unset(src) &&         \
-                !storage_point_is_gap(src)) {           \
-                                                        \
-            if((src).start_time_s < (dst).start_time_s) \
-                (dst).start_time_s = (src).start_time_s;\
-                                                        \
-            if((src).end_time_s > (dst).end_time_s)     \
-                (dst).end_time_s = (src).end_time_s;    \
-                                                        \
-            (dst).min += (src).min;                     \
-            (dst).max += (src).max;                     \
-            (dst).sum += (src).sum;                     \
-                                                        \
-            (dst).count += (src).count;                 \
-            (dst).anomaly_count += (src).anomaly_count; \
-                                                        \
-            (dst).flags |= (src).flags & SN_FLAG_RESET; \
-        }                                               \
-} while(0)
+#define storage_point_merge_to(dst, src) \
+    storage_point_accumulate_to(dst, src, storage_point_merge_values)
+
+#define storage_point_add_to(dst, src) \
+    storage_point_accumulate_to(dst, src, storage_point_add_values)
 
 #define storage_point_make_positive(sp) do {            \
-        if(!storage_point_is_unset(sp) &&               \
-           !storage_point_is_gap(sp)) {                 \
+        if(storage_point_has_value(sp)) {               \
                                                         \
             if(unlikely(signbit((sp).sum)))             \
                 (sp).sum = -(sp).sum;                   \
@@ -118,10 +134,11 @@ typedef struct storage_point {
 } while(0)
 
 #define storage_point_anomaly_rate(sp) \
-    (NETDATA_DOUBLE)(storage_point_is_unset(sp) ? 0.0 : (NETDATA_DOUBLE)((sp).anomaly_count) * 100.0 / (NETDATA_DOUBLE)((sp).count))
+    (NETDATA_DOUBLE)(storage_point_has_value(sp) ? (NETDATA_DOUBLE)((sp).anomaly_count) * 100.0 / (NETDATA_DOUBLE)((sp).count) : 0.0)
 
 #define storage_point_average_value(sp) \
-    ((sp).count ? (sp).sum / (NETDATA_DOUBLE)((sp).count) : 0.0)
+    (storage_point_is_gap(sp) ? NAN : \
+     ((sp).count ? (sp).sum / (NETDATA_DOUBLE)((sp).count) : 0.0))
 
 
 #endif //NETDATA_STORAGE_POINT_H

--- a/tests/run-unit-tests.sh
+++ b/tests/run-unit-tests.sh
@@ -25,6 +25,26 @@ c_unit_tests() {
   "$HOME"/netdata/usr/sbin/netdata -W unittest
 }
 
+rrddim_collection_test() {
+  echo "Running RRD dimension collection component test"
+
+  local build_dir="${NETDATA_BUILD_DIR:-./build}"
+  local config_h="${build_dir}/config.h"
+
+  if [[ ! -r "${config_h}" ]]; then
+    echo >&2 "Cannot read CMake configuration: ${config_h}"
+    return 1
+  fi
+
+  if ! grep -Fqx '#define OS_LINUX' "${config_h}"; then
+    echo "Skipping RRD dimension collection component test (requires Linux)"
+    return 0
+  fi
+
+  cmake --build "${build_dir}" --target rrddim-collection-test || return 1
+  "${build_dir}"/rrddim-collection-test
+}
+
 spawn_server_unit_tests() {
   echo "Running spawn-server unit tests"
 
@@ -43,5 +63,7 @@ spawn_server_unit_tests() {
 install_netdata || exit 1
 
 c_unit_tests || exit 1
+
+rrddim_collection_test || exit 1
 
 spawn_server_unit_tests || exit 1


### PR DESCRIPTION
## Summary

`STORAGE_POINT.count` previously overloaded unset, gap-only, complete numeric, and partial numeric states. That lost missing-slot evidence across storage backends and rollup/backfill boundaries.

This PR:

- adds a canonical four-state storage-point contract using `count` and `gap_count`;
- normalizes RAM, DBENGINE Gorilla/ARRAY32, and higher-tier V1 decoding;
- preserves gap evidence through merge/add, collection, and backfill;
- keeps gap-only storage averages non-numeric once the query consumer retains the gap point;
- preserves the 56-byte LP64 `STORAGE_POINT` layout;
- isolates the expanded native tests from production LTO and dynamic symbol exports.

This is the storage-foundation bug extracted from the validated combined implementation in #23283. It intentionally excludes rate-SUM arithmetic, query-row PARTIAL projection, cadence page planning, frequency-transition persistence, and future DBENGINE page-format work.

## Tests

- GCC LTO + DBENGINE: full `netdata -W unittest` and collection/backfill component pass.
- GCC non-LTO + DBENGINE: full native suite and component pass.
- GCC non-LTO + DBENGINE disabled: full native suite and applicable component pass.
- Direct coverage includes:
  - four-state helpers and merge/add ordering;
  - RAM and ALLOC numeric-gap-numeric iteration;
  - Gorilla, ARRAY32, and ARRAY_TIER1 numeric/partial/gap/nonfinite decoding;
  - ordinary higher-tier rollup, gap-only persistence, one-tier fast path, and real backfill composition.
- `STORAGE_POINT` remains 56 bytes (`gap_count` uses existing tail padding).
- Test bridge objects contain no LTO IR, remain local/hidden, and add no dynamic exports.

## Corpus staging

The relevant contracts are:

- `L1/storage-backend-gap-state`
- `L5/gap-only-db-average-is-null`

On this storage-only PR they fail exactly as on master because both contracts also require the later query-evidence consumer stage: the current executor does not yet attach source gap evidence to derived rows/query statistics. The direct native/component tests isolate and pass the storage contract; the unchanged public corpus contracts become green when this PR is composed with the accepted query-evidence implementation in #23283. The corpus oracle is deliberately not weakened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves missing-slot (“gap”) evidence across RAM and DBEngine by introducing an explicit four‑state `STORAGE_POINT` contract. Previously unset/gap/complete/partial states were conflated and gap evidence was lost across rollup/backfill and backend transitions; now `gap_count` carries that evidence end‑to‑end, and gap‑only averages are NaN.

- Storage-point contract: adds `gap_count`; new helpers (`storage_point_has_value/is_unset/is_gap/is_complete/is_partial`), `storage_point_slots`; merge/add macros accumulate `gap_count`; `storage_point_average_value` returns NaN for gap‑only; struct size stays 56 bytes.
- DBEngine: cursor `pgdc_reset` accepts `slots_per_point`; cursors emit gap points with correct `gap_count` when pages are missing/exhausted/corrupt; Gorilla/ARRAY decoders set `gap_count` and treat absent/non‑numeric as gaps; query init seeds `slots_per_point` from tier grouping.
- RAM/ALLOC and collection: `rrddim_query_next_metric` sets `count/gap_count` from value existence; higher‑tier aggregation uses `storage_point_merge_to` and preserves gaps through virtual/last‑completed points; gap‑only last‑completed points are persisted as empty (NaN payload, `count=0`).
- Tests/build: add hidden no‑LTO bridges (`unit_test_bridge`, `page_test_bridge`); expand unit tests for the contract and page decoding; add a Linux‑only `rrddim-collection-test` and reset backfill capture state for repeatable runs; test runner builds/executes the component test without exporting symbols.

<sup>Written for commit 596d7b8e6efe1c4ae388bd095b75470dc614cc62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing, partial, and anomalous metric points.
  * Preserved gap information across queries, aggregation, rollups, and backfill.
  * Corrected empty-page and corrupted-data handling.
  * Fixed storage validation tests to report failures correctly.

* **Tests**
  * Added comprehensive coverage for storage points, page cursors, aggregation, gaps, anomalies, and backfill.
  * Added an optional Linux test for metric collection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->