### PR TITLE
feat(go.d/prometheus): support Ceph Tentacle hardware and PG rebuild metrics

### DIFF
--- a/.agents/skills/project-prometheus-profiles/proof-authoring.md
+++ b/.agents/skills/project-prometheus-profiles/proof-authoring.md
@@ -107,7 +107,7 @@ Key rules:
 - Pin every public upstream to a full commit and cite repository-relative paths/lines in evidence.
 - Evidence records have one typed `kind`; consumers may reference only compatible kinds. Common kinds include
   `registration`, `availability`, `population`, `lifecycle`, `unit`, `label`, `relationship`, `state_encoding`,
-  `normalization`, `identity`, `deprecation`, `collection_hazard`, `delegation`, and `display_convention`.
+  `normalization`, `identity`, `deprecation`, `collection_hazard`, and `display_convention`.
 - Every inline registration declares an exact or grammar family selector, Prometheus type/shape, optional environment
   condition, and registration evidence.
 - Every signal declares what one observation describes, its components, label domains/stability/cardinality, functional
@@ -235,7 +235,6 @@ and their additional fields are:
 | `not_chartable` | `lost_question`, `required_operation: age_from_unix_epoch` | drop before writer |
 | `metadata_only` | none; value must be a constant metadata carrier | `retain_writable_unrendered` |
 | `collection_hazard` | source hazard evidence | drop before writer |
-| `scope_delegation` | `delegated_domain` | source-backed drop/retain |
 
 `not_chartable` is intentionally narrow: the current strict operation is only deriving age from a Unix timestamp. Do not
 use it as a generic “not useful” escape hatch. `metadata_only` applies to a source-proven constant-one carrier with useful
@@ -245,6 +244,19 @@ metadata labels, not to any gauge that happened to equal one in a fixture.
 
 Use latest testdata `master`; the Netdata repository intentionally does not pin its commit. By default it is cloned at the
 ignored `src/go/testdata`; `--testdata-root` can name another checkout.
+
+For a coordinated source/profile change:
+
+1. Use `src/go/testdata` as a checkout of the contributor's `netdata/testdata` fork.
+2. Create one feature branch in testdata and one matching feature branch in Netdata.
+3. Author and validate the source contract and fixtures on the testdata branch while the Netdata proof consumes that local
+   checkout.
+4. Open the paired pull requests and merge testdata first.
+5. Update `src/go/testdata` to the merged testdata `master`, rerun complete Netdata verification, and then merge the Netdata
+   pull request promptly.
+
+The repositories cannot merge atomically under the latest-testdata model. This ordering keeps the unavoidable compatibility
+window short without adding a testdata pin or weakening consumer verification.
 
 From the Netdata repository root:
 

--- a/src/go/internal/promprofile/README.md
+++ b/src/go/internal/promprofile/README.md
@@ -290,6 +290,11 @@ For a coordinated change, prepare both repositories together, merge the testdata
 requires it, update the local checkout to latest `master`, and rerun complete Netdata verification. This ordering avoids a
 Netdata revision whose required evidence does not yet exist; it is not a substitute for the consumer verification.
 
+During development, use the ignored `src/go/testdata` directory as a checkout of the contributor's testdata fork and work on
+paired feature branches in both repositories. Open paired pull requests, merge testdata first, update the local checkout to
+the merged testdata `master`, and rerun the complete Netdata proof before merging the Netdata pull request. Because the two
+repositories cannot merge atomically, the Netdata merge should follow promptly.
+
 ## Verification ownership
 
 ### Testdata producer checks

--- a/src/go/internal/promprofile/README.md
+++ b/src/go/internal/promprofile/README.md
@@ -286,14 +286,11 @@ Netdata verification intentionally consumes the latest `netdata/testdata` `maste
 - Exact schema compilation, fixture replay, semantic reconciliation, and coverage form the compatibility boundary.
 - Historical Netdata revisions are not guaranteed to validate against later testdata `master` content.
 
-For a coordinated change, prepare both repositories together, merge the testdata evidence before the Netdata consumer that
-requires it, update the local checkout to latest `master`, and rerun complete Netdata verification. This ordering avoids a
-Netdata revision whose required evidence does not yet exist; it is not a substitute for the consumer verification.
-
-During development, use the ignored `src/go/testdata` directory as a checkout of the contributor's testdata fork and work on
-paired feature branches in both repositories. Open paired pull requests, merge testdata first, update the local checkout to
-the merged testdata `master`, and rerun the complete Netdata proof before merging the Netdata pull request. Because the two
-repositories cannot merge atomically, the Netdata merge should follow promptly.
+For a coordinated change, use the ignored `src/go/testdata` directory as a checkout of the contributor's testdata fork and
+work on paired feature branches in both repositories. Open paired pull requests, merge testdata first, update the local
+checkout to the merged testdata `master`, and rerun the complete Netdata proof before merging the Netdata pull request.
+Because the repositories cannot merge atomically, this ordering does not eliminate the latest-testdata compatibility window;
+it verifies the consumer against the source state it will consume, and the Netdata merge should follow promptly.
 
 ## Verification ownership
 

--- a/src/go/internal/promprofile/semantics/evidence.go
+++ b/src/go/internal/promprofile/semantics/evidence.go
@@ -248,8 +248,6 @@ func (c *semanticCompiler) validateEvidenceClosure() error {
 			allowed = []string{"lifecycle", "unit", "label"}
 		case "collection_hazard":
 			allowed = []string{"collection_hazard"}
-		case "scope_delegation":
-			allowed = []string{"delegation"}
 		}
 		if exclusion.Reason == "not_chartable" {
 			if err := useAll(field, exclusion.Evidence, "lifecycle", "unit"); err != nil {

--- a/src/go/internal/promprofile/semantics/load_test.go
+++ b/src/go/internal/promprofile/semantics/load_test.go
@@ -97,7 +97,7 @@ func TestLoadRejectsStrictShapeAndVersionErrors(t *testing.T) {
 				_, err := LoadSourceSemantics(path)
 				return err
 			},
-			wantErr: "must be one of",
+			wantErr: `evidence.request_registration.kind "delegation" must be one of`,
 		},
 		"design retired scope delegation exclusion": {
 			filename: ProfileDesignFilename,
@@ -111,7 +111,22 @@ func TestLoadRejectsStrictShapeAndVersionErrors(t *testing.T) {
 				_, err := LoadProfileDesign(path)
 				return err
 			},
-			wantErr: "must be one of",
+			wantErr: `exclusions.delegated_requests.reason "scope_delegation" must be one of`,
+		},
+		"design retired delegated domain field": {
+			filename: ProfileDesignFilename,
+			content: strings.Replace(validProfileDesignV1, "exclusions: {}", `exclusions:
+  delegated_requests:
+    source: {signal: requests, components: [total]}
+    reason: metadata_only
+    delegated_domain: node_hardware
+    evidence: [request_population]
+    outcome: retain_writable_unrendered`, 1),
+			load: func(path string) error {
+				_, err := LoadProfileDesign(path)
+				return err
+			},
+			wantErr: "field delegated_domain not found",
 		},
 	}
 

--- a/src/go/internal/promprofile/semantics/load_test.go
+++ b/src/go/internal/promprofile/semantics/load_test.go
@@ -90,6 +90,29 @@ func TestLoadRejectsStrictShapeAndVersionErrors(t *testing.T) {
 			},
 			wantErr: "duplicate mapping key",
 		},
+		"source retired delegation evidence": {
+			filename: SourceFilename,
+			content:  strings.Replace(validSourceSemanticsV1, "kind: registration", "kind: delegation", 1),
+			load: func(path string) error {
+				_, err := LoadSourceSemantics(path)
+				return err
+			},
+			wantErr: "must be one of",
+		},
+		"design retired scope delegation exclusion": {
+			filename: ProfileDesignFilename,
+			content: strings.Replace(validProfileDesignV1, "exclusions: {}", `exclusions:
+  delegated_requests:
+    source: {signal: requests, components: [total]}
+    reason: scope_delegation
+    evidence: [request_population]
+    outcome: drop_before_writer`, 1),
+			load: func(path string) error {
+				_, err := LoadProfileDesign(path)
+				return err
+			},
+			wantErr: "must be one of",
+		},
 	}
 
 	for name, tc := range tests {
@@ -109,8 +132,18 @@ func TestLoadRejectsStrictShapeAndVersionErrors(t *testing.T) {
 
 func TestSourceSemanticsV1AcceptsReviewedSourceContracts(t *testing.T) {
 	content := strings.Replace(validSourceSemanticsV1, "kind: cumulative", "kind: constant", 1)
-	content = strings.Replace(content, "labels: {}", "labels:\n      position:\n        meaning: Speculative token position.\n        presence: required\n        domain: {kind: open}\n        endpoint_cardinality: {kind: bounded_configuration}\n        stability: stable\n        evidence: [position_label]", 1)
-	content = strings.Replace(content, "  request_unit:\n", "  position_label:\n    kind: label\n    upstream: exporter\n    locations: [metrics.go:14]\n    claim: One finite label value is registered per configured speculative token.\n  request_unit:\n", 1)
+	content = strings.Replace(
+		content,
+		"labels: {}",
+		"labels:\n      position:\n        meaning: Speculative token position.\n        presence: required\n        domain: {kind: open}\n        endpoint_cardinality: {kind: bounded_configuration}\n        stability: stable\n        evidence: [position_label]",
+		1,
+	)
+	content = strings.Replace(
+		content,
+		"  request_unit:\n",
+		"  position_label:\n    kind: label\n    upstream: exporter\n    locations: [metrics.go:14]\n    claim: One finite label value is registered per configured speculative token.\n  request_unit:\n",
+		1,
+	)
 
 	path := filepath.Join(t.TempDir(), SourceFilename)
 	writeTextFile(t, path, content)
@@ -421,7 +454,12 @@ func TestSourceSemanticsV1RejectsContradictoryAndMalformedConditions(t *testing.
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			content := strings.Replace(validSourceSemanticsV1, "environment:\n  axes: {}\n  policies: {}", tc.environment, 1)
+			content := strings.Replace(
+				validSourceSemanticsV1,
+				"environment:\n  axes: {}\n  policies: {}",
+				tc.environment,
+				1,
+			)
 			content = strings.Replace(content, "evidence:\n", `evidence:
   mode_availability:
     kind: availability
@@ -571,7 +609,12 @@ func TestSourceSemanticsV1StateEncodingRequiresCurrentStateComponent(t *testing.
 		t.Fatalf("LoadSourceSemantics() error = %v, want state-component failure", err)
 	}
 
-	content = strings.Replace(content, "prometheus: {type: counter, shape: scalar}", "prometheus: {type: gauge, shape: scalar}", 1)
+	content = strings.Replace(
+		content,
+		"prometheus: {type: counter, shape: scalar}",
+		"prometheus: {type: gauge, shape: scalar}",
+		1,
+	)
 	content = strings.Replace(content, "kind: cumulative", "kind: current", 1)
 	writeTextFile(t, path, content)
 	if _, err := LoadSourceSemantics(path); err != nil {

--- a/src/go/internal/promprofile/semantics/types_design.go
+++ b/src/go/internal/promprofile/semantics/types_design.go
@@ -191,7 +191,6 @@ type DesignExclusion struct {
 	Replacement       string          `yaml:"replacement,omitempty"`
 	LostQuestion      string          `yaml:"lost_question,omitempty"`
 	RequiredOperation string          `yaml:"required_operation,omitempty"`
-	DelegatedDomain   string          `yaml:"delegated_domain,omitempty"`
 	Evidence          []string        `yaml:"evidence"`
 	Outcome           string          `yaml:"outcome"`
 }

--- a/src/go/internal/promprofile/semantics/validate_design.go
+++ b/src/go/internal/promprofile/semantics/validate_design.go
@@ -175,7 +175,13 @@ func validateView(field string, view ViewDefinition, design ProfileDesignDocumen
 		}
 		for index, component := range input.Components {
 			if !validID(component) {
-				return fmt.Errorf("%s.inputs.%s.components[%d] %q is not a valid component ID", field, id, index, component)
+				return fmt.Errorf(
+					"%s.inputs.%s.components[%d] %q is not a valid component ID",
+					field,
+					id,
+					index,
+					component,
+				)
 			}
 		}
 		if err := validateLabelCondition(field+".inputs."+id+".where", input.Where); err != nil {
@@ -646,7 +652,7 @@ func validateDesignExclusion(field string, exclusion DesignExclusion) error {
 		return err
 	}
 	if err := requireEnum(field+".reason", exclusion.Reason,
-		"equivalent_duplicate", "source_superseded", "not_chartable", "metadata_only", "collection_hazard", "scope_delegation"); err != nil {
+		"equivalent_duplicate", "source_superseded", "not_chartable", "metadata_only", "collection_hazard"); err != nil {
 		return err
 	}
 	if err := requireEnum(field+".outcome",
@@ -662,14 +668,12 @@ func validateDesignExclusion(field string, exclusion DesignExclusion) error {
 		"not_chartable":        {"lost_question", "required_operation"},
 		"metadata_only":        {},
 		"collection_hazard":    {},
-		"scope_delegation":     {"delegated_domain"},
 	}[exclusion.Reason]
 	for name, present := range map[string]bool{
 		"covering_view":      exclusion.CoveringView != "",
 		"replacement":        exclusion.Replacement != "",
 		"lost_question":      exclusion.LostQuestion != "",
 		"required_operation": exclusion.RequiredOperation != "",
-		"delegated_domain":   exclusion.DelegatedDomain != "",
 	} {
 		if present && !slices.Contains(allowed, name) {
 			return fmt.Errorf("%s.%s is not allowed for reason %s", field, name, exclusion.Reason)
@@ -691,8 +695,6 @@ func validateDesignExclusion(field string, exclusion DesignExclusion) error {
 		if exclusion.Outcome != "retain_writable_unrendered" {
 			return fmt.Errorf("%s.outcome must be retain_writable_unrendered", field)
 		}
-	case "scope_delegation":
-		return requireText(field+".delegated_domain", exclusion.DelegatedDomain)
 	}
 	return nil
 }

--- a/src/go/internal/promprofile/semantics/validate_source.go
+++ b/src/go/internal/promprofile/semantics/validate_source.go
@@ -165,7 +165,7 @@ func validateSourceEvidence(
 ) error {
 	if err := requireEnum(field+".kind", evidence.Kind,
 		"availability", "registration", "lifecycle", "unit", "population", "label", "relationship",
-		"state_encoding", "normalization", "identity", "deprecation", "collection_hazard", "delegation",
+		"state_encoding", "normalization", "identity", "deprecation", "collection_hazard",
 		"display_convention"); err != nil {
 		return err
 	}
@@ -303,7 +303,12 @@ func validateSignal(field string, signal SignalDefinition, document SourceSemant
 		}
 		for index, grammar := range generated.Scope.Families.Grammars {
 			if !validID(grammar) {
-				return fmt.Errorf("%s.source.generated.scope.families.grammars[%d] %q is invalid", field, index, grammar)
+				return fmt.Errorf(
+					"%s.source.generated.scope.families.grammars[%d] %q is invalid",
+					field,
+					index,
+					grammar,
+				)
 			}
 		}
 	}
@@ -416,7 +421,12 @@ func validateSignal(field string, signal SignalDefinition, document SourceSemant
 						return fmt.Errorf("%s label %q must have optional presence", constraintField, label)
 					}
 					if owner, ok := claimed[label]; ok {
-						return fmt.Errorf("%s label %q is already owned by constraint %q", constraintField, label, owner)
+						return fmt.Errorf(
+							"%s label %q is already owned by constraint %q",
+							constraintField,
+							label,
+							owner,
+						)
 					}
 					claimed[label] = id
 				}

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -4543,14 +4543,17 @@ modules:
           from host-local `ceph-exporter` daemon availability and MON, MGR, OSD, and RGW performance. Optional branches cover
           CephFS/MDS and CephFS Mirror, RBD images, RBD Mirror, SMB, NVMe-oF, RGW user/bucket/topic/cache/multisite and dmClock
           scheduling, RocksDB binned caches, external block devices, and Ceph client I/O across Reef 18.2.8, Squid 19.2.5,
-          and Tentacle 20.2.2. PG state flags and RGW global/user/bucket views are overlapping diagnostic populations and are
-          not additive totals. Profile relabeling turns dynamic MDS-client, librbd ImageCtx/PWL, ObjectCacher, objecter, RocksDB
-          cache, Finisher, Throttle, KernelDevice, mClock, messenger, RDMA, DPDK, and service-identity family names into stable
-          profile inputs while preserving their source keys as identity labels. The source-complete profile materializes the
-          entire declared release/producer union with zero generic fallback. Unknown future Ceph families remain visible
-          through generic fallback until their source semantics can be curated; generic visibility is a forward-compatibility
-          guard, not evidence that a known source family was fully modeled. The profile drops only the source-proven
-          raw MGR RGW source-zone aliases because the stable normalized family is already charted.
+          and Tentacle 20.2.2. On Tentacle, the endpoints also expose primary-OSD PG-rebuild duration, while the MGR additionally
+          exposes cephadm node-proxy CPU, memory, storage, cooling, temperature, and per-component health metrics. Firmware
+          remains source metadata and is not charted because Ceph exposes it as an info family. PG state flags and RGW
+          global/user/bucket views are overlapping diagnostic populations and are not additive totals. Profile relabeling
+          turns dynamic MDS-client, librbd ImageCtx/PWL, ObjectCacher, objecter, RocksDB cache, Finisher, Throttle, KernelDevice,
+          mClock, messenger, RDMA, DPDK, and service-identity family names into stable profile inputs while preserving their
+          source keys as identity labels. The source-complete profile materializes the entire declared release/producer union
+          with zero generic fallback. Unknown future Ceph families remain visible through generic fallback until their source
+          semantics can be curated; generic visibility is a forward-compatibility guard, not evidence that a known source
+          family was fully modeled. The profile drops only the source-proven raw MGR RGW source-zone aliases because the stable
+          normalized family is already charted.
 
           The chart model follows the producer's source lifecycle rather than relying on Prometheus wire type alone. Current
           populations that Ceph increments and decrements remain absolute, while cumulative work published through gauges is
@@ -4573,7 +4576,9 @@ modules:
               Enable the [Ceph MGR Prometheus module](https://docs.ceph.com/en/latest/mgr/prometheus/) for cluster metrics or
               deploy the official `ceph-exporter` for host-local daemon performance metrics. The stock profile supports the
               default priority threshold and the complete priority-0 surface; use `exporter_prio_limit=0` when those diagnostic
-              counters are required and size the job limits for the resulting series count.
+              counters are required and size the job limits for the resulting series count. When cephadm node-proxy hardware
+              reporting is enabled, hardware series scale with the cluster-wide component inventory; size both
+              `max_time_series` and `max_time_series_per_metric` for that surface.
       configuration:
         <<: *prometheus_configuration
         examples:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/OPERATOR-MODEL.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/OPERATOR-MODEL.md
@@ -118,8 +118,8 @@ retains the stable normalized families. Unknown suffixes are not silently classi
 - Raw process-start epoch cannot be transformed into age, so it is excluded while CPU, memory, and file descriptors remain.
 - Writer-ineligible information families retain their lost metadata questions in the source contract rather than being
   presented as numeric state.
-- Hardware firmware information remains a metadata-only constant-one carrier. Its labels are retained for future metadata
-  consumers but are not presented as a numeric chart.
+- Hardware firmware information remains a metadata-only constant-one carrier. Its labels remain documented in the source
+  contract but the writer-ineligible info family is not presented as a numeric chart.
 - Duplicate aliases are excluded only when source proves the canonical family represents the same observation.
 - Address-bearing objecter families are not discarded: the profile extracts their address identity and charts the finite
   operation branches.

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/OPERATOR-MODEL.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/OPERATOR-MODEL.md
@@ -14,6 +14,7 @@ all machine-verifiable behavior and coverage.
 ```text
 Ceph cluster
   -> control plane: MON, MGR, cephadm, health
+  -> node hardware: CPU, memory, storage, fans, temperatures, component health/firmware
   -> storage topology: pools -> PGs -> OSDs -> BlueStore/BlueFS/devices
   -> client services:
        CephFS -> filesystem -> MDS -> clients/sessions/cache/journal/purge queue
@@ -36,7 +37,8 @@ Ceph cluster
 7. RBD and RBD Mirror: per-image I/O, persistent write log, object cache, and replication progress/outcomes.
 8. RGW: operations, latency/bytes, cache, lifecycle, notifications, topics, and multisite synchronization.
 9. NVMe-oF: gateway/reactor state, host connectivity, subsystem inventory, namespace/listener topology, and bdev I/O.
-10. Shared runtime: schedulers, messenger workers, RDMA/DPDK, finishers, throttles, memory pools, and exporters.
+10. Node hardware: processor and memory inventory, storage capacity, cooling, temperatures, and component health.
+11. Shared runtime: schedulers, messenger workers, RDMA/DPDK, finishers, throttles, memory pools, and exporters.
 
 Navigation starts with service impact and convergence, follows user-facing services, then descends into storage-engine and
 runtime causes. Signals remain with the component that can explain them instead of being grouped globally by unit or type.
@@ -54,6 +56,12 @@ RBD PWL:             {ceph_daemon, librbd_pwl_key, remaining emitted labels}
 runtime component:   {ceph_daemon, normalized component identity, remaining emitted labels}
 RGW entity:          {instance_id, emitted user/bucket/topic/zone labels}
 NVMe-oF entity:      {gateway labels, nqn/host/device labels as emitted}
+hardware component:  {hostname, category, component}
+hardware CPU:        {hostname, cpu, manufacturer, model, total_threads}
+hardware fan:        {hostname, fan_name}
+hardware memory:     {hostname, dimm, type}
+hardware storage:    {hostname, device, model, protocol, firmware_version, slot, serial_number}
+hardware sensor:     {hostname, sensor_name}
 ```
 
 - MGR and ceph-exporter label sets differ by family and remain extensible.
@@ -82,6 +90,8 @@ retains the stable normalized families. Unknown suffixes are not silently classi
 - MGR and ceph-exporter can expose the same daemon schema with different Prometheus wire types. Long-running-average sums are
   cumulative in source and therefore remain incremental in both variants.
 - Release-specific scrub and optional-daemon surfaces remain distinct causal branches where their contracts differ.
+- Tentacle adds node-proxy hardware observations and primary-OSD PG-rebuild duration counters. Hardware measurements are
+  owned by the node-hardware domain; PG-rebuild duration remains with OSD recovery.
 - NVMe-oF process/platform metrics are part of the gateway surface; Python GC is not fabricated because that producer
   unregisters it.
 - The NVMe-oF listener speed family has a misleading bytes suffix. Its implementation reads the kernel interface speed value,
@@ -108,6 +118,8 @@ retains the stable normalized families. Unknown suffixes are not silently classi
 - Raw process-start epoch cannot be transformed into age, so it is excluded while CPU, memory, and file descriptors remain.
 - Writer-ineligible information families retain their lost metadata questions in the source contract rather than being
   presented as numeric state.
+- Hardware firmware information remains a metadata-only constant-one carrier. Its labels are retained for future metadata
+  consumers but are not presented as a numeric chart.
 - Duplicate aliases are excluded only when source proves the canonical family represents the same observation.
 - Address-bearing objecter families are not discarded: the profile extracts their address identity and charts the finite
   operation branches.

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -5833,19 +5833,6 @@ views:
       dimensions: {}
       promote: []
       omit: {}
-  node_hardware.processors.cpu_cores:
-    family: Ceph/Node Hardware/Processors
-    question: How many cores does each reported CPU provide?
-    entity: node_hardware_cpu
-    inputs:
-      value:
-        signal: hardware_cpu_cores
-        components:
-        - value
-    labels:
-      dimensions: {}
-      promote: []
-      omit: {}
   node_hardware.cooling.fan_speed:
     family: Ceph/Node Hardware/Cooling
     question: What is the current speed of each reported fan?
@@ -5879,6 +5866,19 @@ views:
     inputs:
       value:
         signal: hardware_memory_capacity_bytes
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  node_hardware.processors.cpu_cores:
+    family: Ceph/Node Hardware/Processors
+    question: How many cores does each reported CPU provide?
+    entity: node_hardware_cpu
+    inputs:
+      value:
+        signal: hardware_cpu_cores
         components:
         - value
     labels:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -649,6 +649,70 @@ entities:
     identity:
       required: []
       optional: []
+  node_hardware_component:
+    grain: Ceph node hardware component
+    identity:
+      required:
+      - hostname
+      - category
+      - component
+      optional: []
+    high_cardinality_acceptance:
+      operator_value: Per-component identity preserves actionable hardware health observations exposed by Ceph node-proxy.
+  node_hardware_cpu:
+    grain: Ceph node CPU and processor inventory identity
+    identity:
+      required:
+      - hostname
+      - cpu
+      - manufacturer
+      - model
+      - total_threads
+      optional: []
+    high_cardinality_acceptance:
+      operator_value: Per-CPU identity preserves processor capacity observations exposed by Ceph node-proxy.
+  node_hardware_fan:
+    grain: Ceph node fan
+    identity:
+      required:
+      - hostname
+      - fan_name
+      optional: []
+    high_cardinality_acceptance:
+      operator_value: Per-fan identity preserves cooling observations exposed by Ceph node-proxy.
+  node_hardware_memory_module:
+    grain: Ceph node memory module and type
+    identity:
+      required:
+      - hostname
+      - dimm
+      - type
+      optional: []
+    high_cardinality_acceptance:
+      operator_value: Per-DIMM identity preserves memory inventory exposed by Ceph node-proxy.
+  node_hardware_storage_device:
+    grain: Ceph node storage device and inventory identity
+    identity:
+      required:
+      - hostname
+      - device
+      - model
+      - protocol
+      - firmware_version
+      - slot
+      - serial_number
+      optional: []
+    high_cardinality_acceptance:
+      operator_value: Per-device identity preserves storage inventory exposed by Ceph node-proxy.
+  node_hardware_temperature_sensor:
+    grain: Ceph node temperature sensor
+    identity:
+      required:
+      - hostname
+      - sensor_name
+      optional: []
+    high_cardinality_acceptance:
+      operator_value: Per-sensor identity preserves thermal observations exposed by Ceph node-proxy.
 label_policies: {}
 reduction_policies: {}
 normalizations:
@@ -5769,6 +5833,84 @@ views:
       dimensions: {}
       promote: []
       omit: {}
+  node_hardware.processors.cpu_cores:
+    family: Ceph/Node Hardware/Processors
+    question: How many cores does each reported CPU provide?
+    entity: node_hardware_cpu
+    inputs:
+      value:
+        signal: hardware_cpu_cores
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  node_hardware.cooling.fan_speed:
+    family: Ceph/Node Hardware/Cooling
+    question: What is the current speed of each reported fan?
+    entity: node_hardware_fan
+    inputs:
+      value:
+        signal: hardware_fan_rpm
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  node_hardware.health.state:
+    family: Ceph/Node Hardware/Health
+    question: What is the current health state of each reported hardware component?
+    entity: node_hardware_component
+    inputs:
+      value:
+        signal: hardware_health
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  node_hardware.memory.capacity:
+    family: Ceph/Node Hardware/Memory
+    question: What capacity does each reported memory module provide?
+    entity: node_hardware_memory_module
+    inputs:
+      value:
+        signal: hardware_memory_capacity_bytes
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  node_hardware.storage.capacity:
+    family: Ceph/Node Hardware/Storage
+    question: What capacity does each reported storage device provide?
+    entity: node_hardware_storage_device
+    inputs:
+      value:
+        signal: hardware_storage_capacity_bytes
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  node_hardware.temperature.temperature:
+    family: Ceph/Node Hardware/Temperature
+    question: What temperature does each reported hardware sensor observe?
+    entity: node_hardware_temperature_sensor
+    inputs:
+      value:
+        signal: hardware_temperature_celsius
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
   nvme_of.block_devices.byte_throughput:
     family: Ceph/NVMe-oF/Block Devices
     question: What is the byte throughput for each bdev name?
@@ -7828,6 +7970,49 @@ views:
     inputs:
       value:
         signal: osd_recovery_ops
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  osd_recovery.pg_rebuild_accumulated_duration:
+    family: Ceph/OSD Recovery
+    question: At what rate is primary-OSD PG-rebuild duration accumulating for each Ceph daemon?
+    entity: by_ceph_daemon
+    inputs:
+      value:
+        signal: recoverystate_perf_pg_rebuild_duration_sum
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  osd_recovery.pg_rebuild_duration_measurements:
+    family: Ceph/OSD Recovery
+    question: At what rate are primary-OSD PG-rebuild duration measurements recorded for each Ceph daemon?
+    entity: by_ceph_daemon
+    inputs:
+      value:
+        signal: recoverystate_perf_pg_rebuild_duration_count
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  osd_recovery.pg_rebuild_duration_range:
+    family: Ceph/OSD Recovery
+    question: What minimum and maximum PG-rebuild durations does each primary OSD currently report?
+    entity: by_ceph_daemon
+    inputs:
+      maximum:
+        signal: recoverystate_perf_pg_rebuild_max_secs
+        components:
+        - value
+      minimum:
+        signal: recoverystate_perf_pg_rebuild_min_secs
         components:
         - value
     labels:

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -922,6 +922,121 @@ template:
           by_labels:
           - ceph_daemon
           optional_by_labels: []
+  - family: Node Hardware
+    context_namespace: node_hardware
+    groups:
+    - family: Processors
+      context_namespace: processors
+      metrics:
+      - ceph_hardware_cpu_cores
+      charts:
+      - title: CPU Cores
+        context: cpu_cores
+        units: cpu cores
+        label_promotion: []
+        dimensions:
+        - selector: ceph_hardware_cpu_cores
+          name: value
+        instances:
+          by_labels:
+          - hostname
+          - cpu
+          - manufacturer
+          - model
+          - total_threads
+          optional_by_labels: []
+    - family: Cooling
+      context_namespace: cooling
+      metrics:
+      - ceph_hardware_fan_rpm
+      charts:
+      - title: Fan Speed
+        context: fan_speed
+        units: fan revolutions per minute
+        label_promotion: []
+        dimensions:
+        - selector: ceph_hardware_fan_rpm
+          name: value
+        instances:
+          by_labels:
+          - hostname
+          - fan_name
+          optional_by_labels: []
+    - family: Health
+      context_namespace: health
+      metrics:
+      - ceph_hardware_health
+      charts:
+      - title: Hardware Health
+        context: state
+        units: '{status}'
+        label_promotion: []
+        dimensions:
+        - selector: ceph_hardware_health
+          name: value
+        instances:
+          by_labels:
+          - hostname
+          - category
+          - component
+          optional_by_labels: []
+    - family: Memory
+      context_namespace: memory
+      metrics:
+      - ceph_hardware_memory_capacity_bytes
+      charts:
+      - title: Memory Module Capacity
+        context: capacity
+        units: bytes
+        label_promotion: []
+        dimensions:
+        - selector: ceph_hardware_memory_capacity_bytes
+          name: value
+        instances:
+          by_labels:
+          - hostname
+          - dimm
+          - type
+          optional_by_labels: []
+    - family: Storage
+      context_namespace: storage
+      metrics:
+      - ceph_hardware_storage_capacity_bytes
+      charts:
+      - title: Storage Device Capacity
+        context: capacity
+        units: bytes
+        label_promotion: []
+        dimensions:
+        - selector: ceph_hardware_storage_capacity_bytes
+          name: value
+        instances:
+          by_labels:
+          - hostname
+          - device
+          - model
+          - protocol
+          - firmware_version
+          - slot
+          - serial_number
+          optional_by_labels: []
+    - family: Temperature
+      context_namespace: temperature
+      metrics:
+      - ceph_hardware_temperature_celsius
+      charts:
+      - title: Sensor Temperature
+        context: temperature
+        units: Celsius
+        label_promotion: []
+        dimensions:
+        - selector: ceph_hardware_temperature_celsius
+          name: value
+        instances:
+          by_labels:
+          - hostname
+          - sensor_name
+          optional_by_labels: []
   - family: OSD Overview
     context_namespace: osd_overview
     metrics:
@@ -5242,6 +5357,10 @@ template:
     - ceph_osd_l_osd_recovery_scan_queue_latency_sum
     - ceph_osd_recovery_bytes
     - ceph_osd_recovery_ops
+    - ceph_recoverystate_perf_pg_rebuild_duration_count
+    - ceph_recoverystate_perf_pg_rebuild_duration_sum
+    - ceph_recoverystate_perf_pg_rebuild_max_secs
+    - ceph_recoverystate_perf_pg_rebuild_min_secs
     charts:
     - title: Latency Measurements
       context: latency_measurements
@@ -5312,6 +5431,42 @@ template:
       dimensions:
       - selector: ceph_osd_recovery_ops
         name: value
+      instances:
+        by_labels:
+        - ceph_daemon
+        optional_by_labels: []
+    - title: PG Rebuild Duration Measurements
+      context: pg_rebuild_duration_measurements
+      units: duration measurements/s
+      label_promotion: []
+      dimensions:
+      - selector: ceph_recoverystate_perf_pg_rebuild_duration_count
+        name: value
+      instances:
+        by_labels:
+        - ceph_daemon
+        optional_by_labels: []
+    - title: PG Rebuild Accumulated Duration
+      context: pg_rebuild_accumulated_duration
+      units: seconds/s
+      label_promotion: []
+      dimensions:
+      - selector: ceph_recoverystate_perf_pg_rebuild_duration_sum
+        name: value
+      instances:
+        by_labels:
+        - ceph_daemon
+        optional_by_labels: []
+      algorithm: incremental
+    - title: PG Rebuild Duration Range
+      context: pg_rebuild_duration_range
+      units: seconds
+      label_promotion: []
+      dimensions:
+      - selector: ceph_recoverystate_perf_pg_rebuild_max_secs
+        name: maximum
+      - selector: ceph_recoverystate_perf_pg_rebuild_min_secs
+        name: minimum
       instances:
         by_labels:
         - ceph_daemon


### PR DESCRIPTION
##### Summary

Add curated Prometheus profile support for the hardware and PG-rebuild metrics introduced by Ceph Tentacle.


---

The latest Ceph source contract added 11 metric families:
- Seven node-hardware families covering inventory, health, cooling, and temperature.
- Four primary-OSD PG-rebuild duration families.

The source contract also added delegation evidence stating that these metrics required special profile treatment. Netdata’s Ceph profile did not consume that evidence or provide destinations for the new metrics, causing proof verification to fail with:

`source evidence "delegation_hardware_metrics" is unused`

Removing the evidence alone was insufficient: the writer-capable metrics then appeared as unexpected autogenerated charts.

The delegation records also crossed the source/consumer ownership boundary. Source evidence can describe what a metric represents, but the Netdata profile must decide where and how it is presented.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Curates Ceph Tentacle node‑hardware and PG‑rebuild duration metrics in `go.d/prometheus`, and retires the `delegation` evidence kind and `scope_delegation` exclusions. Previously these metrics were unmodeled and proofs failed or auto‑generated charts appeared; now they render under Node Hardware and OSD Recovery, and validators reject the retired semantics.

- Node Hardware: processors (CPU cores), fans (RPM), component health, memory capacity, storage capacity, and temperatures; identities use hostname plus component labels; firmware remains metadata‑only and uncharted.
- OSD Recovery: PG‑rebuild duration adds count and accumulated seconds (incremental) plus min/max per `ceph_daemon`; entities, views, and charts are defined in `PROFILE-DESIGN.yaml` and default `ceph.yaml`.
- Semantics and docs: removed `delegation` evidence and `scope_delegation` exclusions from validators with tests; updated authoring/README guidance for coordinated source/profile changes; module help notes hardware can increase series and to size job limits.

- Merge `netdata/testdata` with the Tentacle contract first, update local `src/go/testdata` to the merged master, and rerun full Netdata verification before merging this PR.
- Remove any `kind: delegation` evidence and `scope_delegation` exclusions from source contracts or profiles; add explicit profile destinations for the Tentacle metrics.

<sup>Written for commit 20464b3e35e7cc41766d53a80542194d9286ec6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ceph node hardware monitoring for CPU cores, fan speed, hardware health, memory, storage, and temperatures.
  * Added Ceph PG rebuild recovery metrics, including duration measurements, accumulated time, and duration ranges.
* **Bug Fixes**
  * Retired unsupported delegation evidence, scope-delegation exclusions, and delegated-domain fields from profile validation.
* **Documentation**
  * Updated guidance for coordinating profile and test-data changes.
  * Documented Ceph hardware and PG rebuild metrics, including time-series sizing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->