### PR TITLE
fix(dbengine): accept valid long page cadences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1386,6 +1386,8 @@ set(DAEMON_FILES
         src/daemon/pipename.h
         src/daemon/unit_test.c
         src/daemon/unit_test.h
+        src/daemon/unit_test_bridge.c
+        src/daemon/unit_test_bridge.h
         src/daemon/dyncfg/dyncfg.c
         src/daemon/dyncfg/dyncfg.h
         src/daemon/dyncfg/dyncfg-files.c
@@ -3585,6 +3587,16 @@ if(OS_WINDOWS)
         configure_file(packaging/windows/Top.bmp Top.bmp COPYONLY)
         configure_file(packaging/windows/BackGround.bmp BackGround.bmp COPYONLY)
         configure_file(src/collectors/windows.plugin/driver/netdata_driver.inf netdata_driver.inf COPYONLY)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$" AND
+   NOT CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+        set_property(
+                SOURCE src/daemon/unit_test_bridge.c
+                APPEND PROPERTY COMPILE_OPTIONS "-fno-lto" "-fvisibility=hidden")
+elseif(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        message(WARNING
+                "Netdata test bridge cannot disable IPO for unsupported C compiler '${CMAKE_C_COMPILER_ID}'")
 endif()
 
 add_executable(netdata

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1939,7 +1939,7 @@ static int test_rrdset_rejects_invalid_update_every(void) {
         }
     }
 
-    const time_t valid_update_every = 7;
+    const time_t valid_update_every = INT32_MAX;
     previous = rrdset_set_update_every_s(st, valid_update_every);
     if(previous != original_update_every || st->update_every != valid_update_every) {
         fprintf(stderr, "%s: valid update every did not change chart from %ld to %ld; current %d\n",

--- a/src/daemon/unit_test_bridge.c
+++ b/src/daemon/unit_test_bridge.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "unit_test_bridge.h"
+
+NOINLINE void unittest_storage_engine_store_metric(
+    STORAGE_COLLECT_HANDLE *sch,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags) {
+    storage_engine_store_metric(
+        sch, point_in_time_ut, n, min_value, max_value, count, anomaly_count, flags);
+}
+
+NOINLINE void unittest_storage_engine_store_change_collection_frequency(
+    STORAGE_COLLECT_HANDLE *sch, int update_every) {
+    storage_engine_store_change_collection_frequency(sch, update_every);
+}
+
+NOINLINE void unittest_storage_engine_store_flush(STORAGE_COLLECT_HANDLE *sch) {
+    storage_engine_store_flush(sch);
+}
+
+NOINLINE void unittest_storage_engine_query_init(
+    STORAGE_ENGINE_BACKEND seb,
+    STORAGE_METRIC_HANDLE *smh,
+    struct storage_engine_query_handle *seqh,
+    time_t start_time_s,
+    time_t end_time_s,
+    STORAGE_PRIORITY priority) {
+    storage_engine_query_init(seb, smh, seqh, start_time_s, end_time_s, priority);
+}
+
+NOINLINE STORAGE_POINT unittest_storage_engine_query_next_metric(
+    struct storage_engine_query_handle *seqh) {
+    return storage_engine_query_next_metric(seqh);
+}
+
+NOINLINE int unittest_storage_engine_query_is_finished(
+    struct storage_engine_query_handle *seqh) {
+    return storage_engine_query_is_finished(seqh);
+}
+
+NOINLINE void unittest_storage_engine_query_finalize(
+    struct storage_engine_query_handle *seqh) {
+    storage_engine_query_finalize(seqh);
+}

--- a/src/daemon/unit_test_bridge.h
+++ b/src/daemon/unit_test_bridge.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_UNIT_TEST_BRIDGE_H
+#define NETDATA_UNIT_TEST_BRIDGE_H
+
+#include "common.h"
+
+void unittest_storage_engine_store_metric(
+    STORAGE_COLLECT_HANDLE *sch,
+    usec_t point_in_time_ut,
+    NETDATA_DOUBLE n,
+    NETDATA_DOUBLE min_value,
+    NETDATA_DOUBLE max_value,
+    uint16_t count,
+    uint16_t anomaly_count,
+    SN_FLAGS flags);
+
+void unittest_storage_engine_store_change_collection_frequency(STORAGE_COLLECT_HANDLE *sch, int update_every);
+void unittest_storage_engine_store_flush(STORAGE_COLLECT_HANDLE *sch);
+
+void unittest_storage_engine_query_init(
+    STORAGE_ENGINE_BACKEND seb,
+    STORAGE_METRIC_HANDLE *smh,
+    struct storage_engine_query_handle *seqh,
+    time_t start_time_s,
+    time_t end_time_s,
+    STORAGE_PRIORITY priority);
+
+STORAGE_POINT unittest_storage_engine_query_next_metric(struct storage_engine_query_handle *seqh);
+int unittest_storage_engine_query_is_finished(struct storage_engine_query_handle *seqh);
+void unittest_storage_engine_query_finalize(struct storage_engine_query_handle *seqh);
+
+#endif // NETDATA_UNIT_TEST_BRIDGE_H

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -2,6 +2,7 @@
 
 #include "database/rrd.h"
 #include "database/rrddim-collection.h"
+#include "daemon/unit_test_bridge.h"
 
 #ifdef ENABLE_DBENGINE
 
@@ -455,6 +456,200 @@ static size_t test_dbengine_burst_retention(RRDHOST *host) {
     return errors;
 }
 
+typedef struct dbengine_cadence_expected_point {
+    time_t start_time_s;
+    time_t end_time_s;
+    NETDATA_DOUBLE value;
+} DBENGINE_CADENCE_EXPECTED_POINT;
+
+static RRDDIM *dbengine_cadence_test_create_metric(
+    RRDHOST *host, const char *id_prefix, int update_every) {
+    char id[128];
+    snprintfz(id, sizeof(id) - 1, "%s-%d", id_prefix, getpid());
+
+    RRDSET *st = rrdset_create(
+        host, "netdata", id, id, "netdata", NULL, "Unit Testing", "a value", "unittest",
+        NULL, 1, update_every, RRDSET_TYPE_LINE);
+    RRDDIM *rd = rrddim_add(st, "dim", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    if(!rd || rd->tiers[0].seb != STORAGE_ENGINE_BACKEND_DBENGINE ||
+       !rd->tiers[0].smh || !rd->tiers[0].sch) {
+        fprintf(stderr, " >>> DBENGINE: %s metric initialization failed\n", id);
+        return NULL;
+    }
+
+    return rd;
+}
+
+static void dbengine_cadence_test_store_point(
+    RRDDIM *rd, time_t end_time_s, NETDATA_DOUBLE value) {
+    unittest_storage_engine_store_metric(
+        rd->tiers[0].sch, (usec_t)end_time_s * USEC_PER_SEC,
+        value, value, value, 1, 0, SN_DEFAULT_FLAGS);
+}
+
+static size_t dbengine_cadence_test_query_points(
+    RRDDIM *rd,
+    time_t start_time_s,
+    time_t end_time_s,
+    const DBENGINE_CADENCE_EXPECTED_POINT *expected,
+    size_t expected_points,
+    const char *id) {
+    size_t errors = 0;
+    struct storage_engine_query_handle seqh = { 0 };
+    unittest_storage_engine_query_init(
+        rd->tiers[0].seb, rd->tiers[0].smh, &seqh,
+        start_time_s, end_time_s, STORAGE_PRIORITY_SYNCHRONOUS);
+
+    size_t points = 0;
+    bool finished = false;
+    for(size_t safety = 0; safety < 8; safety++) {
+        if(unittest_storage_engine_query_is_finished(&seqh)) {
+            finished = true;
+            break;
+        }
+
+        STORAGE_POINT sp = unittest_storage_engine_query_next_metric(&seqh);
+        if(points >= expected_points) {
+            fprintf(stderr,
+                    " >>> DBENGINE: %s returned unexpected point %zu: %jd-%jd, value %f\n",
+                    id, points, (intmax_t)sp.start_time_s, (intmax_t)sp.end_time_s, sp.sum);
+            errors++;
+            points++;
+            continue;
+        }
+
+        const DBENGINE_CADENCE_EXPECTED_POINT *ep = &expected[points];
+        if(sp.start_time_s != ep->start_time_s || sp.end_time_s != ep->end_time_s ||
+           sp.min != ep->value || sp.max != ep->value || sp.sum != ep->value ||
+           storage_point_is_gap(sp) || sp.count != 1 || sp.anomaly_count != 0 ||
+           sp.flags != SN_DEFAULT_FLAGS) {
+            fprintf(stderr,
+                    " >>> DBENGINE: %s point %zu is %jd-%jd min=%f max=%f sum=%f count=%u "
+                    "anomalies=%u flags=0x%x; expected %jd-%jd value=%f\n",
+                    id, points, (intmax_t)sp.start_time_s, (intmax_t)sp.end_time_s,
+                    sp.min, sp.max, sp.sum, sp.count, sp.anomaly_count, (unsigned)sp.flags,
+                    (intmax_t)ep->start_time_s, (intmax_t)ep->end_time_s, ep->value);
+            errors++;
+        }
+
+        points++;
+    }
+
+    if(!finished && unittest_storage_engine_query_is_finished(&seqh))
+        finished = true;
+
+    if(!finished) {
+        fprintf(stderr, " >>> DBENGINE: %s query did not finish within 8 points\n", id);
+        errors++;
+    }
+
+    if(points != expected_points) {
+        fprintf(stderr,
+                " >>> DBENGINE: %s returned %zu points, expected %zu\n",
+                id, points, expected_points);
+        errors++;
+    }
+
+    unittest_storage_engine_query_finalize(&seqh);
+    return errors;
+}
+
+static size_t test_dbengine_long_collection_cadence(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 4000000;
+    const uint32_t update_every = 90000;
+    RRDDIM *rd = dbengine_cadence_test_create_metric(
+        host, "dbengine-long-cadence", (int)update_every);
+    if(!rd)
+        return 1;
+
+    dbengine_cadence_test_store_point(rd, t + update_every, 1);
+    dbengine_cadence_test_store_point(rd, t + 2 * update_every, 2);
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+
+    const DBENGINE_CADENCE_EXPECTED_POINT expected[] = {
+        { t,                t + update_every,     1 },
+        { t + update_every, t + 2 * update_every, 2 },
+    };
+
+    size_t invalid_before =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+    size_t errors = dbengine_cadence_test_query_points(
+        rd, t + update_every, t + 2 * update_every,
+        expected, _countof(expected), "long-cadence");
+    size_t invalid_after =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+
+    if(invalid_after != invalid_before) {
+        fprintf(stderr,
+                " >>> DBENGINE: valid long-cadence query reported %zu invalid page durations, expected 0\n",
+                invalid_after - invalid_before);
+        errors++;
+    }
+
+    return errors;
+}
+
+static size_t test_dbengine_zero_page_cadence_is_repaired(RRDHOST *host) {
+    const time_t t = START_TIMESTAMP + 4250000;
+    RRDDIM *rd = dbengine_cadence_test_create_metric(host, "dbengine-zero-page-cadence", 10);
+    if(!rd)
+        return 1;
+
+    unittest_storage_engine_store_change_collection_frequency(rd->tiers[0].sch, 0);
+    dbengine_cadence_test_store_point(rd, t + 100, 1);
+    dbengine_cadence_test_store_point(rd, t + 110, 2);
+
+    size_t errors = 0;
+    struct rrdeng_collect_handle *handle = (struct rrdeng_collect_handle *)rd->tiers[0].sch;
+    if(!handle->pgc_page || pgc_page_data(handle->pgc_page) == PGD_EMPTY ||
+       pgd_slots_used(pgc_page_data(handle->pgc_page)) != 2 ||
+       pgc_page_start_time_s(handle->pgc_page) != t + 100 ||
+       pgc_page_end_time_s(handle->pgc_page) != t + 110 ||
+       pgc_page_update_every_s(handle->pgc_page) != 0) {
+        fprintf(stderr,
+                " >>> DBENGINE: zero-page-cadence fixture did not retain a nonempty 0-second page\n");
+        errors++;
+        goto cleanup;
+    }
+
+    const DBENGINE_CADENCE_EXPECTED_POINT expected[] = {
+        { t + 90,  t + 100, 1 },
+        { t + 100, t + 110, 2 },
+    };
+
+    size_t invalid_before =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+    errors += dbengine_cadence_test_query_points(
+        rd, t + 100, t + 110, expected, _countof(expected), "zero-page-cadence-first");
+    size_t invalid_after_first =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+
+    if(invalid_after_first != invalid_before + 1 ||
+       pgc_page_update_every_s(handle->pgc_page) != 10) {
+        fprintf(stderr,
+                " >>> DBENGINE: zero page cadence repairs=%zu cadence=%u, expected 1 and 10\n",
+                invalid_after_first - invalid_before,
+                pgc_page_update_every_s(handle->pgc_page));
+        errors++;
+    }
+
+    errors += dbengine_cadence_test_query_points(
+        rd, t + 100, t + 110, expected, _countof(expected), "zero-page-cadence-repeat");
+    size_t invalid_after_repeat =
+        rrdeng_get_cache_efficiency_stats().pages_invalid_update_every_fixed;
+
+    if(invalid_after_repeat != invalid_after_first) {
+        fprintf(stderr,
+                " >>> DBENGINE: repeated zero-page-cadence query reported %zu repairs, expected 0\n",
+                invalid_after_repeat - invalid_after_first);
+        errors++;
+    }
+
+cleanup:
+    unittest_storage_engine_store_flush(rd->tiers[0].sch);
+    return errors;
+}
+
 int test_dbengine(void) {
     // provide enough threads to dbengine
     setenv("UV_THREADPOOL_SIZE", "48", 1);
@@ -510,6 +705,9 @@ int test_dbengine(void) {
     for (size_t current_region = 0 ; current_region < REGIONS ; current_region++) {
         errors += dbengine_test_rrdr_single_region(st, rd, current_region, time_start[current_region], time_end[current_region]);
     }
+
+    errors += test_dbengine_long_collection_cadence(host);
+    errors += test_dbengine_zero_page_cadence_is_repaired(host);
 
     // prevent closing the database before the test is finished
     sleep(5);

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -1005,7 +1005,7 @@ struct pgc_page *pg_cache_lookup_next(
             continue;
         }
         else {
-            if (unlikely(page_update_every_s <= 0 || page_update_every_s > 86400)) {
+            if (unlikely(!page_update_every_s)) {
                 __atomic_add_fetch(&rrdeng_cache_efficiency_stats.pages_invalid_update_every_fixed, 1, __ATOMIC_RELAXED);
                 page_update_every_s = pgc_page_fix_update_every(page, last_update_every_s);
                 pd->update_every_s = page_update_every_s;


### PR DESCRIPTION
## Summary

DBENGINE treated every stored page cadence above one day as invalid. The attempted repair could only replace a zero cadence, so a valid long cadence was left unchanged while false repair telemetry was emitted and a useless atomic operation was performed.

This PR:

- accepts every nonzero cadence already validated and stored in page metadata;
- retains and directly tests repair of the zero-cadence sentinel;
- verifies exact 90,000-second DBENGINE point boundaries and repeat-query behavior;
- verifies the scalar collection-cadence setter accepts the exact `INT32_MAX` boundary;
- isolates the focused native storage tests from production LTO and dynamic symbol exports.

This is the long-page-cadence bug extracted from the validated combined implementation in #23283. It does not change DBENGINE page formats, query aggregation, cadence-transition planning, or higher-tier cadence multiplication.

## Root cause

`page_update_every_s` is unsigned, and `pgc_page_fix_update_every()` performs a compare-and-swap only when the stored cadence is zero. The previous `> 86400` condition could therefore never repair a nonzero long cadence; it only misclassified valid metadata and added work to the page lookup path.

The corrected predicate invokes repair only for the actual sentinel value: zero.

## Tests

- GCC LTO + DBENGINE: complete `netdata -W unittest` passes.
- GCC non-LTO + DBENGINE: complete native suite passes.
- GCC + DBENGINE disabled: complete applicable native suite passes.
- Direct regressions cover:
  - exact 90,000-second page intervals and zero false-repair telemetry;
  - nonempty zero-cadence page repair, persisted cadence, and repeat no-op;
  - exact `INT32_MAX` scalar setter acceptance.
- Reverse mutations independently prove the deleted one-day bound, retained persistent zero repair, and `INT32_MAX` boundary.
- The test bridge object contains no LTO IR, remains hidden/local, and adds no dynamic exports.
- Same-source tests-on/tests-off comparison found identical size and normalized instruction shape for all 19 affected production symbols; the only added LTO clone is the test helper.

## Corpus suitability

No API-value corpus contract directly owns this bug because the old branch returned the same point values; the observable defect was false repair telemetry and unnecessary repair work. The native telemetry assertion is therefore the discriminating regression contract, while the zero-cadence fixture protects the retained repair behavior.

The complete combined 244-contract corpus remains at exactly the five separately approved Cloud/page-format limitations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts valid long DBENGINE page cadences and repairs only zero-cadence pages, removing false-repair telemetry and unnecessary atomic work in page lookup. Previously, any stored cadence > 1 day was treated as invalid; now only a zero sentinel triggers repair.

- Fix: update the `pg_cache_lookup_next` predicate to repair only when `page_update_every_s == 0`.
- Tests: add DBENGINE regressions for exact 90,000-second page boundaries and repeat queries with no repairs; verify zero-cadence pages repair once and persist; accept `INT32_MAX` in the scalar collection-cadence setter.
- Build/test infra: introduce `unit_test_bridge` compiled with `-fno-lto` and hidden visibility to isolate native storage tests and avoid new dynamic exports.
- No DBENGINE page formats, aggregation, cadence transition planning, or higher-tier cadence multiplication changed.

<sup>Written for commit f041ccdeffc321022787ab457eda5871174e7fa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database page update intervals when cadence information is missing.
  * Preserved valid long collection intervals instead of incorrectly adjusting them.
  * Added coverage for zero-second cadence repair, timestamps, page metadata, repeated queries, and cleanup.

* **Tests**
  * Expanded database engine tests for collection cadence and page metadata behavior.
  * Updated validation coverage for the maximum supported update interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->