### PR TITLE
fix(health): avoid reinitializing alerts for unchanged charts

### DIFF
--- a/src/daemon/pulse/pulse-parents.c
+++ b/src/daemon/pulse/pulse-parents.c
@@ -358,6 +358,13 @@ static void pulse_child_chart_labels(RRDSET *st, RRDHOST *host) {
     if(node_id[0])
         rrdlabels_add(st->rrdlabels, "node_id", node_id, RRDLABEL_SRC_AUTO);
     rrdlabels_add(st->rrdlabels, "hops", hops, RRDLABEL_SRC_AUTO);
+
+    // Chart labels are a prototype matching input, and these are written with the
+    // rrdlabels_* primitives directly rather than through rrdset_update_rrdlabels(),
+    // which is what normally raises these flags. The caller only invokes us when the
+    // labels actually need re-applying, so tell health to re-evaluate this chart.
+    rrdset_flag_set(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
+    rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
 }
 
 static void pulse_child_charts_update(RRDHOST *host, PULSE_INBOUND_STATE state) {

--- a/src/database/rrdset-index-id.c
+++ b/src/database/rrdset-index-id.c
@@ -268,8 +268,25 @@ static bool rrdset_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
     rrdset_update_permanent_labels(st);
 
     rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
-    rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-    rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+
+    // Only ask health to re-evaluate this chart when something it cares about
+    // actually changed. This callback runs on every re-registration of an
+    // already-known chart, which on a parent is continuous: children re-send
+    // chart definitions, and setting the flag unconditionally made health
+    // re-run health_prototype_*_for_rrdset() for essentially every chart,
+    // forever. Measured on an 806-node parent an hour after startup, with the
+    // chart population stable: 2124 charts/s re-initialised, 32% of the health
+    // thread.
+    //
+    // react_action is the right condition: every field this function mutates
+    // sets it, and the permanent labels written just above are derived from
+    // st->plugin_name / st->module_name, which are assigned earlier in this
+    // function and already raise RRDSET_REACT_PLUGIN_UPDATED / _MODULE_UPDATED
+    // when they change. So the labels cannot change while react_action is NONE.
+    if(ctr->react_action != RRDSET_REACT_NONE) {
+        rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+        rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    }
 
     return ctr->react_action != RRDSET_REACT_NONE;
 }
@@ -552,6 +569,9 @@ RRDSET *rrdset_create_custom(
         rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
         rrdhost_flag_set(host, RRDHOST_FLAG_METADATA_UPDATE);
         rrdset_metadata_updated(st);
+        // health re-evaluation on rename is queued by rrdset_reset_name() itself;
+        // the branch above only assigns the initial name of a chart we just created,
+        // which rrdset_insert_callback() has already flagged for initialization
     }
 
     dictionary_acquired_item_release(host->rrdset_root_index, st_item);

--- a/src/database/rrdset-index-name.c
+++ b/src/database/rrdset-index-name.c
@@ -53,9 +53,13 @@ int rrdset_reset_name(RRDSET *st, const char *name) {
     STRING *name_string = rrdset_fix_name(host, rrdset_id(st), rrdset_parts_type(st), string2str(st->name), name);
     if(!name_string) return 0;
 
+    bool renamed = false;
     if(st->name) {
         rrdset_index_del_name(host, st);
         SWAP(name_string, st->name);
+        // after the SWAP, name_string holds the old name; STRING is interned, so
+        // pointer inequality means the name really changed
+        renamed = (name_string != st->name);
         string_freez(name_string);
     }
     else
@@ -65,6 +69,20 @@ int rrdset_reset_name(RRDSET *st, const char *name) {
 
     rrdset_flag_clear(st, RRDSET_FLAG_EXPORTING_SEND|RRDSET_FLAG_EXPORTING_IGNORE|RRDSET_FLAG_UPSTREAM_SEND|RRDSET_FLAG_UPSTREAM_IGNORE);
     rrdset_metadata_updated(st);
+
+    // The name is a prototype matching input - prototype_matches_rrdset() compares
+    // ap->match.on.chart against both st->id and st->name - so a rename can both
+    // invalidate the alerts currently attached and enable new matches.
+    // This is the only place a rename is detected, and not all callers go through
+    // rrdset_create_custom() (tc.plugin renames its charts directly), so queue the
+    // re-evaluation here. It has to be the recheck flag: the incremental path only
+    // adds alerts, it never detaches the ones that stopped matching.
+    // Only on a real rename: this function is also called on every re-emission of
+    // every chart, and the recheck is a detach-and-reattach of all its alerts.
+    if(renamed) {
+        rrdset_flag_set(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
+        rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    }
 
     rrdcontext_updated_rrdset_name(st);
     return 2;

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -568,12 +568,28 @@ void rrdcalc_delete_all(RRDHOST *host) {
 void rrdcalc_child_disconnected(RRDHOST *host) {
     rrdcalc_delete_all(host);
 
-    rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    // We just deleted every alert of this host, so we must also ask health to re-create them when
+    // the child comes back. We cannot rely on chart re-registration to do it: rrdset_conflict_callback()
+    // only raises these flags when a chart definition actually changed, and a reconnecting child
+    // normally re-sends identical definitions. RRDHOST_FLAG_INITIALIZED_HEALTH is never cleared, so
+    // health_initialize_rrdhost() will not re-apply the prototypes either.
+    //
+    // This is the initialization flag rather than the label-recheck one on purpose: the alert lists
+    // are now empty, so the incremental apply path is correct and cheaper than detach-and-reattach.
+    //
+    // The flags stay pending, inert, for as long as the child is away: our caller sets
+    // host->health.enabled = false right after us, so rrdhost_should_run_health() is false and
+    // nothing consumes them. They are consumed on the first health pass after the host is online
+    // again, whichever path brings it back.
     RRDSET *st;
     rrdset_foreach_read(st, host) {
-        rrdset_flag_clear(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+        rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
     }
     rrdset_foreach_done(st);
+
+    // last: health_execute_delayed_initializations() consumes the host flag before walking the
+    // charts, so raising it first would let a pass slip through with the chart flags still unset
+    rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
 }
 
 void rrd_alert_match_cleanup(struct rrd_alert_match *am) {


### PR DESCRIPTION
##### Summary
- Queue health re-evaluation only when chart metadata actually changes.
- Prevent continuous child-chart re-registrations from repeatedly re-initializing alert prototypes.
- Preserve health re-evaluation for chart label updates and chart renames.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health monitoring initialization when charts are renamed, re-registered, or their configuration changes.
  * Ensured health alerts are recreated correctly after monitored components disconnect and reconnect.
  * Improved label updates for child charts and their hosts.
  * Reduced unnecessary health re-evaluations during chart registration, improving monitoring efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->