### PR TITLE
fix(query): preserve sum values across row seams

### DIFF
--- a/src/web/api/queries/query-execute.c
+++ b/src/web/api/queries/query-execute.c
@@ -37,22 +37,6 @@ static long rrdr_line_init(RRDR *r __maybe_unused, time_t t __maybe_unused, long
     return rrdr_line;
 }
 
-ALWAYS_INLINE
-static NETDATA_DOUBLE query_point_grouping_value(
-    QUERY_POINT point, QUERY_ENGINE_OPS *ops, RRDR_TIME_GROUPING add_flush) {
-    if(likely(add_flush != RRDR_GROUPING_SUM || !ops->qm->values_stored_as_rates))
-        return point.value;
-
-    if(unlikely(storage_point_is_unset(point.sp) || storage_point_is_gap(point.sp) || !point.sp.count))
-        return point.value;
-
-    time_t duration = point.sp.end_time_s - point.sp.start_time_s;
-    if(unlikely(duration <= 0))
-        return point.value;
-
-    return point.value * (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)point.sp.count;
-}
-
 // ----------------------------------------------------------------------------
 // dimension level query engine
 
@@ -74,6 +58,32 @@ static NETDATA_DOUBLE query_point_grouping_value(
         }                                                               \
 } while(0)
 
+ALWAYS_INLINE
+static NETDATA_DOUBLE query_point_total_projection(
+    const QUERY_POINT *point, time_t row_start_time, time_t row_end_time) {
+    time_t duration = point->sp.end_time_s - point->sp.start_time_s;
+    if(unlikely(duration <= 0))
+        return point->value;
+
+    time_t overlap_start = MAX(point->sp.start_time_s, row_start_time);
+    time_t overlap_end = MIN(point->sp.end_time_s, row_end_time);
+    if(unlikely(overlap_end <= overlap_start))
+        return NAN;
+
+    if(likely(overlap_start == point->sp.start_time_s && overlap_end == point->sp.end_time_s))
+        return point->value;
+
+    return point->value * (NETDATA_DOUBLE)(overlap_end - overlap_start) / (NETDATA_DOUBLE)duration;
+}
+
+#define query_project_point(point, previous, now, view_update_every, point_mode) do { \
+    if(likely((point_mode) == QUERY_POINT_MODE_LINEAR))                              \
+        query_interpolate_point(point, previous, now);                               \
+    else if(unlikely((point_mode) == QUERY_POINT_MODE_TOTAL))                        \
+        (point).value = query_point_total_projection(                                \
+            &(point), (now) - (view_update_every), (now));                           \
+} while(0)
+
 #define query_add_point_to_group(r, point, ops, add_flush, now_end_time, source_end_time) do { \
     if(likely(netdata_double_isnumber((point).value))) {                \
         if(likely(fpclassify((point).value) != FP_ZERO))                \
@@ -86,9 +96,7 @@ static NETDATA_DOUBLE query_point_grouping_value(
         if(unlikely((point).sp.flags & SN_FLAG_RESET) && _sample_in_row) \
             (ops)->group_value_flags |= RRDR_VALUE_RESET;               \
                                                                         \
-        NETDATA_DOUBLE grouping_value =                                    \
-            query_point_grouping_value(point, ops, add_flush);             \
-        time_grouping_add(r, grouping_value, add_flush);                   \
+        time_grouping_add(r, (point).value, add_flush);                  \
                                                                         \
         if((point).tier != 0 || _sample_in_row)                          \
             storage_point_merge_to((ops)->group_point, (point).sp);     \
@@ -159,11 +167,11 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     }
 
     const RRDR_TIME_GROUPING add_flush = r->time_grouping.add_flush;
-
     ops->group_point = STORAGE_POINT_UNSET;
     ops->query_point = STORAGE_POINT_UNSET;
 
     RRDR_OPTIONS options = qt->window.options;
+    bool use_anomaly_bit_as_value = options & RRDR_OPTION_ANOMALY_BIT;
     size_t points_wanted = qt->window.points;
     time_t after_wanted = qt->window.after;
     time_t before_wanted = qt->window.before; (void)before_wanted;
@@ -175,8 +183,6 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     size_t points_added = 0;
 
     long rrdr_line = -1;
-    bool use_anomaly_bit_as_value = (r->internal.qt->window.options & RRDR_OPTION_ANOMALY_BIT) ? true : false;
-
     NETDATA_DOUBLE min = r->view.min, max = r->view.max;
 
     QUERY_POINT last2_point = QUERY_POINT_EMPTY;
@@ -199,8 +205,9 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
     for( ; points_added < points_wanted && query_is_finished_counter <= 10 ;
         now_start_time = now_end_time, now_end_time += ops->view_update_every) {
 
-        if(unlikely(query_plan_should_switch_plan(ops, now_end_time))) {
-            query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s);
+        if(unlikely(query_result_plan_should_switch_plan(ops, now_end_time))) {
+            query_planer_next_plan(
+                ops, now_end_time - ops->plan_switch_time_offset, new_point.sp.end_time_s);
             db_points_read_since_plan_switch = 0;
         }
 
@@ -224,29 +231,28 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 last1_point = new_point;
             }
 
-            if(unlikely(storage_engine_query_is_finished(ops->seqh))) {
-                query_is_finished_counter++;
-
-                if(count_same_end_time != 0) {
-                    last2_point = last1_point;
-                    last1_point = new_point;
-                }
-                new_point = QUERY_POINT_EMPTY;
-                new_point.sp.start_time_s = last1_point.sp.end_time_s;
-                new_point.sp.end_time_s   = now_end_time;
-//
-//                if(debug_this) netdata_log_info("QUERY: is finished() returned true");
-//
-                break;
-            }
-            else
-                query_is_finished_counter = 0;
-
             // fetch the new point
             {
                 STORAGE_POINT sp;
                 uint8_t sp_tier;
                 if(likely(storage_point_is_unset(next1_point))) {
+                    if(unlikely(storage_engine_query_is_finished(ops->seqh))) {
+                        query_is_finished_counter++;
+
+                        if(count_same_end_time != 0) {
+                            last2_point = last1_point;
+                            last1_point = new_point;
+                        }
+                        new_point = QUERY_POINT_EMPTY;
+                        new_point.sp.start_time_s = last1_point.sp.end_time_s;
+                        new_point.sp.end_time_s   = now_end_time;
+//
+//                      if(debug_this) netdata_log_info("QUERY: is finished() returned true");
+//
+                        break;
+                    }
+
+                    query_is_finished_counter = 0;
                     db_points_read_since_plan_switch++;
                     sp_tier = (uint8_t)ops->tier;
                     sp = storage_engine_query_next_metric(ops->seqh);
@@ -257,6 +263,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                         storage_point_make_positive(sp);
                 }
                 else {
+                    query_is_finished_counter = 0;
+
                     // ONE POINT READ-AHEAD
                     sp = next1_point;
                     sp_tier = next1_tier;
@@ -264,9 +272,12 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     db_points_read_since_plan_switch = 1;
                 }
 
+                NETDATA_DOUBLE prepared_sum = sp.sum;
+
                 // ONE POINT READ-AHEAD
                 if(unlikely(query_plan_should_switch_plan(ops, sp.end_time_s) &&
-                    query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s))) {
+                    query_planer_next_plan(
+                        ops, now_end_time - ops->plan_switch_time_offset, new_point.sp.end_time_s))) {
 
                     // The end time of the current point, crosses our plans (tiers)
                     // so, we switched plan (tier)
@@ -284,10 +295,16 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                     if(unlikely(options & RRDR_OPTION_ABSOLUTE))
                         storage_point_make_positive(sp2);
 
-                    if(sp.start_time_s > sp2.start_time_s) {
+                    bool finer_total_overlap =
+                        ops->point_mode == QUERY_POINT_MODE_TOTAL &&
+                        sp2_tier < sp_tier && sp2.start_time_s < sp.end_time_s;
+
+                    if(sp.start_time_s > sp2.start_time_s ||
+                       (finer_total_overlap && sp2.start_time_s <= sp.start_time_s)) {
                         // the point from the previous plan is useless
                         sp = sp2;
                         sp_tier = sp2_tier;
+                        prepared_sum = sp2.sum;
                     }
                     else {
                         // let the query run from the previous plan
@@ -295,6 +312,14 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                         // of the point from the previous plan
                         next1_point = sp2;
                         next1_tier = sp2_tier;
+
+                        if(unlikely(finer_total_overlap)) {
+                            time_t duration = sp.end_time_s - sp.start_time_s;
+                            time_t retained = sp2.start_time_s - sp.start_time_s;
+                            if(!qm->values_stored_as_rates && duration > 0)
+                                prepared_sum *= (NETDATA_DOUBLE)retained / (NETDATA_DOUBLE)duration;
+                            sp.end_time_s = sp2.start_time_s;
+                        }
                     }
                 }
 
@@ -311,8 +336,7 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 if(likely(!storage_point_is_unset(sp) && !storage_point_is_gap(sp))) {
 
                     if(unlikely(use_anomaly_bit_as_value))
-                        new_point.value = storage_point_anomaly_rate(new_point.sp);
-
+                        new_point.value = storage_point_anomaly_rate(sp);
                     else {
                         switch (ops->tier_query_fetch) {
                             default:
@@ -329,7 +353,16 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                                 break;
 
                             case TIER_QUERY_FETCH_SUM:
-                                new_point.value = sp.sum;
+                                new_point.value = prepared_sum;
+                                if(unlikely(qm->values_stored_as_rates)) {
+                                    time_t duration = sp.end_time_s - sp.start_time_s;
+                                    if(likely(duration > 0))
+                                        new_point.value *=
+                                            (NETDATA_DOUBLE)duration / (NETDATA_DOUBLE)sp.count;
+                                }
+                                if(unlikely(sp.start_time_s < now_start_time && sp.end_time_s < now_end_time))
+                                    new_point.value = query_point_total_projection(
+                                        &new_point, now_start_time, now_end_time);
                                 break;
                         }
                     }
@@ -437,6 +470,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
             "QUERY: first part of query provides invalid point to interpolate (now_end_time %ld, stop_time %ld",
             now_end_time, stop_time);
 
+        NETDATA_DOUBLE new_point_total_remaining = NAN;
+
         do {
             // now_start_time is wrong in this loop
             // but, we don't need it
@@ -449,7 +484,20 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 current_point = new_point;
                 source_end_time = new_point.sp.end_time_s;
                 new_point.added = true; // first copy, then set it, so that new_point will not be added again
-                query_interpolate_point(current_point, last1_point, now_end_time);
+                query_project_point(
+                    current_point, last1_point, now_end_time, ops->view_update_every, ops->point_mode);
+
+                if(unlikely(ops->point_mode == QUERY_POINT_MODE_TOTAL &&
+                            netdata_double_isnumber(current_point.value))) {
+                    if(unlikely(!netdata_double_isnumber(new_point_total_remaining))) {
+                        time_t duration = new_point.sp.end_time_s - new_point.sp.start_time_s;
+                        new_point_total_remaining = likely(duration > 0) ?
+                            new_point.value * (NETDATA_DOUBLE)(new_point.sp.end_time_s - now_end_time) /
+                                (NETDATA_DOUBLE)duration : 0.0;
+                    }
+                    else
+                        new_point_total_remaining -= current_point.value;
+                }
 
 //                internal_error(current_point.id > 0
 //                                && last1_point.id == 0
@@ -469,7 +517,8 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
                 current_point = last1_point;
                 source_end_time = last1_point.sp.end_time_s;
                 last1_point.added = true; // first copy, then set it, so that last1_point will not be added again
-                query_interpolate_point(current_point, last2_point, now_end_time);
+                query_project_point(
+                    current_point, last2_point, now_end_time, ops->view_update_every, ops->point_mode);
 
 //                internal_error(current_point.id > 0
 //                                && last2_point.id == 0
@@ -536,6 +585,52 @@ NOT_INLINE_HOT void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY
 
         if(points_added >= points_wanted)
             break;
+
+        time_t next_row_start_time = now_end_time - ops->view_update_every;
+        if(unlikely(new_point.sp.end_time_s > next_row_start_time &&
+                    netdata_double_isnumber(new_point.value) &&
+                    ((new_point.added &&
+                      (ops->point_mode == QUERY_POINT_MODE_TOTAL ||
+                       (new_point.tier == 0 &&
+                        new_point.sp.start_time_s < next_row_start_time))) ||
+                     (!new_point.added &&
+                      ops->point_mode == QUERY_POINT_MODE_TOTAL &&
+                      storage_point_is_unset(next1_point))))) {
+            bool settle_value = ops->point_mode == QUERY_POINT_MODE_TOTAL ||
+                                new_point.sp.end_time_s >= qm->tiers[0].db_last_time_s;
+            NETDATA_DOUBLE carried_value = new_point.value;
+            if(ops->point_mode == QUERY_POINT_MODE_TOTAL && new_point.sp.end_time_s < now_end_time) {
+                if(likely(netdata_double_isnumber(new_point_total_remaining)))
+                    carried_value = new_point_total_remaining;
+                else
+                    carried_value = query_point_total_projection(
+                        &new_point, next_row_start_time, now_end_time);
+            }
+
+            if(likely(netdata_double_isnumber(carried_value))) {
+                if(settle_value) {
+                    if(likely(fpclassify(carried_value) != FP_ZERO))
+                        ops->group_points_non_zero++;
+
+                    if(unlikely(new_point.sp.flags & SN_FLAG_RESET))
+                        ops->group_value_flags |= RRDR_VALUE_RESET;
+
+                    r->time_grouping.add(r, carried_value);
+                    if(!new_point.added)
+                        storage_point_merge_to(ops->query_point, new_point.sp);
+                }
+
+                // tier-0 evidence is carried onto its own row at the top of the
+                // row loop, so only coarser tiers seed evidence from here
+                if(new_point.tier != 0)
+                    storage_point_merge_to(ops->group_point, new_point.sp);
+            }
+
+            if(settle_value) {
+                ops->group_points_added++;
+                new_point.added = true;
+            }
+        }
 
         // the loop above increased "now" by ops->view_update_every,
         // but the main loop will increase it too,

--- a/src/web/api/queries/query-group-over-time.c
+++ b/src/web/api/queries/query-group-over-time.c
@@ -54,6 +54,7 @@ static struct {
     NETDATA_DOUBLE (*flush)(struct rrdresult *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
     TIER_QUERY_FETCH tier_query_fetch;
+    QUERY_POINT_MODE point_mode;
 } api_v1_data_groups[] = {
     {.name = "average",
      .hash  = 0,
@@ -497,7 +498,8 @@ static struct {
      .free  = tg_sum_free,
      .add   = tg_sum_add,
      .flush = tg_sum_flush,
-     .tier_query_fetch = TIER_QUERY_FETCH_SUM
+     .tier_query_fetch = TIER_QUERY_FETCH_SUM,
+     .point_mode = QUERY_POINT_MODE_TOTAL
     },
 
     // standard deviation
@@ -722,6 +724,7 @@ void rrdr_set_grouping_function(RRDR *r, RRDR_TIME_GROUPING group_method) {
             r->time_grouping.add     = api_v1_data_groups[i].add;
             r->time_grouping.flush   = api_v1_data_groups[i].flush;
             r->time_grouping.tier_query_fetch = api_v1_data_groups[i].tier_query_fetch;
+            r->time_grouping.point_mode = api_v1_data_groups[i].point_mode;
             r->time_grouping.add_flush = api_v1_data_groups[i].add_flush;
             found = 1;
         }
@@ -735,6 +738,7 @@ void rrdr_set_grouping_function(RRDR *r, RRDR_TIME_GROUPING group_method) {
         r->time_grouping.add     = tg_average_add;
         r->time_grouping.flush   = tg_average_flush;
         r->time_grouping.tier_query_fetch = TIER_QUERY_FETCH_AVERAGE;
+        r->time_grouping.point_mode = QUERY_POINT_MODE_LINEAR;
         r->time_grouping.add_flush = RRDR_GROUPING_AVERAGE;
     }
 }

--- a/src/web/api/queries/query-internal.h
+++ b/src/web/api/queries/query-internal.h
@@ -48,10 +48,13 @@ typedef struct query_engine_ops {
     time_t view_update_every;
     time_t query_granularity;
     TIER_QUERY_FETCH tier_query_fetch;
+    QUERY_POINT_MODE point_mode;
 
     // query planer
     size_t current_plan;
     time_t current_plan_expire_time;
+    time_t result_plan_expire_time;
+    time_t plan_switch_time_offset;
     time_t plan_expanded_after;
     time_t plan_expanded_before;
 
@@ -70,6 +73,8 @@ typedef struct query_engine_ops {
     // statistics
     size_t db_total_points_read;
     size_t db_points_read_per_tier[RRD_STORAGE_TIERS];
+
+    bool result_plan_expire_time_overflow;
 
     // the LATEST grouping with a single output point reached by the metric's
     // latest collection interval is answered from the collector's cached value,
@@ -95,6 +100,8 @@ typedef struct query_engine_ops_cache {
 
 // query planner
 #define query_plan_should_switch_plan(ops, now) ((now) >= (ops)->current_plan_expire_time)
+#define query_result_plan_should_switch_plan(ops, now) \
+    ((now) >= (ops)->result_plan_expire_time && !(ops)->result_plan_expire_time_overflow)
 bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point_end_time);
 void query_planer_finalize_remaining_plans(QUERY_ENGINE_OPS *ops);
 QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache, size_t query_metric_id);

--- a/src/web/api/queries/query-plan.c
+++ b/src/web/api/queries/query-plan.c
@@ -283,6 +283,14 @@ static bool query_planer_plan_can_be_activated(QUERY_ENGINE_OPS *ops, size_t pla
     return query_plan_tier_is_valid(qm, qm->plan.array[plan_id].tier);
 }
 
+static void query_planer_set_expire_time(QUERY_ENGINE_OPS *ops, time_t expire_time) {
+    ops->current_plan_expire_time = expire_time;
+    ops->result_plan_expire_time_overflow = __builtin_add_overflow(
+        expire_time, ops->plan_switch_time_offset, &ops->result_plan_expire_time);
+    if(unlikely(ops->result_plan_expire_time_overflow))
+        ops->result_plan_expire_time = nd_time_t_max();
+}
+
 static void query_planer_set_active_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, time_t overwrite_after __maybe_unused) {
     QUERY_METRIC *qm = ops->qm;
 
@@ -292,9 +300,9 @@ static void query_planer_set_active_plan(QUERY_ENGINE_OPS *ops, size_t plan_id, 
     ops->current_plan = plan_id;
 
     if(plan_id + 1 < qm->plan.used && qm->plan.array[plan_id + 1].after < qm->plan.array[plan_id].before)
-        ops->current_plan_expire_time = qm->plan.array[plan_id + 1].after;
+        query_planer_set_expire_time(ops, qm->plan.array[plan_id + 1].after);
     else
-        ops->current_plan_expire_time = qm->plan.array[plan_id].before;
+        query_planer_set_expire_time(ops, qm->plan.array[plan_id].before);
 
     ops->plan_expanded_after = ops->plans[plan_id].expanded_after;
     ops->plan_expanded_before = ops->plans[plan_id].expanded_before;
@@ -319,7 +327,7 @@ bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point
 
         if (ops->current_plan >= qm->plan.used) {
             ops->current_plan = old_plan;
-            ops->current_plan_expire_time = ops->r->internal.qt->window.before;
+            query_planer_set_expire_time(ops, ops->r->internal.qt->window.before);
             // let the query run with current plan
             // we will not switch it
             return false;
@@ -330,7 +338,7 @@ bool query_planer_next_plan(QUERY_ENGINE_OPS *ops, time_t now, time_t last_point
 
     if(!query_planer_plan_can_be_activated(ops, ops->current_plan)) {
         ops->current_plan = old_plan;
-        ops->current_plan_expire_time = ops->r->internal.qt->window.before;
+        query_planer_set_expire_time(ops, ops->r->internal.qt->window.before);
         return false;
     }
 
@@ -564,10 +572,18 @@ QUERY_ENGINE_OPS *rrd2rrdr_query_ops_prep(RRDR *r, QUERY_ENGINE_OPS_CACHE *cache
         .r = r,
         .qm = query_metric(qt, query_metric_id),
         .tier_query_fetch = r->time_grouping.tier_query_fetch,
+        .point_mode = r->time_grouping.point_mode,
         .view_update_every = r->view.update_every,
         .query_granularity = (time_t)(r->view.update_every / r->view.group),
         .group_value_flags = RRDR_VALUE_NOTHING,
     };
+
+    if(qt->window.options & RRDR_OPTION_ANOMALY_BIT) {
+        ops->point_mode = QUERY_POINT_MODE_HOLD;
+    }
+
+    ops->plan_switch_time_offset =
+        ops->point_mode == QUERY_POINT_MODE_TOTAL ? ops->view_update_every : 0;
 
     if(query_latest_fast_path(r, ops))
         return ops;
@@ -761,6 +777,61 @@ static int query_plan_unittest_expect_ops_cache_is_local(void) {
             same_cache_reused ? "true" : "false",
             separate_cache_isolated ? "true" : "false");
     return 1;
+}
+
+static int query_plan_unittest_expect_result_expiry(void) {
+    QUERY_ENGINE_OPS ops = {
+        .plan_switch_time_offset = 60,
+    };
+
+    query_planer_set_expire_time(&ops, 100);
+    if(ops.current_plan_expire_time != 100 || ops.result_plan_expire_time != 160 ||
+       ops.result_plan_expire_time_overflow ||
+       query_result_plan_should_switch_plan(&ops, 159) ||
+       !query_result_plan_should_switch_plan(&ops, 160) ||
+       !query_result_plan_should_switch_plan(&ops, 161)) {
+        fprintf(stderr,
+                "FAILED query plan result expiry: expected 100/160/non-overflow with switch from 160 onward, "
+                "got %" PRIdMAX "/%" PRIdMAX "/%d and switches %d/%d/%d at 159/160/161\n",
+                (intmax_t)ops.current_plan_expire_time, (intmax_t)ops.result_plan_expire_time,
+                ops.result_plan_expire_time_overflow,
+                query_result_plan_should_switch_plan(&ops, 159),
+                query_result_plan_should_switch_plan(&ops, 160),
+                query_result_plan_should_switch_plan(&ops, 161));
+        return 1;
+    }
+
+    time_t maximum = nd_time_t_max();
+    query_planer_set_expire_time(&ops, maximum - 30);
+    if(ops.current_plan_expire_time != maximum - 30 || ops.result_plan_expire_time != maximum ||
+       !ops.result_plan_expire_time_overflow ||
+       query_result_plan_should_switch_plan(&ops, maximum)) {
+        fprintf(stderr,
+                "FAILED query plan unreachable result expiry: expected %" PRIdMAX "/%" PRIdMAX
+                "/overflow without switch, got %" PRIdMAX "/%" PRIdMAX "/%d with switch=%d\n",
+                (intmax_t)(maximum - 30), (intmax_t)maximum,
+                (intmax_t)ops.current_plan_expire_time, (intmax_t)ops.result_plan_expire_time,
+                ops.result_plan_expire_time_overflow,
+                query_result_plan_should_switch_plan(&ops, maximum));
+        return 1;
+    }
+
+    query_planer_set_expire_time(&ops, maximum - ops.plan_switch_time_offset);
+    if(ops.current_plan_expire_time != maximum - ops.plan_switch_time_offset ||
+       ops.result_plan_expire_time != maximum || ops.result_plan_expire_time_overflow ||
+       !query_result_plan_should_switch_plan(&ops, maximum)) {
+        fprintf(stderr,
+                "FAILED query plan exact-maximum result expiry: expected %" PRIdMAX "/%" PRIdMAX
+                "/non-overflow with switch, got %" PRIdMAX "/%" PRIdMAX "/%d with switch=%d\n",
+                (intmax_t)(maximum - ops.plan_switch_time_offset), (intmax_t)maximum,
+                (intmax_t)ops.current_plan_expire_time, (intmax_t)ops.result_plan_expire_time,
+                ops.result_plan_expire_time_overflow,
+                query_result_plan_should_switch_plan(&ops, maximum));
+        return 1;
+    }
+
+    fprintf(stderr, "OK query plan result expiry\n");
+    return 0;
 }
 
 int query_plan_unittest(void) {
@@ -1025,6 +1096,7 @@ int query_plan_unittest(void) {
     }
 
     errors += query_plan_unittest_expect_ops_cache_is_local();
+    errors += query_plan_unittest_expect_result_expiry();
 
     nd_profile.storage_tiers = old_storage_tiers;
     nd_profile.update_every = old_update_every;

--- a/src/web/api/queries/rrdr.h
+++ b/src/web/api/queries/rrdr.h
@@ -17,6 +17,12 @@ typedef enum tier_query_fetch {
     TIER_QUERY_FETCH_AVERAGE
 } TIER_QUERY_FETCH;
 
+typedef enum query_point_mode {
+    QUERY_POINT_MODE_LINEAR,
+    QUERY_POINT_MODE_HOLD,
+    QUERY_POINT_MODE_TOTAL,
+} QUERY_POINT_MODE;
+
 typedef enum __attribute__ ((__packed__)) rrdr_value_flag {
 
     // IMPORTANT:
@@ -105,6 +111,7 @@ typedef struct rrdresult {
         NETDATA_DOUBLE (*flush)(struct rrdresult *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
         TIER_QUERY_FETCH tier_query_fetch;  // which value to use from STORAGE_POINT
+        QUERY_POINT_MODE point_mode;
 
         size_t points_wanted;               // used by SES and DES
         size_t resampling_group;            // used by AVERAGE


### PR DESCRIPTION
## Summary

Preserve exact SUM values when stored records span output rows or an automatic storage-tier boundary.

This extracts one complete root-cause fix from #23283 into an independently reviewable PR. It keeps the accepted interval
ownership, unpaid-suffix settlement, expired-prefix handling, pristine source statistics, and result-start plan switching as
one coherent state machine; separating any of those would leave a known incomplete intermediate behavior.

## Root cause

A stored SUM point represents an interval, but the query executor historically treated it as if the whole value belonged to
one result row. A wide point could therefore be overpaid, underpaid, or dropped when a result boundary cut it. Automatic tier
switching made the same problem more subtle: read-ahead can replace or clip a coarse record, and the switch can happen before
the result row that actually owns the remaining interval.

The fix introduces TOTAL point ownership for SUM:

- project each stored total by its exact overlap with the current result row;
- carry the unpaid suffix until its owning row is settled;
- exclude any prefix that expired before the query result begins;
- let finer read-ahead own overlapping time without modifying raw source statistics;
- delay result-plan expiry by one result row and switch using that row's start;
- preserve an overflowing delayed expiry as mathematically unreachable instead of turning `TIME_MAX` into a real boundary.

## Test contract

The focused regression contracts are in #23130 at `4ffe2b0bb4`:

- `CASE-025/carry-survives-gaps` — exact per-row ownership, remainder, and final partial share;
- `CASE-026/settlement-values-belong-to-their-row` — exact SUM/AVERAGE settlement rows;
- `CASE-026/totals-survive-a-plan-switch` — coarse/fine joins, storage holes, expired prefixes, buffered fine points, equal-start
  ownership, and raw source statistics;
- `CASE-029/tier0-slow-metric-totals-at-every-zoom` — exact slicing below the storage cadence.

The corpus now reports value/statistics and ARP/RESET/PARTIAL evidence as independent verdicts without changing fixtures or
expected results. This branch is therefore green for the owned value contracts while the separately owned evidence contracts
remain honestly red.

## Verification

- Current master has 113/253 red corpus contracts; this branch has 99/253, fixing fourteen interval-total contracts with zero
  added regressions.
- The focused master/split/#23283 matrix is red/red, green/red, and green/green respectively for value/evidence contracts.
- Complete GCC LTO and non-LTO native unit suites pass.
- Eight reverse mutations independently fail for overlap projection, carried suffix, expired prefix, source-stat preservation,
  result-start switching, and all three result-expiry boundaries.
- The extracted production behavior matches combined PR #23283 at `5707055e1f`; differences are exactly separately published
  ABS, row-evidence, storage-evidence, rate-gap, and multipass fixes.
- The immutable master/combined crossed benchmark is running as the shared performance gate. A detected regression will reopen
  the affected split before merge.

The corpus PR should merge before this fix so the regression contracts become part of the normal CI surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves exact SUM values when stored intervals span result rows or tier switches. Previously SUM charged the whole interval to one row; now it slices each row’s exact overlap and carries the remainder to the owning row, avoiding over/under counting.

- Adds `QUERY_POINT_MODE_TOTAL` for SUM (default remains linear; anomaly-bit queries use hold). SUM projects totals per row, carries unpaid suffix, drops expired prefixes, and leaves source stats unchanged.
- Converts SUM from rate-stored data to totals before projection; fixes anomaly-bit path to use `storage_point_anomaly_rate(sp)`.
- Refines read-ahead and tier joins: finer tiers own overlapping time; trims coarse points on fine overlap; settles carried totals at row seams.
- Introduces result-plan expiry and switch offset: the switch uses the next row’s start (offset by `view_update_every` for TOTAL). Adds overflow-safe result-plan expiry so unreachable expiries do not create a real boundary.
- Planner/executor wiring: propagates `point_mode`, sets `plan_switch_time_offset`, prepares sums for SUM fetch, and adds a unit test for result-expiry behavior.

<sup>Written for commit af9811970f5503091bfe77c3a62214aeba20b8e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved query results across different time groupings and data-resolution tiers.
  - Total-based calculations now better preserve proportional values when data points overlap.
  - SUM results and rate-based measurements now use more consistent point projection.
  - Anomaly-related queries and plan transitions now handle timing and expiration more reliably.

- **Bug Fixes**
  - Improved handling of residual values and totals at query boundaries.
  - Added safeguards for expiration-time edge cases, including overflow conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->