### PR TITLE
chore(go.d): format prometheus YAML files

### DIFF
--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -12,13 +12,13 @@ entities:
     grain: Ceph allow any host and ceph instance and group and ha enabled and model number and nqn and serial number
     identity:
       required:
-      - allow_any_host
-      - ceph_instance
-      - group
-      - ha_enabled
-      - model_number
-      - nqn
-      - serial_number
+        - allow_any_host
+        - ceph_instance
+        - group
+        - ha_enabled
+        - model_number
+        - nqn
+        - serial_number
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -27,12 +27,12 @@ entities:
     grain: Ceph anagrpid and bdev name and ceph instance and nqn and nsid and rados namespace name
     identity:
       required:
-      - anagrpid
-      - bdev_name
-      - ceph_instance
-      - nqn
-      - nsid
-      - rados_namespace_name
+        - anagrpid
+        - bdev_name
+        - ceph_instance
+        - nqn
+        - nsid
+        - rados_namespace_name
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -41,30 +41,31 @@ entities:
     grain: Ceph application and compression mode and description and name and pool id and type
     identity:
       required:
-      - application
-      - compression_mode
-      - description
-      - name
-      - pool_id
-      - type
+        - application
+        - compression_mode
+        - description
+        - name
+        - pool_id
+        - type
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
   ? by_back_iface_and_ceph_daemon_and_ceph_version_and_cluster_addr_and_device_class_and_front_iface_and_hostname_and_objectstore_and_public_addr
-  : grain: Ceph back iface and ceph daemon and ceph version and cluster addr and device class and front iface and hostname
+    :
+    grain: Ceph back iface and ceph daemon and ceph version and cluster addr and device class and front iface and hostname
       and objectstore and public addr
     identity:
       required:
-      - back_iface
-      - ceph_daemon
-      - ceph_version
-      - cluster_addr
-      - device_class
-      - front_iface
-      - hostname
-      - objectstore
-      - public_addr
+        - back_iface
+        - ceph_daemon
+        - ceph_version
+        - cluster_addr
+        - device_class
+        - front_iface
+        - hostname
+        - objectstore
+        - public_addr
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -73,7 +74,7 @@ entities:
     grain: Ceph bdev name
     identity:
       required:
-      - bdev_name
+        - bdev_name
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -82,12 +83,12 @@ entities:
     grain: Ceph bdev name and block size and ceph instance and namespace and pool name and rbd name
     identity:
       required:
-      - bdev_name
-      - block_size
-      - ceph_instance
-      - namespace
-      - pool_name
-      - rbd_name
+        - bdev_name
+        - block_size
+        - ceph_instance
+        - namespace
+        - pool_name
+        - rbd_name
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -96,8 +97,8 @@ entities:
     grain: Ceph bdev name and ceph instance
     identity:
       required:
-      - bdev_name
-      - ceph_instance
+        - bdev_name
+        - ceph_instance
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -106,7 +107,7 @@ entities:
     grain: Ceph ceph daemon
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -115,13 +116,13 @@ entities:
     grain: Ceph ceph daemon and ceph instance and db device and device and device ids and devices and wal device
     identity:
       required:
-      - ceph_daemon
-      - ceph_instance
-      - db_device
-      - device
-      - device_ids
-      - devices
-      - wal_device
+        - ceph_daemon
+        - ceph_instance
+        - db_device
+        - device
+        - device_ids
+        - devices
+        - wal_device
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -130,9 +131,9 @@ entities:
     grain: Ceph ceph daemon and ceph instance and device
     identity:
       required:
-      - ceph_daemon
-      - ceph_instance
-      - device
+        - ceph_daemon
+        - ceph_instance
+        - device
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -141,12 +142,12 @@ entities:
     grain: Ceph ceph daemon and ceph version and fs id and hostname and public addr and rank
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - fs_id
-      - hostname
-      - public_addr
-      - rank
+        - ceph_daemon
+        - ceph_version
+        - fs_id
+        - hostname
+        - public_addr
+        - rank
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -155,9 +156,9 @@ entities:
     grain: Ceph ceph daemon and ceph version and hostname
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - hostname
+        - ceph_daemon
+        - ceph_version
+        - hostname
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -166,11 +167,11 @@ entities:
     grain: Ceph ceph daemon and ceph version and hostname and id and instance id
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - hostname
-      - id
-      - instance_id
+        - ceph_daemon
+        - ceph_version
+        - hostname
+        - id
+        - instance_id
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -179,10 +180,10 @@ entities:
     grain: Ceph ceph daemon and ceph version and hostname and instance id
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - hostname
-      - instance_id
+        - ceph_daemon
+        - ceph_version
+        - hostname
+        - instance_id
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -191,11 +192,11 @@ entities:
     grain: Ceph ceph daemon and ceph version and hostname and public addr and rank
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - hostname
-      - public_addr
-      - rank
+        - ceph_daemon
+        - ceph_version
+        - hostname
+        - public_addr
+        - rank
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -204,11 +205,11 @@ entities:
     grain: Ceph ceph daemon and client and rank and mds filesystem key
     identity:
       required:
-      - ceph_daemon
-      - client
-      - rank
+        - ceph_daemon
+        - client
+        - rank
       optional:
-      - mds_filesystem_key
+        - mds_filesystem_key
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -216,9 +217,9 @@ entities:
     grain: Ceph ceph daemon and dpdk port
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - dpdk_port
+        - dpdk_port
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -226,9 +227,9 @@ entities:
     grain: Ceph ceph daemon and dpdk queue
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - dpdk_queue
+        - dpdk_queue
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -236,8 +237,8 @@ entities:
     grain: Ceph ceph daemon and filesystem
     identity:
       required:
-      - ceph_daemon
-      - filesystem
+        - ceph_daemon
+        - filesystem
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -246,9 +247,9 @@ entities:
     grain: Ceph ceph daemon and finisher key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - finisher_key
+        - finisher_key
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -256,9 +257,9 @@ entities:
     grain: Ceph ceph daemon and fs name and id
     identity:
       required:
-      - ceph_daemon
-      - fs_name
-      - id
+        - ceph_daemon
+        - fs_name
+        - id
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -267,8 +268,8 @@ entities:
     grain: Ceph ceph daemon and hostname
     identity:
       required:
-      - ceph_daemon
-      - hostname
+        - ceph_daemon
+        - hostname
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -277,9 +278,9 @@ entities:
     grain: Ceph ceph daemon and id and instance id
     identity:
       required:
-      - ceph_daemon
-      - id
-      - instance_id
+        - ceph_daemon
+        - id
+        - instance_id
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -288,10 +289,10 @@ entities:
     grain: Ceph ceph daemon and image and namespace and pool
     identity:
       required:
-      - ceph_daemon
-      - image
-      - namespace
-      - pool
+        - ceph_daemon
+        - image
+        - namespace
+        - pool
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -302,8 +303,8 @@ entities:
       required: []
       optional: []
       alternatives:
-      - - ceph_daemon
-      - - instance_id
+        - - ceph_daemon
+        - - instance_id
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -311,9 +312,9 @@ entities:
     grain: Ceph ceph daemon and kernel device key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - kernel_device_key
+        - kernel_device_key
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -321,9 +322,9 @@ entities:
     grain: Ceph ceph daemon and level and pooltype
     identity:
       required:
-      - ceph_daemon
-      - level
-      - pooltype
+        - ceph_daemon
+        - level
+        - pooltype
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -332,9 +333,9 @@ entities:
     grain: Ceph ceph daemon and librbd image key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - librbd_image_key
+        - librbd_image_key
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -342,9 +343,9 @@ entities:
     grain: Ceph ceph daemon and librbd pwl key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - librbd_pwl_key
+        - librbd_pwl_key
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -352,9 +353,9 @@ entities:
     grain: Ceph ceph daemon and mclock shard
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - mclock_shard
+        - mclock_shard
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -362,9 +363,9 @@ entities:
     grain: Ceph ceph daemon and messenger worker
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - messenger_worker
+        - messenger_worker
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -372,9 +373,9 @@ entities:
     grain: Ceph ceph daemon and objectcacher key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - objectcacher_key
+        - objectcacher_key
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -382,11 +383,11 @@ entities:
     grain: Ceph ceph daemon and peer cluster filesystem and peer cluster name and source filesystem and source fscid
     identity:
       required:
-      - ceph_daemon
-      - peer_cluster_filesystem
-      - peer_cluster_name
-      - source_filesystem
-      - source_fscid
+        - ceph_daemon
+        - peer_cluster_filesystem
+        - peer_cluster_name
+        - source_filesystem
+        - source_fscid
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -395,9 +396,9 @@ entities:
     grain: Ceph ceph daemon and rdma worker
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - rdma_worker
+        - rdma_worker
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -405,9 +406,9 @@ entities:
     grain: Ceph ceph daemon and rocksdb cache key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - rocksdb_cache_key
+        - rocksdb_cache_key
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -415,9 +416,9 @@ entities:
     grain: Ceph ceph daemon and service unique id
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - service_unique_id
+        - service_unique_id
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -425,9 +426,9 @@ entities:
     grain: Ceph ceph daemon and throttle key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - throttle_key
+        - throttle_key
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -435,8 +436,8 @@ entities:
     grain: Ceph ceph daemon and type
     identity:
       required:
-      - ceph_daemon
-      - type
+        - ceph_daemon
+        - type
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -445,10 +446,10 @@ entities:
     grain: Ceph ceph instance and gw name and host nqn and nqn
     identity:
       required:
-      - ceph_instance
-      - gw_name
-      - host_nqn
-      - nqn
+        - ceph_instance
+        - gw_name
+        - host_nqn
+        - nqn
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -457,9 +458,9 @@ entities:
     grain: Ceph ceph instance and mode and name
     identity:
       required:
-      - ceph_instance
-      - mode
-      - name
+        - ceph_instance
+        - mode
+        - name
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -468,8 +469,8 @@ entities:
     grain: Ceph ceph instance and nqn
     identity:
       required:
-      - ceph_instance
-      - nqn
+        - ceph_instance
+        - nqn
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -478,10 +479,10 @@ entities:
     grain: Ceph daemon name and hostname and service name and service type
     identity:
       required:
-      - daemon_name
-      - hostname
-      - service_name
-      - service_type
+        - daemon_name
+        - hostname
+        - service_name
+        - service_type
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -490,10 +491,10 @@ entities:
     grain: Ceph data pools and fs id and metadata pool and name
     identity:
       required:
-      - data_pools
-      - fs_id
-      - metadata_pool
-      - name
+        - data_pools
+        - fs_id
+        - metadata_pool
+        - name
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -502,7 +503,7 @@ entities:
     grain: Ceph device
     identity:
       required:
-      - device
+        - device
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -511,7 +512,7 @@ entities:
     grain: Ceph device class
     identity:
       required:
-      - device_class
+        - device_class
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -520,8 +521,8 @@ entities:
     grain: Ceph function and host
     identity:
       required:
-      - function
-      - host
+        - function
+        - host
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -530,10 +531,10 @@ entities:
     grain: Ceph gw name and host addr and host nqn and nqn
     identity:
       required:
-      - gw_name
-      - host_addr
-      - host_nqn
-      - nqn
+        - gw_name
+        - host_addr
+        - host_nqn
+        - nqn
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -542,9 +543,9 @@ entities:
     grain: Ceph image and namespace and pool
     identity:
       required:
-      - image
-      - namespace
-      - pool
+        - image
+        - namespace
+        - pool
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -553,8 +554,8 @@ entities:
     grain: Ceph image name and pool id
     identity:
       required:
-      - image_name
-      - pool_id
+        - image_name
+        - pool_id
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -563,7 +564,7 @@ entities:
     grain: Ceph instance id
     identity:
       required:
-      - instance_id
+        - instance_id
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -572,9 +573,9 @@ entities:
     grain: Ceph instance id and source zone
     identity:
       required:
-      - instance_id
+        - instance_id
       optional:
-      - source_zone
+        - source_zone
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -582,7 +583,7 @@ entities:
     grain: Ceph method
     identity:
       required:
-      - method
+        - method
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -591,7 +592,7 @@ entities:
     grain: Ceph name
     identity:
       required:
-      - name
+        - name
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -600,8 +601,8 @@ entities:
     grain: Ceph name and severity
     identity:
       required:
-      - name
-      - severity
+        - name
+        - severity
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -610,12 +611,12 @@ entities:
     grain: Ceph netbiosname and share and smb version and subvolume and subvolume group and volume
     identity:
       required:
-      - netbiosname
-      - share
-      - smb_version
-      - subvolume
-      - subvolume_group
-      - volume
+        - netbiosname
+        - share
+        - smb_version
+        - subvolume
+        - subvolume_group
+        - volume
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -624,7 +625,7 @@ entities:
     grain: Ceph nqn
     identity:
       required:
-      - nqn
+        - nqn
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -633,7 +634,7 @@ entities:
     grain: Ceph pool id
     identity:
       required:
-      - pool_id
+        - pool_id
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -643,7 +644,7 @@ entities:
     identity:
       required: []
       optional:
-      - throttle_key
+        - throttle_key
   cluster:
     grain: Ceph cluster endpoint
     identity:
@@ -670,9 +671,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_dpdk_port
+        - label_dpdk_port
     evidence:
-    - normalization_dpdk_port_identity
+      - normalization_dpdk_port_identity
   dpdk_queue_identity:
     kind: embedded_identity_extract
     registry_grammar: dpdk_queue
@@ -686,9 +687,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_dpdk_queue
+        - label_dpdk_queue
     evidence:
-    - normalization_dpdk_queue_identity
+      - normalization_dpdk_queue_identity
   finisher_identity:
     kind: embedded_identity_extract
     registry_grammar: finisher
@@ -702,9 +703,9 @@ normalizations:
         kind: bounded_configuration
       stability: restart_stable
       evidence:
-      - label_finisher_key
+        - label_finisher_key
     evidence:
-    - normalization_finisher_identity
+      - normalization_finisher_identity
   kernel_device_identity:
     kind: embedded_identity_extract
     registry_grammar: kernel_device
@@ -718,9 +719,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_kernel_device_key
+        - label_kernel_device_key
     evidence:
-    - normalization_kernel_device_identity
+      - normalization_kernel_device_identity
   librbd_image_identity:
     kind: embedded_identity_extract
     registry_grammar: librbd_image
@@ -734,9 +735,9 @@ normalizations:
         kind: operational_population
       stability: stable
       evidence:
-      - label_librbd_image_key
+        - label_librbd_image_key
     evidence:
-    - normalization_librbd_image_identity
+      - normalization_librbd_image_identity
   librbd_pwl_identity:
     kind: embedded_identity_extract
     registry_grammar: librbd_pwl
@@ -750,9 +751,9 @@ normalizations:
         kind: operational_population
       stability: stable
       evidence:
-      - label_librbd_pwl_key
+        - label_librbd_pwl_key
     evidence:
-    - normalization_librbd_pwl_identity
+      - normalization_librbd_pwl_identity
   mclock_shard_identity:
     kind: embedded_identity_extract
     registry_grammar: mclock_shard
@@ -766,9 +767,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_mclock_shard
+        - label_mclock_shard
     evidence:
-    - normalization_mclock_shard_identity
+      - normalization_mclock_shard_identity
   mds_client_identity:
     kind: embedded_identity_extract
     registry_grammar: mds_client
@@ -782,9 +783,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_mds_filesystem_key
+        - label_mds_filesystem_key
     evidence:
-    - normalization_mds_client_identity
+      - normalization_mds_client_identity
   messenger_worker_identity:
     kind: embedded_identity_extract
     registry_grammar: messenger_worker
@@ -798,9 +799,9 @@ normalizations:
         kind: bounded_configuration
       stability: restart_stable
       evidence:
-      - label_messenger_worker
+        - label_messenger_worker
     evidence:
-    - normalization_messenger_worker_identity
+      - normalization_messenger_worker_identity
   objectcacher_identity:
     kind: embedded_identity_extract
     registry_grammar: objectcacher
@@ -814,9 +815,9 @@ normalizations:
         kind: operational_population
       stability: restart_stable
       evidence:
-      - label_objectcacher_key
+        - label_objectcacher_key
     evidence:
-    - normalization_objectcacher_identity
+      - normalization_objectcacher_identity
   objecter_identity:
     kind: embedded_identity_extract
     registry_grammar: objecter
@@ -830,9 +831,9 @@ normalizations:
         kind: operational_population
       stability: dynamic
       evidence:
-      - label_objecter_handle
+        - label_objecter_handle
     evidence:
-    - normalization_objecter_identity
+      - normalization_objecter_identity
   rdma_worker_identity:
     kind: embedded_identity_extract
     registry_grammar: rdma_worker
@@ -846,9 +847,9 @@ normalizations:
         kind: bounded_configuration
       stability: restart_stable
       evidence:
-      - label_rdma_worker
+        - label_rdma_worker
     evidence:
-    - normalization_rdma_worker_identity
+      - normalization_rdma_worker_identity
   rgw_sync_identity:
     kind: embedded_identity_repair
     registry_grammar: rgw_sync
@@ -861,8 +862,8 @@ normalizations:
       capture: source_zone_fragment
     identity:
       operands:
-      - source_zone_fragment
-      - source_zone
+        - source_zone_fragment
+        - source_zone
       separator: _
       blank: omit_operand_and_separator
       sanitizer: prometheus_label_value
@@ -870,16 +871,16 @@ normalizations:
       when_identity_label: absent
       outcome: drop_before_writer
       evidence:
-      - rgw_sync_duplicate
+        - rgw_sync_duplicate
     output:
       meaning: Sanitized remote RGW source-zone identity reconstructed from the source family and label.
       endpoint_cardinality:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_rgw_sync_source_zone
+        - label_rgw_sync_source_zone
     evidence:
-    - normalization_rgw_sync_identity
+      - normalization_rgw_sync_identity
   rocksdb_cache_identity:
     kind: embedded_identity_extract
     registry_grammar: rocksdb_cache
@@ -893,9 +894,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_rocksdb_cache_key
+        - label_rocksdb_cache_key
     evidence:
-    - normalization_rocksdb_cache_identity
+      - normalization_rocksdb_cache_identity
   service_unique_id_identity:
     kind: embedded_identity_extract
     registry_grammar: service_unique_id
@@ -909,9 +910,9 @@ normalizations:
         kind: operational_population
       stability: restart_stable
       evidence:
-      - label_service_unique_id
+        - label_service_unique_id
     evidence:
-    - normalization_service_unique_id_identity
+      - normalization_service_unique_id_identity
   throttle_identity:
     kind: embedded_identity_extract
     registry_grammar: throttle
@@ -925,363 +926,363 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_throttle_key
+        - label_throttle_key
     evidence:
-    - normalization_throttle_identity
+      - normalization_throttle_identity
 exclusions: {}
 limitations:
   objecter.accumulated_latency#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.byte_throughput#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.commands#command_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.commands#command_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.latency_measurements#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.lingering_operations#linger_ping:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.lingering_operations#linger_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.lingering_operations#linger_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.maps#map_full:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.maps#map_inc:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operation_vector_entries#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#omap_del:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#omap_rd:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#omap_wr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_pg:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_r:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_reply:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_rmw:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_w:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_append:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_call:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_clonerange:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_cmpxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_create:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_delete:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_getxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_mapext:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_notify:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_other:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_pgls:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_pgls_filter:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_read:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_resetxattrs:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_rmxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_setxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_sparse_read:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_src_cmpxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_stat:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_truncate:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_watch:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_write:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_writefull:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_writesame:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_zero:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.osd_sessions#osd_session_close:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.osd_sessions#osd_session_open:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.pool_operations#poolop_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.pool_operations#poolop_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.replica_reads#replica_read_bounced:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: tentacle_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.replica_reads#replica_read_completed:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: tentacle_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.replica_reads#replica_read_sent:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: tentacle_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.stat_requests#poolstat_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.stat_requests#poolstat_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.stat_requests#statfs_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.stat_requests#statfs_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.submitted_operations#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
 views:
@@ -1293,15 +1294,15 @@ views:
       db_alloc_lat:
         signal: bluefs_db_alloc_lat_sum
         components:
-        - value
+          - value
       slow_alloc_lat:
         signal: bluefs_slow_alloc_lat_sum
         components:
-        - value
+          - value
       wal_alloc_lat:
         signal: bluefs_wal_alloc_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1314,15 +1315,15 @@ views:
       db:
         signal: bluefs_alloc_unit_db
         components:
-        - value
+          - value
       slow:
         signal: bluefs_alloc_unit_slow
         components:
-        - value
+          - value
       wal:
         signal: bluefs_alloc_unit_wal
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1335,15 +1336,15 @@ views:
       db_max_lat:
         signal: bluefs_alloc_db_max_lat
         components:
-        - value
+          - value
       slow_max_lat:
         signal: bluefs_alloc_slow_max_lat
         components:
-        - value
+          - value
       wal_max_lat:
         signal: bluefs_alloc_wal_max_lat
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1356,11 +1357,11 @@ views:
       fallback:
         signal: bluefs_alloc_slow_fallback
         components:
-        - value
+          - value
       size_fallback:
         signal: bluefs_alloc_slow_size_fallback
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1373,15 +1374,15 @@ views:
       db_alloc_lat:
         signal: bluefs_db_alloc_lat_count
         components:
-        - value
+          - value
       slow_alloc_lat:
         signal: bluefs_slow_alloc_lat_count
         components:
-        - value
+          - value
       wal_alloc_lat:
         signal: bluefs_wal_alloc_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1394,11 +1395,11 @@ views:
       lat:
         signal: bluefs_compact_lat_sum
         components:
-        - value
+          - value
       lock_lat:
         signal: bluefs_compact_lock_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1411,7 +1412,7 @@ views:
       value:
         signal: bluefs_log_compactions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1424,11 +1425,11 @@ views:
       lat:
         signal: bluefs_compact_lat_count
         components:
-        - value
+          - value
       lock_lat:
         signal: bluefs_compact_lock_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1441,27 +1442,27 @@ views:
       flush_lat:
         signal: bluefs_flush_lat_sum
         components:
-        - value
+          - value
       fsync_lat:
         signal: bluefs_fsync_lat_sum
         components:
-        - value
+          - value
       read_lat:
         signal: bluefs_read_lat_sum
         components:
-        - value
+          - value
       read_random_lat:
         signal: bluefs_read_random_lat_sum
         components:
-        - value
+          - value
       truncate_lat:
         signal: bluefs_truncate_lat_sum
         components:
-        - value
+          - value
       unlink_lat:
         signal: bluefs_unlink_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1474,55 +1475,55 @@ views:
       read_bytes:
         signal: bluefs_read_bytes
         components:
-        - value
+          - value
       read_disk_bytes:
         signal: bluefs_read_disk_bytes
         components:
-        - value
+          - value
       read_disk_bytes_db:
         signal: bluefs_read_disk_bytes_db
         components:
-        - value
+          - value
       read_disk_bytes_slow:
         signal: bluefs_read_disk_bytes_slow
         components:
-        - value
+          - value
       read_disk_bytes_wal:
         signal: bluefs_read_disk_bytes_wal
         components:
-        - value
+          - value
       read_prefetch_bytes:
         signal: bluefs_read_prefetch_bytes
         components:
-        - value
+          - value
       read_random_buffer_bytes:
         signal: bluefs_read_random_buffer_bytes
         components:
-        - value
+          - value
       read_random_bytes:
         signal: bluefs_read_random_bytes
         components:
-        - value
+          - value
       read_random_disk_bytes:
         signal: bluefs_read_random_disk_bytes
         components:
-        - value
+          - value
       read_random_disk_bytes_db:
         signal: bluefs_read_random_disk_bytes_db
         components:
-        - value
+          - value
       read_random_disk_bytes_slow:
         signal: bluefs_read_random_disk_bytes_slow
         components:
-        - value
+          - value
       read_random_disk_bytes_wal:
         signal: bluefs_read_random_disk_bytes_wal
         components:
-        - value
+          - value
       write_bytes:
         signal: bluefs_write_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1535,27 +1536,27 @@ views:
       flush_lat:
         signal: bluefs_flush_lat_count
         components:
-        - value
+          - value
       fsync_lat:
         signal: bluefs_fsync_lat_count
         components:
-        - value
+          - value
       read_lat:
         signal: bluefs_read_lat_count
         components:
-        - value
+          - value
       read_random_lat:
         signal: bluefs_read_random_lat_count
         components:
-        - value
+          - value
       truncate_lat:
         signal: bluefs_truncate_lat_count
         components:
-        - value
+          - value
       unlink_lat:
         signal: bluefs_unlink_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1568,47 +1569,47 @@ views:
       log_write:
         signal: bluefs_log_write_count
         components:
-        - value
+          - value
       read:
         signal: bluefs_read_count
         components:
-        - value
+          - value
       read_disk:
         signal: bluefs_read_disk_count
         components:
-        - value
+          - value
       read_prefetch:
         signal: bluefs_read_prefetch_count
         components:
-        - value
+          - value
       read_random_buffer:
         signal: bluefs_read_random_buffer_count
         components:
-        - value
+          - value
       read_random:
         signal: bluefs_read_random_count
         components:
-        - value
+          - value
       read_random_disk:
         signal: bluefs_read_random_disk_count
         components:
-        - value
+          - value
       write:
         signal: bluefs_write_count
         components:
-        - value
+          - value
       write_count_sst:
         signal: bluefs_write_count_sst
         components:
-        - value
+          - value
       write_count_wal:
         signal: bluefs_write_count_wal
         components:
-        - value
+          - value
       write_disk:
         signal: bluefs_write_disk_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1621,11 +1622,11 @@ views:
       candidate:
         signal: bluefs_read_zeros_candidate
         components:
-        - value
+          - value
       errors:
         signal: bluefs_read_zeros_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1638,15 +1639,15 @@ views:
       db:
         signal: bluefs_max_bytes_db
         components:
-        - value
+          - value
       slow:
         signal: bluefs_max_bytes_slow
         components:
-        - value
+          - value
       wal:
         signal: bluefs_max_bytes_wal
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1659,19 +1660,19 @@ views:
       bytes_written_slow:
         signal: bluefs_bytes_written_slow
         components:
-        - value
+          - value
       bytes_written_sst:
         signal: bluefs_bytes_written_sst
         components:
-        - value
+          - value
       bytes_written_wal:
         signal: bluefs_bytes_written_wal
         components:
-        - value
+          - value
       logged_bytes:
         signal: bluefs_logged_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1684,7 +1685,7 @@ views:
       value:
         signal: bluefs_num_files
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1697,11 +1698,11 @@ views:
       sst:
         signal: bluefs_files_written_sst
         components:
-        - value
+          - value
       wal:
         signal: bluefs_files_written_wal
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1714,31 +1715,31 @@ views:
       db_total_bytes:
         signal: bluefs_db_total_bytes
         components:
-        - value
+          - value
       db_used_bytes:
         signal: bluefs_db_used_bytes
         components:
-        - value
+          - value
       log_bytes:
         signal: bluefs_log_bytes
         components:
-        - value
+          - value
       slow_total_bytes:
         signal: bluefs_slow_total_bytes
         components:
-        - value
+          - value
       slow_used_bytes:
         signal: bluefs_slow_used_bytes
         components:
-        - value
+          - value
       wal_total_bytes:
         signal: bluefs_wal_total_bytes
         components:
-        - value
+          - value
       wal_used_bytes:
         signal: bluefs_wal_used_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1751,7 +1752,7 @@ views:
       value:
         signal: bluestore_allocator_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1764,7 +1765,7 @@ views:
       allocated:
         signal: bluestore_allocated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1777,7 +1778,7 @@ views:
       alloc_unit:
         signal: bluestore_alloc_unit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1790,7 +1791,7 @@ views:
       value:
         signal: bluestore_allocator_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1803,15 +1804,15 @@ views:
       compress_lat:
         signal: bluestore_compress_lat_sum
         components:
-        - value
+          - value
       csum_lat:
         signal: bluestore_csum_lat_sum
         components:
-        - value
+          - value
       decompress_lat:
         signal: bluestore_decompress_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1824,7 +1825,7 @@ views:
       extent_compress:
         signal: bluestore_extent_compress
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1837,11 +1838,11 @@ views:
       compress_rejected:
         signal: bluestore_compress_rejected_count
         components:
-        - value
+          - value
       compress_success:
         signal: bluestore_compress_success_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1854,15 +1855,15 @@ views:
       compress_lat:
         signal: bluestore_compress_lat_count
         components:
-        - value
+          - value
       csum_lat:
         signal: bluestore_csum_lat_count
         components:
-        - value
+          - value
       decompress_lat:
         signal: bluestore_decompress_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1875,15 +1876,15 @@ views:
       compressed:
         signal: bluestore_compressed
         components:
-        - value
+          - value
       allocated:
         signal: bluestore_compressed_allocated
         components:
-        - value
+          - value
       original:
         signal: bluestore_compressed_original
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1896,27 +1897,27 @@ views:
       read_lat:
         signal: bluestore_read_lat_sum
         components:
-        - value
+          - value
       read_onode_meta_lat:
         signal: bluestore_read_onode_meta_lat_sum
         components:
-        - value
+          - value
       read_wait_aio_lat:
         signal: bluestore_read_wait_aio_lat_sum
         components:
-        - value
+          - value
       remove_lat:
         signal: bluestore_remove_lat_sum
         components:
-        - value
+          - value
       truncate_lat:
         signal: bluestore_truncate_lat_sum
         components:
-        - value
+          - value
       write_lat:
         signal: bluestore_write_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1929,31 +1930,31 @@ views:
       issued_deferred_write_bytes:
         signal: bluestore_issued_deferred_write_bytes
         components:
-        - value
+          - value
       submitted_deferred_write_bytes:
         signal: bluestore_submitted_deferred_write_bytes
         components:
-        - value
+          - value
       write_big_bytes:
         signal: bluestore_write_big_bytes
         components:
-        - value
+          - value
       write_big_skipped_bytes:
         signal: bluestore_write_big_skipped_bytes
         components:
-        - value
+          - value
       write_pad_bytes:
         signal: bluestore_write_pad_bytes
         components:
-        - value
+          - value
       write_small_bytes:
         signal: bluestore_write_small_bytes
         components:
-        - value
+          - value
       write_small_skipped_bytes:
         signal: bluestore_write_small_skipped_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1966,27 +1967,27 @@ views:
       read_lat:
         signal: bluestore_read_lat_count
         components:
-        - value
+          - value
       read_onode_meta_lat:
         signal: bluestore_read_onode_meta_lat_count
         components:
-        - value
+          - value
       read_wait_aio_lat:
         signal: bluestore_read_wait_aio_lat_count
         components:
-        - value
+          - value
       remove_lat:
         signal: bluestore_remove_lat_count
         components:
-        - value
+          - value
       truncate_lat:
         signal: bluestore_truncate_lat_count
         components:
-        - value
+          - value
       write_lat:
         signal: bluestore_write_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1999,7 +2000,7 @@ views:
       write_penalty_read_ops:
         signal: bluestore_write_penalty_read_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2012,11 +2013,11 @@ views:
       read_eio:
         signal: bluestore_read_eio
         components:
-        - value
+          - value
       reads_with_retries:
         signal: bluestore_reads_with_retries
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2029,7 +2030,7 @@ views:
       write_big_skipped_blobs:
         signal: bluestore_write_big_skipped_blobs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2042,7 +2043,7 @@ views:
       write_small_skipped:
         signal: bluestore_write_small_skipped
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2055,7 +2056,7 @@ views:
       slow_aio_wait:
         signal: bluestore_slow_aio_wait_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2068,11 +2069,11 @@ views:
       slow_read_onode_meta:
         signal: bluestore_slow_read_onode_meta_count
         components:
-        - value
+          - value
       slow_read_wait_aio:
         signal: bluestore_slow_read_wait_aio_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2085,35 +2086,35 @@ views:
       issued_deferred_writes:
         signal: bluestore_issued_deferred_writes
         components:
-        - value
+          - value
       submitted_deferred_writes:
         signal: bluestore_submitted_deferred_writes
         components:
-        - value
+          - value
       write_big:
         signal: bluestore_write_big
         components:
-        - value
+          - value
       write_big_deferred:
         signal: bluestore_write_big_deferred
         components:
-        - value
+          - value
       write_new:
         signal: bluestore_write_new
         components:
-        - value
+          - value
       write_small:
         signal: bluestore_write_small
         components:
-        - value
+          - value
       write_small_pre_read:
         signal: bluestore_write_small_pre_read
         components:
-        - value
+          - value
       write_small_unused:
         signal: bluestore_write_small_unused
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2126,7 +2127,7 @@ views:
       write_big_blobs:
         signal: bluestore_write_big_blobs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2139,31 +2140,31 @@ views:
       clear_lat:
         signal: bluestore_omap_clear_lat_sum
         components:
-        - value
+          - value
       get_keys_lat:
         signal: bluestore_omap_get_keys_lat_sum
         components:
-        - value
+          - value
       get_values_lat:
         signal: bluestore_omap_get_values_lat_sum
         components:
-        - value
+          - value
       lower_bound_lat:
         signal: bluestore_omap_lower_bound_lat_sum
         components:
-        - value
+          - value
       next_lat:
         signal: bluestore_omap_next_lat_sum
         components:
-        - value
+          - value
       seek_to_first_lat:
         signal: bluestore_omap_seek_to_first_lat_sum
         components:
-        - value
+          - value
       upper_bound_lat:
         signal: bluestore_omap_upper_bound_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2176,11 +2177,11 @@ views:
       setheader_bytes:
         signal: bluestore_omap_setheader_bytes
         components:
-        - value
+          - value
       setkeys_bytes:
         signal: bluestore_omap_setkeys_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2193,11 +2194,11 @@ views:
       rmkeys:
         signal: bluestore_omap_rmkeys_count
         components:
-        - value
+          - value
       setkeys_records:
         signal: bluestore_omap_setkeys_records
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2210,31 +2211,31 @@ views:
       clear_lat:
         signal: bluestore_omap_clear_lat_count
         components:
-        - value
+          - value
       get_keys_lat:
         signal: bluestore_omap_get_keys_lat_count
         components:
-        - value
+          - value
       get_values_lat:
         signal: bluestore_omap_get_values_lat_count
         components:
-        - value
+          - value
       lower_bound_lat:
         signal: bluestore_omap_lower_bound_lat_count
         components:
-        - value
+          - value
       next_lat:
         signal: bluestore_omap_next_lat_count
         components:
-        - value
+          - value
       seek_to_first_lat:
         signal: bluestore_omap_seek_to_first_lat_count
         components:
-        - value
+          - value
       upper_bound_lat:
         signal: bluestore_omap_upper_bound_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2247,11 +2248,11 @@ views:
       setheader:
         signal: bluestore_omap_setheader_count
         components:
-        - value
+          - value
       setkeys:
         signal: bluestore_omap_setkeys_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2264,7 +2265,7 @@ views:
       iterator:
         signal: bluestore_omap_iterator_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2277,7 +2278,7 @@ views:
       rmkey_range:
         signal: bluestore_omap_rmkey_range_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2290,11 +2291,11 @@ views:
       onode_blobs:
         signal: bluestore_onode_blobs
         components:
-        - value
+          - value
       onode_spanning_blobs:
         signal: bluestore_onode_spanning_blobs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2307,7 +2308,7 @@ views:
       value:
         signal: bluestore_onode_reshard
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2320,7 +2321,7 @@ views:
       onode_extents:
         signal: bluestore_onode_extents
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2333,11 +2334,11 @@ views:
       hits:
         signal: bluestore_onode_hits
         components:
-        - value
+          - value
       misses:
         signal: bluestore_onode_misses
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2350,11 +2351,11 @@ views:
       onodes:
         signal: bluestore_onodes
         components:
-        - value
+          - value
       onodes_pinned:
         signal: bluestore_onodes_pinned
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2367,11 +2368,11 @@ views:
       shard_hits:
         signal: bluestore_onode_shard_hits
         components:
-        - value
+          - value
       shard_misses:
         signal: bluestore_onode_shard_misses
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2384,59 +2385,59 @@ views:
       committed_bytes:
         signal: bluestore_pricache_data_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: bluestore_pricache_data_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: bluestore_pricache_data_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: bluestore_pricache_data_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: bluestore_pricache_data_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: bluestore_pricache_data_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: bluestore_pricache_data_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: bluestore_pricache_data_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: bluestore_pricache_data_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: bluestore_pricache_data_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: bluestore_pricache_data_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: bluestore_pricache_data_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: bluestore_pricache_data_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: bluestore_pricache_data_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2449,59 +2450,59 @@ views:
       committed_bytes:
         signal: bluestore_pricache_kv_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: bluestore_pricache_kv_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: bluestore_pricache_kv_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: bluestore_pricache_kv_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: bluestore_pricache_kv_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: bluestore_pricache_kv_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: bluestore_pricache_kv_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: bluestore_pricache_kv_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: bluestore_pricache_kv_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: bluestore_pricache_kv_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: bluestore_pricache_kv_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: bluestore_pricache_kv_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: bluestore_pricache_kv_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: bluestore_pricache_kv_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2514,59 +2515,59 @@ views:
       committed_bytes:
         signal: bluestore_pricache_kv_onode_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: bluestore_pricache_kv_onode_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: bluestore_pricache_kv_onode_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: bluestore_pricache_kv_onode_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: bluestore_pricache_kv_onode_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: bluestore_pricache_kv_onode_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: bluestore_pricache_kv_onode_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: bluestore_pricache_kv_onode_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: bluestore_pricache_kv_onode_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: bluestore_pricache_kv_onode_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: bluestore_pricache_kv_onode_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: bluestore_pricache_kv_onode_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: bluestore_pricache_kv_onode_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: bluestore_pricache_kv_onode_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2579,59 +2580,59 @@ views:
       committed_bytes:
         signal: bluestore_pricache_meta_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: bluestore_pricache_meta_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: bluestore_pricache_meta_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: bluestore_pricache_meta_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: bluestore_pricache_meta_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: bluestore_pricache_meta_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: bluestore_pricache_meta_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: bluestore_pricache_meta_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: bluestore_pricache_meta_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: bluestore_pricache_meta_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: bluestore_pricache_meta_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: bluestore_pricache_meta_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: bluestore_pricache_meta_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: bluestore_pricache_meta_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2644,23 +2645,23 @@ views:
       cache_bytes:
         signal: bluestore_pricache_cache_bytes
         components:
-        - value
+          - value
       heap_bytes:
         signal: bluestore_pricache_heap_bytes
         components:
-        - value
+          - value
       mapped_bytes:
         signal: bluestore_pricache_mapped_bytes
         components:
-        - value
+          - value
       target_bytes:
         signal: bluestore_pricache_target_bytes
         components:
-        - value
+          - value
       unmapped_bytes:
         signal: bluestore_pricache_unmapped_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2673,23 +2674,23 @@ views:
       clist_lat:
         signal: bluestore_clist_lat_sum
         components:
-        - value
+          - value
       kv_commit_lat:
         signal: bluestore_kv_commit_lat_sum
         components:
-        - value
+          - value
       kv_final_lat:
         signal: bluestore_kv_final_lat_sum
         components:
-        - value
+          - value
       kv_flush_lat:
         signal: bluestore_kv_flush_lat_sum
         components:
-        - value
+          - value
       kv_sync_lat:
         signal: bluestore_kv_sync_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2702,7 +2703,7 @@ views:
       blob_split:
         signal: bluestore_blob_split
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2715,7 +2716,7 @@ views:
       buffer_bytes:
         signal: bluestore_buffer_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2728,11 +2729,11 @@ views:
       hit_bytes:
         signal: bluestore_buffer_hit_bytes
         components:
-        - value
+          - value
       miss_bytes:
         signal: bluestore_buffer_miss_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2745,7 +2746,7 @@ views:
       value:
         signal: bluestore_buffers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2758,7 +2759,7 @@ views:
       value:
         signal: bluestore_slow_committed_kv_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2771,7 +2772,7 @@ views:
       value:
         signal: bluestore_fragmentation_micros
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2780,7 +2781,7 @@ views:
       convention: per_mille
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   bluestore.space_and_core_state.gc_merge_throughput:
     family: Ceph/BlueStore/Space and Core State
     question: What is the garbage-collection merge throughput for each ceph daemon?
@@ -2789,7 +2790,7 @@ views:
       gc_merged:
         signal: bluestore_gc_merged
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2802,23 +2803,23 @@ views:
       clist_lat:
         signal: bluestore_clist_lat_count
         components:
-        - value
+          - value
       kv_commit_lat:
         signal: bluestore_kv_commit_lat_count
         components:
-        - value
+          - value
       kv_final_lat:
         signal: bluestore_kv_final_lat_count
         components:
-        - value
+          - value
       kv_flush_lat:
         signal: bluestore_kv_flush_lat_count
         components:
-        - value
+          - value
       kv_sync_lat:
         signal: bluestore_kv_sync_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2831,7 +2832,7 @@ views:
       stored:
         signal: bluestore_stored
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2844,59 +2845,59 @@ views:
       state_aio_wait_lat:
         signal: bluestore_state_aio_wait_lat_sum
         components:
-        - value
+          - value
       state_deferred_aio_wait_lat:
         signal: bluestore_state_deferred_aio_wait_lat_sum
         components:
-        - value
+          - value
       state_deferred_cleanup_lat:
         signal: bluestore_state_deferred_cleanup_lat_sum
         components:
-        - value
+          - value
       state_deferred_queued_lat:
         signal: bluestore_state_deferred_queued_lat_sum
         components:
-        - value
+          - value
       state_done_lat:
         signal: bluestore_state_done_lat_sum
         components:
-        - value
+          - value
       state_finishing_lat:
         signal: bluestore_state_finishing_lat_sum
         components:
-        - value
+          - value
       state_io_done_lat:
         signal: bluestore_state_io_done_lat_sum
         components:
-        - value
+          - value
       state_kv_commiting_lat:
         signal: bluestore_state_kv_commiting_lat_sum
         components:
-        - value
+          - value
       state_kv_done_lat:
         signal: bluestore_state_kv_done_lat_sum
         components:
-        - value
+          - value
       state_kv_queued_lat:
         signal: bluestore_state_kv_queued_lat_sum
         components:
-        - value
+          - value
       state_prepare_lat:
         signal: bluestore_state_prepare_lat_sum
         components:
-        - value
+          - value
       txc_commit_lat:
         signal: bluestore_txc_commit_lat_sum
         components:
-        - value
+          - value
       txc_submit_lat:
         signal: bluestore_txc_submit_lat_sum
         components:
-        - value
+          - value
       txc_throttle_lat:
         signal: bluestore_txc_throttle_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2909,59 +2910,59 @@ views:
       state_aio_wait_lat:
         signal: bluestore_state_aio_wait_lat_count
         components:
-        - value
+          - value
       state_deferred_aio_wait_lat:
         signal: bluestore_state_deferred_aio_wait_lat_count
         components:
-        - value
+          - value
       state_deferred_cleanup_lat:
         signal: bluestore_state_deferred_cleanup_lat_count
         components:
-        - value
+          - value
       state_deferred_queued_lat:
         signal: bluestore_state_deferred_queued_lat_count
         components:
-        - value
+          - value
       state_done_lat:
         signal: bluestore_state_done_lat_count
         components:
-        - value
+          - value
       state_finishing_lat:
         signal: bluestore_state_finishing_lat_count
         components:
-        - value
+          - value
       state_io_done_lat:
         signal: bluestore_state_io_done_lat_count
         components:
-        - value
+          - value
       state_kv_commiting_lat:
         signal: bluestore_state_kv_commiting_lat_count
         components:
-        - value
+          - value
       state_kv_done_lat:
         signal: bluestore_state_kv_done_lat_count
         components:
-        - value
+          - value
       state_kv_queued_lat:
         signal: bluestore_state_kv_queued_lat_count
         components:
-        - value
+          - value
       state_prepare_lat:
         signal: bluestore_state_prepare_lat_count
         components:
-        - value
+          - value
       txc_commit_lat:
         signal: bluestore_txc_commit_lat_count
         components:
-        - value
+          - value
       txc_submit_lat:
         signal: bluestore_txc_submit_lat_count
         components:
-        - value
+          - value
       txc_throttle_lat:
         signal: bluestore_txc_throttle_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2974,7 +2975,7 @@ views:
       value:
         signal: bluestore_txc_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2987,15 +2988,15 @@ views:
       degraded:
         signal: num_objects_degraded
         components:
-        - value
+          - value
       misplaced:
         signal: num_objects_misplaced
         components:
-        - value
+          - value
       unfound:
         signal: num_objects_unfound
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3008,15 +3009,15 @@ views:
       bytes:
         signal: cluster_total_bytes
         components:
-        - value
+          - value
       used_bytes:
         signal: cluster_total_used_bytes
         components:
-        - value
+          - value
       used_raw_bytes:
         signal: cluster_total_used_raw_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3029,15 +3030,15 @@ views:
       bytes:
         signal: cluster_by_class_total_bytes
         components:
-        - value
+          - value
       used_bytes:
         signal: cluster_by_class_total_used_bytes
         components:
-        - value
+          - value
       used_raw_bytes:
         signal: cluster_by_class_total_used_raw_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3050,15 +3051,15 @@ views:
       metadata:
         signal: client_mdops
         components:
-        - value
+          - value
       read:
         signal: client_rdops
         components:
-        - value
+          - value
       write:
         signal: client_wrops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3071,27 +3072,27 @@ views:
       rmxattr_latency:
         signal: mds_server_req_rmxattr_latency_sum
         components:
-        - value
+          - value
       setattr_latency:
         signal: mds_server_req_setattr_latency_sum
         components:
-        - value
+          - value
       setdirlayout_latency:
         signal: mds_server_req_setdirlayout_latency_sum
         components:
-        - value
+          - value
       setfilelock_latency:
         signal: mds_server_req_setfilelock_latency_sum
         components:
-        - value
+          - value
       setlayout_latency:
         signal: mds_server_req_setlayout_latency_sum
         components:
-        - value
+          - value
       setxattr_latency:
         signal: mds_server_req_setxattr_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3104,27 +3105,27 @@ views:
       rmxattr_latency:
         signal: mds_server_req_rmxattr_latency_count
         components:
-        - value
+          - value
       setattr_latency:
         signal: mds_server_req_setattr_latency_count
         components:
-        - value
+          - value
       setdirlayout_latency:
         signal: mds_server_req_setdirlayout_latency_count
         components:
-        - value
+          - value
       setfilelock_latency:
         signal: mds_server_req_setfilelock_latency_count
         components:
-        - value
+          - value
       setlayout_latency:
         signal: mds_server_req_setlayout_latency_count
         components:
-        - value
+          - value
       setxattr_latency:
         signal: mds_server_req_setxattr_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3137,15 +3138,15 @@ views:
       handle_client_cap_release:
         signal: mds_handle_client_cap_release
         components:
-        - value
+          - value
       handle_client_caps:
         signal: mds_handle_client_caps
         components:
-        - value
+          - value
       handle_client_caps_dirty:
         signal: mds_handle_client_caps_dirty
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3158,7 +3159,7 @@ views:
       value:
         signal: mds_caps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3171,7 +3172,7 @@ views:
       server_cap_revoke_eviction:
         signal: mds_server_cap_revoke_eviction
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3184,7 +3185,7 @@ views:
       value:
         signal: mds_inodes_with_caps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3197,7 +3198,7 @@ views:
       value:
         signal: mds_handle_inode_file_caps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3210,27 +3211,27 @@ views:
       ceph_cap_op_flush_ack:
         signal: mds_ceph_cap_op_flush_ack
         components:
-        - value
+          - value
       ceph_cap_op_flushsnap_ack:
         signal: mds_ceph_cap_op_flushsnap_ack
         components:
-        - value
+          - value
       ceph_cap_op_grant:
         signal: mds_ceph_cap_op_grant
         components:
-        - value
+          - value
       ceph_cap_op_revoke:
         signal: mds_ceph_cap_op_revoke
         components:
-        - value
+          - value
       ceph_cap_op_trunc:
         signal: mds_ceph_cap_op_trunc
         components:
-        - value
+          - value
       process_request_cap_release:
         signal: mds_process_request_cap_release
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3243,7 +3244,7 @@ views:
       server_cap_acquisition_throttle:
         signal: mds_server_cap_acquisition_throttle
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3256,7 +3257,7 @@ views:
       value:
         signal: mds_log_jlat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3269,15 +3270,15 @@ views:
       ev:
         signal: mds_log_ev
         components:
-        - value
+          - value
       evexd:
         signal: mds_log_evexd
         components:
-        - value
+          - value
       evexg:
         signal: mds_log_evexg
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3290,19 +3291,19 @@ views:
       evadd:
         signal: mds_log_evadd
         components:
-        - value
+          - value
       evex:
         signal: mds_log_evex
         components:
-        - value
+          - value
       evtrm:
         signal: mds_log_evtrm
         components:
-        - value
+          - value
       replayed:
         signal: mds_log_replayed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3315,15 +3316,15 @@ views:
       expos:
         signal: mds_log_expos
         components:
-        - value
+          - value
       rdpos:
         signal: mds_log_rdpos
         components:
-        - value
+          - value
       wrpos:
         signal: mds_log_wrpos
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3336,15 +3337,15 @@ views:
       segadd:
         signal: mds_log_segadd
         components:
-        - value
+          - value
       segex:
         signal: mds_log_segex
         components:
-        - value
+          - value
       segtrm:
         signal: mds_log_segtrm
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3357,7 +3358,7 @@ views:
       evlrg:
         signal: mds_log_evlrg
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3370,7 +3371,7 @@ views:
       value:
         signal: mds_log_jlat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3383,19 +3384,19 @@ views:
       seg:
         signal: mds_log_seg
         components:
-        - value
+          - value
       segexd:
         signal: mds_log_segexd
         components:
-        - value
+          - value
       segexg:
         signal: mds_log_segexg
         components:
-        - value
+          - value
       segmjr:
         signal: mds_log_segmjr
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3408,7 +3409,7 @@ views:
       try_discover:
         signal: mds_cache_dir_try_discover
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3421,11 +3422,11 @@ views:
       handle_discover:
         signal: mds_cache_dir_handle_discover
         components:
-        - value
+          - value
       send_discover:
         signal: mds_cache_dir_send_discover
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3438,11 +3439,11 @@ views:
       update:
         signal: mds_cache_dir_update
         components:
-        - value
+          - value
       update_receipt:
         signal: mds_cache_dir_update_receipt
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3455,11 +3456,11 @@ views:
       inodestats:
         signal: mds_cache_ireq_inodestats
         components:
-        - value
+          - value
       quiesce_inode:
         signal: mds_cache_ireq_quiesce_inode
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3472,23 +3473,23 @@ views:
       exportdir:
         signal: mds_cache_ireq_exportdir
         components:
-        - value
+          - value
       flush:
         signal: mds_cache_ireq_flush
         components:
-        - value
+          - value
       fragmentdir:
         signal: mds_cache_ireq_fragmentdir
         components:
-        - value
+          - value
       fragstats:
         signal: mds_cache_ireq_fragstats
         components:
-        - value
+          - value
       quiesce_path:
         signal: mds_cache_ireq_quiesce_path
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3501,7 +3502,7 @@ views:
       value:
         signal: mds_cache_ireq_enqueue_scrub
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3514,15 +3515,15 @@ views:
       strays:
         signal: mds_cache_num_strays
         components:
-        - value
+          - value
       delayed:
         signal: mds_cache_num_strays_delayed
         components:
-        - value
+          - value
       enqueuing:
         signal: mds_cache_num_strays_enqueuing
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3535,19 +3536,19 @@ views:
       created:
         signal: mds_cache_strays_created
         components:
-        - value
+          - value
       enqueued:
         signal: mds_cache_strays_enqueued
         components:
-        - value
+          - value
       migrated:
         signal: mds_cache_strays_migrated
         components:
-        - value
+          - value
       reintegrated:
         signal: mds_cache_strays_reintegrated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3560,15 +3561,15 @@ views:
       enqueued:
         signal: mds_cache_num_recovering_enqueued
         components:
-        - value
+          - value
       prioritized:
         signal: mds_cache_num_recovering_prioritized
         components:
-        - value
+          - value
       processing:
         signal: mds_cache_num_recovering_processing
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3581,11 +3582,11 @@ views:
       completed:
         signal: mds_cache_recovery_completed
         components:
-        - value
+          - value
       started:
         signal: mds_cache_recovery_started
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3598,11 +3599,11 @@ views:
       started:
         signal: mds_cache_uninline_started
         components:
-        - value
+          - value
       succeeded:
         signal: mds_cache_uninline_succeeded
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3615,7 +3616,7 @@ views:
       value:
         signal: mds_cache_uninline_write_failed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3628,35 +3629,35 @@ views:
       create_latency:
         signal: mds_server_req_create_latency_sum
         components:
-        - value
+          - value
       link_latency:
         signal: mds_server_req_link_latency_sum
         components:
-        - value
+          - value
       mkdir_latency:
         signal: mds_server_req_mkdir_latency_sum
         components:
-        - value
+          - value
       mknod_latency:
         signal: mds_server_req_mknod_latency_sum
         components:
-        - value
+          - value
       rename_latency:
         signal: mds_server_req_rename_latency_sum
         components:
-        - value
+          - value
       rmdir_latency:
         signal: mds_server_req_rmdir_latency_sum
         components:
-        - value
+          - value
       symlink_latency:
         signal: mds_server_req_symlink_latency_sum
         components:
-        - value
+          - value
       unlink_latency:
         signal: mds_server_req_unlink_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3669,35 +3670,35 @@ views:
       create_latency:
         signal: mds_server_req_create_latency_count
         components:
-        - value
+          - value
       link_latency:
         signal: mds_server_req_link_latency_count
         components:
-        - value
+          - value
       mkdir_latency:
         signal: mds_server_req_mkdir_latency_count
         components:
-        - value
+          - value
       mknod_latency:
         signal: mds_server_req_mknod_latency_count
         components:
-        - value
+          - value
       rename_latency:
         signal: mds_server_req_rename_latency_count
         components:
-        - value
+          - value
       rmdir_latency:
         signal: mds_server_req_rmdir_latency_count
         components:
-        - value
+          - value
       symlink_latency:
         signal: mds_server_req_symlink_latency_count
         components:
-        - value
+          - value
       unlink_latency:
         signal: mds_server_req_unlink_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3710,15 +3711,15 @@ views:
       dir_fetch_complete:
         signal: mds_dir_fetch_complete
         components:
-        - value
+          - value
       dir_merge:
         signal: mds_dir_merge
         components:
-        - value
+          - value
       dir_split:
         signal: mds_dir_split
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3731,7 +3732,7 @@ views:
       value:
         signal: mds_openino_peer_discover
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3744,7 +3745,7 @@ views:
       value:
         signal: mds_dir_fetch_keys
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3757,7 +3758,7 @@ views:
       value:
         signal: mds_traverse_hit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3770,15 +3771,15 @@ views:
       dir_commit:
         signal: mds_dir_commit
         components:
-        - value
+          - value
       openino_backtrace_fetch:
         signal: mds_openino_backtrace_fetch
         components:
-        - value
+          - value
       openino_dir_fetch:
         signal: mds_openino_dir_fetch
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3791,27 +3792,27 @@ views:
       traverse:
         signal: mds_traverse
         components:
-        - value
+          - value
       traverse_dir_fetch:
         signal: mds_traverse_dir_fetch
         components:
-        - value
+          - value
       traverse_discover:
         signal: mds_traverse_discover
         components:
-        - value
+          - value
       traverse_forward:
         signal: mds_traverse_forward
         components:
-        - value
+          - value
       traverse_lock:
         signal: mds_traverse_lock
         components:
-        - value
+          - value
       traverse_remote_ino:
         signal: mds_traverse_remote_ino
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3824,7 +3825,7 @@ views:
       value:
         signal: purge_queue_pq_item_in_journal
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3837,7 +3838,7 @@ views:
       value:
         signal: purge_queue_pq_executed_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3850,11 +3851,11 @@ views:
       ops:
         signal: purge_queue_pq_executing_ops
         components:
-        - value
+          - value
       high_water:
         signal: purge_queue_pq_executing_ops_high_water
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3867,7 +3868,7 @@ views:
       value:
         signal: purge_queue_pq_executed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3880,11 +3881,11 @@ views:
       executing:
         signal: purge_queue_pq_executing
         components:
-        - value
+          - value
       high_water:
         signal: purge_queue_pq_executing_high_water
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3897,11 +3898,11 @@ views:
       exported:
         signal: mds_exported
         components:
-        - value
+          - value
       imported:
         signal: mds_imported
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3914,11 +3915,11 @@ views:
       exported_inodes:
         signal: mds_exported_inodes
         components:
-        - value
+          - value
       imported_inodes:
         signal: mds_imported_inodes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3931,51 +3932,51 @@ views:
       blockdiff_latency:
         signal: mds_server_req_blockdiff_latency_sum
         components:
-        - value
+          - value
       getattr_latency:
         signal: mds_server_req_getattr_latency_sum
         components:
-        - value
+          - value
       getfilelock_latency:
         signal: mds_server_req_getfilelock_latency_sum
         components:
-        - value
+          - value
       getvxattr_latency:
         signal: mds_server_req_getvxattr_latency_sum
         components:
-        - value
+          - value
       lookup_latency:
         signal: mds_server_req_lookup_latency_sum
         components:
-        - value
+          - value
       lookuphash_latency:
         signal: mds_server_req_lookuphash_latency_sum
         components:
-        - value
+          - value
       lookupino_latency:
         signal: mds_server_req_lookupino_latency_sum
         components:
-        - value
+          - value
       lookupname_latency:
         signal: mds_server_req_lookupname_latency_sum
         components:
-        - value
+          - value
       lookupparent_latency:
         signal: mds_server_req_lookupparent_latency_sum
         components:
-        - value
+          - value
       lookupsnap_latency:
         signal: mds_server_req_lookupsnap_latency_sum
         components:
-        - value
+          - value
       open_latency:
         signal: mds_server_req_open_latency_sum
         components:
-        - value
+          - value
       readdir_latency:
         signal: mds_server_req_readdir_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3988,51 +3989,51 @@ views:
       blockdiff_latency:
         signal: mds_server_req_blockdiff_latency_count
         components:
-        - value
+          - value
       getattr_latency:
         signal: mds_server_req_getattr_latency_count
         components:
-        - value
+          - value
       getfilelock_latency:
         signal: mds_server_req_getfilelock_latency_count
         components:
-        - value
+          - value
       getvxattr_latency:
         signal: mds_server_req_getvxattr_latency_count
         components:
-        - value
+          - value
       lookup_latency:
         signal: mds_server_req_lookup_latency_count
         components:
-        - value
+          - value
       lookuphash_latency:
         signal: mds_server_req_lookuphash_latency_count
         components:
-        - value
+          - value
       lookupino_latency:
         signal: mds_server_req_lookupino_latency_count
         components:
-        - value
+          - value
       lookupname_latency:
         signal: mds_server_req_lookupname_latency_count
         components:
-        - value
+          - value
       lookupparent_latency:
         signal: mds_server_req_lookupparent_latency_count
         components:
-        - value
+          - value
       lookupsnap_latency:
         signal: mds_server_req_lookupsnap_latency_count
         components:
-        - value
+          - value
       open_latency:
         signal: mds_server_req_open_latency_count
         components:
-        - value
+          - value
       readdir_latency:
         signal: mds_server_req_readdir_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4045,7 +4046,7 @@ views:
       value:
         signal: mds_reply_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4058,7 +4059,7 @@ views:
       client_metrics_num_clients:
         signal: mds_client_metrics_num_clients
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4071,11 +4072,11 @@ views:
       reply:
         signal: mds_reply
         components:
-        - value
+          - value
       server_handle_client_session:
         signal: mds_server_handle_client_session
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4088,7 +4089,7 @@ views:
       expired:
         signal: mds_inodes_expired
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4101,7 +4102,7 @@ views:
       value:
         signal: mds_slow_reply
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4114,7 +4115,7 @@ views:
       value:
         signal: mds_root_rfiles
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4127,23 +4128,23 @@ views:
       inodes:
         signal: mds_inodes
         components:
-        - value
+          - value
       bottom:
         signal: mds_inodes_bottom
         components:
-        - value
+          - value
       pin_tail:
         signal: mds_inodes_pin_tail
         components:
-        - value
+          - value
       pinned:
         signal: mds_inodes_pinned
         components:
-        - value
+          - value
       top:
         signal: mds_inodes_top
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4156,7 +4157,7 @@ views:
       value:
         signal: mds_reply_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4169,7 +4170,7 @@ views:
       value:
         signal: mds_load_cent
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4182,27 +4183,27 @@ views:
       forward:
         signal: mds_forward
         components:
-        - value
+          - value
       request:
         signal: mds_request
         components:
-        - value
+          - value
       server_dispatch_client_request:
         signal: mds_server_dispatch_client_request
         components:
-        - value
+          - value
       server_dispatch_server_request:
         signal: mds_server_dispatch_server_request
         components:
-        - value
+          - value
       server_handle_client_request:
         signal: mds_server_handle_client_request
         components:
-        - value
+          - value
       server_handle_peer_request:
         signal: mds_server_handle_peer_request
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4215,7 +4216,7 @@ views:
       q:
         signal: mds_q
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4228,7 +4229,7 @@ views:
       value:
         signal: mds_root_rsnaps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4241,7 +4242,7 @@ views:
       value:
         signal: mds_root_rbytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4254,7 +4255,7 @@ views:
       value:
         signal: mds_subtrees
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4267,7 +4268,7 @@ views:
       set_tag:
         signal: mds_scrub_set_tag
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4280,11 +4281,11 @@ views:
       backtrace_fetch:
         signal: mds_scrub_backtrace_fetch
         components:
-        - value
+          - value
       backtrace_repaired:
         signal: mds_scrub_backtrace_repaired
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4297,7 +4298,7 @@ views:
       value:
         signal: mds_scrub_dirfrag_rstats
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4310,7 +4311,7 @@ views:
       inotable_repaired:
         signal: mds_scrub_inotable_repaired
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4323,15 +4324,15 @@ views:
       dir_base_inodes:
         signal: mds_scrub_dir_base_inodes
         components:
-        - value
+          - value
       dir_inodes:
         signal: mds_scrub_dir_inodes
         components:
-        - value
+          - value
       file_inodes:
         signal: mds_scrub_file_inodes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4344,23 +4345,23 @@ views:
       lssnap_latency:
         signal: mds_server_req_lssnap_latency_sum
         components:
-        - value
+          - value
       mksnap_latency:
         signal: mds_server_req_mksnap_latency_sum
         components:
-        - value
+          - value
       renamesnap_latency:
         signal: mds_server_req_renamesnap_latency_sum
         components:
-        - value
+          - value
       rmsnap_latency:
         signal: mds_server_req_rmsnap_latency_sum
         components:
-        - value
+          - value
       snapdiff_latency:
         signal: mds_server_req_snapdiff_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4373,23 +4374,23 @@ views:
       lssnap_latency:
         signal: mds_server_req_lssnap_latency_count
         components:
-        - value
+          - value
       mksnap_latency:
         signal: mds_server_req_mksnap_latency_count
         components:
-        - value
+          - value
       renamesnap_latency:
         signal: mds_server_req_renamesnap_latency_count
         components:
-        - value
+          - value
       rmsnap_latency:
         signal: mds_server_req_rmsnap_latency_count
         components:
-        - value
+          - value
       snapdiff_latency:
         signal: mds_server_req_snapdiff_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4402,15 +4403,15 @@ views:
       read:
         signal: mds_per_client_avg_read_latency
         components:
-        - value
+          - value
       write:
         signal: mds_per_client_avg_write_latency
         components:
-        - value
+          - value
       metadata:
         signal: mds_per_client_avg_metadata_latency
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4423,11 +4424,11 @@ views:
       hits:
         signal: mds_per_client_cap_hits
         components:
-        - value
+          - value
       misses:
         signal: mds_per_client_cap_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4440,11 +4441,11 @@ views:
       hits:
         signal: mds_per_client_dentry_lease_hits
         components:
-        - value
+          - value
       misses:
         signal: mds_per_client_dentry_lease_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4457,11 +4458,11 @@ views:
       open:
         signal: mds_per_client_opened_inodes
         components:
-        - value
+          - value
       total:
         signal: mds_per_client_total_inodes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4474,7 +4475,7 @@ views:
       open:
         signal: mds_per_client_opened_files
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4487,7 +4488,7 @@ views:
       pinned:
         signal: mds_per_client_pinned_icaps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4500,11 +4501,11 @@ views:
       read:
         signal: mds_per_client_total_read_ops
         components:
-        - value
+          - value
       write:
         signal: mds_per_client_total_write_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4517,11 +4518,11 @@ views:
       read:
         signal: mds_per_client_total_read_size
         components:
-        - value
+          - value
       write:
         signal: mds_per_client_total_write_size
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4534,7 +4535,7 @@ views:
       value:
         signal: mds_mem_cap
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4547,11 +4548,11 @@ views:
       minus:
         signal: mds_mem_cap_minus
         components:
-        - value
+          - value
       plus:
         signal: mds_mem_cap_plus
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4564,7 +4565,7 @@ views:
       value:
         signal: mds_mem_dn
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4577,11 +4578,11 @@ views:
       minus:
         signal: mds_mem_dn_minus
         components:
-        - value
+          - value
       plus:
         signal: mds_mem_dn_plus
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4594,7 +4595,7 @@ views:
       value:
         signal: mds_mem_dir
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4607,11 +4608,11 @@ views:
       minus:
         signal: mds_mem_dir_minus
         components:
-        - value
+          - value
       plus:
         signal: mds_mem_dir_plus
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4624,7 +4625,7 @@ views:
       value:
         signal: mds_mem_ino
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4637,11 +4638,11 @@ views:
       minus:
         signal: mds_mem_ino_minus
         components:
-        - value
+          - value
       plus:
         signal: mds_mem_ino_plus
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4654,11 +4655,11 @@ views:
       heap:
         signal: mds_mem_heap
         components:
-        - value
+          - value
       rss:
         signal: mds_mem_rss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4671,7 +4672,7 @@ views:
       average_load:
         signal: mds_sessions_average_load
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4684,7 +4685,7 @@ views:
       value:
         signal: mds_sessions_avg_session_uptime
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4697,11 +4698,11 @@ views:
       add:
         signal: mds_sessions_session_add
         components:
-        - value
+          - value
       remove:
         signal: mds_sessions_session_remove
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4714,7 +4715,7 @@ views:
       value:
         signal: mds_sessions_mdthresh_evicted
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4727,15 +4728,15 @@ views:
       session:
         signal: mds_sessions_session_count
         components:
-        - value
+          - value
       sessions_open:
         signal: mds_sessions_sessions_open
         components:
-        - value
+          - value
       sessions_stale:
         signal: mds_sessions_sessions_stale
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4748,7 +4749,7 @@ views:
       total_load:
         signal: mds_sessions_total_load
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4761,7 +4762,7 @@ views:
       value:
         signal: fs_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4775,7 +4776,7 @@ views:
       value:
         signal: mds_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4788,7 +4789,7 @@ views:
       directories:
         signal: cephfs_mirror_mirrored_filesystems_directory_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4801,7 +4802,7 @@ views:
       peers:
         signal: cephfs_mirror_mirrored_filesystems_mirroring_peers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4815,7 +4816,7 @@ views:
       time:
         signal: cephfs_mirror_peers_avg_sync_time_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4829,7 +4830,7 @@ views:
       duration:
         signal: cephfs_mirror_peers_last_synced_duration
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4843,7 +4844,7 @@ views:
       bytes:
         signal: cephfs_mirror_peers_last_synced_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4857,11 +4858,11 @@ views:
       started:
         signal: cephfs_mirror_peers_last_synced_start
         components:
-        - value
+          - value
       ended:
         signal: cephfs_mirror_peers_last_synced_end
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4875,19 +4876,19 @@ views:
       synced:
         signal: cephfs_mirror_peers_snaps_synced
         components:
-        - value
+          - value
       deleted:
         signal: cephfs_mirror_peers_snaps_deleted
         components:
-        - value
+          - value
       renamed:
         signal: cephfs_mirror_peers_snaps_renamed
         components:
-        - value
+          - value
       failed:
         signal: cephfs_mirror_peers_sync_failures
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4901,7 +4902,7 @@ views:
       bytes:
         signal: cephfs_mirror_peers_sync_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4915,7 +4916,7 @@ views:
       snapshots:
         signal: cephfs_mirror_peers_avg_sync_time_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4928,7 +4929,7 @@ views:
       failures:
         signal: cephfs_mirror_mirror_enable_failures
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4941,7 +4942,7 @@ views:
       mirrored:
         signal: cephfs_mirror_mirrored_filesystems
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4954,7 +4955,7 @@ views:
       value:
         signal: prometheus_collect_duration_seconds_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4967,7 +4968,7 @@ views:
       value:
         signal: cluster_osd_blocklist_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4980,7 +4981,7 @@ views:
       value:
         signal: prometheus_collect_duration_seconds_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4993,7 +4994,7 @@ views:
       human:
         signal: disk_occupation_human
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5007,7 +5008,7 @@ views:
       occupation:
         signal: disk_occupation
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5020,7 +5021,7 @@ views:
       value:
         signal: cephadm_daemon_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5033,7 +5034,7 @@ views:
       metadata:
         signal: mgr_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5046,7 +5047,7 @@ views:
       status:
         signal: mgr_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5059,11 +5060,11 @@ views:
       can_run:
         signal: mgr_module_can_run
         components:
-        - value
+          - value
       status:
         signal: mgr_module_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5077,7 +5078,7 @@ views:
       metadata:
         signal: mon_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5090,7 +5091,7 @@ views:
       quorum_status:
         signal: mon_quorum_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5103,23 +5104,23 @@ views:
       begin_bytes:
         signal: paxos_begin_bytes_sum
         components:
-        - value
+          - value
       collect_bytes:
         signal: paxos_collect_bytes_sum
         components:
-        - value
+          - value
       commit_bytes:
         signal: paxos_commit_bytes_sum
         components:
-        - value
+          - value
       share_state_bytes:
         signal: paxos_share_state_bytes_sum
         components:
-        - value
+          - value
       store_state_bytes:
         signal: paxos_store_state_bytes_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5132,23 +5133,23 @@ views:
       begin_keys:
         signal: paxos_begin_keys_sum
         components:
-        - value
+          - value
       collect_keys:
         signal: paxos_collect_keys_sum
         components:
-        - value
+          - value
       commit_keys:
         signal: paxos_commit_keys_sum
         components:
-        - value
+          - value
       share_state_keys:
         signal: paxos_share_state_keys_sum
         components:
-        - value
+          - value
       store_state_keys:
         signal: paxos_store_state_keys_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5161,27 +5162,27 @@ views:
       begin_latency:
         signal: paxos_begin_latency_sum
         components:
-        - value
+          - value
       collect_latency:
         signal: paxos_collect_latency_sum
         components:
-        - value
+          - value
       commit_latency:
         signal: paxos_commit_latency_sum
         components:
-        - value
+          - value
       new_pn_latency:
         signal: paxos_new_pn_latency_sum
         components:
-        - value
+          - value
       refresh_latency:
         signal: paxos_refresh_latency_sum
         components:
-        - value
+          - value
       store_state_latency:
         signal: paxos_store_state_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5194,23 +5195,23 @@ views:
       begin_bytes:
         signal: paxos_begin_bytes_count
         components:
-        - value
+          - value
       collect_bytes:
         signal: paxos_collect_bytes_count
         components:
-        - value
+          - value
       commit_bytes:
         signal: paxos_commit_bytes_count
         components:
-        - value
+          - value
       share_state_bytes:
         signal: paxos_share_state_bytes_count
         components:
-        - value
+          - value
       store_state_bytes:
         signal: paxos_store_state_bytes_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5223,7 +5224,7 @@ views:
       collect_uncommitted:
         signal: paxos_collect_uncommitted
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5236,31 +5237,31 @@ views:
       new_pn:
         signal: paxos_new_pn
         components:
-        - value
+          - value
       refresh:
         signal: paxos_refresh
         components:
-        - value
+          - value
       restart:
         signal: paxos_restart
         components:
-        - value
+          - value
       share_state:
         signal: paxos_share_state
         components:
-        - value
+          - value
       start_leader:
         signal: paxos_start_leader
         components:
-        - value
+          - value
       start_peon:
         signal: paxos_start_peon
         components:
-        - value
+          - value
       store_state:
         signal: paxos_store_state
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5273,19 +5274,19 @@ views:
       accept_timeout:
         signal: paxos_accept_timeout
         components:
-        - value
+          - value
       collect_timeout:
         signal: paxos_collect_timeout
         components:
-        - value
+          - value
       lease_ack_timeout:
         signal: paxos_lease_ack_timeout
         components:
-        - value
+          - value
       lease_timeout:
         signal: paxos_lease_timeout
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5298,23 +5299,23 @@ views:
       begin_keys:
         signal: paxos_begin_keys_count
         components:
-        - value
+          - value
       collect_keys:
         signal: paxos_collect_keys_count
         components:
-        - value
+          - value
       commit_keys:
         signal: paxos_commit_keys_count
         components:
-        - value
+          - value
       share_state_keys:
         signal: paxos_share_state_keys_count
         components:
-        - value
+          - value
       store_state_keys:
         signal: paxos_store_state_keys_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5327,27 +5328,27 @@ views:
       begin_latency:
         signal: paxos_begin_latency_count
         components:
-        - value
+          - value
       collect_latency:
         signal: paxos_collect_latency_count
         components:
-        - value
+          - value
       commit_latency:
         signal: paxos_commit_latency_count
         components:
-        - value
+          - value
       new_pn_latency:
         signal: paxos_new_pn_latency_count
         components:
-        - value
+          - value
       refresh_latency:
         signal: paxos_refresh_latency_count
         components:
-        - value
+          - value
       store_state_latency:
         signal: paxos_store_state_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5360,15 +5361,15 @@ views:
       begin:
         signal: paxos_begin
         components:
-        - value
+          - value
       collect:
         signal: paxos_collect
         components:
-        - value
+          - value
       commit:
         signal: paxos_commit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5381,7 +5382,7 @@ views:
       duration:
         signal: exporter_scrape_time
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5394,7 +5395,7 @@ views:
       reachable:
         signal: daemon_socket_up
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5407,7 +5408,7 @@ views:
       cpu_time:
         signal: exporter_cpu_total
         components:
-        - value
+          - value
     labels:
       dimensions:
         mode:
@@ -5422,7 +5423,7 @@ views:
       utilization:
         signal: exporter_cpu_usage
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5431,7 +5432,7 @@ views:
       convention: percentage
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   exporter_and_process_runtime.daemon_processes.memory:
     family: Ceph/Exporter and Process Runtime/Daemon Processes
     question: What is the memory for each ceph daemon?
@@ -5440,11 +5441,11 @@ views:
       virtual:
         signal: exporter_vm_size
         components:
-        - value
+          - value
       resident:
         signal: exporter_resident_size
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5457,11 +5458,11 @@ views:
       minor:
         signal: exporter_minflt_total
         components:
-        - value
+          - value
       major:
         signal: exporter_majflt_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5474,7 +5475,7 @@ views:
       threads:
         signal: exporter_num_threads
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5487,7 +5488,7 @@ views:
       value:
         signal: health_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5500,7 +5501,7 @@ views:
       value:
         signal: daemon_health_metrics
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5513,7 +5514,7 @@ views:
       value:
         signal: health_detail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5526,7 +5527,7 @@ views:
       value:
         signal: healthcheck_slow_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5539,11 +5540,11 @@ views:
       hit:
         signal: mgr_cache_hit
         components:
-        - value
+          - value
       miss:
         signal: mgr_cache_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5556,7 +5557,7 @@ views:
       active_queue_pair:
         signal: asyncmessenger_rdmadispatcher_active_queue_pair
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5569,11 +5570,11 @@ views:
       async_last_wqe_events:
         signal: asyncmessenger_rdmadispatcher_async_last_wqe_events
         components:
-        - value
+          - value
       total_async_events:
         signal: asyncmessenger_rdmadispatcher_total_async_events
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5586,11 +5587,11 @@ views:
       worker_msgr_connection_idle_timeouts:
         signal: asyncmessenger_worker_msgr_connection_idle_timeouts
         components:
-        - value
+          - value
       worker_msgr_connection_ready_timeouts:
         signal: asyncmessenger_worker_msgr_connection_ready_timeouts
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5603,7 +5604,7 @@ views:
       created_queue_pair:
         signal: asyncmessenger_rdmadispatcher_created_queue_pair
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5616,7 +5617,7 @@ views:
       inflight_tx_chunks:
         signal: asyncmessenger_rdmadispatcher_inflight_tx_chunks
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5629,7 +5630,7 @@ views:
       polling:
         signal: asyncmessenger_rdmadispatcher_polling
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5642,23 +5643,23 @@ views:
       rdmadispatcher_handshake_errors:
         signal: asyncmessenger_rdmadispatcher_handshake_errors
         components:
-        - value
+          - value
       rdmadispatcher_rx_total_wc_errors:
         signal: asyncmessenger_rdmadispatcher_rx_total_wc_errors
         components:
-        - value
+          - value
       rdmadispatcher_tx_retry_errors:
         signal: asyncmessenger_rdmadispatcher_tx_retry_errors
         components:
-        - value
+          - value
       rdmadispatcher_tx_total_wc_errors:
         signal: asyncmessenger_rdmadispatcher_tx_total_wc_errors
         components:
-        - value
+          - value
       rdmadispatcher_tx_wr_flush_errors:
         signal: asyncmessenger_rdmadispatcher_tx_wr_flush_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5671,11 +5672,11 @@ views:
       rx_bufs_in_use:
         signal: asyncmessenger_rdmadispatcher_rx_bufs_in_use
         components:
-        - value
+          - value
       rx_bufs:
         signal: asyncmessenger_rdmadispatcher_rx_bufs_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5688,7 +5689,7 @@ views:
       rx_fin:
         signal: asyncmessenger_rdmadispatcher_rx_fin
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5701,11 +5702,11 @@ views:
       rx_total_wc:
         signal: asyncmessenger_rdmadispatcher_rx_total_wc
         components:
-        - value
+          - value
       tx_total_wc:
         signal: asyncmessenger_rdmadispatcher_tx_total_wc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5718,19 +5719,19 @@ views:
       election_call:
         signal: mon_election_call
         components:
-        - value
+          - value
       election_lose:
         signal: mon_election_lose
         components:
-        - value
+          - value
       election_win:
         signal: mon_election_win
         components:
-        - value
+          - value
       num_elections:
         signal: mon_num_elections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5743,7 +5744,7 @@ views:
       value:
         signal: mon_num_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5756,15 +5757,15 @@ views:
       add:
         signal: mon_session_add
         components:
-        - value
+          - value
       rm:
         signal: mon_session_rm
         components:
-        - value
+          - value
       trim:
         signal: mon_session_trim
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5777,11 +5778,11 @@ views:
       read_bytes:
         signal: nvmeof_bdev_read_bytes_total
         components:
-        - value
+          - value
       written_bytes:
         signal: nvmeof_bdev_written_bytes_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5794,11 +5795,11 @@ views:
       reads_completed:
         signal: nvmeof_bdev_reads_completed_total
         components:
-        - value
+          - value
       writes_completed:
         signal: nvmeof_bdev_writes_completed_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5811,7 +5812,7 @@ views:
       value:
         signal: nvmeof_bdev_capacity_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5825,7 +5826,7 @@ views:
       value:
         signal: nvmeof_bdev_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5838,11 +5839,11 @@ views:
       read_seconds:
         signal: nvmeof_bdev_read_seconds_total
         components:
-        - value
+          - value
       write_seconds:
         signal: nvmeof_bdev_write_seconds_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5855,7 +5856,7 @@ views:
       value:
         signal: nvmeof_rpc_method_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5868,7 +5869,7 @@ views:
       value:
         signal: nvmeof_reactor_seconds_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5881,7 +5882,7 @@ views:
       value:
         signal: nvmeof_host_connection_state
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5894,7 +5895,7 @@ views:
       value:
         signal: nvmeof_host_keepalive_timeout
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5907,7 +5908,7 @@ views:
       value:
         signal: nvmeof_subsystem_host_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5920,7 +5921,7 @@ views:
       value:
         signal: nvmeof_subsystem_listener_iface_speed_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5929,7 +5930,7 @@ views:
       convention: network_megabits_per_second
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - nvmeof_display_conventions
+        - nvmeof_display_conventions
   nvme_of.subsystems.listener_state:
     family: Ceph/NVMe-oF/Subsystems
     question: What is the listener addresses for each ceph instance and nqn?
@@ -5938,7 +5939,7 @@ views:
       value:
         signal: nvmeof_subsystem_listener_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5951,7 +5952,7 @@ views:
       nvmeof_subsystem_namespace_count:
         signal: nvmeof_subsystem_namespace_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5964,7 +5965,7 @@ views:
       limit:
         signal: nvmeof_subsystem_namespace_limit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5978,7 +5979,7 @@ views:
       metadata:
         signal: nvmeof_subsystem_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5992,7 +5993,7 @@ views:
       namespace_metadata:
         signal: nvmeof_subsystem_namespace_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6005,7 +6006,7 @@ views:
       value:
         signal: rgw_lc_abort_mpu
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6018,23 +6019,23 @@ views:
       expire_current:
         signal: rgw_lc_expire_current
         components:
-        - value
+          - value
       expire_dm:
         signal: rgw_lc_expire_dm
         components:
-        - value
+          - value
       expire_noncurrent:
         signal: rgw_lc_expire_noncurrent
         components:
-        - value
+          - value
       transition_current:
         signal: rgw_lc_transition_current
         components:
-        - value
+          - value
       transition_noncurrent:
         signal: rgw_lc_transition_noncurrent
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6047,7 +6048,7 @@ views:
       value:
         signal: rgw_lua_current_vms
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6056,7 +6057,7 @@ views:
       convention: virtual_machines
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   object_gateway.lua.script_executions:
     family: Ceph/Object Gateway/Lua
     question: What is the lua script executions for each instance id?
@@ -6065,11 +6066,11 @@ views:
       success:
         signal: rgw_lua_script_ok
         components:
-        - value
+          - value
       failure:
         signal: rgw_lua_script_fail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6082,7 +6083,7 @@ views:
       value:
         signal: rgw_pubsub_events
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6095,19 +6096,19 @@ views:
       event_lost:
         signal: rgw_pubsub_event_lost
         components:
-        - value
+          - value
       event_triggered:
         signal: rgw_pubsub_event_triggered
         components:
-        - value
+          - value
       push_ok:
         signal: rgw_pubsub_push_ok
         components:
-        - value
+          - value
       store_ok:
         signal: rgw_pubsub_store_ok
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6120,11 +6121,11 @@ views:
       push_failed:
         signal: rgw_pubsub_push_failed
         components:
-        - value
+          - value
       store_fail:
         signal: rgw_pubsub_store_fail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6137,7 +6138,7 @@ views:
       value:
         signal: rgw_pubsub_missing_conf
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6150,7 +6151,7 @@ views:
       value:
         signal: rgw_pubsub_push_pending
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6163,11 +6164,11 @@ views:
       get_initial_lat:
         signal: rgw_get_initial_lat_sum
         components:
-        - value
+          - value
       put_initial_lat:
         signal: rgw_put_initial_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6180,11 +6181,11 @@ views:
       get_b:
         signal: rgw_get_b
         components:
-        - value
+          - value
       put_b:
         signal: rgw_put_b
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6197,11 +6198,11 @@ views:
       qactive:
         signal: rgw_qactive
         components:
-        - value
+          - value
       qlen:
         signal: rgw_qlen
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6214,7 +6215,7 @@ views:
       value:
         signal: rgw_failed_req
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6227,11 +6228,11 @@ views:
       get_initial_lat:
         signal: rgw_get_initial_lat_count
         components:
-        - value
+          - value
       put_initial_lat:
         signal: rgw_put_initial_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6244,7 +6245,7 @@ views:
       value:
         signal: rgw_gc_retire_object
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6257,15 +6258,15 @@ views:
       get:
         signal: rgw_get
         components:
-        - value
+          - value
       put:
         signal: rgw_put
         components:
-        - value
+          - value
       req:
         signal: rgw_req
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6278,11 +6279,11 @@ views:
       hit:
         signal: rgw_keystone_token_cache_hit
         components:
-        - value
+          - value
       miss:
         signal: rgw_keystone_token_cache_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6295,11 +6296,11 @@ views:
       cache_hit:
         signal: rgw_cache_hit
         components:
-        - value
+          - value
       cache_miss:
         signal: rgw_cache_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6312,7 +6313,7 @@ views:
       value:
         signal: rgw_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6325,7 +6326,7 @@ views:
       value:
         signal: data_sync_from_zone_fetch_bytes_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6338,11 +6339,11 @@ views:
       lock_latency:
         signal: data_sync_from_zone_lock_latency_sum
         components:
-        - value
+          - value
       poll_latency:
         signal: data_sync_from_zone_poll_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6355,11 +6356,11 @@ views:
       lock_latency:
         signal: data_sync_from_zone_lock_latency_count
         components:
-        - value
+          - value
       poll_latency:
         signal: data_sync_from_zone_poll_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6372,11 +6373,11 @@ views:
       errors:
         signal: data_sync_from_zone_fetch_errors
         components:
-        - value
+          - value
       not_modified:
         signal: data_sync_from_zone_fetch_not_modified
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6389,7 +6390,7 @@ views:
       value:
         signal: data_sync_from_zone_fetch_bytes_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6402,7 +6403,7 @@ views:
       value:
         signal: data_sync_from_zone_poll_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6415,35 +6416,35 @@ views:
       admin_reservation:
         signal: dmclock_admin_res_latency_sum
         components:
-        - value
+          - value
       admin_priority:
         signal: dmclock_admin_prio_latency_sum
         components:
-        - value
+          - value
       auth_reservation:
         signal: dmclock_auth_res_latency_sum
         components:
-        - value
+          - value
       auth_priority:
         signal: dmclock_auth_prio_latency_sum
         components:
-        - value
+          - value
       data_reservation:
         signal: dmclock_data_res_latency_sum
         components:
-        - value
+          - value
       data_priority:
         signal: dmclock_data_prio_latency_sum
         components:
-        - value
+          - value
       metadata_reservation:
         signal: dmclock_metadata_res_latency_sum
         components:
-        - value
+          - value
       metadata_priority:
         signal: dmclock_metadata_prio_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6456,35 +6457,35 @@ views:
       admin_reservation:
         signal: dmclock_admin_res_latency_count
         components:
-        - value
+          - value
       admin_priority:
         signal: dmclock_admin_prio_latency_count
         components:
-        - value
+          - value
       auth_reservation:
         signal: dmclock_auth_res_latency_count
         components:
-        - value
+          - value
       auth_priority:
         signal: dmclock_auth_prio_latency_count
         components:
-        - value
+          - value
       data_reservation:
         signal: dmclock_data_res_latency_count
         components:
-        - value
+          - value
       data_priority:
         signal: dmclock_data_prio_latency_count
         components:
-        - value
+          - value
       metadata_reservation:
         signal: dmclock_metadata_res_latency_count
         components:
-        - value
+          - value
       metadata_priority:
         signal: dmclock_metadata_prio_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6497,7 +6498,7 @@ views:
       outstanding:
         signal: dmclock_scheduler_outstanding
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6510,19 +6511,19 @@ views:
       admin:
         signal: dmclock_admin_cost
         components:
-        - value
+          - value
       auth:
         signal: dmclock_auth_cost
         components:
-        - value
+          - value
       data:
         signal: dmclock_data_cost
         components:
-        - value
+          - value
       metadata:
         signal: dmclock_metadata_cost
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6535,19 +6536,19 @@ views:
       admin:
         signal: dmclock_admin_qlen
         components:
-        - value
+          - value
       auth:
         signal: dmclock_auth_qlen
         components:
-        - value
+          - value
       data:
         signal: dmclock_data_qlen
         components:
-        - value
+          - value
       metadata:
         signal: dmclock_metadata_qlen
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6560,35 +6561,35 @@ views:
       admin_limited:
         signal: dmclock_admin_limit
         components:
-        - value
+          - value
       admin_cancelled:
         signal: dmclock_admin_cancel
         components:
-        - value
+          - value
       auth_limited:
         signal: dmclock_auth_limit
         components:
-        - value
+          - value
       auth_cancelled:
         signal: dmclock_auth_cancel
         components:
-        - value
+          - value
       data_limited:
         signal: dmclock_data_limit
         components:
-        - value
+          - value
       data_cancelled:
         signal: dmclock_data_cancel
         components:
-        - value
+          - value
       metadata_limited:
         signal: dmclock_metadata_limit
         components:
-        - value
+          - value
       metadata_cancelled:
         signal: dmclock_metadata_cancel
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6601,67 +6602,67 @@ views:
       admin_reservation:
         signal: dmclock_admin_res_cost
         components:
-        - value
+          - value
       admin_priority:
         signal: dmclock_admin_prio_cost
         components:
-        - value
+          - value
       admin_limited:
         signal: dmclock_admin_limit_cost
         components:
-        - value
+          - value
       admin_cancelled:
         signal: dmclock_admin_cancel_cost
         components:
-        - value
+          - value
       auth_reservation:
         signal: dmclock_auth_res_cost
         components:
-        - value
+          - value
       auth_priority:
         signal: dmclock_auth_prio_cost
         components:
-        - value
+          - value
       auth_limited:
         signal: dmclock_auth_limit_cost
         components:
-        - value
+          - value
       auth_cancelled:
         signal: dmclock_auth_cancel_cost
         components:
-        - value
+          - value
       data_reservation:
         signal: dmclock_data_res_cost
         components:
-        - value
+          - value
       data_priority:
         signal: dmclock_data_prio_cost
         components:
-        - value
+          - value
       data_limited:
         signal: dmclock_data_limit_cost
         components:
-        - value
+          - value
       data_cancelled:
         signal: dmclock_data_cancel_cost
         components:
-        - value
+          - value
       metadata_reservation:
         signal: dmclock_metadata_res_cost
         components:
-        - value
+          - value
       metadata_priority:
         signal: dmclock_metadata_prio_cost
         components:
-        - value
+          - value
       metadata_limited:
         signal: dmclock_metadata_limit_cost
         components:
-        - value
+          - value
       metadata_cancelled:
         signal: dmclock_metadata_cancel_cost
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6674,35 +6675,35 @@ views:
       admin_reservation:
         signal: dmclock_admin_res
         components:
-        - value
+          - value
       admin_priority:
         signal: dmclock_admin_prio
         components:
-        - value
+          - value
       auth_reservation:
         signal: dmclock_auth_res
         components:
-        - value
+          - value
       auth_priority:
         signal: dmclock_auth_prio
         components:
-        - value
+          - value
       data_reservation:
         signal: dmclock_data_res
         components:
-        - value
+          - value
       data_priority:
         signal: dmclock_data_prio
         components:
-        - value
+          - value
       metadata_reservation:
         signal: dmclock_metadata_res
         components:
-        - value
+          - value
       metadata_priority:
         signal: dmclock_metadata_prio
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6715,7 +6716,7 @@ views:
       throttled:
         signal: dmclock_scheduler_throttle
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6728,7 +6729,7 @@ views:
       value:
         signal: objecter_op_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6745,7 +6746,7 @@ views:
       command_active:
         signal: objecter_command_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6762,7 +6763,7 @@ views:
       linger_active:
         signal: objecter_linger_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6779,15 +6780,15 @@ views:
       op_active:
         signal: objecter_op_active
         components:
-        - value
+          - value
       op_inflight:
         signal: objecter_op_inflight
         components:
-        - value
+          - value
       op_laggy:
         signal: objecter_op_laggy
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6804,7 +6805,7 @@ views:
       poolop_active:
         signal: objecter_poolop_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6821,7 +6822,7 @@ views:
       poolstat_active:
         signal: objecter_poolstat_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6838,7 +6839,7 @@ views:
       statfs_active:
         signal: objecter_statfs_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6855,7 +6856,7 @@ views:
       value:
         signal: objecter_op_send_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6872,11 +6873,11 @@ views:
       command_resend:
         signal: objecter_command_resend
         components:
-        - value
+          - value
       command_send:
         signal: objecter_command_send
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6893,7 +6894,7 @@ views:
       value:
         signal: objecter_op_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6910,15 +6911,15 @@ views:
       linger_ping:
         signal: objecter_linger_ping
         components:
-        - value
+          - value
       linger_resend:
         signal: objecter_linger_resend
         components:
-        - value
+          - value
       linger_send:
         signal: objecter_linger_send
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6935,7 +6936,7 @@ views:
       map_epoch:
         signal: objecter_map_epoch
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6952,11 +6953,11 @@ views:
       map_full:
         signal: objecter_map_full
         components:
-        - value
+          - value
       map_inc:
         signal: objecter_map_inc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6973,7 +6974,7 @@ views:
       value:
         signal: objecter_oplen_avg_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6990,147 +6991,147 @@ views:
       omap_del:
         signal: objecter_omap_del
         components:
-        - value
+          - value
       omap_rd:
         signal: objecter_omap_rd
         components:
-        - value
+          - value
       omap_wr:
         signal: objecter_omap_wr
         components:
-        - value
+          - value
       op:
         signal: objecter_op
         components:
-        - value
+          - value
       op_pg:
         signal: objecter_op_pg
         components:
-        - value
+          - value
       op_r:
         signal: objecter_op_r
         components:
-        - value
+          - value
       op_reply:
         signal: objecter_op_reply
         components:
-        - value
+          - value
       op_resend:
         signal: objecter_op_resend
         components:
-        - value
+          - value
       op_rmw:
         signal: objecter_op_rmw
         components:
-        - value
+          - value
       op_send:
         signal: objecter_op_send
         components:
-        - value
+          - value
       op_w:
         signal: objecter_op_w
         components:
-        - value
+          - value
       osdop_append:
         signal: objecter_osdop_append
         components:
-        - value
+          - value
       osdop_call:
         signal: objecter_osdop_call
         components:
-        - value
+          - value
       osdop_clonerange:
         signal: objecter_osdop_clonerange
         components:
-        - value
+          - value
       osdop_cmpxattr:
         signal: objecter_osdop_cmpxattr
         components:
-        - value
+          - value
       osdop_create:
         signal: objecter_osdop_create
         components:
-        - value
+          - value
       osdop_delete:
         signal: objecter_osdop_delete
         components:
-        - value
+          - value
       osdop_getxattr:
         signal: objecter_osdop_getxattr
         components:
-        - value
+          - value
       osdop_mapext:
         signal: objecter_osdop_mapext
         components:
-        - value
+          - value
       osdop_notify:
         signal: objecter_osdop_notify
         components:
-        - value
+          - value
       osdop_other:
         signal: objecter_osdop_other
         components:
-        - value
+          - value
       osdop_pgls:
         signal: objecter_osdop_pgls
         components:
-        - value
+          - value
       osdop_pgls_filter:
         signal: objecter_osdop_pgls_filter
         components:
-        - value
+          - value
       osdop_read:
         signal: objecter_osdop_read
         components:
-        - value
+          - value
       osdop_resetxattrs:
         signal: objecter_osdop_resetxattrs
         components:
-        - value
+          - value
       osdop_rmxattr:
         signal: objecter_osdop_rmxattr
         components:
-        - value
+          - value
       osdop_setxattr:
         signal: objecter_osdop_setxattr
         components:
-        - value
+          - value
       osdop_sparse_read:
         signal: objecter_osdop_sparse_read
         components:
-        - value
+          - value
       osdop_src_cmpxattr:
         signal: objecter_osdop_src_cmpxattr
         components:
-        - value
+          - value
       osdop_stat:
         signal: objecter_osdop_stat
         components:
-        - value
+          - value
       osdop_truncate:
         signal: objecter_osdop_truncate
         components:
-        - value
+          - value
       osdop_watch:
         signal: objecter_osdop_watch
         components:
-        - value
+          - value
       osdop_write:
         signal: objecter_osdop_write
         components:
-        - value
+          - value
       osdop_writefull:
         signal: objecter_osdop_writefull
         components:
-        - value
+          - value
       osdop_writesame:
         signal: objecter_osdop_writesame
         components:
-        - value
+          - value
       osdop_zero:
         signal: objecter_osdop_zero
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7147,11 +7148,11 @@ views:
       osd_session_close:
         signal: objecter_osd_session_close
         components:
-        - value
+          - value
       osd_session_open:
         signal: objecter_osd_session_open
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7168,11 +7169,11 @@ views:
       poolop_resend:
         signal: objecter_poolop_resend
         components:
-        - value
+          - value
       poolop_send:
         signal: objecter_poolop_send
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7189,15 +7190,15 @@ views:
       replica_read_sent:
         signal: objecter_replica_read_sent
         components:
-        - value
+          - value
       replica_read_bounced:
         signal: objecter_replica_read_bounced
         components:
-        - value
+          - value
       replica_read_completed:
         signal: objecter_replica_read_completed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7214,11 +7215,11 @@ views:
       laggy:
         signal: objecter_osd_laggy
         components:
-        - value
+          - value
       sessions:
         signal: objecter_osd_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7235,19 +7236,19 @@ views:
       poolstat_resend:
         signal: objecter_poolstat_resend
         components:
-        - value
+          - value
       poolstat_send:
         signal: objecter_poolstat_send
         components:
-        - value
+          - value
       statfs_resend:
         signal: objecter_statfs_resend
         components:
-        - value
+          - value
       statfs_send:
         signal: objecter_statfs_send
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7264,7 +7265,7 @@ views:
       value:
         signal: objecter_oplen_avg_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7281,31 +7282,31 @@ views:
       nodeep_scrub:
         signal: osd_flag_nodeep_scrub
         components:
-        - value
+          - value
       nodown:
         signal: osd_flag_nodown
         components:
-        - value
+          - value
       noin:
         signal: osd_flag_noin
         components:
-        - value
+          - value
       noout:
         signal: osd_flag_noout
         components:
-        - value
+          - value
       norebalance:
         signal: osd_flag_norebalance
         components:
-        - value
+          - value
       noscrub:
         signal: osd_flag_noscrub
         components:
-        - value
+          - value
       noup:
         signal: osd_flag_noup
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7318,11 +7319,11 @@ views:
       full_ratio:
         signal: osd_full_ratio
         components:
-        - value
+          - value
       nearfull_ratio:
         signal: osd_nearfull_ratio
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7336,7 +7337,7 @@ views:
       value:
         signal: osd_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7349,11 +7350,11 @@ views:
       in:
         signal: osd_in
         components:
-        - value
+          - value
       up:
         signal: osd_up
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7366,7 +7367,7 @@ views:
       weight:
         signal: osd_weight
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7379,75 +7380,75 @@ views:
       op_before_dequeue_op_lat:
         signal: osd_op_before_dequeue_op_lat_sum
         components:
-        - value
+          - value
       op_before_queue_op_lat:
         signal: osd_op_before_queue_op_lat_sum
         components:
-        - value
+          - value
       op_latency:
         signal: osd_op_latency_sum
         components:
-        - value
+          - value
       op_prepare_latency:
         signal: osd_op_prepare_latency_sum
         components:
-        - value
+          - value
       op_process_latency:
         signal: osd_op_process_latency_sum
         components:
-        - value
+          - value
       op_r_latency:
         signal: osd_op_r_latency_sum
         components:
-        - value
+          - value
       op_r_prepare_latency:
         signal: osd_op_r_prepare_latency_sum
         components:
-        - value
+          - value
       op_r_process_latency:
         signal: osd_op_r_process_latency_sum
         components:
-        - value
+          - value
       op_rw_latency:
         signal: osd_op_rw_latency_sum
         components:
-        - value
+          - value
       op_rw_prepare_latency:
         signal: osd_op_rw_prepare_latency_sum
         components:
-        - value
+          - value
       op_rw_process_latency:
         signal: osd_op_rw_process_latency_sum
         components:
-        - value
+          - value
       op_w_latency:
         signal: osd_op_w_latency_sum
         components:
-        - value
+          - value
       op_w_prepare_latency:
         signal: osd_op_w_prepare_latency_sum
         components:
-        - value
+          - value
       op_w_process_latency:
         signal: osd_op_w_process_latency_sum
         components:
-        - value
+          - value
       subop_latency:
         signal: osd_subop_latency_sum
         components:
-        - value
+          - value
       subop_pull_latency:
         signal: osd_subop_pull_latency_sum
         components:
-        - value
+          - value
       subop_push_latency:
         signal: osd_subop_push_latency_sum
         components:
-        - value
+          - value
       subop_w_latency:
         signal: osd_subop_w_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7460,39 +7461,39 @@ views:
       op_in_bytes:
         signal: osd_op_in_bytes
         components:
-        - value
+          - value
       op_out_bytes:
         signal: osd_op_out_bytes
         components:
-        - value
+          - value
       op_r_out_bytes:
         signal: osd_op_r_out_bytes
         components:
-        - value
+          - value
       op_rw_in_bytes:
         signal: osd_op_rw_in_bytes
         components:
-        - value
+          - value
       op_rw_out_bytes:
         signal: osd_op_rw_out_bytes
         components:
-        - value
+          - value
       op_w_in_bytes:
         signal: osd_op_w_in_bytes
         components:
-        - value
+          - value
       subop_in_bytes:
         signal: osd_subop_in_bytes
         components:
-        - value
+          - value
       subop_push_in_bytes:
         signal: osd_subop_push_in_bytes
         components:
-        - value
+          - value
       subop_w_in_bytes:
         signal: osd_subop_w_in_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7505,7 +7506,7 @@ views:
       value:
         signal: osd_op_wip
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7518,7 +7519,7 @@ views:
       value:
         signal: osd_subop_push
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7531,7 +7532,7 @@ views:
       value:
         signal: osd_slow_ops_slow_ops_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7544,75 +7545,75 @@ views:
       op_before_dequeue_op_lat:
         signal: osd_op_before_dequeue_op_lat_count
         components:
-        - value
+          - value
       op_before_queue_op_lat:
         signal: osd_op_before_queue_op_lat_count
         components:
-        - value
+          - value
       op_latency:
         signal: osd_op_latency_count
         components:
-        - value
+          - value
       op_prepare_latency:
         signal: osd_op_prepare_latency_count
         components:
-        - value
+          - value
       op_process_latency:
         signal: osd_op_process_latency_count
         components:
-        - value
+          - value
       op_r_latency:
         signal: osd_op_r_latency_count
         components:
-        - value
+          - value
       op_r_prepare_latency:
         signal: osd_op_r_prepare_latency_count
         components:
-        - value
+          - value
       op_r_process_latency:
         signal: osd_op_r_process_latency_count
         components:
-        - value
+          - value
       op_rw_latency:
         signal: osd_op_rw_latency_count
         components:
-        - value
+          - value
       op_rw_prepare_latency:
         signal: osd_op_rw_prepare_latency_count
         components:
-        - value
+          - value
       op_rw_process_latency:
         signal: osd_op_rw_process_latency_count
         components:
-        - value
+          - value
       op_w_latency:
         signal: osd_op_w_latency_count
         components:
-        - value
+          - value
       op_w_prepare_latency:
         signal: osd_op_w_prepare_latency_count
         components:
-        - value
+          - value
       op_w_process_latency:
         signal: osd_op_w_process_latency_count
         components:
-        - value
+          - value
       subop_latency:
         signal: osd_subop_latency_count
         components:
-        - value
+          - value
       subop_pull_latency:
         signal: osd_subop_pull_latency_count
         components:
-        - value
+          - value
       subop_push_latency:
         signal: osd_subop_push_latency_count
         components:
-        - value
+          - value
       subop_w_latency:
         signal: osd_subop_w_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7625,7 +7626,7 @@ views:
       value:
         signal: osd_op_cache_hit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7638,15 +7639,15 @@ views:
       op_delayed_degraded:
         signal: osd_op_delayed_degraded
         components:
-        - value
+          - value
       op_delayed_unreadable:
         signal: osd_op_delayed_unreadable
         components:
-        - value
+          - value
       replica_read_redirect_missing:
         signal: osd_replica_read_redirect_missing
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7659,47 +7660,47 @@ views:
       op:
         signal: osd_op
         components:
-        - value
+          - value
       op_r:
         signal: osd_op_r
         components:
-        - value
+          - value
       op_rw:
         signal: osd_op_rw
         components:
-        - value
+          - value
       op_w:
         signal: osd_op_w
         components:
-        - value
+          - value
       replica_read:
         signal: osd_replica_read
         components:
-        - value
+          - value
       replica_read_redirect_conflict:
         signal: osd_replica_read_redirect_conflict
         components:
-        - value
+          - value
       replica_read_served:
         signal: osd_replica_read_served
         components:
-        - value
+          - value
       subop_pull:
         signal: osd_subop_pull
         components:
-        - value
+          - value
       subop_w:
         signal: osd_subop_w
         components:
-        - value
+          - value
       tier_proxy_read:
         signal: osd_tier_proxy_read
         components:
-        - value
+          - value
       tier_proxy_write:
         signal: osd_tier_proxy_write
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7712,11 +7713,11 @@ views:
       apply_latency_ms:
         signal: osd_apply_latency_ms
         components:
-        - value
+          - value
       commit_latency_ms:
         signal: osd_commit_latency_ms
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7725,7 +7726,7 @@ views:
       convention: duration_milliseconds
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   osd_recovery.accumulated_latency:
     family: Ceph/OSD Recovery
     question: What is the accumulated latency for each ceph daemon?
@@ -7734,35 +7735,35 @@ views:
       backfill_queue_latency:
         signal: osd_l_osd_recovery_backfill_queue_latency_sum
         components:
-        - value
+          - value
       backfill_remove_queue_latency:
         signal: osd_l_osd_recovery_backfill_remove_queue_latency_sum
         components:
-        - value
+          - value
       context_queue_latency:
         signal: osd_l_osd_recovery_context_queue_latency_sum
         components:
-        - value
+          - value
       pull_queue_latency:
         signal: osd_l_osd_recovery_pull_queue_latency_sum
         components:
-        - value
+          - value
       push_queue_latency:
         signal: osd_l_osd_recovery_push_queue_latency_sum
         components:
-        - value
+          - value
       push_reply_queue_latency:
         signal: osd_l_osd_recovery_push_reply_queue_latency_sum
         components:
-        - value
+          - value
       queue_latency:
         signal: osd_l_osd_recovery_queue_latency_sum
         components:
-        - value
+          - value
       scan_queue_latency:
         signal: osd_l_osd_recovery_scan_queue_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7775,7 +7776,7 @@ views:
       value:
         signal: osd_recovery_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7788,35 +7789,35 @@ views:
       backfill_queue_latency:
         signal: osd_l_osd_recovery_backfill_queue_latency_count
         components:
-        - value
+          - value
       backfill_remove_queue_latency:
         signal: osd_l_osd_recovery_backfill_remove_queue_latency_count
         components:
-        - value
+          - value
       context_queue_latency:
         signal: osd_l_osd_recovery_context_queue_latency_count
         components:
-        - value
+          - value
       pull_queue_latency:
         signal: osd_l_osd_recovery_pull_queue_latency_count
         components:
-        - value
+          - value
       push_queue_latency:
         signal: osd_l_osd_recovery_push_queue_latency_count
         components:
-        - value
+          - value
       push_reply_queue_latency:
         signal: osd_l_osd_recovery_push_reply_queue_latency_count
         components:
-        - value
+          - value
       queue_latency:
         signal: osd_l_osd_recovery_queue_latency_count
         components:
-        - value
+          - value
       scan_queue_latency:
         signal: osd_l_osd_recovery_scan_queue_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7829,7 +7830,7 @@ views:
       value:
         signal: osd_recovery_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7842,15 +7843,15 @@ views:
       flush_lat:
         signal: osd_osd_tier_flush_lat_sum
         components:
-        - value
+          - value
       promote_lat:
         signal: osd_osd_tier_promote_lat_sum
         components:
-        - value
+          - value
       r_lat:
         signal: osd_osd_tier_r_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7863,7 +7864,7 @@ views:
       value:
         signal: osd_osd_map_cache_miss_low_avg_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7876,7 +7877,7 @@ views:
       value:
         signal: osd_push_out_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7889,7 +7890,7 @@ views:
       copyfrom:
         signal: osd_copyfrom
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7902,15 +7903,15 @@ views:
       cached_crc:
         signal: osd_cached_crc
         components:
-        - value
+          - value
       cached_crc_adjusted:
         signal: osd_cached_crc_adjusted
         components:
-        - value
+          - value
       missed_crc:
         signal: osd_missed_crc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7923,11 +7924,11 @@ views:
       tier_flush_fail:
         signal: osd_tier_flush_fail
         components:
-        - value
+          - value
       tier_try_flush_fail:
         signal: osd_tier_try_flush_fail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7940,7 +7941,7 @@ views:
       heartbeat_to_peers:
         signal: osd_heartbeat_to_peers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7953,15 +7954,15 @@ views:
       flush_lat:
         signal: osd_osd_tier_flush_lat_count
         components:
-        - value
+          - value
       promote_lat:
         signal: osd_osd_tier_promote_lat_count
         components:
-        - value
+          - value
       r_lat:
         signal: osd_osd_tier_r_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7974,7 +7975,7 @@ views:
       loadavg:
         signal: osd_loadavg
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7987,11 +7988,11 @@ views:
       osd_map_bl_cache_hit:
         signal: osd_osd_map_bl_cache_hit
         components:
-        - value
+          - value
       osd_map_bl_cache_miss:
         signal: osd_osd_map_bl_cache_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8004,15 +8005,15 @@ views:
       osd_map_cache_hit:
         signal: osd_osd_map_cache_hit
         components:
-        - value
+          - value
       osd_map_cache_miss:
         signal: osd_osd_map_cache_miss
         components:
-        - value
+          - value
       osd_map_cache_miss_low:
         signal: osd_osd_map_cache_miss_low
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8025,11 +8026,11 @@ views:
       map_message_epochs:
         signal: osd_map_message_epochs
         components:
-        - value
+          - value
       map_message_epoch_dups:
         signal: osd_map_message_epoch_dups
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8042,11 +8043,11 @@ views:
       map_messages:
         signal: osd_map_messages
         components:
-        - value
+          - value
       messages_delayed_for_map:
         signal: osd_messages_delayed_for_map
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8059,11 +8060,11 @@ views:
       object_ctx_cache_hit:
         signal: osd_object_ctx_cache_hit
         components:
-        - value
+          - value
       object_ctx_cache:
         signal: osd_object_ctx_cache_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8076,23 +8077,23 @@ views:
       numpg:
         signal: osd_numpg
         components:
-        - value
+          - value
       primary:
         signal: osd_numpg_primary
         components:
-        - value
+          - value
       removing:
         signal: osd_numpg_removing
         components:
-        - value
+          - value
       replica:
         signal: osd_numpg_replica
         components:
-        - value
+          - value
       stray:
         signal: osd_numpg_stray
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8101,7 +8102,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   osd_runtime.pg_updates:
     family: Ceph/OSD Runtime
     question: What is the placement-group updates for each ceph daemon?
@@ -8110,11 +8111,11 @@ views:
       osd_pg_biginfo:
         signal: osd_osd_pg_biginfo
         components:
-        - value
+          - value
       osd_pg_fastinfo:
         signal: osd_osd_pg_fastinfo
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8127,7 +8128,7 @@ views:
       total:
         signal: osd_osd_pg_info
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8140,7 +8141,7 @@ views:
       pull:
         signal: osd_pull
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8153,7 +8154,7 @@ views:
       push:
         signal: osd_push
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8166,7 +8167,7 @@ views:
       agent_skip:
         signal: osd_agent_skip
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8179,15 +8180,15 @@ views:
       bytes:
         signal: osd_stat_bytes
         components:
-        - value
+          - value
       avail:
         signal: osd_stat_bytes_avail
         components:
-        - value
+          - value
       used:
         signal: osd_stat_bytes_used
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8200,7 +8201,7 @@ views:
       subop:
         signal: osd_subop
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8213,31 +8214,31 @@ views:
       agent_evict:
         signal: osd_agent_evict
         components:
-        - value
+          - value
       agent_wake:
         signal: osd_agent_wake
         components:
-        - value
+          - value
       tier_clean:
         signal: osd_tier_clean
         components:
-        - value
+          - value
       tier_delay:
         signal: osd_tier_delay
         components:
-        - value
+          - value
       tier_dirty:
         signal: osd_tier_dirty
         components:
-        - value
+          - value
       tier_evict:
         signal: osd_tier_evict
         components:
-        - value
+          - value
       tier_promote:
         signal: osd_tier_promote
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8250,15 +8251,15 @@ views:
       agent_flush:
         signal: osd_agent_flush
         components:
-        - value
+          - value
       tier_flush:
         signal: osd_tier_flush
         components:
-        - value
+          - value
       tier_try_flush:
         signal: osd_tier_try_flush
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8271,7 +8272,7 @@ views:
       tier_whiteout:
         signal: osd_tier_whiteout
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8284,7 +8285,7 @@ views:
       value:
         signal: osd_osd_map_cache_miss_low_avg_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8297,7 +8298,7 @@ views:
       watch_timeouts:
         signal: osd_watch_timeouts
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8310,35 +8311,35 @@ views:
       dp_ec_failed_reservations_elapsed:
         signal: osd_scrub_dp_ec_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       dp_ec_successful_reservations_elapsed:
         signal: osd_scrub_dp_ec_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
       dp_repl_failed_reservations_elapsed:
         signal: osd_scrub_dp_repl_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       dp_repl_successful_reservations_elapsed:
         signal: osd_scrub_dp_repl_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
       sh_ec_failed_reservations_elapsed:
         signal: osd_scrub_sh_ec_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       sh_ec_successful_reservations_elapsed:
         signal: osd_scrub_sh_ec_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
       sh_repl_failed_reservations_elapsed:
         signal: osd_scrub_sh_repl_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       sh_repl_successful_reservations_elapsed:
         signal: osd_scrub_sh_repl_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8351,35 +8352,35 @@ views:
       dp_ec_failed_scrubs_elapsed:
         signal: osd_scrub_dp_ec_failed_scrubs_elapsed_sum
         components:
-        - value
+          - value
       dp_ec_successful_scrubs_elapsed:
         signal: osd_scrub_dp_ec_successful_scrubs_elapsed_sum
         components:
-        - value
+          - value
       dp_repl_failed_scrubs_elapsed:
         signal: osd_scrub_dp_repl_failed_scrubs_elapsed_sum
         components:
-        - value
+          - value
       dp_repl_successful_scrubs_elapsed:
         signal: osd_scrub_dp_repl_successful_scrubs_elapsed_sum
         components:
-        - value
+          - value
       sh_ec_failed_scrubs_elapsed:
         signal: osd_scrub_sh_ec_failed_scrubs_elapsed_sum
         components:
-        - value
+          - value
       sh_ec_successful_scrubs_elapsed:
         signal: osd_scrub_sh_ec_successful_scrubs_elapsed_sum
         components:
-        - value
+          - value
       sh_repl_failed_scrubs_elapsed:
         signal: osd_scrub_sh_repl_failed_scrubs_elapsed_sum
         components:
-        - value
+          - value
       sh_repl_successful_scrubs_elapsed:
         signal: osd_scrub_sh_repl_successful_scrubs_elapsed_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8392,35 +8393,35 @@ views:
       dp_ec_failed_reservations_elapsed:
         signal: osd_scrub_dp_ec_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       dp_ec_successful_reservations_elapsed:
         signal: osd_scrub_dp_ec_successful_reservations_elapsed_count
         components:
-        - value
+          - value
       dp_repl_failed_reservations_elapsed:
         signal: osd_scrub_dp_repl_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       dp_repl_successful_reservations_elapsed:
         signal: osd_scrub_dp_repl_successful_reservations_elapsed_count
         components:
-        - value
+          - value
       sh_ec_failed_reservations_elapsed:
         signal: osd_scrub_sh_ec_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       sh_ec_successful_reservations_elapsed:
         signal: osd_scrub_sh_ec_successful_reservations_elapsed_count
         components:
-        - value
+          - value
       sh_repl_failed_reservations_elapsed:
         signal: osd_scrub_sh_repl_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       sh_repl_successful_reservations_elapsed:
         signal: osd_scrub_sh_repl_successful_reservations_elapsed_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8433,35 +8434,35 @@ views:
       dp_ec_failed_scrubs_elapsed:
         signal: osd_scrub_dp_ec_failed_scrubs_elapsed_count
         components:
-        - value
+          - value
       dp_ec_successful_scrubs_elapsed:
         signal: osd_scrub_dp_ec_successful_scrubs_elapsed_count
         components:
-        - value
+          - value
       dp_repl_failed_scrubs_elapsed:
         signal: osd_scrub_dp_repl_failed_scrubs_elapsed_count
         components:
-        - value
+          - value
       dp_repl_successful_scrubs_elapsed:
         signal: osd_scrub_dp_repl_successful_scrubs_elapsed_count
         components:
-        - value
+          - value
       sh_ec_failed_scrubs_elapsed:
         signal: osd_scrub_sh_ec_failed_scrubs_elapsed_count
         components:
-        - value
+          - value
       sh_ec_successful_scrubs_elapsed:
         signal: osd_scrub_sh_ec_successful_scrubs_elapsed_count
         components:
-        - value
+          - value
       sh_repl_failed_scrubs_elapsed:
         signal: osd_scrub_sh_repl_failed_scrubs_elapsed_count
         components:
-        - value
+          - value
       sh_repl_successful_scrubs_elapsed:
         signal: osd_scrub_sh_repl_successful_scrubs_elapsed_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8474,51 +8475,51 @@ views:
       dp_ec_failed_scrubs:
         signal: osd_scrub_dp_ec_failed_scrubs
         components:
-        - value
+          - value
       dp_ec_num_scrubs_started:
         signal: osd_scrub_dp_ec_num_scrubs_started
         components:
-        - value
+          - value
       dp_ec_successful_scrubs:
         signal: osd_scrub_dp_ec_successful_scrubs
         components:
-        - value
+          - value
       dp_repl_failed_scrubs:
         signal: osd_scrub_dp_repl_failed_scrubs
         components:
-        - value
+          - value
       dp_repl_num_scrubs_started:
         signal: osd_scrub_dp_repl_num_scrubs_started
         components:
-        - value
+          - value
       dp_repl_successful_scrubs:
         signal: osd_scrub_dp_repl_successful_scrubs
         components:
-        - value
+          - value
       sh_ec_failed_scrubs:
         signal: osd_scrub_sh_ec_failed_scrubs
         components:
-        - value
+          - value
       sh_ec_num_scrubs_started:
         signal: osd_scrub_sh_ec_num_scrubs_started
         components:
-        - value
+          - value
       sh_ec_successful_scrubs:
         signal: osd_scrub_sh_ec_successful_scrubs
         components:
-        - value
+          - value
       sh_repl_failed_scrubs:
         signal: osd_scrub_sh_repl_failed_scrubs
         components:
-        - value
+          - value
       sh_repl_num_scrubs_started:
         signal: osd_scrub_sh_repl_num_scrubs_started
         components:
-        - value
+          - value
       sh_repl_successful_scrubs:
         signal: osd_scrub_sh_repl_successful_scrubs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8531,19 +8532,19 @@ views:
       dp_ec_replicas_in_reservation:
         signal: osd_scrub_dp_ec_replicas_in_reservation
         components:
-        - value
+          - value
       dp_repl_replicas_in_reservation:
         signal: osd_scrub_dp_repl_replicas_in_reservation
         components:
-        - value
+          - value
       sh_ec_replicas_in_reservation:
         signal: osd_scrub_sh_ec_replicas_in_reservation
         components:
-        - value
+          - value
       sh_repl_replicas_in_reservation:
         signal: osd_scrub_sh_repl_replicas_in_reservation
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8556,51 +8557,51 @@ views:
       dp_ec_reservation_process_aborted:
         signal: osd_scrub_dp_ec_reservation_process_aborted
         components:
-        - value
+          - value
       dp_ec_reservation_process_failure:
         signal: osd_scrub_dp_ec_reservation_process_failure
         components:
-        - value
+          - value
       dp_ec_reservation_process_skipped:
         signal: osd_scrub_dp_ec_reservation_process_skipped
         components:
-        - value
+          - value
       dp_repl_reservation_process_aborted:
         signal: osd_scrub_dp_repl_reservation_process_aborted
         components:
-        - value
+          - value
       dp_repl_reservation_process_failure:
         signal: osd_scrub_dp_repl_reservation_process_failure
         components:
-        - value
+          - value
       dp_repl_reservation_process_skipped:
         signal: osd_scrub_dp_repl_reservation_process_skipped
         components:
-        - value
+          - value
       sh_ec_reservation_process_aborted:
         signal: osd_scrub_sh_ec_reservation_process_aborted
         components:
-        - value
+          - value
       sh_ec_reservation_process_failure:
         signal: osd_scrub_sh_ec_reservation_process_failure
         components:
-        - value
+          - value
       sh_ec_reservation_process_skipped:
         signal: osd_scrub_sh_ec_reservation_process_skipped
         components:
-        - value
+          - value
       sh_repl_reservation_process_aborted:
         signal: osd_scrub_sh_repl_reservation_process_aborted
         components:
-        - value
+          - value
       sh_repl_reservation_process_failure:
         signal: osd_scrub_sh_repl_reservation_process_failure
         components:
-        - value
+          - value
       sh_repl_reservation_process_skipped:
         signal: osd_scrub_sh_repl_reservation_process_skipped
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8613,19 +8614,19 @@ views:
       dp_ec_num_scrubs_past_reservation:
         signal: osd_scrub_dp_ec_num_scrubs_past_reservation
         components:
-        - value
+          - value
       dp_repl_num_scrubs_past_reservation:
         signal: osd_scrub_dp_repl_num_scrubs_past_reservation
         components:
-        - value
+          - value
       sh_ec_num_scrubs_past_reservation:
         signal: osd_scrub_sh_ec_num_scrubs_past_reservation
         components:
-        - value
+          - value
       sh_repl_num_scrubs_past_reservation:
         signal: osd_scrub_sh_repl_num_scrubs_past_reservation
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8638,19 +8639,19 @@ views:
       scrub_ec_failed_reservations_elapsed:
         signal: osd_scrub_ec_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       scrub_ec_successful_reservations_elapsed:
         signal: osd_scrub_ec_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
       scrub_replicated_failed_reservations_elapsed:
         signal: osd_scrub_replicated_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       scrub_replicated_successful_reservations_elapsed:
         signal: osd_scrub_replicated_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8663,19 +8664,19 @@ views:
       failed_scrubs_ec_elapsed:
         signal: osd_failed_scrubs_ec_elapsed_sum
         components:
-        - value
+          - value
       failed_scrubs_replicated_elapsed:
         signal: osd_failed_scrubs_replicated_elapsed_sum
         components:
-        - value
+          - value
       successful_scrubs_ec_elapsed:
         signal: osd_successful_scrubs_ec_elapsed_sum
         components:
-        - value
+          - value
       successful_scrubs_replicated_elapsed:
         signal: osd_successful_scrubs_replicated_elapsed_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8688,19 +8689,19 @@ views:
       scrub_ec_failed_reservations_elapsed:
         signal: osd_scrub_ec_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       scrub_ec_successful_reservations_elapsed:
         signal: osd_scrub_ec_successful_reservations_elapsed_count
         components:
-        - value
+          - value
       scrub_replicated_failed_reservations_elapsed:
         signal: osd_scrub_replicated_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       scrub_replicated_successful_reservations_elapsed:
         signal: osd_scrub_replicated_successful_reservations_elapsed_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8713,19 +8714,19 @@ views:
       failed_scrubs_ec_elapsed:
         signal: osd_failed_scrubs_ec_elapsed_count
         components:
-        - value
+          - value
       failed_scrubs_replicated_elapsed:
         signal: osd_failed_scrubs_replicated_elapsed_count
         components:
-        - value
+          - value
       successful_scrubs_ec_elapsed:
         signal: osd_successful_scrubs_ec_elapsed_count
         components:
-        - value
+          - value
       successful_scrubs_replicated_elapsed:
         signal: osd_successful_scrubs_replicated_elapsed_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8738,19 +8739,19 @@ views:
       ec_io_blocked:
         signal: osd_scrub_ec_io_blocked
         components:
-        - value
+          - value
       ec_io_intersects:
         signal: osd_scrub_ec_io_intersects
         components:
-        - value
+          - value
       replicated_io_blocked:
         signal: osd_scrub_replicated_io_blocked
         components:
-        - value
+          - value
       replicated_io_intersects:
         signal: osd_scrub_replicated_io_intersects
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8763,27 +8764,27 @@ views:
       failed_scrubs_ec:
         signal: osd_failed_scrubs_ec
         components:
-        - value
+          - value
       failed_scrubs_replicated:
         signal: osd_failed_scrubs_replicated
         components:
-        - value
+          - value
       num_scrubs_started_ec:
         signal: osd_num_scrubs_started_ec
         components:
-        - value
+          - value
       num_scrubs_started_replicated:
         signal: osd_num_scrubs_started_replicated
         components:
-        - value
+          - value
       successful_scrubs_ec:
         signal: osd_successful_scrubs_ec
         components:
-        - value
+          - value
       successful_scrubs_replicated:
         signal: osd_successful_scrubs_replicated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8796,11 +8797,11 @@ views:
       ec_replicas_in_reservation:
         signal: osd_scrub_ec_replicas_in_reservation
         components:
-        - value
+          - value
       replicated_replicas_in_reservation:
         signal: osd_scrub_replicated_replicas_in_reservation
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8813,35 +8814,35 @@ views:
       scrub_ec_reservation_process_aborted:
         signal: osd_scrub_ec_reservation_process_aborted
         components:
-        - value
+          - value
       scrub_ec_reservation_process_failure:
         signal: osd_scrub_ec_reservation_process_failure
         components:
-        - value
+          - value
       scrub_ec_reservation_process_skipped:
         signal: osd_scrub_ec_reservation_process_skipped
         components:
-        - value
+          - value
       scrub_ec_reservations_completed:
         signal: osd_scrub_ec_reservations_completed
         components:
-        - value
+          - value
       scrub_replicated_reservation_process_aborted:
         signal: osd_scrub_replicated_reservation_process_aborted
         components:
-        - value
+          - value
       scrub_replicated_reservation_process_failure:
         signal: osd_scrub_replicated_reservation_process_failure
         components:
-        - value
+          - value
       scrub_replicated_reservation_process_skipped:
         signal: osd_scrub_replicated_reservation_process_skipped
         components:
-        - value
+          - value
       scrub_replicated_scrub_reservations_completed:
         signal: osd_scrub_replicated_scrub_reservations_completed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8854,11 +8855,11 @@ views:
       num_scrubs_past_reservation_ec:
         signal: osd_num_scrubs_past_reservation_ec
         components:
-        - value
+          - value
       num_scrubs_past_reservation_replicated:
         signal: osd_num_scrubs_past_reservation_replicated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8871,11 +8872,11 @@ views:
       ec_read_bytes:
         signal: osd_scrub_ec_read_bytes
         components:
-        - value
+          - value
       replicated_read_bytes:
         signal: osd_scrub_replicated_read_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8888,27 +8889,27 @@ views:
       ec_getattr_cnt:
         signal: osd_scrub_ec_getattr_cnt
         components:
-        - value
+          - value
       ec_read_cnt:
         signal: osd_scrub_ec_read_cnt
         components:
-        - value
+          - value
       ec_stats_cnt:
         signal: osd_scrub_ec_stats_cnt
         components:
-        - value
+          - value
       replicated_getattr_cnt:
         signal: osd_scrub_replicated_getattr_cnt
         components:
-        - value
+          - value
       replicated_read_cnt:
         signal: osd_scrub_replicated_read_cnt
         components:
-        - value
+          - value
       replicated_stats_cnt:
         signal: osd_scrub_replicated_stats_cnt
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8921,19 +8922,19 @@ views:
       dp_ec_write_blocked_by_scrub:
         signal: osd_scrub_dp_ec_write_blocked_by_scrub
         components:
-        - value
+          - value
       dp_repl_write_blocked_by_scrub:
         signal: osd_scrub_dp_repl_write_blocked_by_scrub
         components:
-        - value
+          - value
       sh_ec_write_blocked_by_scrub:
         signal: osd_scrub_sh_ec_write_blocked_by_scrub
         components:
-        - value
+          - value
       sh_repl_write_blocked_by_scrub:
         signal: osd_scrub_sh_repl_write_blocked_by_scrub
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8946,35 +8947,35 @@ views:
       dp_ec_chunk_busy:
         signal: osd_scrub_dp_ec_chunk_busy
         components:
-        - value
+          - value
       dp_ec_chunk_selected:
         signal: osd_scrub_dp_ec_chunk_selected
         components:
-        - value
+          - value
       dp_repl_chunk_busy:
         signal: osd_scrub_dp_repl_chunk_busy
         components:
-        - value
+          - value
       dp_repl_chunk_selected:
         signal: osd_scrub_dp_repl_chunk_selected
         components:
-        - value
+          - value
       sh_ec_chunk_busy:
         signal: osd_scrub_sh_ec_chunk_busy
         components:
-        - value
+          - value
       sh_ec_chunk_selected:
         signal: osd_scrub_sh_ec_chunk_selected
         components:
-        - value
+          - value
       sh_repl_chunk_busy:
         signal: osd_scrub_sh_repl_chunk_busy
         components:
-        - value
+          - value
       sh_repl_chunk_selected:
         signal: osd_scrub_sh_repl_chunk_selected
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8987,19 +8988,19 @@ views:
       dp_ec_locked_object:
         signal: osd_scrub_dp_ec_locked_object
         components:
-        - value
+          - value
       dp_repl_locked_object:
         signal: osd_scrub_dp_repl_locked_object
         components:
-        - value
+          - value
       sh_ec_locked_object:
         signal: osd_scrub_sh_ec_locked_object
         components:
-        - value
+          - value
       sh_repl_locked_object:
         signal: osd_scrub_sh_repl_locked_object
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9012,19 +9013,19 @@ views:
       dp_ec_preemptions:
         signal: osd_scrub_dp_ec_preemptions
         components:
-        - value
+          - value
       dp_repl_preemptions:
         signal: osd_scrub_dp_repl_preemptions
         components:
-        - value
+          - value
       sh_ec_preemptions:
         signal: osd_scrub_sh_ec_preemptions
         components:
-        - value
+          - value
       sh_repl_preemptions:
         signal: osd_scrub_sh_repl_preemptions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9037,19 +9038,19 @@ views:
       dp_ec_scrub_reservations_completed:
         signal: osd_scrub_dp_ec_scrub_reservations_completed
         components:
-        - value
+          - value
       dp_repl_scrub_reservations_completed:
         signal: osd_scrub_dp_repl_scrub_reservations_completed
         components:
-        - value
+          - value
       sh_ec_scrub_reservations_completed:
         signal: osd_scrub_sh_ec_scrub_reservations_completed
         components:
-        - value
+          - value
       sh_repl_scrub_reservations_completed:
         signal: osd_scrub_sh_repl_scrub_reservations_completed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9062,11 +9063,11 @@ views:
       omapget_bytes:
         signal: osd_scrub_omapget_bytes
         components:
-        - value
+          - value
       omapgetheader_bytes:
         signal: osd_scrub_omapgetheader_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9079,11 +9080,11 @@ views:
       omapget_cnt:
         signal: osd_scrub_omapget_cnt
         components:
-        - value
+          - value
       omapgetheader_cnt:
         signal: osd_scrub_omapgetheader_cnt
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9096,27 +9097,27 @@ views:
       backfill_toofull:
         signal: pg_backfill_toofull
         components:
-        - value
+          - value
       backfill_unfound:
         signal: pg_backfill_unfound
         components:
-        - value
+          - value
       backfill_wait:
         signal: pg_backfill_wait
         components:
-        - value
+          - value
       backfilling:
         signal: pg_backfilling
         components:
-        - value
+          - value
       forced_backfill:
         signal: pg_forced_backfill
         components:
-        - value
+          - value
       remapped:
         signal: pg_remapped
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9125,7 +9126,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   placement_groups_and_recovery.healthy_state.pg_state:
     family: Ceph/Placement Groups and Recovery/Healthy State
     question: What is the placement groups for each pool id?
@@ -9134,19 +9135,19 @@ views:
       active:
         signal: pg_active
         components:
-        - value
+          - value
       clean:
         signal: pg_clean
         components:
-        - value
+          - value
       deep:
         signal: pg_deep
         components:
-        - value
+          - value
       pg_total:
         signal: pg_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9155,7 +9156,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   placement_groups_and_recovery.peering_and_availability.pg_state:
     family: Ceph/Placement Groups and Recovery/Peering and Availability
     question: What is the placement groups for each pool id?
@@ -9164,47 +9165,47 @@ views:
       activating:
         signal: pg_activating
         components:
-        - value
+          - value
       creating:
         signal: pg_creating
         components:
-        - value
+          - value
       down:
         signal: pg_down
         components:
-        - value
+          - value
       incomplete:
         signal: pg_incomplete
         components:
-        - value
+          - value
       laggy:
         signal: pg_laggy
         components:
-        - value
+          - value
       peered:
         signal: pg_peered
         components:
-        - value
+          - value
       peering:
         signal: pg_peering
         components:
-        - value
+          - value
       premerge:
         signal: pg_premerge
         components:
-        - value
+          - value
       stale:
         signal: pg_stale
         components:
-        - value
+          - value
       unknown:
         signal: pg_unknown
         components:
-        - value
+          - value
       wait:
         signal: pg_wait
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9213,7 +9214,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   placement_groups_and_recovery.recovery_and_degradation.pg_state:
     family: Ceph/Placement Groups and Recovery/Recovery and Degradation
     question: What is the placement groups for each pool id?
@@ -9222,31 +9223,31 @@ views:
       degraded:
         signal: pg_degraded
         components:
-        - value
+          - value
       forced_recovery:
         signal: pg_forced_recovery
         components:
-        - value
+          - value
       recovering:
         signal: pg_recovering
         components:
-        - value
+          - value
       recovery_toofull:
         signal: pg_recovery_toofull
         components:
-        - value
+          - value
       recovery_unfound:
         signal: pg_recovery_unfound
         components:
-        - value
+          - value
       recovery_wait:
         signal: pg_recovery_wait
         components:
-        - value
+          - value
       undersized:
         signal: pg_undersized
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9255,7 +9256,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   placement_groups_and_recovery.recovery_flags.state:
     family: Ceph/Placement Groups and Recovery/Recovery Flags
     question: What is the state and metadata?
@@ -9264,11 +9265,11 @@ views:
       nobackfill:
         signal: osd_flag_nobackfill
         components:
-        - value
+          - value
       norecover:
         signal: osd_flag_norecover
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9281,31 +9282,31 @@ views:
       failed_repair:
         signal: pg_failed_repair
         components:
-        - value
+          - value
       inconsistent:
         signal: pg_inconsistent
         components:
-        - value
+          - value
       repair:
         signal: pg_repair
         components:
-        - value
+          - value
       scrubbing:
         signal: pg_scrubbing
         components:
-        - value
+          - value
       snaptrim:
         signal: pg_snaptrim
         components:
-        - value
+          - value
       snaptrim_error:
         signal: pg_snaptrim_error
         components:
-        - value
+          - value
       snaptrim_wait:
         signal: pg_snaptrim_wait
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9314,7 +9315,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   pools.capacity_and_quotas.compression_space:
     family: Ceph/Pools/Capacity and Quotas
     question: What is the compression space for each pool id?
@@ -9323,11 +9324,11 @@ views:
       compress_bytes_used:
         signal: pool_compress_bytes_used
         components:
-        - value
+          - value
       compress_under_bytes:
         signal: pool_compress_under_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9340,15 +9341,15 @@ views:
       max_avail:
         signal: pool_max_avail
         components:
-        - value
+          - value
       quota_bytes:
         signal: pool_quota_bytes
         components:
-        - value
+          - value
       stored:
         signal: pool_stored
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9361,7 +9362,7 @@ views:
       value:
         signal: pool_quota_objects
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9374,15 +9375,15 @@ views:
       avail_raw:
         signal: pool_avail_raw
         components:
-        - value
+          - value
       bytes_used:
         signal: pool_bytes_used
         components:
-        - value
+          - value
       stored_raw:
         signal: pool_stored_raw
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9395,7 +9396,7 @@ views:
       value:
         signal: pool_percent_used
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9404,7 +9405,7 @@ views:
       convention: percentage
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   pools.client_i_o.byte_throughput:
     family: Ceph/Pools/Client I/O
     question: What is the byte throughput for each pool id?
@@ -9413,11 +9414,11 @@ views:
       rd_bytes:
         signal: pool_rd_bytes
         components:
-        - value
+          - value
       wr_bytes:
         signal: pool_wr_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9430,11 +9431,11 @@ views:
       rd:
         signal: pool_rd
         components:
-        - value
+          - value
       wr:
         signal: pool_wr
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9448,7 +9449,7 @@ views:
       value:
         signal: pool_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9461,11 +9462,11 @@ views:
       dirty:
         signal: pool_dirty
         components:
-        - value
+          - value
       objects:
         signal: pool_objects
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9478,7 +9479,7 @@ views:
       value:
         signal: pool_recovering_bytes_per_sec
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9491,7 +9492,7 @@ views:
       value:
         signal: pool_recovering_keys_per_sec
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9504,7 +9505,7 @@ views:
       value:
         signal: pool_recovering_objects_per_sec
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9517,7 +9518,7 @@ views:
       value:
         signal: pool_num_objects_recovered
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9530,7 +9531,7 @@ views:
       value:
         signal: pool_objects_repaired
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9543,7 +9544,7 @@ views:
       value:
         signal: pool_num_bytes_recovered
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9556,15 +9557,15 @@ views:
       discard:
         signal: rbd_librbd_image_discard_latency_sum
         components:
-        - value
+          - value
       write_same:
         signal: rbd_librbd_image_ws_latency_sum
         components:
-        - value
+          - value
       compare_and_write:
         signal: rbd_librbd_image_cmp_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9577,7 +9578,7 @@ views:
       flush:
         signal: rbd_librbd_image_flush_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9590,11 +9591,11 @@ views:
       read:
         signal: rbd_librbd_image_rd_latency_sum
         components:
-        - value
+          - value
       write:
         signal: rbd_librbd_image_wr_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9607,15 +9608,15 @@ views:
       discard:
         signal: rbd_librbd_image_discard_bytes
         components:
-        - value
+          - value
       write_same:
         signal: rbd_librbd_image_ws_bytes
         components:
-        - value
+          - value
       compare_and_write:
         signal: rbd_librbd_image_cmp_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9628,15 +9629,15 @@ views:
       discard:
         signal: rbd_librbd_image_discard_latency_count
         components:
-        - value
+          - value
       write_same:
         signal: rbd_librbd_image_ws_latency_count
         components:
-        - value
+          - value
       compare_and_write:
         signal: rbd_librbd_image_cmp_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9649,15 +9650,15 @@ views:
       discard:
         signal: rbd_librbd_image_discard
         components:
-        - value
+          - value
       write_same:
         signal: rbd_librbd_image_ws
         components:
-        - value
+          - value
       compare_and_write:
         signal: rbd_librbd_image_cmp
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9670,7 +9671,7 @@ views:
       flush:
         signal: rbd_librbd_image_flush_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9683,7 +9684,7 @@ views:
       flush:
         signal: rbd_librbd_image_flush
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9696,11 +9697,11 @@ views:
       read:
         signal: rbd_librbd_image_rd_bytes
         components:
-        - value
+          - value
       write:
         signal: rbd_librbd_image_wr_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9713,11 +9714,11 @@ views:
       read:
         signal: rbd_librbd_image_rd_latency_count
         components:
-        - value
+          - value
       write:
         signal: rbd_librbd_image_wr_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9730,11 +9731,11 @@ views:
       read:
         signal: rbd_librbd_image_rd
         components:
-        - value
+          - value
       write:
         signal: rbd_librbd_image_wr
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9747,11 +9748,11 @@ views:
       opened:
         signal: rbd_librbd_image_opened_time
         components:
-        - value
+          - value
       lock_acquired:
         signal: rbd_librbd_image_lock_acquired_time
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9764,19 +9765,19 @@ views:
       notify:
         signal: rbd_librbd_image_notify
         components:
-        - value
+          - value
       resize:
         signal: rbd_librbd_image_resize
         components:
-        - value
+          - value
       readahead:
         signal: rbd_librbd_image_readahead
         components:
-        - value
+          - value
       invalidate_cache:
         signal: rbd_librbd_image_invalidate_cache
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9789,7 +9790,7 @@ views:
       readahead:
         signal: rbd_librbd_image_readahead_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9802,19 +9803,19 @@ views:
       create:
         signal: rbd_librbd_image_snap_create
         components:
-        - value
+          - value
       remove:
         signal: rbd_librbd_image_snap_remove
         components:
-        - value
+          - value
       rollback:
         signal: rbd_librbd_image_snap_rollback
         components:
-        - value
+          - value
       rename:
         signal: rbd_librbd_image_snap_rename
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9827,11 +9828,11 @@ views:
       read_bytes:
         signal: rbd_read_bytes
         components:
-        - value
+          - value
       write_bytes:
         signal: rbd_write_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9844,11 +9845,11 @@ views:
       read_ops:
         signal: rbd_read_ops
         components:
-        - value
+          - value
       write_ops:
         signal: rbd_write_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9861,7 +9862,7 @@ views:
       value:
         signal: rbd_image_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9874,11 +9875,11 @@ views:
       read_latency:
         signal: rbd_read_latency_sum
         components:
-        - value
+          - value
       write_latency:
         signal: rbd_write_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9891,11 +9892,11 @@ views:
       read_latency:
         signal: rbd_read_latency_count
         components:
-        - value
+          - value
       write_latency:
         signal: rbd_write_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9908,7 +9909,7 @@ views:
       value:
         signal: rbd_mirror_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9921,7 +9922,7 @@ views:
       value:
         signal: rbd_mirror_journal_replay_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9934,7 +9935,7 @@ views:
       value:
         signal: rbd_mirror_journal_replay_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9947,7 +9948,7 @@ views:
       value:
         signal: rbd_mirror_journal_image_replay_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9960,7 +9961,7 @@ views:
       value:
         signal: rbd_mirror_journal_image_replay_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9973,7 +9974,7 @@ views:
       value:
         signal: rbd_mirror_journal_image_entries
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9986,7 +9987,7 @@ views:
       value:
         signal: rbd_mirror_journal_image_replay_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9999,7 +10000,7 @@ views:
       value:
         signal: rbd_mirror_journal_entries
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10012,7 +10013,7 @@ views:
       value:
         signal: rbd_mirror_journal_replay_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10025,7 +10026,7 @@ views:
       image_sync_time:
         signal: rbd_mirror_snapshot_image_sync_time_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10038,7 +10039,7 @@ views:
       sync_time:
         signal: rbd_mirror_snapshot_sync_time_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10051,7 +10052,7 @@ views:
       image_sync_bytes:
         signal: rbd_mirror_snapshot_image_sync_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10064,7 +10065,7 @@ views:
       sync_bytes:
         signal: rbd_mirror_snapshot_sync_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10077,7 +10078,7 @@ views:
       value:
         signal: rbd_mirror_snapshot_image_last_sync_time
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10090,7 +10091,7 @@ views:
       value:
         signal: rbd_mirror_snapshot_image_last_sync_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10104,7 +10105,7 @@ views:
       image_sync_time:
         signal: rbd_mirror_snapshot_image_sync_time_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10117,7 +10118,7 @@ views:
       sync_time:
         signal: rbd_mirror_snapshot_sync_time_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10130,7 +10131,7 @@ views:
       image_snapshots:
         signal: rbd_mirror_snapshot_image_snapshots
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10143,7 +10144,7 @@ views:
       snapshots:
         signal: rbd_mirror_snapshot_snapshots
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10156,11 +10157,11 @@ views:
       local_timestamp:
         signal: rbd_mirror_snapshot_image_local_timestamp
         components:
-        - value
+          - value
       remote_timestamp:
         signal: rbd_mirror_snapshot_image_remote_timestamp
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10173,7 +10174,7 @@ views:
       client_lat:
         signal: client_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10186,19 +10187,19 @@ views:
       client_fsync:
         signal: client_fsync_sum
         components:
-        - value
+          - value
       client_rdlat:
         signal: client_rdlat_sum
         components:
-        - value
+          - value
       client_reply:
         signal: client_reply_sum
         components:
-        - value
+          - value
       client_wrlat:
         signal: client_wrlat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10211,23 +10212,23 @@ views:
       kstore_state_done_lat:
         signal: kstore_state_done_lat_sum
         components:
-        - value
+          - value
       kstore_state_finishing_lat:
         signal: kstore_state_finishing_lat_sum
         components:
-        - value
+          - value
       kstore_state_kv_done_lat:
         signal: kstore_state_kv_done_lat_sum
         components:
-        - value
+          - value
       kstore_state_kv_queued_lat:
         signal: kstore_state_kv_queued_lat_sum
         components:
-        - value
+          - value
       kstore_state_prepare_lat:
         signal: kstore_state_prepare_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10240,127 +10241,127 @@ views:
       recoverystate_perf_activating_latency:
         signal: recoverystate_perf_activating_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_active_latency:
         signal: recoverystate_perf_active_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_backfilling_latency:
         signal: recoverystate_perf_backfilling_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_clean_latency:
         signal: recoverystate_perf_clean_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_down_latency:
         signal: recoverystate_perf_down_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_getinfo_latency:
         signal: recoverystate_perf_getinfo_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_getlog_latency:
         signal: recoverystate_perf_getlog_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_getmissing_latency:
         signal: recoverystate_perf_getmissing_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_incomplete_latency:
         signal: recoverystate_perf_incomplete_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_initial_latency:
         signal: recoverystate_perf_initial_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_notbackfilling_latency:
         signal: recoverystate_perf_notbackfilling_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_notrecovering_latency:
         signal: recoverystate_perf_notrecovering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_peering_latency:
         signal: recoverystate_perf_peering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_primary_latency:
         signal: recoverystate_perf_primary_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_recovered_latency:
         signal: recoverystate_perf_recovered_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_recovering_latency:
         signal: recoverystate_perf_recovering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_replicaactive_latency:
         signal: recoverystate_perf_replicaactive_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_repnotrecovering_latency:
         signal: recoverystate_perf_repnotrecovering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_reprecovering_latency:
         signal: recoverystate_perf_reprecovering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_repwaitbackfillreserved_latency:
         signal: recoverystate_perf_repwaitbackfillreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_repwaitrecoveryreserved_latency:
         signal: recoverystate_perf_repwaitrecoveryreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_reset_latency:
         signal: recoverystate_perf_reset_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_start_latency:
         signal: recoverystate_perf_start_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_started_latency:
         signal: recoverystate_perf_started_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_stray_latency:
         signal: recoverystate_perf_stray_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitactingchange_latency:
         signal: recoverystate_perf_waitactingchange_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitlocalbackfillreserved_latency:
         signal: recoverystate_perf_waitlocalbackfillreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitlocalrecoveryreserved_latency:
         signal: recoverystate_perf_waitlocalrecoveryreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitremotebackfillreserved_latency:
         signal: recoverystate_perf_waitremotebackfillreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitremoterecoveryreserved_latency:
         signal: recoverystate_perf_waitremoterecoveryreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitupthru_latency:
         signal: recoverystate_perf_waitupthru_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10373,71 +10374,71 @@ views:
       libcephsqlite_vfs_op_access:
         signal: libcephsqlite_vfs_op_access_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_currenttime:
         signal: libcephsqlite_vfs_op_currenttime_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_delete:
         signal: libcephsqlite_vfs_op_delete_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_fullpathname:
         signal: libcephsqlite_vfs_op_fullpathname_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_open:
         signal: libcephsqlite_vfs_op_open_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_checkreservedlock:
         signal: libcephsqlite_vfs_opf_checkreservedlock_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_close:
         signal: libcephsqlite_vfs_opf_close_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_devicecharacteristics:
         signal: libcephsqlite_vfs_opf_devicecharacteristics_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_filecontrol:
         signal: libcephsqlite_vfs_opf_filecontrol_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_filesize:
         signal: libcephsqlite_vfs_opf_filesize_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_lock:
         signal: libcephsqlite_vfs_opf_lock_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_read:
         signal: libcephsqlite_vfs_opf_read_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_sectorsize:
         signal: libcephsqlite_vfs_opf_sectorsize_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_sync:
         signal: libcephsqlite_vfs_opf_sync_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_truncate:
         signal: libcephsqlite_vfs_opf_truncate_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_unlock:
         signal: libcephsqlite_vfs_opf_unlock_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_write:
         signal: libcephsqlite_vfs_opf_write_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10450,7 +10451,7 @@ views:
       client_lat:
         signal: client_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10463,15 +10464,15 @@ views:
       client_mdsqsum:
         signal: client_mdsqsum
         components:
-        - value
+          - value
       client_readsqsum:
         signal: client_readsqsum
         components:
-        - value
+          - value
       client_writesqsum:
         signal: client_writesqsum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10480,7 +10481,7 @@ views:
       convention: duration_squared_microseconds_per_second
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   runtime.shared_daemon.client_operation_latency_measurements:
     family: Ceph/Runtime/Shared Daemon
     question: What is the client operation latency measurements for each ceph daemon?
@@ -10489,19 +10490,19 @@ views:
       client_fsync:
         signal: client_fsync_count
         components:
-        - value
+          - value
       client_rdlat:
         signal: client_rdlat_count
         components:
-        - value
+          - value
       client_reply:
         signal: client_reply_count
         components:
-        - value
+          - value
       client_wrlat:
         signal: client_wrlat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10514,15 +10515,15 @@ views:
       mdavg:
         signal: client_mdavg
         components:
-        - value
+          - value
       readavg:
         signal: client_readavg
         components:
-        - value
+          - value
       writeavg:
         signal: client_writeavg
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10535,7 +10536,7 @@ views:
       value:
         signal: recoverystate_perf_stats_invalidated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10548,23 +10549,23 @@ views:
       kstore_state_done_lat:
         signal: kstore_state_done_lat_count
         components:
-        - value
+          - value
       kstore_state_finishing_lat:
         signal: kstore_state_finishing_lat_count
         components:
-        - value
+          - value
       kstore_state_kv_done_lat:
         signal: kstore_state_kv_done_lat_count
         components:
-        - value
+          - value
       kstore_state_kv_queued_lat:
         signal: kstore_state_kv_queued_lat_count
         components:
-        - value
+          - value
       kstore_state_prepare_lat:
         signal: kstore_state_prepare_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10577,11 +10578,11 @@ views:
       num_mon:
         signal: cluster_num_mon
         components:
-        - value
+          - value
       cluster_num_mon_quorum:
         signal: cluster_num_mon_quorum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10594,19 +10595,19 @@ views:
       object:
         signal: cluster_num_object
         components:
-        - value
+          - value
       degraded:
         signal: cluster_num_object_degraded
         components:
-        - value
+          - value
       misplaced:
         signal: cluster_num_object_misplaced
         components:
-        - value
+          - value
       unfound:
         signal: cluster_num_object_unfound
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10619,7 +10620,7 @@ views:
       oft_omap_total_kv_pairs:
         signal: oft_omap_total_kv_pairs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10632,7 +10633,7 @@ views:
       oft_omap_total_objs:
         signal: oft_omap_total_objs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10645,11 +10646,11 @@ views:
       oft_omap_total_updates:
         signal: oft_omap_total_updates
         components:
-        - value
+          - value
       oft_omap_total_removes:
         signal: oft_omap_total_removes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10662,7 +10663,7 @@ views:
       value:
         signal: ipv4_dpdk_ip_linearize_operations
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10675,7 +10676,7 @@ views:
       osd_epoch:
         signal: cluster_osd_epoch
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10688,15 +10689,15 @@ views:
       num_osd:
         signal: cluster_num_osd
         components:
-        - value
+          - value
       cluster_num_osd_in:
         signal: cluster_num_osd_in
         components:
-        - value
+          - value
       cluster_num_osd_up:
         signal: cluster_num_osd_up
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10705,7 +10706,7 @@ views:
       convention: osds
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   runtime.shared_daemon.pg_state:
     family: Ceph/Runtime/Shared Daemon
     question: What is the placement groups for each ceph daemon?
@@ -10714,19 +10715,19 @@ views:
       cluster_num_pg:
         signal: cluster_num_pg
         components:
-        - value
+          - value
       cluster_num_pg_active:
         signal: cluster_num_pg_active
         components:
-        - value
+          - value
       cluster_num_pg_active_clean:
         signal: cluster_num_pg_active_clean
         components:
-        - value
+          - value
       cluster_num_pg_peering:
         signal: cluster_num_pg_peering
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10735,7 +10736,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   runtime.shared_daemon.pool_state:
     family: Ceph/Runtime/Shared Daemon
     question: What is the pools for each ceph daemon?
@@ -10744,7 +10745,7 @@ views:
       num_pool:
         signal: cluster_num_pool
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10757,127 +10758,127 @@ views:
       recoverystate_perf_activating_latency:
         signal: recoverystate_perf_activating_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_active_latency:
         signal: recoverystate_perf_active_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_backfilling_latency:
         signal: recoverystate_perf_backfilling_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_clean_latency:
         signal: recoverystate_perf_clean_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_down_latency:
         signal: recoverystate_perf_down_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_getinfo_latency:
         signal: recoverystate_perf_getinfo_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_getlog_latency:
         signal: recoverystate_perf_getlog_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_getmissing_latency:
         signal: recoverystate_perf_getmissing_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_incomplete_latency:
         signal: recoverystate_perf_incomplete_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_initial_latency:
         signal: recoverystate_perf_initial_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_notbackfilling_latency:
         signal: recoverystate_perf_notbackfilling_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_notrecovering_latency:
         signal: recoverystate_perf_notrecovering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_peering_latency:
         signal: recoverystate_perf_peering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_primary_latency:
         signal: recoverystate_perf_primary_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_recovered_latency:
         signal: recoverystate_perf_recovered_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_recovering_latency:
         signal: recoverystate_perf_recovering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_replicaactive_latency:
         signal: recoverystate_perf_replicaactive_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_repnotrecovering_latency:
         signal: recoverystate_perf_repnotrecovering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_reprecovering_latency:
         signal: recoverystate_perf_reprecovering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_repwaitbackfillreserved_latency:
         signal: recoverystate_perf_repwaitbackfillreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_repwaitrecoveryreserved_latency:
         signal: recoverystate_perf_repwaitrecoveryreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_reset_latency:
         signal: recoverystate_perf_reset_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_start_latency:
         signal: recoverystate_perf_start_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_started_latency:
         signal: recoverystate_perf_started_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_stray_latency:
         signal: recoverystate_perf_stray_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitactingchange_latency:
         signal: recoverystate_perf_waitactingchange_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitlocalbackfillreserved_latency:
         signal: recoverystate_perf_waitlocalbackfillreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitlocalrecoveryreserved_latency:
         signal: recoverystate_perf_waitlocalrecoveryreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitremotebackfillreserved_latency:
         signal: recoverystate_perf_waitremotebackfillreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitremoterecoveryreserved_latency:
         signal: recoverystate_perf_waitremoterecoveryreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitupthru_latency:
         signal: recoverystate_perf_waitupthru_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10890,19 +10891,19 @@ views:
       num_bytes:
         signal: cluster_num_bytes
         components:
-        - value
+          - value
       osd_bytes:
         signal: cluster_osd_bytes
         components:
-        - value
+          - value
       osd_bytes_avail:
         signal: cluster_osd_bytes_avail
         components:
-        - value
+          - value
       osd_bytes_used:
         signal: cluster_osd_bytes_used
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10915,71 +10916,71 @@ views:
       libcephsqlite_vfs_op_access:
         signal: libcephsqlite_vfs_op_access_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_currenttime:
         signal: libcephsqlite_vfs_op_currenttime_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_delete:
         signal: libcephsqlite_vfs_op_delete_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_fullpathname:
         signal: libcephsqlite_vfs_op_fullpathname_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_open:
         signal: libcephsqlite_vfs_op_open_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_checkreservedlock:
         signal: libcephsqlite_vfs_opf_checkreservedlock_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_close:
         signal: libcephsqlite_vfs_opf_close_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_devicecharacteristics:
         signal: libcephsqlite_vfs_opf_devicecharacteristics_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_filecontrol:
         signal: libcephsqlite_vfs_opf_filecontrol_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_filesize:
         signal: libcephsqlite_vfs_opf_filesize_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_lock:
         signal: libcephsqlite_vfs_opf_lock_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_read:
         signal: libcephsqlite_vfs_opf_read_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_sectorsize:
         signal: libcephsqlite_vfs_opf_sectorsize_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_sync:
         signal: libcephsqlite_vfs_opf_sync_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_truncate:
         signal: libcephsqlite_vfs_opf_truncate_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_unlock:
         signal: libcephsqlite_vfs_opf_unlock_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_write:
         signal: libcephsqlite_vfs_opf_write_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10992,11 +10993,11 @@ views:
       cct_total_workers:
         signal: cct_total_workers
         components:
-        - value
+          - value
       cct_unhealthy_workers:
         signal: cct_unhealthy_workers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11009,7 +11010,7 @@ views:
       value:
         signal: trackedop_slow_ops_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11022,7 +11023,7 @@ views:
       received:
         signal: dpdk_port_dpdk_device_receive_multicast_packets
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11035,19 +11036,19 @@ views:
       badcrc:
         signal: dpdk_port_dpdk_device_receive_badcrc_errors
         components:
-        - value
+          - value
       total:
         signal: dpdk_port_dpdk_device_receive_total_errors
         components:
-        - value
+          - value
       dropped:
         signal: dpdk_port_dpdk_device_receive_dropped_errors
         components:
-        - value
+          - value
       nombuf:
         signal: dpdk_port_dpdk_device_receive_nombuf_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11060,7 +11061,7 @@ views:
       total:
         signal: dpdk_port_dpdk_device_send_total_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11073,19 +11074,19 @@ views:
       receive:
         signal: dpdk_queue_dpdk_receive_bytes
         components:
-        - value
+          - value
       send:
         signal: dpdk_queue_dpdk_send_bytes
         components:
-        - value
+          - value
       receive_copy:
         signal: dpdk_queue_dpdk_receive_copy_bytes
         components:
-        - value
+          - value
       send_copy:
         signal: dpdk_queue_dpdk_send_copy_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11098,19 +11099,19 @@ views:
       receive_copy_ops:
         signal: dpdk_queue_dpdk_receive_copy_ops
         components:
-        - value
+          - value
       send_copy_ops:
         signal: dpdk_queue_dpdk_send_copy_ops
         components:
-        - value
+          - value
       receive_linearize_ops:
         signal: dpdk_queue_dpdk_receive_linearize_ops
         components:
-        - value
+          - value
       send_linearize_ops:
         signal: dpdk_queue_dpdk_send_linearize_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11123,11 +11124,11 @@ views:
       receive:
         signal: dpdk_queue_dpdk_receive_last_bunch
         components:
-        - value
+          - value
       send:
         signal: dpdk_queue_dpdk_send_last_bunch
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11140,11 +11141,11 @@ views:
       receive_fragments:
         signal: dpdk_queue_dpdk_receive_fragments
         components:
-        - value
+          - value
       send_fragments:
         signal: dpdk_queue_dpdk_send_fragments
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11157,11 +11158,11 @@ views:
       receive:
         signal: dpdk_queue_dpdk_receive_packets
         components:
-        - value
+          - value
       send:
         signal: dpdk_queue_dpdk_send_packets
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11174,11 +11175,11 @@ views:
       bad_checksum:
         signal: dpdk_queue_dpdk_receive_bad_checksum_errors
         components:
-        - value
+          - value
       no_memory:
         signal: dpdk_queue_dpdk_receive_no_memory_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11191,7 +11192,7 @@ views:
       queued:
         signal: dpdk_queue_dpdk_send_queue_length
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11204,7 +11205,7 @@ views:
       latency:
         signal: finisher_complete_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11217,7 +11218,7 @@ views:
       completed:
         signal: finisher_complete_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11230,7 +11231,7 @@ views:
       queued:
         signal: finisher_queue_len
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11243,7 +11244,7 @@ views:
       discard:
         signal: kernel_device_discard_op
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11256,7 +11257,7 @@ views:
       threads:
         signal: kernel_device_discard_threads
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11269,23 +11270,23 @@ views:
       immediate:
         signal: mclock_shard_mclock_immediate_queue_len
         components:
-        - value
+          - value
       client:
         signal: mclock_shard_mclock_client_queue_len
         components:
-        - value
+          - value
       recovery:
         signal: mclock_shard_mclock_recovery_queue_len
         components:
-        - value
+          - value
       best_effort:
         signal: mclock_shard_mclock_best_effort_queue_len
         components:
-        - value
+          - value
       all_type:
         signal: mclock_shard_mclock_all_type_queue_len
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11298,123 +11299,123 @@ views:
       bloom_filter:
         signal: mempool_bloom_filter_items
         components:
-        - value
+          - value
       bluestore_alloc:
         signal: mempool_bluestore_alloc_items
         components:
-        - value
+          - value
       bluestore_cache_data:
         signal: mempool_bluestore_cache_data_items
         components:
-        - value
+          - value
       bluestore_cache_onode:
         signal: mempool_bluestore_cache_onode_items
         components:
-        - value
+          - value
       bluestore_cache_meta:
         signal: mempool_bluestore_cache_meta_items
         components:
-        - value
+          - value
       bluestore_cache_other:
         signal: mempool_bluestore_cache_other_items
         components:
-        - value
+          - value
       bluestore_cache_buffer:
         signal: mempool_bluestore_cache_buffer_items
         components:
-        - value
+          - value
       bluestore_extent:
         signal: mempool_bluestore_extent_items
         components:
-        - value
+          - value
       bluestore_blob:
         signal: mempool_bluestore_blob_items
         components:
-        - value
+          - value
       bluestore_shared_blob:
         signal: mempool_bluestore_shared_blob_items
         components:
-        - value
+          - value
       bluestore_inline_bl:
         signal: mempool_bluestore_inline_bl_items
         components:
-        - value
+          - value
       bluestore_fsck:
         signal: mempool_bluestore_fsck_items
         components:
-        - value
+          - value
       bluestore_txc:
         signal: mempool_bluestore_txc_items
         components:
-        - value
+          - value
       bluestore_writing_deferred:
         signal: mempool_bluestore_writing_deferred_items
         components:
-        - value
+          - value
       bluestore_writing:
         signal: mempool_bluestore_writing_items
         components:
-        - value
+          - value
       bluefs:
         signal: mempool_bluefs_items
         components:
-        - value
+          - value
       bluefs_file_reader:
         signal: mempool_bluefs_file_reader_items
         components:
-        - value
+          - value
       bluefs_file_writer:
         signal: mempool_bluefs_file_writer_items
         components:
-        - value
+          - value
       buffer_anon:
         signal: mempool_buffer_anon_items
         components:
-        - value
+          - value
       buffer_meta:
         signal: mempool_buffer_meta_items
         components:
-        - value
+          - value
       osd:
         signal: mempool_osd_items
         components:
-        - value
+          - value
       osd_mapbl:
         signal: mempool_osd_mapbl_items
         components:
-        - value
+          - value
       osd_pglog:
         signal: mempool_osd_pglog_items
         components:
-        - value
+          - value
       osdmap:
         signal: mempool_osdmap_items
         components:
-        - value
+          - value
       osdmap_mapping:
         signal: mempool_osdmap_mapping_items
         components:
-        - value
+          - value
       pgmap:
         signal: mempool_pgmap_items
         components:
-        - value
+          - value
       mds_co:
         signal: mempool_mds_co_items
         components:
-        - value
+          - value
       unittest_1:
         signal: mempool_unittest_1_items
         components:
-        - value
+          - value
       unittest_2:
         signal: mempool_unittest_2_items
         components:
-        - value
+          - value
       ec_extent_cache:
         signal: mempool_ec_extent_cache_items
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11427,123 +11428,123 @@ views:
       bloom_filter:
         signal: mempool_bloom_filter_bytes
         components:
-        - value
+          - value
       bluestore_alloc:
         signal: mempool_bluestore_alloc_bytes
         components:
-        - value
+          - value
       bluestore_cache_data:
         signal: mempool_bluestore_cache_data_bytes
         components:
-        - value
+          - value
       bluestore_cache_onode:
         signal: mempool_bluestore_cache_onode_bytes
         components:
-        - value
+          - value
       bluestore_cache_meta:
         signal: mempool_bluestore_cache_meta_bytes
         components:
-        - value
+          - value
       bluestore_cache_other:
         signal: mempool_bluestore_cache_other_bytes
         components:
-        - value
+          - value
       bluestore_cache_buffer:
         signal: mempool_bluestore_cache_buffer_bytes
         components:
-        - value
+          - value
       bluestore_extent:
         signal: mempool_bluestore_extent_bytes
         components:
-        - value
+          - value
       bluestore_blob:
         signal: mempool_bluestore_blob_bytes
         components:
-        - value
+          - value
       bluestore_shared_blob:
         signal: mempool_bluestore_shared_blob_bytes
         components:
-        - value
+          - value
       bluestore_inline_bl:
         signal: mempool_bluestore_inline_bl_bytes
         components:
-        - value
+          - value
       bluestore_fsck:
         signal: mempool_bluestore_fsck_bytes
         components:
-        - value
+          - value
       bluestore_txc:
         signal: mempool_bluestore_txc_bytes
         components:
-        - value
+          - value
       bluestore_writing_deferred:
         signal: mempool_bluestore_writing_deferred_bytes
         components:
-        - value
+          - value
       bluestore_writing:
         signal: mempool_bluestore_writing_bytes
         components:
-        - value
+          - value
       bluefs:
         signal: mempool_bluefs_bytes
         components:
-        - value
+          - value
       bluefs_file_reader:
         signal: mempool_bluefs_file_reader_bytes
         components:
-        - value
+          - value
       bluefs_file_writer:
         signal: mempool_bluefs_file_writer_bytes
         components:
-        - value
+          - value
       buffer_anon:
         signal: mempool_buffer_anon_bytes
         components:
-        - value
+          - value
       buffer_meta:
         signal: mempool_buffer_meta_bytes
         components:
-        - value
+          - value
       osd:
         signal: mempool_osd_bytes
         components:
-        - value
+          - value
       osd_mapbl:
         signal: mempool_osd_mapbl_bytes
         components:
-        - value
+          - value
       osd_pglog:
         signal: mempool_osd_pglog_bytes
         components:
-        - value
+          - value
       osdmap:
         signal: mempool_osdmap_bytes
         components:
-        - value
+          - value
       osdmap_mapping:
         signal: mempool_osdmap_mapping_bytes
         components:
-        - value
+          - value
       pgmap:
         signal: mempool_pgmap_bytes
         components:
-        - value
+          - value
       mds_co:
         signal: mempool_mds_co_bytes
         components:
-        - value
+          - value
       unittest_1:
         signal: mempool_unittest_1_bytes
         components:
-        - value
+          - value
       unittest_2:
         signal: mempool_unittest_2_bytes
         components:
-        - value
+          - value
       ec_extent_cache:
         signal: mempool_ec_extent_cache_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11556,7 +11557,7 @@ views:
       handle_ack:
         signal: async_messenger_worker_msgr_handle_ack_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11569,7 +11570,7 @@ views:
       send_messages_queue:
         signal: async_messenger_worker_msgr_send_messages_queue_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11582,19 +11583,19 @@ views:
       total:
         signal: async_messenger_worker_msgr_running_total_time
         components:
-        - value
+          - value
       send:
         signal: async_messenger_worker_msgr_running_send_time
         components:
-        - value
+          - value
       recv:
         signal: async_messenger_worker_msgr_running_recv_time
         components:
-        - value
+          - value
       fast_dispatch:
         signal: async_messenger_worker_msgr_running_fast_dispatch_time
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11607,7 +11608,7 @@ views:
       handle_ack:
         signal: async_messenger_worker_msgr_handle_ack_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11620,19 +11621,19 @@ views:
       recv:
         signal: async_messenger_worker_msgr_recv_bytes
         components:
-        - value
+          - value
       send:
         signal: async_messenger_worker_msgr_send_bytes
         components:
-        - value
+          - value
       recv_encrypted:
         signal: async_messenger_worker_msgr_recv_encrypted_bytes
         components:
-        - value
+          - value
       send_encrypted:
         signal: async_messenger_worker_msgr_send_encrypted_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11645,7 +11646,7 @@ views:
       active:
         signal: async_messenger_worker_msgr_active_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11658,7 +11659,7 @@ views:
       created:
         signal: async_messenger_worker_msgr_created_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11671,11 +11672,11 @@ views:
       recv:
         signal: async_messenger_worker_msgr_recv_messages
         components:
-        - value
+          - value
       send:
         signal: async_messenger_worker_msgr_send_messages
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11688,7 +11689,7 @@ views:
       send_messages_queue:
         signal: async_messenger_worker_msgr_send_messages_queue_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11701,7 +11702,7 @@ views:
       bytes:
         signal: objectcacher_write_bytes_blocked
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11714,7 +11715,7 @@ views:
       time:
         signal: objectcacher_write_time_blocked
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11727,7 +11728,7 @@ views:
       operations:
         signal: objectcacher_write_ops_blocked
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11740,11 +11741,11 @@ views:
       hit:
         signal: objectcacher_cache_bytes_hit
         components:
-        - value
+          - value
       miss:
         signal: objectcacher_cache_bytes_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11757,11 +11758,11 @@ views:
       hit:
         signal: objectcacher_cache_ops_hit
         components:
-        - value
+          - value
       miss:
         signal: objectcacher_cache_ops_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11774,19 +11775,19 @@ views:
       read:
         signal: objectcacher_data_read
         components:
-        - value
+          - value
       written:
         signal: objectcacher_data_written
         components:
-        - value
+          - value
       flushed:
         signal: objectcacher_data_flushed
         components:
-        - value
+          - value
       overwritten_while_flushing:
         signal: objectcacher_data_overwritten_while_flushing
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11799,31 +11800,31 @@ views:
       update_metadata:
         signal: libcephsqlite_striper_update_metadata
         components:
-        - value
+          - value
       update_allocated:
         signal: libcephsqlite_striper_update_allocated
         components:
-        - value
+          - value
       update_size:
         signal: libcephsqlite_striper_update_size
         components:
-        - value
+          - value
       update_version:
         signal: libcephsqlite_striper_update_version
         components:
-        - value
+          - value
       shrink:
         signal: libcephsqlite_striper_shrink
         components:
-        - value
+          - value
       lock:
         signal: libcephsqlite_striper_lock
         components:
-        - value
+          - value
       unlock:
         signal: libcephsqlite_striper_unlock
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11836,7 +11837,7 @@ views:
       bytes:
         signal: libcephsqlite_striper_shrink_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11849,23 +11850,23 @@ views:
       discard_lat_sum:
         signal: rbd_librbd_pwl_discard_lat_sum
         components:
-        - value
+          - value
       aio_flush_lat_sum:
         signal: rbd_librbd_pwl_aio_flush_lat_sum
         components:
-        - value
+          - value
       ws_lat_sum:
         signal: rbd_librbd_pwl_ws_lat_sum
         components:
-        - value
+          - value
       cmp_lat_sum:
         signal: rbd_librbd_pwl_cmp_lat_sum
         components:
-        - value
+          - value
       writeback_lat_sum:
         signal: rbd_librbd_pwl_writeback_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11878,35 +11879,35 @@ views:
       op_alloc_t_sum:
         signal: rbd_librbd_pwl_op_alloc_t_sum
         components:
-        - value
+          - value
       op_dis_to_buf_t_sum:
         signal: rbd_librbd_pwl_op_dis_to_buf_t_sum
         components:
-        - value
+          - value
       op_dis_to_app_t_sum:
         signal: rbd_librbd_pwl_op_dis_to_app_t_sum
         components:
-        - value
+          - value
       op_dis_to_cmp_t_sum:
         signal: rbd_librbd_pwl_op_dis_to_cmp_t_sum
         components:
-        - value
+          - value
       op_buf_to_app_t_sum:
         signal: rbd_librbd_pwl_op_buf_to_app_t_sum
         components:
-        - value
+          - value
       op_buf_to_bufc_t_sum:
         signal: rbd_librbd_pwl_op_buf_to_bufc_t_sum
         components:
-        - value
+          - value
       op_app_to_cmp_t_sum:
         signal: rbd_librbd_pwl_op_app_to_cmp_t_sum
         components:
-        - value
+          - value
       op_app_to_appc_t_sum:
         signal: rbd_librbd_pwl_op_app_to_appc_t_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11919,11 +11920,11 @@ views:
       rd_latency_sum:
         signal: rbd_librbd_pwl_rd_latency_sum
         components:
-        - value
+          - value
       hit_rd_latency_sum:
         signal: rbd_librbd_pwl_hit_rd_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11936,11 +11937,11 @@ views:
       append_tx_lat_sum:
         signal: rbd_librbd_pwl_append_tx_lat_sum
         components:
-        - value
+          - value
       retire_tx_lat_sum:
         signal: rbd_librbd_pwl_retire_tx_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11953,43 +11954,43 @@ views:
       req_arr_to_all_t_sum:
         signal: rbd_librbd_pwl_req_arr_to_all_t_sum
         components:
-        - value
+          - value
       req_arr_to_dis_t_sum:
         signal: rbd_librbd_pwl_req_arr_to_dis_t_sum
         components:
-        - value
+          - value
       req_all_to_dis_t_sum:
         signal: rbd_librbd_pwl_req_all_to_dis_t_sum
         components:
-        - value
+          - value
       wr_latency_sum:
         signal: rbd_librbd_pwl_wr_latency_sum
         components:
-        - value
+          - value
       caller_wr_latency_sum:
         signal: rbd_librbd_pwl_caller_wr_latency_sum
         components:
-        - value
+          - value
       req_arr_to_all_nw_t_sum:
         signal: rbd_librbd_pwl_req_arr_to_all_nw_t_sum
         components:
-        - value
+          - value
       req_arr_to_dis_nw_t_sum:
         signal: rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
         components:
-        - value
+          - value
       req_all_to_dis_nw_t_sum:
         signal: rbd_librbd_pwl_req_all_to_dis_nw_t_sum
         components:
-        - value
+          - value
       wr_latency_nw_sum:
         signal: rbd_librbd_pwl_wr_latency_nw_sum
         components:
-        - value
+          - value
       caller_wr_latency_nw_sum:
         signal: rbd_librbd_pwl_caller_wr_latency_nw_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12002,35 +12003,35 @@ views:
       discard:
         signal: rbd_librbd_pwl_discard
         components:
-        - value
+          - value
       aio_flush:
         signal: rbd_librbd_pwl_aio_flush
         components:
-        - value
+          - value
       aio_flush_def:
         signal: rbd_librbd_pwl_aio_flush_def
         components:
-        - value
+          - value
       ws:
         signal: rbd_librbd_pwl_ws
         components:
-        - value
+          - value
       cmp:
         signal: rbd_librbd_pwl_cmp
         components:
-        - value
+          - value
       cmp_fails:
         signal: rbd_librbd_pwl_cmp_fails
         components:
-        - value
+          - value
       internal_flush:
         signal: rbd_librbd_pwl_internal_flush
         components:
-        - value
+          - value
       invalidate:
         signal: rbd_librbd_pwl_invalidate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12043,23 +12044,23 @@ views:
       discard_lat_count:
         signal: rbd_librbd_pwl_discard_lat_count
         components:
-        - value
+          - value
       aio_flush_lat_count:
         signal: rbd_librbd_pwl_aio_flush_lat_count
         components:
-        - value
+          - value
       ws_lat_count:
         signal: rbd_librbd_pwl_ws_lat_count
         components:
-        - value
+          - value
       cmp_lat_count:
         signal: rbd_librbd_pwl_cmp_lat_count
         components:
-        - value
+          - value
       writeback_lat_count:
         signal: rbd_librbd_pwl_writeback_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12072,15 +12073,15 @@ views:
       discard_bytes:
         signal: rbd_librbd_pwl_discard_bytes
         components:
-        - value
+          - value
       ws_bytes:
         signal: rbd_librbd_pwl_ws_bytes
         components:
-        - value
+          - value
       cmp_bytes:
         signal: rbd_librbd_pwl_cmp_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12093,7 +12094,7 @@ views:
       log_op_bytes_count:
         signal: rbd_librbd_pwl_log_op_bytes_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12106,7 +12107,7 @@ views:
       log_op_bytes_sum:
         signal: rbd_librbd_pwl_log_op_bytes_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12119,7 +12120,7 @@ views:
       log_ops:
         signal: rbd_librbd_pwl_log_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12132,35 +12133,35 @@ views:
       op_alloc_t_count:
         signal: rbd_librbd_pwl_op_alloc_t_count
         components:
-        - value
+          - value
       op_dis_to_buf_t_count:
         signal: rbd_librbd_pwl_op_dis_to_buf_t_count
         components:
-        - value
+          - value
       op_dis_to_app_t_count:
         signal: rbd_librbd_pwl_op_dis_to_app_t_count
         components:
-        - value
+          - value
       op_dis_to_cmp_t_count:
         signal: rbd_librbd_pwl_op_dis_to_cmp_t_count
         components:
-        - value
+          - value
       op_buf_to_app_t_count:
         signal: rbd_librbd_pwl_op_buf_to_app_t_count
         components:
-        - value
+          - value
       op_buf_to_bufc_t_count:
         signal: rbd_librbd_pwl_op_buf_to_bufc_t_count
         components:
-        - value
+          - value
       op_app_to_cmp_t_count:
         signal: rbd_librbd_pwl_op_app_to_cmp_t_count
         components:
-        - value
+          - value
       op_app_to_appc_t_count:
         signal: rbd_librbd_pwl_op_app_to_appc_t_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12173,11 +12174,11 @@ views:
       rd_latency_count:
         signal: rbd_librbd_pwl_rd_latency_count
         components:
-        - value
+          - value
       hit_rd_latency_count:
         signal: rbd_librbd_pwl_hit_rd_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12190,11 +12191,11 @@ views:
       rd_bytes:
         signal: rbd_librbd_pwl_rd_bytes
         components:
-        - value
+          - value
       rd_hit_bytes:
         signal: rbd_librbd_pwl_rd_hit_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12207,15 +12208,15 @@ views:
       rd:
         signal: rbd_librbd_pwl_rd
         components:
-        - value
+          - value
       hit_rd:
         signal: rbd_librbd_pwl_hit_rd
         components:
-        - value
+          - value
       part_hit_rd:
         signal: rbd_librbd_pwl_part_hit_rd
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12228,11 +12229,11 @@ views:
       append_tx_lat_count:
         signal: rbd_librbd_pwl_append_tx_lat_count
         components:
-        - value
+          - value
       retire_tx_lat_count:
         signal: rbd_librbd_pwl_retire_tx_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12245,43 +12246,43 @@ views:
       req_arr_to_all_t_count:
         signal: rbd_librbd_pwl_req_arr_to_all_t_count
         components:
-        - value
+          - value
       req_arr_to_dis_t_count:
         signal: rbd_librbd_pwl_req_arr_to_dis_t_count
         components:
-        - value
+          - value
       req_all_to_dis_t_count:
         signal: rbd_librbd_pwl_req_all_to_dis_t_count
         components:
-        - value
+          - value
       wr_latency_count:
         signal: rbd_librbd_pwl_wr_latency_count
         components:
-        - value
+          - value
       caller_wr_latency_count:
         signal: rbd_librbd_pwl_caller_wr_latency_count
         components:
-        - value
+          - value
       req_arr_to_all_nw_t_count:
         signal: rbd_librbd_pwl_req_arr_to_all_nw_t_count
         components:
-        - value
+          - value
       req_arr_to_dis_nw_t_count:
         signal: rbd_librbd_pwl_req_arr_to_dis_nw_t_count
         components:
-        - value
+          - value
       req_all_to_dis_nw_t_count:
         signal: rbd_librbd_pwl_req_all_to_dis_nw_t_count
         components:
-        - value
+          - value
       wr_latency_nw_count:
         signal: rbd_librbd_pwl_wr_latency_nw_count
         components:
-        - value
+          - value
       caller_wr_latency_nw_count:
         signal: rbd_librbd_pwl_caller_wr_latency_nw_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12294,7 +12295,7 @@ views:
       wr_bytes:
         signal: rbd_librbd_pwl_wr_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12307,31 +12308,31 @@ views:
       wr:
         signal: rbd_librbd_pwl_wr
         components:
-        - value
+          - value
       wr_def:
         signal: rbd_librbd_pwl_wr_def
         components:
-        - value
+          - value
       wr_def_lanes:
         signal: rbd_librbd_pwl_wr_def_lanes
         components:
-        - value
+          - value
       wr_def_log:
         signal: rbd_librbd_pwl_wr_def_log
         components:
-        - value
+          - value
       wr_def_buf:
         signal: rbd_librbd_pwl_wr_def_buf
         components:
-        - value
+          - value
       wr_overlap:
         signal: rbd_librbd_pwl_wr_overlap
         components:
-        - value
+          - value
       wr_q_barrier:
         signal: rbd_librbd_pwl_wr_q_barrier
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12344,11 +12345,11 @@ views:
       tx:
         signal: async_messenger_rdma_worker_tx_bytes
         components:
-        - value
+          - value
       rx:
         signal: async_messenger_rdma_worker_rx_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12361,11 +12362,11 @@ views:
       tx:
         signal: async_messenger_rdma_worker_tx_chunks
         components:
-        - value
+          - value
       rx:
         signal: async_messenger_rdma_worker_rx_chunks
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12378,7 +12379,7 @@ views:
       pending:
         signal: async_messenger_rdma_worker_pending_sent_conns
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12391,15 +12392,15 @@ views:
       tx_no_mem:
         signal: async_messenger_rdma_worker_tx_no_mem
         components:
-        - value
+          - value
       tx_parital_mem:
         signal: async_messenger_rdma_worker_tx_parital_mem
         components:
-        - value
+          - value
       tx_failed_post:
         signal: async_messenger_rdma_worker_tx_failed_post
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12412,7 +12413,7 @@ views:
       present:
         signal: service_unique_id
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12425,7 +12426,7 @@ views:
       wait:
         signal: throttle_wait_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12438,27 +12439,27 @@ views:
       get_started:
         signal: throttle_get_started
         components:
-        - value
+          - value
       get:
         signal: throttle_get
         components:
-        - value
+          - value
       get_or_fail_fail:
         signal: throttle_get_or_fail_fail
         components:
-        - value
+          - value
       get_or_fail_success:
         signal: throttle_get_or_fail_success
         components:
-        - value
+          - value
       take:
         signal: throttle_take
         components:
-        - value
+          - value
       put:
         signal: throttle_put
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12471,15 +12472,15 @@ views:
       get_sum:
         signal: throttle_get_sum
         components:
-        - value
+          - value
       take_sum:
         signal: throttle_take_sum
         components:
-        - value
+          - value
       put_sum:
         signal: throttle_put_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12492,11 +12493,11 @@ views:
       val:
         signal: throttle_val
         components:
-        - value
+          - value
       max:
         signal: throttle_max
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12509,7 +12510,7 @@ views:
       waits:
         signal: throttle_wait_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12523,7 +12524,7 @@ views:
       value:
         signal: smb_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12536,59 +12537,59 @@ views:
       committed_bytes:
         signal: prioritycache_full_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: prioritycache_full_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: prioritycache_full_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: prioritycache_full_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: prioritycache_full_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: prioritycache_full_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: prioritycache_full_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: prioritycache_full_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: prioritycache_full_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: prioritycache_full_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: prioritycache_full_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: prioritycache_full_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: prioritycache_full_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: prioritycache_full_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12601,59 +12602,59 @@ views:
       committed_bytes:
         signal: prioritycache_inc_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: prioritycache_inc_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: prioritycache_inc_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: prioritycache_inc_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: prioritycache_inc_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: prioritycache_inc_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: prioritycache_inc_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: prioritycache_inc_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: prioritycache_inc_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: prioritycache_inc_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: prioritycache_inc_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: prioritycache_inc_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: prioritycache_inc_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: prioritycache_inc_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12666,59 +12667,59 @@ views:
       committed_bytes:
         signal: prioritycache_kv_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: prioritycache_kv_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: prioritycache_kv_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: prioritycache_kv_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: prioritycache_kv_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: prioritycache_kv_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: prioritycache_kv_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: prioritycache_kv_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: prioritycache_kv_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: prioritycache_kv_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: prioritycache_kv_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: prioritycache_kv_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: prioritycache_kv_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: prioritycache_kv_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12731,23 +12732,23 @@ views:
       cache_bytes:
         signal: prioritycache_cache_bytes
         components:
-        - value
+          - value
       heap_bytes:
         signal: prioritycache_heap_bytes
         components:
-        - value
+          - value
       mapped_bytes:
         signal: prioritycache_mapped_bytes
         components:
-        - value
+          - value
       target_bytes:
         signal: prioritycache_target_bytes
         components:
-        - value
+          - value
       unmapped_bytes:
         signal: prioritycache_unmapped_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12760,11 +12761,11 @@ views:
       queue_len:
         signal: rocksdb_compact_queue_len
         components:
-        - value
+          - value
       running:
         signal: rocksdb_compact_running
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12777,11 +12778,11 @@ views:
       compact:
         signal: rocksdb_compact
         components:
-        - value
+          - value
       completed:
         signal: rocksdb_compact_completed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12794,7 +12795,7 @@ views:
       value:
         signal: rocksdb_compact_lasted
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12807,7 +12808,7 @@ views:
       queue_merge:
         signal: rocksdb_compact_queue_merge
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12820,15 +12821,15 @@ views:
       get_latency:
         signal: rocksdb_get_latency_sum
         components:
-        - value
+          - value
       submit_latency:
         signal: rocksdb_submit_latency_sum
         components:
-        - value
+          - value
       submit_sync_latency:
         signal: rocksdb_submit_sync_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12841,15 +12842,15 @@ views:
       get_latency:
         signal: rocksdb_get_latency_count
         components:
-        - value
+          - value
       submit_latency:
         signal: rocksdb_submit_latency_count
         components:
-        - value
+          - value
       submit_sync_latency:
         signal: rocksdb_submit_sync_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12862,19 +12863,19 @@ views:
       delay_time:
         signal: rocksdb_rocksdb_write_delay_time_sum
         components:
-        - value
+          - value
       memtable_time:
         signal: rocksdb_rocksdb_write_memtable_time_sum
         components:
-        - value
+          - value
       pre_and_post_time:
         signal: rocksdb_rocksdb_write_pre_and_post_time_sum
         components:
-        - value
+          - value
       wal_time:
         signal: rocksdb_rocksdb_write_wal_time_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12887,19 +12888,19 @@ views:
       delay_time:
         signal: rocksdb_rocksdb_write_delay_time_count
         components:
-        - value
+          - value
       memtable_time:
         signal: rocksdb_rocksdb_write_memtable_time_count
         components:
-        - value
+          - value
       pre_and_post_time:
         signal: rocksdb_rocksdb_write_pre_and_post_time_count
         components:
-        - value
+          - value
       wal_time:
         signal: rocksdb_rocksdb_write_wal_time_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12912,11 +12913,11 @@ views:
       physical:
         signal: extblkdev_dev_phy_size
         components:
-        - value
+          - value
       logical:
         signal: extblkdev_dev_log_size
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12929,11 +12930,11 @@ views:
       physical:
         signal: extblkdev_dev_phy_util
         components:
-        - value
+          - value
       logical:
         signal: extblkdev_dev_log_util
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12946,19 +12947,19 @@ views:
       physical_size:
         signal: extblkdev_part_phy_size
         components:
-        - value
+          - value
       logical_size:
         signal: extblkdev_part_log_size
         components:
-        - value
+          - value
       physical_available:
         signal: extblkdev_part_phy_avail
         components:
-        - value
+          - value
       logical_available:
         signal: extblkdev_part_log_avail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12971,7 +12972,7 @@ views:
       fcm:
         signal: extblkdev_fcm
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12984,7 +12985,7 @@ views:
       items:
         signal: rocksdb_binned_cache_elems
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12997,7 +12998,7 @@ views:
       insertions:
         signal: rocksdb_binned_cache_inserts
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13010,11 +13011,11 @@ views:
       hits:
         signal: rocksdb_binned_cache_hits
         components:
-        - value
+          - value
       misses:
         signal: rocksdb_binned_cache_misses
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13027,7 +13028,7 @@ views:
       lookups:
         signal: rocksdb_binned_cache_lookups
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13040,15 +13041,15 @@ views:
       capacity:
         signal: rocksdb_binned_cache_capacity
         components:
-        - value
+          - value
       used:
         signal: rocksdb_binned_cache_usage
         components:
-        - value
+          - value
       pinned:
         signal: rocksdb_binned_cache_pinned
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
@@ -188,798 +188,798 @@ cases:
         mgr_rbd_stats: enabled
     coverage: true
     steps:
-    - fixture: fixtures/ceph_reef_ceph_exporter_limit11.prom
-      expected:
-        verdict: PASS
-      observations:
-        objecter.accumulated_latency#value:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.accumulated_latency#value
-        objecter.byte_throughput#value:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.byte_throughput#value
-        objecter.commands#command_resend:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.commands#command_resend
-        objecter.commands#command_send:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.commands#command_send
-        objecter.latency_measurements#value:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.latency_measurements#value
-        objecter.lingering_operations#linger_ping:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.lingering_operations#linger_ping
-        objecter.lingering_operations#linger_resend:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.lingering_operations#linger_resend
-        objecter.lingering_operations#linger_send:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.lingering_operations#linger_send
-        objecter.maps#map_full:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.maps#map_full
-        objecter.maps#map_inc:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.maps#map_inc
-        objecter.operation_vector_entries#value:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operation_vector_entries#value
-        objecter.operations#omap_del:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#omap_del
-        objecter.operations#omap_rd:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#omap_rd
-        objecter.operations#omap_wr:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#omap_wr
-        objecter.operations#op:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#op
-        objecter.operations#op_pg:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#op_pg
-        objecter.operations#op_r:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#op_r
-        objecter.operations#op_reply:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#op_reply
-        objecter.operations#op_resend:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#op_resend
-        objecter.operations#op_rmw:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#op_rmw
-        objecter.operations#op_send:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#op_send
-        objecter.operations#op_w:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#op_w
-        objecter.operations#osdop_append:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_append
-        objecter.operations#osdop_call:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_call
-        objecter.operations#osdop_clonerange:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_clonerange
-        objecter.operations#osdop_cmpxattr:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_cmpxattr
-        objecter.operations#osdop_create:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_create
-        objecter.operations#osdop_delete:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_delete
-        objecter.operations#osdop_getxattr:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_getxattr
-        objecter.operations#osdop_mapext:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_mapext
-        objecter.operations#osdop_notify:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_notify
-        objecter.operations#osdop_other:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_other
-        objecter.operations#osdop_pgls:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_pgls
-        objecter.operations#osdop_pgls_filter:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_pgls_filter
-        objecter.operations#osdop_read:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_read
-        objecter.operations#osdop_resetxattrs:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_resetxattrs
-        objecter.operations#osdop_rmxattr:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_rmxattr
-        objecter.operations#osdop_setxattr:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_setxattr
-        objecter.operations#osdop_sparse_read:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_sparse_read
-        objecter.operations#osdop_src_cmpxattr:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_src_cmpxattr
-        objecter.operations#osdop_stat:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_stat
-        objecter.operations#osdop_truncate:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_truncate
-        objecter.operations#osdop_watch:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_watch
-        objecter.operations#osdop_write:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_write
-        objecter.operations#osdop_writefull:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_writefull
-        objecter.operations#osdop_writesame:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_writesame
-        objecter.operations#osdop_zero:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.operations#osdop_zero
-        objecter.osd_sessions#osd_session_close:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.osd_sessions#osd_session_close
-        objecter.osd_sessions#osd_session_open:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.osd_sessions#osd_session_open
-        objecter.pool_operations#poolop_resend:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.pool_operations#poolop_resend
-        objecter.pool_operations#poolop_send:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.pool_operations#poolop_send
-        objecter.stat_requests#poolstat_resend:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.stat_requests#poolstat_resend
-        objecter.stat_requests#poolstat_send:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.stat_requests#poolstat_send
-        objecter.stat_requests#statfs_resend:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.stat_requests#statfs_resend
-        objecter.stat_requests#statfs_send:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.stat_requests#statfs_send
-        objecter.submitted_operations#value:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.submitted_operations#value
-    - fixture: fixtures/ceph_reef_ceph_exporter_objecter_churn.prom
-      expected:
-        verdict: PASS
-      observations:
-        objecter.accumulated_latency#value:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.accumulated_latency#value
-        objecter.byte_throughput#value:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.byte_throughput#value
-        objecter.commands#command_resend:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.commands#command_resend
-        objecter.commands#command_send:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.commands#command_send
-        objecter.latency_measurements#value:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.latency_measurements#value
-        objecter.lingering_operations#linger_ping:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.lingering_operations#linger_ping
-        objecter.lingering_operations#linger_resend:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.lingering_operations#linger_resend
-        objecter.lingering_operations#linger_send:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.lingering_operations#linger_send
-        objecter.maps#map_full:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.maps#map_full
-        objecter.maps#map_inc:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.maps#map_inc
-        objecter.operation_vector_entries#value:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operation_vector_entries#value
-        objecter.operations#omap_del:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#omap_del
-        objecter.operations#omap_rd:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#omap_rd
-        objecter.operations#omap_wr:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#omap_wr
-        objecter.operations#op:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#op
-        objecter.operations#op_pg:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#op_pg
-        objecter.operations#op_r:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#op_r
-        objecter.operations#op_reply:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#op_reply
-        objecter.operations#op_resend:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#op_resend
-        objecter.operations#op_rmw:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#op_rmw
-        objecter.operations#op_send:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#op_send
-        objecter.operations#op_w:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#op_w
-        objecter.operations#osdop_append:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_append
-        objecter.operations#osdop_call:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_call
-        objecter.operations#osdop_clonerange:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_clonerange
-        objecter.operations#osdop_cmpxattr:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_cmpxattr
-        objecter.operations#osdop_create:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_create
-        objecter.operations#osdop_delete:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_delete
-        objecter.operations#osdop_getxattr:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_getxattr
-        objecter.operations#osdop_mapext:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_mapext
-        objecter.operations#osdop_notify:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_notify
-        objecter.operations#osdop_other:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_other
-        objecter.operations#osdop_pgls:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_pgls
-        objecter.operations#osdop_pgls_filter:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_pgls_filter
-        objecter.operations#osdop_read:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_read
-        objecter.operations#osdop_resetxattrs:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_resetxattrs
-        objecter.operations#osdop_rmxattr:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_rmxattr
-        objecter.operations#osdop_setxattr:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_setxattr
-        objecter.operations#osdop_sparse_read:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_sparse_read
-        objecter.operations#osdop_src_cmpxattr:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_src_cmpxattr
-        objecter.operations#osdop_stat:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_stat
-        objecter.operations#osdop_truncate:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_truncate
-        objecter.operations#osdop_watch:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_watch
-        objecter.operations#osdop_write:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_write
-        objecter.operations#osdop_writefull:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_writefull
-        objecter.operations#osdop_writesame:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_writesame
-        objecter.operations#osdop_zero:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.operations#osdop_zero
-        objecter.osd_sessions#osd_session_close:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.osd_sessions#osd_session_close
-        objecter.osd_sessions#osd_session_open:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.osd_sessions#osd_session_open
-        objecter.pool_operations#poolop_resend:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.pool_operations#poolop_resend
-        objecter.pool_operations#poolop_send:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.pool_operations#poolop_send
-        objecter.stat_requests#poolstat_resend:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.stat_requests#poolstat_resend
-        objecter.stat_requests#poolstat_send:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.stat_requests#poolstat_send
-        objecter.stat_requests#statfs_resend:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.stat_requests#statfs_resend
-        objecter.stat_requests#statfs_send:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.stat_requests#statfs_send
-        objecter.submitted_operations#value:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.submitted_operations#value
+      - fixture: fixtures/ceph_reef_ceph_exporter_limit11.prom
+        expected:
+          verdict: PASS
+        observations:
+          objecter.accumulated_latency#value:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.accumulated_latency#value
+          objecter.byte_throughput#value:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.byte_throughput#value
+          objecter.commands#command_resend:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.commands#command_resend
+          objecter.commands#command_send:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.commands#command_send
+          objecter.latency_measurements#value:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.latency_measurements#value
+          objecter.lingering_operations#linger_ping:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.lingering_operations#linger_ping
+          objecter.lingering_operations#linger_resend:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.lingering_operations#linger_resend
+          objecter.lingering_operations#linger_send:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.lingering_operations#linger_send
+          objecter.maps#map_full:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.maps#map_full
+          objecter.maps#map_inc:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.maps#map_inc
+          objecter.operation_vector_entries#value:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operation_vector_entries#value
+          objecter.operations#omap_del:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#omap_del
+          objecter.operations#omap_rd:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#omap_rd
+          objecter.operations#omap_wr:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#omap_wr
+          objecter.operations#op:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#op
+          objecter.operations#op_pg:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#op_pg
+          objecter.operations#op_r:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#op_r
+          objecter.operations#op_reply:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#op_reply
+          objecter.operations#op_resend:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#op_resend
+          objecter.operations#op_rmw:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#op_rmw
+          objecter.operations#op_send:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#op_send
+          objecter.operations#op_w:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#op_w
+          objecter.operations#osdop_append:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_append
+          objecter.operations#osdop_call:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_call
+          objecter.operations#osdop_clonerange:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_clonerange
+          objecter.operations#osdop_cmpxattr:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_cmpxattr
+          objecter.operations#osdop_create:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_create
+          objecter.operations#osdop_delete:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_delete
+          objecter.operations#osdop_getxattr:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_getxattr
+          objecter.operations#osdop_mapext:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_mapext
+          objecter.operations#osdop_notify:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_notify
+          objecter.operations#osdop_other:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_other
+          objecter.operations#osdop_pgls:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_pgls
+          objecter.operations#osdop_pgls_filter:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_pgls_filter
+          objecter.operations#osdop_read:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_read
+          objecter.operations#osdop_resetxattrs:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_resetxattrs
+          objecter.operations#osdop_rmxattr:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_rmxattr
+          objecter.operations#osdop_setxattr:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_setxattr
+          objecter.operations#osdop_sparse_read:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_sparse_read
+          objecter.operations#osdop_src_cmpxattr:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_src_cmpxattr
+          objecter.operations#osdop_stat:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_stat
+          objecter.operations#osdop_truncate:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_truncate
+          objecter.operations#osdop_watch:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_watch
+          objecter.operations#osdop_write:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_write
+          objecter.operations#osdop_writefull:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_writefull
+          objecter.operations#osdop_writesame:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_writesame
+          objecter.operations#osdop_zero:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.operations#osdop_zero
+          objecter.osd_sessions#osd_session_close:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.osd_sessions#osd_session_close
+          objecter.osd_sessions#osd_session_open:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.osd_sessions#osd_session_open
+          objecter.pool_operations#poolop_resend:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.pool_operations#poolop_resend
+          objecter.pool_operations#poolop_send:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.pool_operations#poolop_send
+          objecter.stat_requests#poolstat_resend:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.stat_requests#poolstat_resend
+          objecter.stat_requests#poolstat_send:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.stat_requests#poolstat_send
+          objecter.stat_requests#statfs_resend:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.stat_requests#statfs_resend
+          objecter.stat_requests#statfs_send:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.stat_requests#statfs_send
+          objecter.submitted_operations#value:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.submitted_operations#value
+      - fixture: fixtures/ceph_reef_ceph_exporter_objecter_churn.prom
+        expected:
+          verdict: PASS
+        observations:
+          objecter.accumulated_latency#value:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.accumulated_latency#value
+          objecter.byte_throughput#value:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.byte_throughput#value
+          objecter.commands#command_resend:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.commands#command_resend
+          objecter.commands#command_send:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.commands#command_send
+          objecter.latency_measurements#value:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.latency_measurements#value
+          objecter.lingering_operations#linger_ping:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.lingering_operations#linger_ping
+          objecter.lingering_operations#linger_resend:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.lingering_operations#linger_resend
+          objecter.lingering_operations#linger_send:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.lingering_operations#linger_send
+          objecter.maps#map_full:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.maps#map_full
+          objecter.maps#map_inc:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.maps#map_inc
+          objecter.operation_vector_entries#value:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operation_vector_entries#value
+          objecter.operations#omap_del:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#omap_del
+          objecter.operations#omap_rd:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#omap_rd
+          objecter.operations#omap_wr:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#omap_wr
+          objecter.operations#op:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#op
+          objecter.operations#op_pg:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#op_pg
+          objecter.operations#op_r:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#op_r
+          objecter.operations#op_reply:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#op_reply
+          objecter.operations#op_resend:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#op_resend
+          objecter.operations#op_rmw:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#op_rmw
+          objecter.operations#op_send:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#op_send
+          objecter.operations#op_w:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#op_w
+          objecter.operations#osdop_append:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_append
+          objecter.operations#osdop_call:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_call
+          objecter.operations#osdop_clonerange:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_clonerange
+          objecter.operations#osdop_cmpxattr:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_cmpxattr
+          objecter.operations#osdop_create:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_create
+          objecter.operations#osdop_delete:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_delete
+          objecter.operations#osdop_getxattr:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_getxattr
+          objecter.operations#osdop_mapext:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_mapext
+          objecter.operations#osdop_notify:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_notify
+          objecter.operations#osdop_other:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_other
+          objecter.operations#osdop_pgls:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_pgls
+          objecter.operations#osdop_pgls_filter:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_pgls_filter
+          objecter.operations#osdop_read:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_read
+          objecter.operations#osdop_resetxattrs:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_resetxattrs
+          objecter.operations#osdop_rmxattr:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_rmxattr
+          objecter.operations#osdop_setxattr:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_setxattr
+          objecter.operations#osdop_sparse_read:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_sparse_read
+          objecter.operations#osdop_src_cmpxattr:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_src_cmpxattr
+          objecter.operations#osdop_stat:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_stat
+          objecter.operations#osdop_truncate:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_truncate
+          objecter.operations#osdop_watch:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_watch
+          objecter.operations#osdop_write:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_write
+          objecter.operations#osdop_writefull:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_writefull
+          objecter.operations#osdop_writesame:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_writesame
+          objecter.operations#osdop_zero:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.operations#osdop_zero
+          objecter.osd_sessions#osd_session_close:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.osd_sessions#osd_session_close
+          objecter.osd_sessions#osd_session_open:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.osd_sessions#osd_session_open
+          objecter.pool_operations#poolop_resend:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.pool_operations#poolop_resend
+          objecter.pool_operations#poolop_send:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.pool_operations#poolop_send
+          objecter.stat_requests#poolstat_resend:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.stat_requests#poolstat_resend
+          objecter.stat_requests#poolstat_send:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.stat_requests#poolstat_send
+          objecter.stat_requests#statfs_resend:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.stat_requests#statfs_resend
+          objecter.stat_requests#statfs_send:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.stat_requests#statfs_send
+          objecter.submitted_operations#value:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.submitted_operations#value
   tentacle_ceph_exporter_objecter_churn:
     environment:
       ceph:
@@ -990,53 +990,53 @@ cases:
         mgr_rbd_stats: enabled
     coverage: true
     steps:
-    - fixture: fixtures/ceph_tentacle_ceph_exporter_limit11.prom
-      expected:
-        verdict: PASS
-      observations:
-        objecter.replica_reads#replica_read_bounced:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.replica_reads#replica_read_bounced
-        objecter.replica_reads#replica_read_completed:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.replica_reads#replica_read_completed
-        objecter.replica_reads#replica_read_sent:
-          state: current
-          predicates:
-            membership: establish
-            aggregate: matches_reducer
-            identity: establish
-          limitation: objecter.replica_reads#replica_read_sent
-    - fixture: fixtures/ceph_tentacle_ceph_exporter_objecter_churn.prom
-      expected:
-        verdict: PASS
-      observations:
-        objecter.replica_reads#replica_read_bounced:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.replica_reads#replica_read_bounced
-        objecter.replica_reads#replica_read_completed:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.replica_reads#replica_read_completed
-        objecter.replica_reads#replica_read_sent:
-          state: current
-          predicates:
-            membership: removed
-            aggregate: decreased
-            identity: unchanged
-          limitation: objecter.replica_reads#replica_read_sent
+      - fixture: fixtures/ceph_tentacle_ceph_exporter_limit11.prom
+        expected:
+          verdict: PASS
+        observations:
+          objecter.replica_reads#replica_read_bounced:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.replica_reads#replica_read_bounced
+          objecter.replica_reads#replica_read_completed:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.replica_reads#replica_read_completed
+          objecter.replica_reads#replica_read_sent:
+            state: current
+            predicates:
+              membership: establish
+              aggregate: matches_reducer
+              identity: establish
+            limitation: objecter.replica_reads#replica_read_sent
+      - fixture: fixtures/ceph_tentacle_ceph_exporter_objecter_churn.prom
+        expected:
+          verdict: PASS
+        observations:
+          objecter.replica_reads#replica_read_bounced:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.replica_reads#replica_read_bounced
+          objecter.replica_reads#replica_read_completed:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.replica_reads#replica_read_completed
+          objecter.replica_reads#replica_read_sent:
+            state: current
+            predicates:
+              membership: removed
+              aggregate: decreased
+              identity: unchanged
+            limitation: objecter.replica_reads#replica_read_sent

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/haproxy/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/haproxy/PROFILE-DESIGN.yaml
@@ -17,41 +17,41 @@ entities:
     grain: HAProxy frontend
     identity:
       required:
-      - proxy
+        - proxy
       optional: []
   listener:
     grain: HAProxy listener
     identity:
       required:
-      - proxy
-      - listener
+        - proxy
+        - listener
       optional: []
   backend:
     grain: HAProxy backend
     identity:
       required:
-      - proxy
+        - proxy
       optional: []
   server:
     grain: HAProxy server
     identity:
       required:
-      - proxy
-      - server
+        - proxy
+        - server
       optional: []
   resolver:
     grain: HAProxy nameserver
     identity:
       required:
-      - resolver
-      - nameserver
+        - resolver
+        - nameserver
       optional: []
   sticktable:
     grain: HAProxy stick table
     identity:
       required:
-      - name
-      - type
+        - name
+        - type
       optional: []
 label_policies: {}
 reduction_policies: {}
@@ -61,45 +61,45 @@ exclusions:
     source:
       signal: process_start_time_seconds
       components:
-      - value
+        - value
     reason: not_chartable
     lost_question: How long has the HAProxy worker process been running?
     required_operation: age_from_unix_epoch
     evidence:
-    - process_lifecycle
-    - process_unit
+      - process_lifecycle
+      - process_unit
     outcome: retain_writable_unrendered
   process_node_metadata:
     source:
       signal: process_node
       components:
-      - value
+        - value
     reason: metadata_only
     evidence:
-    - process_lifecycle
-    - process_unit
-    - process_labels
+      - process_lifecycle
+      - process_unit
+      - process_labels
     outcome: retain_writable_unrendered
   process_description_metadata:
     source:
       signal: process_description
       components:
-      - value
+        - value
     reason: metadata_only
     evidence:
-    - process_lifecycle
-    - process_unit
-    - process_labels
+      - process_lifecycle
+      - process_unit
+      - process_labels
     outcome: retain_writable_unrendered
   deprecated_backend_aggregate_status:
     source:
       signal: backend_agg_server_check_status
       components:
-      - value
+        - value
     reason: equivalent_duplicate
     covering_view: backend_agg_server_status
     evidence:
-    - aggregate_status_replacement
+      - aggregate_status_replacement
     outcome: retain_writable_unrendered
 limitations: {}
 views:
@@ -111,7 +111,7 @@ views:
       value:
         signal: process_recv_logs_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -124,7 +124,7 @@ views:
       value:
         signal: process_relative_process_id
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -137,7 +137,7 @@ views:
       value:
         signal: process_requests_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -150,7 +150,7 @@ views:
       value:
         signal: process_nbthread
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -163,7 +163,7 @@ views:
       value:
         signal: process_nbproc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -176,7 +176,7 @@ views:
       value:
         signal: process_current_zlib_memory
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -189,7 +189,7 @@ views:
       value:
         signal: process_limit_http_comp
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -202,7 +202,7 @@ views:
       value:
         signal: process_max_zlib_memory
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -215,7 +215,7 @@ views:
       value:
         signal: process_connections_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -228,7 +228,7 @@ views:
       value:
         signal: process_current_connection_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -241,7 +241,7 @@ views:
       value:
         signal: process_current_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -254,7 +254,7 @@ views:
       value:
         signal: process_hard_max_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -267,7 +267,7 @@ views:
       value:
         signal: process_limit_connection_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -280,7 +280,7 @@ views:
       value:
         signal: process_max_connection_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -293,7 +293,7 @@ views:
       value:
         signal: process_max_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -306,7 +306,7 @@ views:
       value:
         signal: process_max_fds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -319,7 +319,7 @@ views:
       value:
         signal: process_max_pipes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -332,7 +332,7 @@ views:
       value:
         signal: process_max_sockets
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -345,11 +345,11 @@ views:
       used:
         signal: process_pipes_used_total
         components:
-        - value
+          - value
       free:
         signal: process_pipes_free_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -362,7 +362,7 @@ views:
       value:
         signal: process_dropped_logs_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -375,7 +375,7 @@ views:
       value:
         signal: process_failed_resolutions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -388,7 +388,7 @@ views:
       value:
         signal: process_total_warnings
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -401,7 +401,7 @@ views:
       value:
         signal: process_active_peers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -414,7 +414,7 @@ views:
       value:
         signal: process_max_memory_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -427,7 +427,7 @@ views:
       value:
         signal: process_pool_allocated_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -440,7 +440,7 @@ views:
       value:
         signal: process_pool_failures_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -453,7 +453,7 @@ views:
       value:
         signal: process_pool_used_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -466,7 +466,7 @@ views:
       value:
         signal: process_current_run_queue
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -479,7 +479,7 @@ views:
       value:
         signal: process_current_backend_ssl_key_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -492,7 +492,7 @@ views:
       value:
         signal: process_current_frontend_ssl_key_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -505,7 +505,7 @@ views:
       value:
         signal: process_current_ssl_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -518,7 +518,7 @@ views:
       value:
         signal: process_current_ssl_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -531,7 +531,7 @@ views:
       value:
         signal: process_frontend_ssl_reuse
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -540,7 +540,7 @@ views:
       convention: percentage
       reason: HAProxy exports this ratio on the operator-facing zero-to-one-hundred percentage scale.
       evidence:
-      - percentage_display
+        - percentage_display
   process_limit_ssl_rate:
     family: HAProxy/Process/SSL
     question: What value does HAProxy currently report for limit ssl rate?
@@ -549,7 +549,7 @@ views:
       value:
         signal: process_limit_ssl_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -562,7 +562,7 @@ views:
       value:
         signal: process_max_backend_ssl_key_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -575,7 +575,7 @@ views:
       value:
         signal: process_max_frontend_ssl_key_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -588,7 +588,7 @@ views:
       value:
         signal: process_max_ssl_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -601,7 +601,7 @@ views:
       value:
         signal: process_max_ssl_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -614,7 +614,7 @@ views:
       value:
         signal: process_ssl_cache_lookups_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -627,7 +627,7 @@ views:
       value:
         signal: process_ssl_cache_misses_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -640,7 +640,7 @@ views:
       value:
         signal: process_ssl_connections_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -653,7 +653,7 @@ views:
       value:
         signal: process_connected_peers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -666,7 +666,7 @@ views:
       value:
         signal: process_current_tasks
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -679,7 +679,7 @@ views:
       value:
         signal: process_jobs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -692,7 +692,7 @@ views:
       value:
         signal: process_listeners
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -705,7 +705,7 @@ views:
       value:
         signal: process_unstoppable_jobs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -718,7 +718,7 @@ views:
       value:
         signal: process_current_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -731,7 +731,7 @@ views:
       value:
         signal: process_limit_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -744,7 +744,7 @@ views:
       value:
         signal: process_max_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -757,7 +757,7 @@ views:
       value:
         signal: process_busy_polling_enabled
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -770,7 +770,7 @@ views:
       value:
         signal: process_stopping
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -783,7 +783,7 @@ views:
       value:
         signal: process_idle_time_percent
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -792,7 +792,7 @@ views:
       convention: percentage
       reason: HAProxy exports this ratio on the operator-facing zero-to-one-hundred percentage scale.
       evidence:
-      - percentage_display
+        - percentage_display
   process_uptime_seconds:
     family: HAProxy/Process/Timing
     question: What value does HAProxy currently report for uptime seconds?
@@ -801,7 +801,7 @@ views:
       value:
         signal: process_uptime_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -814,7 +814,7 @@ views:
       value:
         signal: process_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -827,7 +827,7 @@ views:
       value:
         signal: process_bytes_out_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -840,7 +840,7 @@ views:
       value:
         signal: process_http_comp_bytes_in_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -853,7 +853,7 @@ views:
       value:
         signal: process_http_comp_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -866,7 +866,7 @@ views:
       value:
         signal: process_spliced_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -879,7 +879,7 @@ views:
       value:
         signal: frontend_http_comp_responses_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -892,7 +892,7 @@ views:
       value:
         signal: frontend_connections_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -905,7 +905,7 @@ views:
       value:
         signal: frontend_connections_rate_max
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -918,7 +918,7 @@ views:
       value:
         signal: frontend_denied_connections_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -931,15 +931,15 @@ views:
       request:
         signal: frontend_request_errors_total
         components:
-        - value
+          - value
       header_rewriting:
         signal: frontend_failed_header_rewriting_total
         components:
-        - value
+          - value
       internal:
         signal: frontend_internal_errors_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -952,7 +952,7 @@ views:
       value:
         signal: frontend_requests_denied_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -965,7 +965,7 @@ views:
       value:
         signal: frontend_responses_denied_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -978,7 +978,7 @@ views:
       value:
         signal: frontend_http_cache_hits_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -991,7 +991,7 @@ views:
       value:
         signal: frontend_http_cache_lookups_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1004,7 +1004,7 @@ views:
       value:
         signal: frontend_http_requests_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1017,7 +1017,7 @@ views:
       value:
         signal: frontend_http_requests_rate_max
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1030,7 +1030,7 @@ views:
       code:
         signal: frontend_http_responses_total
         components:
-        - value
+          - value
     labels:
       dimensions:
         code:
@@ -1045,7 +1045,7 @@ views:
       value:
         signal: frontend_intercepted_requests_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1058,7 +1058,7 @@ views:
       value:
         signal: frontend_current_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1071,7 +1071,7 @@ views:
       value:
         signal: frontend_current_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1084,7 +1084,7 @@ views:
       value:
         signal: frontend_denied_sessions_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1097,7 +1097,7 @@ views:
       value:
         signal: frontend_limit_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1110,7 +1110,7 @@ views:
       value:
         signal: frontend_limit_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1123,7 +1123,7 @@ views:
       value:
         signal: frontend_max_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1136,7 +1136,7 @@ views:
       value:
         signal: frontend_max_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1149,7 +1149,7 @@ views:
       value:
         signal: frontend_sessions_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1162,7 +1162,7 @@ views:
       state:
         signal: frontend_status
         components:
-        - value
+          - value
     labels:
       dimensions:
         state:
@@ -1177,7 +1177,7 @@ views:
       value:
         signal: frontend_http_comp_bytes_bypassed_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1190,7 +1190,7 @@ views:
       value:
         signal: frontend_http_comp_bytes_in_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1203,7 +1203,7 @@ views:
       value:
         signal: frontend_http_comp_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1216,11 +1216,11 @@ views:
       in:
         signal: frontend_bytes_in_total
         components:
-        - value
+          - value
       out:
         signal: frontend_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1233,7 +1233,7 @@ views:
       value:
         signal: listener_connections_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1246,7 +1246,7 @@ views:
       value:
         signal: listener_denied_connections_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1259,15 +1259,15 @@ views:
       request:
         signal: listener_request_errors_total
         components:
-        - value
+          - value
       header_rewriting:
         signal: listener_failed_header_rewriting_total
         components:
-        - value
+          - value
       internal:
         signal: listener_internal_errors_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1280,7 +1280,7 @@ views:
       value:
         signal: listener_requests_denied_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1293,7 +1293,7 @@ views:
       value:
         signal: listener_responses_denied_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1306,7 +1306,7 @@ views:
       value:
         signal: listener_current_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1319,7 +1319,7 @@ views:
       value:
         signal: listener_denied_sessions_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1332,7 +1332,7 @@ views:
       value:
         signal: listener_limit_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1345,7 +1345,7 @@ views:
       value:
         signal: listener_max_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1358,7 +1358,7 @@ views:
       value:
         signal: listener_sessions_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1371,7 +1371,7 @@ views:
       state:
         signal: listener_status
         components:
-        - value
+          - value
     labels:
       dimensions:
         state:
@@ -1386,11 +1386,11 @@ views:
       in:
         signal: listener_bytes_in_total
         components:
-        - value
+          - value
       out:
         signal: listener_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1403,7 +1403,7 @@ views:
       value:
         signal: backend_http_comp_responses_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1416,7 +1416,7 @@ views:
       value:
         signal: backend_connection_attempts_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1429,7 +1429,7 @@ views:
       value:
         signal: backend_connection_reuses_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1442,11 +1442,11 @@ views:
       client:
         signal: backend_client_aborts_total
         components:
-        - value
+          - value
       server:
         signal: backend_server_aborts_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1459,19 +1459,19 @@ views:
       response:
         signal: backend_response_errors_total
         components:
-        - value
+          - value
       connection:
         signal: backend_connection_errors_total
         components:
-        - value
+          - value
       header_rewriting:
         signal: backend_failed_header_rewriting_total
         components:
-        - value
+          - value
       internal:
         signal: backend_internal_errors_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1484,7 +1484,7 @@ views:
       value:
         signal: backend_requests_denied_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1497,7 +1497,7 @@ views:
       value:
         signal: backend_responses_denied_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1510,11 +1510,11 @@ views:
       retry:
         signal: backend_retry_warnings_total
         components:
-        - value
+          - value
       redispatch:
         signal: backend_redispatch_warnings_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1527,7 +1527,7 @@ views:
       value:
         signal: backend_http_cache_hits_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1540,7 +1540,7 @@ views:
       value:
         signal: backend_http_cache_lookups_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1553,7 +1553,7 @@ views:
       value:
         signal: backend_http_requests_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1566,7 +1566,7 @@ views:
       code:
         signal: backend_http_responses_total
         components:
-        - value
+          - value
     labels:
       dimensions:
         code:
@@ -1581,11 +1581,11 @@ views:
       active:
         signal: backend_active_servers
         components:
-        - value
+          - value
       backup:
         signal: backend_backup_servers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1598,7 +1598,7 @@ views:
       value:
         signal: backend_check_last_change_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1611,7 +1611,7 @@ views:
       value:
         signal: backend_downtime_seconds_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1624,7 +1624,7 @@ views:
       value:
         signal: backend_check_up_down_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1637,7 +1637,7 @@ views:
       value:
         signal: backend_loadbalanced_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1650,7 +1650,7 @@ views:
       value:
         signal: backend_uweight
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1663,7 +1663,7 @@ views:
       value:
         signal: backend_weight
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1676,7 +1676,7 @@ views:
       value:
         signal: backend_current_queue
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1689,7 +1689,7 @@ views:
       value:
         signal: backend_max_queue
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1702,7 +1702,7 @@ views:
       value:
         signal: backend_max_queue_time_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1715,7 +1715,7 @@ views:
       value:
         signal: backend_queue_time_average_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1728,7 +1728,7 @@ views:
       value:
         signal: backend_current_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1741,7 +1741,7 @@ views:
       value:
         signal: backend_current_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1754,7 +1754,7 @@ views:
       value:
         signal: backend_last_session_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1767,7 +1767,7 @@ views:
       value:
         signal: backend_limit_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1780,7 +1780,7 @@ views:
       value:
         signal: backend_max_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1793,7 +1793,7 @@ views:
       value:
         signal: backend_max_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1806,7 +1806,7 @@ views:
       value:
         signal: backend_sessions_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1819,7 +1819,7 @@ views:
       state:
         signal: backend_agg_check_status
         components:
-        - value
+          - value
     labels:
       dimensions:
         state:
@@ -1834,7 +1834,7 @@ views:
       state:
         signal: backend_agg_server_status
         components:
-        - value
+          - value
     labels:
       dimensions:
         state:
@@ -1849,7 +1849,7 @@ views:
       state:
         signal: backend_status
         components:
-        - value
+          - value
     labels:
       dimensions:
         state:
@@ -1864,7 +1864,7 @@ views:
       value:
         signal: backend_total_time_average_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1877,7 +1877,7 @@ views:
       value:
         signal: backend_connect_time_average_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1890,7 +1890,7 @@ views:
       value:
         signal: backend_max_connect_time_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1903,7 +1903,7 @@ views:
       value:
         signal: backend_max_response_time_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1916,7 +1916,7 @@ views:
       value:
         signal: backend_max_total_time_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1929,7 +1929,7 @@ views:
       value:
         signal: backend_response_time_average_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1942,7 +1942,7 @@ views:
       value:
         signal: backend_http_comp_bytes_bypassed_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1955,7 +1955,7 @@ views:
       value:
         signal: backend_http_comp_bytes_in_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1968,7 +1968,7 @@ views:
       value:
         signal: backend_http_comp_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1981,11 +1981,11 @@ views:
       in:
         signal: backend_bytes_in_total
         components:
-        - value
+          - value
       out:
         signal: backend_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1998,7 +1998,7 @@ views:
       value:
         signal: server_connection_attempts_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2011,7 +2011,7 @@ views:
       value:
         signal: server_connection_reuses_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2024,7 +2024,7 @@ views:
       value:
         signal: server_idle_connections_current
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2037,7 +2037,7 @@ views:
       value:
         signal: server_used_connections_current
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2050,7 +2050,7 @@ views:
       value:
         signal: server_idle_connections_limit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2063,11 +2063,11 @@ views:
       safe:
         signal: server_safe_idle_connections_current
         components:
-        - value
+          - value
       unsafe:
         signal: server_unsafe_idle_connections_current
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2080,7 +2080,7 @@ views:
       value:
         signal: server_need_connections_current
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2093,11 +2093,11 @@ views:
       client:
         signal: server_client_aborts_total
         components:
-        - value
+          - value
       server:
         signal: server_server_aborts_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2110,7 +2110,7 @@ views:
       value:
         signal: server_check_failures_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2123,19 +2123,19 @@ views:
       response:
         signal: server_response_errors_total
         components:
-        - value
+          - value
       connection:
         signal: server_connection_errors_total
         components:
-        - value
+          - value
       header_rewriting:
         signal: server_failed_header_rewriting_total
         components:
-        - value
+          - value
       internal:
         signal: server_internal_errors_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2148,7 +2148,7 @@ views:
       value:
         signal: server_responses_denied_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2161,11 +2161,11 @@ views:
       retry:
         signal: server_retry_warnings_total
         components:
-        - value
+          - value
       redispatch:
         signal: server_redispatch_warnings_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2178,7 +2178,7 @@ views:
       value:
         signal: server_http_requests_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2191,7 +2191,7 @@ views:
       code:
         signal: server_http_responses_total
         components:
-        - value
+          - value
     labels:
       dimensions:
         code:
@@ -2206,7 +2206,7 @@ views:
       value:
         signal: server_agent_code
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2219,7 +2219,7 @@ views:
       value:
         signal: server_agent_duration_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2232,7 +2232,7 @@ views:
       value:
         signal: server_check_code
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2245,7 +2245,7 @@ views:
       value:
         signal: server_check_duration_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2258,7 +2258,7 @@ views:
       value:
         signal: server_check_last_change_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2271,7 +2271,7 @@ views:
       value:
         signal: server_current_throttle
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2280,7 +2280,7 @@ views:
       convention: percentage
       reason: HAProxy exports this ratio on the operator-facing zero-to-one-hundred percentage scale.
       evidence:
-      - percentage_display
+        - percentage_display
   server_downtime_seconds_total:
     family: HAProxy/Servers/Health
     question: What per-second rate does HAProxy report for downtime seconds?
@@ -2289,7 +2289,7 @@ views:
       value:
         signal: server_downtime_seconds_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2302,7 +2302,7 @@ views:
       value:
         signal: server_check_up_down_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2315,7 +2315,7 @@ views:
       value:
         signal: server_loadbalanced_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2328,11 +2328,11 @@ views:
       active:
         signal: server_active
         components:
-        - value
+          - value
       backup:
         signal: server_backup
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2345,7 +2345,7 @@ views:
       value:
         signal: server_uweight
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2358,7 +2358,7 @@ views:
       value:
         signal: server_weight
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2371,7 +2371,7 @@ views:
       value:
         signal: server_current_queue
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2384,7 +2384,7 @@ views:
       value:
         signal: server_max_queue
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2397,7 +2397,7 @@ views:
       value:
         signal: server_max_queue_time_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2410,7 +2410,7 @@ views:
       value:
         signal: server_queue_limit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2423,7 +2423,7 @@ views:
       value:
         signal: server_queue_time_average_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2436,7 +2436,7 @@ views:
       value:
         signal: server_current_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2449,7 +2449,7 @@ views:
       value:
         signal: server_current_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2462,7 +2462,7 @@ views:
       value:
         signal: server_last_session_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2475,7 +2475,7 @@ views:
       value:
         signal: server_limit_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2488,7 +2488,7 @@ views:
       value:
         signal: server_max_session_rate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2501,7 +2501,7 @@ views:
       value:
         signal: server_max_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2514,7 +2514,7 @@ views:
       value:
         signal: server_sessions_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2527,7 +2527,7 @@ views:
       state:
         signal: server_agent_status
         components:
-        - value
+          - value
     labels:
       dimensions:
         state:
@@ -2542,7 +2542,7 @@ views:
       state:
         signal: server_check_status
         components:
-        - value
+          - value
     labels:
       dimensions:
         state:
@@ -2557,7 +2557,7 @@ views:
       state:
         signal: server_status
         components:
-        - value
+          - value
     labels:
       dimensions:
         state:
@@ -2572,7 +2572,7 @@ views:
       value:
         signal: server_total_time_average_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2585,7 +2585,7 @@ views:
       value:
         signal: server_connect_time_average_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2598,7 +2598,7 @@ views:
       value:
         signal: server_max_connect_time_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2611,7 +2611,7 @@ views:
       value:
         signal: server_max_response_time_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2624,7 +2624,7 @@ views:
       value:
         signal: server_max_total_time_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2637,7 +2637,7 @@ views:
       value:
         signal: server_response_time_average_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2650,11 +2650,11 @@ views:
       in:
         signal: server_bytes_in_total
         components:
-        - value
+          - value
       out:
         signal: server_bytes_out_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2667,7 +2667,7 @@ views:
       value:
         signal: resolver_any_err
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2680,7 +2680,7 @@ views:
       value:
         signal: resolver_cname
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2693,7 +2693,7 @@ views:
       value:
         signal: resolver_cname_error
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2706,7 +2706,7 @@ views:
       value:
         signal: resolver_invalid
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2719,7 +2719,7 @@ views:
       value:
         signal: resolver_nx
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2732,7 +2732,7 @@ views:
       value:
         signal: resolver_other
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2745,7 +2745,7 @@ views:
       value:
         signal: resolver_outdated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2758,7 +2758,7 @@ views:
       value:
         signal: resolver_refused
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2771,7 +2771,7 @@ views:
       value:
         signal: resolver_send_error
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2784,7 +2784,7 @@ views:
       value:
         signal: resolver_sent
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2797,7 +2797,7 @@ views:
       value:
         signal: resolver_timeout
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2810,7 +2810,7 @@ views:
       value:
         signal: resolver_too_big
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2823,7 +2823,7 @@ views:
       value:
         signal: resolver_truncated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2836,7 +2836,7 @@ views:
       value:
         signal: resolver_update
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2849,7 +2849,7 @@ views:
       value:
         signal: resolver_valid
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2862,7 +2862,7 @@ views:
       value:
         signal: sticktable_size
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2875,7 +2875,7 @@ views:
       value:
         signal: sticktable_used
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/litellm/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/litellm/PROFILE-DESIGN.yaml
@@ -16,8 +16,8 @@ entities:
     grain: api_provider, model
     identity:
       required:
-      - api_provider
-      - model
+        - api_provider
+        - model
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -26,9 +26,9 @@ entities:
     grain: api_provider
     identity:
       required:
-      - api_provider
+        - api_provider
       optional:
-      - pid
+        - pid
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
         through Netdata aggregation.
@@ -36,7 +36,7 @@ entities:
     grain: callback_name
     identity:
       required:
-      - callback_name
+        - callback_name
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -50,7 +50,7 @@ entities:
     grain: end_user
     identity:
       required:
-      - end_user
+        - end_user
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -59,8 +59,8 @@ entities:
     grain: function_name, error_class
     identity:
       required:
-      - function_name
-      - error_class
+        - function_name
+        - error_class
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -69,8 +69,8 @@ entities:
     grain: guardrail_name, hook_type
     identity:
       required:
-      - guardrail_name
-      - hook_type
+        - guardrail_name
+        - hook_type
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -79,9 +79,9 @@ entities:
     grain: guardrail_name, hook_type, error_type
     identity:
       required:
-      - guardrail_name
-      - hook_type
-      - error_type
+        - guardrail_name
+        - hook_type
+        - error_type
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -90,9 +90,9 @@ entities:
     grain: guardrail_name, hook_type, status
     identity:
       required:
-      - guardrail_name
-      - hook_type
-      - status
+        - guardrail_name
+        - hook_type
+        - status
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -101,7 +101,7 @@ entities:
     grain: hashed_api_key
     identity:
       required:
-      - hashed_api_key
+        - hashed_api_key
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -110,10 +110,10 @@ entities:
     grain: hashed_api_key, model
     identity:
       required:
-      - hashed_api_key
-      - model
+        - hashed_api_key
+        - model
       optional:
-      - pid
+        - pid
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
         through Netdata aggregation.
@@ -121,9 +121,9 @@ entities:
     grain: hashed_api_key
     identity:
       required:
-      - hashed_api_key
+        - hashed_api_key
       optional:
-      - pid
+        - pid
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
         through Netdata aggregation.
@@ -131,8 +131,8 @@ entities:
     grain: mcp_server_name, mcp_tool_name
     identity:
       required:
-      - mcp_server_name
-      - mcp_tool_name
+        - mcp_server_name
+        - mcp_tool_name
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -141,7 +141,7 @@ entities:
     grain: model_id
     identity:
       required:
-      - model_id
+        - model_id
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -150,8 +150,8 @@ entities:
     grain: model_id, service_tier
     identity:
       required:
-      - model_id
-      - service_tier
+        - model_id
+        - service_tier
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -160,8 +160,8 @@ entities:
     grain: model_id, status_class
     identity:
       required:
-      - model_id
-      - status_class
+        - model_id
+        - status_class
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -170,9 +170,9 @@ entities:
     grain: model_id, status_class, exception_class
     identity:
       required:
-      - model_id
-      - status_class
-      - exception_class
+        - model_id
+        - status_class
+        - exception_class
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -181,9 +181,9 @@ entities:
     grain: model_id
     identity:
       required:
-      - model_id
+        - model_id
       optional:
-      - pid
+        - pid
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
         through Netdata aggregation.
@@ -191,7 +191,7 @@ entities:
     grain: org_id
     identity:
       required:
-      - org_id
+        - org_id
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -200,9 +200,9 @@ entities:
     grain: org_id
     identity:
       required:
-      - org_id
+        - org_id
       optional:
-      - pid
+        - pid
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
         through Netdata aggregation.
@@ -210,14 +210,14 @@ entities:
     grain: rate_limit_category, rate_limit_type
     identity:
       required:
-      - rate_limit_category
-      - rate_limit_type
+        - rate_limit_category
+        - rate_limit_type
       optional: []
   requested_model:
     grain: requested_model
     identity:
       required:
-      - requested_model
+        - requested_model
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -226,8 +226,8 @@ entities:
     grain: requested_model, fallback_model
     identity:
       required:
-      - requested_model
-      - fallback_model
+        - requested_model
+        - fallback_model
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -236,14 +236,14 @@ entities:
     grain: result
     identity:
       required:
-      - result
+        - result
       optional: []
   route_status_class:
     grain: route, status_class
     identity:
       required:
-      - route
-      - status_class
+        - route
+        - status_class
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -252,14 +252,14 @@ entities:
     grain: service
     identity:
       required:
-      - service
+        - service
       optional: []
   status_class_exception_class:
     grain: status_class, exception_class
     identity:
       required:
-      - status_class
-      - exception_class
+        - status_class
+        - exception_class
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -268,7 +268,7 @@ entities:
     grain: team
     identity:
       required:
-      - team
+        - team
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -277,9 +277,9 @@ entities:
     grain: team
     identity:
       required:
-      - team
+        - team
       optional:
-      - pid
+        - pid
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
         through Netdata aggregation.
@@ -287,7 +287,7 @@ entities:
     grain: user
     identity:
       required:
-      - user
+        - user
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
@@ -296,9 +296,9 @@ entities:
     grain: user
     identity:
       required:
-      - user
+        - user
       optional:
-      - pid
+        - pid
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
         through Netdata aggregation.
@@ -307,7 +307,7 @@ entities:
     identity:
       required: []
       optional:
-      - pid
+        - pid
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful LiteLLM entity supports direct diagnosis while broader views remain available
         through Netdata aggregation.
@@ -322,9 +322,9 @@ normalizations:
       component: scalar
     outcome: drop_before_writer
     evidence:
-    - created_registration
-    - component_lifecycle
-    - source_units
+      - created_registration
+      - component_lifecycle
+      - source_units
   requested_model_label:
     kind: label_rename
     source_label: model_group
@@ -340,25 +340,25 @@ normalizations:
     applies_to:
       signal: proxy_total_requests_metric_total
       components:
-      - value
+        - value
     source_label: status_code
     target_label: status_class
     ranges:
-    - min: 100
-      max: 199
-      value: 1xx
-    - min: 200
-      max: 299
-      value: 2xx
-    - min: 300
-      max: 399
-      value: 3xx
-    - min: 400
-      max: 499
-      value: 4xx
-    - min: 500
-      max: 599
-      value: 5xx
+      - min: 100
+        max: 199
+        value: 1xx
+      - min: 200
+        max: 299
+        value: 2xx
+      - min: 300
+        max: 399
+        value: 3xx
+      - min: 400
+        max: 499
+        value: 4xx
+      - min: 500
+        max: 599
+        value: 5xx
     missing:
       set: unclassified
     malformed:
@@ -368,33 +368,33 @@ normalizations:
     output:
       meaning: Bounded HTTP status class.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   proxy_failure_status_class:
     kind: category
     applies_to:
       signal: proxy_failed_requests_metric_total
       components:
-      - value
+        - value
     source_label: exception_status
     target_label: status_class
     ranges:
-    - min: 100
-      max: 199
-      value: 1xx
-    - min: 200
-      max: 299
-      value: 2xx
-    - min: 300
-      max: 399
-      value: 3xx
-    - min: 400
-      max: 499
-      value: 4xx
-    - min: 500
-      max: 599
-      value: 5xx
+      - min: 100
+        max: 199
+        value: 1xx
+      - min: 200
+        max: 299
+        value: 2xx
+      - min: 300
+        max: 399
+        value: 3xx
+      - min: 400
+        max: 499
+        value: 4xx
+      - min: 500
+        max: 599
+        value: 5xx
     missing:
       set: unclassified
     malformed:
@@ -404,33 +404,33 @@ normalizations:
     output:
       meaning: Bounded HTTP status class.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   deployment_failure_status_class:
     kind: category
     applies_to:
       signal: deployment_failure_responses_total
       components:
-      - value
+        - value
     source_label: exception_status
     target_label: status_class
     ranges:
-    - min: 100
-      max: 199
-      value: 1xx
-    - min: 200
-      max: 299
-      value: 2xx
-    - min: 300
-      max: 399
-      value: 3xx
-    - min: 400
-      max: 499
-      value: 4xx
-    - min: 500
-      max: 599
-      value: 5xx
+      - min: 100
+        max: 199
+        value: 1xx
+      - min: 200
+        max: 299
+        value: 2xx
+      - min: 300
+        max: 399
+        value: 3xx
+      - min: 400
+        max: 499
+        value: 4xx
+      - min: 500
+        max: 599
+        value: 5xx
     missing:
       set: unclassified
     malformed:
@@ -440,33 +440,33 @@ normalizations:
     output:
       meaning: Bounded HTTP status class.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   deployment_cooldown_status_class:
     kind: category
     applies_to:
       signal: deployment_cooled_down_total
       components:
-      - value
+        - value
     source_label: exception_status
     target_label: status_class
     ranges:
-    - min: 100
-      max: 199
-      value: 1xx
-    - min: 200
-      max: 299
-      value: 2xx
-    - min: 300
-      max: 399
-      value: 3xx
-    - min: 400
-      max: 499
-      value: 4xx
-    - min: 500
-      max: 599
-      value: 5xx
+      - min: 100
+        max: 199
+        value: 1xx
+      - min: 200
+        max: 299
+        value: 2xx
+      - min: 300
+        max: 399
+        value: 3xx
+      - min: 400
+        max: 499
+        value: 4xx
+      - min: 500
+        max: 599
+        value: 5xx
     missing:
       set: unclassified
     malformed:
@@ -476,17 +476,17 @@ normalizations:
     output:
       meaning: Bounded HTTP status class.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   internal_latency_service:
     kind: category
     applies_to:
       signal: internal_service_latency
       components:
-      - bucket
-      - count
-      - sum
+        - bucket
+        - count
+        - sum
     source_label: __name__
     target_label: service
     exact:
@@ -532,15 +532,15 @@ normalizations:
     output:
       meaning: Internal LiteLLM service category encoded in the metric name.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   internal_failure_service:
     kind: category
     applies_to:
       signal: internal_service_failures
       components:
-      - value
+        - value
     source_label: __name__
     target_label: service
     exact:
@@ -564,15 +564,15 @@ normalizations:
     output:
       meaning: Internal LiteLLM service category encoded in the metric name.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   internal_total_service:
     kind: category
     applies_to:
       signal: internal_service_totals
       components:
-      - value
+        - value
     source_label: __name__
     target_label: service
     exact:
@@ -596,17 +596,17 @@ normalizations:
     output:
       meaning: Internal LiteLLM service category encoded in the metric name.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   internal_success_outcome:
     kind: category
     applies_to:
       signal: internal_service_latency
       components:
-      - bucket
-      - count
-      - sum
+        - bucket
+        - count
+        - sum
     source_label: __name__
     target_label: outcome
     exact:
@@ -652,15 +652,15 @@ normalizations:
     output:
       meaning: Internal service request outcome encoded in the metric name.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   internal_failure_outcome:
     kind: category
     applies_to:
       signal: internal_service_failures
       components:
-      - value
+        - value
     source_label: __name__
     target_label: outcome
     exact:
@@ -684,17 +684,17 @@ normalizations:
     output:
       meaning: Internal service request outcome encoded in the metric name.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
   internal_latency_measurement:
     kind: category
     applies_to:
       signal: internal_service_latency
       components:
-      - bucket
-      - count
-      - sum
+        - bucket
+        - count
+        - sum
     source_label: __name__
     target_label: measurement
     exact:
@@ -740,97 +740,97 @@ normalizations:
     output:
       meaning: Internal service measurement category encoded in the metric name.
       evidence:
-      - source_labels
+        - source_labels
     evidence:
-    - normalization_contract
+      - normalization_contract
 exclusions:
   deprecated_failed_requests:
     source:
       signal: deprecated_failed_requests
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: proxy_failed_requests_metric_total
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_total_requests:
     source:
       signal: deprecated_total_requests
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: proxy_total_requests_metric_total
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   batch_cost_poll_timestamp:
     source:
       signal: check_batch_cost_last_run_timestamp
       components:
-      - value
+        - value
     reason: not_chartable
     lost_question: How long has it been since the batch-cost poll last ran?
     required_operation: age_from_unix_epoch
     evidence:
-    - component_lifecycle
-    - source_units
+      - component_lifecycle
+      - source_units
     outcome: drop_before_writer
   internal_service_totals:
     source:
       signal: internal_service_totals
       components:
-      - value
+        - value
     reason: equivalent_duplicate
     covering_view: internal_services.request_outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   guardrail_requests_counter:
     source:
       signal: guardrail_requests_total
       components:
-      - value
+        - value
     reason: equivalent_duplicate
     covering_view: guardrails.invocations
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   check_batch_cost_jobs_polled:
     source:
       signal: check_batch_cost_jobs_polled
       components:
-      - value
+        - value
     reason: collection_hazard
     evidence:
-    - collection_hazards
+      - collection_hazards
     outcome: retain_writable_unrendered
   managed_file_size_bytes:
     source:
       signal: managed_file_size_bytes
       components:
-      - value
+        - value
     reason: collection_hazard
     evidence:
-    - collection_hazards
+      - collection_hazards
     outcome: retain_writable_unrendered
   pod_lock_manager_size:
     source:
       signal: pod_lock_manager_size
       components:
-      - value
+        - value
     reason: collection_hazard
     evidence:
-    - collection_hazards
+      - collection_hazards
     outcome: retain_writable_unrendered
   spend_update_queue_sizes:
     source:
       signal: spend_update_queue_sizes
       components:
-      - value
+        - value
     reason: collection_hazard
     evidence:
-    - collection_hazards
+      - collection_hazards
     outcome: retain_writable_unrendered
 limitations: {}
 views:
@@ -842,7 +842,7 @@ views:
       requests:
         signal: proxy_total_requests_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -877,7 +877,7 @@ views:
       failures:
         signal: proxy_failed_requests_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -912,14 +912,14 @@ views:
       failures:
         signal: proxy_failed_requests_metric_total
         components:
-        - value
+          - value
         where:
           any:
-          - all:
-            - label: rate_limit_category
-              op: nonblank
-            - label: rate_limit_type
-              op: nonblank
+            - all:
+                - label: rate_limit_category
+                  op: nonblank
+                - label: rate_limit_type
+                  op: nonblank
     labels:
       dimensions: {}
       promote: []
@@ -954,7 +954,7 @@ views:
       requests:
         signal: in_flight_requests
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -967,12 +967,12 @@ views:
       distribution:
         signal: request_queue_time_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -995,12 +995,12 @@ views:
       requests:
         signal: request_queue_time_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1023,12 +1023,12 @@ views:
       time:
         signal: request_queue_time_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1051,12 +1051,12 @@ views:
       distribution:
         signal: request_total_latency_metric
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1079,12 +1079,12 @@ views:
       requests:
         signal: request_total_latency_metric
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1107,12 +1107,12 @@ views:
       time:
         signal: request_total_latency_metric
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1135,12 +1135,12 @@ views:
       distribution:
         signal: overhead_latency_metric
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1158,12 +1158,12 @@ views:
       requests:
         signal: overhead_latency_metric
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1181,12 +1181,12 @@ views:
       time:
         signal: overhead_latency_metric
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1204,12 +1204,12 @@ views:
       distribution:
         signal: overhead_with_guardrails_latency_metric
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1227,12 +1227,12 @@ views:
       requests:
         signal: overhead_with_guardrails_latency_metric
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1250,12 +1250,12 @@ views:
       time:
         signal: overhead_with_guardrails_latency_metric
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1273,12 +1273,12 @@ views:
       requests:
         signal: deployment_total_requests_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1300,16 +1300,16 @@ views:
       successful:
         signal: deployment_success_responses_total
         components:
-        - value
+          - value
       failed:
         signal: deployment_failure_responses_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1334,7 +1334,7 @@ views:
       failures:
         signal: deployment_failure_responses_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1358,7 +1358,7 @@ views:
       convention: request_failures
       reason: The existing operator view expresses the source measurement as failures/s.
       evidence:
-      - display_conventions
+        - display_conventions
   routing.deployment_health.cooldowns:
     family: LiteLLM/Routing and Deployments/Deployment Health
     question: What does deployment cooldowns report for each model_id, status_class?
@@ -1367,7 +1367,7 @@ views:
       cooldowns:
         signal: deployment_cooled_down_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1388,12 +1388,12 @@ views:
       state:
         signal: deployment_state
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
     reduction:
@@ -1408,12 +1408,12 @@ views:
       limit:
         signal: deployment_rpm_limit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
     reduction:
@@ -1424,7 +1424,7 @@ views:
       convention: requests_per_minute
       reason: The existing operator view expresses the source measurement as requests/min.
       evidence:
-      - display_conventions
+        - display_conventions
   routing.deployment_capacity.token_limit:
     family: LiteLLM/Routing and Deployments/Deployment Capacity
     question: What does deployment token limit report for each model_id?
@@ -1433,12 +1433,12 @@ views:
       limit:
         signal: deployment_tpm_limit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
     reduction:
@@ -1449,7 +1449,7 @@ views:
       convention: tokens_per_minute
       reason: The existing operator view expresses the source measurement as tokens/min.
       evidence:
-      - display_conventions
+        - display_conventions
   routing.deployment_capacity.remaining_requests:
     family: LiteLLM/Routing and Deployments/Deployment Capacity
     question: What does provider remaining requests report for each model_id?
@@ -1458,12 +1458,12 @@ views:
       remaining:
         signal: remaining_requests_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1483,12 +1483,12 @@ views:
       remaining:
         signal: remaining_tokens_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1508,12 +1508,12 @@ views:
       distribution:
         signal: deployment_latency_per_output_token
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1534,12 +1534,12 @@ views:
       requests:
         signal: deployment_latency_per_output_token
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1560,12 +1560,12 @@ views:
       time:
         signal: deployment_latency_per_output_token
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_base: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1586,11 +1586,11 @@ views:
       successful:
         signal: deployment_successful_fallbacks_total
         components:
-        - value
+          - value
       failed:
         signal: deployment_failed_fallbacks_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1614,12 +1614,12 @@ views:
       distribution:
         signal: llm_api_latency_metric
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1642,12 +1642,12 @@ views:
       requests:
         signal: llm_api_latency_metric
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1670,12 +1670,12 @@ views:
       time:
         signal: llm_api_latency_metric
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1698,12 +1698,12 @@ views:
       distribution:
         signal: llm_api_time_to_first_token_metric
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1726,12 +1726,12 @@ views:
       requests:
         signal: llm_api_time_to_first_token_metric
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1754,12 +1754,12 @@ views:
       time:
         signal: llm_api_time_to_first_token_metric
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1782,16 +1782,16 @@ views:
       input:
         signal: input_tokens_metric_total
         components:
-        - value
+          - value
       output:
         signal: output_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1815,12 +1815,12 @@ views:
       total:
         signal: total_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1844,12 +1844,12 @@ views:
       spend:
         signal: spend_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         client_ip: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1877,20 +1877,20 @@ views:
       input_audio:
         signal: input_audio_tokens_metric_total
         components:
-        - value
+          - value
       output_audio:
         signal: output_audio_tokens_metric_total
         components:
-        - value
+          - value
       output_reasoning:
         signal: output_reasoning_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1912,12 +1912,12 @@ views:
       images:
         signal: images_generated_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1941,12 +1941,12 @@ views:
       duration:
         signal: video_duration_seconds_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -1970,15 +1970,15 @@ views:
       input:
         signal: input_tokens_metric_total
         components:
-        - value
+          - value
       output:
         signal: output_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_key_alias
+        - api_key_alias
       omit:
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2003,11 +2003,11 @@ views:
       total:
         signal: total_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_key_alias
+        - api_key_alias
       omit:
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2032,11 +2032,11 @@ views:
       spend:
         signal: spend_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_key_alias
+        - api_key_alias
       omit:
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
         client_ip: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2066,15 +2066,15 @@ views:
       input:
         signal: input_tokens_metric_total
         components:
-        - value
+          - value
       output:
         signal: output_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - team_alias
+        - team_alias
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2099,11 +2099,11 @@ views:
       total:
         signal: total_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - team_alias
+        - team_alias
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2128,11 +2128,11 @@ views:
       spend:
         signal: spend_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - team_alias
+        - team_alias
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2162,11 +2162,11 @@ views:
       input:
         signal: input_tokens_metric_total
         components:
-        - value
+          - value
       output:
         signal: output_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2195,7 +2195,7 @@ views:
       total:
         signal: total_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2224,7 +2224,7 @@ views:
       spend:
         signal: spend_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2258,15 +2258,15 @@ views:
       input:
         signal: input_tokens_metric_total
         components:
-        - value
+          - value
       output:
         signal: output_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - org_alias
+        - org_alias
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2291,11 +2291,11 @@ views:
       total:
         signal: total_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - org_alias
+        - org_alias
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2320,11 +2320,11 @@ views:
       spend:
         signal: spend_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - org_alias
+        - org_alias
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         api_provider: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2354,11 +2354,11 @@ views:
       input:
         signal: input_tokens_metric_total
         components:
-        - value
+          - value
       output:
         signal: output_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2387,7 +2387,7 @@ views:
       total:
         signal: total_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2416,7 +2416,7 @@ views:
       spend:
         signal: spend_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2450,11 +2450,11 @@ views:
       input:
         signal: input_tokens_metric_total
         components:
-        - value
+          - value
       output:
         signal: output_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2483,7 +2483,7 @@ views:
       total:
         signal: total_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2512,7 +2512,7 @@ views:
       spend:
         signal: spend_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2546,16 +2546,16 @@ views:
       hits:
         signal: cache_hits_metric_total
         components:
-        - value
+          - value
       misses:
         signal: cache_misses_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2575,12 +2575,12 @@ views:
       cached:
         signal: cached_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2600,16 +2600,16 @@ views:
       read:
         signal: input_cached_tokens_metric_total
         components:
-        - value
+          - value
       creation:
         signal: input_cache_creation_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2631,16 +2631,16 @@ views:
       read:
         signal: provider_cache_read_input_tokens_metric_total
         components:
-        - value
+          - value
       creation:
         signal: provider_cache_creation_input_tokens_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_provider
-      - model
+        - api_provider
+        - model
       omit:
         api_key_alias: This source label does not define the selected operator entity or a useful chart dimension/label.
         end_user: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2660,11 +2660,11 @@ views:
       remaining:
         signal: remaining_api_key_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_key_alias
+        - api_key_alias
       omit: {}
   governance.api_keys.budget_limit:
     family: LiteLLM/Governance/API Keys
@@ -2674,11 +2674,11 @@ views:
       limit:
         signal: api_key_max_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_key_alias
+        - api_key_alias
       omit: {}
   governance.api_keys.budget_reset_window:
     family: LiteLLM/Governance/API Keys
@@ -2688,17 +2688,17 @@ views:
       remaining:
         signal: api_key_budget_remaining_hours_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_key_alias
+        - api_key_alias
       omit: {}
     display:
       convention: duration_hours
       reason: The existing operator view expresses the source measurement as hours.
       evidence:
-      - display_conventions
+        - display_conventions
   governance.api_keys.model_request_headroom:
     family: LiteLLM/Governance/API Keys
     question: What does api-key model request headroom report for each hashed_api_key, model?
@@ -2707,11 +2707,11 @@ views:
       remaining:
         signal: remaining_api_key_requests_for_model
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_key_alias
+        - api_key_alias
       omit:
         metadata_project: This source label does not define the selected operator entity or a useful chart dimension/label.
         model_id: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2728,11 +2728,11 @@ views:
       remaining:
         signal: remaining_api_key_tokens_for_model
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - api_key_alias
+        - api_key_alias
       omit:
         metadata_project: This source label does not define the selected operator entity or a useful chart dimension/label.
         model_id: This source label does not define the selected operator entity or a useful chart dimension/label.
@@ -2749,11 +2749,11 @@ views:
       remaining:
         signal: remaining_org_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - org_alias
+        - org_alias
       omit: {}
   governance.organizations.budget_limit:
     family: LiteLLM/Governance/Organizations
@@ -2763,11 +2763,11 @@ views:
       limit:
         signal: org_max_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - org_alias
+        - org_alias
       omit: {}
   governance.organizations.budget_reset_window:
     family: LiteLLM/Governance/Organizations
@@ -2777,17 +2777,17 @@ views:
       remaining:
         signal: org_budget_remaining_hours_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - org_alias
+        - org_alias
       omit: {}
     display:
       convention: duration_hours
       reason: The existing operator view expresses the source measurement as hours.
       evidence:
-      - display_conventions
+        - display_conventions
   governance.teams.remaining_budget:
     family: LiteLLM/Governance/Teams
     question: What does team remaining budget report for each team?
@@ -2796,11 +2796,11 @@ views:
       remaining:
         signal: remaining_team_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - team_alias
+        - team_alias
       omit: {}
   governance.teams.budget_limit:
     family: LiteLLM/Governance/Teams
@@ -2810,11 +2810,11 @@ views:
       limit:
         signal: team_max_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - team_alias
+        - team_alias
       omit: {}
   governance.teams.budget_reset_window:
     family: LiteLLM/Governance/Teams
@@ -2824,17 +2824,17 @@ views:
       remaining:
         signal: team_budget_remaining_hours_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - team_alias
+        - team_alias
       omit: {}
     display:
       convention: duration_hours
       reason: The existing operator view expresses the source measurement as hours.
       evidence:
-      - display_conventions
+        - display_conventions
   governance.teams.membership:
     family: LiteLLM/Governance/Teams
     question: What does team membership report for each team?
@@ -2843,11 +2843,11 @@ views:
       members:
         signal: team_members_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - team_alias
+        - team_alias
       omit: {}
   governance.users.remaining_budget:
     family: LiteLLM/Governance/Users
@@ -2857,7 +2857,7 @@ views:
       remaining:
         signal: remaining_user_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2876,7 +2876,7 @@ views:
       limit:
         signal: user_max_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2895,7 +2895,7 @@ views:
       remaining:
         signal: user_budget_remaining_hours_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2910,7 +2910,7 @@ views:
       convention: duration_hours
       reason: The existing operator view expresses the source measurement as hours.
       evidence:
-      - display_conventions
+        - display_conventions
   governance.providers.remaining_budget:
     family: LiteLLM/Governance/Providers
     question: What does provider remaining budget report for each api_provider?
@@ -2919,7 +2919,7 @@ views:
       remaining:
         signal: provider_remaining_budget_metric
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2932,7 +2932,7 @@ views:
       invocations:
         signal: guardrail_latency_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote: []
@@ -2949,7 +2949,7 @@ views:
       errors:
         signal: guardrail_errors_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2962,7 +2962,7 @@ views:
       distribution:
         signal: guardrail_latency_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote: []
@@ -2981,7 +2981,7 @@ views:
       time:
         signal: guardrail_latency_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote: []
@@ -3000,7 +3000,7 @@ views:
       calls:
         signal: mcp_tool_calls_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3023,7 +3023,7 @@ views:
       spend:
         signal: mcp_tool_call_spend_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3046,7 +3046,7 @@ views:
       created:
         signal: managed_batch_created_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3066,7 +3066,7 @@ views:
       cost_tracked:
         signal: check_batch_cost_jobs_processed_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3079,7 +3079,7 @@ views:
       errors:
         signal: check_batch_cost_errors_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3097,7 +3097,7 @@ views:
       created:
         signal: managed_file_created_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3117,7 +3117,7 @@ views:
       deletions:
         signal: managed_file_deleted_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3130,7 +3130,7 @@ views:
       distribution:
         signal: managed_batch_duration_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote: []
@@ -3143,7 +3143,7 @@ views:
       completed:
         signal: managed_batch_duration_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote: []
@@ -3156,7 +3156,7 @@ views:
       time:
         signal: managed_batch_duration_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote: []
@@ -3169,7 +3169,7 @@ views:
       users:
         signal: total_users
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3182,7 +3182,7 @@ views:
       users:
         signal: active_users
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3195,7 +3195,7 @@ views:
       teams:
         signal: teams_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3208,7 +3208,7 @@ views:
       failures:
         signal: callback_logging_failures_metric_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3221,11 +3221,11 @@ views:
       outcome_successful:
         signal: internal_service_latency
         components:
-        - count
+          - count
       outcome_failed:
         signal: internal_service_failures
         components:
-        - value
+          - value
     labels:
       dimensions:
         outcome:
@@ -3259,9 +3259,10 @@ views:
     entity: function_name_error_class
     inputs:
       ? service_auth_batch_write_to_db_postgres_proxy_pre_call_redis_redis_daily_org_spend_update_queue_redis_daily_tag_spend_update_queue_redis_daily_team_spend_update_queue_reset_budget_job_router_self
-      : signal: internal_service_failures
+        :
+        signal: internal_service_failures
         components:
-        - value
+          - value
     labels:
       dimensions:
         service:
@@ -3287,7 +3288,7 @@ views:
       convention: request_failures
       reason: The existing operator view expresses the source measurement as failures/s.
       evidence:
-      - display_conventions
+        - display_conventions
   internal_services.latency_distribution:
     family: LiteLLM/Internal Services
     question: What does internal service latency distribution report for each service?
@@ -3296,7 +3297,7 @@ views:
       distribution:
         signal: internal_service_latency
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote: []
@@ -3325,7 +3326,7 @@ views:
       measurement_time:
         signal: internal_service_latency
         components:
-        - sum
+          - sum
     labels:
       dimensions:
         measurement:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/vllm/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/vllm/PROFILE-DESIGN.yaml
@@ -18,11 +18,11 @@ entities:
     grain: model_name and engine
     identity:
       required:
-      - model_name
-      - engine
+        - model_name
+        - engine
       optional:
-      - ReplicaId
-      - WorkerId
+        - ReplicaId
+        - WorkerId
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful source entity lets operators diagnose it directly and aggregate broader
         service views in Netdata.
@@ -30,12 +30,12 @@ entities:
     grain: model_name and engine and finished_reason
     identity:
       required:
-      - model_name
-      - engine
-      - finished_reason
+        - model_name
+        - engine
+        - finished_reason
       optional:
-      - ReplicaId
-      - WorkerId
+        - ReplicaId
+        - WorkerId
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful source entity lets operators diagnose it directly and aggregate broader
         service views in Netdata.
@@ -43,13 +43,13 @@ entities:
     grain: model_name and engine and operation and status
     identity:
       required:
-      - model_name
-      - engine
-      - operation
-      - status
+        - model_name
+        - engine
+        - operation
+        - status
       optional:
-      - ReplicaId
-      - WorkerId
+        - ReplicaId
+        - WorkerId
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful source entity lets operators diagnose it directly and aggregate broader
         service views in Netdata.
@@ -62,10 +62,10 @@ entities:
     grain: model_name and request_type and mode and outcome
     identity:
       required:
-      - model_name
-      - request_type
-      - mode
-      - outcome
+        - model_name
+        - request_type
+        - mode
+        - outcome
       optional: []
     high_cardinality_acceptance:
       operator_value: Preserving this finest useful source entity lets operators diagnose it directly and aggregate broader
@@ -79,7 +79,7 @@ normalizations:
     source_prefix: ray_vllm_
     target_prefix: 'vllm:'
     evidence:
-    - ray_namespace_relationship
+      - ray_namespace_relationship
   generated_registration_epochs:
     kind: generated_component_exclusion
     source:
@@ -88,699 +88,699 @@ normalizations:
       component: scalar
     outcome: drop_before_writer
     evidence:
-    - created_registration
-    - component_lifecycle
-    - source_units
+      - created_registration
+      - component_lifecycle
+      - source_units
 exclusions:
   duplicate_e2e_request_latency_seconds_count:
     source:
       signal: e2e_request_latency_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_kv_block_idle_before_evict_seconds_count:
     source:
       signal: kv_block_idle_before_evict_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: kv_cache_residency.events
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_kv_offload_load_size_sum:
     source:
       signal: kv_offload_load_size
       components:
-      - sum
+        - sum
     reason: equivalent_duplicate
     covering_view: kv_offloading.transfer_bytes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_kv_offload_store_size_sum:
     source:
       signal: kv_offload_store_size
       components:
-      - sum
+        - sum
     reason: equivalent_duplicate
     covering_view: kv_offloading.transfer_bytes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_mooncake_store_operation_time_seconds_count:
     source:
       signal: mooncake_store_operation_time_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: mooncake_connector.timing.operations
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_nixl_bytes_transferred_count:
     source:
       signal: nixl_bytes_transferred
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: nixl_connector.successful_transfers
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_nixl_num_descriptors_count:
     source:
       signal: nixl_num_descriptors
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: nixl_connector.successful_transfers
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_nixl_post_time_seconds_count:
     source:
       signal: nixl_post_time_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: nixl_connector.successful_transfers
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_num_requests_waiting:
     source:
       signal: num_requests_waiting
       components:
-      - value
+        - value
     reason: equivalent_duplicate
     covering_view: scheduler.request_state
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_prompt_tokens_cached_total:
     source:
       signal: prompt_tokens_cached_total
       components:
-      - value
+        - value
     reason: equivalent_duplicate
     covering_view: prefill.prompt_tokens_by_source
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_prompt_tokens_total:
     source:
       signal: prompt_tokens_total
       components:
-      - value
+        - value
     reason: equivalent_duplicate
     covering_view: prefill.prompt_tokens_by_source
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_decode_time_seconds_count:
     source:
       signal: request_decode_time_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_generation_tokens_count:
     source:
       signal: request_generation_tokens
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_inference_time_seconds_count:
     source:
       signal: request_inference_time_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_max_num_generation_tokens_count:
     source:
       signal: request_max_num_generation_tokens
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.parent_requests
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_prefill_kv_computed_tokens_count:
     source:
       signal: request_prefill_kv_computed_tokens
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_prefill_time_seconds_count:
     source:
       signal: request_prefill_time_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_prompt_tokens_count:
     source:
       signal: request_prompt_tokens
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_queue_time_seconds_count:
     source:
       signal: request_queue_time_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   duplicate_request_time_per_output_token_seconds_count:
     source:
       signal: request_time_per_output_token_seconds
       components:
-      - count
+        - count
     reason: equivalent_duplicate
     covering_view: request_lifecycle.outcomes
     evidence:
-    - source_relationships
+      - source_relationships
     outcome: retain_writable_unrendered
   deprecated_offload_bytes_cpu_to_gpu:
     source:
       signal: deprecated_offload_bytes_total
       components:
-      - value
+        - value
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: CPU_to_GPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: CPU_to_GPU
     reason: source_superseded
     replacement: kv_offload_load_bytes_total
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_bytes_gpu_to_cpu:
     source:
       signal: deprecated_offload_bytes_total
       components:
-      - value
+        - value
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: GPU_to_CPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: GPU_to_CPU
     reason: source_superseded
     replacement: kv_offload_store_bytes_total
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_time_cpu_to_gpu:
     source:
       signal: deprecated_offload_time_total
       components:
-      - value
+        - value
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: CPU_to_GPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: CPU_to_GPU
     reason: source_superseded
     replacement: kv_offload_load_time_total
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_time_gpu_to_cpu:
     source:
       signal: deprecated_offload_time_total
       components:
-      - value
+        - value
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: GPU_to_CPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: GPU_to_CPU
     reason: source_superseded
     replacement: kv_offload_store_time_total
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_size_cpu_to_gpu:
     source:
       signal: deprecated_offload_size
       components:
-      - bucket
+        - bucket
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: CPU_to_GPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: CPU_to_GPU
     reason: source_superseded
     replacement: kv_offload_load_size
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_size_gpu_to_cpu:
     source:
       signal: deprecated_offload_size
       components:
-      - bucket
+        - bucket
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: GPU_to_CPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: GPU_to_CPU
     reason: source_superseded
     replacement: kv_offload_store_size
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_size_count_cpu_to_gpu:
     source:
       signal: deprecated_offload_size
       components:
-      - count
+        - count
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: CPU_to_GPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: CPU_to_GPU
     reason: source_superseded
     replacement: kv_offload_load_size
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_size_count_gpu_to_cpu:
     source:
       signal: deprecated_offload_size
       components:
-      - count
+        - count
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: GPU_to_CPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: GPU_to_CPU
     reason: source_superseded
     replacement: kv_offload_store_size
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_size_sum_cpu_to_gpu:
     source:
       signal: deprecated_offload_size
       components:
-      - sum
+        - sum
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: CPU_to_GPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: CPU_to_GPU
     reason: source_superseded
     replacement: kv_offload_load_size
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   deprecated_offload_size_sum_gpu_to_cpu:
     source:
       signal: deprecated_offload_size
       components:
-      - sum
+        - sum
       where:
         any:
-        - all:
-          - label: transfer_type
-            op: eq
-            value: GPU_to_CPU
+          - all:
+              - label: transfer_type
+                op: eq
+                value: GPU_to_CPU
     reason: source_superseded
     replacement: kv_offload_store_size
     evidence:
-    - deprecated_sources
+      - deprecated_sources
     outcome: drop_before_writer
   ray_alias_corrupted_requests_total:
     source:
       signal: ray_alias_corrupted_requests_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: corrupted_requests_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_deprecated_offload_bytes_total:
     source:
       signal: ray_alias_deprecated_offload_bytes_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: deprecated_offload_bytes_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_deprecated_offload_time_total:
     source:
       signal: ray_alias_deprecated_offload_time_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: deprecated_offload_time_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_diffusion_num_canvas_positions_total:
     source:
       signal: ray_alias_diffusion_num_canvas_positions_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: diffusion_num_canvas_positions_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_diffusion_num_committed_tokens_total:
     source:
       signal: ray_alias_diffusion_num_committed_tokens_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: diffusion_num_committed_tokens_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_diffusion_num_denoising_steps_total:
     source:
       signal: ray_alias_diffusion_num_denoising_steps_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: diffusion_num_denoising_steps_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_external_prefix_cache_hits_total:
     source:
       signal: ray_alias_external_prefix_cache_hits_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: external_prefix_cache_hits_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_external_prefix_cache_queries_total:
     source:
       signal: ray_alias_external_prefix_cache_queries_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: external_prefix_cache_queries_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_generation_tokens_total:
     source:
       signal: ray_alias_generation_tokens_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: generation_tokens_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_hf3fs_num_failed_load_total:
     source:
       signal: ray_alias_hf3fs_num_failed_load_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: hf3fs_num_failed_load_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_hf3fs_num_failed_save_total:
     source:
       signal: ray_alias_hf3fs_num_failed_save_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: hf3fs_num_failed_save_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_kv_offload_allocation_failure_total:
     source:
       signal: ray_alias_kv_offload_allocation_failure_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: kv_offload_allocation_failure_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_kv_offload_load_bytes_total:
     source:
       signal: ray_alias_kv_offload_load_bytes_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: kv_offload_load_bytes_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_kv_offload_load_time_total:
     source:
       signal: ray_alias_kv_offload_load_time_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: kv_offload_load_time_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_kv_offload_store_bytes_total:
     source:
       signal: ray_alias_kv_offload_store_bytes_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: kv_offload_store_bytes_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_kv_offload_store_time_total:
     source:
       signal: ray_alias_kv_offload_store_time_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: kv_offload_store_time_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_kv_offload_stores_skipped_total:
     source:
       signal: ray_alias_kv_offload_stores_skipped_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: kv_offload_stores_skipped_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_mm_cache_hits_total:
     source:
       signal: ray_alias_mm_cache_hits_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: mm_cache_hits_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_mm_cache_queries_total:
     source:
       signal: ray_alias_mm_cache_queries_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: mm_cache_queries_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_nixl_num_failed_notifications_total:
     source:
       signal: ray_alias_nixl_num_failed_notifications_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: nixl_num_failed_notifications_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_nixl_num_failed_transfers_total:
     source:
       signal: ray_alias_nixl_num_failed_transfers_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: nixl_num_failed_transfers_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_nixl_num_kv_expired_reqs_total:
     source:
       signal: ray_alias_nixl_num_kv_expired_reqs_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: nixl_num_kv_expired_reqs_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_num_preemptions_total:
     source:
       signal: ray_alias_num_preemptions_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: num_preemptions_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_prefix_cache_hits_total:
     source:
       signal: ray_alias_prefix_cache_hits_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: prefix_cache_hits_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_prefix_cache_queries_total:
     source:
       signal: ray_alias_prefix_cache_queries_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: prefix_cache_queries_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_prompt_tokens_by_source_total:
     source:
       signal: ray_alias_prompt_tokens_by_source_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: prompt_tokens_by_source_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_prompt_tokens_cached_total:
     source:
       signal: ray_alias_prompt_tokens_cached_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: prompt_tokens_cached_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_prompt_tokens_total:
     source:
       signal: ray_alias_prompt_tokens_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: prompt_tokens_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_request_success_total:
     source:
       signal: ray_alias_request_success_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: request_success_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_spec_decode_num_accepted_tokens_per_pos_total:
     source:
       signal: ray_alias_spec_decode_num_accepted_tokens_per_pos_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: spec_decode_num_accepted_tokens_per_pos_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_spec_decode_num_accepted_tokens_total:
     source:
       signal: ray_alias_spec_decode_num_accepted_tokens_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: spec_decode_num_accepted_tokens_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_spec_decode_num_draft_tokens_total:
     source:
       signal: ray_alias_spec_decode_num_draft_tokens_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: spec_decode_num_draft_tokens_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
   ray_alias_spec_decode_num_drafts_total:
     source:
       signal: ray_alias_spec_decode_num_drafts_total
       components:
-      - value
+        - value
     reason: source_superseded
     replacement: spec_decode_num_drafts_total
     evidence:
-    - ray_compatibility_deprecation
+      - ray_compatibility_deprecation
     outcome: drop_before_writer
 limitations: {}
 views:
@@ -792,13 +792,13 @@ views:
       corrupted:
         signal: corrupted_requests_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.time_to_first_token:
     family: vLLM/Request Lifecycle
@@ -808,13 +808,13 @@ views:
       time_to_first_token:
         signal: time_to_first_token_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.end_to_end_latency:
     family: vLLM/Request Lifecycle
@@ -824,13 +824,13 @@ views:
       end_to_end_latency:
         signal: e2e_request_latency_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.first_token_requests:
     family: vLLM/Request Lifecycle
@@ -840,13 +840,13 @@ views:
       requests:
         signal: time_to_first_token_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.completed_pre_response_time:
     family: vLLM/Request Lifecycle
@@ -856,13 +856,13 @@ views:
       time:
         signal: time_to_first_token_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.completed_end_to_end_time:
     family: vLLM/Request Lifecycle
@@ -872,13 +872,13 @@ views:
       time:
         signal: e2e_request_latency_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.requested_sequences:
     family: vLLM/Request Lifecycle
@@ -888,13 +888,13 @@ views:
       requested_sequences:
         signal: request_params_n
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.requested_sequence_volume:
     family: vLLM/Request Lifecycle
@@ -904,13 +904,13 @@ views:
       sequences:
         signal: request_params_n
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.requested_token_limit:
     family: vLLM/Request Lifecycle
@@ -920,13 +920,13 @@ views:
       requested_token_limit:
         signal: request_params_max_tokens
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.requested_token_limits_sum:
     family: vLLM/Request Lifecycle
@@ -936,13 +936,13 @@ views:
       token_limits:
         signal: request_params_max_tokens
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.requests_with_explicit_token_limit:
     family: vLLM/Request Lifecycle
@@ -952,13 +952,13 @@ views:
       requests:
         signal: request_params_max_tokens
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.maximum_generated_tokens:
     family: vLLM/Request Lifecycle
@@ -968,13 +968,13 @@ views:
       maximum_generated_tokens:
         signal: request_max_num_generation_tokens
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.maximum_generated_tokens_sum:
     family: vLLM/Request Lifecycle
@@ -984,13 +984,13 @@ views:
       maximums:
         signal: request_max_num_generation_tokens
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.parent_requests:
     family: vLLM/Request Lifecycle
@@ -1000,13 +1000,13 @@ views:
       requests:
         signal: request_params_n
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   request_lifecycle.outcomes:
     family: vLLM/Request Lifecycle/Outcomes
@@ -1016,13 +1016,13 @@ views:
       requests:
         signal: request_success_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   scheduler.request_state:
     family: vLLM/Scheduler
@@ -1032,35 +1032,35 @@ views:
       running:
         signal: num_requests_running
         components:
-        - value
+          - value
       waiting_capacity:
         signal: num_requests_waiting_by_reason
         components:
-        - value
+          - value
         where:
           any:
-          - all:
-            - label: reason
-              op: eq
-              value: capacity
+            - all:
+                - label: reason
+                  op: eq
+                  value: capacity
       waiting_deferred:
         signal: num_requests_waiting_by_reason
         components:
-        - value
+          - value
         where:
           any:
-          - all:
-            - label: reason
-              op: eq
-              value: deferred
+            - all:
+                - label: reason
+                  op: eq
+                  value: deferred
     labels:
       dimensions:
         reason:
           render: input_role
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   scheduler.preemptions:
     family: vLLM/Scheduler
@@ -1070,13 +1070,13 @@ views:
       preemptions:
         signal: num_preemptions_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   scheduler.sleep_state:
     family: vLLM/Scheduler
@@ -1086,15 +1086,15 @@ views:
       sleep_state:
         signal: engine_sleep_state
         components:
-        - value
+          - value
     labels:
       dimensions:
         sleep_state:
           render: label_value
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   scheduler.queue_time:
     family: vLLM/Scheduler
@@ -1104,13 +1104,13 @@ views:
       queue_time:
         signal: request_queue_time_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   scheduler.completed_queue_time:
     family: vLLM/Scheduler
@@ -1120,13 +1120,13 @@ views:
       time:
         signal: request_queue_time_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   prefill.prompt_tokens_by_source:
     family: vLLM/Prefill
@@ -1136,15 +1136,15 @@ views:
       source:
         signal: prompt_tokens_by_source_total
         components:
-        - value
+          - value
     labels:
       dimensions:
         source:
           render: label_value
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   prefill.prompt_size:
     family: vLLM/Prefill
@@ -1154,13 +1154,13 @@ views:
       prompt_size:
         signal: request_prompt_tokens
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   prefill.prefill_time:
     family: vLLM/Prefill
@@ -1170,13 +1170,13 @@ views:
       prefill_time:
         signal: request_prefill_time_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   prefill.computed_kv_tokens:
     family: vLLM/Prefill
@@ -1186,13 +1186,13 @@ views:
       computed_kv_tokens:
         signal: request_prefill_kv_computed_tokens
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   prefill.completed_request_prompt_volume:
     family: vLLM/Prefill
@@ -1202,13 +1202,13 @@ views:
       prompt_tokens:
         signal: request_prompt_tokens
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   prefill.computed_kv_token_volume:
     family: vLLM/Prefill
@@ -1218,13 +1218,13 @@ views:
       computed_tokens:
         signal: request_prefill_kv_computed_tokens
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   prefill.completed_time:
     family: vLLM/Prefill
@@ -1234,13 +1234,13 @@ views:
       time:
         signal: request_prefill_time_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.generation_throughput:
     family: vLLM/Decode
@@ -1250,13 +1250,13 @@ views:
       generated:
         signal: generation_tokens_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.output_size:
     family: vLLM/Decode
@@ -1266,13 +1266,13 @@ views:
       output_size:
         signal: request_generation_tokens
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.decode_time:
     family: vLLM/Decode
@@ -1282,13 +1282,13 @@ views:
       decode_time:
         signal: request_decode_time_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.inter_token_latency:
     family: vLLM/Decode
@@ -1298,13 +1298,13 @@ views:
       inter_token_latency:
         signal: inter_token_latency_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.mean_output_token_time:
     family: vLLM/Decode
@@ -1314,13 +1314,13 @@ views:
       mean_output_token_time:
         signal: request_time_per_output_token_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.output_token_volume:
     family: vLLM/Decode
@@ -1330,13 +1330,13 @@ views:
       output_tokens:
         signal: request_generation_tokens
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.completed_time:
     family: vLLM/Decode
@@ -1346,13 +1346,13 @@ views:
       time:
         signal: request_decode_time_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.inter_token_intervals:
     family: vLLM/Decode
@@ -1362,13 +1362,13 @@ views:
       intervals:
         signal: inter_token_latency_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.inter_token_interval_time:
     family: vLLM/Decode
@@ -1378,13 +1378,13 @@ views:
       intervals:
         signal: inter_token_latency_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   decode.accumulated_mean_output_token_time:
     family: vLLM/Decode
@@ -1394,13 +1394,13 @@ views:
       request_means:
         signal: request_time_per_output_token_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   engine_execution.inference_time:
     family: vLLM/Engine Execution
@@ -1410,13 +1410,13 @@ views:
       inference_time:
         signal: request_inference_time_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   engine_execution.completed_time:
     family: vLLM/Engine Execution
@@ -1426,13 +1426,13 @@ views:
       time:
         signal: request_inference_time_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   engine_execution.tokens_per_step:
     family: vLLM/Engine Execution
@@ -1442,13 +1442,13 @@ views:
       tokens_per_step:
         signal: iteration_tokens_total
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   engine_execution.engine_steps:
     family: vLLM/Engine Execution
@@ -1458,13 +1458,13 @@ views:
       steps:
         signal: iteration_tokens_total
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   engine_execution.step_token_volume:
     family: vLLM/Engine Execution
@@ -1474,13 +1474,13 @@ views:
       tokens:
         signal: iteration_tokens_total
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   engine_execution.estimated_compute:
     family: vLLM/Engine Execution
@@ -1490,19 +1490,19 @@ views:
       compute:
         signal: estimated_flops_per_gpu_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
     display:
       convention: gflops_per_second_per_gpu
       reason: Operators compare accelerator work in billions of floating-point operations per second per GPU.
       evidence:
-      - display_conventions
+        - display_conventions
   engine_execution.estimated_memory_bandwidth:
     family: vLLM/Engine Execution
     question: At what rate does estimated memory bandwidth per gpu change?
@@ -1511,23 +1511,23 @@ views:
       read:
         signal: estimated_read_bytes_per_gpu_total
         components:
-        - value
+          - value
       write:
         signal: estimated_write_bytes_per_gpu_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
     display:
       convention: gigabytes_per_second_per_gpu
       reason: Operators compare accelerator memory traffic in gigabytes per second per GPU.
       evidence:
-      - display_conventions
+        - display_conventions
   kv_cache.usage:
     family: vLLM/KV Cache
     question: What is the current kv cache usage?
@@ -1536,19 +1536,19 @@ views:
       used:
         signal: kv_cache_usage_perc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
     display:
       convention: percentage
       reason: Operators interpret the exported ratio as a percentage.
       evidence:
-      - display_conventions
+        - display_conventions
   kv_cache.local_prefix:
     family: vLLM/KV Cache
     question: At what rate does local prefix cache change?
@@ -1557,17 +1557,17 @@ views:
       queries:
         signal: prefix_cache_queries_total
         components:
-        - value
+          - value
       hits:
         signal: prefix_cache_hits_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_cache.external_prefix:
     family: vLLM/KV Cache
@@ -1577,17 +1577,17 @@ views:
       queries:
         signal: external_prefix_cache_queries_total
         components:
-        - value
+          - value
       hits:
         signal: external_prefix_cache_hits_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_cache.multimodal:
     family: vLLM/KV Cache
@@ -1597,17 +1597,17 @@ views:
       queries:
         signal: mm_cache_queries_total
         components:
-        - value
+          - value
       hits:
         signal: mm_cache_hits_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_cache_residency.block_lifetime:
     family: vLLM/KV Cache Residency
@@ -1617,13 +1617,13 @@ views:
       block_lifetime:
         signal: kv_block_lifetime_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_cache_residency.idle_before_eviction:
     family: vLLM/KV Cache Residency
@@ -1633,13 +1633,13 @@ views:
       idle_before_eviction:
         signal: kv_block_idle_before_evict_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_cache_residency.reuse_gap:
     family: vLLM/KV Cache Residency
@@ -1649,13 +1649,13 @@ views:
       reuse_gap:
         signal: kv_block_reuse_gap_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_cache_residency.events:
     family: vLLM/KV Cache Residency
@@ -1665,17 +1665,17 @@ views:
       evictions:
         signal: kv_block_lifetime_seconds
         components:
-        - count
+          - count
       reuse_gaps:
         signal: kv_block_reuse_gap_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_cache_residency.accumulated_time:
     family: vLLM/KV Cache Residency
@@ -1685,21 +1685,21 @@ views:
       lifetime:
         signal: kv_block_lifetime_seconds
         components:
-        - sum
+          - sum
       idle_before_eviction:
         signal: kv_block_idle_before_evict_seconds
         components:
-        - sum
+          - sum
       reuse_gap:
         signal: kv_block_reuse_gap_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.load_size:
     family: vLLM/KV Offloading
@@ -1709,13 +1709,13 @@ views:
       load_size:
         signal: kv_offload_load_size
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.store_size:
     family: vLLM/KV Offloading
@@ -1725,13 +1725,13 @@ views:
       store_size:
         signal: kv_offload_store_size
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.transfer_operations:
     family: vLLM/KV Offloading
@@ -1741,17 +1741,17 @@ views:
       loads:
         signal: kv_offload_load_size
         components:
-        - count
+          - count
       stores:
         signal: kv_offload_store_size
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.transfer_bytes:
     family: vLLM/KV Offloading
@@ -1761,17 +1761,17 @@ views:
       loaded:
         signal: kv_offload_load_bytes_total
         components:
-        - value
+          - value
       stored:
         signal: kv_offload_store_bytes_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.completed_transfer_time:
     family: vLLM/KV Offloading
@@ -1781,17 +1781,17 @@ views:
       load:
         signal: kv_offload_load_time_total
         components:
-        - value
+          - value
       store:
         signal: kv_offload_store_time_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.lookup_sync_delay:
     family: vLLM/KV Offloading
@@ -1801,13 +1801,13 @@ views:
       lookup_sync_delay:
         signal: kv_offload_lookup_sync_delay_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.lookup_async_delay:
     family: vLLM/KV Offloading
@@ -1817,13 +1817,13 @@ views:
       lookup_async_delay:
         signal: kv_offload_lookup_async_delay_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.lookup_measurements:
     family: vLLM/KV Offloading
@@ -1833,17 +1833,17 @@ views:
       synchronous:
         signal: kv_offload_lookup_sync_delay_seconds
         components:
-        - count
+          - count
       asynchronous:
         signal: kv_offload_lookup_async_delay_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.lookup_delay_accumulation:
     family: vLLM/KV Offloading
@@ -1853,17 +1853,17 @@ views:
       synchronous:
         signal: kv_offload_lookup_sync_delay_seconds
         components:
-        - sum
+          - sum
       asynchronous:
         signal: kv_offload_lookup_async_delay_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.cpu_cache_usage:
     family: vLLM/KV Offloading
@@ -1873,27 +1873,27 @@ views:
       total:
         signal: kv_offload_cpu_cache_usage_perc
         components:
-        - value
+          - value
       writes:
         signal: kv_offload_cpu_cache_write_usage_perc
         components:
-        - value
+          - value
       reads:
         signal: kv_offload_cpu_cache_read_usage_perc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
     display:
       convention: percentage
       reason: Operators interpret the exported ratio as a percentage.
       evidence:
-      - display_conventions
+        - display_conventions
   kv_offloading.cpu_allocation_size:
     family: vLLM/KV Offloading
     question: How is cpu kv allocation size distributed?
@@ -1902,13 +1902,13 @@ views:
       cpu_allocation_size:
         signal: kv_offload_cpu_allocation_size
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.cpu_allocation_measurements:
     family: vLLM/KV Offloading
@@ -1918,13 +1918,13 @@ views:
       allocations:
         signal: kv_offload_cpu_allocation_size
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.cpu_allocation_volume:
     family: vLLM/KV Offloading
@@ -1934,13 +1934,13 @@ views:
       blocks:
         signal: kv_offload_cpu_allocation_size
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.admission_outcomes:
     family: vLLM/KV Offloading
@@ -1950,17 +1950,17 @@ views:
       allocation_failures:
         signal: kv_offload_allocation_failure_total
         components:
-        - value
+          - value
       stores_skipped:
         signal: kv_offload_stores_skipped_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.tiering_lookup_sync_delay:
     family: vLLM/KV Offloading
@@ -1970,13 +1970,13 @@ views:
       tiering_lookup_sync_delay:
         signal: kv_offload_tiering_lookup_sync_delay_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.tiering_lookup_async_delay:
     family: vLLM/KV Offloading
@@ -1986,13 +1986,13 @@ views:
       tiering_lookup_async_delay:
         signal: kv_offload_tiering_lookup_async_delay_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.tiering_lookup_measurements:
     family: vLLM/KV Offloading
@@ -2002,17 +2002,17 @@ views:
       synchronous:
         signal: kv_offload_tiering_lookup_sync_delay_seconds
         components:
-        - count
+          - count
       asynchronous:
         signal: kv_offload_tiering_lookup_async_delay_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   kv_offloading.tiering_lookup_delay_accumulation:
     family: vLLM/KV Offloading
@@ -2022,17 +2022,17 @@ views:
       synchronous:
         signal: kv_offload_tiering_lookup_sync_delay_seconds
         components:
-        - sum
+          - sum
       asynchronous:
         signal: kv_offload_tiering_lookup_async_delay_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.transfer_duration:
     family: vLLM/NIXL Connector
@@ -2042,13 +2042,13 @@ views:
       transfer_duration:
         signal: nixl_xfer_time_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.post_time:
     family: vLLM/NIXL Connector
@@ -2058,13 +2058,13 @@ views:
       post_time:
         signal: nixl_post_time_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.transfer_size:
     family: vLLM/NIXL Connector
@@ -2074,13 +2074,13 @@ views:
       transfer_size:
         signal: nixl_bytes_transferred
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.transfer_descriptors:
     family: vLLM/NIXL Connector
@@ -2090,13 +2090,13 @@ views:
       transfer_descriptors:
         signal: nixl_num_descriptors
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.successful_transfers:
     family: vLLM/NIXL Connector
@@ -2106,13 +2106,13 @@ views:
       transfers:
         signal: nixl_xfer_time_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.completed_transfer_time:
     family: vLLM/NIXL Connector
@@ -2122,17 +2122,17 @@ views:
       transfer:
         signal: nixl_xfer_time_seconds
         components:
-        - sum
+          - sum
       post:
         signal: nixl_post_time_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.transfer_throughput:
     family: vLLM/NIXL Connector
@@ -2142,13 +2142,13 @@ views:
       transferred:
         signal: nixl_bytes_transferred
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.descriptor_throughput:
     family: vLLM/NIXL Connector
@@ -2158,13 +2158,13 @@ views:
       descriptors:
         signal: nixl_num_descriptors
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.failures:
     family: vLLM/NIXL Connector
@@ -2174,17 +2174,17 @@ views:
       transfers:
         signal: nixl_num_failed_transfers_total
         components:
-        - value
+          - value
       notifications:
         signal: nixl_num_failed_notifications_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   nixl_connector.expired_requests:
     family: vLLM/NIXL Connector
@@ -2194,13 +2194,13 @@ views:
       expired:
         signal: nixl_num_kv_expired_reqs_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   hf3fs_connector.save_duration:
     family: vLLM/HF3FS Connector
@@ -2210,13 +2210,13 @@ views:
       save_duration:
         signal: hf3fs_save_duration_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   hf3fs_connector.load_duration:
     family: vLLM/HF3FS Connector
@@ -2226,13 +2226,13 @@ views:
       load_duration:
         signal: hf3fs_load_duration_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   hf3fs_connector.transfer_measurements:
     family: vLLM/HF3FS Connector
@@ -2242,17 +2242,17 @@ views:
       saves:
         signal: hf3fs_save_duration_seconds
         components:
-        - count
+          - count
       loads:
         signal: hf3fs_load_duration_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   hf3fs_connector.completed_transfer_time:
     family: vLLM/HF3FS Connector
@@ -2262,17 +2262,17 @@ views:
       saves:
         signal: hf3fs_save_duration_seconds
         components:
-        - sum
+          - sum
       loads:
         signal: hf3fs_load_duration_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   hf3fs_connector.failures:
     family: vLLM/HF3FS Connector
@@ -2282,17 +2282,17 @@ views:
       saves:
         signal: hf3fs_num_failed_save_total
         components:
-        - value
+          - value
       loads:
         signal: hf3fs_num_failed_load_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   mooncake_connector.timing.duration:
     family: vLLM/Mooncake Connector/Operation Timing
@@ -2302,13 +2302,13 @@ views:
       duration:
         signal: mooncake_store_operation_time_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   mooncake_connector.timing.operations:
     family: vLLM/Mooncake Connector/Operation Timing
@@ -2318,13 +2318,13 @@ views:
       operations:
         signal: mooncake_store_operation_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   mooncake_connector.timing.completed_time:
     family: vLLM/Mooncake Connector/Operation Timing
@@ -2334,13 +2334,13 @@ views:
       time:
         signal: mooncake_store_operation_time_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   mooncake_connector.volume.keys:
     family: vLLM/Mooncake Connector/Operation Volume
@@ -2350,13 +2350,13 @@ views:
       keys:
         signal: mooncake_store_operation_keys_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   mooncake_connector.volume.bytes:
     family: vLLM/Mooncake Connector/Operation Volume
@@ -2366,13 +2366,13 @@ views:
       bytes:
         signal: mooncake_store_operation_bytes_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   mooncake_connector.volume.failed_keys:
     family: vLLM/Mooncake Connector/Operation Volume
@@ -2382,13 +2382,13 @@ views:
       failed:
         signal: mooncake_store_operation_failed_keys_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   speculative_decoding.drafts:
     family: vLLM/Speculative Decoding
@@ -2398,13 +2398,13 @@ views:
       drafts:
         signal: spec_decode_num_drafts_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   speculative_decoding.token_outcomes:
     family: vLLM/Speculative Decoding
@@ -2414,17 +2414,17 @@ views:
       proposed:
         signal: spec_decode_num_draft_tokens_total
         components:
-        - value
+          - value
       accepted:
         signal: spec_decode_num_accepted_tokens_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   speculative_decoding.accepted_by_position:
     family: vLLM/Speculative Decoding
@@ -2434,15 +2434,15 @@ views:
       position:
         signal: spec_decode_num_accepted_tokens_per_pos_total
         components:
-        - value
+          - value
     labels:
       dimensions:
         position:
           render: label_value
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   diffusion_decoding.denoising_steps:
     family: vLLM/Diffusion Decoding
@@ -2452,13 +2452,13 @@ views:
       steps:
         signal: diffusion_num_denoising_steps_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   diffusion_decoding.canvas_positions:
     family: vLLM/Diffusion Decoding
@@ -2468,13 +2468,13 @@ views:
       positions:
         signal: diffusion_num_canvas_positions_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   diffusion_decoding.committed_tokens:
     family: vLLM/Diffusion Decoding
@@ -2484,13 +2484,13 @@ views:
       committed:
         signal: diffusion_num_committed_tokens_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
-      - Component
-      - SessionName
-      - Version
+        - Component
+        - SessionName
+        - Version
       omit: {}
   websocket_service.active_connections:
     family: vLLM/WebSocket Service
@@ -2500,7 +2500,7 @@ views:
       active:
         signal: websocket_connections_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2513,11 +2513,11 @@ views:
       opened:
         signal: websocket_connections_total
         components:
-        - value
+          - value
       closed:
         signal: websocket_connection_duration_seconds
         components:
-        - count
+          - count
     labels:
       dimensions: {}
       promote: []
@@ -2530,7 +2530,7 @@ views:
       connection_duration:
         signal: websocket_connection_duration_seconds
         components:
-        - bucket
+          - bucket
     labels:
       dimensions: {}
       promote: []
@@ -2543,7 +2543,7 @@ views:
       time:
         signal: websocket_connection_duration_seconds
         components:
-        - sum
+          - sum
     labels:
       dimensions: {}
       promote: []
@@ -2556,7 +2556,7 @@ views:
       invocations:
         signal: tool_call_parser_invocations_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -4,11162 +4,11162 @@ match: ceph_*
 app: ceph
 fallback_type:
   gauge:
-  - ceph_disk_occupation
-  - ceph_disk_occupation_human
-  - ceph_fs_metadata
-  - ceph_health_status
-  - ceph_mds_metadata
-  - ceph_mon_metadata
-  - ceph_osd_flag_nobackfill
-  - ceph_osd_flag_nodeep_scrub
-  - ceph_osd_flag_nodown
-  - ceph_osd_flag_noin
-  - ceph_osd_flag_noout
-  - ceph_osd_flag_norebalance
-  - ceph_osd_flag_norecover
-  - ceph_osd_flag_noscrub
-  - ceph_osd_flag_noup
-  - ceph_osd_in
-  - ceph_osd_metadata
-  - ceph_osd_up
-  - ceph_osd_weight
-  - ceph_pool_metadata
-  - ceph_rbd_image_metadata
-  - ceph_rbd_mirror_metadata
-  - ceph_rgw_metadata
-  - ceph_smb_metadata
+    - ceph_disk_occupation
+    - ceph_disk_occupation_human
+    - ceph_fs_metadata
+    - ceph_health_status
+    - ceph_mds_metadata
+    - ceph_mon_metadata
+    - ceph_osd_flag_nobackfill
+    - ceph_osd_flag_nodeep_scrub
+    - ceph_osd_flag_nodown
+    - ceph_osd_flag_noin
+    - ceph_osd_flag_noout
+    - ceph_osd_flag_norebalance
+    - ceph_osd_flag_norecover
+    - ceph_osd_flag_noscrub
+    - ceph_osd_flag_noup
+    - ceph_osd_in
+    - ceph_osd_metadata
+    - ceph_osd_up
+    - ceph_osd_weight
+    - ceph_pool_metadata
+    - ceph_rbd_image_metadata
+    - ceph_rbd_mirror_metadata
+    - ceph_rgw_metadata
+    - ceph_smb_metadata
 relabeling:
-- match: ceph_*
-  metric_relabel_configs:
-  - regex: instance
-    action: labelmap
-    replacement: ceph_instance
-  - regex: instance
-    action: labeldrop
-- match: '!ceph_data_sync_from_zone_* ceph_data_sync_from_*'
-  metric_relabel_configs:
-  - source_labels:
-    - source_zone
-    - __name__
-    regex: ;ceph_data_sync_from_.+_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
-    action: drop
-  - source_labels:
-    - __name__
-    regex: ceph_data_sync_from_(.+?)_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
-    target_label: source_zone_fragment
-    replacement: ${1}
-  - source_labels:
-    - source_zone_fragment
-    - source_zone
-    regex: (.+);(.+)
-    target_label: source_zone
-    replacement: ${1}_${2}
-  - source_labels:
-    - __name__
-    regex: ceph_data_sync_from_(.+?)_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
-    target_label: __name__
-    replacement: ceph_data_sync_from_zone_${2}
-  - regex: source_zone_fragment
-    action: labeldrop
-- match: ceph_port*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_port(.+?)_(dpdk_device_receive_multicast_packets|dpdk_device_receive_dropped_errors|dpdk_device_receive_badcrc_errors|dpdk_device_receive_nombuf_errors|dpdk_device_receive_total_errors|dpdk_device_send_total_errors)
-    target_label: dpdk_port
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_port(.+?)_(dpdk_device_receive_multicast_packets|dpdk_device_receive_dropped_errors|dpdk_device_receive_badcrc_errors|dpdk_device_receive_nombuf_errors|dpdk_device_receive_total_errors|dpdk_device_send_total_errors)
-    target_label: __name__
-    replacement: ceph_dpdk_port_${2}
-- match: ceph_queue*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_queue(.+?)_(dpdk_receive_bad_checksum_errors|dpdk_receive_no_memory_errors|dpdk_receive_linearize_ops|dpdk_receive_copy_bytes|dpdk_receive_last_bunch|dpdk_send_linearize_ops|dpdk_receive_fragments|dpdk_send_queue_length|dpdk_receive_copy_ops|dpdk_receive_packets|dpdk_send_copy_bytes|dpdk_send_last_bunch|dpdk_send_fragments|dpdk_receive_bytes|dpdk_send_copy_ops|dpdk_send_packets|dpdk_send_bytes)
-    target_label: dpdk_queue
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_queue(.+?)_(dpdk_receive_bad_checksum_errors|dpdk_receive_no_memory_errors|dpdk_receive_linearize_ops|dpdk_receive_copy_bytes|dpdk_receive_last_bunch|dpdk_send_linearize_ops|dpdk_receive_fragments|dpdk_send_queue_length|dpdk_receive_copy_ops|dpdk_receive_packets|dpdk_send_copy_bytes|dpdk_send_last_bunch|dpdk_send_fragments|dpdk_receive_bytes|dpdk_send_copy_ops|dpdk_send_packets|dpdk_send_bytes)
-    target_label: __name__
-    replacement: ceph_dpdk_queue_${2}
-- match: ceph_finisher_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_finisher_(.+?)_(complete_latency_count|complete_latency_sum|queue_len)
-    target_label: finisher_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_finisher_(.+?)_(complete_latency_count|complete_latency_sum|queue_len)
-    target_label: __name__
-    replacement: ceph_finisher_${2}
-- match: ceph_blk_kernel_device_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_blk_kernel_device_(.+?)_(discard_threads|discard_op)
-    target_label: kernel_device_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_blk_kernel_device_(.+?)_(discard_threads|discard_op)
-    target_label: __name__
-    replacement: ceph_kernel_device_${2}
-- match: '!ceph_librbd_pwl_* ceph_librbd_*'
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_librbd_(.+?)_(discard_latency_count|discard_latency_sum|flush_latency_count|lock_acquired_time|cmp_latency_count|flush_latency_sum|invalidate_cache|rd_latency_count|wr_latency_count|ws_latency_count|cmp_latency_sum|readahead_bytes|rd_latency_sum|wr_latency_sum|ws_latency_sum|discard_bytes|snap_rollback|opened_time|snap_create|snap_remove|snap_rename|cmp_bytes|readahead|rd_bytes|wr_bytes|ws_bytes|discard|notify|resize|flush|cmp|rd|wr|ws)
-    target_label: librbd_image_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_librbd_(.+?)_(discard_latency_count|discard_latency_sum|flush_latency_count|lock_acquired_time|cmp_latency_count|flush_latency_sum|invalidate_cache|rd_latency_count|wr_latency_count|ws_latency_count|cmp_latency_sum|readahead_bytes|rd_latency_sum|wr_latency_sum|ws_latency_sum|discard_bytes|snap_rollback|opened_time|snap_create|snap_remove|snap_rename|cmp_bytes|readahead|rd_bytes|wr_bytes|ws_bytes|discard|notify|resize|flush|cmp|rd|wr|ws)
-    target_label: __name__
-    replacement: ceph_rbd_librbd_image_${2}
-- match: ceph_librbd_pwl_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_librbd_pwl_(.+?)_(caller_wr_latency_nw_count|req_all_to_dis_nw_t_count|req_arr_to_all_nw_t_count|req_arr_to_dis_nw_t_count|caller_wr_latency_nw_sum|caller_wr_latency_count|req_all_to_dis_nw_t_sum|req_arr_to_all_nw_t_sum|req_arr_to_dis_nw_t_sum|op_app_to_appc_t_count|op_buf_to_bufc_t_count|req_all_to_dis_t_count|req_arr_to_all_t_count|req_arr_to_dis_t_count|caller_wr_latency_sum|op_app_to_cmp_t_count|op_buf_to_app_t_count|op_dis_to_app_t_count|op_dis_to_buf_t_count|op_dis_to_cmp_t_count|hit_rd_latency_count|op_app_to_appc_t_sum|op_buf_to_bufc_t_sum|req_all_to_dis_t_sum|req_arr_to_all_t_sum|req_arr_to_dis_t_sum|aio_flush_lat_count|append_tx_lat_count|op_app_to_cmp_t_sum|op_buf_to_app_t_sum|op_dis_to_app_t_sum|op_dis_to_buf_t_sum|op_dis_to_cmp_t_sum|retire_tx_lat_count|wr_latency_nw_count|writeback_lat_count|hit_rd_latency_sum|log_op_bytes_count|aio_flush_lat_sum|append_tx_lat_sum|discard_lat_count|retire_tx_lat_sum|wr_latency_nw_sum|writeback_lat_sum|log_op_bytes_sum|op_alloc_t_count|rd_latency_count|wr_latency_count|discard_lat_sum|internal_flush|op_alloc_t_sum|rd_latency_sum|wr_latency_sum|aio_flush_def|cmp_lat_count|discard_bytes|rd_hit_bytes|wr_def_lanes|wr_q_barrier|ws_lat_count|cmp_lat_sum|part_hit_rd|invalidate|wr_def_buf|wr_def_log|wr_overlap|ws_lat_sum|aio_flush|cmp_bytes|cmp_fails|rd_bytes|wr_bytes|ws_bytes|discard|log_ops|hit_rd|wr_def|cmp|rd|wr|ws)
-    target_label: librbd_pwl_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_librbd_pwl_(.+?)_(caller_wr_latency_nw_count|req_all_to_dis_nw_t_count|req_arr_to_all_nw_t_count|req_arr_to_dis_nw_t_count|caller_wr_latency_nw_sum|caller_wr_latency_count|req_all_to_dis_nw_t_sum|req_arr_to_all_nw_t_sum|req_arr_to_dis_nw_t_sum|op_app_to_appc_t_count|op_buf_to_bufc_t_count|req_all_to_dis_t_count|req_arr_to_all_t_count|req_arr_to_dis_t_count|caller_wr_latency_sum|op_app_to_cmp_t_count|op_buf_to_app_t_count|op_dis_to_app_t_count|op_dis_to_buf_t_count|op_dis_to_cmp_t_count|hit_rd_latency_count|op_app_to_appc_t_sum|op_buf_to_bufc_t_sum|req_all_to_dis_t_sum|req_arr_to_all_t_sum|req_arr_to_dis_t_sum|aio_flush_lat_count|append_tx_lat_count|op_app_to_cmp_t_sum|op_buf_to_app_t_sum|op_dis_to_app_t_sum|op_dis_to_buf_t_sum|op_dis_to_cmp_t_sum|retire_tx_lat_count|wr_latency_nw_count|writeback_lat_count|hit_rd_latency_sum|log_op_bytes_count|aio_flush_lat_sum|append_tx_lat_sum|discard_lat_count|retire_tx_lat_sum|wr_latency_nw_sum|writeback_lat_sum|log_op_bytes_sum|op_alloc_t_count|rd_latency_count|wr_latency_count|discard_lat_sum|internal_flush|op_alloc_t_sum|rd_latency_sum|wr_latency_sum|aio_flush_def|cmp_lat_count|discard_bytes|rd_hit_bytes|wr_def_lanes|wr_q_barrier|ws_lat_count|cmp_lat_sum|part_hit_rd|invalidate|wr_def_buf|wr_def_log|wr_overlap|ws_lat_sum|aio_flush|cmp_bytes|cmp_fails|rd_bytes|wr_bytes|ws_bytes|discard|log_ops|hit_rd|wr_def|cmp|rd|wr|ws)
-    target_label: __name__
-    replacement: ceph_rbd_librbd_pwl_${2}
-- match: ceph_mclock_shard_queue_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_mclock_shard_queue_(.+?)_(mclock_best_effort_queue_len|mclock_immediate_queue_len|mclock_all_type_queue_len|mclock_recovery_queue_len|mclock_client_queue_len)
-    target_label: mclock_shard
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_mclock_shard_queue_(.+?)_(mclock_best_effort_queue_len|mclock_immediate_queue_len|mclock_all_type_queue_len|mclock_recovery_queue_len|mclock_client_queue_len)
-    target_label: __name__
-    replacement: ceph_mclock_shard_${2}
-- match: ceph_mds_client_metrics_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_mds_client_metrics_(.+?)_(avg_metadata_latency|avg_write_latency|dentry_lease_hits|dentry_lease_miss|avg_read_latency|total_write_size|total_read_size|total_write_ops|total_read_ops|opened_inodes|opened_files|pinned_icaps|total_inodes|cap_hits|cap_miss)
-    target_label: mds_filesystem_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_mds_client_metrics_(.+?)_(avg_metadata_latency|avg_write_latency|dentry_lease_hits|dentry_lease_miss|avg_read_latency|total_write_size|total_read_size|total_write_ops|total_read_ops|opened_inodes|opened_files|pinned_icaps|total_inodes|cap_hits|cap_miss)
-    target_label: __name__
-    replacement: ceph_mds_per_client_${2}
-- match: ceph_AsyncMessenger_Worker_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_AsyncMessenger_Worker_(.+?)_(msgr_send_messages_queue_lat_count|msgr_send_messages_queue_lat_sum|msgr_running_fast_dispatch_time|msgr_handle_ack_lat_count|msgr_recv_encrypted_bytes|msgr_send_encrypted_bytes|msgr_created_connections|msgr_active_connections|msgr_handle_ack_lat_sum|msgr_running_total_time|msgr_running_recv_time|msgr_running_send_time|msgr_recv_messages|msgr_send_messages|msgr_recv_bytes|msgr_send_bytes)
-    target_label: messenger_worker
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_AsyncMessenger_Worker_(.+?)_(msgr_send_messages_queue_lat_count|msgr_send_messages_queue_lat_sum|msgr_running_fast_dispatch_time|msgr_handle_ack_lat_count|msgr_recv_encrypted_bytes|msgr_send_encrypted_bytes|msgr_created_connections|msgr_active_connections|msgr_handle_ack_lat_sum|msgr_running_total_time|msgr_running_recv_time|msgr_running_send_time|msgr_recv_messages|msgr_send_messages|msgr_recv_bytes|msgr_send_bytes)
-    target_label: __name__
-    replacement: ceph_async_messenger_worker_${2}
-- match: ceph_objectcacher_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_objectcacher_(.+?)_(data_overwritten_while_flushing|write_bytes_blocked|write_time_blocked|write_ops_blocked|cache_bytes_miss|cache_bytes_hit|cache_ops_miss|cache_ops_hit|data_flushed|data_written|data_read)
-    target_label: objectcacher_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_objectcacher_(.+?)_(data_overwritten_while_flushing|write_bytes_blocked|write_time_blocked|write_ops_blocked|cache_bytes_miss|cache_bytes_hit|cache_ops_miss|cache_ops_hit|data_flushed|data_written|data_read)
-    target_label: __name__
-    replacement: ceph_objectcacher_${2}
-- match: ceph_objecter_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_objecter_(.+?)_(replica_read_completed|replica_read_bounced|osdop_src_cmpxattr|osd_session_close|osdop_pgls_filter|osdop_resetxattrs|osdop_sparse_read|replica_read_sent|op_latency_count|osd_session_open|osdop_clonerange|oplen_avg_count|osdop_writefull|osdop_writesame|poolstat_active|poolstat_resend|command_active|command_resend|op_latency_sum|osdop_cmpxattr|osdop_getxattr|osdop_setxattr|osdop_truncate|linger_active|linger_resend|op_send_bytes|oplen_avg_sum|osdop_rmxattr|poolop_active|poolop_resend|poolstat_send|statfs_active|statfs_resend|command_send|osd_sessions|osdop_append|osdop_create|osdop_delete|osdop_mapext|osdop_notify|linger_ping|linger_send|op_inflight|osdop_other|osdop_watch|osdop_write|poolop_send|statfs_send|osdop_call|osdop_pgls|osdop_read|osdop_stat|osdop_zero|map_epoch|op_active|op_resend|osd_laggy|map_full|omap_del|op_laggy|op_reply|map_inc|omap_rd|omap_wr|op_send|op_rmw|op_pg|op_r|op_w|op)
-    target_label: objecter_handle
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_objecter_(.+?)_(replica_read_completed|replica_read_bounced|osdop_src_cmpxattr|osd_session_close|osdop_pgls_filter|osdop_resetxattrs|osdop_sparse_read|replica_read_sent|op_latency_count|osd_session_open|osdop_clonerange|oplen_avg_count|osdop_writefull|osdop_writesame|poolstat_active|poolstat_resend|command_active|command_resend|op_latency_sum|osdop_cmpxattr|osdop_getxattr|osdop_setxattr|osdop_truncate|linger_active|linger_resend|op_send_bytes|oplen_avg_sum|osdop_rmxattr|poolop_active|poolop_resend|poolstat_send|statfs_active|statfs_resend|command_send|osd_sessions|osdop_append|osdop_create|osdop_delete|osdop_mapext|osdop_notify|linger_ping|linger_send|op_inflight|osdop_other|osdop_watch|osdop_write|poolop_send|statfs_send|osdop_call|osdop_pgls|osdop_read|osdop_stat|osdop_zero|map_epoch|op_active|op_resend|osd_laggy|map_full|omap_del|op_laggy|op_reply|map_inc|omap_rd|omap_wr|op_send|op_rmw|op_pg|op_r|op_w|op)
-    target_label: __name__
-    replacement: ceph_objecter_${2}
-- match: ceph_AsyncMessenger_RDMAWorker_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_AsyncMessenger_RDMAWorker_(.+?)_(pending_sent_conns|tx_failed_post|tx_parital_mem|rx_chunks|tx_chunks|tx_no_mem|rx_bytes|tx_bytes)
-    target_label: rdma_worker
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_AsyncMessenger_RDMAWorker_(.+?)_(pending_sent_conns|tx_failed_post|tx_parital_mem|rx_chunks|tx_chunks|tx_no_mem|rx_bytes|tx_bytes)
-    target_label: __name__
-    replacement: ceph_async_messenger_rdma_worker_${2}
-- match: ceph_rocksdb_cache_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_rocksdb_cache_(.+?)_(capacity|inserts|lookups|misses|pinned|elems|usage|hits)
-    target_label: rocksdb_cache_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_rocksdb_cache_(.+?)_(capacity|inserts|lookups|misses|pinned|elems|usage|hits)
-    target_label: __name__
-    replacement: ceph_rocksdb_binned_cache_${2}
-- match: ceph_service_unique_id_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_service_unique_id_(.+)
-    target_label: service_unique_id
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_service_unique_id_(.+)
-    target_label: __name__
-    replacement: ceph_service_unique_id
-- match: ceph_throttle_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_throttle_(.+?)_(get_or_fail_success|get_or_fail_fail|get_started|wait_count|take_sum|wait_sum|get_sum|put_sum|take|get|max|put|val)
-    target_label: throttle_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_throttle_(.+?)_(get_or_fail_success|get_or_fail_fail|get_started|wait_count|take_sum|wait_sum|get_sum|put_sum|take|get|max|put|val)
-    target_label: __name__
-    replacement: ceph_throttle_${2}
+  - match: ceph_*
+    metric_relabel_configs:
+      - regex: instance
+        action: labelmap
+        replacement: ceph_instance
+      - regex: instance
+        action: labeldrop
+  - match: '!ceph_data_sync_from_zone_* ceph_data_sync_from_*'
+    metric_relabel_configs:
+      - source_labels:
+          - source_zone
+          - __name__
+        regex: ;ceph_data_sync_from_.+_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
+        action: drop
+      - source_labels:
+          - __name__
+        regex: ceph_data_sync_from_(.+?)_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
+        target_label: source_zone_fragment
+        replacement: ${1}
+      - source_labels:
+          - source_zone_fragment
+          - source_zone
+        regex: (.+);(.+)
+        target_label: source_zone
+        replacement: ${1}_${2}
+      - source_labels:
+          - __name__
+        regex: ceph_data_sync_from_(.+?)_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
+        target_label: __name__
+        replacement: ceph_data_sync_from_zone_${2}
+      - regex: source_zone_fragment
+        action: labeldrop
+  - match: ceph_port*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_port(.+?)_(dpdk_device_receive_multicast_packets|dpdk_device_receive_dropped_errors|dpdk_device_receive_badcrc_errors|dpdk_device_receive_nombuf_errors|dpdk_device_receive_total_errors|dpdk_device_send_total_errors)
+        target_label: dpdk_port
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_port(.+?)_(dpdk_device_receive_multicast_packets|dpdk_device_receive_dropped_errors|dpdk_device_receive_badcrc_errors|dpdk_device_receive_nombuf_errors|dpdk_device_receive_total_errors|dpdk_device_send_total_errors)
+        target_label: __name__
+        replacement: ceph_dpdk_port_${2}
+  - match: ceph_queue*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_queue(.+?)_(dpdk_receive_bad_checksum_errors|dpdk_receive_no_memory_errors|dpdk_receive_linearize_ops|dpdk_receive_copy_bytes|dpdk_receive_last_bunch|dpdk_send_linearize_ops|dpdk_receive_fragments|dpdk_send_queue_length|dpdk_receive_copy_ops|dpdk_receive_packets|dpdk_send_copy_bytes|dpdk_send_last_bunch|dpdk_send_fragments|dpdk_receive_bytes|dpdk_send_copy_ops|dpdk_send_packets|dpdk_send_bytes)
+        target_label: dpdk_queue
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_queue(.+?)_(dpdk_receive_bad_checksum_errors|dpdk_receive_no_memory_errors|dpdk_receive_linearize_ops|dpdk_receive_copy_bytes|dpdk_receive_last_bunch|dpdk_send_linearize_ops|dpdk_receive_fragments|dpdk_send_queue_length|dpdk_receive_copy_ops|dpdk_receive_packets|dpdk_send_copy_bytes|dpdk_send_last_bunch|dpdk_send_fragments|dpdk_receive_bytes|dpdk_send_copy_ops|dpdk_send_packets|dpdk_send_bytes)
+        target_label: __name__
+        replacement: ceph_dpdk_queue_${2}
+  - match: ceph_finisher_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_finisher_(.+?)_(complete_latency_count|complete_latency_sum|queue_len)
+        target_label: finisher_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_finisher_(.+?)_(complete_latency_count|complete_latency_sum|queue_len)
+        target_label: __name__
+        replacement: ceph_finisher_${2}
+  - match: ceph_blk_kernel_device_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_blk_kernel_device_(.+?)_(discard_threads|discard_op)
+        target_label: kernel_device_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_blk_kernel_device_(.+?)_(discard_threads|discard_op)
+        target_label: __name__
+        replacement: ceph_kernel_device_${2}
+  - match: '!ceph_librbd_pwl_* ceph_librbd_*'
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_librbd_(.+?)_(discard_latency_count|discard_latency_sum|flush_latency_count|lock_acquired_time|cmp_latency_count|flush_latency_sum|invalidate_cache|rd_latency_count|wr_latency_count|ws_latency_count|cmp_latency_sum|readahead_bytes|rd_latency_sum|wr_latency_sum|ws_latency_sum|discard_bytes|snap_rollback|opened_time|snap_create|snap_remove|snap_rename|cmp_bytes|readahead|rd_bytes|wr_bytes|ws_bytes|discard|notify|resize|flush|cmp|rd|wr|ws)
+        target_label: librbd_image_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_librbd_(.+?)_(discard_latency_count|discard_latency_sum|flush_latency_count|lock_acquired_time|cmp_latency_count|flush_latency_sum|invalidate_cache|rd_latency_count|wr_latency_count|ws_latency_count|cmp_latency_sum|readahead_bytes|rd_latency_sum|wr_latency_sum|ws_latency_sum|discard_bytes|snap_rollback|opened_time|snap_create|snap_remove|snap_rename|cmp_bytes|readahead|rd_bytes|wr_bytes|ws_bytes|discard|notify|resize|flush|cmp|rd|wr|ws)
+        target_label: __name__
+        replacement: ceph_rbd_librbd_image_${2}
+  - match: ceph_librbd_pwl_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_librbd_pwl_(.+?)_(caller_wr_latency_nw_count|req_all_to_dis_nw_t_count|req_arr_to_all_nw_t_count|req_arr_to_dis_nw_t_count|caller_wr_latency_nw_sum|caller_wr_latency_count|req_all_to_dis_nw_t_sum|req_arr_to_all_nw_t_sum|req_arr_to_dis_nw_t_sum|op_app_to_appc_t_count|op_buf_to_bufc_t_count|req_all_to_dis_t_count|req_arr_to_all_t_count|req_arr_to_dis_t_count|caller_wr_latency_sum|op_app_to_cmp_t_count|op_buf_to_app_t_count|op_dis_to_app_t_count|op_dis_to_buf_t_count|op_dis_to_cmp_t_count|hit_rd_latency_count|op_app_to_appc_t_sum|op_buf_to_bufc_t_sum|req_all_to_dis_t_sum|req_arr_to_all_t_sum|req_arr_to_dis_t_sum|aio_flush_lat_count|append_tx_lat_count|op_app_to_cmp_t_sum|op_buf_to_app_t_sum|op_dis_to_app_t_sum|op_dis_to_buf_t_sum|op_dis_to_cmp_t_sum|retire_tx_lat_count|wr_latency_nw_count|writeback_lat_count|hit_rd_latency_sum|log_op_bytes_count|aio_flush_lat_sum|append_tx_lat_sum|discard_lat_count|retire_tx_lat_sum|wr_latency_nw_sum|writeback_lat_sum|log_op_bytes_sum|op_alloc_t_count|rd_latency_count|wr_latency_count|discard_lat_sum|internal_flush|op_alloc_t_sum|rd_latency_sum|wr_latency_sum|aio_flush_def|cmp_lat_count|discard_bytes|rd_hit_bytes|wr_def_lanes|wr_q_barrier|ws_lat_count|cmp_lat_sum|part_hit_rd|invalidate|wr_def_buf|wr_def_log|wr_overlap|ws_lat_sum|aio_flush|cmp_bytes|cmp_fails|rd_bytes|wr_bytes|ws_bytes|discard|log_ops|hit_rd|wr_def|cmp|rd|wr|ws)
+        target_label: librbd_pwl_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_librbd_pwl_(.+?)_(caller_wr_latency_nw_count|req_all_to_dis_nw_t_count|req_arr_to_all_nw_t_count|req_arr_to_dis_nw_t_count|caller_wr_latency_nw_sum|caller_wr_latency_count|req_all_to_dis_nw_t_sum|req_arr_to_all_nw_t_sum|req_arr_to_dis_nw_t_sum|op_app_to_appc_t_count|op_buf_to_bufc_t_count|req_all_to_dis_t_count|req_arr_to_all_t_count|req_arr_to_dis_t_count|caller_wr_latency_sum|op_app_to_cmp_t_count|op_buf_to_app_t_count|op_dis_to_app_t_count|op_dis_to_buf_t_count|op_dis_to_cmp_t_count|hit_rd_latency_count|op_app_to_appc_t_sum|op_buf_to_bufc_t_sum|req_all_to_dis_t_sum|req_arr_to_all_t_sum|req_arr_to_dis_t_sum|aio_flush_lat_count|append_tx_lat_count|op_app_to_cmp_t_sum|op_buf_to_app_t_sum|op_dis_to_app_t_sum|op_dis_to_buf_t_sum|op_dis_to_cmp_t_sum|retire_tx_lat_count|wr_latency_nw_count|writeback_lat_count|hit_rd_latency_sum|log_op_bytes_count|aio_flush_lat_sum|append_tx_lat_sum|discard_lat_count|retire_tx_lat_sum|wr_latency_nw_sum|writeback_lat_sum|log_op_bytes_sum|op_alloc_t_count|rd_latency_count|wr_latency_count|discard_lat_sum|internal_flush|op_alloc_t_sum|rd_latency_sum|wr_latency_sum|aio_flush_def|cmp_lat_count|discard_bytes|rd_hit_bytes|wr_def_lanes|wr_q_barrier|ws_lat_count|cmp_lat_sum|part_hit_rd|invalidate|wr_def_buf|wr_def_log|wr_overlap|ws_lat_sum|aio_flush|cmp_bytes|cmp_fails|rd_bytes|wr_bytes|ws_bytes|discard|log_ops|hit_rd|wr_def|cmp|rd|wr|ws)
+        target_label: __name__
+        replacement: ceph_rbd_librbd_pwl_${2}
+  - match: ceph_mclock_shard_queue_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_mclock_shard_queue_(.+?)_(mclock_best_effort_queue_len|mclock_immediate_queue_len|mclock_all_type_queue_len|mclock_recovery_queue_len|mclock_client_queue_len)
+        target_label: mclock_shard
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_mclock_shard_queue_(.+?)_(mclock_best_effort_queue_len|mclock_immediate_queue_len|mclock_all_type_queue_len|mclock_recovery_queue_len|mclock_client_queue_len)
+        target_label: __name__
+        replacement: ceph_mclock_shard_${2}
+  - match: ceph_mds_client_metrics_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_mds_client_metrics_(.+?)_(avg_metadata_latency|avg_write_latency|dentry_lease_hits|dentry_lease_miss|avg_read_latency|total_write_size|total_read_size|total_write_ops|total_read_ops|opened_inodes|opened_files|pinned_icaps|total_inodes|cap_hits|cap_miss)
+        target_label: mds_filesystem_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_mds_client_metrics_(.+?)_(avg_metadata_latency|avg_write_latency|dentry_lease_hits|dentry_lease_miss|avg_read_latency|total_write_size|total_read_size|total_write_ops|total_read_ops|opened_inodes|opened_files|pinned_icaps|total_inodes|cap_hits|cap_miss)
+        target_label: __name__
+        replacement: ceph_mds_per_client_${2}
+  - match: ceph_AsyncMessenger_Worker_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_AsyncMessenger_Worker_(.+?)_(msgr_send_messages_queue_lat_count|msgr_send_messages_queue_lat_sum|msgr_running_fast_dispatch_time|msgr_handle_ack_lat_count|msgr_recv_encrypted_bytes|msgr_send_encrypted_bytes|msgr_created_connections|msgr_active_connections|msgr_handle_ack_lat_sum|msgr_running_total_time|msgr_running_recv_time|msgr_running_send_time|msgr_recv_messages|msgr_send_messages|msgr_recv_bytes|msgr_send_bytes)
+        target_label: messenger_worker
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_AsyncMessenger_Worker_(.+?)_(msgr_send_messages_queue_lat_count|msgr_send_messages_queue_lat_sum|msgr_running_fast_dispatch_time|msgr_handle_ack_lat_count|msgr_recv_encrypted_bytes|msgr_send_encrypted_bytes|msgr_created_connections|msgr_active_connections|msgr_handle_ack_lat_sum|msgr_running_total_time|msgr_running_recv_time|msgr_running_send_time|msgr_recv_messages|msgr_send_messages|msgr_recv_bytes|msgr_send_bytes)
+        target_label: __name__
+        replacement: ceph_async_messenger_worker_${2}
+  - match: ceph_objectcacher_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_objectcacher_(.+?)_(data_overwritten_while_flushing|write_bytes_blocked|write_time_blocked|write_ops_blocked|cache_bytes_miss|cache_bytes_hit|cache_ops_miss|cache_ops_hit|data_flushed|data_written|data_read)
+        target_label: objectcacher_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_objectcacher_(.+?)_(data_overwritten_while_flushing|write_bytes_blocked|write_time_blocked|write_ops_blocked|cache_bytes_miss|cache_bytes_hit|cache_ops_miss|cache_ops_hit|data_flushed|data_written|data_read)
+        target_label: __name__
+        replacement: ceph_objectcacher_${2}
+  - match: ceph_objecter_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_objecter_(.+?)_(replica_read_completed|replica_read_bounced|osdop_src_cmpxattr|osd_session_close|osdop_pgls_filter|osdop_resetxattrs|osdop_sparse_read|replica_read_sent|op_latency_count|osd_session_open|osdop_clonerange|oplen_avg_count|osdop_writefull|osdop_writesame|poolstat_active|poolstat_resend|command_active|command_resend|op_latency_sum|osdop_cmpxattr|osdop_getxattr|osdop_setxattr|osdop_truncate|linger_active|linger_resend|op_send_bytes|oplen_avg_sum|osdop_rmxattr|poolop_active|poolop_resend|poolstat_send|statfs_active|statfs_resend|command_send|osd_sessions|osdop_append|osdop_create|osdop_delete|osdop_mapext|osdop_notify|linger_ping|linger_send|op_inflight|osdop_other|osdop_watch|osdop_write|poolop_send|statfs_send|osdop_call|osdop_pgls|osdop_read|osdop_stat|osdop_zero|map_epoch|op_active|op_resend|osd_laggy|map_full|omap_del|op_laggy|op_reply|map_inc|omap_rd|omap_wr|op_send|op_rmw|op_pg|op_r|op_w|op)
+        target_label: objecter_handle
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_objecter_(.+?)_(replica_read_completed|replica_read_bounced|osdop_src_cmpxattr|osd_session_close|osdop_pgls_filter|osdop_resetxattrs|osdop_sparse_read|replica_read_sent|op_latency_count|osd_session_open|osdop_clonerange|oplen_avg_count|osdop_writefull|osdop_writesame|poolstat_active|poolstat_resend|command_active|command_resend|op_latency_sum|osdop_cmpxattr|osdop_getxattr|osdop_setxattr|osdop_truncate|linger_active|linger_resend|op_send_bytes|oplen_avg_sum|osdop_rmxattr|poolop_active|poolop_resend|poolstat_send|statfs_active|statfs_resend|command_send|osd_sessions|osdop_append|osdop_create|osdop_delete|osdop_mapext|osdop_notify|linger_ping|linger_send|op_inflight|osdop_other|osdop_watch|osdop_write|poolop_send|statfs_send|osdop_call|osdop_pgls|osdop_read|osdop_stat|osdop_zero|map_epoch|op_active|op_resend|osd_laggy|map_full|omap_del|op_laggy|op_reply|map_inc|omap_rd|omap_wr|op_send|op_rmw|op_pg|op_r|op_w|op)
+        target_label: __name__
+        replacement: ceph_objecter_${2}
+  - match: ceph_AsyncMessenger_RDMAWorker_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_AsyncMessenger_RDMAWorker_(.+?)_(pending_sent_conns|tx_failed_post|tx_parital_mem|rx_chunks|tx_chunks|tx_no_mem|rx_bytes|tx_bytes)
+        target_label: rdma_worker
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_AsyncMessenger_RDMAWorker_(.+?)_(pending_sent_conns|tx_failed_post|tx_parital_mem|rx_chunks|tx_chunks|tx_no_mem|rx_bytes|tx_bytes)
+        target_label: __name__
+        replacement: ceph_async_messenger_rdma_worker_${2}
+  - match: ceph_rocksdb_cache_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_rocksdb_cache_(.+?)_(capacity|inserts|lookups|misses|pinned|elems|usage|hits)
+        target_label: rocksdb_cache_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_rocksdb_cache_(.+?)_(capacity|inserts|lookups|misses|pinned|elems|usage|hits)
+        target_label: __name__
+        replacement: ceph_rocksdb_binned_cache_${2}
+  - match: ceph_service_unique_id_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_service_unique_id_(.+)
+        target_label: service_unique_id
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_service_unique_id_(.+)
+        target_label: __name__
+        replacement: ceph_service_unique_id
+  - match: ceph_throttle_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_throttle_(.+?)_(get_or_fail_success|get_or_fail_fail|get_started|wait_count|take_sum|wait_sum|get_sum|put_sum|take|get|max|put|val)
+        target_label: throttle_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_throttle_(.+?)_(get_or_fail_success|get_or_fail_fail|get_started|wait_count|take_sum|wait_sum|get_sum|put_sum|take|get|max|put|val)
+        target_label: __name__
+        replacement: ceph_throttle_${2}
 template:
   family: Ceph
   context_namespace: ceph
   groups:
-  - family: Capacity
-    context_namespace: capacity
-    groups:
-    - family: Object Health
-      context_namespace: object_health
+    - family: Capacity
+      context_namespace: capacity
+      groups:
+        - family: Object Health
+          context_namespace: object_health
+          metrics:
+            - ceph_num_objects_degraded
+            - ceph_num_objects_misplaced
+            - ceph_num_objects_unfound
+          charts:
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_num_objects_degraded
+                  name: degraded
+                - selector: ceph_num_objects_misplaced
+                  name: misplaced
+                - selector: ceph_num_objects_unfound
+                  name: unfound
+        - family: Overall Cluster Space
+          context_namespace: overall_cluster_space
+          metrics:
+            - ceph_cluster_total_bytes
+            - ceph_cluster_total_used_bytes
+            - ceph_cluster_total_used_raw_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_total_bytes
+                  name: bytes
+                - selector: ceph_cluster_total_used_bytes
+                  name: used_bytes
+                - selector: ceph_cluster_total_used_raw_bytes
+                  name: used_raw_bytes
+        - family: Space by Device Class
+          context_namespace: space_by_device_class
+          metrics:
+            - ceph_cluster_by_class_total_bytes
+            - ceph_cluster_by_class_total_used_bytes
+            - ceph_cluster_by_class_total_used_raw_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_by_class_total_bytes
+                  name: bytes
+                - selector: ceph_cluster_by_class_total_used_bytes
+                  name: used_bytes
+                - selector: ceph_cluster_by_class_total_used_raw_bytes
+                  name: used_raw_bytes
+              instances:
+                by_labels:
+                  - device_class
+                optional_by_labels: []
+    - family: CephFS Metadata
+      context_namespace: cephfs_metadata
+      groups:
+        - family: Filesystem Metadata
+          context_namespace: filesystem_metadata
+          metrics:
+            - ceph_fs_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_fs_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - data_pools
+                  - fs_id
+                  - metadata_pool
+                  - name
+                optional_by_labels: []
+        - family: MDS Metadata
+          context_namespace: mds_metadata
+          metrics:
+            - ceph_mds_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - ceph_version
+                  - fs_id
+                  - hostname
+                  - public_addr
+                  - rank
+                optional_by_labels: []
+    - family: Cluster Overview
+      context_namespace: cluster_overview
       metrics:
-      - ceph_num_objects_degraded
-      - ceph_num_objects_misplaced
-      - ceph_num_objects_unfound
+        - ceph_cluster_osd_blocklist_count
+        - ceph_disk_occupation
+        - ceph_disk_occupation_human
+        - ceph_prometheus_collect_duration_seconds_count
+        - ceph_prometheus_collect_duration_seconds_sum
       charts:
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_num_objects_degraded
-          name: degraded
-        - selector: ceph_num_objects_misplaced
-          name: misplaced
-        - selector: ceph_num_objects_unfound
-          name: unfound
-    - family: Overall Cluster Space
-      context_namespace: overall_cluster_space
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_prometheus_collect_duration_seconds_count
+              name: value
+          instances:
+            by_labels:
+              - method
+            optional_by_labels: []
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_prometheus_collect_duration_seconds_sum
+              name: value
+          instances:
+            by_labels:
+              - method
+            optional_by_labels: []
+        - title: Current Work
+          context: current_work
+          units: items
+          label_promotion: []
+          dimensions:
+            - selector: ceph_cluster_osd_blocklist_count
+              name: value
+        - title: State and Metadata — Occupation
+          context: state_occupation
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_disk_occupation
+              name: occupation
+          instances:
+            by_labels:
+              - ceph_daemon
+              - ceph_instance
+              - db_device
+              - device
+              - device_ids
+              - devices
+              - wal_device
+            optional_by_labels: []
+        - title: State and Metadata — Human
+          context: state_human
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_disk_occupation_human
+              name: human
+          instances:
+            by_labels:
+              - ceph_daemon
+              - ceph_instance
+              - device
+            optional_by_labels: []
+    - family: Control Plane
+      context_namespace: control_plane
+      groups:
+        - family: Cephadm
+          context_namespace: cephadm
+          metrics:
+            - ceph_cephadm_daemon_status
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephadm_daemon_status
+                  name: value
+              instances:
+                by_labels:
+                  - daemon_name
+                  - hostname
+                  - service_name
+                  - service_type
+                optional_by_labels: []
+        - family: Manager
+          context_namespace: manager
+          metrics:
+            - ceph_mgr_metadata
+            - ceph_mgr_status
+          charts:
+            - title: State and Metadata — Metadata
+              context: state_metadata
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mgr_metadata
+                  name: metadata
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - ceph_version
+                  - hostname
+                optional_by_labels: []
+            - title: State and Metadata — Status
+              context: state_status
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mgr_status
+                  name: status
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Manager Modules
+          context_namespace: manager_modules
+          metrics:
+            - ceph_mgr_module_can_run
+            - ceph_mgr_module_status
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mgr_module_can_run
+                  name: can_run
+                - selector: ceph_mgr_module_status
+                  name: status
+              instances:
+                by_labels:
+                  - name
+                optional_by_labels: []
+        - family: Monitor
+          context_namespace: monitor
+          metrics:
+            - ceph_mon_metadata
+            - ceph_mon_quorum_status
+          charts:
+            - title: State and Metadata — Metadata
+              context: state_metadata
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mon_metadata
+                  name: metadata
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - ceph_version
+                  - hostname
+                  - public_addr
+                  - rank
+                optional_by_labels: []
+            - title: State and Metadata — Quorum Status
+              context: state_quorum_status
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mon_quorum_status
+                  name: quorum_status
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Paxos
+          context_namespace: paxos
+          metrics:
+            - ceph_paxos_accept_timeout
+            - ceph_paxos_begin
+            - ceph_paxos_begin_bytes_count
+            - ceph_paxos_begin_bytes_sum
+            - ceph_paxos_begin_keys_count
+            - ceph_paxos_begin_keys_sum
+            - ceph_paxos_begin_latency_count
+            - ceph_paxos_begin_latency_sum
+            - ceph_paxos_collect
+            - ceph_paxos_collect_bytes_count
+            - ceph_paxos_collect_bytes_sum
+            - ceph_paxos_collect_keys_count
+            - ceph_paxos_collect_keys_sum
+            - ceph_paxos_collect_latency_count
+            - ceph_paxos_collect_latency_sum
+            - ceph_paxos_collect_timeout
+            - ceph_paxos_collect_uncommitted
+            - ceph_paxos_commit
+            - ceph_paxos_commit_bytes_count
+            - ceph_paxos_commit_bytes_sum
+            - ceph_paxos_commit_keys_count
+            - ceph_paxos_commit_keys_sum
+            - ceph_paxos_commit_latency_count
+            - ceph_paxos_commit_latency_sum
+            - ceph_paxos_lease_ack_timeout
+            - ceph_paxos_lease_timeout
+            - ceph_paxos_new_pn
+            - ceph_paxos_new_pn_latency_count
+            - ceph_paxos_new_pn_latency_sum
+            - ceph_paxos_refresh
+            - ceph_paxos_refresh_latency_count
+            - ceph_paxos_refresh_latency_sum
+            - ceph_paxos_restart
+            - ceph_paxos_share_state
+            - ceph_paxos_share_state_bytes_count
+            - ceph_paxos_share_state_bytes_sum
+            - ceph_paxos_share_state_keys_count
+            - ceph_paxos_share_state_keys_sum
+            - ceph_paxos_start_leader
+            - ceph_paxos_start_peon
+            - ceph_paxos_store_state
+            - ceph_paxos_store_state_bytes_count
+            - ceph_paxos_store_state_bytes_sum
+            - ceph_paxos_store_state_keys_count
+            - ceph_paxos_store_state_keys_sum
+            - ceph_paxos_store_state_latency_count
+            - ceph_paxos_store_state_latency_sum
+          charts:
+            - title: Byte Measurement Measurements
+              context: bytes_measurements
+              units: measurements/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_bytes_count
+                  name: begin_bytes
+                - selector: ceph_paxos_collect_bytes_count
+                  name: collect_bytes
+                - selector: ceph_paxos_commit_bytes_count
+                  name: commit_bytes
+                - selector: ceph_paxos_share_state_bytes_count
+                  name: share_state_bytes
+                - selector: ceph_paxos_store_state_bytes_count
+                  name: store_state_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Byte Measurement
+              context: accumulated_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_bytes_sum
+                  name: begin_bytes
+                - selector: ceph_paxos_collect_bytes_sum
+                  name: collect_bytes
+                - selector: ceph_paxos_commit_bytes_sum
+                  name: commit_bytes
+                - selector: ceph_paxos_share_state_bytes_sum
+                  name: share_state_bytes
+                - selector: ceph_paxos_store_state_bytes_sum
+                  name: store_state_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Key Measurement Measurements
+              context: keys_measurements
+              units: measurements/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_keys_count
+                  name: begin_keys
+                - selector: ceph_paxos_collect_keys_count
+                  name: collect_keys
+                - selector: ceph_paxos_commit_keys_count
+                  name: commit_keys
+                - selector: ceph_paxos_share_state_keys_count
+                  name: share_state_keys
+                - selector: ceph_paxos_store_state_keys_count
+                  name: store_state_keys
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Key Measurement
+              context: accumulated_keys
+              units: keys/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_keys_sum
+                  name: begin_keys
+                - selector: ceph_paxos_collect_keys_sum
+                  name: collect_keys
+                - selector: ceph_paxos_commit_keys_sum
+                  name: commit_keys
+                - selector: ceph_paxos_share_state_keys_sum
+                  name: share_state_keys
+                - selector: ceph_paxos_store_state_keys_sum
+                  name: store_state_keys
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_latency_count
+                  name: begin_latency
+                - selector: ceph_paxos_collect_latency_count
+                  name: collect_latency
+                - selector: ceph_paxos_commit_latency_count
+                  name: commit_latency
+                - selector: ceph_paxos_new_pn_latency_count
+                  name: new_pn_latency
+                - selector: ceph_paxos_refresh_latency_count
+                  name: refresh_latency
+                - selector: ceph_paxos_store_state_latency_count
+                  name: store_state_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_latency_sum
+                  name: begin_latency
+                - selector: ceph_paxos_collect_latency_sum
+                  name: collect_latency
+                - selector: ceph_paxos_commit_latency_sum
+                  name: commit_latency
+                - selector: ceph_paxos_new_pn_latency_sum
+                  name: new_pn_latency
+                - selector: ceph_paxos_refresh_latency_sum
+                  name: refresh_latency
+                - selector: ceph_paxos_store_state_latency_sum
+                  name: store_state_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_new_pn
+                  name: new_pn
+                - selector: ceph_paxos_refresh
+                  name: refresh
+                - selector: ceph_paxos_restart
+                  name: restart
+                - selector: ceph_paxos_share_state
+                  name: share_state
+                - selector: ceph_paxos_start_leader
+                  name: start_leader
+                - selector: ceph_paxos_start_peon
+                  name: start_peon
+                - selector: ceph_paxos_store_state
+                  name: store_state
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_accept_timeout
+                  name: accept_timeout
+                - selector: ceph_paxos_collect_timeout
+                  name: collect_timeout
+                - selector: ceph_paxos_lease_ack_timeout
+                  name: lease_ack_timeout
+                - selector: ceph_paxos_lease_timeout
+                  name: lease_timeout
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Paxos Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin
+                  name: begin
+                - selector: ceph_paxos_collect
+                  name: collect
+                - selector: ceph_paxos_commit
+                  name: commit
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Collected Uncommitted Values
+              context: collected_uncommitted_values
+              units: values/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_collect_uncommitted
+                  name: collect_uncommitted
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Health
+      context_namespace: health
+      groups:
+        - family: Cluster Status
+          context_namespace: cluster_status
+          metrics:
+            - ceph_health_status
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_health_status
+                  name: value
+        - family: Daemon Health
+          context_namespace: daemon_health
+          metrics:
+            - ceph_daemon_health_metrics
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_daemon_health_metrics
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - type
+                optional_by_labels: []
+        - family: Health Checks
+          context_namespace: health_checks
+          metrics:
+            - ceph_health_detail
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_health_detail
+                  name: value
+              instances:
+                by_labels:
+                  - name
+                  - severity
+                optional_by_labels: []
+        - family: Slow Operations
+          context_namespace: slow_operations
+          metrics:
+            - ceph_healthcheck_slow_ops
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_healthcheck_slow_ops
+                  name: value
+    - family: OSD Capacity and State
+      context_namespace: osd_capacity_and_state
+      groups:
+        - family: Cluster Flags
+          context_namespace: cluster_flags
+          metrics:
+            - ceph_osd_flag_nodeep_scrub
+            - ceph_osd_flag_nodown
+            - ceph_osd_flag_noin
+            - ceph_osd_flag_noout
+            - ceph_osd_flag_norebalance
+            - ceph_osd_flag_noscrub
+            - ceph_osd_flag_noup
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_flag_nodeep_scrub
+                  name: nodeep_scrub
+                - selector: ceph_osd_flag_nodown
+                  name: nodown
+                - selector: ceph_osd_flag_noin
+                  name: noin
+                - selector: ceph_osd_flag_noout
+                  name: noout
+                - selector: ceph_osd_flag_norebalance
+                  name: norebalance
+                - selector: ceph_osd_flag_noscrub
+                  name: noscrub
+                - selector: ceph_osd_flag_noup
+                  name: noup
+        - family: Fullness Thresholds
+          context_namespace: fullness_thresholds
+          metrics:
+            - ceph_osd_full_ratio
+            - ceph_osd_nearfull_ratio
+          charts:
+            - title: Ratios
+              context: ratio
+              units: ratio
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_full_ratio
+                  name: full_ratio
+                - selector: ceph_osd_nearfull_ratio
+                  name: nearfull_ratio
+        - family: Metadata
+          context_namespace: metadata
+          metrics:
+            - ceph_osd_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - back_iface
+                  - ceph_daemon
+                  - ceph_version
+                  - cluster_addr
+                  - device_class
+                  - front_iface
+                  - hostname
+                  - objectstore
+                  - public_addr
+                optional_by_labels: []
+        - family: OSD State
+          context_namespace: osd_state
+          metrics:
+            - ceph_osd_in
+            - ceph_osd_up
+            - ceph_osd_weight
+          charts:
+            - title: OSD State
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_in
+                  name: in
+                - selector: ceph_osd_up
+                  name: up
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OSD Weight
+              context: weight
+              units: ratio
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_weight
+                  name: weight
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: OSD Overview
+      context_namespace: osd_overview
       metrics:
-      - ceph_cluster_total_bytes
-      - ceph_cluster_total_used_bytes
-      - ceph_cluster_total_used_raw_bytes
+        - ceph_osd_apply_latency_ms
+        - ceph_osd_commit_latency_ms
       charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_total_bytes
-          name: bytes
-        - selector: ceph_cluster_total_used_bytes
-          name: used_bytes
-        - selector: ceph_cluster_total_used_raw_bytes
-          name: used_raw_bytes
-    - family: Space by Device Class
-      context_namespace: space_by_device_class
+        - title: Latency
+          context: latency
+          units: milliseconds
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_apply_latency_ms
+              name: apply_latency_ms
+            - selector: ceph_osd_commit_latency_ms
+              name: commit_latency_ms
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: Object Gateway Metadata
+      context_namespace: object_gateway_metadata
       metrics:
-      - ceph_cluster_by_class_total_bytes
-      - ceph_cluster_by_class_total_used_bytes
-      - ceph_cluster_by_class_total_used_raw_bytes
+        - ceph_rgw_metadata
       charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_by_class_total_bytes
-          name: bytes
-        - selector: ceph_cluster_by_class_total_used_bytes
-          name: used_bytes
-        - selector: ceph_cluster_by_class_total_used_raw_bytes
-          name: used_raw_bytes
-        instances:
-          by_labels:
-          - device_class
-          optional_by_labels: []
-  - family: CephFS Metadata
-    context_namespace: cephfs_metadata
-    groups:
-    - family: Filesystem Metadata
-      context_namespace: filesystem_metadata
+        - title: State and Metadata
+          context: state
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_metadata
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+              - ceph_version
+              - hostname
+              - instance_id
+            optional_by_labels: []
+    - family: Placement Groups and Recovery
+      context_namespace: placement_groups_and_recovery
+      groups:
+        - family: Backfill
+          context_namespace: backfill
+          metrics:
+            - ceph_pg_backfill_toofull
+            - ceph_pg_backfill_unfound
+            - ceph_pg_backfill_wait
+            - ceph_pg_backfilling
+            - ceph_pg_forced_backfill
+            - ceph_pg_remapped
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_backfill_toofull
+                  name: backfill_toofull
+                - selector: ceph_pg_backfill_unfound
+                  name: backfill_unfound
+                - selector: ceph_pg_backfill_wait
+                  name: backfill_wait
+                - selector: ceph_pg_backfilling
+                  name: backfilling
+                - selector: ceph_pg_forced_backfill
+                  name: forced_backfill
+                - selector: ceph_pg_remapped
+                  name: remapped
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Healthy State
+          context_namespace: healthy_state
+          metrics:
+            - ceph_pg_active
+            - ceph_pg_clean
+            - ceph_pg_deep
+            - ceph_pg_total
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_active
+                  name: active
+                - selector: ceph_pg_clean
+                  name: clean
+                - selector: ceph_pg_deep
+                  name: deep
+                - selector: ceph_pg_total
+                  name: pg_total
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Peering and Availability
+          context_namespace: peering_and_availability
+          metrics:
+            - ceph_pg_activating
+            - ceph_pg_creating
+            - ceph_pg_down
+            - ceph_pg_incomplete
+            - ceph_pg_laggy
+            - ceph_pg_peered
+            - ceph_pg_peering
+            - ceph_pg_premerge
+            - ceph_pg_stale
+            - ceph_pg_unknown
+            - ceph_pg_wait
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_activating
+                  name: activating
+                - selector: ceph_pg_creating
+                  name: creating
+                - selector: ceph_pg_down
+                  name: down
+                - selector: ceph_pg_incomplete
+                  name: incomplete
+                - selector: ceph_pg_laggy
+                  name: laggy
+                - selector: ceph_pg_peered
+                  name: peered
+                - selector: ceph_pg_peering
+                  name: peering
+                - selector: ceph_pg_premerge
+                  name: premerge
+                - selector: ceph_pg_stale
+                  name: stale
+                - selector: ceph_pg_unknown
+                  name: unknown
+                - selector: ceph_pg_wait
+                  name: wait
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Recovery Flags
+          context_namespace: recovery_flags
+          metrics:
+            - ceph_osd_flag_nobackfill
+            - ceph_osd_flag_norecover
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_flag_nobackfill
+                  name: nobackfill
+                - selector: ceph_osd_flag_norecover
+                  name: norecover
+        - family: Recovery and Degradation
+          context_namespace: recovery_and_degradation
+          metrics:
+            - ceph_pg_degraded
+            - ceph_pg_forced_recovery
+            - ceph_pg_recovering
+            - ceph_pg_recovery_toofull
+            - ceph_pg_recovery_unfound
+            - ceph_pg_recovery_wait
+            - ceph_pg_undersized
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_degraded
+                  name: degraded
+                - selector: ceph_pg_forced_recovery
+                  name: forced_recovery
+                - selector: ceph_pg_recovering
+                  name: recovering
+                - selector: ceph_pg_recovery_toofull
+                  name: recovery_toofull
+                - selector: ceph_pg_recovery_unfound
+                  name: recovery_unfound
+                - selector: ceph_pg_recovery_wait
+                  name: recovery_wait
+                - selector: ceph_pg_undersized
+                  name: undersized
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Scrub and Repair State
+          context_namespace: scrub_and_repair_state
+          metrics:
+            - ceph_pg_failed_repair
+            - ceph_pg_inconsistent
+            - ceph_pg_repair
+            - ceph_pg_scrubbing
+            - ceph_pg_snaptrim
+            - ceph_pg_snaptrim_error
+            - ceph_pg_snaptrim_wait
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_failed_repair
+                  name: failed_repair
+                - selector: ceph_pg_inconsistent
+                  name: inconsistent
+                - selector: ceph_pg_repair
+                  name: repair
+                - selector: ceph_pg_scrubbing
+                  name: scrubbing
+                - selector: ceph_pg_snaptrim
+                  name: snaptrim
+                - selector: ceph_pg_snaptrim_error
+                  name: snaptrim_error
+                - selector: ceph_pg_snaptrim_wait
+                  name: snaptrim_wait
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+    - family: Pools
+      context_namespace: pools
+      groups:
+        - family: Capacity and Quotas
+          context_namespace: capacity_and_quotas
+          metrics:
+            - ceph_pool_avail_raw
+            - ceph_pool_bytes_used
+            - ceph_pool_compress_bytes_used
+            - ceph_pool_compress_under_bytes
+            - ceph_pool_max_avail
+            - ceph_pool_percent_used
+            - ceph_pool_quota_bytes
+            - ceph_pool_quota_objects
+            - ceph_pool_stored
+            - ceph_pool_stored_raw
+          charts:
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_quota_objects
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Logical Pool Capacity
+              context: logical_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_max_avail
+                  name: max_avail
+                - selector: ceph_pool_quota_bytes
+                  name: quota_bytes
+                - selector: ceph_pool_stored
+                  name: stored
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Raw Pool Capacity
+              context: raw_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_avail_raw
+                  name: avail_raw
+                - selector: ceph_pool_bytes_used
+                  name: bytes_used
+                - selector: ceph_pool_stored_raw
+                  name: stored_raw
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Compression Space
+              context: compression_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_compress_bytes_used
+                  name: compress_bytes_used
+                - selector: ceph_pool_compress_under_bytes
+                  name: compress_under_bytes
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Utilization
+              context: utilization
+              units: percentage
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_percent_used
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Client I/O
+          context_namespace: client_i_o
+          metrics:
+            - ceph_pool_rd
+            - ceph_pool_rd_bytes
+            - ceph_pool_wr
+            - ceph_pool_wr_bytes
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_rd_bytes
+                  name: rd_bytes
+                - selector: ceph_pool_wr_bytes
+                  name: wr_bytes
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_rd
+                  name: rd
+                - selector: ceph_pool_wr
+                  name: wr
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Metadata
+          context_namespace: metadata
+          metrics:
+            - ceph_pool_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - application
+                  - compression_mode
+                  - description
+                  - name
+                  - pool_id
+                  - type
+                optional_by_labels: []
+        - family: Objects
+          context_namespace: objects
+          metrics:
+            - ceph_pool_dirty
+            - ceph_pool_objects
+          charts:
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_dirty
+                  name: dirty
+                - selector: ceph_pool_objects
+                  name: objects
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Recovery
+          context_namespace: recovery
+          metrics:
+            - ceph_pool_num_bytes_recovered
+            - ceph_pool_num_objects_recovered
+            - ceph_pool_objects_repaired
+            - ceph_pool_recovering_bytes_per_sec
+            - ceph_pool_recovering_keys_per_sec
+            - ceph_pool_recovering_objects_per_sec
+          charts:
+            - title: Current Throughput
+              context: current_throughput_bytes_s
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_recovering_bytes_per_sec
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Current Throughput
+              context: current_throughput_keys_s
+              units: keys/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_recovering_keys_per_sec
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Current Throughput
+              context: current_throughput_objects_s
+              units: objects/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_recovering_objects_per_sec
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_num_objects_recovered
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Object Work
+              context: object_work
+              units: objects/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_objects_repaired
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Pool Capacity and Data Volume
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_num_bytes_recovered
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+    - family: RBD Images
+      context_namespace: rbd_images
+      groups:
+        - family: I/O
+          context_namespace: i_o
+          metrics:
+            - ceph_rbd_read_bytes
+            - ceph_rbd_read_ops
+            - ceph_rbd_write_bytes
+            - ceph_rbd_write_ops
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_read_bytes
+                  name: read_bytes
+                - selector: ceph_rbd_write_bytes
+                  name: write_bytes
+              instances:
+                by_labels:
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_read_ops
+                  name: read_ops
+                - selector: ceph_rbd_write_ops
+                  name: write_ops
+              instances:
+                by_labels:
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+        - family: Image Metadata
+          context_namespace: image_metadata
+          metrics:
+            - ceph_rbd_image_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_image_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - image_name
+                  - pool_id
+                optional_by_labels: []
+        - family: Latency
+          context_namespace: latency
+          metrics:
+            - ceph_rbd_read_latency_count
+            - ceph_rbd_read_latency_sum
+            - ceph_rbd_write_latency_count
+            - ceph_rbd_write_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_read_latency_count
+                  name: read_latency
+                - selector: ceph_rbd_write_latency_count
+                  name: write_latency
+              instances:
+                by_labels:
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_read_latency_sum
+                  name: read_latency
+                - selector: ceph_rbd_write_latency_sum
+                  name: write_latency
+              instances:
+                by_labels:
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+        - family: Mirror Metadata
+          context_namespace: mirror_metadata
+          metrics:
+            - ceph_rbd_mirror_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - ceph_version
+                  - hostname
+                  - id
+                  - instance_id
+                optional_by_labels: []
+    - family: SMB Metadata
+      context_namespace: smb_metadata
       metrics:
-      - ceph_fs_metadata
+        - ceph_smb_metadata
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_fs_metadata
-          name: value
-        instances:
-          by_labels:
-          - data_pools
-          - fs_id
-          - metadata_pool
-          - name
-          optional_by_labels: []
-    - family: MDS Metadata
-      context_namespace: mds_metadata
+        - title: State and Metadata
+          context: state
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_smb_metadata
+              name: value
+          instances:
+            by_labels:
+              - netbiosname
+              - share
+              - smb_version
+              - subvolume
+              - subvolume_group
+              - volume
+            optional_by_labels: []
+    - family: BlueFS
+      context_namespace: bluefs
+      groups:
+        - family: Allocation
+          context_namespace: allocation
+          metrics:
+            - ceph_bluefs_alloc_db_max_lat
+            - ceph_bluefs_alloc_slow_fallback
+            - ceph_bluefs_alloc_slow_max_lat
+            - ceph_bluefs_alloc_slow_size_fallback
+            - ceph_bluefs_alloc_unit_db
+            - ceph_bluefs_alloc_unit_slow
+            - ceph_bluefs_alloc_unit_wal
+            - ceph_bluefs_alloc_wal_max_lat
+            - ceph_bluefs_db_alloc_lat_count
+            - ceph_bluefs_db_alloc_lat_sum
+            - ceph_bluefs_slow_alloc_lat_count
+            - ceph_bluefs_slow_alloc_lat_sum
+            - ceph_bluefs_wal_alloc_lat_count
+            - ceph_bluefs_wal_alloc_lat_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_db_alloc_lat_count
+                  name: db_alloc_lat
+                - selector: ceph_bluefs_slow_alloc_lat_count
+                  name: slow_alloc_lat
+                - selector: ceph_bluefs_wal_alloc_lat_count
+                  name: wal_alloc_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_db_alloc_lat_sum
+                  name: db_alloc_lat
+                - selector: ceph_bluefs_slow_alloc_lat_sum
+                  name: slow_alloc_lat
+                - selector: ceph_bluefs_wal_alloc_lat_sum
+                  name: wal_alloc_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Allocation Sizes and High-Water Marks
+              context: allocation_high_water
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_alloc_unit_db
+                  name: db
+                - selector: ceph_bluefs_alloc_unit_slow
+                  name: slow
+                - selector: ceph_bluefs_alloc_unit_wal
+                  name: wal
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: absolute
+            - title: Duration and Time
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_alloc_db_max_lat
+                  name: db_max_lat
+                - selector: ceph_bluefs_alloc_slow_max_lat
+                  name: slow_max_lat
+                - selector: ceph_bluefs_alloc_wal_max_lat
+                  name: wal_max_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_alloc_slow_fallback
+                  name: fallback
+                - selector: ceph_bluefs_alloc_slow_size_fallback
+                  name: size_fallback
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Compaction
+          context_namespace: compaction
+          metrics:
+            - ceph_bluefs_compact_lat_count
+            - ceph_bluefs_compact_lat_sum
+            - ceph_bluefs_compact_lock_lat_count
+            - ceph_bluefs_compact_lock_lat_sum
+            - ceph_bluefs_log_compactions
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_compact_lat_count
+                  name: lat
+                - selector: ceph_bluefs_compact_lock_lat_count
+                  name: lock_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_compact_lat_sum
+                  name: lat
+                - selector: ceph_bluefs_compact_lock_lat_sum
+                  name: lock_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_log_compactions
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: I/O and Files
+          context_namespace: i_o_and_files
+          metrics:
+            - ceph_bluefs_flush_lat_count
+            - ceph_bluefs_flush_lat_sum
+            - ceph_bluefs_fsync_lat_count
+            - ceph_bluefs_fsync_lat_sum
+            - ceph_bluefs_log_write_count
+            - ceph_bluefs_read_bytes
+            - ceph_bluefs_read_count
+            - ceph_bluefs_read_disk_bytes
+            - ceph_bluefs_read_disk_bytes_db
+            - ceph_bluefs_read_disk_bytes_slow
+            - ceph_bluefs_read_disk_bytes_wal
+            - ceph_bluefs_read_disk_count
+            - ceph_bluefs_read_lat_count
+            - ceph_bluefs_read_lat_sum
+            - ceph_bluefs_read_prefetch_bytes
+            - ceph_bluefs_read_prefetch_count
+            - ceph_bluefs_read_random_buffer_bytes
+            - ceph_bluefs_read_random_buffer_count
+            - ceph_bluefs_read_random_bytes
+            - ceph_bluefs_read_random_count
+            - ceph_bluefs_read_random_disk_bytes
+            - ceph_bluefs_read_random_disk_bytes_db
+            - ceph_bluefs_read_random_disk_bytes_slow
+            - ceph_bluefs_read_random_disk_bytes_wal
+            - ceph_bluefs_read_random_disk_count
+            - ceph_bluefs_read_random_lat_count
+            - ceph_bluefs_read_random_lat_sum
+            - ceph_bluefs_read_zeros_candidate
+            - ceph_bluefs_read_zeros_errors
+            - ceph_bluefs_truncate_lat_count
+            - ceph_bluefs_truncate_lat_sum
+            - ceph_bluefs_unlink_lat_count
+            - ceph_bluefs_unlink_lat_sum
+            - ceph_bluefs_write_bytes
+            - ceph_bluefs_write_count
+            - ceph_bluefs_write_count_sst
+            - ceph_bluefs_write_count_wal
+            - ceph_bluefs_write_disk_count
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_flush_lat_count
+                  name: flush_lat
+                - selector: ceph_bluefs_fsync_lat_count
+                  name: fsync_lat
+                - selector: ceph_bluefs_read_lat_count
+                  name: read_lat
+                - selector: ceph_bluefs_read_random_lat_count
+                  name: read_random_lat
+                - selector: ceph_bluefs_truncate_lat_count
+                  name: truncate_lat
+                - selector: ceph_bluefs_unlink_lat_count
+                  name: unlink_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_flush_lat_sum
+                  name: flush_lat
+                - selector: ceph_bluefs_fsync_lat_sum
+                  name: fsync_lat
+                - selector: ceph_bluefs_read_lat_sum
+                  name: read_lat
+                - selector: ceph_bluefs_read_random_lat_sum
+                  name: read_random_lat
+                - selector: ceph_bluefs_truncate_lat_sum
+                  name: truncate_lat
+                - selector: ceph_bluefs_unlink_lat_sum
+                  name: unlink_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_read_bytes
+                  name: read_bytes
+                - selector: ceph_bluefs_read_disk_bytes
+                  name: read_disk_bytes
+                - selector: ceph_bluefs_read_disk_bytes_db
+                  name: read_disk_bytes_db
+                - selector: ceph_bluefs_read_disk_bytes_slow
+                  name: read_disk_bytes_slow
+                - selector: ceph_bluefs_read_disk_bytes_wal
+                  name: read_disk_bytes_wal
+                - selector: ceph_bluefs_read_prefetch_bytes
+                  name: read_prefetch_bytes
+                - selector: ceph_bluefs_read_random_buffer_bytes
+                  name: read_random_buffer_bytes
+                - selector: ceph_bluefs_read_random_bytes
+                  name: read_random_bytes
+                - selector: ceph_bluefs_read_random_disk_bytes
+                  name: read_random_disk_bytes
+                - selector: ceph_bluefs_read_random_disk_bytes_db
+                  name: read_random_disk_bytes_db
+                - selector: ceph_bluefs_read_random_disk_bytes_slow
+                  name: read_random_disk_bytes_slow
+                - selector: ceph_bluefs_read_random_disk_bytes_wal
+                  name: read_random_disk_bytes_wal
+                - selector: ceph_bluefs_write_bytes
+                  name: write_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_log_write_count
+                  name: log_write
+                - selector: ceph_bluefs_read_count
+                  name: read
+                - selector: ceph_bluefs_read_disk_count
+                  name: read_disk
+                - selector: ceph_bluefs_read_prefetch_count
+                  name: read_prefetch
+                - selector: ceph_bluefs_read_random_buffer_count
+                  name: read_random_buffer
+                - selector: ceph_bluefs_read_random_count
+                  name: read_random
+                - selector: ceph_bluefs_read_random_disk_count
+                  name: read_random_disk
+                - selector: ceph_bluefs_write_count
+                  name: write
+                - selector: ceph_bluefs_write_count_sst
+                  name: write_count_sst
+                - selector: ceph_bluefs_write_count_wal
+                  name: write_count_wal
+                - selector: ceph_bluefs_write_disk_count
+                  name: write_disk
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Zero-Read Outcomes
+              context: zero_read_outcomes
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_read_zeros_candidate
+                  name: candidate
+                - selector: ceph_bluefs_read_zeros_errors
+                  name: errors
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Space and Files
+          context_namespace: space_and_files
+          metrics:
+            - ceph_bluefs_bytes_written_slow
+            - ceph_bluefs_bytes_written_sst
+            - ceph_bluefs_bytes_written_wal
+            - ceph_bluefs_db_total_bytes
+            - ceph_bluefs_db_used_bytes
+            - ceph_bluefs_files_written_sst
+            - ceph_bluefs_files_written_wal
+            - ceph_bluefs_log_bytes
+            - ceph_bluefs_logged_bytes
+            - ceph_bluefs_max_bytes_db
+            - ceph_bluefs_max_bytes_slow
+            - ceph_bluefs_max_bytes_wal
+            - ceph_bluefs_num_files
+            - ceph_bluefs_slow_total_bytes
+            - ceph_bluefs_slow_used_bytes
+            - ceph_bluefs_wal_total_bytes
+            - ceph_bluefs_wal_used_bytes
+          charts:
+            - title: Allocation Sizes and High-Water Marks
+              context: allocation_high_water
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_max_bytes_db
+                  name: db
+                - selector: ceph_bluefs_max_bytes_slow
+                  name: slow
+                - selector: ceph_bluefs_max_bytes_wal
+                  name: wal
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: absolute
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_bytes_written_slow
+                  name: bytes_written_slow
+                - selector: ceph_bluefs_bytes_written_sst
+                  name: bytes_written_sst
+                - selector: ceph_bluefs_bytes_written_wal
+                  name: bytes_written_wal
+                - selector: ceph_bluefs_logged_bytes
+                  name: logged_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Files
+              context: file_state
+              units: files
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_num_files
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: File Work
+              context: file_work
+              units: files/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_files_written_sst
+                  name: sst
+                - selector: ceph_bluefs_files_written_wal
+                  name: wal
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_db_total_bytes
+                  name: db_total_bytes
+                - selector: ceph_bluefs_db_used_bytes
+                  name: db_used_bytes
+                - selector: ceph_bluefs_log_bytes
+                  name: log_bytes
+                - selector: ceph_bluefs_slow_total_bytes
+                  name: slow_total_bytes
+                - selector: ceph_bluefs_slow_used_bytes
+                  name: slow_used_bytes
+                - selector: ceph_bluefs_wal_total_bytes
+                  name: wal_total_bytes
+                - selector: ceph_bluefs_wal_used_bytes
+                  name: wal_used_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: BlueStore
+      context_namespace: bluestore
+      groups:
+        - family: Allocation
+          context_namespace: allocation
+          metrics:
+            - ceph_bluestore_alloc_unit
+            - ceph_bluestore_allocated
+            - ceph_bluestore_allocator_lat_count
+            - ceph_bluestore_allocator_lat_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_allocator_lat_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_allocator_lat_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Allocation Unit
+              context: allocation_unit
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_alloc_unit
+                  name: alloc_unit
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Allocated Space
+              context: allocated_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_allocated
+                  name: allocated
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Compression and Checksums
+          context_namespace: compression_and_checksums
+          metrics:
+            - ceph_bluestore_compress_lat_count
+            - ceph_bluestore_compress_lat_sum
+            - ceph_bluestore_compress_rejected_count
+            - ceph_bluestore_compress_success_count
+            - ceph_bluestore_compressed
+            - ceph_bluestore_compressed_allocated
+            - ceph_bluestore_compressed_original
+            - ceph_bluestore_csum_lat_count
+            - ceph_bluestore_csum_lat_sum
+            - ceph_bluestore_decompress_lat_count
+            - ceph_bluestore_decompress_lat_sum
+            - ceph_bluestore_extent_compress
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_compress_lat_count
+                  name: compress_lat
+                - selector: ceph_bluestore_csum_lat_count
+                  name: csum_lat
+                - selector: ceph_bluestore_decompress_lat_count
+                  name: decompress_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_compress_lat_sum
+                  name: compress_lat
+                - selector: ceph_bluestore_csum_lat_sum
+                  name: csum_lat
+                - selector: ceph_bluestore_decompress_lat_sum
+                  name: decompress_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Compression Operations
+              context: compression_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_compress_rejected_count
+                  name: compress_rejected
+                - selector: ceph_bluestore_compress_success_count
+                  name: compress_success
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Compressed Extents
+              context: compressed_extents
+              units: extents/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_extent_compress
+                  name: extent_compress
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_compressed
+                  name: compressed
+                - selector: ceph_bluestore_compressed_allocated
+                  name: allocated
+                - selector: ceph_bluestore_compressed_original
+                  name: original
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: I/O
+          context_namespace: i_o
+          metrics:
+            - ceph_bluestore_issued_deferred_write_bytes
+            - ceph_bluestore_issued_deferred_writes
+            - ceph_bluestore_read_eio
+            - ceph_bluestore_read_lat_count
+            - ceph_bluestore_read_lat_sum
+            - ceph_bluestore_read_onode_meta_lat_count
+            - ceph_bluestore_read_onode_meta_lat_sum
+            - ceph_bluestore_read_wait_aio_lat_count
+            - ceph_bluestore_read_wait_aio_lat_sum
+            - ceph_bluestore_reads_with_retries
+            - ceph_bluestore_remove_lat_count
+            - ceph_bluestore_remove_lat_sum
+            - ceph_bluestore_slow_aio_wait_count
+            - ceph_bluestore_slow_read_onode_meta_count
+            - ceph_bluestore_slow_read_wait_aio_count
+            - ceph_bluestore_submitted_deferred_write_bytes
+            - ceph_bluestore_submitted_deferred_writes
+            - ceph_bluestore_truncate_lat_count
+            - ceph_bluestore_truncate_lat_sum
+            - ceph_bluestore_write_big
+            - ceph_bluestore_write_big_blobs
+            - ceph_bluestore_write_big_bytes
+            - ceph_bluestore_write_big_deferred
+            - ceph_bluestore_write_big_skipped_blobs
+            - ceph_bluestore_write_big_skipped_bytes
+            - ceph_bluestore_write_lat_count
+            - ceph_bluestore_write_lat_sum
+            - ceph_bluestore_write_new
+            - ceph_bluestore_write_pad_bytes
+            - ceph_bluestore_write_penalty_read_ops
+            - ceph_bluestore_write_small
+            - ceph_bluestore_write_small_bytes
+            - ceph_bluestore_write_small_pre_read
+            - ceph_bluestore_write_small_skipped
+            - ceph_bluestore_write_small_skipped_bytes
+            - ceph_bluestore_write_small_unused
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_read_lat_count
+                  name: read_lat
+                - selector: ceph_bluestore_read_onode_meta_lat_count
+                  name: read_onode_meta_lat
+                - selector: ceph_bluestore_read_wait_aio_lat_count
+                  name: read_wait_aio_lat
+                - selector: ceph_bluestore_remove_lat_count
+                  name: remove_lat
+                - selector: ceph_bluestore_truncate_lat_count
+                  name: truncate_lat
+                - selector: ceph_bluestore_write_lat_count
+                  name: write_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_read_lat_sum
+                  name: read_lat
+                - selector: ceph_bluestore_read_onode_meta_lat_sum
+                  name: read_onode_meta_lat
+                - selector: ceph_bluestore_read_wait_aio_lat_sum
+                  name: read_wait_aio_lat
+                - selector: ceph_bluestore_remove_lat_sum
+                  name: remove_lat
+                - selector: ceph_bluestore_truncate_lat_sum
+                  name: truncate_lat
+                - selector: ceph_bluestore_write_lat_sum
+                  name: write_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_issued_deferred_write_bytes
+                  name: issued_deferred_write_bytes
+                - selector: ceph_bluestore_submitted_deferred_write_bytes
+                  name: submitted_deferred_write_bytes
+                - selector: ceph_bluestore_write_big_bytes
+                  name: write_big_bytes
+                - selector: ceph_bluestore_write_big_skipped_bytes
+                  name: write_big_skipped_bytes
+                - selector: ceph_bluestore_write_pad_bytes
+                  name: write_pad_bytes
+                - selector: ceph_bluestore_write_small_bytes
+                  name: write_small_bytes
+                - selector: ceph_bluestore_write_small_skipped_bytes
+                  name: write_small_skipped_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Read Outcomes
+              context: read_outcomes
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_read_eio
+                  name: read_eio
+                - selector: ceph_bluestore_reads_with_retries
+                  name: reads_with_retries
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Slow Reads
+              context: slow_reads
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_slow_read_onode_meta_count
+                  name: slow_read_onode_meta
+                - selector: ceph_bluestore_slow_read_wait_aio_count
+                  name: slow_read_wait_aio
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Slow AIO Waits
+              context: slow_aio_waits
+              units: waits/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_slow_aio_wait_count
+                  name: slow_aio_wait
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Skipped Blobs
+              context: skipped_blobs
+              units: blobs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_write_big_skipped_blobs
+                  name: write_big_skipped_blobs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Skipped Writes
+              context: skipped_writes
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_write_small_skipped
+                  name: write_small_skipped
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Write Operations
+              context: write_operations
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_issued_deferred_writes
+                  name: issued_deferred_writes
+                - selector: ceph_bluestore_submitted_deferred_writes
+                  name: submitted_deferred_writes
+                - selector: ceph_bluestore_write_big
+                  name: write_big
+                - selector: ceph_bluestore_write_big_deferred
+                  name: write_big_deferred
+                - selector: ceph_bluestore_write_new
+                  name: write_new
+                - selector: ceph_bluestore_write_small
+                  name: write_small
+                - selector: ceph_bluestore_write_small_pre_read
+                  name: write_small_pre_read
+                - selector: ceph_bluestore_write_small_unused
+                  name: write_small_unused
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Written Blobs
+              context: written_blobs
+              units: blobs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_write_big_blobs
+                  name: write_big_blobs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Penalty Reads
+              context: penalty_reads
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_write_penalty_read_ops
+                  name: write_penalty_read_ops
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: OMAP
+          context_namespace: omap
+          metrics:
+            - ceph_bluestore_omap_clear_lat_count
+            - ceph_bluestore_omap_clear_lat_sum
+            - ceph_bluestore_omap_get_keys_lat_count
+            - ceph_bluestore_omap_get_keys_lat_sum
+            - ceph_bluestore_omap_get_values_lat_count
+            - ceph_bluestore_omap_get_values_lat_sum
+            - ceph_bluestore_omap_iterator_count
+            - ceph_bluestore_omap_lower_bound_lat_count
+            - ceph_bluestore_omap_lower_bound_lat_sum
+            - ceph_bluestore_omap_next_lat_count
+            - ceph_bluestore_omap_next_lat_sum
+            - ceph_bluestore_omap_rmkey_range_count
+            - ceph_bluestore_omap_rmkeys_count
+            - ceph_bluestore_omap_seek_to_first_lat_count
+            - ceph_bluestore_omap_seek_to_first_lat_sum
+            - ceph_bluestore_omap_setheader_bytes
+            - ceph_bluestore_omap_setheader_count
+            - ceph_bluestore_omap_setkeys_bytes
+            - ceph_bluestore_omap_setkeys_count
+            - ceph_bluestore_omap_setkeys_records
+            - ceph_bluestore_omap_upper_bound_lat_count
+            - ceph_bluestore_omap_upper_bound_lat_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_clear_lat_count
+                  name: clear_lat
+                - selector: ceph_bluestore_omap_get_keys_lat_count
+                  name: get_keys_lat
+                - selector: ceph_bluestore_omap_get_values_lat_count
+                  name: get_values_lat
+                - selector: ceph_bluestore_omap_lower_bound_lat_count
+                  name: lower_bound_lat
+                - selector: ceph_bluestore_omap_next_lat_count
+                  name: next_lat
+                - selector: ceph_bluestore_omap_seek_to_first_lat_count
+                  name: seek_to_first_lat
+                - selector: ceph_bluestore_omap_upper_bound_lat_count
+                  name: upper_bound_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_clear_lat_sum
+                  name: clear_lat
+                - selector: ceph_bluestore_omap_get_keys_lat_sum
+                  name: get_keys_lat
+                - selector: ceph_bluestore_omap_get_values_lat_sum
+                  name: get_values_lat
+                - selector: ceph_bluestore_omap_lower_bound_lat_sum
+                  name: lower_bound_lat
+                - selector: ceph_bluestore_omap_next_lat_sum
+                  name: next_lat
+                - selector: ceph_bluestore_omap_seek_to_first_lat_sum
+                  name: seek_to_first_lat
+                - selector: ceph_bluestore_omap_upper_bound_lat_sum
+                  name: upper_bound_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_setheader_bytes
+                  name: setheader_bytes
+                - selector: ceph_bluestore_omap_setkeys_bytes
+                  name: setkeys_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Open Iterators
+              context: open_iterators
+              units: iterators
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_iterator_count
+                  name: iterator
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: absolute
+            - title: Mutation Calls
+              context: mutation_calls
+              units: calls/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_setheader_count
+                  name: setheader
+                - selector: ceph_bluestore_omap_setkeys_count
+                  name: setkeys
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Removed Key Ranges
+              context: removed_key_ranges
+              units: ranges/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_rmkey_range_count
+                  name: rmkey_range
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Key Mutations
+              context: key_mutations
+              units: keys/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_rmkeys_count
+                  name: rmkeys
+                - selector: ceph_bluestore_omap_setkeys_records
+                  name: setkeys_records
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Onode Cache
+          context_namespace: onode_cache
+          metrics:
+            - ceph_bluestore_onode_blobs
+            - ceph_bluestore_onode_extents
+            - ceph_bluestore_onode_hits
+            - ceph_bluestore_onode_misses
+            - ceph_bluestore_onode_reshard
+            - ceph_bluestore_onode_shard_hits
+            - ceph_bluestore_onode_shard_misses
+            - ceph_bluestore_onode_spanning_blobs
+            - ceph_bluestore_onodes
+            - ceph_bluestore_onodes_pinned
+          charts:
+            - title: Onode Blobs
+              context: blob_state
+              units: blobs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_blobs
+                  name: onode_blobs
+                - selector: ceph_bluestore_onode_spanning_blobs
+                  name: onode_spanning_blobs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Onode Extents
+              context: extent_state
+              units: extents
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_extents
+                  name: onode_extents
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Onodes
+              context: onode_state
+              units: onodes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onodes
+                  name: onodes
+                - selector: ceph_bluestore_onodes_pinned
+                  name: onodes_pinned
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_reshard
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Onode Lookup Outcomes
+              context: onode_lookup_outcomes
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_hits
+                  name: hits
+                - selector: ceph_bluestore_onode_misses
+                  name: misses
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Onode Shard Lookup Outcomes
+              context: shard_lookup_outcomes
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_shard_hits
+                  name: shard_hits
+                - selector: ceph_bluestore_onode_shard_misses
+                  name: shard_misses
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Data
+          context_namespace: priority_cache_data
+          metrics:
+            - ceph_bluestore_pricache:data_committed_bytes
+            - ceph_bluestore_pricache:data_pri0_bytes
+            - ceph_bluestore_pricache:data_pri10_bytes
+            - ceph_bluestore_pricache:data_pri11_bytes
+            - ceph_bluestore_pricache:data_pri1_bytes
+            - ceph_bluestore_pricache:data_pri2_bytes
+            - ceph_bluestore_pricache:data_pri3_bytes
+            - ceph_bluestore_pricache:data_pri4_bytes
+            - ceph_bluestore_pricache:data_pri5_bytes
+            - ceph_bluestore_pricache:data_pri6_bytes
+            - ceph_bluestore_pricache:data_pri7_bytes
+            - ceph_bluestore_pricache:data_pri8_bytes
+            - ceph_bluestore_pricache:data_pri9_bytes
+            - ceph_bluestore_pricache:data_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache:data_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_bluestore_pricache:data_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_bluestore_pricache:data_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_bluestore_pricache:data_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_bluestore_pricache:data_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_bluestore_pricache:data_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_bluestore_pricache:data_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_bluestore_pricache:data_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_bluestore_pricache:data_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_bluestore_pricache:data_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_bluestore_pricache:data_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_bluestore_pricache:data_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_bluestore_pricache:data_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_bluestore_pricache:data_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache KV
+          context_namespace: priority_cache_kv
+          metrics:
+            - ceph_bluestore_pricache:kv_committed_bytes
+            - ceph_bluestore_pricache:kv_pri0_bytes
+            - ceph_bluestore_pricache:kv_pri10_bytes
+            - ceph_bluestore_pricache:kv_pri11_bytes
+            - ceph_bluestore_pricache:kv_pri1_bytes
+            - ceph_bluestore_pricache:kv_pri2_bytes
+            - ceph_bluestore_pricache:kv_pri3_bytes
+            - ceph_bluestore_pricache:kv_pri4_bytes
+            - ceph_bluestore_pricache:kv_pri5_bytes
+            - ceph_bluestore_pricache:kv_pri6_bytes
+            - ceph_bluestore_pricache:kv_pri7_bytes
+            - ceph_bluestore_pricache:kv_pri8_bytes
+            - ceph_bluestore_pricache:kv_pri9_bytes
+            - ceph_bluestore_pricache:kv_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache:kv_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_bluestore_pricache:kv_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_bluestore_pricache:kv_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_bluestore_pricache:kv_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_bluestore_pricache:kv_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_bluestore_pricache:kv_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_bluestore_pricache:kv_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_bluestore_pricache:kv_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_bluestore_pricache:kv_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_bluestore_pricache:kv_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_bluestore_pricache:kv_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_bluestore_pricache:kv_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_bluestore_pricache:kv_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_bluestore_pricache:kv_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache KV Onode
+          context_namespace: priority_cache_kv_onode
+          metrics:
+            - ceph_bluestore_pricache:kv_onode_committed_bytes
+            - ceph_bluestore_pricache:kv_onode_pri0_bytes
+            - ceph_bluestore_pricache:kv_onode_pri10_bytes
+            - ceph_bluestore_pricache:kv_onode_pri11_bytes
+            - ceph_bluestore_pricache:kv_onode_pri1_bytes
+            - ceph_bluestore_pricache:kv_onode_pri2_bytes
+            - ceph_bluestore_pricache:kv_onode_pri3_bytes
+            - ceph_bluestore_pricache:kv_onode_pri4_bytes
+            - ceph_bluestore_pricache:kv_onode_pri5_bytes
+            - ceph_bluestore_pricache:kv_onode_pri6_bytes
+            - ceph_bluestore_pricache:kv_onode_pri7_bytes
+            - ceph_bluestore_pricache:kv_onode_pri8_bytes
+            - ceph_bluestore_pricache:kv_onode_pri9_bytes
+            - ceph_bluestore_pricache:kv_onode_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache:kv_onode_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Metadata
+          context_namespace: priority_cache_metadata
+          metrics:
+            - ceph_bluestore_pricache:meta_committed_bytes
+            - ceph_bluestore_pricache:meta_pri0_bytes
+            - ceph_bluestore_pricache:meta_pri10_bytes
+            - ceph_bluestore_pricache:meta_pri11_bytes
+            - ceph_bluestore_pricache:meta_pri1_bytes
+            - ceph_bluestore_pricache:meta_pri2_bytes
+            - ceph_bluestore_pricache:meta_pri3_bytes
+            - ceph_bluestore_pricache:meta_pri4_bytes
+            - ceph_bluestore_pricache:meta_pri5_bytes
+            - ceph_bluestore_pricache:meta_pri6_bytes
+            - ceph_bluestore_pricache:meta_pri7_bytes
+            - ceph_bluestore_pricache:meta_pri8_bytes
+            - ceph_bluestore_pricache:meta_pri9_bytes
+            - ceph_bluestore_pricache:meta_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache:meta_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_bluestore_pricache:meta_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_bluestore_pricache:meta_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_bluestore_pricache:meta_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_bluestore_pricache:meta_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_bluestore_pricache:meta_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_bluestore_pricache:meta_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_bluestore_pricache:meta_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_bluestore_pricache:meta_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_bluestore_pricache:meta_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_bluestore_pricache:meta_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_bluestore_pricache:meta_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_bluestore_pricache:meta_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_bluestore_pricache:meta_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Runtime
+          context_namespace: priority_cache_runtime
+          metrics:
+            - ceph_bluestore_pricache_cache_bytes
+            - ceph_bluestore_pricache_heap_bytes
+            - ceph_bluestore_pricache_mapped_bytes
+            - ceph_bluestore_pricache_target_bytes
+            - ceph_bluestore_pricache_unmapped_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache_cache_bytes
+                  name: cache_bytes
+                - selector: ceph_bluestore_pricache_heap_bytes
+                  name: heap_bytes
+                - selector: ceph_bluestore_pricache_mapped_bytes
+                  name: mapped_bytes
+                - selector: ceph_bluestore_pricache_target_bytes
+                  name: target_bytes
+                - selector: ceph_bluestore_pricache_unmapped_bytes
+                  name: unmapped_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Space and Core State
+          context_namespace: space_and_core_state
+          metrics:
+            - ceph_bluestore_blob_split
+            - ceph_bluestore_buffer_bytes
+            - ceph_bluestore_buffer_hit_bytes
+            - ceph_bluestore_buffer_miss_bytes
+            - ceph_bluestore_buffers
+            - ceph_bluestore_clist_lat_count
+            - ceph_bluestore_clist_lat_sum
+            - ceph_bluestore_fragmentation_micros
+            - ceph_bluestore_gc_merged
+            - ceph_bluestore_kv_commit_lat_count
+            - ceph_bluestore_kv_commit_lat_sum
+            - ceph_bluestore_kv_final_lat_count
+            - ceph_bluestore_kv_final_lat_sum
+            - ceph_bluestore_kv_flush_lat_count
+            - ceph_bluestore_kv_flush_lat_sum
+            - ceph_bluestore_kv_sync_lat_count
+            - ceph_bluestore_kv_sync_lat_sum
+            - ceph_bluestore_slow_committed_kv_count
+            - ceph_bluestore_stored
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_clist_lat_count
+                  name: clist_lat
+                - selector: ceph_bluestore_kv_commit_lat_count
+                  name: kv_commit_lat
+                - selector: ceph_bluestore_kv_final_lat_count
+                  name: kv_final_lat
+                - selector: ceph_bluestore_kv_flush_lat_count
+                  name: kv_flush_lat
+                - selector: ceph_bluestore_kv_sync_lat_count
+                  name: kv_sync_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_clist_lat_sum
+                  name: clist_lat
+                - selector: ceph_bluestore_kv_commit_lat_sum
+                  name: kv_commit_lat
+                - selector: ceph_bluestore_kv_final_lat_sum
+                  name: kv_final_lat
+                - selector: ceph_bluestore_kv_flush_lat_sum
+                  name: kv_flush_lat
+                - selector: ceph_bluestore_kv_sync_lat_sum
+                  name: kv_sync_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_buffer_hit_bytes
+                  name: hit_bytes
+                - selector: ceph_bluestore_buffer_miss_bytes
+                  name: miss_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Current Work
+              context: current_work
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_buffers
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Blob Splits
+              context: blob_splits
+              units: blobs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_blob_split
+                  name: blob_split
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Garbage-Collection Merge Throughput
+              context: gc_merge_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_gc_merged
+                  name: gc_merged
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_slow_committed_kv_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Fragmentation
+              context: fragmentation
+              units: per mille
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_fragmentation_micros
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Buffer Cache Residency
+              context: buffer_cache_residency
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_buffer_bytes
+                  name: buffer_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Logical Stored Data
+              context: logical_stored_data
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_stored
+                  name: stored
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Transaction Pipeline
+          context_namespace: transaction_pipeline
+          metrics:
+            - ceph_bluestore_state_aio_wait_lat_count
+            - ceph_bluestore_state_aio_wait_lat_sum
+            - ceph_bluestore_state_deferred_aio_wait_lat_count
+            - ceph_bluestore_state_deferred_aio_wait_lat_sum
+            - ceph_bluestore_state_deferred_cleanup_lat_count
+            - ceph_bluestore_state_deferred_cleanup_lat_sum
+            - ceph_bluestore_state_deferred_queued_lat_count
+            - ceph_bluestore_state_deferred_queued_lat_sum
+            - ceph_bluestore_state_done_lat_count
+            - ceph_bluestore_state_done_lat_sum
+            - ceph_bluestore_state_finishing_lat_count
+            - ceph_bluestore_state_finishing_lat_sum
+            - ceph_bluestore_state_io_done_lat_count
+            - ceph_bluestore_state_io_done_lat_sum
+            - ceph_bluestore_state_kv_commiting_lat_count
+            - ceph_bluestore_state_kv_commiting_lat_sum
+            - ceph_bluestore_state_kv_done_lat_count
+            - ceph_bluestore_state_kv_done_lat_sum
+            - ceph_bluestore_state_kv_queued_lat_count
+            - ceph_bluestore_state_kv_queued_lat_sum
+            - ceph_bluestore_state_prepare_lat_count
+            - ceph_bluestore_state_prepare_lat_sum
+            - ceph_bluestore_txc_commit_lat_count
+            - ceph_bluestore_txc_commit_lat_sum
+            - ceph_bluestore_txc_count
+            - ceph_bluestore_txc_submit_lat_count
+            - ceph_bluestore_txc_submit_lat_sum
+            - ceph_bluestore_txc_throttle_lat_count
+            - ceph_bluestore_txc_throttle_lat_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_state_aio_wait_lat_count
+                  name: state_aio_wait_lat
+                - selector: ceph_bluestore_state_deferred_aio_wait_lat_count
+                  name: state_deferred_aio_wait_lat
+                - selector: ceph_bluestore_state_deferred_cleanup_lat_count
+                  name: state_deferred_cleanup_lat
+                - selector: ceph_bluestore_state_deferred_queued_lat_count
+                  name: state_deferred_queued_lat
+                - selector: ceph_bluestore_state_done_lat_count
+                  name: state_done_lat
+                - selector: ceph_bluestore_state_finishing_lat_count
+                  name: state_finishing_lat
+                - selector: ceph_bluestore_state_io_done_lat_count
+                  name: state_io_done_lat
+                - selector: ceph_bluestore_state_kv_commiting_lat_count
+                  name: state_kv_commiting_lat
+                - selector: ceph_bluestore_state_kv_done_lat_count
+                  name: state_kv_done_lat
+                - selector: ceph_bluestore_state_kv_queued_lat_count
+                  name: state_kv_queued_lat
+                - selector: ceph_bluestore_state_prepare_lat_count
+                  name: state_prepare_lat
+                - selector: ceph_bluestore_txc_commit_lat_count
+                  name: txc_commit_lat
+                - selector: ceph_bluestore_txc_submit_lat_count
+                  name: txc_submit_lat
+                - selector: ceph_bluestore_txc_throttle_lat_count
+                  name: txc_throttle_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_state_aio_wait_lat_sum
+                  name: state_aio_wait_lat
+                - selector: ceph_bluestore_state_deferred_aio_wait_lat_sum
+                  name: state_deferred_aio_wait_lat
+                - selector: ceph_bluestore_state_deferred_cleanup_lat_sum
+                  name: state_deferred_cleanup_lat
+                - selector: ceph_bluestore_state_deferred_queued_lat_sum
+                  name: state_deferred_queued_lat
+                - selector: ceph_bluestore_state_done_lat_sum
+                  name: state_done_lat
+                - selector: ceph_bluestore_state_finishing_lat_sum
+                  name: state_finishing_lat
+                - selector: ceph_bluestore_state_io_done_lat_sum
+                  name: state_io_done_lat
+                - selector: ceph_bluestore_state_kv_commiting_lat_sum
+                  name: state_kv_commiting_lat
+                - selector: ceph_bluestore_state_kv_done_lat_sum
+                  name: state_kv_done_lat
+                - selector: ceph_bluestore_state_kv_queued_lat_sum
+                  name: state_kv_queued_lat
+                - selector: ceph_bluestore_state_prepare_lat_sum
+                  name: state_prepare_lat
+                - selector: ceph_bluestore_txc_commit_lat_sum
+                  name: txc_commit_lat
+                - selector: ceph_bluestore_txc_submit_lat_sum
+                  name: txc_submit_lat
+                - selector: ceph_bluestore_txc_throttle_lat_sum
+                  name: txc_throttle_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_txc_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: CephFS MDS
+      context_namespace: cephfs_mds
+      groups:
+        - family: Attribute and Layout Mutation Latency
+          context_namespace: attribute_and_layout_mutation_latency
+          metrics:
+            - ceph_mds_server_req_rmxattr_latency_count
+            - ceph_mds_server_req_rmxattr_latency_sum
+            - ceph_mds_server_req_setattr_latency_count
+            - ceph_mds_server_req_setattr_latency_sum
+            - ceph_mds_server_req_setdirlayout_latency_count
+            - ceph_mds_server_req_setdirlayout_latency_sum
+            - ceph_mds_server_req_setfilelock_latency_count
+            - ceph_mds_server_req_setfilelock_latency_sum
+            - ceph_mds_server_req_setlayout_latency_count
+            - ceph_mds_server_req_setlayout_latency_sum
+            - ceph_mds_server_req_setxattr_latency_count
+            - ceph_mds_server_req_setxattr_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_rmxattr_latency_count
+                  name: rmxattr_latency
+                - selector: ceph_mds_server_req_setattr_latency_count
+                  name: setattr_latency
+                - selector: ceph_mds_server_req_setdirlayout_latency_count
+                  name: setdirlayout_latency
+                - selector: ceph_mds_server_req_setfilelock_latency_count
+                  name: setfilelock_latency
+                - selector: ceph_mds_server_req_setlayout_latency_count
+                  name: setlayout_latency
+                - selector: ceph_mds_server_req_setxattr_latency_count
+                  name: setxattr_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_rmxattr_latency_sum
+                  name: rmxattr_latency
+                - selector: ceph_mds_server_req_setattr_latency_sum
+                  name: setattr_latency
+                - selector: ceph_mds_server_req_setdirlayout_latency_sum
+                  name: setdirlayout_latency
+                - selector: ceph_mds_server_req_setfilelock_latency_sum
+                  name: setfilelock_latency
+                - selector: ceph_mds_server_req_setlayout_latency_sum
+                  name: setlayout_latency
+                - selector: ceph_mds_server_req_setxattr_latency_sum
+                  name: setxattr_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Capabilities
+          context_namespace: capabilities
+          metrics:
+            - ceph_mds_caps
+            - ceph_mds_ceph_cap_op_flush_ack
+            - ceph_mds_ceph_cap_op_flushsnap_ack
+            - ceph_mds_ceph_cap_op_grant
+            - ceph_mds_ceph_cap_op_revoke
+            - ceph_mds_ceph_cap_op_trunc
+            - ceph_mds_handle_client_cap_release
+            - ceph_mds_handle_client_caps
+            - ceph_mds_handle_client_caps_dirty
+            - ceph_mds_handle_inode_file_caps
+            - ceph_mds_inodes_with_caps
+            - ceph_mds_process_request_cap_release
+            - ceph_mds_server_cap_acquisition_throttle
+            - ceph_mds_server_cap_revoke_eviction
+          charts:
+            - title: Capabilities
+              context: capability_state
+              units: capabilities
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_caps
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Capability Messages
+              context: capability_messages
+              units: messages/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_handle_client_cap_release
+                  name: handle_client_cap_release
+                - selector: ceph_mds_handle_client_caps
+                  name: handle_client_caps
+                - selector: ceph_mds_handle_client_caps_dirty
+                  name: handle_client_caps_dirty
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Capability-Throttled Requests
+              context: throttled_requests
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_cap_acquisition_throttle
+                  name: server_cap_acquisition_throttle
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Capability-Revoke Evictions
+              context: evicted_clients
+              units: clients/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_cap_revoke_eviction
+                  name: server_cap_revoke_eviction
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inodes
+              context: inode_state
+              units: inodes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_inodes_with_caps
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inode Work
+              context: inode_work
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_handle_inode_file_caps
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_ceph_cap_op_flush_ack
+                  name: ceph_cap_op_flush_ack
+                - selector: ceph_mds_ceph_cap_op_flushsnap_ack
+                  name: ceph_cap_op_flushsnap_ack
+                - selector: ceph_mds_ceph_cap_op_grant
+                  name: ceph_cap_op_grant
+                - selector: ceph_mds_ceph_cap_op_revoke
+                  name: ceph_cap_op_revoke
+                - selector: ceph_mds_ceph_cap_op_trunc
+                  name: ceph_cap_op_trunc
+                - selector: ceph_mds_process_request_cap_release
+                  name: process_request_cap_release
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Journal
+          context_namespace: journal
+          metrics:
+            - ceph_mds_log_ev
+            - ceph_mds_log_evadd
+            - ceph_mds_log_evex
+            - ceph_mds_log_evexd
+            - ceph_mds_log_evexg
+            - ceph_mds_log_evlrg
+            - ceph_mds_log_evtrm
+            - ceph_mds_log_expos
+            - ceph_mds_log_jlat_count
+            - ceph_mds_log_jlat_sum
+            - ceph_mds_log_rdpos
+            - ceph_mds_log_replayed
+            - ceph_mds_log_seg
+            - ceph_mds_log_segadd
+            - ceph_mds_log_segex
+            - ceph_mds_log_segexd
+            - ceph_mds_log_segexg
+            - ceph_mds_log_segmjr
+            - ceph_mds_log_segtrm
+            - ceph_mds_log_wrpos
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_jlat_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_jlat_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Current Journal Events
+              context: events_current
+              units: events
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_ev
+                  name: ev
+                - selector: ceph_mds_log_evexd
+                  name: evexd
+                - selector: ceph_mds_log_evexg
+                  name: evexg
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Large Journal Events
+              context: large_events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_evlrg
+                  name: evlrg
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Journal Events
+              context: journal_events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_evadd
+                  name: evadd
+                - selector: ceph_mds_log_evex
+                  name: evex
+                - selector: ceph_mds_log_evtrm
+                  name: evtrm
+                - selector: ceph_mds_log_replayed
+                  name: replayed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Journal Positions
+              context: journal_positions
+              units: position
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_expos
+                  name: expos
+                - selector: ceph_mds_log_rdpos
+                  name: rdpos
+                - selector: ceph_mds_log_wrpos
+                  name: wrpos
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Journal Segments
+              context: journal_segments
+              units: segments/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_segadd
+                  name: segadd
+                - selector: ceph_mds_log_segex
+                  name: segex
+                - selector: ceph_mds_log_segtrm
+                  name: segtrm
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Journal Segments
+              context: segments_current
+              units: segments
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_seg
+                  name: seg
+                - selector: ceph_mds_log_segexd
+                  name: segexd
+                - selector: ceph_mds_log_segexg
+                  name: segexg
+                - selector: ceph_mds_log_segmjr
+                  name: segmjr
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Metadata Cache Directory
+          context_namespace: metadata_cache_directory
+          metrics:
+            - ceph_mds_cache_dir_handle_discover
+            - ceph_mds_cache_dir_send_discover
+            - ceph_mds_cache_dir_try_discover
+            - ceph_mds_cache_dir_update
+            - ceph_mds_cache_dir_update_receipt
+          charts:
+            - title: Discovery Messages
+              context: discovery_messages
+              units: messages/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_dir_handle_discover
+                  name: handle_discover
+                - selector: ceph_mds_cache_dir_send_discover
+                  name: send_discover
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Discovery Attempts
+              context: discovery_attempts
+              units: attempts/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_dir_try_discover
+                  name: try_discover
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Replication Directives
+              context: replication_directives
+              units: directives/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_dir_update
+                  name: update
+                - selector: ceph_mds_cache_dir_update_receipt
+                  name: update_receipt
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Metadata Cache Internal Requests
+          context_namespace: metadata_cache_internal_requests
+          metrics:
+            - ceph_mds_cache_ireq_enqueue_scrub
+            - ceph_mds_cache_ireq_exportdir
+            - ceph_mds_cache_ireq_flush
+            - ceph_mds_cache_ireq_fragmentdir
+            - ceph_mds_cache_ireq_fragstats
+            - ceph_mds_cache_ireq_inodestats
+            - ceph_mds_cache_ireq_quiesce_inode
+            - ceph_mds_cache_ireq_quiesce_path
+          charts:
+            - title: Inode Work
+              context: inode_work
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_ireq_inodestats
+                  name: inodestats
+                - selector: ceph_mds_cache_ireq_quiesce_inode
+                  name: quiesce_inode
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_ireq_exportdir
+                  name: exportdir
+                - selector: ceph_mds_cache_ireq_flush
+                  name: flush
+                - selector: ceph_mds_cache_ireq_fragmentdir
+                  name: fragmentdir
+                - selector: ceph_mds_cache_ireq_fragstats
+                  name: fragstats
+                - selector: ceph_mds_cache_ireq_quiesce_path
+                  name: quiesce_path
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Scrub Work
+              context: scrub_work
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_ireq_enqueue_scrub
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Metadata Cache Recovery
+          context_namespace: metadata_cache_recovery
+          metrics:
+            - ceph_mds_cache_num_recovering_enqueued
+            - ceph_mds_cache_num_recovering_prioritized
+            - ceph_mds_cache_num_recovering_processing
+            - ceph_mds_cache_num_strays
+            - ceph_mds_cache_num_strays_delayed
+            - ceph_mds_cache_num_strays_enqueuing
+            - ceph_mds_cache_recovery_completed
+            - ceph_mds_cache_recovery_started
+            - ceph_mds_cache_strays_created
+            - ceph_mds_cache_strays_enqueued
+            - ceph_mds_cache_strays_migrated
+            - ceph_mds_cache_strays_reintegrated
+          charts:
+            - title: Current Work
+              context: current_work
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_num_strays
+                  name: strays
+                - selector: ceph_mds_cache_num_strays_delayed
+                  name: delayed
+                - selector: ceph_mds_cache_num_strays_enqueuing
+                  name: enqueuing
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_strays_created
+                  name: created
+                - selector: ceph_mds_cache_strays_enqueued
+                  name: enqueued
+                - selector: ceph_mds_cache_strays_migrated
+                  name: migrated
+                - selector: ceph_mds_cache_strays_reintegrated
+                  name: reintegrated
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Files
+              context: file_state
+              units: files
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_num_recovering_enqueued
+                  name: enqueued
+                - selector: ceph_mds_cache_num_recovering_prioritized
+                  name: prioritized
+                - selector: ceph_mds_cache_num_recovering_processing
+                  name: processing
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: File Work
+              context: file_work
+              units: files/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_recovery_completed
+                  name: completed
+                - selector: ceph_mds_cache_recovery_started
+                  name: started
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Metadata Cache Uninline
+          context_namespace: metadata_cache_uninline
+          metrics:
+            - ceph_mds_cache_uninline_started
+            - ceph_mds_cache_uninline_succeeded
+            - ceph_mds_cache_uninline_write_failed
+          charts:
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_uninline_started
+                  name: started
+                - selector: ceph_mds_cache_uninline_succeeded
+                  name: succeeded
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_uninline_write_failed
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Namespace Mutation Latency
+          context_namespace: namespace_mutation_latency
+          metrics:
+            - ceph_mds_server_req_create_latency_count
+            - ceph_mds_server_req_create_latency_sum
+            - ceph_mds_server_req_link_latency_count
+            - ceph_mds_server_req_link_latency_sum
+            - ceph_mds_server_req_mkdir_latency_count
+            - ceph_mds_server_req_mkdir_latency_sum
+            - ceph_mds_server_req_mknod_latency_count
+            - ceph_mds_server_req_mknod_latency_sum
+            - ceph_mds_server_req_rename_latency_count
+            - ceph_mds_server_req_rename_latency_sum
+            - ceph_mds_server_req_rmdir_latency_count
+            - ceph_mds_server_req_rmdir_latency_sum
+            - ceph_mds_server_req_symlink_latency_count
+            - ceph_mds_server_req_symlink_latency_sum
+            - ceph_mds_server_req_unlink_latency_count
+            - ceph_mds_server_req_unlink_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_create_latency_count
+                  name: create_latency
+                - selector: ceph_mds_server_req_link_latency_count
+                  name: link_latency
+                - selector: ceph_mds_server_req_mkdir_latency_count
+                  name: mkdir_latency
+                - selector: ceph_mds_server_req_mknod_latency_count
+                  name: mknod_latency
+                - selector: ceph_mds_server_req_rename_latency_count
+                  name: rename_latency
+                - selector: ceph_mds_server_req_rmdir_latency_count
+                  name: rmdir_latency
+                - selector: ceph_mds_server_req_symlink_latency_count
+                  name: symlink_latency
+                - selector: ceph_mds_server_req_unlink_latency_count
+                  name: unlink_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_create_latency_sum
+                  name: create_latency
+                - selector: ceph_mds_server_req_link_latency_sum
+                  name: link_latency
+                - selector: ceph_mds_server_req_mkdir_latency_sum
+                  name: mkdir_latency
+                - selector: ceph_mds_server_req_mknod_latency_sum
+                  name: mknod_latency
+                - selector: ceph_mds_server_req_rename_latency_sum
+                  name: rename_latency
+                - selector: ceph_mds_server_req_rmdir_latency_sum
+                  name: rmdir_latency
+                - selector: ceph_mds_server_req_symlink_latency_sum
+                  name: symlink_latency
+                - selector: ceph_mds_server_req_unlink_latency_sum
+                  name: unlink_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Namespace Traversal
+          context_namespace: namespace_traversal
+          metrics:
+            - ceph_mds_dir_commit
+            - ceph_mds_dir_fetch_complete
+            - ceph_mds_dir_fetch_keys
+            - ceph_mds_dir_merge
+            - ceph_mds_dir_split
+            - ceph_mds_openino_backtrace_fetch
+            - ceph_mds_openino_dir_fetch
+            - ceph_mds_openino_peer_discover
+            - ceph_mds_traverse
+            - ceph_mds_traverse_dir_fetch
+            - ceph_mds_traverse_discover
+            - ceph_mds_traverse_forward
+            - ceph_mds_traverse_hit
+            - ceph_mds_traverse_lock
+            - ceph_mds_traverse_remote_ino
+          charts:
+            - title: Directory-Fragment Lifecycle
+              context: dirfrag_lifecycle
+              units: dirfrags/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_dir_fetch_complete
+                  name: dir_fetch_complete
+                - selector: ceph_mds_dir_merge
+                  name: dir_merge
+                - selector: ceph_mds_dir_split
+                  name: dir_split
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Namespace Traversals
+              context: traversals
+              units: traversals/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_traverse
+                  name: traverse
+                - selector: ceph_mds_traverse_dir_fetch
+                  name: traverse_dir_fetch
+                - selector: ceph_mds_traverse_discover
+                  name: traverse_discover
+                - selector: ceph_mds_traverse_forward
+                  name: traverse_forward
+                - selector: ceph_mds_traverse_lock
+                  name: traverse_lock
+                - selector: ceph_mds_traverse_remote_ino
+                  name: traverse_remote_ino
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inode Work
+              context: inode_work
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_openino_peer_discover
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Key Work
+              context: key_work
+              units: keys/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_dir_fetch_keys
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Lookup Outcomes
+              context: lookup_outcomes
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_traverse_hit
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_dir_commit
+                  name: dir_commit
+                - selector: ceph_mds_openino_backtrace_fetch
+                  name: openino_backtrace_fetch
+                - selector: ceph_mds_openino_dir_fetch
+                  name: openino_dir_fetch
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Purge Queue
+          context_namespace: purge_queue
+          metrics:
+            - ceph_purge_queue_pq_executed
+            - ceph_purge_queue_pq_executed_ops
+            - ceph_purge_queue_pq_executing
+            - ceph_purge_queue_pq_executing_high_water
+            - ceph_purge_queue_pq_executing_ops
+            - ceph_purge_queue_pq_executing_ops_high_water
+            - ceph_purge_queue_pq_item_in_journal
+          charts:
+            - title: Current Work
+              context: current_work
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_item_in_journal
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Executed Purge Operations
+              context: purge_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_executed_ops
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Purge Operations in Flight
+              context: purge_operations_state
+              units: operations
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_executing_ops
+                  name: ops
+                - selector: ceph_purge_queue_pq_executing_ops_high_water
+                  name: high_water
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Executed Purge Tasks
+              context: purge_tasks
+              units: tasks/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_executed
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Purge Tasks in Flight
+              context: purge_tasks_state
+              units: tasks
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_executing
+                  name: executing
+                - selector: ceph_purge_queue_pq_executing_high_water
+                  name: high_water
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Rank Migration
+          context_namespace: rank_migration
+          metrics:
+            - ceph_mds_exported
+            - ceph_mds_exported_inodes
+            - ceph_mds_imported
+            - ceph_mds_imported_inodes
+          charts:
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_exported
+                  name: exported
+                - selector: ceph_mds_imported
+                  name: imported
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inode Work
+              context: inode_work
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_exported_inodes
+                  name: exported_inodes
+                - selector: ceph_mds_imported_inodes
+                  name: imported_inodes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Read Request Latency
+          context_namespace: read_request_latency
+          metrics:
+            - ceph_mds_server_req_blockdiff_latency_count
+            - ceph_mds_server_req_blockdiff_latency_sum
+            - ceph_mds_server_req_getattr_latency_count
+            - ceph_mds_server_req_getattr_latency_sum
+            - ceph_mds_server_req_getfilelock_latency_count
+            - ceph_mds_server_req_getfilelock_latency_sum
+            - ceph_mds_server_req_getvxattr_latency_count
+            - ceph_mds_server_req_getvxattr_latency_sum
+            - ceph_mds_server_req_lookup_latency_count
+            - ceph_mds_server_req_lookup_latency_sum
+            - ceph_mds_server_req_lookuphash_latency_count
+            - ceph_mds_server_req_lookuphash_latency_sum
+            - ceph_mds_server_req_lookupino_latency_count
+            - ceph_mds_server_req_lookupino_latency_sum
+            - ceph_mds_server_req_lookupname_latency_count
+            - ceph_mds_server_req_lookupname_latency_sum
+            - ceph_mds_server_req_lookupparent_latency_count
+            - ceph_mds_server_req_lookupparent_latency_sum
+            - ceph_mds_server_req_lookupsnap_latency_count
+            - ceph_mds_server_req_lookupsnap_latency_sum
+            - ceph_mds_server_req_open_latency_count
+            - ceph_mds_server_req_open_latency_sum
+            - ceph_mds_server_req_readdir_latency_count
+            - ceph_mds_server_req_readdir_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_blockdiff_latency_count
+                  name: blockdiff_latency
+                - selector: ceph_mds_server_req_getattr_latency_count
+                  name: getattr_latency
+                - selector: ceph_mds_server_req_getfilelock_latency_count
+                  name: getfilelock_latency
+                - selector: ceph_mds_server_req_getvxattr_latency_count
+                  name: getvxattr_latency
+                - selector: ceph_mds_server_req_lookup_latency_count
+                  name: lookup_latency
+                - selector: ceph_mds_server_req_lookuphash_latency_count
+                  name: lookuphash_latency
+                - selector: ceph_mds_server_req_lookupino_latency_count
+                  name: lookupino_latency
+                - selector: ceph_mds_server_req_lookupname_latency_count
+                  name: lookupname_latency
+                - selector: ceph_mds_server_req_lookupparent_latency_count
+                  name: lookupparent_latency
+                - selector: ceph_mds_server_req_lookupsnap_latency_count
+                  name: lookupsnap_latency
+                - selector: ceph_mds_server_req_open_latency_count
+                  name: open_latency
+                - selector: ceph_mds_server_req_readdir_latency_count
+                  name: readdir_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_blockdiff_latency_sum
+                  name: blockdiff_latency
+                - selector: ceph_mds_server_req_getattr_latency_sum
+                  name: getattr_latency
+                - selector: ceph_mds_server_req_getfilelock_latency_sum
+                  name: getfilelock_latency
+                - selector: ceph_mds_server_req_getvxattr_latency_sum
+                  name: getvxattr_latency
+                - selector: ceph_mds_server_req_lookup_latency_sum
+                  name: lookup_latency
+                - selector: ceph_mds_server_req_lookuphash_latency_sum
+                  name: lookuphash_latency
+                - selector: ceph_mds_server_req_lookupino_latency_sum
+                  name: lookupino_latency
+                - selector: ceph_mds_server_req_lookupname_latency_sum
+                  name: lookupname_latency
+                - selector: ceph_mds_server_req_lookupparent_latency_sum
+                  name: lookupparent_latency
+                - selector: ceph_mds_server_req_lookupsnap_latency_sum
+                  name: lookupsnap_latency
+                - selector: ceph_mds_server_req_open_latency_sum
+                  name: open_latency
+                - selector: ceph_mds_server_req_readdir_latency_sum
+                  name: readdir_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Request Handling and State
+          context_namespace: request_handling_and_state
+          metrics:
+            - ceph_mds_client_metrics_num_clients
+            - ceph_mds_forward
+            - ceph_mds_inodes
+            - ceph_mds_inodes_bottom
+            - ceph_mds_inodes_expired
+            - ceph_mds_inodes_pin_tail
+            - ceph_mds_inodes_pinned
+            - ceph_mds_inodes_top
+            - ceph_mds_load_cent
+            - ceph_mds_q
+            - ceph_mds_reply
+            - ceph_mds_reply_latency_count
+            - ceph_mds_reply_latency_sum
+            - ceph_mds_request
+            - ceph_mds_root_rbytes
+            - ceph_mds_root_rfiles
+            - ceph_mds_root_rsnaps
+            - ceph_mds_server_dispatch_client_request
+            - ceph_mds_server_dispatch_server_request
+            - ceph_mds_server_handle_client_request
+            - ceph_mds_server_handle_client_session
+            - ceph_mds_server_handle_peer_request
+            - ceph_mds_slow_reply
+            - ceph_mds_subtrees
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_reply_latency_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_reply_latency_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Connected Clients
+              context: connected_clients
+              units: clients
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_client_metrics_num_clients
+                  name: client_metrics_num_clients
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - fs_name
+                  - id
+                optional_by_labels: []
+            - title: Queued Requests
+              context: queued_requests
+              units: requests
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_q
+                  name: q
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_reply
+                  name: reply
+                - selector: ceph_mds_server_handle_client_session
+                  name: server_handle_client_session
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_slow_reply
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Files
+              context: file_state
+              units: files
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_root_rfiles
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inodes
+              context: inode_state
+              units: inodes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_inodes
+                  name: inodes
+                - selector: ceph_mds_inodes_bottom
+                  name: bottom
+                - selector: ceph_mds_inodes_pin_tail
+                  name: pin_tail
+                - selector: ceph_mds_inodes_pinned
+                  name: pinned
+                - selector: ceph_mds_inodes_top
+                  name: top
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Expired Inodes
+              context: expired_inodes
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_inodes_expired
+                  name: expired
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Load
+              context: load
+              units: load
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_load_cent
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_forward
+                  name: forward
+                - selector: ceph_mds_request
+                  name: request
+                - selector: ceph_mds_server_dispatch_client_request
+                  name: server_dispatch_client_request
+                - selector: ceph_mds_server_dispatch_server_request
+                  name: server_dispatch_server_request
+                - selector: ceph_mds_server_handle_client_request
+                  name: server_handle_client_request
+                - selector: ceph_mds_server_handle_peer_request
+                  name: server_handle_peer_request
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Snapshots
+              context: snapshot_state
+              units: snapshots
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_root_rsnaps
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_root_rbytes
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Subtrees
+              context: subtrees
+              units: subtrees
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_subtrees
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Scrubbing
+          context_namespace: scrubbing
+          metrics:
+            - ceph_mds_scrub_backtrace_fetch
+            - ceph_mds_scrub_backtrace_repaired
+            - ceph_mds_scrub_dir_base_inodes
+            - ceph_mds_scrub_dir_inodes
+            - ceph_mds_scrub_dirfrag_rstats
+            - ceph_mds_scrub_file_inodes
+            - ceph_mds_scrub_inotable_repaired
+            - ceph_mds_scrub_set_tag
+          charts:
+            - title: Scrubbed Inodes
+              context: scrubbed_inodes
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_dir_base_inodes
+                  name: dir_base_inodes
+                - selector: ceph_mds_scrub_dir_inodes
+                  name: dir_inodes
+                - selector: ceph_mds_scrub_file_inodes
+                  name: file_inodes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Backtrace Work
+              context: backtrace_work
+              units: backtraces/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_backtrace_fetch
+                  name: backtrace_fetch
+                - selector: ceph_mds_scrub_backtrace_repaired
+                  name: backtrace_repaired
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Repaired Inotables
+              context: repaired_inotables
+              units: inotables/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_inotable_repaired
+                  name: inotable_repaired
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Applied Scrub Tags
+              context: applied_tags
+              units: tags/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_set_tag
+                  name: set_tag
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Directory-Fragment Recursive-Stat Updates
+              context: dirfrag_rstat_updates
+              units: dirfrags/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_dirfrag_rstats
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Snapshot Mutation Latency
+          context_namespace: snapshot_mutation_latency
+          metrics:
+            - ceph_mds_server_req_lssnap_latency_count
+            - ceph_mds_server_req_lssnap_latency_sum
+            - ceph_mds_server_req_mksnap_latency_count
+            - ceph_mds_server_req_mksnap_latency_sum
+            - ceph_mds_server_req_renamesnap_latency_count
+            - ceph_mds_server_req_renamesnap_latency_sum
+            - ceph_mds_server_req_rmsnap_latency_count
+            - ceph_mds_server_req_rmsnap_latency_sum
+            - ceph_mds_server_req_snapdiff_latency_count
+            - ceph_mds_server_req_snapdiff_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_lssnap_latency_count
+                  name: lssnap_latency
+                - selector: ceph_mds_server_req_mksnap_latency_count
+                  name: mksnap_latency
+                - selector: ceph_mds_server_req_renamesnap_latency_count
+                  name: renamesnap_latency
+                - selector: ceph_mds_server_req_rmsnap_latency_count
+                  name: rmsnap_latency
+                - selector: ceph_mds_server_req_snapdiff_latency_count
+                  name: snapdiff_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_lssnap_latency_sum
+                  name: lssnap_latency
+                - selector: ceph_mds_server_req_mksnap_latency_sum
+                  name: mksnap_latency
+                - selector: ceph_mds_server_req_renamesnap_latency_sum
+                  name: renamesnap_latency
+                - selector: ceph_mds_server_req_rmsnap_latency_sum
+                  name: rmsnap_latency
+                - selector: ceph_mds_server_req_snapdiff_latency_sum
+                  name: snapdiff_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+    - family: CephFS MDS Memory
+      context_namespace: cephfs_mds_memory
       metrics:
-      - ceph_mds_metadata
+        - ceph_mds_mem_cap
+        - ceph_mds_mem_cap_minus
+        - ceph_mds_mem_cap_plus
+        - ceph_mds_mem_dir
+        - ceph_mds_mem_dir_minus
+        - ceph_mds_mem_dir_plus
+        - ceph_mds_mem_dn
+        - ceph_mds_mem_dn_minus
+        - ceph_mds_mem_dn_plus
+        - ceph_mds_mem_heap
+        - ceph_mds_mem_ino
+        - ceph_mds_mem_ino_minus
+        - ceph_mds_mem_ino_plus
+        - ceph_mds_mem_rss
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_metadata
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - ceph_version
-          - fs_id
-          - hostname
-          - public_addr
-          - rank
-          optional_by_labels: []
-  - family: Cluster Overview
-    context_namespace: cluster_overview
-    metrics:
-    - ceph_cluster_osd_blocklist_count
-    - ceph_disk_occupation
-    - ceph_disk_occupation_human
-    - ceph_prometheus_collect_duration_seconds_count
-    - ceph_prometheus_collect_duration_seconds_sum
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_prometheus_collect_duration_seconds_count
-        name: value
-      instances:
-        by_labels:
-        - method
-        optional_by_labels: []
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_prometheus_collect_duration_seconds_sum
-        name: value
-      instances:
-        by_labels:
-        - method
-        optional_by_labels: []
-    - title: Current Work
-      context: current_work
-      units: items
-      label_promotion: []
-      dimensions:
-      - selector: ceph_cluster_osd_blocklist_count
-        name: value
-    - title: State and Metadata — Occupation
-      context: state_occupation
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_disk_occupation
-        name: occupation
-      instances:
-        by_labels:
-        - ceph_daemon
-        - ceph_instance
-        - db_device
-        - device
-        - device_ids
-        - devices
-        - wal_device
-        optional_by_labels: []
-    - title: State and Metadata — Human
-      context: state_human
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_disk_occupation_human
-        name: human
-      instances:
-        by_labels:
-        - ceph_daemon
-        - ceph_instance
-        - device
-        optional_by_labels: []
-  - family: Control Plane
-    context_namespace: control_plane
-    groups:
-    - family: Cephadm
-      context_namespace: cephadm
+        - title: Capabilities
+          context: capability_state
+          units: capabilities
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_cap
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Capability Work
+          context: capability_work
+          units: capabilities/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_cap_minus
+              name: minus
+            - selector: ceph_mds_mem_cap_plus
+              name: plus
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Dentries
+          context: dentry_state
+          units: dentries
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_dn
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Dentry Cache Churn
+          context: dentry_work
+          units: dentries/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_dn_minus
+              name: minus
+            - selector: ceph_mds_mem_dn_plus
+              name: plus
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Directories
+          context: directory_state
+          units: directories
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_dir
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Directory Cache Churn
+          context: directory_work
+          units: directories/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_dir_minus
+              name: minus
+            - selector: ceph_mds_mem_dir_plus
+              name: plus
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Inodes
+          context: inode_state
+          units: inodes
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_ino
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Inode Work
+          context: inode_work
+          units: inodes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_ino_minus
+              name: minus
+            - selector: ceph_mds_mem_ino_plus
+              name: plus
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Space and Memory
+          context: space
+          units: bytes
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_heap
+              name: heap
+            - selector: ceph_mds_mem_rss
+              name: rss
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: CephFS MDS Sessions
+      context_namespace: cephfs_mds_sessions
       metrics:
-      - ceph_cephadm_daemon_status
+        - ceph_mds_sessions_average_load
+        - ceph_mds_sessions_avg_session_uptime
+        - ceph_mds_sessions_mdthresh_evicted
+        - ceph_mds_sessions_session_add
+        - ceph_mds_sessions_session_count
+        - ceph_mds_sessions_session_remove
+        - ceph_mds_sessions_sessions_open
+        - ceph_mds_sessions_sessions_stale
+        - ceph_mds_sessions_total_load
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephadm_daemon_status
-          name: value
-        instances:
-          by_labels:
-          - daemon_name
-          - hostname
-          - service_name
-          - service_type
-          optional_by_labels: []
-    - family: Manager
-      context_namespace: manager
+        - title: Duration and Time
+          context: duration
+          units: seconds
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_avg_session_uptime
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Events
+          context: events
+          units: events/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_session_add
+              name: add
+            - selector: ceph_mds_sessions_session_remove
+              name: remove
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Average Session Load
+          context: average_load
+          units: load
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_average_load
+              name: average_load
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Total Session Load
+          context: total_load
+          units: load
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_total_load
+              name: total_load
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Metadata-Threshold Evictions
+          context: metadata_threshold_evictions
+          units: sessions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_mdthresh_evicted
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Sessions
+          context: session_state
+          units: sessions
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_session_count
+              name: session
+            - selector: ceph_mds_sessions_sessions_open
+              name: sessions_open
+            - selector: ceph_mds_sessions_sessions_stale
+              name: sessions_stale
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: CephFS MDS Clients
+      context_namespace: cephfs_mds_clients
       metrics:
-      - ceph_mgr_metadata
-      - ceph_mgr_status
+        - ceph_mds_per_client_avg_metadata_latency
+        - ceph_mds_per_client_avg_read_latency
+        - ceph_mds_per_client_avg_write_latency
+        - ceph_mds_per_client_cap_hits
+        - ceph_mds_per_client_cap_miss
+        - ceph_mds_per_client_dentry_lease_hits
+        - ceph_mds_per_client_dentry_lease_miss
+        - ceph_mds_per_client_opened_files
+        - ceph_mds_per_client_opened_inodes
+        - ceph_mds_per_client_pinned_icaps
+        - ceph_mds_per_client_total_inodes
+        - ceph_mds_per_client_total_read_ops
+        - ceph_mds_per_client_total_read_size
+        - ceph_mds_per_client_total_write_ops
+        - ceph_mds_per_client_total_write_size
       charts:
-      - title: State and Metadata — Metadata
-        context: state_metadata
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mgr_metadata
-          name: metadata
-        instances:
-          by_labels:
-          - ceph_daemon
-          - ceph_version
-          - hostname
-          optional_by_labels: []
-      - title: State and Metadata — Status
-        context: state_status
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mgr_status
-          name: status
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Manager Modules
-      context_namespace: manager_modules
+        - title: Capability Access Outcomes
+          context: capability_outcomes
+          units: accesses/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_cap_hits
+              name: hits
+            - selector: ceph_mds_per_client_cap_miss
+              name: misses
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+          algorithm: incremental
+        - title: Dentry Lease Lookup Outcomes
+          context: dentry_lease_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_dentry_lease_hits
+              name: hits
+            - selector: ceph_mds_per_client_dentry_lease_miss
+              name: misses
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+          algorithm: incremental
+        - title: Average Operation Latency
+          context: average_operation_latency
+          units: seconds
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_avg_read_latency
+              name: read
+            - selector: ceph_mds_per_client_avg_write_latency
+              name: write
+            - selector: ceph_mds_per_client_avg_metadata_latency
+              name: metadata
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+        - title: Open Files
+          context: open_files
+          units: files
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_opened_files
+              name: open
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+        - title: Inode State
+          context: inode_state
+          units: inodes
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_opened_inodes
+              name: open
+            - selector: ceph_mds_per_client_total_inodes
+              name: total
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+        - title: Pinned Inode Capabilities
+          context: pinned_inode_capabilities
+          units: capabilities
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_pinned_icaps
+              name: pinned
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+        - title: Reported I/O Operations
+          context: reported_io_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_total_read_ops
+              name: read
+            - selector: ceph_mds_per_client_total_write_ops
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+          algorithm: incremental
+        - title: Reported I/O Volume
+          context: reported_io_volume
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_total_read_size
+              name: read
+            - selector: ceph_mds_per_client_total_write_size
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+          algorithm: incremental
+    - family: Exporter and Process Runtime
+      context_namespace: exporter_and_process_runtime
+      groups:
+        - family: Collection
+          context_namespace: collection
+          metrics:
+            - ceph_exporter_scrape_time
+          charts:
+            - title: Collection Duration
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_scrape_time
+                  name: duration
+              instances:
+                by_labels:
+                  - function
+                  - host
+                optional_by_labels: []
+        - family: Daemon Availability
+          context_namespace: daemon_availability
+          metrics:
+            - ceph_daemon_socket_up
+          charts:
+            - title: Daemon Socket State
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_daemon_socket_up
+                  name: reachable
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - hostname
+                optional_by_labels: []
+        - family: Daemon Processes
+          context_namespace: daemon_processes
+          metrics:
+            - ceph_exporter_cpu_total
+            - ceph_exporter_cpu_usage
+            - ceph_exporter_majflt_total
+            - ceph_exporter_minflt_total
+            - ceph_exporter_num_threads
+            - ceph_exporter_resident_size
+            - ceph_exporter_vm_size
+          charts:
+            - title: Page Faults
+              context: page_faults
+              units: faults/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_minflt_total
+                  name: minor
+                - selector: ceph_exporter_majflt_total
+                  name: major
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Threads
+              context: threads
+              units: threads
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_num_threads
+                  name: threads
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: CPU Utilization
+              context: cpu_utilization
+              units: percentage
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_cpu_usage
+                  name: utilization
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: CPU Time
+              context: cpu_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_cpu_total
+                  name_from_label: mode
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Memory
+              context: memory
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_vm_size
+                  name: virtual
+                - selector: ceph_exporter_resident_size
+                  name: resident
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Manager Daemons
+      context_namespace: manager_daemons
       metrics:
-      - ceph_mgr_module_can_run
-      - ceph_mgr_module_status
+        - ceph_mgr_cache_hit
+        - ceph_mgr_cache_miss
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mgr_module_can_run
-          name: can_run
-        - selector: ceph_mgr_module_status
-          name: status
-        instances:
-          by_labels:
-          - name
-          optional_by_labels: []
-    - family: Monitor
-      context_namespace: monitor
+        - title: Lookup Outcomes
+          context: lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mgr_cache_hit
+              name: hit
+            - selector: ceph_mgr_cache_miss
+              name: miss
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: Messenger
+      context_namespace: messenger
       metrics:
-      - ceph_mon_metadata
-      - ceph_mon_quorum_status
+        - ceph_AsyncMessenger_RDMADispatcher_active_queue_pair
+        - ceph_AsyncMessenger_RDMADispatcher_async_last_wqe_events
+        - ceph_AsyncMessenger_RDMADispatcher_created_queue_pair
+        - ceph_AsyncMessenger_RDMADispatcher_handshake_errors
+        - ceph_AsyncMessenger_RDMADispatcher_inflight_tx_chunks
+        - ceph_AsyncMessenger_RDMADispatcher_polling
+        - ceph_AsyncMessenger_RDMADispatcher_rx_bufs_in_use
+        - ceph_AsyncMessenger_RDMADispatcher_rx_bufs_total
+        - ceph_AsyncMessenger_RDMADispatcher_rx_fin
+        - ceph_AsyncMessenger_RDMADispatcher_rx_total_wc
+        - ceph_AsyncMessenger_RDMADispatcher_rx_total_wc_errors
+        - ceph_AsyncMessenger_RDMADispatcher_total_async_events
+        - ceph_AsyncMessenger_RDMADispatcher_tx_retry_errors
+        - ceph_AsyncMessenger_RDMADispatcher_tx_total_wc
+        - ceph_AsyncMessenger_RDMADispatcher_tx_total_wc_errors
+        - ceph_AsyncMessenger_RDMADispatcher_tx_wr_flush_errors
+        - ceph_AsyncMessenger_Worker_msgr_connection_idle_timeouts
+        - ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
       charts:
-      - title: State and Metadata — Metadata
-        context: state_metadata
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mon_metadata
-          name: metadata
-        instances:
-          by_labels:
-          - ceph_daemon
-          - ceph_version
-          - hostname
-          - public_addr
-          - rank
-          optional_by_labels: []
-      - title: State and Metadata — Quorum Status
-        context: state_quorum_status
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mon_quorum_status
-          name: quorum_status
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Paxos
-      context_namespace: paxos
+        - title: RDMA Errors
+          context: rdma_errors
+          units: errors/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_handshake_errors
+              name: rdmadispatcher_handshake_errors
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_total_wc_errors
+              name: rdmadispatcher_rx_total_wc_errors
+            - selector: ceph_AsyncMessenger_RDMADispatcher_tx_retry_errors
+              name: rdmadispatcher_tx_retry_errors
+            - selector: ceph_AsyncMessenger_RDMADispatcher_tx_total_wc_errors
+              name: rdmadispatcher_tx_total_wc_errors
+            - selector: ceph_AsyncMessenger_RDMADispatcher_tx_wr_flush_errors
+              name: rdmadispatcher_tx_wr_flush_errors
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Connection Timeouts
+          context: connection_timeouts
+          units: connections/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_Worker_msgr_connection_idle_timeouts
+              name: worker_msgr_connection_idle_timeouts
+            - selector: ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
+              name: worker_msgr_connection_ready_timeouts
+          instances:
+            by_labels:
+              - ceph_daemon
+              - id
+              - instance_id
+            optional_by_labels: []
+        - title: Active Queue Pairs
+          context: active_queue_pairs
+          units: queue pairs
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_active_queue_pair
+              name: active_queue_pair
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: absolute
+        - title: Created Queue Pairs
+          context: created_queue_pairs
+          units: queue pairs/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_created_queue_pair
+              name: created_queue_pair
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: In-Flight Transmit Chunks
+          context: inflight_tx_chunks
+          units: chunks
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_inflight_tx_chunks
+              name: inflight_tx_chunks
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: absolute
+        - title: Polling State
+          context: polling_state
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_polling
+              name: polling
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: absolute
+        - title: Receive Buffers
+          context: receive_buffers
+          units: buffers
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_bufs_in_use
+              name: rx_bufs_in_use
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_bufs_total
+              name: rx_bufs
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: absolute
+        - title: Asynchronous Events
+          context: async_events
+          units: events/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_async_last_wqe_events
+              name: async_last_wqe_events
+            - selector: ceph_AsyncMessenger_RDMADispatcher_total_async_events
+              name: total_async_events
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Work Completions
+          context: work_completions
+          units: completions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_total_wc
+              name: rx_total_wc
+            - selector: ceph_AsyncMessenger_RDMADispatcher_tx_total_wc
+              name: tx_total_wc
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Received FIN Messages
+          context: received_fin_messages
+          units: messages/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_fin
+              name: rx_fin
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: Monitor Daemons
+      context_namespace: monitor_daemons
       metrics:
-      - ceph_paxos_accept_timeout
-      - ceph_paxos_begin
-      - ceph_paxos_begin_bytes_count
-      - ceph_paxos_begin_bytes_sum
-      - ceph_paxos_begin_keys_count
-      - ceph_paxos_begin_keys_sum
-      - ceph_paxos_begin_latency_count
-      - ceph_paxos_begin_latency_sum
-      - ceph_paxos_collect
-      - ceph_paxos_collect_bytes_count
-      - ceph_paxos_collect_bytes_sum
-      - ceph_paxos_collect_keys_count
-      - ceph_paxos_collect_keys_sum
-      - ceph_paxos_collect_latency_count
-      - ceph_paxos_collect_latency_sum
-      - ceph_paxos_collect_timeout
-      - ceph_paxos_collect_uncommitted
-      - ceph_paxos_commit
-      - ceph_paxos_commit_bytes_count
-      - ceph_paxos_commit_bytes_sum
-      - ceph_paxos_commit_keys_count
-      - ceph_paxos_commit_keys_sum
-      - ceph_paxos_commit_latency_count
-      - ceph_paxos_commit_latency_sum
-      - ceph_paxos_lease_ack_timeout
-      - ceph_paxos_lease_timeout
-      - ceph_paxos_new_pn
-      - ceph_paxos_new_pn_latency_count
-      - ceph_paxos_new_pn_latency_sum
-      - ceph_paxos_refresh
-      - ceph_paxos_refresh_latency_count
-      - ceph_paxos_refresh_latency_sum
-      - ceph_paxos_restart
-      - ceph_paxos_share_state
-      - ceph_paxos_share_state_bytes_count
-      - ceph_paxos_share_state_bytes_sum
-      - ceph_paxos_share_state_keys_count
-      - ceph_paxos_share_state_keys_sum
-      - ceph_paxos_start_leader
-      - ceph_paxos_start_peon
-      - ceph_paxos_store_state
-      - ceph_paxos_store_state_bytes_count
-      - ceph_paxos_store_state_bytes_sum
-      - ceph_paxos_store_state_keys_count
-      - ceph_paxos_store_state_keys_sum
-      - ceph_paxos_store_state_latency_count
-      - ceph_paxos_store_state_latency_sum
+        - ceph_mon_election_call
+        - ceph_mon_election_lose
+        - ceph_mon_election_win
+        - ceph_mon_num_elections
+        - ceph_mon_num_sessions
+        - ceph_mon_session_add
+        - ceph_mon_session_rm
+        - ceph_mon_session_trim
       charts:
-      - title: Byte Measurement Measurements
-        context: bytes_measurements
-        units: measurements/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_bytes_count
-          name: begin_bytes
-        - selector: ceph_paxos_collect_bytes_count
-          name: collect_bytes
-        - selector: ceph_paxos_commit_bytes_count
-          name: commit_bytes
-        - selector: ceph_paxos_share_state_bytes_count
-          name: share_state_bytes
-        - selector: ceph_paxos_store_state_bytes_count
-          name: store_state_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Byte Measurement
-        context: accumulated_bytes
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_bytes_sum
-          name: begin_bytes
-        - selector: ceph_paxos_collect_bytes_sum
-          name: collect_bytes
-        - selector: ceph_paxos_commit_bytes_sum
-          name: commit_bytes
-        - selector: ceph_paxos_share_state_bytes_sum
-          name: share_state_bytes
-        - selector: ceph_paxos_store_state_bytes_sum
-          name: store_state_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Key Measurement Measurements
-        context: keys_measurements
-        units: measurements/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_keys_count
-          name: begin_keys
-        - selector: ceph_paxos_collect_keys_count
-          name: collect_keys
-        - selector: ceph_paxos_commit_keys_count
-          name: commit_keys
-        - selector: ceph_paxos_share_state_keys_count
-          name: share_state_keys
-        - selector: ceph_paxos_store_state_keys_count
-          name: store_state_keys
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Key Measurement
-        context: accumulated_keys
-        units: keys/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_keys_sum
-          name: begin_keys
-        - selector: ceph_paxos_collect_keys_sum
-          name: collect_keys
-        - selector: ceph_paxos_commit_keys_sum
-          name: commit_keys
-        - selector: ceph_paxos_share_state_keys_sum
-          name: share_state_keys
-        - selector: ceph_paxos_store_state_keys_sum
-          name: store_state_keys
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_latency_count
-          name: begin_latency
-        - selector: ceph_paxos_collect_latency_count
-          name: collect_latency
-        - selector: ceph_paxos_commit_latency_count
-          name: commit_latency
-        - selector: ceph_paxos_new_pn_latency_count
-          name: new_pn_latency
-        - selector: ceph_paxos_refresh_latency_count
-          name: refresh_latency
-        - selector: ceph_paxos_store_state_latency_count
-          name: store_state_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_latency_sum
-          name: begin_latency
-        - selector: ceph_paxos_collect_latency_sum
-          name: collect_latency
-        - selector: ceph_paxos_commit_latency_sum
-          name: commit_latency
-        - selector: ceph_paxos_new_pn_latency_sum
-          name: new_pn_latency
-        - selector: ceph_paxos_refresh_latency_sum
-          name: refresh_latency
-        - selector: ceph_paxos_store_state_latency_sum
-          name: store_state_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_new_pn
-          name: new_pn
-        - selector: ceph_paxos_refresh
-          name: refresh
-        - selector: ceph_paxos_restart
-          name: restart
-        - selector: ceph_paxos_share_state
-          name: share_state
-        - selector: ceph_paxos_start_leader
-          name: start_leader
-        - selector: ceph_paxos_start_peon
-          name: start_peon
-        - selector: ceph_paxos_store_state
-          name: store_state
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_accept_timeout
-          name: accept_timeout
-        - selector: ceph_paxos_collect_timeout
-          name: collect_timeout
-        - selector: ceph_paxos_lease_ack_timeout
-          name: lease_ack_timeout
-        - selector: ceph_paxos_lease_timeout
-          name: lease_timeout
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Paxos Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin
-          name: begin
-        - selector: ceph_paxos_collect
-          name: collect
-        - selector: ceph_paxos_commit
-          name: commit
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Collected Uncommitted Values
-        context: collected_uncommitted_values
-        units: values/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_collect_uncommitted
-          name: collect_uncommitted
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Health
-    context_namespace: health
-    groups:
-    - family: Cluster Status
-      context_namespace: cluster_status
+        - title: Elections
+          context: elections
+          units: elections/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mon_election_call
+              name: election_call
+            - selector: ceph_mon_election_lose
+              name: election_lose
+            - selector: ceph_mon_election_win
+              name: election_win
+            - selector: ceph_mon_num_elections
+              name: num_elections
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Sessions
+          context: session_state
+          units: sessions
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mon_num_sessions
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Session Churn
+          context: session_work
+          units: sessions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mon_session_add
+              name: add
+            - selector: ceph_mon_session_rm
+              name: rm
+            - selector: ceph_mon_session_trim
+              name: trim
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: OSD Client I/O
+      context_namespace: osd_client_i_o
       metrics:
-      - ceph_health_status
+        - ceph_osd_op
+        - ceph_osd_op_before_dequeue_op_lat_count
+        - ceph_osd_op_before_dequeue_op_lat_sum
+        - ceph_osd_op_before_queue_op_lat_count
+        - ceph_osd_op_before_queue_op_lat_sum
+        - ceph_osd_op_cache_hit
+        - ceph_osd_op_delayed_degraded
+        - ceph_osd_op_delayed_unreadable
+        - ceph_osd_op_in_bytes
+        - ceph_osd_op_latency_count
+        - ceph_osd_op_latency_sum
+        - ceph_osd_op_out_bytes
+        - ceph_osd_op_prepare_latency_count
+        - ceph_osd_op_prepare_latency_sum
+        - ceph_osd_op_process_latency_count
+        - ceph_osd_op_process_latency_sum
+        - ceph_osd_op_r
+        - ceph_osd_op_r_latency_count
+        - ceph_osd_op_r_latency_sum
+        - ceph_osd_op_r_out_bytes
+        - ceph_osd_op_r_prepare_latency_count
+        - ceph_osd_op_r_prepare_latency_sum
+        - ceph_osd_op_r_process_latency_count
+        - ceph_osd_op_r_process_latency_sum
+        - ceph_osd_op_rw
+        - ceph_osd_op_rw_in_bytes
+        - ceph_osd_op_rw_latency_count
+        - ceph_osd_op_rw_latency_sum
+        - ceph_osd_op_rw_out_bytes
+        - ceph_osd_op_rw_prepare_latency_count
+        - ceph_osd_op_rw_prepare_latency_sum
+        - ceph_osd_op_rw_process_latency_count
+        - ceph_osd_op_rw_process_latency_sum
+        - ceph_osd_op_w
+        - ceph_osd_op_w_in_bytes
+        - ceph_osd_op_w_latency_count
+        - ceph_osd_op_w_latency_sum
+        - ceph_osd_op_w_prepare_latency_count
+        - ceph_osd_op_w_prepare_latency_sum
+        - ceph_osd_op_w_process_latency_count
+        - ceph_osd_op_w_process_latency_sum
+        - ceph_osd_op_wip
+        - ceph_osd_replica_read
+        - ceph_osd_replica_read_redirect_conflict
+        - ceph_osd_replica_read_redirect_missing
+        - ceph_osd_replica_read_served
+        - ceph_osd_slow_ops_slow_ops_count
+        - ceph_osd_subop_in_bytes
+        - ceph_osd_subop_latency_count
+        - ceph_osd_subop_latency_sum
+        - ceph_osd_subop_pull
+        - ceph_osd_subop_pull_latency_count
+        - ceph_osd_subop_pull_latency_sum
+        - ceph_osd_subop_push
+        - ceph_osd_subop_push_in_bytes
+        - ceph_osd_subop_push_latency_count
+        - ceph_osd_subop_push_latency_sum
+        - ceph_osd_subop_w
+        - ceph_osd_subop_w_in_bytes
+        - ceph_osd_subop_w_latency_count
+        - ceph_osd_subop_w_latency_sum
+        - ceph_osd_tier_proxy_read
+        - ceph_osd_tier_proxy_write
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_health_status
-          name: value
-    - family: Daemon Health
-      context_namespace: daemon_health
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_before_dequeue_op_lat_count
+              name: op_before_dequeue_op_lat
+            - selector: ceph_osd_op_before_queue_op_lat_count
+              name: op_before_queue_op_lat
+            - selector: ceph_osd_op_latency_count
+              name: op_latency
+            - selector: ceph_osd_op_prepare_latency_count
+              name: op_prepare_latency
+            - selector: ceph_osd_op_process_latency_count
+              name: op_process_latency
+            - selector: ceph_osd_op_r_latency_count
+              name: op_r_latency
+            - selector: ceph_osd_op_r_prepare_latency_count
+              name: op_r_prepare_latency
+            - selector: ceph_osd_op_r_process_latency_count
+              name: op_r_process_latency
+            - selector: ceph_osd_op_rw_latency_count
+              name: op_rw_latency
+            - selector: ceph_osd_op_rw_prepare_latency_count
+              name: op_rw_prepare_latency
+            - selector: ceph_osd_op_rw_process_latency_count
+              name: op_rw_process_latency
+            - selector: ceph_osd_op_w_latency_count
+              name: op_w_latency
+            - selector: ceph_osd_op_w_prepare_latency_count
+              name: op_w_prepare_latency
+            - selector: ceph_osd_op_w_process_latency_count
+              name: op_w_process_latency
+            - selector: ceph_osd_subop_latency_count
+              name: subop_latency
+            - selector: ceph_osd_subop_pull_latency_count
+              name: subop_pull_latency
+            - selector: ceph_osd_subop_push_latency_count
+              name: subop_push_latency
+            - selector: ceph_osd_subop_w_latency_count
+              name: subop_w_latency
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_before_dequeue_op_lat_sum
+              name: op_before_dequeue_op_lat
+            - selector: ceph_osd_op_before_queue_op_lat_sum
+              name: op_before_queue_op_lat
+            - selector: ceph_osd_op_latency_sum
+              name: op_latency
+            - selector: ceph_osd_op_prepare_latency_sum
+              name: op_prepare_latency
+            - selector: ceph_osd_op_process_latency_sum
+              name: op_process_latency
+            - selector: ceph_osd_op_r_latency_sum
+              name: op_r_latency
+            - selector: ceph_osd_op_r_prepare_latency_sum
+              name: op_r_prepare_latency
+            - selector: ceph_osd_op_r_process_latency_sum
+              name: op_r_process_latency
+            - selector: ceph_osd_op_rw_latency_sum
+              name: op_rw_latency
+            - selector: ceph_osd_op_rw_prepare_latency_sum
+              name: op_rw_prepare_latency
+            - selector: ceph_osd_op_rw_process_latency_sum
+              name: op_rw_process_latency
+            - selector: ceph_osd_op_w_latency_sum
+              name: op_w_latency
+            - selector: ceph_osd_op_w_prepare_latency_sum
+              name: op_w_prepare_latency
+            - selector: ceph_osd_op_w_process_latency_sum
+              name: op_w_process_latency
+            - selector: ceph_osd_subop_latency_sum
+              name: subop_latency
+            - selector: ceph_osd_subop_pull_latency_sum
+              name: subop_pull_latency
+            - selector: ceph_osd_subop_push_latency_sum
+              name: subop_push_latency
+            - selector: ceph_osd_subop_w_latency_sum
+              name: subop_w_latency
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Byte Throughput
+          context: byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_in_bytes
+              name: op_in_bytes
+            - selector: ceph_osd_op_out_bytes
+              name: op_out_bytes
+            - selector: ceph_osd_op_r_out_bytes
+              name: op_r_out_bytes
+            - selector: ceph_osd_op_rw_in_bytes
+              name: op_rw_in_bytes
+            - selector: ceph_osd_op_rw_out_bytes
+              name: op_rw_out_bytes
+            - selector: ceph_osd_op_w_in_bytes
+              name: op_w_in_bytes
+            - selector: ceph_osd_subop_in_bytes
+              name: subop_in_bytes
+            - selector: ceph_osd_subop_push_in_bytes
+              name: subop_push_in_bytes
+            - selector: ceph_osd_subop_w_in_bytes
+              name: subop_w_in_bytes
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Operations in Progress
+          context: current_operations
+          units: operations
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_wip
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Events
+          context: events
+          units: events/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_subop_push
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Failure and Delay Outcomes
+          context: failure_outcomes
+          units: events/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_slow_ops_slow_ops_count
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Lookup Outcomes
+          context: lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_cache_hit
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Object Work
+          context: object_work
+          units: objects/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_delayed_degraded
+              name: op_delayed_degraded
+            - selector: ceph_osd_op_delayed_unreadable
+              name: op_delayed_unreadable
+            - selector: ceph_osd_replica_read_redirect_missing
+              name: replica_read_redirect_missing
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Operations
+          context: operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op
+              name: op
+            - selector: ceph_osd_op_r
+              name: op_r
+            - selector: ceph_osd_op_rw
+              name: op_rw
+            - selector: ceph_osd_op_w
+              name: op_w
+            - selector: ceph_osd_replica_read
+              name: replica_read
+            - selector: ceph_osd_replica_read_redirect_conflict
+              name: replica_read_redirect_conflict
+            - selector: ceph_osd_replica_read_served
+              name: replica_read_served
+            - selector: ceph_osd_subop_pull
+              name: subop_pull
+            - selector: ceph_osd_subop_w
+              name: subop_w
+            - selector: ceph_osd_tier_proxy_read
+              name: tier_proxy_read
+            - selector: ceph_osd_tier_proxy_write
+              name: tier_proxy_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: OSD Recovery
+      context_namespace: osd_recovery
       metrics:
-      - ceph_daemon_health_metrics
+        - ceph_osd_l_osd_recovery_backfill_queue_latency_count
+        - ceph_osd_l_osd_recovery_backfill_queue_latency_sum
+        - ceph_osd_l_osd_recovery_backfill_remove_queue_latency_count
+        - ceph_osd_l_osd_recovery_backfill_remove_queue_latency_sum
+        - ceph_osd_l_osd_recovery_context_queue_latency_count
+        - ceph_osd_l_osd_recovery_context_queue_latency_sum
+        - ceph_osd_l_osd_recovery_pull_queue_latency_count
+        - ceph_osd_l_osd_recovery_pull_queue_latency_sum
+        - ceph_osd_l_osd_recovery_push_queue_latency_count
+        - ceph_osd_l_osd_recovery_push_queue_latency_sum
+        - ceph_osd_l_osd_recovery_push_reply_queue_latency_count
+        - ceph_osd_l_osd_recovery_push_reply_queue_latency_sum
+        - ceph_osd_l_osd_recovery_queue_latency_count
+        - ceph_osd_l_osd_recovery_queue_latency_sum
+        - ceph_osd_l_osd_recovery_scan_queue_latency_count
+        - ceph_osd_l_osd_recovery_scan_queue_latency_sum
+        - ceph_osd_recovery_bytes
+        - ceph_osd_recovery_ops
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_daemon_health_metrics
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - type
-          optional_by_labels: []
-    - family: Health Checks
-      context_namespace: health_checks
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_l_osd_recovery_backfill_queue_latency_count
+              name: backfill_queue_latency
+            - selector: ceph_osd_l_osd_recovery_backfill_remove_queue_latency_count
+              name: backfill_remove_queue_latency
+            - selector: ceph_osd_l_osd_recovery_context_queue_latency_count
+              name: context_queue_latency
+            - selector: ceph_osd_l_osd_recovery_pull_queue_latency_count
+              name: pull_queue_latency
+            - selector: ceph_osd_l_osd_recovery_push_queue_latency_count
+              name: push_queue_latency
+            - selector: ceph_osd_l_osd_recovery_push_reply_queue_latency_count
+              name: push_reply_queue_latency
+            - selector: ceph_osd_l_osd_recovery_queue_latency_count
+              name: queue_latency
+            - selector: ceph_osd_l_osd_recovery_scan_queue_latency_count
+              name: scan_queue_latency
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_l_osd_recovery_backfill_queue_latency_sum
+              name: backfill_queue_latency
+            - selector: ceph_osd_l_osd_recovery_backfill_remove_queue_latency_sum
+              name: backfill_remove_queue_latency
+            - selector: ceph_osd_l_osd_recovery_context_queue_latency_sum
+              name: context_queue_latency
+            - selector: ceph_osd_l_osd_recovery_pull_queue_latency_sum
+              name: pull_queue_latency
+            - selector: ceph_osd_l_osd_recovery_push_queue_latency_sum
+              name: push_queue_latency
+            - selector: ceph_osd_l_osd_recovery_push_reply_queue_latency_sum
+              name: push_reply_queue_latency
+            - selector: ceph_osd_l_osd_recovery_queue_latency_sum
+              name: queue_latency
+            - selector: ceph_osd_l_osd_recovery_scan_queue_latency_sum
+              name: scan_queue_latency
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Byte Throughput
+          context: byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_recovery_bytes
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Operations
+          context: operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_recovery_ops
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: OSD Runtime
+      context_namespace: osd_runtime
       metrics:
-      - ceph_health_detail
+        - ceph_osd_agent_evict
+        - ceph_osd_agent_flush
+        - ceph_osd_agent_skip
+        - ceph_osd_agent_wake
+        - ceph_osd_cached_crc
+        - ceph_osd_cached_crc_adjusted
+        - ceph_osd_copyfrom
+        - ceph_osd_heartbeat_to_peers
+        - ceph_osd_loadavg
+        - ceph_osd_map_message_epoch_dups
+        - ceph_osd_map_message_epochs
+        - ceph_osd_map_messages
+        - ceph_osd_messages_delayed_for_map
+        - ceph_osd_missed_crc
+        - ceph_osd_numpg
+        - ceph_osd_numpg_primary
+        - ceph_osd_numpg_removing
+        - ceph_osd_numpg_replica
+        - ceph_osd_numpg_stray
+        - ceph_osd_object_ctx_cache_hit
+        - ceph_osd_object_ctx_cache_total
+        - ceph_osd_osd_map_bl_cache_hit
+        - ceph_osd_osd_map_bl_cache_miss
+        - ceph_osd_osd_map_cache_hit
+        - ceph_osd_osd_map_cache_miss
+        - ceph_osd_osd_map_cache_miss_low
+        - ceph_osd_osd_map_cache_miss_low_avg_count
+        - ceph_osd_osd_map_cache_miss_low_avg_sum
+        - ceph_osd_osd_pg_biginfo
+        - ceph_osd_osd_pg_fastinfo
+        - ceph_osd_osd_pg_info
+        - ceph_osd_osd_tier_flush_lat_count
+        - ceph_osd_osd_tier_flush_lat_sum
+        - ceph_osd_osd_tier_promote_lat_count
+        - ceph_osd_osd_tier_promote_lat_sum
+        - ceph_osd_osd_tier_r_lat_count
+        - ceph_osd_osd_tier_r_lat_sum
+        - ceph_osd_pull
+        - ceph_osd_push
+        - ceph_osd_push_out_bytes
+        - ceph_osd_stat_bytes
+        - ceph_osd_stat_bytes_avail
+        - ceph_osd_stat_bytes_used
+        - ceph_osd_subop
+        - ceph_osd_tier_clean
+        - ceph_osd_tier_delay
+        - ceph_osd_tier_dirty
+        - ceph_osd_tier_evict
+        - ceph_osd_tier_flush
+        - ceph_osd_tier_flush_fail
+        - ceph_osd_tier_promote
+        - ceph_osd_tier_try_flush
+        - ceph_osd_tier_try_flush_fail
+        - ceph_osd_tier_whiteout
+        - ceph_osd_watch_timeouts
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_health_detail
-          name: value
-        instances:
-          by_labels:
-          - name
-          - severity
-          optional_by_labels: []
-    - family: Slow Operations
-      context_namespace: slow_operations
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_tier_flush_lat_count
+              name: flush_lat
+            - selector: ceph_osd_osd_tier_promote_lat_count
+              name: promote_lat
+            - selector: ceph_osd_osd_tier_r_lat_count
+              name: r_lat
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_tier_flush_lat_sum
+              name: flush_lat
+            - selector: ceph_osd_osd_tier_promote_lat_sum
+              name: promote_lat
+            - selector: ceph_osd_osd_tier_r_lat_sum
+              name: r_lat
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Value Measurement Measurements
+          context: value_measurements
+          units: measurements/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_map_cache_miss_low_avg_count
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Value Measurement
+          context: accumulated_value
+          units: value/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_map_cache_miss_low_avg_sum
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Byte Throughput
+          context: byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_push_out_bytes
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: CRC Cache Lookup Outcomes
+          context: crc_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_cached_crc
+              name: cached_crc
+            - selector: ceph_osd_cached_crc_adjusted
+              name: cached_crc_adjusted
+            - selector: ceph_osd_missed_crc
+              name: missed_crc
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Tier-Agent Actions
+          context: tier_agent_actions
+          units: actions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_agent_evict
+              name: agent_evict
+            - selector: ceph_osd_agent_wake
+              name: agent_wake
+            - selector: ceph_osd_tier_clean
+              name: tier_clean
+            - selector: ceph_osd_tier_delay
+              name: tier_delay
+            - selector: ceph_osd_tier_dirty
+              name: tier_dirty
+            - selector: ceph_osd_tier_evict
+              name: tier_evict
+            - selector: ceph_osd_tier_promote
+              name: tier_promote
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Copy-From Operations
+          context: copyfrom_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_copyfrom
+              name: copyfrom
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: OSD-Map Messages
+          context: map_messages
+          units: messages/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_map_messages
+              name: map_messages
+            - selector: ceph_osd_messages_delayed_for_map
+              name: messages_delayed_for_map
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: OSD-Map Epochs
+          context: map_epochs
+          units: epochs/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_map_message_epochs
+              name: map_message_epochs
+            - selector: ceph_osd_map_message_epoch_dups
+              name: map_message_epoch_dups
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Placement-Group Updates
+          context: pg_updates
+          units: updates/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_pg_biginfo
+              name: osd_pg_biginfo
+            - selector: ceph_osd_osd_pg_fastinfo
+              name: osd_pg_fastinfo
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Total Placement-Group Updates
+          context: pg_updates_total
+          units: placement group updates/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_pg_info
+              name: total
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Pushes
+          context: pushes
+          units: pushes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_push
+              name: push
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Suboperations
+          context: suboperations
+          units: suboperations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_subop
+              name: subop
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Failed Tier Flush Attempts
+          context: failed_tier_flush_attempts
+          units: attempts/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_tier_flush_fail
+              name: tier_flush_fail
+            - selector: ceph_osd_tier_try_flush_fail
+              name: tier_try_flush_fail
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Watch Timeouts
+          context: watch_timeouts
+          units: watches/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_watch_timeouts
+              name: watch_timeouts
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: OSD-Map Buffer-Cache Lookup Outcomes
+          context: map_buffer_cache_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_map_bl_cache_hit
+              name: osd_map_bl_cache_hit
+            - selector: ceph_osd_osd_map_bl_cache_miss
+              name: osd_map_bl_cache_miss
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Decoded OSD-Map Cache Lookup Outcomes
+          context: map_cache_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_map_cache_hit
+              name: osd_map_cache_hit
+            - selector: ceph_osd_osd_map_cache_miss
+              name: osd_map_cache_miss
+            - selector: ceph_osd_osd_map_cache_miss_low
+              name: osd_map_cache_miss_low
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Tier Whiteouts
+          context: tier_whiteouts
+          units: whiteouts/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_tier_whiteout
+              name: tier_whiteout
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Skipped Objects
+          context: skipped_objects
+          units: objects/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_agent_skip
+              name: agent_skip
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Object-Context Cache Lookup Outcomes
+          context: object_context_cache_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_object_ctx_cache_hit
+              name: object_ctx_cache_hit
+            - selector: ceph_osd_object_ctx_cache_total
+              name: object_ctx_cache
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Tier Flush Attempts
+          context: tier_flush_attempts
+          units: attempts/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_agent_flush
+              name: agent_flush
+            - selector: ceph_osd_tier_flush
+              name: tier_flush
+            - selector: ceph_osd_tier_try_flush
+              name: tier_try_flush
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Pulls
+          context: pulls
+          units: pulls/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_pull
+              name: pull
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Placement Groups
+          context: pg_state
+          units: PGs
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_numpg
+              name: numpg
+            - selector: ceph_osd_numpg_primary
+              name: primary
+            - selector: ceph_osd_numpg_removing
+              name: removing
+            - selector: ceph_osd_numpg_replica
+              name: replica
+            - selector: ceph_osd_numpg_stray
+              name: stray
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Space and Memory
+          context: space
+          units: bytes
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_stat_bytes
+              name: bytes
+            - selector: ceph_osd_stat_bytes_avail
+              name: avail
+            - selector: ceph_osd_stat_bytes_used
+              name: used
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Heartbeat Peers
+          context: heartbeat_peers
+          units: peers
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_heartbeat_to_peers
+              name: heartbeat_to_peers
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: OSD Load Average
+          context: load_average
+          units: load
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_loadavg
+              name: loadavg
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: OSD Scrubbing - Ceph 19
+      context_namespace: osd_scrubbing_ceph_19
+      groups:
+        - family: Elapsed Time
+          context_namespace: elapsed_time
+          metrics:
+            - ceph_osd_scrub_dp_ec_failed_reservations_elapsed_count
+            - ceph_osd_scrub_dp_ec_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_count
+            - ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_sum
+            - ceph_osd_scrub_dp_ec_successful_reservations_elapsed_count
+            - ceph_osd_scrub_dp_ec_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_count
+            - ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_sum
+            - ceph_osd_scrub_dp_repl_failed_reservations_elapsed_count
+            - ceph_osd_scrub_dp_repl_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_count
+            - ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_sum
+            - ceph_osd_scrub_dp_repl_successful_reservations_elapsed_count
+            - ceph_osd_scrub_dp_repl_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_count
+            - ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_sum
+            - ceph_osd_scrub_sh_ec_failed_reservations_elapsed_count
+            - ceph_osd_scrub_sh_ec_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_count
+            - ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_sum
+            - ceph_osd_scrub_sh_ec_successful_reservations_elapsed_count
+            - ceph_osd_scrub_sh_ec_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_count
+            - ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_sum
+            - ceph_osd_scrub_sh_repl_failed_reservations_elapsed_count
+            - ceph_osd_scrub_sh_repl_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_count
+            - ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_sum
+            - ceph_osd_scrub_sh_repl_successful_reservations_elapsed_count
+            - ceph_osd_scrub_sh_repl_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_count
+            - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
+          charts:
+            - title: Scrub Elapsed-Time Measurements
+              context: scrub_latency_measurements
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_count
+                  name: dp_ec_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_count
+                  name: dp_ec_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_count
+                  name: dp_repl_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_count
+                  name: dp_repl_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_count
+                  name: sh_ec_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_count
+                  name: sh_ec_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_count
+                  name: sh_repl_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_count
+                  name: sh_repl_successful_scrubs_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Reservation Elapsed-Time Measurements
+              context: reservation_latency_measurements
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_reservations_elapsed_count
+                  name: dp_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_ec_successful_reservations_elapsed_count
+                  name: dp_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_repl_failed_reservations_elapsed_count
+                  name: dp_repl_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_repl_successful_reservations_elapsed_count
+                  name: dp_repl_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_ec_failed_reservations_elapsed_count
+                  name: sh_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_ec_successful_reservations_elapsed_count
+                  name: sh_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_repl_failed_reservations_elapsed_count
+                  name: sh_repl_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_repl_successful_reservations_elapsed_count
+                  name: sh_repl_successful_reservations_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Accumulated Scrub Elapsed Time
+              context: accumulated_scrub_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_sum
+                  name: dp_ec_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_sum
+                  name: dp_ec_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_sum
+                  name: dp_repl_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_sum
+                  name: dp_repl_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_sum
+                  name: sh_ec_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_sum
+                  name: sh_ec_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_sum
+                  name: sh_repl_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
+                  name: sh_repl_successful_scrubs_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Reservation Elapsed Time
+              context: accumulated_reservation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_reservations_elapsed_sum
+                  name: dp_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_ec_successful_reservations_elapsed_sum
+                  name: dp_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_repl_failed_reservations_elapsed_sum
+                  name: dp_repl_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_repl_successful_reservations_elapsed_sum
+                  name: dp_repl_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_ec_failed_reservations_elapsed_sum
+                  name: sh_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_ec_successful_reservations_elapsed_sum
+                  name: sh_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_repl_failed_reservations_elapsed_sum
+                  name: sh_repl_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_repl_successful_reservations_elapsed_sum
+                  name: sh_repl_successful_reservations_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Outcomes
+          context_namespace: outcomes
+          metrics:
+            - ceph_osd_scrub_dp_ec_failed_scrubs
+            - ceph_osd_scrub_dp_ec_num_scrubs_started
+            - ceph_osd_scrub_dp_ec_successful_scrubs
+            - ceph_osd_scrub_dp_repl_failed_scrubs
+            - ceph_osd_scrub_dp_repl_num_scrubs_started
+            - ceph_osd_scrub_dp_repl_successful_scrubs
+            - ceph_osd_scrub_sh_ec_failed_scrubs
+            - ceph_osd_scrub_sh_ec_num_scrubs_started
+            - ceph_osd_scrub_sh_ec_successful_scrubs
+            - ceph_osd_scrub_sh_repl_failed_scrubs
+            - ceph_osd_scrub_sh_repl_num_scrubs_started
+            - ceph_osd_scrub_sh_repl_successful_scrubs
+          charts:
+            - title: Scrub Work
+              context: scrub_work
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_scrubs
+                  name: dp_ec_failed_scrubs
+                - selector: ceph_osd_scrub_dp_ec_num_scrubs_started
+                  name: dp_ec_num_scrubs_started
+                - selector: ceph_osd_scrub_dp_ec_successful_scrubs
+                  name: dp_ec_successful_scrubs
+                - selector: ceph_osd_scrub_dp_repl_failed_scrubs
+                  name: dp_repl_failed_scrubs
+                - selector: ceph_osd_scrub_dp_repl_num_scrubs_started
+                  name: dp_repl_num_scrubs_started
+                - selector: ceph_osd_scrub_dp_repl_successful_scrubs
+                  name: dp_repl_successful_scrubs
+                - selector: ceph_osd_scrub_sh_ec_failed_scrubs
+                  name: sh_ec_failed_scrubs
+                - selector: ceph_osd_scrub_sh_ec_num_scrubs_started
+                  name: sh_ec_num_scrubs_started
+                - selector: ceph_osd_scrub_sh_ec_successful_scrubs
+                  name: sh_ec_successful_scrubs
+                - selector: ceph_osd_scrub_sh_repl_failed_scrubs
+                  name: sh_repl_failed_scrubs
+                - selector: ceph_osd_scrub_sh_repl_num_scrubs_started
+                  name: sh_repl_num_scrubs_started
+                - selector: ceph_osd_scrub_sh_repl_successful_scrubs
+                  name: sh_repl_successful_scrubs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+        - family: Reservations
+          context_namespace: reservations
+          metrics:
+            - ceph_osd_scrub_dp_ec_num_scrubs_past_reservation
+            - ceph_osd_scrub_dp_ec_replicas_in_reservation
+            - ceph_osd_scrub_dp_ec_reservation_process_aborted
+            - ceph_osd_scrub_dp_ec_reservation_process_failure
+            - ceph_osd_scrub_dp_ec_reservation_process_skipped
+            - ceph_osd_scrub_dp_repl_num_scrubs_past_reservation
+            - ceph_osd_scrub_dp_repl_replicas_in_reservation
+            - ceph_osd_scrub_dp_repl_reservation_process_aborted
+            - ceph_osd_scrub_dp_repl_reservation_process_failure
+            - ceph_osd_scrub_dp_repl_reservation_process_skipped
+            - ceph_osd_scrub_sh_ec_num_scrubs_past_reservation
+            - ceph_osd_scrub_sh_ec_replicas_in_reservation
+            - ceph_osd_scrub_sh_ec_reservation_process_aborted
+            - ceph_osd_scrub_sh_ec_reservation_process_failure
+            - ceph_osd_scrub_sh_ec_reservation_process_skipped
+            - ceph_osd_scrub_sh_repl_num_scrubs_past_reservation
+            - ceph_osd_scrub_sh_repl_replicas_in_reservation
+            - ceph_osd_scrub_sh_repl_reservation_process_aborted
+            - ceph_osd_scrub_sh_repl_reservation_process_failure
+            - ceph_osd_scrub_sh_repl_reservation_process_skipped
+          charts:
+            - title: Replicas in Reservation
+              context: replicas_in_reservation
+              units: replicas
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_replicas_in_reservation
+                  name: dp_ec_replicas_in_reservation
+                - selector: ceph_osd_scrub_dp_repl_replicas_in_reservation
+                  name: dp_repl_replicas_in_reservation
+                - selector: ceph_osd_scrub_sh_ec_replicas_in_reservation
+                  name: sh_ec_replicas_in_reservation
+                - selector: ceph_osd_scrub_sh_repl_replicas_in_reservation
+                  name: sh_repl_replicas_in_reservation
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Scrubs Past Reservation
+              context: scrubs_past_reservation
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_num_scrubs_past_reservation
+                  name: dp_ec_num_scrubs_past_reservation
+                - selector: ceph_osd_scrub_dp_repl_num_scrubs_past_reservation
+                  name: dp_repl_num_scrubs_past_reservation
+                - selector: ceph_osd_scrub_sh_ec_num_scrubs_past_reservation
+                  name: sh_ec_num_scrubs_past_reservation
+                - selector: ceph_osd_scrub_sh_repl_num_scrubs_past_reservation
+                  name: sh_repl_num_scrubs_past_reservation
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Reservation Process Outcomes
+              context: reservation_process_outcomes
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_reservation_process_aborted
+                  name: dp_ec_reservation_process_aborted
+                - selector: ceph_osd_scrub_dp_ec_reservation_process_failure
+                  name: dp_ec_reservation_process_failure
+                - selector: ceph_osd_scrub_dp_ec_reservation_process_skipped
+                  name: dp_ec_reservation_process_skipped
+                - selector: ceph_osd_scrub_dp_repl_reservation_process_aborted
+                  name: dp_repl_reservation_process_aborted
+                - selector: ceph_osd_scrub_dp_repl_reservation_process_failure
+                  name: dp_repl_reservation_process_failure
+                - selector: ceph_osd_scrub_dp_repl_reservation_process_skipped
+                  name: dp_repl_reservation_process_skipped
+                - selector: ceph_osd_scrub_sh_ec_reservation_process_aborted
+                  name: sh_ec_reservation_process_aborted
+                - selector: ceph_osd_scrub_sh_ec_reservation_process_failure
+                  name: sh_ec_reservation_process_failure
+                - selector: ceph_osd_scrub_sh_ec_reservation_process_skipped
+                  name: sh_ec_reservation_process_skipped
+                - selector: ceph_osd_scrub_sh_repl_reservation_process_aborted
+                  name: sh_repl_reservation_process_aborted
+                - selector: ceph_osd_scrub_sh_repl_reservation_process_failure
+                  name: sh_repl_reservation_process_failure
+                - selector: ceph_osd_scrub_sh_repl_reservation_process_skipped
+                  name: sh_repl_reservation_process_skipped
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+    - family: OSD Scrubbing - Ceph 20
+      context_namespace: osd_scrubbing_ceph_20
+      groups:
+        - family: Elapsed Time
+          context_namespace: elapsed_time
+          metrics:
+            - ceph_osd_failed_scrubs_ec_elapsed_count
+            - ceph_osd_failed_scrubs_ec_elapsed_sum
+            - ceph_osd_failed_scrubs_replicated_elapsed_count
+            - ceph_osd_failed_scrubs_replicated_elapsed_sum
+            - ceph_osd_scrub_ec_failed_reservations_elapsed_count
+            - ceph_osd_scrub_ec_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_ec_successful_reservations_elapsed_count
+            - ceph_osd_scrub_ec_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_replicated_failed_reservations_elapsed_count
+            - ceph_osd_scrub_replicated_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_replicated_successful_reservations_elapsed_count
+            - ceph_osd_scrub_replicated_successful_reservations_elapsed_sum
+            - ceph_osd_successful_scrubs_ec_elapsed_count
+            - ceph_osd_successful_scrubs_ec_elapsed_sum
+            - ceph_osd_successful_scrubs_replicated_elapsed_count
+            - ceph_osd_successful_scrubs_replicated_elapsed_sum
+          charts:
+            - title: Scrub Elapsed-Time Measurements
+              context: scrub_latency_measurements
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_failed_scrubs_ec_elapsed_count
+                  name: failed_scrubs_ec_elapsed
+                - selector: ceph_osd_failed_scrubs_replicated_elapsed_count
+                  name: failed_scrubs_replicated_elapsed
+                - selector: ceph_osd_successful_scrubs_ec_elapsed_count
+                  name: successful_scrubs_ec_elapsed
+                - selector: ceph_osd_successful_scrubs_replicated_elapsed_count
+                  name: successful_scrubs_replicated_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Reservation Elapsed-Time Measurements
+              context: reservation_latency_measurements
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_failed_reservations_elapsed_count
+                  name: scrub_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_ec_successful_reservations_elapsed_count
+                  name: scrub_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_replicated_failed_reservations_elapsed_count
+                  name: scrub_replicated_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_replicated_successful_reservations_elapsed_count
+                  name: scrub_replicated_successful_reservations_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Scrub Elapsed Time
+              context: accumulated_scrub_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_failed_scrubs_ec_elapsed_sum
+                  name: failed_scrubs_ec_elapsed
+                - selector: ceph_osd_failed_scrubs_replicated_elapsed_sum
+                  name: failed_scrubs_replicated_elapsed
+                - selector: ceph_osd_successful_scrubs_ec_elapsed_sum
+                  name: successful_scrubs_ec_elapsed
+                - selector: ceph_osd_successful_scrubs_replicated_elapsed_sum
+                  name: successful_scrubs_replicated_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Reservation Elapsed Time
+              context: accumulated_reservation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_failed_reservations_elapsed_sum
+                  name: scrub_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_ec_successful_reservations_elapsed_sum
+                  name: scrub_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_replicated_failed_reservations_elapsed_sum
+                  name: scrub_replicated_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_replicated_successful_reservations_elapsed_sum
+                  name: scrub_replicated_successful_reservations_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Interference and Scheduling
+          context_namespace: interference_and_scheduling
+          metrics:
+            - ceph_osd_scrub_ec_io_blocked
+            - ceph_osd_scrub_ec_io_intersects
+            - ceph_osd_scrub_replicated_io_blocked
+            - ceph_osd_scrub_replicated_io_intersects
+          charts:
+            - title: Client Write Interference
+              context: client_write_interference
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_io_blocked
+                  name: ec_io_blocked
+                - selector: ceph_osd_scrub_ec_io_intersects
+                  name: ec_io_intersects
+                - selector: ceph_osd_scrub_replicated_io_blocked
+                  name: replicated_io_blocked
+                - selector: ceph_osd_scrub_replicated_io_intersects
+                  name: replicated_io_intersects
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Outcomes
+          context_namespace: outcomes
+          metrics:
+            - ceph_osd_failed_scrubs_ec
+            - ceph_osd_failed_scrubs_replicated
+            - ceph_osd_num_scrubs_started_ec
+            - ceph_osd_num_scrubs_started_replicated
+            - ceph_osd_successful_scrubs_ec
+            - ceph_osd_successful_scrubs_replicated
+          charts:
+            - title: Scrub Work
+              context: scrub_work
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_failed_scrubs_ec
+                  name: failed_scrubs_ec
+                - selector: ceph_osd_failed_scrubs_replicated
+                  name: failed_scrubs_replicated
+                - selector: ceph_osd_num_scrubs_started_ec
+                  name: num_scrubs_started_ec
+                - selector: ceph_osd_num_scrubs_started_replicated
+                  name: num_scrubs_started_replicated
+                - selector: ceph_osd_successful_scrubs_ec
+                  name: successful_scrubs_ec
+                - selector: ceph_osd_successful_scrubs_replicated
+                  name: successful_scrubs_replicated
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Reservations
+          context_namespace: reservations
+          metrics:
+            - ceph_osd_num_scrubs_past_reservation_ec
+            - ceph_osd_num_scrubs_past_reservation_replicated
+            - ceph_osd_scrub_ec_replicas_in_reservation
+            - ceph_osd_scrub_ec_reservation_process_aborted
+            - ceph_osd_scrub_ec_reservation_process_failure
+            - ceph_osd_scrub_ec_reservation_process_skipped
+            - ceph_osd_scrub_ec_reservations_completed
+            - ceph_osd_scrub_replicated_replicas_in_reservation
+            - ceph_osd_scrub_replicated_reservation_process_aborted
+            - ceph_osd_scrub_replicated_reservation_process_failure
+            - ceph_osd_scrub_replicated_reservation_process_skipped
+            - ceph_osd_scrub_replicated_scrub_reservations_completed
+          charts:
+            - title: Replicas in Reservation
+              context: replicas_in_reservation
+              units: replicas
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_replicas_in_reservation
+                  name: ec_replicas_in_reservation
+                - selector: ceph_osd_scrub_replicated_replicas_in_reservation
+                  name: replicated_replicas_in_reservation
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Scrubs Past Reservation
+              context: scrubs_past_reservation
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_num_scrubs_past_reservation_ec
+                  name: num_scrubs_past_reservation_ec
+                - selector: ceph_osd_num_scrubs_past_reservation_replicated
+                  name: num_scrubs_past_reservation_replicated
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Reservation Process Outcomes
+              context: reservation_process_outcomes
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_reservation_process_aborted
+                  name: scrub_ec_reservation_process_aborted
+                - selector: ceph_osd_scrub_ec_reservation_process_failure
+                  name: scrub_ec_reservation_process_failure
+                - selector: ceph_osd_scrub_ec_reservation_process_skipped
+                  name: scrub_ec_reservation_process_skipped
+                - selector: ceph_osd_scrub_ec_reservations_completed
+                  name: scrub_ec_reservations_completed
+                - selector: ceph_osd_scrub_replicated_reservation_process_aborted
+                  name: scrub_replicated_reservation_process_aborted
+                - selector: ceph_osd_scrub_replicated_reservation_process_failure
+                  name: scrub_replicated_reservation_process_failure
+                - selector: ceph_osd_scrub_replicated_reservation_process_skipped
+                  name: scrub_replicated_reservation_process_skipped
+                - selector: ceph_osd_scrub_replicated_scrub_reservations_completed
+                  name: scrub_replicated_scrub_reservations_completed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Scrub Work
+          context_namespace: scrub_work
+          metrics:
+            - ceph_osd_scrub_ec_getattr_cnt
+            - ceph_osd_scrub_ec_read_bytes
+            - ceph_osd_scrub_ec_read_cnt
+            - ceph_osd_scrub_ec_stats_cnt
+            - ceph_osd_scrub_replicated_getattr_cnt
+            - ceph_osd_scrub_replicated_read_bytes
+            - ceph_osd_scrub_replicated_read_cnt
+            - ceph_osd_scrub_replicated_stats_cnt
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_read_bytes
+                  name: ec_read_bytes
+                - selector: ceph_osd_scrub_replicated_read_bytes
+                  name: replicated_read_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Scrub Calls
+              context: scrub_calls
+              units: calls/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_getattr_cnt
+                  name: ec_getattr_cnt
+                - selector: ceph_osd_scrub_ec_read_cnt
+                  name: ec_read_cnt
+                - selector: ceph_osd_scrub_ec_stats_cnt
+                  name: ec_stats_cnt
+                - selector: ceph_osd_scrub_replicated_getattr_cnt
+                  name: replicated_getattr_cnt
+                - selector: ceph_osd_scrub_replicated_read_cnt
+                  name: replicated_read_cnt
+                - selector: ceph_osd_scrub_replicated_stats_cnt
+                  name: replicated_stats_cnt
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: OSD Scrubbing - Common Work
+      context_namespace: osd_scrubbing_common_work
+      groups:
+        - family: Interference and Scheduling
+          context_namespace: interference_and_scheduling
+          metrics:
+            - ceph_osd_scrub_dp_ec_chunk_busy
+            - ceph_osd_scrub_dp_ec_chunk_selected
+            - ceph_osd_scrub_dp_ec_locked_object
+            - ceph_osd_scrub_dp_ec_preemptions
+            - ceph_osd_scrub_dp_ec_write_blocked_by_scrub
+            - ceph_osd_scrub_dp_repl_chunk_busy
+            - ceph_osd_scrub_dp_repl_chunk_selected
+            - ceph_osd_scrub_dp_repl_locked_object
+            - ceph_osd_scrub_dp_repl_preemptions
+            - ceph_osd_scrub_dp_repl_write_blocked_by_scrub
+            - ceph_osd_scrub_sh_ec_chunk_busy
+            - ceph_osd_scrub_sh_ec_chunk_selected
+            - ceph_osd_scrub_sh_ec_locked_object
+            - ceph_osd_scrub_sh_ec_preemptions
+            - ceph_osd_scrub_sh_ec_write_blocked_by_scrub
+            - ceph_osd_scrub_sh_repl_chunk_busy
+            - ceph_osd_scrub_sh_repl_chunk_selected
+            - ceph_osd_scrub_sh_repl_locked_object
+            - ceph_osd_scrub_sh_repl_preemptions
+            - ceph_osd_scrub_sh_repl_write_blocked_by_scrub
+          charts:
+            - title: Object-Lock Waits
+              context: object_lock_waits
+              units: waits/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_locked_object
+                  name: dp_ec_locked_object
+                - selector: ceph_osd_scrub_dp_repl_locked_object
+                  name: dp_repl_locked_object
+                - selector: ceph_osd_scrub_sh_ec_locked_object
+                  name: sh_ec_locked_object
+                - selector: ceph_osd_scrub_sh_repl_locked_object
+                  name: sh_repl_locked_object
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Chunk Selection Outcomes
+              context: chunk_selection_outcomes
+              units: chunks/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_chunk_busy
+                  name: dp_ec_chunk_busy
+                - selector: ceph_osd_scrub_dp_ec_chunk_selected
+                  name: dp_ec_chunk_selected
+                - selector: ceph_osd_scrub_dp_repl_chunk_busy
+                  name: dp_repl_chunk_busy
+                - selector: ceph_osd_scrub_dp_repl_chunk_selected
+                  name: dp_repl_chunk_selected
+                - selector: ceph_osd_scrub_sh_ec_chunk_busy
+                  name: sh_ec_chunk_busy
+                - selector: ceph_osd_scrub_sh_ec_chunk_selected
+                  name: sh_ec_chunk_selected
+                - selector: ceph_osd_scrub_sh_repl_chunk_busy
+                  name: sh_repl_chunk_busy
+                - selector: ceph_osd_scrub_sh_repl_chunk_selected
+                  name: sh_repl_chunk_selected
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Scrub Preemptions
+              context: preemptions
+              units: preemptions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_preemptions
+                  name: dp_ec_preemptions
+                - selector: ceph_osd_scrub_dp_repl_preemptions
+                  name: dp_repl_preemptions
+                - selector: ceph_osd_scrub_sh_ec_preemptions
+                  name: sh_ec_preemptions
+                - selector: ceph_osd_scrub_sh_repl_preemptions
+                  name: sh_repl_preemptions
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Client Writes Blocked by Scrub
+              context: blocked_client_writes
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_write_blocked_by_scrub
+                  name: dp_ec_write_blocked_by_scrub
+                - selector: ceph_osd_scrub_dp_repl_write_blocked_by_scrub
+                  name: dp_repl_write_blocked_by_scrub
+                - selector: ceph_osd_scrub_sh_ec_write_blocked_by_scrub
+                  name: sh_ec_write_blocked_by_scrub
+                - selector: ceph_osd_scrub_sh_repl_write_blocked_by_scrub
+                  name: sh_repl_write_blocked_by_scrub
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+        - family: Reservations
+          context_namespace: reservations
+          metrics:
+            - ceph_osd_scrub_dp_ec_scrub_reservations_completed
+            - ceph_osd_scrub_dp_repl_scrub_reservations_completed
+            - ceph_osd_scrub_sh_ec_scrub_reservations_completed
+            - ceph_osd_scrub_sh_repl_scrub_reservations_completed
+          charts:
+            - title: Completed Scrub Reservations
+              context: completed_reservations
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_scrub_reservations_completed
+                  name: dp_ec_scrub_reservations_completed
+                - selector: ceph_osd_scrub_dp_repl_scrub_reservations_completed
+                  name: dp_repl_scrub_reservations_completed
+                - selector: ceph_osd_scrub_sh_ec_scrub_reservations_completed
+                  name: sh_ec_scrub_reservations_completed
+                - selector: ceph_osd_scrub_sh_repl_scrub_reservations_completed
+                  name: sh_repl_scrub_reservations_completed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+        - family: Scrub Work
+          context_namespace: scrub_work
+          metrics:
+            - ceph_osd_scrub_omapget_bytes
+            - ceph_osd_scrub_omapget_cnt
+            - ceph_osd_scrub_omapgetheader_bytes
+            - ceph_osd_scrub_omapgetheader_cnt
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_omapget_bytes
+                  name: omapget_bytes
+                - selector: ceph_osd_scrub_omapgetheader_bytes
+                  name: omapgetheader_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OMAP Scrub Calls
+              context: omap_calls
+              units: calls/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_omapget_cnt
+                  name: omapget_cnt
+                - selector: ceph_osd_scrub_omapgetheader_cnt
+                  name: omapgetheader_cnt
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Object Gateway
+      context_namespace: object_gateway
+      groups:
+        - family: Lifecycle
+          context_namespace: lifecycle
+          metrics:
+            - ceph_rgw_lc_abort_mpu
+            - ceph_rgw_lc_expire_current
+            - ceph_rgw_lc_expire_dm
+            - ceph_rgw_lc_expire_noncurrent
+            - ceph_rgw_lc_transition_current
+            - ceph_rgw_lc_transition_noncurrent
+          charts:
+            - title: Lifecycle Actions
+              context: lifecycle_actions
+              units: actions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_lc_expire_current
+                  name: expire_current
+                - selector: ceph_rgw_lc_expire_dm
+                  name: expire_dm
+                - selector: ceph_rgw_lc_expire_noncurrent
+                  name: expire_noncurrent
+                - selector: ceph_rgw_lc_transition_current
+                  name: transition_current
+                - selector: ceph_rgw_lc_transition_noncurrent
+                  name: transition_noncurrent
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Aborted Multipart Uploads
+              context: aborted_multipart_uploads
+              units: uploads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_lc_abort_mpu
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+        - family: Lua
+          context_namespace: lua
+          metrics:
+            - ceph_rgw_lua_current_vms
+            - ceph_rgw_lua_script_fail
+            - ceph_rgw_lua_script_ok
+          charts:
+            - title: Current Lua Virtual Machines
+              context: current_vms
+              units: VMs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_lua_current_vms
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Lua Script Executions
+              context: script_executions
+              units: executions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_lua_script_ok
+                  name: success
+                - selector: ceph_rgw_lua_script_fail
+                  name: failure
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+        - family: Notifications
+          context_namespace: notifications
+          metrics:
+            - ceph_rgw_pubsub_event_lost
+            - ceph_rgw_pubsub_event_triggered
+            - ceph_rgw_pubsub_events
+            - ceph_rgw_pubsub_missing_conf
+            - ceph_rgw_pubsub_push_failed
+            - ceph_rgw_pubsub_push_ok
+            - ceph_rgw_pubsub_push_pending
+            - ceph_rgw_pubsub_store_fail
+            - ceph_rgw_pubsub_store_ok
+          charts:
+            - title: Pending Notification Events
+              context: pending_events
+              units: events
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_push_pending
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Stored Events
+              context: event_state
+              units: events
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_events
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_event_lost
+                  name: event_lost
+                - selector: ceph_rgw_pubsub_event_triggered
+                  name: event_triggered
+                - selector: ceph_rgw_pubsub_push_ok
+                  name: push_ok
+                - selector: ceph_rgw_pubsub_store_ok
+                  name: store_ok
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_push_failed
+                  name: push_failed
+                - selector: ceph_rgw_pubsub_store_fail
+                  name: store_fail
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Missing Notification Configurations
+              context: missing_configurations
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_missing_conf
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+        - family: Requests and Queue
+          context_namespace: requests_and_queue
+          metrics:
+            - ceph_rgw_failed_req
+            - ceph_rgw_gc_retire_object
+            - ceph_rgw_get
+            - ceph_rgw_get_b
+            - ceph_rgw_get_initial_lat_count
+            - ceph_rgw_get_initial_lat_sum
+            - ceph_rgw_put
+            - ceph_rgw_put_b
+            - ceph_rgw_put_initial_lat_count
+            - ceph_rgw_put_initial_lat_sum
+            - ceph_rgw_qactive
+            - ceph_rgw_qlen
+            - ceph_rgw_req
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_get_initial_lat_count
+                  name: get_initial_lat
+                - selector: ceph_rgw_put_initial_lat_count
+                  name: put_initial_lat
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_get_initial_lat_sum
+                  name: get_initial_lat
+                - selector: ceph_rgw_put_initial_lat_sum
+                  name: put_initial_lat
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_get_b
+                  name: get_b
+                - selector: ceph_rgw_put_b
+                  name: put_b
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Queued and Active Requests
+              context: current_requests
+              units: requests
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_qactive
+                  name: qactive
+                - selector: ceph_rgw_qlen
+                  name: qlen
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Failed Requests
+              context: failed_requests
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_failed_req
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Object Work
+              context: object_work
+              units: objects/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_gc_retire_object
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Requests
+              context: requests
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_get
+                  name: get
+                - selector: ceph_rgw_put
+                  name: put
+                - selector: ceph_rgw_req
+                  name: req
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+    - family: Object Gateway Cache
+      context_namespace: object_gateway_cache
       metrics:
-      - ceph_healthcheck_slow_ops
+        - ceph_rgw_cache_hit
+        - ceph_rgw_cache_miss
+        - ceph_rgw_keystone_token_cache_hit
+        - ceph_rgw_keystone_token_cache_miss
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_healthcheck_slow_ops
-          name: value
-  - family: OSD Capacity and State
-    context_namespace: osd_capacity_and_state
-    groups:
-    - family: Cluster Flags
-      context_namespace: cluster_flags
+        - title: Keystone Token Cache Lookup Outcomes
+          context: keystone_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_keystone_token_cache_hit
+              name: hit
+            - selector: ceph_rgw_keystone_token_cache_miss
+              name: miss
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels: []
+        - title: Lookup Outcomes
+          context: lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_cache_hit
+              name: cache_hit
+            - selector: ceph_rgw_cache_miss
+              name: cache_miss
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels: []
+    - family: Object Gateway Multisite
+      context_namespace: object_gateway_multisite
       metrics:
-      - ceph_osd_flag_nodeep_scrub
-      - ceph_osd_flag_nodown
-      - ceph_osd_flag_noin
-      - ceph_osd_flag_noout
-      - ceph_osd_flag_norebalance
-      - ceph_osd_flag_noscrub
-      - ceph_osd_flag_noup
+        - ceph_data_sync_from_zone_fetch_bytes_count
+        - ceph_data_sync_from_zone_fetch_bytes_sum
+        - ceph_data_sync_from_zone_fetch_errors
+        - ceph_data_sync_from_zone_fetch_not_modified
+        - ceph_data_sync_from_zone_lock_latency_count
+        - ceph_data_sync_from_zone_lock_latency_sum
+        - ceph_data_sync_from_zone_poll_errors
+        - ceph_data_sync_from_zone_poll_latency_count
+        - ceph_data_sync_from_zone_poll_latency_sum
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_flag_nodeep_scrub
-          name: nodeep_scrub
-        - selector: ceph_osd_flag_nodown
-          name: nodown
-        - selector: ceph_osd_flag_noin
-          name: noin
-        - selector: ceph_osd_flag_noout
-          name: noout
-        - selector: ceph_osd_flag_norebalance
-          name: norebalance
-        - selector: ceph_osd_flag_noscrub
-          name: noscrub
-        - selector: ceph_osd_flag_noup
-          name: noup
-    - family: Fullness Thresholds
-      context_namespace: fullness_thresholds
+        - title: Replicated Objects
+          context: replicated_objects
+          units: objects/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_fetch_bytes_count
+              name: value
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+        - title: Accumulated Byte Measurement
+          context: accumulated_bytes
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_fetch_bytes_sum
+              name: value
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+          algorithm: incremental
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_lock_latency_count
+              name: lock_latency
+            - selector: ceph_data_sync_from_zone_poll_latency_count
+              name: poll_latency
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_lock_latency_sum
+              name: lock_latency
+            - selector: ceph_data_sync_from_zone_poll_latency_sum
+              name: poll_latency
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+          algorithm: incremental
+        - title: Replication-Log Request Errors
+          context: replication_log_request_errors
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_poll_errors
+              name: value
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+        - title: Object Work
+          context: object_work
+          units: objects/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_fetch_errors
+              name: errors
+            - selector: ceph_data_sync_from_zone_fetch_not_modified
+              name: not_modified
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+    - family: Objecter
+      context_namespace: objecter
       metrics:
-      - ceph_osd_full_ratio
-      - ceph_osd_nearfull_ratio
+        - ceph_objecter_command_active
+        - ceph_objecter_command_resend
+        - ceph_objecter_command_send
+        - ceph_objecter_linger_active
+        - ceph_objecter_linger_ping
+        - ceph_objecter_linger_resend
+        - ceph_objecter_linger_send
+        - ceph_objecter_map_epoch
+        - ceph_objecter_map_full
+        - ceph_objecter_map_inc
+        - ceph_objecter_omap_del
+        - ceph_objecter_omap_rd
+        - ceph_objecter_omap_wr
+        - ceph_objecter_op
+        - ceph_objecter_op_active
+        - ceph_objecter_op_inflight
+        - ceph_objecter_op_laggy
+        - ceph_objecter_op_latency_count
+        - ceph_objecter_op_latency_sum
+        - ceph_objecter_op_pg
+        - ceph_objecter_op_r
+        - ceph_objecter_op_reply
+        - ceph_objecter_op_resend
+        - ceph_objecter_op_rmw
+        - ceph_objecter_op_send
+        - ceph_objecter_op_send_bytes
+        - ceph_objecter_op_w
+        - ceph_objecter_oplen_avg_count
+        - ceph_objecter_oplen_avg_sum
+        - ceph_objecter_osd_laggy
+        - ceph_objecter_osd_session_close
+        - ceph_objecter_osd_session_open
+        - ceph_objecter_osd_sessions
+        - ceph_objecter_osdop_append
+        - ceph_objecter_osdop_call
+        - ceph_objecter_osdop_clonerange
+        - ceph_objecter_osdop_cmpxattr
+        - ceph_objecter_osdop_create
+        - ceph_objecter_osdop_delete
+        - ceph_objecter_osdop_getxattr
+        - ceph_objecter_osdop_mapext
+        - ceph_objecter_osdop_notify
+        - ceph_objecter_osdop_other
+        - ceph_objecter_osdop_pgls
+        - ceph_objecter_osdop_pgls_filter
+        - ceph_objecter_osdop_read
+        - ceph_objecter_osdop_resetxattrs
+        - ceph_objecter_osdop_rmxattr
+        - ceph_objecter_osdop_setxattr
+        - ceph_objecter_osdop_sparse_read
+        - ceph_objecter_osdop_src_cmpxattr
+        - ceph_objecter_osdop_stat
+        - ceph_objecter_osdop_truncate
+        - ceph_objecter_osdop_watch
+        - ceph_objecter_osdop_write
+        - ceph_objecter_osdop_writefull
+        - ceph_objecter_osdop_writesame
+        - ceph_objecter_osdop_zero
+        - ceph_objecter_poolop_active
+        - ceph_objecter_poolop_resend
+        - ceph_objecter_poolop_send
+        - ceph_objecter_poolstat_active
+        - ceph_objecter_poolstat_resend
+        - ceph_objecter_poolstat_send
+        - ceph_objecter_replica_read_bounced
+        - ceph_objecter_replica_read_completed
+        - ceph_objecter_replica_read_sent
+        - ceph_objecter_statfs_active
+        - ceph_objecter_statfs_resend
+        - ceph_objecter_statfs_send
       charts:
-      - title: Ratios
-        context: ratio
-        units: ratio
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_full_ratio
-          name: full_ratio
-        - selector: ceph_osd_nearfull_ratio
-          name: nearfull_ratio
-    - family: Metadata
-      context_namespace: metadata
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_op_latency_count
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_op_latency_sum
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          algorithm: incremental
+          aggregation: sum
+        - title: Submitted Top-Level Operations
+          context: submitted_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_oplen_avg_count
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Operation-Vector Entries
+          context: operation_vector_entries
+          units: entries/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_oplen_avg_sum
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          algorithm: incremental
+          aggregation: sum
+        - title: Byte Throughput
+          context: byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_op_send_bytes
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active Commands
+          context: active_commands
+          units: commands
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_command_active
+              name: command_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active Lingering Operations
+          context: active_lingering_operations
+          units: operations
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_linger_active
+              name: linger_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: OSD-Map Epoch
+          context: map_epoch
+          units: epoch
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_map_epoch
+              name: map_epoch
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: min
+        - title: Objecter Operations
+          context: active_operations
+          units: operations
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_op_active
+              name: op_active
+            - selector: ceph_objecter_op_inflight
+              name: op_inflight
+            - selector: ceph_objecter_op_laggy
+              name: op_laggy
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active Pool Operations
+          context: active_pool_operations
+          units: operations
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_poolop_active
+              name: poolop_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active Pool-Stat Requests
+          context: active_poolstat_requests
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_poolstat_active
+              name: poolstat_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active StatFS Requests
+          context: active_statfs_requests
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_statfs_active
+              name: statfs_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Commands
+          context: commands
+          units: commands/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_command_resend
+              name: command_resend
+            - selector: ceph_objecter_command_send
+              name: command_send
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Lingering Operations
+          context: lingering_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_linger_ping
+              name: linger_ping
+            - selector: ceph_objecter_linger_resend
+              name: linger_resend
+            - selector: ceph_objecter_linger_send
+              name: linger_send
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: OSD Maps
+          context: maps
+          units: maps/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_map_full
+              name: map_full
+            - selector: ceph_objecter_map_inc
+              name: map_inc
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Object Operations
+          context: operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_omap_del
+              name: omap_del
+            - selector: ceph_objecter_omap_rd
+              name: omap_rd
+            - selector: ceph_objecter_omap_wr
+              name: omap_wr
+            - selector: ceph_objecter_op
+              name: op
+            - selector: ceph_objecter_op_pg
+              name: op_pg
+            - selector: ceph_objecter_op_r
+              name: op_r
+            - selector: ceph_objecter_op_reply
+              name: op_reply
+            - selector: ceph_objecter_op_resend
+              name: op_resend
+            - selector: ceph_objecter_op_rmw
+              name: op_rmw
+            - selector: ceph_objecter_op_send
+              name: op_send
+            - selector: ceph_objecter_op_w
+              name: op_w
+            - selector: ceph_objecter_osdop_append
+              name: osdop_append
+            - selector: ceph_objecter_osdop_call
+              name: osdop_call
+            - selector: ceph_objecter_osdop_clonerange
+              name: osdop_clonerange
+            - selector: ceph_objecter_osdop_cmpxattr
+              name: osdop_cmpxattr
+            - selector: ceph_objecter_osdop_create
+              name: osdop_create
+            - selector: ceph_objecter_osdop_delete
+              name: osdop_delete
+            - selector: ceph_objecter_osdop_getxattr
+              name: osdop_getxattr
+            - selector: ceph_objecter_osdop_mapext
+              name: osdop_mapext
+            - selector: ceph_objecter_osdop_notify
+              name: osdop_notify
+            - selector: ceph_objecter_osdop_other
+              name: osdop_other
+            - selector: ceph_objecter_osdop_pgls
+              name: osdop_pgls
+            - selector: ceph_objecter_osdop_pgls_filter
+              name: osdop_pgls_filter
+            - selector: ceph_objecter_osdop_read
+              name: osdop_read
+            - selector: ceph_objecter_osdop_resetxattrs
+              name: osdop_resetxattrs
+            - selector: ceph_objecter_osdop_rmxattr
+              name: osdop_rmxattr
+            - selector: ceph_objecter_osdop_setxattr
+              name: osdop_setxattr
+            - selector: ceph_objecter_osdop_sparse_read
+              name: osdop_sparse_read
+            - selector: ceph_objecter_osdop_src_cmpxattr
+              name: osdop_src_cmpxattr
+            - selector: ceph_objecter_osdop_stat
+              name: osdop_stat
+            - selector: ceph_objecter_osdop_truncate
+              name: osdop_truncate
+            - selector: ceph_objecter_osdop_watch
+              name: osdop_watch
+            - selector: ceph_objecter_osdop_write
+              name: osdop_write
+            - selector: ceph_objecter_osdop_writefull
+              name: osdop_writefull
+            - selector: ceph_objecter_osdop_writesame
+              name: osdop_writesame
+            - selector: ceph_objecter_osdop_zero
+              name: osdop_zero
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Replica Reads
+          context: replica_reads
+          units: reads/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_replica_read_sent
+              name: replica_read_sent
+            - selector: ceph_objecter_replica_read_bounced
+              name: replica_read_bounced
+            - selector: ceph_objecter_replica_read_completed
+              name: replica_read_completed
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: OSD Sessions
+          context: osd_sessions
+          units: sessions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_osd_session_close
+              name: osd_session_close
+            - selector: ceph_objecter_osd_session_open
+              name: osd_session_open
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Pool Operations
+          context: pool_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_poolop_resend
+              name: poolop_resend
+            - selector: ceph_objecter_poolop_send
+              name: poolop_send
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Pool-Stat and StatFS Requests
+          context: stat_requests
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_poolstat_resend
+              name: poolstat_resend
+            - selector: ceph_objecter_poolstat_send
+              name: poolstat_send
+            - selector: ceph_objecter_statfs_resend
+              name: statfs_resend
+            - selector: ceph_objecter_statfs_send
+              name: statfs_send
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Sessions
+          context: session_state
+          units: sessions
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_osd_laggy
+              name: laggy
+            - selector: ceph_objecter_osd_sessions
+              name: sessions
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+    - family: RBD Client Images
+      context_namespace: rbd_client_images
       metrics:
-      - ceph_osd_metadata
+        - ceph_rbd_librbd_image_cmp
+        - ceph_rbd_librbd_image_cmp_bytes
+        - ceph_rbd_librbd_image_cmp_latency_count
+        - ceph_rbd_librbd_image_cmp_latency_sum
+        - ceph_rbd_librbd_image_discard
+        - ceph_rbd_librbd_image_discard_bytes
+        - ceph_rbd_librbd_image_discard_latency_count
+        - ceph_rbd_librbd_image_discard_latency_sum
+        - ceph_rbd_librbd_image_flush
+        - ceph_rbd_librbd_image_flush_latency_count
+        - ceph_rbd_librbd_image_flush_latency_sum
+        - ceph_rbd_librbd_image_invalidate_cache
+        - ceph_rbd_librbd_image_lock_acquired_time
+        - ceph_rbd_librbd_image_notify
+        - ceph_rbd_librbd_image_opened_time
+        - ceph_rbd_librbd_image_rd
+        - ceph_rbd_librbd_image_rd_bytes
+        - ceph_rbd_librbd_image_rd_latency_count
+        - ceph_rbd_librbd_image_rd_latency_sum
+        - ceph_rbd_librbd_image_readahead
+        - ceph_rbd_librbd_image_readahead_bytes
+        - ceph_rbd_librbd_image_resize
+        - ceph_rbd_librbd_image_snap_create
+        - ceph_rbd_librbd_image_snap_remove
+        - ceph_rbd_librbd_image_snap_rename
+        - ceph_rbd_librbd_image_snap_rollback
+        - ceph_rbd_librbd_image_wr
+        - ceph_rbd_librbd_image_wr_bytes
+        - ceph_rbd_librbd_image_wr_latency_count
+        - ceph_rbd_librbd_image_wr_latency_sum
+        - ceph_rbd_librbd_image_ws
+        - ceph_rbd_librbd_image_ws_bytes
+        - ceph_rbd_librbd_image_ws_latency_count
+        - ceph_rbd_librbd_image_ws_latency_sum
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_metadata
-          name: value
-        instances:
-          by_labels:
-          - back_iface
-          - ceph_daemon
-          - ceph_version
-          - cluster_addr
-          - device_class
-          - front_iface
-          - hostname
-          - objectstore
-          - public_addr
-          optional_by_labels: []
-    - family: OSD State
-      context_namespace: osd_state
+        - title: I/O Operations
+          context: io_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_rd
+              name: read
+            - selector: ceph_rbd_librbd_image_wr
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: I/O Byte Throughput
+          context: io_byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_rd_bytes
+              name: read
+            - selector: ceph_rbd_librbd_image_wr_bytes
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: I/O Latency Measurements
+          context: io_latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_rd_latency_count
+              name: read
+            - selector: ceph_rbd_librbd_image_wr_latency_count
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Accumulated I/O Latency
+          context: accumulated_io_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_rd_latency_sum
+              name: read
+            - selector: ceph_rbd_librbd_image_wr_latency_sum
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+          algorithm: incremental
+        - title: Lifecycle Timestamps
+          context: lifecycle_timestamps
+          units: seconds since epoch
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_opened_time
+              name: opened
+            - selector: ceph_rbd_librbd_image_lock_acquired_time
+              name: lock_acquired
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Data Operations
+          context: data_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_discard
+              name: discard
+            - selector: ceph_rbd_librbd_image_ws
+              name: write_same
+            - selector: ceph_rbd_librbd_image_cmp
+              name: compare_and_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Data Operation Byte Throughput
+          context: data_operation_byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_discard_bytes
+              name: discard
+            - selector: ceph_rbd_librbd_image_ws_bytes
+              name: write_same
+            - selector: ceph_rbd_librbd_image_cmp_bytes
+              name: compare_and_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Data Operation Latency Measurements
+          context: data_operation_latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_discard_latency_count
+              name: discard
+            - selector: ceph_rbd_librbd_image_ws_latency_count
+              name: write_same
+            - selector: ceph_rbd_librbd_image_cmp_latency_count
+              name: compare_and_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Accumulated Data Operation Latency
+          context: accumulated_data_operation_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_discard_latency_sum
+              name: discard
+            - selector: ceph_rbd_librbd_image_ws_latency_sum
+              name: write_same
+            - selector: ceph_rbd_librbd_image_cmp_latency_sum
+              name: compare_and_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+          algorithm: incremental
+        - title: Flush Operations
+          context: flush_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_flush
+              name: flush
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Flush Latency Measurements
+          context: flush_latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_flush_latency_count
+              name: flush
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Accumulated Flush Latency
+          context: accumulated_flush_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_flush_latency_sum
+              name: flush
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+          algorithm: incremental
+        - title: Snapshot Mutations
+          context: snapshot_mutations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_snap_create
+              name: create
+            - selector: ceph_rbd_librbd_image_snap_remove
+              name: remove
+            - selector: ceph_rbd_librbd_image_snap_rollback
+              name: rollback
+            - selector: ceph_rbd_librbd_image_snap_rename
+              name: rename
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Maintenance Operations
+          context: maintenance_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_notify
+              name: notify
+            - selector: ceph_rbd_librbd_image_resize
+              name: resize
+            - selector: ceph_rbd_librbd_image_readahead
+              name: readahead
+            - selector: ceph_rbd_librbd_image_invalidate_cache
+              name: invalidate_cache
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Readahead Byte Throughput
+          context: readahead_byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_readahead_bytes
+              name: readahead
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+    - family: RBD Mirror
+      context_namespace: rbd_mirror
+      groups:
+        - family: Journal
+          context_namespace: journal
+          metrics:
+            - ceph_rbd_mirror_journal_entries
+            - ceph_rbd_mirror_journal_image_entries
+            - ceph_rbd_mirror_journal_image_replay_bytes
+            - ceph_rbd_mirror_journal_image_replay_latency_count
+            - ceph_rbd_mirror_journal_image_replay_latency_sum
+            - ceph_rbd_mirror_journal_replay_bytes
+            - ceph_rbd_mirror_journal_replay_latency_count
+            - ceph_rbd_mirror_journal_replay_latency_sum
+          charts:
+            - title: Journal Replay Latency Measurements
+              context: latency_measurements
+              units: entries/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_replay_latency_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Image Journal Replay Latency Measurements
+              context: image_latency_measurements
+              units: entries/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_image_replay_latency_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_replay_latency_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Image Journal Replay Latency
+              context: image_accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_image_replay_latency_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_replay_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Image Journal Replay Byte Throughput
+              context: image_byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_image_replay_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Journal Entries
+              context: journal_entries
+              units: entries/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_entries
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Journal Entries Queued for Replay
+              context: image_journal_entries
+              units: entries/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_image_entries
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+        - family: Snapshot Replication
+          context_namespace: snapshot_replication
+          metrics:
+            - ceph_rbd_mirror_snapshot_image_last_sync_bytes
+            - ceph_rbd_mirror_snapshot_image_last_sync_time
+            - ceph_rbd_mirror_snapshot_image_local_timestamp
+            - ceph_rbd_mirror_snapshot_image_remote_timestamp
+            - ceph_rbd_mirror_snapshot_image_snapshots
+            - ceph_rbd_mirror_snapshot_image_sync_bytes
+            - ceph_rbd_mirror_snapshot_image_sync_time_count
+            - ceph_rbd_mirror_snapshot_image_sync_time_sum
+            - ceph_rbd_mirror_snapshot_snapshots
+            - ceph_rbd_mirror_snapshot_sync_bytes
+            - ceph_rbd_mirror_snapshot_sync_time_count
+            - ceph_rbd_mirror_snapshot_sync_time_sum
+          charts:
+            - title: Snapshot Sync Latency Measurements — Image Sync Time
+              context: latency_measurements_image_sync_time
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_sync_time_count
+                  name: image_sync_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Snapshot Sync Latency Measurements — Sync Time
+              context: latency_measurements_sync_time
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_sync_time_count
+                  name: sync_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency — Image Sync Time
+              context: accumulated_latency_image_sync_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_sync_time_sum
+                  name: image_sync_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Latency — Sync Time
+              context: accumulated_latency_sync_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_sync_time_sum
+                  name: sync_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput — Image Sync Bytes
+              context: byte_throughput_image_sync_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_sync_bytes
+                  name: image_sync_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Byte Throughput — Sync Bytes
+              context: byte_throughput_sync_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_sync_bytes
+                  name: sync_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Last Snapshot Sync Duration
+              context: last_sync_duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_last_sync_time
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Last Snapshot Sync Size
+              context: last_sync_size
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_last_sync_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Snapshot Work — Image Snapshots
+              context: snapshot_work_image_snapshots
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_snapshots
+                  name: image_snapshots
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Snapshot Work — Snapshots
+              context: snapshot_work_snapshots
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_snapshots
+                  name: snapshots
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Timestamps
+              context: timestamp
+              units: seconds since epoch
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_local_timestamp
+                  name: local_timestamp
+                - selector: ceph_rbd_mirror_snapshot_image_remote_timestamp
+                  name: remote_timestamp
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+    - family: Runtime
+      context_namespace: runtime
+      groups:
+        - family: Shared Daemon
+          context_namespace: shared_daemon
+          metrics:
+            - ceph_KStore_state_done_lat_count
+            - ceph_KStore_state_done_lat_sum
+            - ceph_KStore_state_finishing_lat_count
+            - ceph_KStore_state_finishing_lat_sum
+            - ceph_KStore_state_kv_done_lat_count
+            - ceph_KStore_state_kv_done_lat_sum
+            - ceph_KStore_state_kv_queued_lat_count
+            - ceph_KStore_state_kv_queued_lat_sum
+            - ceph_KStore_state_prepare_lat_count
+            - ceph_KStore_state_prepare_lat_sum
+            - ceph_cct_total_workers
+            - ceph_cct_unhealthy_workers
+            - ceph_client_fsync_count
+            - ceph_client_fsync_sum
+            - ceph_client_lat_count
+            - ceph_client_lat_sum
+            - ceph_client_mdavg
+            - ceph_client_mdsqsum
+            - ceph_client_rdlat_count
+            - ceph_client_rdlat_sum
+            - ceph_client_readavg
+            - ceph_client_readsqsum
+            - ceph_client_reply_count
+            - ceph_client_reply_sum
+            - ceph_client_writeavg
+            - ceph_client_writesqsum
+            - ceph_client_wrlat_count
+            - ceph_client_wrlat_sum
+            - ceph_cluster_num_bytes
+            - ceph_cluster_num_mon
+            - ceph_cluster_num_mon_quorum
+            - ceph_cluster_num_object
+            - ceph_cluster_num_object_degraded
+            - ceph_cluster_num_object_misplaced
+            - ceph_cluster_num_object_unfound
+            - ceph_cluster_num_osd
+            - ceph_cluster_num_osd_in
+            - ceph_cluster_num_osd_up
+            - ceph_cluster_num_pg
+            - ceph_cluster_num_pg_active
+            - ceph_cluster_num_pg_active_clean
+            - ceph_cluster_num_pg_peering
+            - ceph_cluster_num_pool
+            - ceph_cluster_osd_bytes
+            - ceph_cluster_osd_bytes_avail
+            - ceph_cluster_osd_bytes_used
+            - ceph_cluster_osd_epoch
+            - ceph_ipv4_dpdk_ip_linearize_operations
+            - ceph_libcephsqlite_vfs_op_access_count
+            - ceph_libcephsqlite_vfs_op_access_sum
+            - ceph_libcephsqlite_vfs_op_currenttime_count
+            - ceph_libcephsqlite_vfs_op_currenttime_sum
+            - ceph_libcephsqlite_vfs_op_delete_count
+            - ceph_libcephsqlite_vfs_op_delete_sum
+            - ceph_libcephsqlite_vfs_op_fullpathname_count
+            - ceph_libcephsqlite_vfs_op_fullpathname_sum
+            - ceph_libcephsqlite_vfs_op_open_count
+            - ceph_libcephsqlite_vfs_op_open_sum
+            - ceph_libcephsqlite_vfs_opf_checkreservedlock_count
+            - ceph_libcephsqlite_vfs_opf_checkreservedlock_sum
+            - ceph_libcephsqlite_vfs_opf_close_count
+            - ceph_libcephsqlite_vfs_opf_close_sum
+            - ceph_libcephsqlite_vfs_opf_devicecharacteristics_count
+            - ceph_libcephsqlite_vfs_opf_devicecharacteristics_sum
+            - ceph_libcephsqlite_vfs_opf_filecontrol_count
+            - ceph_libcephsqlite_vfs_opf_filecontrol_sum
+            - ceph_libcephsqlite_vfs_opf_filesize_count
+            - ceph_libcephsqlite_vfs_opf_filesize_sum
+            - ceph_libcephsqlite_vfs_opf_lock_count
+            - ceph_libcephsqlite_vfs_opf_lock_sum
+            - ceph_libcephsqlite_vfs_opf_read_count
+            - ceph_libcephsqlite_vfs_opf_read_sum
+            - ceph_libcephsqlite_vfs_opf_sectorsize_count
+            - ceph_libcephsqlite_vfs_opf_sectorsize_sum
+            - ceph_libcephsqlite_vfs_opf_sync_count
+            - ceph_libcephsqlite_vfs_opf_sync_sum
+            - ceph_libcephsqlite_vfs_opf_truncate_count
+            - ceph_libcephsqlite_vfs_opf_truncate_sum
+            - ceph_libcephsqlite_vfs_opf_unlock_count
+            - ceph_libcephsqlite_vfs_opf_unlock_sum
+            - ceph_libcephsqlite_vfs_opf_write_count
+            - ceph_libcephsqlite_vfs_opf_write_sum
+            - ceph_oft_omap_total_kv_pairs
+            - ceph_oft_omap_total_objs
+            - ceph_oft_omap_total_removes
+            - ceph_oft_omap_total_updates
+            - ceph_recoverystate_perf_activating_latency_count
+            - ceph_recoverystate_perf_activating_latency_sum
+            - ceph_recoverystate_perf_active_latency_count
+            - ceph_recoverystate_perf_active_latency_sum
+            - ceph_recoverystate_perf_backfilling_latency_count
+            - ceph_recoverystate_perf_backfilling_latency_sum
+            - ceph_recoverystate_perf_clean_latency_count
+            - ceph_recoverystate_perf_clean_latency_sum
+            - ceph_recoverystate_perf_down_latency_count
+            - ceph_recoverystate_perf_down_latency_sum
+            - ceph_recoverystate_perf_getinfo_latency_count
+            - ceph_recoverystate_perf_getinfo_latency_sum
+            - ceph_recoverystate_perf_getlog_latency_count
+            - ceph_recoverystate_perf_getlog_latency_sum
+            - ceph_recoverystate_perf_getmissing_latency_count
+            - ceph_recoverystate_perf_getmissing_latency_sum
+            - ceph_recoverystate_perf_incomplete_latency_count
+            - ceph_recoverystate_perf_incomplete_latency_sum
+            - ceph_recoverystate_perf_initial_latency_count
+            - ceph_recoverystate_perf_initial_latency_sum
+            - ceph_recoverystate_perf_notbackfilling_latency_count
+            - ceph_recoverystate_perf_notbackfilling_latency_sum
+            - ceph_recoverystate_perf_notrecovering_latency_count
+            - ceph_recoverystate_perf_notrecovering_latency_sum
+            - ceph_recoverystate_perf_peering_latency_count
+            - ceph_recoverystate_perf_peering_latency_sum
+            - ceph_recoverystate_perf_primary_latency_count
+            - ceph_recoverystate_perf_primary_latency_sum
+            - ceph_recoverystate_perf_recovered_latency_count
+            - ceph_recoverystate_perf_recovered_latency_sum
+            - ceph_recoverystate_perf_recovering_latency_count
+            - ceph_recoverystate_perf_recovering_latency_sum
+            - ceph_recoverystate_perf_replicaactive_latency_count
+            - ceph_recoverystate_perf_replicaactive_latency_sum
+            - ceph_recoverystate_perf_repnotrecovering_latency_count
+            - ceph_recoverystate_perf_repnotrecovering_latency_sum
+            - ceph_recoverystate_perf_reprecovering_latency_count
+            - ceph_recoverystate_perf_reprecovering_latency_sum
+            - ceph_recoverystate_perf_repwaitbackfillreserved_latency_count
+            - ceph_recoverystate_perf_repwaitbackfillreserved_latency_sum
+            - ceph_recoverystate_perf_repwaitrecoveryreserved_latency_count
+            - ceph_recoverystate_perf_repwaitrecoveryreserved_latency_sum
+            - ceph_recoverystate_perf_reset_latency_count
+            - ceph_recoverystate_perf_reset_latency_sum
+            - ceph_recoverystate_perf_start_latency_count
+            - ceph_recoverystate_perf_start_latency_sum
+            - ceph_recoverystate_perf_started_latency_count
+            - ceph_recoverystate_perf_started_latency_sum
+            - ceph_recoverystate_perf_stats_invalidated
+            - ceph_recoverystate_perf_stray_latency_count
+            - ceph_recoverystate_perf_stray_latency_sum
+            - ceph_recoverystate_perf_waitactingchange_latency_count
+            - ceph_recoverystate_perf_waitactingchange_latency_sum
+            - ceph_recoverystate_perf_waitlocalbackfillreserved_latency_count
+            - ceph_recoverystate_perf_waitlocalbackfillreserved_latency_sum
+            - ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_count
+            - ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_sum
+            - ceph_recoverystate_perf_waitremotebackfillreserved_latency_count
+            - ceph_recoverystate_perf_waitremotebackfillreserved_latency_sum
+            - ceph_recoverystate_perf_waitremoterecoveryreserved_latency_count
+            - ceph_recoverystate_perf_waitremoterecoveryreserved_latency_sum
+            - ceph_recoverystate_perf_waitupthru_latency_count
+            - ceph_recoverystate_perf_waitupthru_latency_sum
+          charts:
+            - title: KStore Transaction Latency Measurements
+              context: kstore_latency_measurements
+              units: transactions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_KStore_state_done_lat_count
+                  name: kstore_state_done_lat
+                - selector: ceph_KStore_state_finishing_lat_count
+                  name: kstore_state_finishing_lat
+                - selector: ceph_KStore_state_kv_done_lat_count
+                  name: kstore_state_kv_done_lat
+                - selector: ceph_KStore_state_kv_queued_lat_count
+                  name: kstore_state_kv_queued_lat
+                - selector: ceph_KStore_state_prepare_lat_count
+                  name: kstore_state_prepare_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Client Request Latency Measurements
+              context: client_latency_measurements
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_lat_count
+                  name: client_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Recovery-State Transition Latency Measurements
+              context: recovery_state_latency_measurements
+              units: state transitions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_recoverystate_perf_activating_latency_count
+                  name: recoverystate_perf_activating_latency
+                - selector: ceph_recoverystate_perf_active_latency_count
+                  name: recoverystate_perf_active_latency
+                - selector: ceph_recoverystate_perf_backfilling_latency_count
+                  name: recoverystate_perf_backfilling_latency
+                - selector: ceph_recoverystate_perf_clean_latency_count
+                  name: recoverystate_perf_clean_latency
+                - selector: ceph_recoverystate_perf_down_latency_count
+                  name: recoverystate_perf_down_latency
+                - selector: ceph_recoverystate_perf_getinfo_latency_count
+                  name: recoverystate_perf_getinfo_latency
+                - selector: ceph_recoverystate_perf_getlog_latency_count
+                  name: recoverystate_perf_getlog_latency
+                - selector: ceph_recoverystate_perf_getmissing_latency_count
+                  name: recoverystate_perf_getmissing_latency
+                - selector: ceph_recoverystate_perf_incomplete_latency_count
+                  name: recoverystate_perf_incomplete_latency
+                - selector: ceph_recoverystate_perf_initial_latency_count
+                  name: recoverystate_perf_initial_latency
+                - selector: ceph_recoverystate_perf_notbackfilling_latency_count
+                  name: recoverystate_perf_notbackfilling_latency
+                - selector: ceph_recoverystate_perf_notrecovering_latency_count
+                  name: recoverystate_perf_notrecovering_latency
+                - selector: ceph_recoverystate_perf_peering_latency_count
+                  name: recoverystate_perf_peering_latency
+                - selector: ceph_recoverystate_perf_primary_latency_count
+                  name: recoverystate_perf_primary_latency
+                - selector: ceph_recoverystate_perf_recovered_latency_count
+                  name: recoverystate_perf_recovered_latency
+                - selector: ceph_recoverystate_perf_recovering_latency_count
+                  name: recoverystate_perf_recovering_latency
+                - selector: ceph_recoverystate_perf_replicaactive_latency_count
+                  name: recoverystate_perf_replicaactive_latency
+                - selector: ceph_recoverystate_perf_repnotrecovering_latency_count
+                  name: recoverystate_perf_repnotrecovering_latency
+                - selector: ceph_recoverystate_perf_reprecovering_latency_count
+                  name: recoverystate_perf_reprecovering_latency
+                - selector: ceph_recoverystate_perf_repwaitbackfillreserved_latency_count
+                  name: recoverystate_perf_repwaitbackfillreserved_latency
+                - selector: ceph_recoverystate_perf_repwaitrecoveryreserved_latency_count
+                  name: recoverystate_perf_repwaitrecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_reset_latency_count
+                  name: recoverystate_perf_reset_latency
+                - selector: ceph_recoverystate_perf_start_latency_count
+                  name: recoverystate_perf_start_latency
+                - selector: ceph_recoverystate_perf_started_latency_count
+                  name: recoverystate_perf_started_latency
+                - selector: ceph_recoverystate_perf_stray_latency_count
+                  name: recoverystate_perf_stray_latency
+                - selector: ceph_recoverystate_perf_waitactingchange_latency_count
+                  name: recoverystate_perf_waitactingchange_latency
+                - selector: ceph_recoverystate_perf_waitlocalbackfillreserved_latency_count
+                  name: recoverystate_perf_waitlocalbackfillreserved_latency
+                - selector: ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_count
+                  name: recoverystate_perf_waitlocalrecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_waitremotebackfillreserved_latency_count
+                  name: recoverystate_perf_waitremotebackfillreserved_latency
+                - selector: ceph_recoverystate_perf_waitremoterecoveryreserved_latency_count
+                  name: recoverystate_perf_waitremoterecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_waitupthru_latency_count
+                  name: recoverystate_perf_waitupthru_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated KStore Transaction Latency
+              context: accumulated_kstore_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_KStore_state_done_lat_sum
+                  name: kstore_state_done_lat
+                - selector: ceph_KStore_state_finishing_lat_sum
+                  name: kstore_state_finishing_lat
+                - selector: ceph_KStore_state_kv_done_lat_sum
+                  name: kstore_state_kv_done_lat
+                - selector: ceph_KStore_state_kv_queued_lat_sum
+                  name: kstore_state_kv_queued_lat
+                - selector: ceph_KStore_state_prepare_lat_sum
+                  name: kstore_state_prepare_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Client Request Latency
+              context: accumulated_client_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_lat_sum
+                  name: client_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Recovery-State Transition Latency
+              context: accumulated_recovery_state_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_recoverystate_perf_activating_latency_sum
+                  name: recoverystate_perf_activating_latency
+                - selector: ceph_recoverystate_perf_active_latency_sum
+                  name: recoverystate_perf_active_latency
+                - selector: ceph_recoverystate_perf_backfilling_latency_sum
+                  name: recoverystate_perf_backfilling_latency
+                - selector: ceph_recoverystate_perf_clean_latency_sum
+                  name: recoverystate_perf_clean_latency
+                - selector: ceph_recoverystate_perf_down_latency_sum
+                  name: recoverystate_perf_down_latency
+                - selector: ceph_recoverystate_perf_getinfo_latency_sum
+                  name: recoverystate_perf_getinfo_latency
+                - selector: ceph_recoverystate_perf_getlog_latency_sum
+                  name: recoverystate_perf_getlog_latency
+                - selector: ceph_recoverystate_perf_getmissing_latency_sum
+                  name: recoverystate_perf_getmissing_latency
+                - selector: ceph_recoverystate_perf_incomplete_latency_sum
+                  name: recoverystate_perf_incomplete_latency
+                - selector: ceph_recoverystate_perf_initial_latency_sum
+                  name: recoverystate_perf_initial_latency
+                - selector: ceph_recoverystate_perf_notbackfilling_latency_sum
+                  name: recoverystate_perf_notbackfilling_latency
+                - selector: ceph_recoverystate_perf_notrecovering_latency_sum
+                  name: recoverystate_perf_notrecovering_latency
+                - selector: ceph_recoverystate_perf_peering_latency_sum
+                  name: recoverystate_perf_peering_latency
+                - selector: ceph_recoverystate_perf_primary_latency_sum
+                  name: recoverystate_perf_primary_latency
+                - selector: ceph_recoverystate_perf_recovered_latency_sum
+                  name: recoverystate_perf_recovered_latency
+                - selector: ceph_recoverystate_perf_recovering_latency_sum
+                  name: recoverystate_perf_recovering_latency
+                - selector: ceph_recoverystate_perf_replicaactive_latency_sum
+                  name: recoverystate_perf_replicaactive_latency
+                - selector: ceph_recoverystate_perf_repnotrecovering_latency_sum
+                  name: recoverystate_perf_repnotrecovering_latency
+                - selector: ceph_recoverystate_perf_reprecovering_latency_sum
+                  name: recoverystate_perf_reprecovering_latency
+                - selector: ceph_recoverystate_perf_repwaitbackfillreserved_latency_sum
+                  name: recoverystate_perf_repwaitbackfillreserved_latency
+                - selector: ceph_recoverystate_perf_repwaitrecoveryreserved_latency_sum
+                  name: recoverystate_perf_repwaitrecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_reset_latency_sum
+                  name: recoverystate_perf_reset_latency
+                - selector: ceph_recoverystate_perf_start_latency_sum
+                  name: recoverystate_perf_start_latency
+                - selector: ceph_recoverystate_perf_started_latency_sum
+                  name: recoverystate_perf_started_latency
+                - selector: ceph_recoverystate_perf_stray_latency_sum
+                  name: recoverystate_perf_stray_latency
+                - selector: ceph_recoverystate_perf_waitactingchange_latency_sum
+                  name: recoverystate_perf_waitactingchange_latency
+                - selector: ceph_recoverystate_perf_waitlocalbackfillreserved_latency_sum
+                  name: recoverystate_perf_waitlocalbackfillreserved_latency
+                - selector: ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_sum
+                  name: recoverystate_perf_waitlocalrecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_waitremotebackfillreserved_latency_sum
+                  name: recoverystate_perf_waitremotebackfillreserved_latency
+                - selector: ceph_recoverystate_perf_waitremoterecoveryreserved_latency_sum
+                  name: recoverystate_perf_waitremoterecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_waitupthru_latency_sum
+                  name: recoverystate_perf_waitupthru_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Client Operation Latency Measurements
+              context: client_operation_latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_fsync_count
+                  name: client_fsync
+                - selector: ceph_client_rdlat_count
+                  name: client_rdlat
+                - selector: ceph_client_reply_count
+                  name: client_reply
+                - selector: ceph_client_wrlat_count
+                  name: client_wrlat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: SQLite VFS Operation Latency Measurements
+              context: sqlite_vfs_latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_libcephsqlite_vfs_op_access_count
+                  name: libcephsqlite_vfs_op_access
+                - selector: ceph_libcephsqlite_vfs_op_currenttime_count
+                  name: libcephsqlite_vfs_op_currenttime
+                - selector: ceph_libcephsqlite_vfs_op_delete_count
+                  name: libcephsqlite_vfs_op_delete
+                - selector: ceph_libcephsqlite_vfs_op_fullpathname_count
+                  name: libcephsqlite_vfs_op_fullpathname
+                - selector: ceph_libcephsqlite_vfs_op_open_count
+                  name: libcephsqlite_vfs_op_open
+                - selector: ceph_libcephsqlite_vfs_opf_checkreservedlock_count
+                  name: libcephsqlite_vfs_opf_checkreservedlock
+                - selector: ceph_libcephsqlite_vfs_opf_close_count
+                  name: libcephsqlite_vfs_opf_close
+                - selector: ceph_libcephsqlite_vfs_opf_devicecharacteristics_count
+                  name: libcephsqlite_vfs_opf_devicecharacteristics
+                - selector: ceph_libcephsqlite_vfs_opf_filecontrol_count
+                  name: libcephsqlite_vfs_opf_filecontrol
+                - selector: ceph_libcephsqlite_vfs_opf_filesize_count
+                  name: libcephsqlite_vfs_opf_filesize
+                - selector: ceph_libcephsqlite_vfs_opf_lock_count
+                  name: libcephsqlite_vfs_opf_lock
+                - selector: ceph_libcephsqlite_vfs_opf_read_count
+                  name: libcephsqlite_vfs_opf_read
+                - selector: ceph_libcephsqlite_vfs_opf_sectorsize_count
+                  name: libcephsqlite_vfs_opf_sectorsize
+                - selector: ceph_libcephsqlite_vfs_opf_sync_count
+                  name: libcephsqlite_vfs_opf_sync
+                - selector: ceph_libcephsqlite_vfs_opf_truncate_count
+                  name: libcephsqlite_vfs_opf_truncate
+                - selector: ceph_libcephsqlite_vfs_opf_unlock_count
+                  name: libcephsqlite_vfs_opf_unlock
+                - selector: ceph_libcephsqlite_vfs_opf_write_count
+                  name: libcephsqlite_vfs_opf_write
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Client Operation Latency
+              context: accumulated_client_operation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_fsync_sum
+                  name: client_fsync
+                - selector: ceph_client_rdlat_sum
+                  name: client_rdlat
+                - selector: ceph_client_reply_sum
+                  name: client_reply
+                - selector: ceph_client_wrlat_sum
+                  name: client_wrlat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated SQLite VFS Operation Latency
+              context: accumulated_sqlite_vfs_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_libcephsqlite_vfs_op_access_sum
+                  name: libcephsqlite_vfs_op_access
+                - selector: ceph_libcephsqlite_vfs_op_currenttime_sum
+                  name: libcephsqlite_vfs_op_currenttime
+                - selector: ceph_libcephsqlite_vfs_op_delete_sum
+                  name: libcephsqlite_vfs_op_delete
+                - selector: ceph_libcephsqlite_vfs_op_fullpathname_sum
+                  name: libcephsqlite_vfs_op_fullpathname
+                - selector: ceph_libcephsqlite_vfs_op_open_sum
+                  name: libcephsqlite_vfs_op_open
+                - selector: ceph_libcephsqlite_vfs_opf_checkreservedlock_sum
+                  name: libcephsqlite_vfs_opf_checkreservedlock
+                - selector: ceph_libcephsqlite_vfs_opf_close_sum
+                  name: libcephsqlite_vfs_opf_close
+                - selector: ceph_libcephsqlite_vfs_opf_devicecharacteristics_sum
+                  name: libcephsqlite_vfs_opf_devicecharacteristics
+                - selector: ceph_libcephsqlite_vfs_opf_filecontrol_sum
+                  name: libcephsqlite_vfs_opf_filecontrol
+                - selector: ceph_libcephsqlite_vfs_opf_filesize_sum
+                  name: libcephsqlite_vfs_opf_filesize
+                - selector: ceph_libcephsqlite_vfs_opf_lock_sum
+                  name: libcephsqlite_vfs_opf_lock
+                - selector: ceph_libcephsqlite_vfs_opf_read_sum
+                  name: libcephsqlite_vfs_opf_read
+                - selector: ceph_libcephsqlite_vfs_opf_sectorsize_sum
+                  name: libcephsqlite_vfs_opf_sectorsize
+                - selector: ceph_libcephsqlite_vfs_opf_sync_sum
+                  name: libcephsqlite_vfs_opf_sync
+                - selector: ceph_libcephsqlite_vfs_opf_truncate_sum
+                  name: libcephsqlite_vfs_opf_truncate
+                - selector: ceph_libcephsqlite_vfs_opf_unlock_sum
+                  name: libcephsqlite_vfs_opf_unlock
+                - selector: ceph_libcephsqlite_vfs_opf_write_sum
+                  name: libcephsqlite_vfs_opf_write
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Monitors
+              context: monitor_state
+              units: monitors
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_mon
+                  name: num_mon
+                - selector: ceph_cluster_num_mon_quorum
+                  name: cluster_num_mon_quorum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OSDs
+              context: osd_state
+              units: OSDs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_osd
+                  name: num_osd
+                - selector: ceph_cluster_num_osd_in
+                  name: cluster_num_osd_in
+                - selector: ceph_cluster_num_osd_up
+                  name: cluster_num_osd_up
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Pools
+              context: pool_state
+              units: pools
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_pool
+                  name: num_pool
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OSD-Map Epoch
+              context: osd_map_epoch
+              units: epoch
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_osd_epoch
+                  name: osd_epoch
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Duration and Time
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_mdavg
+                  name: mdavg
+                - selector: ceph_client_readavg
+                  name: readavg
+                - selector: ceph_client_writeavg
+                  name: writeavg
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Invalidated Recovery Statistics
+              context: invalidations
+              units: invalidations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_recoverystate_perf_stats_invalidated
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_object
+                  name: object
+                - selector: ceph_cluster_num_object_degraded
+                  name: degraded
+                - selector: ceph_cluster_num_object_misplaced
+                  name: misplaced
+                - selector: ceph_cluster_num_object_unfound
+                  name: unfound
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_ipv4_dpdk_ip_linearize_operations
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_bytes
+                  name: num_bytes
+                - selector: ceph_cluster_osd_bytes
+                  name: osd_bytes
+                - selector: ceph_cluster_osd_bytes_avail
+                  name: osd_bytes_avail
+                - selector: ceph_cluster_osd_bytes_used
+                  name: osd_bytes_used
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_pg
+                  name: cluster_num_pg
+                - selector: ceph_cluster_num_pg_active
+                  name: cluster_num_pg_active
+                - selector: ceph_cluster_num_pg_active_clean
+                  name: cluster_num_pg_active_clean
+                - selector: ceph_cluster_num_pg_peering
+                  name: cluster_num_pg_peering
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Client Latency Squared-Deviation Accumulators
+              context: client_latency_sqsum
+              units: microseconds²/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_mdsqsum
+                  name: client_mdsqsum
+                - selector: ceph_client_readsqsum
+                  name: client_readsqsum
+                - selector: ceph_client_writesqsum
+                  name: client_writesqsum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: OpenFileTable OMAP Mutations
+              context: oft_omap_mutations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_oft_omap_total_updates
+                  name: oft_omap_total_updates
+                - selector: ceph_oft_omap_total_removes
+                  name: oft_omap_total_removes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Context Workers
+              context: worker_state
+              units: workers
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cct_total_workers
+                  name: cct_total_workers
+                - selector: ceph_cct_unhealthy_workers
+                  name: cct_unhealthy_workers
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OpenFileTable Objects
+              context: oft_object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_oft_omap_total_objs
+                  name: oft_omap_total_objs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OpenFileTable Key-Value Pairs
+              context: oft_entry_state
+              units: entries
+              label_promotion: []
+              dimensions:
+                - selector: ceph_oft_omap_total_kv_pairs
+                  name: oft_omap_total_kv_pairs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Slow Operations
+          context_namespace: slow_operations
+          metrics:
+            - ceph_trackedop_slow_ops_count
+          charts:
+            - title: Slow Operations
+              context: slow_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_trackedop_slow_ops_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Storage Engine
+      context_namespace: storage_engine
+      groups:
+        - family: Priority Cache Full
+          context_namespace: priority_cache_full
+          metrics:
+            - ceph_prioritycache:full_committed_bytes
+            - ceph_prioritycache:full_pri0_bytes
+            - ceph_prioritycache:full_pri10_bytes
+            - ceph_prioritycache:full_pri11_bytes
+            - ceph_prioritycache:full_pri1_bytes
+            - ceph_prioritycache:full_pri2_bytes
+            - ceph_prioritycache:full_pri3_bytes
+            - ceph_prioritycache:full_pri4_bytes
+            - ceph_prioritycache:full_pri5_bytes
+            - ceph_prioritycache:full_pri6_bytes
+            - ceph_prioritycache:full_pri7_bytes
+            - ceph_prioritycache:full_pri8_bytes
+            - ceph_prioritycache:full_pri9_bytes
+            - ceph_prioritycache:full_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_prioritycache:full_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_prioritycache:full_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_prioritycache:full_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_prioritycache:full_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_prioritycache:full_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_prioritycache:full_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_prioritycache:full_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_prioritycache:full_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_prioritycache:full_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_prioritycache:full_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_prioritycache:full_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_prioritycache:full_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_prioritycache:full_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_prioritycache:full_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Incremental
+          context_namespace: priority_cache_incremental
+          metrics:
+            - ceph_prioritycache:inc_committed_bytes
+            - ceph_prioritycache:inc_pri0_bytes
+            - ceph_prioritycache:inc_pri10_bytes
+            - ceph_prioritycache:inc_pri11_bytes
+            - ceph_prioritycache:inc_pri1_bytes
+            - ceph_prioritycache:inc_pri2_bytes
+            - ceph_prioritycache:inc_pri3_bytes
+            - ceph_prioritycache:inc_pri4_bytes
+            - ceph_prioritycache:inc_pri5_bytes
+            - ceph_prioritycache:inc_pri6_bytes
+            - ceph_prioritycache:inc_pri7_bytes
+            - ceph_prioritycache:inc_pri8_bytes
+            - ceph_prioritycache:inc_pri9_bytes
+            - ceph_prioritycache:inc_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_prioritycache:inc_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_prioritycache:inc_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_prioritycache:inc_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_prioritycache:inc_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_prioritycache:inc_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_prioritycache:inc_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_prioritycache:inc_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_prioritycache:inc_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_prioritycache:inc_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_prioritycache:inc_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_prioritycache:inc_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_prioritycache:inc_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_prioritycache:inc_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_prioritycache:inc_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache KV
+          context_namespace: priority_cache_kv
+          metrics:
+            - ceph_prioritycache:kv_committed_bytes
+            - ceph_prioritycache:kv_pri0_bytes
+            - ceph_prioritycache:kv_pri10_bytes
+            - ceph_prioritycache:kv_pri11_bytes
+            - ceph_prioritycache:kv_pri1_bytes
+            - ceph_prioritycache:kv_pri2_bytes
+            - ceph_prioritycache:kv_pri3_bytes
+            - ceph_prioritycache:kv_pri4_bytes
+            - ceph_prioritycache:kv_pri5_bytes
+            - ceph_prioritycache:kv_pri6_bytes
+            - ceph_prioritycache:kv_pri7_bytes
+            - ceph_prioritycache:kv_pri8_bytes
+            - ceph_prioritycache:kv_pri9_bytes
+            - ceph_prioritycache:kv_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_prioritycache:kv_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_prioritycache:kv_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_prioritycache:kv_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_prioritycache:kv_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_prioritycache:kv_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_prioritycache:kv_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_prioritycache:kv_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_prioritycache:kv_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_prioritycache:kv_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_prioritycache:kv_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_prioritycache:kv_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_prioritycache:kv_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_prioritycache:kv_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_prioritycache:kv_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Runtime
+          context_namespace: priority_cache_runtime
+          metrics:
+            - ceph_prioritycache_cache_bytes
+            - ceph_prioritycache_heap_bytes
+            - ceph_prioritycache_mapped_bytes
+            - ceph_prioritycache_target_bytes
+            - ceph_prioritycache_unmapped_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_prioritycache_cache_bytes
+                  name: cache_bytes
+                - selector: ceph_prioritycache_heap_bytes
+                  name: heap_bytes
+                - selector: ceph_prioritycache_mapped_bytes
+                  name: mapped_bytes
+                - selector: ceph_prioritycache_target_bytes
+                  name: target_bytes
+                - selector: ceph_prioritycache_unmapped_bytes
+                  name: unmapped_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: RocksDB Compaction
+          context_namespace: rocksdb_compaction
+          metrics:
+            - ceph_rocksdb_compact
+            - ceph_rocksdb_compact_completed
+            - ceph_rocksdb_compact_lasted
+            - ceph_rocksdb_compact_queue_len
+            - ceph_rocksdb_compact_queue_merge
+            - ceph_rocksdb_compact_running
+          charts:
+            - title: Compaction Work
+              context: compaction_state
+              units: compactions
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_compact_queue_len
+                  name: queue_len
+                - selector: ceph_rocksdb_compact_running
+                  name: running
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: absolute
+            - title: Duration and Time
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_compact_lasted
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Compactions
+              context: compactions
+              units: compactions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_compact
+                  name: compact
+                - selector: ceph_rocksdb_compact_completed
+                  name: completed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Compaction Queue Merges
+              context: queue_merges
+              units: merges/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_compact_queue_merge
+                  name: queue_merge
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: RocksDB Requests
+          context_namespace: rocksdb_requests
+          metrics:
+            - ceph_rocksdb_get_latency_count
+            - ceph_rocksdb_get_latency_sum
+            - ceph_rocksdb_submit_latency_count
+            - ceph_rocksdb_submit_latency_sum
+            - ceph_rocksdb_submit_sync_latency_count
+            - ceph_rocksdb_submit_sync_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_get_latency_count
+                  name: get_latency
+                - selector: ceph_rocksdb_submit_latency_count
+                  name: submit_latency
+                - selector: ceph_rocksdb_submit_sync_latency_count
+                  name: submit_sync_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_get_latency_sum
+                  name: get_latency
+                - selector: ceph_rocksdb_submit_latency_sum
+                  name: submit_latency
+                - selector: ceph_rocksdb_submit_sync_latency_sum
+                  name: submit_sync_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: RocksDB Write Path
+          context_namespace: rocksdb_write_path
+          metrics:
+            - ceph_rocksdb_rocksdb_write_delay_time_count
+            - ceph_rocksdb_rocksdb_write_delay_time_sum
+            - ceph_rocksdb_rocksdb_write_memtable_time_count
+            - ceph_rocksdb_rocksdb_write_memtable_time_sum
+            - ceph_rocksdb_rocksdb_write_pre_and_post_time_count
+            - ceph_rocksdb_rocksdb_write_pre_and_post_time_sum
+            - ceph_rocksdb_rocksdb_write_wal_time_count
+            - ceph_rocksdb_rocksdb_write_wal_time_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_rocksdb_write_delay_time_count
+                  name: delay_time
+                - selector: ceph_rocksdb_rocksdb_write_memtable_time_count
+                  name: memtable_time
+                - selector: ceph_rocksdb_rocksdb_write_pre_and_post_time_count
+                  name: pre_and_post_time
+                - selector: ceph_rocksdb_rocksdb_write_wal_time_count
+                  name: wal_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_rocksdb_write_delay_time_sum
+                  name: delay_time
+                - selector: ceph_rocksdb_rocksdb_write_memtable_time_sum
+                  name: memtable_time
+                - selector: ceph_rocksdb_rocksdb_write_pre_and_post_time_sum
+                  name: pre_and_post_time
+                - selector: ceph_rocksdb_rocksdb_write_wal_time_sum
+                  name: wal_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+    - family: Runtime and Client Components
+      context_namespace: runtime_and_client_components
+      groups:
+        - family: RBD Persistent Write Log
+          context_namespace: rbd_persistent_write_log
+          metrics:
+            - ceph_rbd_librbd_pwl_aio_flush
+            - ceph_rbd_librbd_pwl_aio_flush_def
+            - ceph_rbd_librbd_pwl_aio_flush_lat_count
+            - ceph_rbd_librbd_pwl_aio_flush_lat_sum
+            - ceph_rbd_librbd_pwl_append_tx_lat_count
+            - ceph_rbd_librbd_pwl_append_tx_lat_sum
+            - ceph_rbd_librbd_pwl_caller_wr_latency_count
+            - ceph_rbd_librbd_pwl_caller_wr_latency_nw_count
+            - ceph_rbd_librbd_pwl_caller_wr_latency_nw_sum
+            - ceph_rbd_librbd_pwl_caller_wr_latency_sum
+            - ceph_rbd_librbd_pwl_cmp
+            - ceph_rbd_librbd_pwl_cmp_bytes
+            - ceph_rbd_librbd_pwl_cmp_fails
+            - ceph_rbd_librbd_pwl_cmp_lat_count
+            - ceph_rbd_librbd_pwl_cmp_lat_sum
+            - ceph_rbd_librbd_pwl_discard
+            - ceph_rbd_librbd_pwl_discard_bytes
+            - ceph_rbd_librbd_pwl_discard_lat_count
+            - ceph_rbd_librbd_pwl_discard_lat_sum
+            - ceph_rbd_librbd_pwl_hit_rd
+            - ceph_rbd_librbd_pwl_hit_rd_latency_count
+            - ceph_rbd_librbd_pwl_hit_rd_latency_sum
+            - ceph_rbd_librbd_pwl_internal_flush
+            - ceph_rbd_librbd_pwl_invalidate
+            - ceph_rbd_librbd_pwl_log_op_bytes_count
+            - ceph_rbd_librbd_pwl_log_op_bytes_sum
+            - ceph_rbd_librbd_pwl_log_ops
+            - ceph_rbd_librbd_pwl_op_alloc_t_count
+            - ceph_rbd_librbd_pwl_op_alloc_t_sum
+            - ceph_rbd_librbd_pwl_op_app_to_appc_t_count
+            - ceph_rbd_librbd_pwl_op_app_to_appc_t_sum
+            - ceph_rbd_librbd_pwl_op_app_to_cmp_t_count
+            - ceph_rbd_librbd_pwl_op_app_to_cmp_t_sum
+            - ceph_rbd_librbd_pwl_op_buf_to_app_t_count
+            - ceph_rbd_librbd_pwl_op_buf_to_app_t_sum
+            - ceph_rbd_librbd_pwl_op_buf_to_bufc_t_count
+            - ceph_rbd_librbd_pwl_op_buf_to_bufc_t_sum
+            - ceph_rbd_librbd_pwl_op_dis_to_app_t_count
+            - ceph_rbd_librbd_pwl_op_dis_to_app_t_sum
+            - ceph_rbd_librbd_pwl_op_dis_to_buf_t_count
+            - ceph_rbd_librbd_pwl_op_dis_to_buf_t_sum
+            - ceph_rbd_librbd_pwl_op_dis_to_cmp_t_count
+            - ceph_rbd_librbd_pwl_op_dis_to_cmp_t_sum
+            - ceph_rbd_librbd_pwl_part_hit_rd
+            - ceph_rbd_librbd_pwl_rd
+            - ceph_rbd_librbd_pwl_rd_bytes
+            - ceph_rbd_librbd_pwl_rd_hit_bytes
+            - ceph_rbd_librbd_pwl_rd_latency_count
+            - ceph_rbd_librbd_pwl_rd_latency_sum
+            - ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_count
+            - ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_sum
+            - ceph_rbd_librbd_pwl_req_all_to_dis_t_count
+            - ceph_rbd_librbd_pwl_req_all_to_dis_t_sum
+            - ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_count
+            - ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_sum
+            - ceph_rbd_librbd_pwl_req_arr_to_all_t_count
+            - ceph_rbd_librbd_pwl_req_arr_to_all_t_sum
+            - ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_count
+            - ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
+            - ceph_rbd_librbd_pwl_req_arr_to_dis_t_count
+            - ceph_rbd_librbd_pwl_req_arr_to_dis_t_sum
+            - ceph_rbd_librbd_pwl_retire_tx_lat_count
+            - ceph_rbd_librbd_pwl_retire_tx_lat_sum
+            - ceph_rbd_librbd_pwl_wr
+            - ceph_rbd_librbd_pwl_wr_bytes
+            - ceph_rbd_librbd_pwl_wr_def
+            - ceph_rbd_librbd_pwl_wr_def_buf
+            - ceph_rbd_librbd_pwl_wr_def_lanes
+            - ceph_rbd_librbd_pwl_wr_def_log
+            - ceph_rbd_librbd_pwl_wr_latency_count
+            - ceph_rbd_librbd_pwl_wr_latency_nw_count
+            - ceph_rbd_librbd_pwl_wr_latency_nw_sum
+            - ceph_rbd_librbd_pwl_wr_latency_sum
+            - ceph_rbd_librbd_pwl_wr_overlap
+            - ceph_rbd_librbd_pwl_wr_q_barrier
+            - ceph_rbd_librbd_pwl_writeback_lat_count
+            - ceph_rbd_librbd_pwl_writeback_lat_sum
+            - ceph_rbd_librbd_pwl_ws
+            - ceph_rbd_librbd_pwl_ws_bytes
+            - ceph_rbd_librbd_pwl_ws_lat_count
+            - ceph_rbd_librbd_pwl_ws_lat_sum
+          charts:
+            - title: Reads
+              context: reads
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_rd
+                  name: rd
+                - selector: ceph_rbd_librbd_pwl_hit_rd
+                  name: hit_rd
+                - selector: ceph_rbd_librbd_pwl_part_hit_rd
+                  name: part_hit_rd
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Writes
+              context: writes
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_wr
+                  name: wr
+                - selector: ceph_rbd_librbd_pwl_wr_def
+                  name: wr_def
+                - selector: ceph_rbd_librbd_pwl_wr_def_lanes
+                  name: wr_def_lanes
+                - selector: ceph_rbd_librbd_pwl_wr_def_log
+                  name: wr_def_log
+                - selector: ceph_rbd_librbd_pwl_wr_def_buf
+                  name: wr_def_buf
+                - selector: ceph_rbd_librbd_pwl_wr_overlap
+                  name: wr_overlap
+                - selector: ceph_rbd_librbd_pwl_wr_q_barrier
+                  name: wr_q_barrier
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Log Appends
+              context: log_appends
+              units: appends/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_log_ops
+                  name: log_ops
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Cache and Image Operations
+              context: cache_image_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_discard
+                  name: discard
+                - selector: ceph_rbd_librbd_pwl_aio_flush
+                  name: aio_flush
+                - selector: ceph_rbd_librbd_pwl_aio_flush_def
+                  name: aio_flush_def
+                - selector: ceph_rbd_librbd_pwl_ws
+                  name: ws
+                - selector: ceph_rbd_librbd_pwl_cmp
+                  name: cmp
+                - selector: ceph_rbd_librbd_pwl_cmp_fails
+                  name: cmp_fails
+                - selector: ceph_rbd_librbd_pwl_internal_flush
+                  name: internal_flush
+                - selector: ceph_rbd_librbd_pwl_invalidate
+                  name: invalidate
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Read Throughput
+              context: read_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_rd_bytes
+                  name: rd_bytes
+                - selector: ceph_rbd_librbd_pwl_rd_hit_bytes
+                  name: rd_hit_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Write Throughput
+              context: write_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_wr_bytes
+                  name: wr_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Data-Operation Throughput
+              context: data_operation_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_discard_bytes
+                  name: discard_bytes
+                - selector: ceph_rbd_librbd_pwl_ws_bytes
+                  name: ws_bytes
+                - selector: ceph_rbd_librbd_pwl_cmp_bytes
+                  name: cmp_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Log-Append Throughput
+              context: log_append_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_log_op_bytes_sum
+                  name: log_op_bytes_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Read Request Latency Measurements
+              context: read_latency_measurements
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_rd_latency_count
+                  name: rd_latency_count
+                - selector: ceph_rbd_librbd_pwl_hit_rd_latency_count
+                  name: hit_rd_latency_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Log-Append Size Measurements
+              context: log_append_size_measurements
+              units: appends/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_log_op_bytes_count
+                  name: log_op_bytes_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Write Request Latency Measurements
+              context: write_latency_measurements
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_all_t_count
+                  name: req_arr_to_all_t_count
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_t_count
+                  name: req_arr_to_dis_t_count
+                - selector: ceph_rbd_librbd_pwl_req_all_to_dis_t_count
+                  name: req_all_to_dis_t_count
+                - selector: ceph_rbd_librbd_pwl_wr_latency_count
+                  name: wr_latency_count
+                - selector: ceph_rbd_librbd_pwl_caller_wr_latency_count
+                  name: caller_wr_latency_count
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_count
+                  name: req_arr_to_all_nw_t_count
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_count
+                  name: req_arr_to_dis_nw_t_count
+                - selector: ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_count
+                  name: req_all_to_dis_nw_t_count
+                - selector: ceph_rbd_librbd_pwl_wr_latency_nw_count
+                  name: wr_latency_nw_count
+                - selector: ceph_rbd_librbd_pwl_caller_wr_latency_nw_count
+                  name: caller_wr_latency_nw_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Log Operation Latency Measurements
+              context: log_operation_latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_op_alloc_t_count
+                  name: op_alloc_t_count
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_buf_t_count
+                  name: op_dis_to_buf_t_count
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_app_t_count
+                  name: op_dis_to_app_t_count
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_cmp_t_count
+                  name: op_dis_to_cmp_t_count
+                - selector: ceph_rbd_librbd_pwl_op_buf_to_app_t_count
+                  name: op_buf_to_app_t_count
+                - selector: ceph_rbd_librbd_pwl_op_buf_to_bufc_t_count
+                  name: op_buf_to_bufc_t_count
+                - selector: ceph_rbd_librbd_pwl_op_app_to_cmp_t_count
+                  name: op_app_to_cmp_t_count
+                - selector: ceph_rbd_librbd_pwl_op_app_to_appc_t_count
+                  name: op_app_to_appc_t_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Data Operation Latency Measurements
+              context: data_operation_latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_discard_lat_count
+                  name: discard_lat_count
+                - selector: ceph_rbd_librbd_pwl_aio_flush_lat_count
+                  name: aio_flush_lat_count
+                - selector: ceph_rbd_librbd_pwl_ws_lat_count
+                  name: ws_lat_count
+                - selector: ceph_rbd_librbd_pwl_cmp_lat_count
+                  name: cmp_lat_count
+                - selector: ceph_rbd_librbd_pwl_writeback_lat_count
+                  name: writeback_lat_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Transaction Latency Measurements
+              context: transaction_latency_measurements
+              units: transactions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_append_tx_lat_count
+                  name: append_tx_lat_count
+                - selector: ceph_rbd_librbd_pwl_retire_tx_lat_count
+                  name: retire_tx_lat_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Accumulated Read Request Latency
+              context: accumulated_read_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_rd_latency_sum
+                  name: rd_latency_sum
+                - selector: ceph_rbd_librbd_pwl_hit_rd_latency_sum
+                  name: hit_rd_latency_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Accumulated Write Request Latency
+              context: accumulated_write_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_all_t_sum
+                  name: req_arr_to_all_t_sum
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_t_sum
+                  name: req_arr_to_dis_t_sum
+                - selector: ceph_rbd_librbd_pwl_req_all_to_dis_t_sum
+                  name: req_all_to_dis_t_sum
+                - selector: ceph_rbd_librbd_pwl_wr_latency_sum
+                  name: wr_latency_sum
+                - selector: ceph_rbd_librbd_pwl_caller_wr_latency_sum
+                  name: caller_wr_latency_sum
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_sum
+                  name: req_arr_to_all_nw_t_sum
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
+                  name: req_arr_to_dis_nw_t_sum
+                - selector: ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_sum
+                  name: req_all_to_dis_nw_t_sum
+                - selector: ceph_rbd_librbd_pwl_wr_latency_nw_sum
+                  name: wr_latency_nw_sum
+                - selector: ceph_rbd_librbd_pwl_caller_wr_latency_nw_sum
+                  name: caller_wr_latency_nw_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Accumulated Log Operation Latency
+              context: accumulated_log_operation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_op_alloc_t_sum
+                  name: op_alloc_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_buf_t_sum
+                  name: op_dis_to_buf_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_app_t_sum
+                  name: op_dis_to_app_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_cmp_t_sum
+                  name: op_dis_to_cmp_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_buf_to_app_t_sum
+                  name: op_buf_to_app_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_buf_to_bufc_t_sum
+                  name: op_buf_to_bufc_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_app_to_cmp_t_sum
+                  name: op_app_to_cmp_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_app_to_appc_t_sum
+                  name: op_app_to_appc_t_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Accumulated Data Operation Latency
+              context: accumulated_data_operation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_discard_lat_sum
+                  name: discard_lat_sum
+                - selector: ceph_rbd_librbd_pwl_aio_flush_lat_sum
+                  name: aio_flush_lat_sum
+                - selector: ceph_rbd_librbd_pwl_ws_lat_sum
+                  name: ws_lat_sum
+                - selector: ceph_rbd_librbd_pwl_cmp_lat_sum
+                  name: cmp_lat_sum
+                - selector: ceph_rbd_librbd_pwl_writeback_lat_sum
+                  name: writeback_lat_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Accumulated Transaction Latency
+              context: accumulated_transaction_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_append_tx_lat_sum
+                  name: append_tx_lat_sum
+                - selector: ceph_rbd_librbd_pwl_retire_tx_lat_sum
+                  name: retire_tx_lat_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+        - family: Object Caches
+          context_namespace: object_caches
+          metrics:
+            - ceph_objectcacher_cache_bytes_hit
+            - ceph_objectcacher_cache_bytes_miss
+            - ceph_objectcacher_cache_ops_hit
+            - ceph_objectcacher_cache_ops_miss
+            - ceph_objectcacher_data_flushed
+            - ceph_objectcacher_data_overwritten_while_flushing
+            - ceph_objectcacher_data_read
+            - ceph_objectcacher_data_written
+            - ceph_objectcacher_write_bytes_blocked
+            - ceph_objectcacher_write_ops_blocked
+            - ceph_objectcacher_write_time_blocked
+          charts:
+            - title: Cache Outcomes
+              context: cache_outcomes
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_cache_ops_hit
+                  name: hit
+                - selector: ceph_objectcacher_cache_ops_miss
+                  name: miss
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Cache Byte Outcomes
+              context: cache_byte_outcomes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_cache_bytes_hit
+                  name: hit
+                - selector: ceph_objectcacher_cache_bytes_miss
+                  name: miss
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Data Throughput
+              context: data_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_data_read
+                  name: read
+                - selector: ceph_objectcacher_data_written
+                  name: written
+                - selector: ceph_objectcacher_data_flushed
+                  name: flushed
+                - selector: ceph_objectcacher_data_overwritten_while_flushing
+                  name: overwritten_while_flushing
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Blocked Writes
+              context: blocked_writes
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_write_ops_blocked
+                  name: operations
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Blocked Write Throughput
+              context: blocked_write_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_write_bytes_blocked
+                  name: bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Blocked Write Time
+              context: blocked_write_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_write_time_blocked
+                  name: time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+              algorithm: incremental
+        - family: Finishers
+          context_namespace: finishers
+          metrics:
+            - ceph_finisher_complete_latency_count
+            - ceph_finisher_complete_latency_sum
+            - ceph_finisher_queue_len
+          charts:
+            - title: Queued Callbacks
+              context: queue_depth
+              units: callbacks
+              label_promotion: []
+              dimensions:
+                - selector: ceph_finisher_queue_len
+                  name: queued
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - finisher_key
+            - title: Drained Completion Batches
+              context: completions
+              units: batches/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_finisher_complete_latency_count
+                  name: completed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - finisher_key
+            - title: Accumulated Completion Latency
+              context: accumulated_completion_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_finisher_complete_latency_sum
+                  name: latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - finisher_key
+              algorithm: incremental
+        - family: Throttles
+          context_namespace: throttles
+          metrics:
+            - ceph_throttle_get
+            - ceph_throttle_get_or_fail_fail
+            - ceph_throttle_get_or_fail_success
+            - ceph_throttle_get_started
+            - ceph_throttle_get_sum
+            - ceph_throttle_max
+            - ceph_throttle_put
+            - ceph_throttle_put_sum
+            - ceph_throttle_take
+            - ceph_throttle_take_sum
+            - ceph_throttle_val
+            - ceph_throttle_wait_count
+            - ceph_throttle_wait_sum
+          charts:
+            - title: Utilization
+              context: utilization
+              units: slots
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_val
+                  name: val
+                - selector: ceph_throttle_max
+                  name: max
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - throttle_key
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_get_started
+                  name: get_started
+                - selector: ceph_throttle_get
+                  name: get
+                - selector: ceph_throttle_get_or_fail_fail
+                  name: get_or_fail_fail
+                - selector: ceph_throttle_get_or_fail_success
+                  name: get_or_fail_success
+                - selector: ceph_throttle_take
+                  name: take
+                - selector: ceph_throttle_put
+                  name: put
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - throttle_key
+            - title: Slot Throughput
+              context: slot_throughput
+              units: slots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_get_sum
+                  name: get_sum
+                - selector: ceph_throttle_take_sum
+                  name: take_sum
+                - selector: ceph_throttle_put_sum
+                  name: put_sum
+              instances:
+                by_labels: []
+                optional_by_labels:
+                  - throttle_key
+            - title: Waits
+              context: wait_measurements
+              units: waits/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_wait_count
+                  name: waits
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - throttle_key
+            - title: Accumulated Wait Time
+              context: accumulated_wait_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_wait_sum
+                  name: wait
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - throttle_key
+              algorithm: incremental
+        - family: Kernel Devices
+          context_namespace: kernel_devices
+          metrics:
+            - ceph_kernel_device_discard_op
+            - ceph_kernel_device_discard_threads
+          charts:
+            - title: Discard Operations
+              context: discard_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_kernel_device_discard_op
+                  name: discard
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - kernel_device_key
+            - title: Discard Threads
+              context: discard_threads
+              units: threads
+              label_promotion: []
+              dimensions:
+                - selector: ceph_kernel_device_discard_threads
+                  name: threads
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - kernel_device_key
+              algorithm: absolute
+        - family: mClock Shards
+          context_namespace: mclock_shards
+          metrics:
+            - ceph_mclock_shard_mclock_all_type_queue_len
+            - ceph_mclock_shard_mclock_best_effort_queue_len
+            - ceph_mclock_shard_mclock_client_queue_len
+            - ceph_mclock_shard_mclock_immediate_queue_len
+            - ceph_mclock_shard_mclock_recovery_queue_len
+          charts:
+            - title: Queue Depth
+              context: queue_depth
+              units: operations
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mclock_shard_mclock_immediate_queue_len
+                  name: immediate
+                - selector: ceph_mclock_shard_mclock_client_queue_len
+                  name: client
+                - selector: ceph_mclock_shard_mclock_recovery_queue_len
+                  name: recovery
+                - selector: ceph_mclock_shard_mclock_best_effort_queue_len
+                  name: best_effort
+                - selector: ceph_mclock_shard_mclock_all_type_queue_len
+                  name: all_type
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - mclock_shard
+              algorithm: absolute
+        - family: Messenger Workers
+          context_namespace: messenger_workers
+          metrics:
+            - ceph_async_messenger_worker_msgr_active_connections
+            - ceph_async_messenger_worker_msgr_created_connections
+            - ceph_async_messenger_worker_msgr_handle_ack_lat_count
+            - ceph_async_messenger_worker_msgr_handle_ack_lat_sum
+            - ceph_async_messenger_worker_msgr_recv_bytes
+            - ceph_async_messenger_worker_msgr_recv_encrypted_bytes
+            - ceph_async_messenger_worker_msgr_recv_messages
+            - ceph_async_messenger_worker_msgr_running_fast_dispatch_time
+            - ceph_async_messenger_worker_msgr_running_recv_time
+            - ceph_async_messenger_worker_msgr_running_send_time
+            - ceph_async_messenger_worker_msgr_running_total_time
+            - ceph_async_messenger_worker_msgr_send_bytes
+            - ceph_async_messenger_worker_msgr_send_encrypted_bytes
+            - ceph_async_messenger_worker_msgr_send_messages
+            - ceph_async_messenger_worker_msgr_send_messages_queue_lat_count
+            - ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
+          charts:
+            - title: Messages
+              context: messages
+              units: messages/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_recv_messages
+                  name: recv
+                - selector: ceph_async_messenger_worker_msgr_send_messages
+                  name: send
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_recv_bytes
+                  name: recv
+                - selector: ceph_async_messenger_worker_msgr_send_bytes
+                  name: send
+                - selector: ceph_async_messenger_worker_msgr_recv_encrypted_bytes
+                  name: recv_encrypted
+                - selector: ceph_async_messenger_worker_msgr_send_encrypted_bytes
+                  name: send_encrypted
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Connections
+              context: connections
+              units: connections
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_active_connections
+                  name: active
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+              algorithm: absolute
+            - title: Created Connections
+              context: created_connections
+              units: connections/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_created_connections
+                  name: created
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Accumulated Worker Time
+              context: accumulated_worker_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_running_total_time
+                  name: total
+                - selector: ceph_async_messenger_worker_msgr_running_send_time
+                  name: send
+                - selector: ceph_async_messenger_worker_msgr_running_recv_time
+                  name: recv
+                - selector: ceph_async_messenger_worker_msgr_running_fast_dispatch_time
+                  name: fast_dispatch
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+              algorithm: incremental
+            - title: Send-Queue Latency Measurements
+              context: send_queue_latency_measurements
+              units: messages/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_send_messages_queue_lat_count
+                  name: send_messages_queue
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Acknowledgement Latency Measurements
+              context: ack_latency_measurements
+              units: acknowledgements/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_handle_ack_lat_count
+                  name: handle_ack
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Accumulated Send-Queue Latency
+              context: accumulated_send_queue_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
+                  name: send_messages_queue
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+              algorithm: incremental
+            - title: Accumulated Acknowledgement Latency
+              context: accumulated_ack_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_handle_ack_lat_sum
+                  name: handle_ack
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+              algorithm: incremental
+        - family: RDMA Workers
+          context_namespace: rdma_workers
+          metrics:
+            - ceph_async_messenger_rdma_worker_pending_sent_conns
+            - ceph_async_messenger_rdma_worker_rx_bytes
+            - ceph_async_messenger_rdma_worker_rx_chunks
+            - ceph_async_messenger_rdma_worker_tx_bytes
+            - ceph_async_messenger_rdma_worker_tx_chunks
+            - ceph_async_messenger_rdma_worker_tx_failed_post
+            - ceph_async_messenger_rdma_worker_tx_no_mem
+            - ceph_async_messenger_rdma_worker_tx_parital_mem
+          charts:
+            - title: RDMA Transfer Errors
+              context: transfer_errors
+              units: errors/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_rdma_worker_tx_no_mem
+                  name: tx_no_mem
+                - selector: ceph_async_messenger_rdma_worker_tx_parital_mem
+                  name: tx_parital_mem
+                - selector: ceph_async_messenger_rdma_worker_tx_failed_post
+                  name: tx_failed_post
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rdma_worker
+            - title: Chunk Throughput
+              context: chunk_throughput
+              units: chunks/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_rdma_worker_tx_chunks
+                  name: tx
+                - selector: ceph_async_messenger_rdma_worker_rx_chunks
+                  name: rx
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rdma_worker
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_rdma_worker_tx_bytes
+                  name: tx
+                - selector: ceph_async_messenger_rdma_worker_rx_bytes
+                  name: rx
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rdma_worker
+            - title: Pending Connections
+              context: pending_connections
+              units: connections
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_rdma_worker_pending_sent_conns
+                  name: pending
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rdma_worker
+              algorithm: absolute
+        - family: DPDK Queues
+          context_namespace: dpdk_queues
+          metrics:
+            - ceph_dpdk_queue_dpdk_receive_bad_checksum_errors
+            - ceph_dpdk_queue_dpdk_receive_bytes
+            - ceph_dpdk_queue_dpdk_receive_copy_bytes
+            - ceph_dpdk_queue_dpdk_receive_copy_ops
+            - ceph_dpdk_queue_dpdk_receive_fragments
+            - ceph_dpdk_queue_dpdk_receive_last_bunch
+            - ceph_dpdk_queue_dpdk_receive_linearize_ops
+            - ceph_dpdk_queue_dpdk_receive_no_memory_errors
+            - ceph_dpdk_queue_dpdk_receive_packets
+            - ceph_dpdk_queue_dpdk_send_bytes
+            - ceph_dpdk_queue_dpdk_send_copy_bytes
+            - ceph_dpdk_queue_dpdk_send_copy_ops
+            - ceph_dpdk_queue_dpdk_send_fragments
+            - ceph_dpdk_queue_dpdk_send_last_bunch
+            - ceph_dpdk_queue_dpdk_send_linearize_ops
+            - ceph_dpdk_queue_dpdk_send_packets
+            - ceph_dpdk_queue_dpdk_send_queue_length
+          charts:
+            - title: Packets
+              context: packets
+              units: packets/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_packets
+                  name: receive
+                - selector: ceph_dpdk_queue_dpdk_send_packets
+                  name: send
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_bytes
+                  name: receive
+                - selector: ceph_dpdk_queue_dpdk_send_bytes
+                  name: send
+                - selector: ceph_dpdk_queue_dpdk_receive_copy_bytes
+                  name: receive_copy
+                - selector: ceph_dpdk_queue_dpdk_send_copy_bytes
+                  name: send_copy
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Packet Fragments
+              context: packet_fragments
+              units: fragments/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_fragments
+                  name: receive_fragments
+                - selector: ceph_dpdk_queue_dpdk_send_fragments
+                  name: send_fragments
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Copy and Linearize Operations
+              context: copy_linearize_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_copy_ops
+                  name: receive_copy_ops
+                - selector: ceph_dpdk_queue_dpdk_send_copy_ops
+                  name: send_copy_ops
+                - selector: ceph_dpdk_queue_dpdk_receive_linearize_ops
+                  name: receive_linearize_ops
+                - selector: ceph_dpdk_queue_dpdk_send_linearize_ops
+                  name: send_linearize_ops
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Receive Errors
+              context: receive_errors
+              units: errors/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_bad_checksum_errors
+                  name: bad_checksum
+                - selector: ceph_dpdk_queue_dpdk_receive_no_memory_errors
+                  name: no_memory
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Last Batch Size
+              context: last_batch_size
+              units: packets
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_last_bunch
+                  name: receive
+                - selector: ceph_dpdk_queue_dpdk_send_last_bunch
+                  name: send
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+              algorithm: absolute
+            - title: Send Queue Depth
+              context: send_queue_depth
+              units: packets
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_send_queue_length
+                  name: queued
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+              algorithm: absolute
+        - family: DPDK Ports
+          context_namespace: dpdk_ports
+          metrics:
+            - ceph_dpdk_port_dpdk_device_receive_badcrc_errors
+            - ceph_dpdk_port_dpdk_device_receive_dropped_errors
+            - ceph_dpdk_port_dpdk_device_receive_multicast_packets
+            - ceph_dpdk_port_dpdk_device_receive_nombuf_errors
+            - ceph_dpdk_port_dpdk_device_receive_total_errors
+            - ceph_dpdk_port_dpdk_device_send_total_errors
+          charts:
+            - title: Multicast Packets
+              context: multicast_packets
+              units: packets/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_port_dpdk_device_receive_multicast_packets
+                  name: received
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_port
+            - title: Receive Errors
+              context: receive_errors
+              units: errors/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_port_dpdk_device_receive_badcrc_errors
+                  name: badcrc
+                - selector: ceph_dpdk_port_dpdk_device_receive_total_errors
+                  name: total
+                - selector: ceph_dpdk_port_dpdk_device_receive_dropped_errors
+                  name: dropped
+                - selector: ceph_dpdk_port_dpdk_device_receive_nombuf_errors
+                  name: nombuf
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_port
+            - title: Send Errors
+              context: send_errors
+              units: errors/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_port_dpdk_device_send_total_errors
+                  name: total
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_port
+        - family: Service Identity
+          context_namespace: service_identity
+          metrics:
+            - ceph_service_unique_id
+          charts:
+            - title: Service Identity Metadata Sentinel
+              context: identity_metadata
+              units: identifier
+              label_promotion: []
+              dimensions:
+                - selector: ceph_service_unique_id
+                  name: present
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - service_unique_id
+        - family: RADOS Striper
+          context_namespace: rados_striper
+          metrics:
+            - ceph_libcephsqlite_striper_lock
+            - ceph_libcephsqlite_striper_shrink
+            - ceph_libcephsqlite_striper_shrink_bytes
+            - ceph_libcephsqlite_striper_unlock
+            - ceph_libcephsqlite_striper_update_allocated
+            - ceph_libcephsqlite_striper_update_metadata
+            - ceph_libcephsqlite_striper_update_size
+            - ceph_libcephsqlite_striper_update_version
+          charts:
+            - title: Metadata and Lock Work
+              context: metadata_and_lock_work
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_libcephsqlite_striper_update_metadata
+                  name: update_metadata
+                - selector: ceph_libcephsqlite_striper_update_allocated
+                  name: update_allocated
+                - selector: ceph_libcephsqlite_striper_update_size
+                  name: update_size
+                - selector: ceph_libcephsqlite_striper_update_version
+                  name: update_version
+                - selector: ceph_libcephsqlite_striper_shrink
+                  name: shrink
+                - selector: ceph_libcephsqlite_striper_lock
+                  name: lock
+                - selector: ceph_libcephsqlite_striper_unlock
+                  name: unlock
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Shrink Throughput
+              context: shrink_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_libcephsqlite_striper_shrink_bytes
+                  name: bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Memory Pools
+          context_namespace: memory_pools
+          metrics:
+            - ceph_mempool_bloom_filter_bytes
+            - ceph_mempool_bloom_filter_items
+            - ceph_mempool_bluefs_bytes
+            - ceph_mempool_bluefs_file_reader_bytes
+            - ceph_mempool_bluefs_file_reader_items
+            - ceph_mempool_bluefs_file_writer_bytes
+            - ceph_mempool_bluefs_file_writer_items
+            - ceph_mempool_bluefs_items
+            - ceph_mempool_bluestore_alloc_bytes
+            - ceph_mempool_bluestore_alloc_items
+            - ceph_mempool_bluestore_blob_bytes
+            - ceph_mempool_bluestore_blob_items
+            - ceph_mempool_bluestore_cache_buffer_bytes
+            - ceph_mempool_bluestore_cache_buffer_items
+            - ceph_mempool_bluestore_cache_data_bytes
+            - ceph_mempool_bluestore_cache_data_items
+            - ceph_mempool_bluestore_cache_meta_bytes
+            - ceph_mempool_bluestore_cache_meta_items
+            - ceph_mempool_bluestore_cache_onode_bytes
+            - ceph_mempool_bluestore_cache_onode_items
+            - ceph_mempool_bluestore_cache_other_bytes
+            - ceph_mempool_bluestore_cache_other_items
+            - ceph_mempool_bluestore_extent_bytes
+            - ceph_mempool_bluestore_extent_items
+            - ceph_mempool_bluestore_fsck_bytes
+            - ceph_mempool_bluestore_fsck_items
+            - ceph_mempool_bluestore_inline_bl_bytes
+            - ceph_mempool_bluestore_inline_bl_items
+            - ceph_mempool_bluestore_shared_blob_bytes
+            - ceph_mempool_bluestore_shared_blob_items
+            - ceph_mempool_bluestore_txc_bytes
+            - ceph_mempool_bluestore_txc_items
+            - ceph_mempool_bluestore_writing_bytes
+            - ceph_mempool_bluestore_writing_deferred_bytes
+            - ceph_mempool_bluestore_writing_deferred_items
+            - ceph_mempool_bluestore_writing_items
+            - ceph_mempool_buffer_anon_bytes
+            - ceph_mempool_buffer_anon_items
+            - ceph_mempool_buffer_meta_bytes
+            - ceph_mempool_buffer_meta_items
+            - ceph_mempool_ec_extent_cache_bytes
+            - ceph_mempool_ec_extent_cache_items
+            - ceph_mempool_mds_co_bytes
+            - ceph_mempool_mds_co_items
+            - ceph_mempool_osd_bytes
+            - ceph_mempool_osd_items
+            - ceph_mempool_osd_mapbl_bytes
+            - ceph_mempool_osd_mapbl_items
+            - ceph_mempool_osd_pglog_bytes
+            - ceph_mempool_osd_pglog_items
+            - ceph_mempool_osdmap_bytes
+            - ceph_mempool_osdmap_items
+            - ceph_mempool_osdmap_mapping_bytes
+            - ceph_mempool_osdmap_mapping_items
+            - ceph_mempool_pgmap_bytes
+            - ceph_mempool_pgmap_items
+            - ceph_mempool_unittest_1_bytes
+            - ceph_mempool_unittest_1_items
+            - ceph_mempool_unittest_2_bytes
+            - ceph_mempool_unittest_2_items
+          charts:
+            - title: Memory Use
+              context: memory_use
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mempool_bloom_filter_bytes
+                  name: bloom_filter
+                - selector: ceph_mempool_bluestore_alloc_bytes
+                  name: bluestore_alloc
+                - selector: ceph_mempool_bluestore_cache_data_bytes
+                  name: bluestore_cache_data
+                - selector: ceph_mempool_bluestore_cache_onode_bytes
+                  name: bluestore_cache_onode
+                - selector: ceph_mempool_bluestore_cache_meta_bytes
+                  name: bluestore_cache_meta
+                - selector: ceph_mempool_bluestore_cache_other_bytes
+                  name: bluestore_cache_other
+                - selector: ceph_mempool_bluestore_cache_buffer_bytes
+                  name: bluestore_cache_buffer
+                - selector: ceph_mempool_bluestore_extent_bytes
+                  name: bluestore_extent
+                - selector: ceph_mempool_bluestore_blob_bytes
+                  name: bluestore_blob
+                - selector: ceph_mempool_bluestore_shared_blob_bytes
+                  name: bluestore_shared_blob
+                - selector: ceph_mempool_bluestore_inline_bl_bytes
+                  name: bluestore_inline_bl
+                - selector: ceph_mempool_bluestore_fsck_bytes
+                  name: bluestore_fsck
+                - selector: ceph_mempool_bluestore_txc_bytes
+                  name: bluestore_txc
+                - selector: ceph_mempool_bluestore_writing_deferred_bytes
+                  name: bluestore_writing_deferred
+                - selector: ceph_mempool_bluestore_writing_bytes
+                  name: bluestore_writing
+                - selector: ceph_mempool_bluefs_bytes
+                  name: bluefs
+                - selector: ceph_mempool_bluefs_file_reader_bytes
+                  name: bluefs_file_reader
+                - selector: ceph_mempool_bluefs_file_writer_bytes
+                  name: bluefs_file_writer
+                - selector: ceph_mempool_buffer_anon_bytes
+                  name: buffer_anon
+                - selector: ceph_mempool_buffer_meta_bytes
+                  name: buffer_meta
+                - selector: ceph_mempool_osd_bytes
+                  name: osd
+                - selector: ceph_mempool_osd_mapbl_bytes
+                  name: osd_mapbl
+                - selector: ceph_mempool_osd_pglog_bytes
+                  name: osd_pglog
+                - selector: ceph_mempool_osdmap_bytes
+                  name: osdmap
+                - selector: ceph_mempool_osdmap_mapping_bytes
+                  name: osdmap_mapping
+                - selector: ceph_mempool_pgmap_bytes
+                  name: pgmap
+                - selector: ceph_mempool_mds_co_bytes
+                  name: mds_co
+                - selector: ceph_mempool_unittest_1_bytes
+                  name: unittest_1
+                - selector: ceph_mempool_unittest_2_bytes
+                  name: unittest_2
+                - selector: ceph_mempool_ec_extent_cache_bytes
+                  name: ec_extent_cache
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Item Count
+              context: item_count
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mempool_bloom_filter_items
+                  name: bloom_filter
+                - selector: ceph_mempool_bluestore_alloc_items
+                  name: bluestore_alloc
+                - selector: ceph_mempool_bluestore_cache_data_items
+                  name: bluestore_cache_data
+                - selector: ceph_mempool_bluestore_cache_onode_items
+                  name: bluestore_cache_onode
+                - selector: ceph_mempool_bluestore_cache_meta_items
+                  name: bluestore_cache_meta
+                - selector: ceph_mempool_bluestore_cache_other_items
+                  name: bluestore_cache_other
+                - selector: ceph_mempool_bluestore_cache_buffer_items
+                  name: bluestore_cache_buffer
+                - selector: ceph_mempool_bluestore_extent_items
+                  name: bluestore_extent
+                - selector: ceph_mempool_bluestore_blob_items
+                  name: bluestore_blob
+                - selector: ceph_mempool_bluestore_shared_blob_items
+                  name: bluestore_shared_blob
+                - selector: ceph_mempool_bluestore_inline_bl_items
+                  name: bluestore_inline_bl
+                - selector: ceph_mempool_bluestore_fsck_items
+                  name: bluestore_fsck
+                - selector: ceph_mempool_bluestore_txc_items
+                  name: bluestore_txc
+                - selector: ceph_mempool_bluestore_writing_deferred_items
+                  name: bluestore_writing_deferred
+                - selector: ceph_mempool_bluestore_writing_items
+                  name: bluestore_writing
+                - selector: ceph_mempool_bluefs_items
+                  name: bluefs
+                - selector: ceph_mempool_bluefs_file_reader_items
+                  name: bluefs_file_reader
+                - selector: ceph_mempool_bluefs_file_writer_items
+                  name: bluefs_file_writer
+                - selector: ceph_mempool_buffer_anon_items
+                  name: buffer_anon
+                - selector: ceph_mempool_buffer_meta_items
+                  name: buffer_meta
+                - selector: ceph_mempool_osd_items
+                  name: osd
+                - selector: ceph_mempool_osd_mapbl_items
+                  name: osd_mapbl
+                - selector: ceph_mempool_osd_pglog_items
+                  name: osd_pglog
+                - selector: ceph_mempool_osdmap_items
+                  name: osdmap
+                - selector: ceph_mempool_osdmap_mapping_items
+                  name: osdmap_mapping
+                - selector: ceph_mempool_pgmap_items
+                  name: pgmap
+                - selector: ceph_mempool_mds_co_items
+                  name: mds_co
+                - selector: ceph_mempool_unittest_1_items
+                  name: unittest_1
+                - selector: ceph_mempool_unittest_2_items
+                  name: unittest_2
+                - selector: ceph_mempool_ec_extent_cache_items
+                  name: ec_extent_cache
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: CephFS Mirror
+      context_namespace: cephfs_mirror
+      groups:
+        - family: Service
+          context_namespace: service
+          metrics:
+            - ceph_cephfs_mirror_mirror_enable_failures
+            - ceph_cephfs_mirror_mirrored_filesystems
+          charts:
+            - title: Mirrored Filesystems
+              context: filesystems
+              units: filesystems
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_mirrored_filesystems
+                  name: mirrored
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Mirroring Enable Failures
+              context: enable_failures
+              units: failures/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_mirror_enable_failures
+                  name: failures
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Filesystems
+          context_namespace: filesystems
+          metrics:
+            - ceph_cephfs_mirror_mirrored_filesystems_directory_count
+            - ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
+          charts:
+            - title: Mirroring Peers
+              context: peers
+              units: peers
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
+                  name: peers
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - filesystem
+                optional_by_labels: []
+            - title: Mirrored Directories
+              context: directories
+              units: directories
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_mirrored_filesystems_directory_count
+                  name: directories
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - filesystem
+                optional_by_labels: []
+        - family: Peers
+          context_namespace: peers
+          metrics:
+            - ceph_cephfs_mirror_peers_avg_sync_time_count
+            - ceph_cephfs_mirror_peers_avg_sync_time_sum
+            - ceph_cephfs_mirror_peers_last_synced_bytes
+            - ceph_cephfs_mirror_peers_last_synced_duration
+            - ceph_cephfs_mirror_peers_last_synced_end
+            - ceph_cephfs_mirror_peers_last_synced_start
+            - ceph_cephfs_mirror_peers_snaps_deleted
+            - ceph_cephfs_mirror_peers_snaps_renamed
+            - ceph_cephfs_mirror_peers_snaps_synced
+            - ceph_cephfs_mirror_peers_sync_bytes
+            - ceph_cephfs_mirror_peers_sync_failures
+          charts:
+            - title: Snapshot Outcomes
+              context: snapshot_outcomes
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_snaps_synced
+                  name: synced
+                - selector: ceph_cephfs_mirror_peers_snaps_deleted
+                  name: deleted
+                - selector: ceph_cephfs_mirror_peers_snaps_renamed
+                  name: renamed
+                - selector: ceph_cephfs_mirror_peers_sync_failures
+                  name: failed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Sync-Time Measurements
+              context: sync_time_measurements
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_avg_sync_time_count
+                  name: snapshots
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Accumulated Sync Time
+              context: accumulated_sync_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_avg_sync_time_sum
+                  name: time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Sync Throughput
+              context: sync_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_sync_bytes
+                  name: bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Last Sync Timestamps
+              context: last_sync_timestamps
+              units: seconds since epoch
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_last_synced_start
+                  name: started
+                - selector: ceph_cephfs_mirror_peers_last_synced_end
+                  name: ended
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Last Sync Duration
+              context: last_sync_duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_last_synced_duration
+                  name: duration
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Last Sync Size
+              context: last_sync_size
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_last_synced_bytes
+                  name: bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+              algorithm: absolute
+    - family: Object Gateway Scheduling
+      context_namespace: object_gateway_scheduling
       metrics:
-      - ceph_osd_in
-      - ceph_osd_up
-      - ceph_osd_weight
+        - ceph_dmclock_admin_cancel
+        - ceph_dmclock_admin_cancel_cost
+        - ceph_dmclock_admin_cost
+        - ceph_dmclock_admin_limit
+        - ceph_dmclock_admin_limit_cost
+        - ceph_dmclock_admin_prio
+        - ceph_dmclock_admin_prio_cost
+        - ceph_dmclock_admin_prio_latency_count
+        - ceph_dmclock_admin_prio_latency_sum
+        - ceph_dmclock_admin_qlen
+        - ceph_dmclock_admin_res
+        - ceph_dmclock_admin_res_cost
+        - ceph_dmclock_admin_res_latency_count
+        - ceph_dmclock_admin_res_latency_sum
+        - ceph_dmclock_auth_cancel
+        - ceph_dmclock_auth_cancel_cost
+        - ceph_dmclock_auth_cost
+        - ceph_dmclock_auth_limit
+        - ceph_dmclock_auth_limit_cost
+        - ceph_dmclock_auth_prio
+        - ceph_dmclock_auth_prio_cost
+        - ceph_dmclock_auth_prio_latency_count
+        - ceph_dmclock_auth_prio_latency_sum
+        - ceph_dmclock_auth_qlen
+        - ceph_dmclock_auth_res
+        - ceph_dmclock_auth_res_cost
+        - ceph_dmclock_auth_res_latency_count
+        - ceph_dmclock_auth_res_latency_sum
+        - ceph_dmclock_data_cancel
+        - ceph_dmclock_data_cancel_cost
+        - ceph_dmclock_data_cost
+        - ceph_dmclock_data_limit
+        - ceph_dmclock_data_limit_cost
+        - ceph_dmclock_data_prio
+        - ceph_dmclock_data_prio_cost
+        - ceph_dmclock_data_prio_latency_count
+        - ceph_dmclock_data_prio_latency_sum
+        - ceph_dmclock_data_qlen
+        - ceph_dmclock_data_res
+        - ceph_dmclock_data_res_cost
+        - ceph_dmclock_data_res_latency_count
+        - ceph_dmclock_data_res_latency_sum
+        - ceph_dmclock_metadata_cancel
+        - ceph_dmclock_metadata_cancel_cost
+        - ceph_dmclock_metadata_cost
+        - ceph_dmclock_metadata_limit
+        - ceph_dmclock_metadata_limit_cost
+        - ceph_dmclock_metadata_prio
+        - ceph_dmclock_metadata_prio_cost
+        - ceph_dmclock_metadata_prio_latency_count
+        - ceph_dmclock_metadata_prio_latency_sum
+        - ceph_dmclock_metadata_qlen
+        - ceph_dmclock_metadata_res
+        - ceph_dmclock_metadata_res_cost
+        - ceph_dmclock_metadata_res_latency_count
+        - ceph_dmclock_metadata_res_latency_sum
+        - ceph_dmclock_scheduler_outstanding
+        - ceph_dmclock_scheduler_throttle
       charts:
-      - title: OSD State
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_in
-          name: in
-        - selector: ceph_osd_up
-          name: up
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OSD Weight
-        context: weight
-        units: ratio
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_weight
-          name: weight
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: OSD Overview
-    context_namespace: osd_overview
-    metrics:
-    - ceph_osd_apply_latency_ms
-    - ceph_osd_commit_latency_ms
-    charts:
-    - title: Latency
-      context: latency
-      units: milliseconds
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_apply_latency_ms
-        name: apply_latency_ms
-      - selector: ceph_osd_commit_latency_ms
-        name: commit_latency_ms
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: Object Gateway Metadata
-    context_namespace: object_gateway_metadata
-    metrics:
-    - ceph_rgw_metadata
-    charts:
-    - title: State and Metadata
-      context: state
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rgw_metadata
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        - ceph_version
-        - hostname
-        - instance_id
-        optional_by_labels: []
-  - family: Placement Groups and Recovery
-    context_namespace: placement_groups_and_recovery
-    groups:
-    - family: Backfill
-      context_namespace: backfill
+        - title: Queue Depth
+          context: queue_depth
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_qlen
+              name: admin
+            - selector: ceph_dmclock_auth_qlen
+              name: auth
+            - selector: ceph_dmclock_data_qlen
+              name: data
+            - selector: ceph_dmclock_metadata_qlen
+              name: metadata
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Queued Request Cost
+          context: queue_cost
+          units: cost
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_cost
+              name: admin
+            - selector: ceph_dmclock_auth_cost
+              name: auth
+            - selector: ceph_dmclock_data_cost
+              name: data
+            - selector: ceph_dmclock_metadata_cost
+              name: metadata
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Scheduled Requests
+          context: scheduled_requests
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_res
+              name: admin_reservation
+            - selector: ceph_dmclock_admin_prio
+              name: admin_priority
+            - selector: ceph_dmclock_auth_res
+              name: auth_reservation
+            - selector: ceph_dmclock_auth_prio
+              name: auth_priority
+            - selector: ceph_dmclock_data_res
+              name: data_reservation
+            - selector: ceph_dmclock_data_prio
+              name: data_priority
+            - selector: ceph_dmclock_metadata_res
+              name: metadata_reservation
+            - selector: ceph_dmclock_metadata_prio
+              name: metadata_priority
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Rejected and Cancelled Requests
+          context: rejected_and_cancelled_requests
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_limit
+              name: admin_limited
+            - selector: ceph_dmclock_admin_cancel
+              name: admin_cancelled
+            - selector: ceph_dmclock_auth_limit
+              name: auth_limited
+            - selector: ceph_dmclock_auth_cancel
+              name: auth_cancelled
+            - selector: ceph_dmclock_data_limit
+              name: data_limited
+            - selector: ceph_dmclock_data_cancel
+              name: data_cancelled
+            - selector: ceph_dmclock_metadata_limit
+              name: metadata_limited
+            - selector: ceph_dmclock_metadata_cancel
+              name: metadata_cancelled
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Scheduled and Rejected Cost
+          context: scheduled_and_rejected_cost
+          units: cost/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_res_cost
+              name: admin_reservation
+            - selector: ceph_dmclock_admin_prio_cost
+              name: admin_priority
+            - selector: ceph_dmclock_admin_limit_cost
+              name: admin_limited
+            - selector: ceph_dmclock_admin_cancel_cost
+              name: admin_cancelled
+            - selector: ceph_dmclock_auth_res_cost
+              name: auth_reservation
+            - selector: ceph_dmclock_auth_prio_cost
+              name: auth_priority
+            - selector: ceph_dmclock_auth_limit_cost
+              name: auth_limited
+            - selector: ceph_dmclock_auth_cancel_cost
+              name: auth_cancelled
+            - selector: ceph_dmclock_data_res_cost
+              name: data_reservation
+            - selector: ceph_dmclock_data_prio_cost
+              name: data_priority
+            - selector: ceph_dmclock_data_limit_cost
+              name: data_limited
+            - selector: ceph_dmclock_data_cancel_cost
+              name: data_cancelled
+            - selector: ceph_dmclock_metadata_res_cost
+              name: metadata_reservation
+            - selector: ceph_dmclock_metadata_prio_cost
+              name: metadata_priority
+            - selector: ceph_dmclock_metadata_limit_cost
+              name: metadata_limited
+            - selector: ceph_dmclock_metadata_cancel_cost
+              name: metadata_cancelled
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Scheduling-Latency Measurements
+          context: latency_measurements
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_res_latency_count
+              name: admin_reservation
+            - selector: ceph_dmclock_admin_prio_latency_count
+              name: admin_priority
+            - selector: ceph_dmclock_auth_res_latency_count
+              name: auth_reservation
+            - selector: ceph_dmclock_auth_prio_latency_count
+              name: auth_priority
+            - selector: ceph_dmclock_data_res_latency_count
+              name: data_reservation
+            - selector: ceph_dmclock_data_prio_latency_count
+              name: data_priority
+            - selector: ceph_dmclock_metadata_res_latency_count
+              name: metadata_reservation
+            - selector: ceph_dmclock_metadata_prio_latency_count
+              name: metadata_priority
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Scheduling Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_res_latency_sum
+              name: admin_reservation
+            - selector: ceph_dmclock_admin_prio_latency_sum
+              name: admin_priority
+            - selector: ceph_dmclock_auth_res_latency_sum
+              name: auth_reservation
+            - selector: ceph_dmclock_auth_prio_latency_sum
+              name: auth_priority
+            - selector: ceph_dmclock_data_res_latency_sum
+              name: data_reservation
+            - selector: ceph_dmclock_data_prio_latency_sum
+              name: data_priority
+            - selector: ceph_dmclock_metadata_res_latency_sum
+              name: metadata_reservation
+            - selector: ceph_dmclock_metadata_prio_latency_sum
+              name: metadata_priority
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Throttled Requests
+          context: throttled_requests
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_scheduler_throttle
+              name: throttled
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Outstanding Requests
+          context: outstanding_requests
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_scheduler_outstanding
+              name: outstanding
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: Storage Engine Extensions
+      context_namespace: storage_engine_extensions
+      groups:
+        - family: RocksDB Binned Cache
+          context_namespace: rocksdb_binned_cache
+          metrics:
+            - ceph_rocksdb_binned_cache_capacity
+            - ceph_rocksdb_binned_cache_elems
+            - ceph_rocksdb_binned_cache_hits
+            - ceph_rocksdb_binned_cache_inserts
+            - ceph_rocksdb_binned_cache_lookups
+            - ceph_rocksdb_binned_cache_misses
+            - ceph_rocksdb_binned_cache_pinned
+            - ceph_rocksdb_binned_cache_usage
+          charts:
+            - title: Cache Memory
+              context: memory
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_capacity
+                  name: capacity
+                - selector: ceph_rocksdb_binned_cache_usage
+                  name: used
+                - selector: ceph_rocksdb_binned_cache_pinned
+                  name: pinned
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+            - title: Cache Entries
+              context: entries
+              units: entries
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_elems
+                  name: items
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+            - title: Cache Insertions
+              context: insertions
+              units: insertions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_inserts
+                  name: insertions
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+              algorithm: incremental
+            - title: Cache Lookups
+              context: lookups
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_lookups
+                  name: lookups
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+              algorithm: incremental
+            - title: Cache Lookup Outcomes
+              context: lookup_outcomes
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_hits
+                  name: hits
+                - selector: ceph_rocksdb_binned_cache_misses
+                  name: misses
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+              algorithm: incremental
+        - family: External Block Devices
+          context_namespace: external_block_devices
+          metrics:
+            - ceph_extblkdev_dev_log_size
+            - ceph_extblkdev_dev_log_util
+            - ceph_extblkdev_dev_phy_size
+            - ceph_extblkdev_dev_phy_util
+            - ceph_extblkdev_fcm
+            - ceph_extblkdev_part_log_avail
+            - ceph_extblkdev_part_log_size
+            - ceph_extblkdev_part_phy_avail
+            - ceph_extblkdev_part_phy_size
+          charts:
+            - title: FCM Plugin State
+              context: plugin_state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_extblkdev_fcm
+                  name: fcm
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Device Size
+              context: device_size
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_extblkdev_dev_phy_size
+                  name: physical
+                - selector: ceph_extblkdev_dev_log_size
+                  name: logical
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Device Utilization
+              context: device_utilization
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_extblkdev_dev_phy_util
+                  name: physical
+                - selector: ceph_extblkdev_dev_log_util
+                  name: logical
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Partition Space
+              context: partition_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_extblkdev_part_phy_size
+                  name: physical_size
+                - selector: ceph_extblkdev_part_log_size
+                  name: logical_size
+                - selector: ceph_extblkdev_part_phy_avail
+                  name: physical_available
+                - selector: ceph_extblkdev_part_log_avail
+                  name: logical_available
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Ceph Clients
+      context_namespace: ceph_clients
       metrics:
-      - ceph_pg_backfill_toofull
-      - ceph_pg_backfill_unfound
-      - ceph_pg_backfill_wait
-      - ceph_pg_backfilling
-      - ceph_pg_forced_backfill
-      - ceph_pg_remapped
+        - ceph_client_mdops
+        - ceph_client_rdops
+        - ceph_client_wrops
       charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_backfill_toofull
-          name: backfill_toofull
-        - selector: ceph_pg_backfill_unfound
-          name: backfill_unfound
-        - selector: ceph_pg_backfill_wait
-          name: backfill_wait
-        - selector: ceph_pg_backfilling
-          name: backfilling
-        - selector: ceph_pg_forced_backfill
-          name: forced_backfill
-        - selector: ceph_pg_remapped
-          name: remapped
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Healthy State
-      context_namespace: healthy_state
-      metrics:
-      - ceph_pg_active
-      - ceph_pg_clean
-      - ceph_pg_deep
-      - ceph_pg_total
-      charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_active
-          name: active
-        - selector: ceph_pg_clean
-          name: clean
-        - selector: ceph_pg_deep
-          name: deep
-        - selector: ceph_pg_total
-          name: pg_total
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Peering and Availability
-      context_namespace: peering_and_availability
-      metrics:
-      - ceph_pg_activating
-      - ceph_pg_creating
-      - ceph_pg_down
-      - ceph_pg_incomplete
-      - ceph_pg_laggy
-      - ceph_pg_peered
-      - ceph_pg_peering
-      - ceph_pg_premerge
-      - ceph_pg_stale
-      - ceph_pg_unknown
-      - ceph_pg_wait
-      charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_activating
-          name: activating
-        - selector: ceph_pg_creating
-          name: creating
-        - selector: ceph_pg_down
-          name: down
-        - selector: ceph_pg_incomplete
-          name: incomplete
-        - selector: ceph_pg_laggy
-          name: laggy
-        - selector: ceph_pg_peered
-          name: peered
-        - selector: ceph_pg_peering
-          name: peering
-        - selector: ceph_pg_premerge
-          name: premerge
-        - selector: ceph_pg_stale
-          name: stale
-        - selector: ceph_pg_unknown
-          name: unknown
-        - selector: ceph_pg_wait
-          name: wait
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Recovery Flags
-      context_namespace: recovery_flags
-      metrics:
-      - ceph_osd_flag_nobackfill
-      - ceph_osd_flag_norecover
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_flag_nobackfill
-          name: nobackfill
-        - selector: ceph_osd_flag_norecover
-          name: norecover
-    - family: Recovery and Degradation
-      context_namespace: recovery_and_degradation
-      metrics:
-      - ceph_pg_degraded
-      - ceph_pg_forced_recovery
-      - ceph_pg_recovering
-      - ceph_pg_recovery_toofull
-      - ceph_pg_recovery_unfound
-      - ceph_pg_recovery_wait
-      - ceph_pg_undersized
-      charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_degraded
-          name: degraded
-        - selector: ceph_pg_forced_recovery
-          name: forced_recovery
-        - selector: ceph_pg_recovering
-          name: recovering
-        - selector: ceph_pg_recovery_toofull
-          name: recovery_toofull
-        - selector: ceph_pg_recovery_unfound
-          name: recovery_unfound
-        - selector: ceph_pg_recovery_wait
-          name: recovery_wait
-        - selector: ceph_pg_undersized
-          name: undersized
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Scrub and Repair State
-      context_namespace: scrub_and_repair_state
-      metrics:
-      - ceph_pg_failed_repair
-      - ceph_pg_inconsistent
-      - ceph_pg_repair
-      - ceph_pg_scrubbing
-      - ceph_pg_snaptrim
-      - ceph_pg_snaptrim_error
-      - ceph_pg_snaptrim_wait
-      charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_failed_repair
-          name: failed_repair
-        - selector: ceph_pg_inconsistent
-          name: inconsistent
-        - selector: ceph_pg_repair
-          name: repair
-        - selector: ceph_pg_scrubbing
-          name: scrubbing
-        - selector: ceph_pg_snaptrim
-          name: snaptrim
-        - selector: ceph_pg_snaptrim_error
-          name: snaptrim_error
-        - selector: ceph_pg_snaptrim_wait
-          name: snaptrim_wait
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-  - family: Pools
-    context_namespace: pools
-    groups:
-    - family: Capacity and Quotas
-      context_namespace: capacity_and_quotas
-      metrics:
-      - ceph_pool_avail_raw
-      - ceph_pool_bytes_used
-      - ceph_pool_compress_bytes_used
-      - ceph_pool_compress_under_bytes
-      - ceph_pool_max_avail
-      - ceph_pool_percent_used
-      - ceph_pool_quota_bytes
-      - ceph_pool_quota_objects
-      - ceph_pool_stored
-      - ceph_pool_stored_raw
-      charts:
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_quota_objects
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Logical Pool Capacity
-        context: logical_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_max_avail
-          name: max_avail
-        - selector: ceph_pool_quota_bytes
-          name: quota_bytes
-        - selector: ceph_pool_stored
-          name: stored
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Raw Pool Capacity
-        context: raw_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_avail_raw
-          name: avail_raw
-        - selector: ceph_pool_bytes_used
-          name: bytes_used
-        - selector: ceph_pool_stored_raw
-          name: stored_raw
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Compression Space
-        context: compression_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_compress_bytes_used
-          name: compress_bytes_used
-        - selector: ceph_pool_compress_under_bytes
-          name: compress_under_bytes
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Utilization
-        context: utilization
-        units: percentage
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_percent_used
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Client I/O
-      context_namespace: client_i_o
-      metrics:
-      - ceph_pool_rd
-      - ceph_pool_rd_bytes
-      - ceph_pool_wr
-      - ceph_pool_wr_bytes
-      charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_rd_bytes
-          name: rd_bytes
-        - selector: ceph_pool_wr_bytes
-          name: wr_bytes
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_rd
-          name: rd
-        - selector: ceph_pool_wr
-          name: wr
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Metadata
-      context_namespace: metadata
-      metrics:
-      - ceph_pool_metadata
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_metadata
-          name: value
-        instances:
-          by_labels:
-          - application
-          - compression_mode
-          - description
-          - name
-          - pool_id
-          - type
-          optional_by_labels: []
-    - family: Objects
-      context_namespace: objects
-      metrics:
-      - ceph_pool_dirty
-      - ceph_pool_objects
-      charts:
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_dirty
-          name: dirty
-        - selector: ceph_pool_objects
-          name: objects
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Recovery
-      context_namespace: recovery
-      metrics:
-      - ceph_pool_num_bytes_recovered
-      - ceph_pool_num_objects_recovered
-      - ceph_pool_objects_repaired
-      - ceph_pool_recovering_bytes_per_sec
-      - ceph_pool_recovering_keys_per_sec
-      - ceph_pool_recovering_objects_per_sec
-      charts:
-      - title: Current Throughput
-        context: current_throughput_bytes_s
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_recovering_bytes_per_sec
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Current Throughput
-        context: current_throughput_keys_s
-        units: keys/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_recovering_keys_per_sec
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Current Throughput
-        context: current_throughput_objects_s
-        units: objects/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_recovering_objects_per_sec
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_num_objects_recovered
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Object Work
-        context: object_work
-        units: objects/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_objects_repaired
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Pool Capacity and Data Volume
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_num_bytes_recovered
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-  - family: RBD Images
-    context_namespace: rbd_images
-    groups:
-    - family: I/O
-      context_namespace: i_o
-      metrics:
-      - ceph_rbd_read_bytes
-      - ceph_rbd_read_ops
-      - ceph_rbd_write_bytes
-      - ceph_rbd_write_ops
-      charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_read_bytes
-          name: read_bytes
-        - selector: ceph_rbd_write_bytes
-          name: write_bytes
-        instances:
-          by_labels:
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_read_ops
-          name: read_ops
-        - selector: ceph_rbd_write_ops
-          name: write_ops
-        instances:
-          by_labels:
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-    - family: Image Metadata
-      context_namespace: image_metadata
-      metrics:
-      - ceph_rbd_image_metadata
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_image_metadata
-          name: value
-        instances:
-          by_labels:
-          - image_name
-          - pool_id
-          optional_by_labels: []
-    - family: Latency
-      context_namespace: latency
-      metrics:
-      - ceph_rbd_read_latency_count
-      - ceph_rbd_read_latency_sum
-      - ceph_rbd_write_latency_count
-      - ceph_rbd_write_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_read_latency_count
-          name: read_latency
-        - selector: ceph_rbd_write_latency_count
-          name: write_latency
-        instances:
-          by_labels:
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_read_latency_sum
-          name: read_latency
-        - selector: ceph_rbd_write_latency_sum
-          name: write_latency
-        instances:
-          by_labels:
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-    - family: Mirror Metadata
-      context_namespace: mirror_metadata
-      metrics:
-      - ceph_rbd_mirror_metadata
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_metadata
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - ceph_version
-          - hostname
-          - id
-          - instance_id
-          optional_by_labels: []
-  - family: SMB Metadata
-    context_namespace: smb_metadata
-    metrics:
-    - ceph_smb_metadata
-    charts:
-    - title: State and Metadata
-      context: state
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_smb_metadata
-        name: value
-      instances:
-        by_labels:
-        - netbiosname
-        - share
-        - smb_version
-        - subvolume
-        - subvolume_group
-        - volume
-        optional_by_labels: []
-  - family: BlueFS
-    context_namespace: bluefs
-    groups:
-    - family: Allocation
-      context_namespace: allocation
-      metrics:
-      - ceph_bluefs_alloc_db_max_lat
-      - ceph_bluefs_alloc_slow_fallback
-      - ceph_bluefs_alloc_slow_max_lat
-      - ceph_bluefs_alloc_slow_size_fallback
-      - ceph_bluefs_alloc_unit_db
-      - ceph_bluefs_alloc_unit_slow
-      - ceph_bluefs_alloc_unit_wal
-      - ceph_bluefs_alloc_wal_max_lat
-      - ceph_bluefs_db_alloc_lat_count
-      - ceph_bluefs_db_alloc_lat_sum
-      - ceph_bluefs_slow_alloc_lat_count
-      - ceph_bluefs_slow_alloc_lat_sum
-      - ceph_bluefs_wal_alloc_lat_count
-      - ceph_bluefs_wal_alloc_lat_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_db_alloc_lat_count
-          name: db_alloc_lat
-        - selector: ceph_bluefs_slow_alloc_lat_count
-          name: slow_alloc_lat
-        - selector: ceph_bluefs_wal_alloc_lat_count
-          name: wal_alloc_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_db_alloc_lat_sum
-          name: db_alloc_lat
-        - selector: ceph_bluefs_slow_alloc_lat_sum
-          name: slow_alloc_lat
-        - selector: ceph_bluefs_wal_alloc_lat_sum
-          name: wal_alloc_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Allocation Sizes and High-Water Marks
-        context: allocation_high_water
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_alloc_unit_db
-          name: db
-        - selector: ceph_bluefs_alloc_unit_slow
-          name: slow
-        - selector: ceph_bluefs_alloc_unit_wal
-          name: wal
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: absolute
-      - title: Duration and Time
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_alloc_db_max_lat
-          name: db_max_lat
-        - selector: ceph_bluefs_alloc_slow_max_lat
-          name: slow_max_lat
-        - selector: ceph_bluefs_alloc_wal_max_lat
-          name: wal_max_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_alloc_slow_fallback
-          name: fallback
-        - selector: ceph_bluefs_alloc_slow_size_fallback
-          name: size_fallback
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Compaction
-      context_namespace: compaction
-      metrics:
-      - ceph_bluefs_compact_lat_count
-      - ceph_bluefs_compact_lat_sum
-      - ceph_bluefs_compact_lock_lat_count
-      - ceph_bluefs_compact_lock_lat_sum
-      - ceph_bluefs_log_compactions
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_compact_lat_count
-          name: lat
-        - selector: ceph_bluefs_compact_lock_lat_count
-          name: lock_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_compact_lat_sum
-          name: lat
-        - selector: ceph_bluefs_compact_lock_lat_sum
-          name: lock_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_log_compactions
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: I/O and Files
-      context_namespace: i_o_and_files
-      metrics:
-      - ceph_bluefs_flush_lat_count
-      - ceph_bluefs_flush_lat_sum
-      - ceph_bluefs_fsync_lat_count
-      - ceph_bluefs_fsync_lat_sum
-      - ceph_bluefs_log_write_count
-      - ceph_bluefs_read_bytes
-      - ceph_bluefs_read_count
-      - ceph_bluefs_read_disk_bytes
-      - ceph_bluefs_read_disk_bytes_db
-      - ceph_bluefs_read_disk_bytes_slow
-      - ceph_bluefs_read_disk_bytes_wal
-      - ceph_bluefs_read_disk_count
-      - ceph_bluefs_read_lat_count
-      - ceph_bluefs_read_lat_sum
-      - ceph_bluefs_read_prefetch_bytes
-      - ceph_bluefs_read_prefetch_count
-      - ceph_bluefs_read_random_buffer_bytes
-      - ceph_bluefs_read_random_buffer_count
-      - ceph_bluefs_read_random_bytes
-      - ceph_bluefs_read_random_count
-      - ceph_bluefs_read_random_disk_bytes
-      - ceph_bluefs_read_random_disk_bytes_db
-      - ceph_bluefs_read_random_disk_bytes_slow
-      - ceph_bluefs_read_random_disk_bytes_wal
-      - ceph_bluefs_read_random_disk_count
-      - ceph_bluefs_read_random_lat_count
-      - ceph_bluefs_read_random_lat_sum
-      - ceph_bluefs_read_zeros_candidate
-      - ceph_bluefs_read_zeros_errors
-      - ceph_bluefs_truncate_lat_count
-      - ceph_bluefs_truncate_lat_sum
-      - ceph_bluefs_unlink_lat_count
-      - ceph_bluefs_unlink_lat_sum
-      - ceph_bluefs_write_bytes
-      - ceph_bluefs_write_count
-      - ceph_bluefs_write_count_sst
-      - ceph_bluefs_write_count_wal
-      - ceph_bluefs_write_disk_count
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_flush_lat_count
-          name: flush_lat
-        - selector: ceph_bluefs_fsync_lat_count
-          name: fsync_lat
-        - selector: ceph_bluefs_read_lat_count
-          name: read_lat
-        - selector: ceph_bluefs_read_random_lat_count
-          name: read_random_lat
-        - selector: ceph_bluefs_truncate_lat_count
-          name: truncate_lat
-        - selector: ceph_bluefs_unlink_lat_count
-          name: unlink_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_flush_lat_sum
-          name: flush_lat
-        - selector: ceph_bluefs_fsync_lat_sum
-          name: fsync_lat
-        - selector: ceph_bluefs_read_lat_sum
-          name: read_lat
-        - selector: ceph_bluefs_read_random_lat_sum
-          name: read_random_lat
-        - selector: ceph_bluefs_truncate_lat_sum
-          name: truncate_lat
-        - selector: ceph_bluefs_unlink_lat_sum
-          name: unlink_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_read_bytes
-          name: read_bytes
-        - selector: ceph_bluefs_read_disk_bytes
-          name: read_disk_bytes
-        - selector: ceph_bluefs_read_disk_bytes_db
-          name: read_disk_bytes_db
-        - selector: ceph_bluefs_read_disk_bytes_slow
-          name: read_disk_bytes_slow
-        - selector: ceph_bluefs_read_disk_bytes_wal
-          name: read_disk_bytes_wal
-        - selector: ceph_bluefs_read_prefetch_bytes
-          name: read_prefetch_bytes
-        - selector: ceph_bluefs_read_random_buffer_bytes
-          name: read_random_buffer_bytes
-        - selector: ceph_bluefs_read_random_bytes
-          name: read_random_bytes
-        - selector: ceph_bluefs_read_random_disk_bytes
-          name: read_random_disk_bytes
-        - selector: ceph_bluefs_read_random_disk_bytes_db
-          name: read_random_disk_bytes_db
-        - selector: ceph_bluefs_read_random_disk_bytes_slow
-          name: read_random_disk_bytes_slow
-        - selector: ceph_bluefs_read_random_disk_bytes_wal
-          name: read_random_disk_bytes_wal
-        - selector: ceph_bluefs_write_bytes
-          name: write_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_log_write_count
-          name: log_write
-        - selector: ceph_bluefs_read_count
-          name: read
-        - selector: ceph_bluefs_read_disk_count
-          name: read_disk
-        - selector: ceph_bluefs_read_prefetch_count
-          name: read_prefetch
-        - selector: ceph_bluefs_read_random_buffer_count
-          name: read_random_buffer
-        - selector: ceph_bluefs_read_random_count
-          name: read_random
-        - selector: ceph_bluefs_read_random_disk_count
-          name: read_random_disk
-        - selector: ceph_bluefs_write_count
-          name: write
-        - selector: ceph_bluefs_write_count_sst
-          name: write_count_sst
-        - selector: ceph_bluefs_write_count_wal
-          name: write_count_wal
-        - selector: ceph_bluefs_write_disk_count
-          name: write_disk
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Zero-Read Outcomes
-        context: zero_read_outcomes
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_read_zeros_candidate
-          name: candidate
-        - selector: ceph_bluefs_read_zeros_errors
-          name: errors
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Space and Files
-      context_namespace: space_and_files
-      metrics:
-      - ceph_bluefs_bytes_written_slow
-      - ceph_bluefs_bytes_written_sst
-      - ceph_bluefs_bytes_written_wal
-      - ceph_bluefs_db_total_bytes
-      - ceph_bluefs_db_used_bytes
-      - ceph_bluefs_files_written_sst
-      - ceph_bluefs_files_written_wal
-      - ceph_bluefs_log_bytes
-      - ceph_bluefs_logged_bytes
-      - ceph_bluefs_max_bytes_db
-      - ceph_bluefs_max_bytes_slow
-      - ceph_bluefs_max_bytes_wal
-      - ceph_bluefs_num_files
-      - ceph_bluefs_slow_total_bytes
-      - ceph_bluefs_slow_used_bytes
-      - ceph_bluefs_wal_total_bytes
-      - ceph_bluefs_wal_used_bytes
-      charts:
-      - title: Allocation Sizes and High-Water Marks
-        context: allocation_high_water
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_max_bytes_db
-          name: db
-        - selector: ceph_bluefs_max_bytes_slow
-          name: slow
-        - selector: ceph_bluefs_max_bytes_wal
-          name: wal
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: absolute
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_bytes_written_slow
-          name: bytes_written_slow
-        - selector: ceph_bluefs_bytes_written_sst
-          name: bytes_written_sst
-        - selector: ceph_bluefs_bytes_written_wal
-          name: bytes_written_wal
-        - selector: ceph_bluefs_logged_bytes
-          name: logged_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Files
-        context: file_state
-        units: files
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_num_files
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: File Work
-        context: file_work
-        units: files/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_files_written_sst
-          name: sst
-        - selector: ceph_bluefs_files_written_wal
-          name: wal
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_db_total_bytes
-          name: db_total_bytes
-        - selector: ceph_bluefs_db_used_bytes
-          name: db_used_bytes
-        - selector: ceph_bluefs_log_bytes
-          name: log_bytes
-        - selector: ceph_bluefs_slow_total_bytes
-          name: slow_total_bytes
-        - selector: ceph_bluefs_slow_used_bytes
-          name: slow_used_bytes
-        - selector: ceph_bluefs_wal_total_bytes
-          name: wal_total_bytes
-        - selector: ceph_bluefs_wal_used_bytes
-          name: wal_used_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: BlueStore
-    context_namespace: bluestore
-    groups:
-    - family: Allocation
-      context_namespace: allocation
-      metrics:
-      - ceph_bluestore_alloc_unit
-      - ceph_bluestore_allocated
-      - ceph_bluestore_allocator_lat_count
-      - ceph_bluestore_allocator_lat_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_allocator_lat_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_allocator_lat_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Allocation Unit
-        context: allocation_unit
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_alloc_unit
-          name: alloc_unit
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Allocated Space
-        context: allocated_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_allocated
-          name: allocated
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Compression and Checksums
-      context_namespace: compression_and_checksums
-      metrics:
-      - ceph_bluestore_compress_lat_count
-      - ceph_bluestore_compress_lat_sum
-      - ceph_bluestore_compress_rejected_count
-      - ceph_bluestore_compress_success_count
-      - ceph_bluestore_compressed
-      - ceph_bluestore_compressed_allocated
-      - ceph_bluestore_compressed_original
-      - ceph_bluestore_csum_lat_count
-      - ceph_bluestore_csum_lat_sum
-      - ceph_bluestore_decompress_lat_count
-      - ceph_bluestore_decompress_lat_sum
-      - ceph_bluestore_extent_compress
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_compress_lat_count
-          name: compress_lat
-        - selector: ceph_bluestore_csum_lat_count
-          name: csum_lat
-        - selector: ceph_bluestore_decompress_lat_count
-          name: decompress_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_compress_lat_sum
-          name: compress_lat
-        - selector: ceph_bluestore_csum_lat_sum
-          name: csum_lat
-        - selector: ceph_bluestore_decompress_lat_sum
-          name: decompress_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Compression Operations
-        context: compression_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_compress_rejected_count
-          name: compress_rejected
-        - selector: ceph_bluestore_compress_success_count
-          name: compress_success
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Compressed Extents
-        context: compressed_extents
-        units: extents/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_extent_compress
-          name: extent_compress
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_compressed
-          name: compressed
-        - selector: ceph_bluestore_compressed_allocated
-          name: allocated
-        - selector: ceph_bluestore_compressed_original
-          name: original
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: I/O
-      context_namespace: i_o
-      metrics:
-      - ceph_bluestore_issued_deferred_write_bytes
-      - ceph_bluestore_issued_deferred_writes
-      - ceph_bluestore_read_eio
-      - ceph_bluestore_read_lat_count
-      - ceph_bluestore_read_lat_sum
-      - ceph_bluestore_read_onode_meta_lat_count
-      - ceph_bluestore_read_onode_meta_lat_sum
-      - ceph_bluestore_read_wait_aio_lat_count
-      - ceph_bluestore_read_wait_aio_lat_sum
-      - ceph_bluestore_reads_with_retries
-      - ceph_bluestore_remove_lat_count
-      - ceph_bluestore_remove_lat_sum
-      - ceph_bluestore_slow_aio_wait_count
-      - ceph_bluestore_slow_read_onode_meta_count
-      - ceph_bluestore_slow_read_wait_aio_count
-      - ceph_bluestore_submitted_deferred_write_bytes
-      - ceph_bluestore_submitted_deferred_writes
-      - ceph_bluestore_truncate_lat_count
-      - ceph_bluestore_truncate_lat_sum
-      - ceph_bluestore_write_big
-      - ceph_bluestore_write_big_blobs
-      - ceph_bluestore_write_big_bytes
-      - ceph_bluestore_write_big_deferred
-      - ceph_bluestore_write_big_skipped_blobs
-      - ceph_bluestore_write_big_skipped_bytes
-      - ceph_bluestore_write_lat_count
-      - ceph_bluestore_write_lat_sum
-      - ceph_bluestore_write_new
-      - ceph_bluestore_write_pad_bytes
-      - ceph_bluestore_write_penalty_read_ops
-      - ceph_bluestore_write_small
-      - ceph_bluestore_write_small_bytes
-      - ceph_bluestore_write_small_pre_read
-      - ceph_bluestore_write_small_skipped
-      - ceph_bluestore_write_small_skipped_bytes
-      - ceph_bluestore_write_small_unused
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_read_lat_count
-          name: read_lat
-        - selector: ceph_bluestore_read_onode_meta_lat_count
-          name: read_onode_meta_lat
-        - selector: ceph_bluestore_read_wait_aio_lat_count
-          name: read_wait_aio_lat
-        - selector: ceph_bluestore_remove_lat_count
-          name: remove_lat
-        - selector: ceph_bluestore_truncate_lat_count
-          name: truncate_lat
-        - selector: ceph_bluestore_write_lat_count
-          name: write_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_read_lat_sum
-          name: read_lat
-        - selector: ceph_bluestore_read_onode_meta_lat_sum
-          name: read_onode_meta_lat
-        - selector: ceph_bluestore_read_wait_aio_lat_sum
-          name: read_wait_aio_lat
-        - selector: ceph_bluestore_remove_lat_sum
-          name: remove_lat
-        - selector: ceph_bluestore_truncate_lat_sum
-          name: truncate_lat
-        - selector: ceph_bluestore_write_lat_sum
-          name: write_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_issued_deferred_write_bytes
-          name: issued_deferred_write_bytes
-        - selector: ceph_bluestore_submitted_deferred_write_bytes
-          name: submitted_deferred_write_bytes
-        - selector: ceph_bluestore_write_big_bytes
-          name: write_big_bytes
-        - selector: ceph_bluestore_write_big_skipped_bytes
-          name: write_big_skipped_bytes
-        - selector: ceph_bluestore_write_pad_bytes
-          name: write_pad_bytes
-        - selector: ceph_bluestore_write_small_bytes
-          name: write_small_bytes
-        - selector: ceph_bluestore_write_small_skipped_bytes
-          name: write_small_skipped_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Read Outcomes
-        context: read_outcomes
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_read_eio
-          name: read_eio
-        - selector: ceph_bluestore_reads_with_retries
-          name: reads_with_retries
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Slow Reads
-        context: slow_reads
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_slow_read_onode_meta_count
-          name: slow_read_onode_meta
-        - selector: ceph_bluestore_slow_read_wait_aio_count
-          name: slow_read_wait_aio
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Slow AIO Waits
-        context: slow_aio_waits
-        units: waits/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_slow_aio_wait_count
-          name: slow_aio_wait
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Skipped Blobs
-        context: skipped_blobs
-        units: blobs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_write_big_skipped_blobs
-          name: write_big_skipped_blobs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Skipped Writes
-        context: skipped_writes
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_write_small_skipped
-          name: write_small_skipped
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Write Operations
-        context: write_operations
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_issued_deferred_writes
-          name: issued_deferred_writes
-        - selector: ceph_bluestore_submitted_deferred_writes
-          name: submitted_deferred_writes
-        - selector: ceph_bluestore_write_big
-          name: write_big
-        - selector: ceph_bluestore_write_big_deferred
-          name: write_big_deferred
-        - selector: ceph_bluestore_write_new
-          name: write_new
-        - selector: ceph_bluestore_write_small
-          name: write_small
-        - selector: ceph_bluestore_write_small_pre_read
-          name: write_small_pre_read
-        - selector: ceph_bluestore_write_small_unused
-          name: write_small_unused
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Written Blobs
-        context: written_blobs
-        units: blobs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_write_big_blobs
-          name: write_big_blobs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Penalty Reads
-        context: penalty_reads
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_write_penalty_read_ops
-          name: write_penalty_read_ops
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: OMAP
-      context_namespace: omap
-      metrics:
-      - ceph_bluestore_omap_clear_lat_count
-      - ceph_bluestore_omap_clear_lat_sum
-      - ceph_bluestore_omap_get_keys_lat_count
-      - ceph_bluestore_omap_get_keys_lat_sum
-      - ceph_bluestore_omap_get_values_lat_count
-      - ceph_bluestore_omap_get_values_lat_sum
-      - ceph_bluestore_omap_iterator_count
-      - ceph_bluestore_omap_lower_bound_lat_count
-      - ceph_bluestore_omap_lower_bound_lat_sum
-      - ceph_bluestore_omap_next_lat_count
-      - ceph_bluestore_omap_next_lat_sum
-      - ceph_bluestore_omap_rmkey_range_count
-      - ceph_bluestore_omap_rmkeys_count
-      - ceph_bluestore_omap_seek_to_first_lat_count
-      - ceph_bluestore_omap_seek_to_first_lat_sum
-      - ceph_bluestore_omap_setheader_bytes
-      - ceph_bluestore_omap_setheader_count
-      - ceph_bluestore_omap_setkeys_bytes
-      - ceph_bluestore_omap_setkeys_count
-      - ceph_bluestore_omap_setkeys_records
-      - ceph_bluestore_omap_upper_bound_lat_count
-      - ceph_bluestore_omap_upper_bound_lat_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_clear_lat_count
-          name: clear_lat
-        - selector: ceph_bluestore_omap_get_keys_lat_count
-          name: get_keys_lat
-        - selector: ceph_bluestore_omap_get_values_lat_count
-          name: get_values_lat
-        - selector: ceph_bluestore_omap_lower_bound_lat_count
-          name: lower_bound_lat
-        - selector: ceph_bluestore_omap_next_lat_count
-          name: next_lat
-        - selector: ceph_bluestore_omap_seek_to_first_lat_count
-          name: seek_to_first_lat
-        - selector: ceph_bluestore_omap_upper_bound_lat_count
-          name: upper_bound_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_clear_lat_sum
-          name: clear_lat
-        - selector: ceph_bluestore_omap_get_keys_lat_sum
-          name: get_keys_lat
-        - selector: ceph_bluestore_omap_get_values_lat_sum
-          name: get_values_lat
-        - selector: ceph_bluestore_omap_lower_bound_lat_sum
-          name: lower_bound_lat
-        - selector: ceph_bluestore_omap_next_lat_sum
-          name: next_lat
-        - selector: ceph_bluestore_omap_seek_to_first_lat_sum
-          name: seek_to_first_lat
-        - selector: ceph_bluestore_omap_upper_bound_lat_sum
-          name: upper_bound_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_setheader_bytes
-          name: setheader_bytes
-        - selector: ceph_bluestore_omap_setkeys_bytes
-          name: setkeys_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Open Iterators
-        context: open_iterators
-        units: iterators
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_iterator_count
-          name: iterator
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: absolute
-      - title: Mutation Calls
-        context: mutation_calls
-        units: calls/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_setheader_count
-          name: setheader
-        - selector: ceph_bluestore_omap_setkeys_count
-          name: setkeys
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Removed Key Ranges
-        context: removed_key_ranges
-        units: ranges/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_rmkey_range_count
-          name: rmkey_range
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Key Mutations
-        context: key_mutations
-        units: keys/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_rmkeys_count
-          name: rmkeys
-        - selector: ceph_bluestore_omap_setkeys_records
-          name: setkeys_records
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Onode Cache
-      context_namespace: onode_cache
-      metrics:
-      - ceph_bluestore_onode_blobs
-      - ceph_bluestore_onode_extents
-      - ceph_bluestore_onode_hits
-      - ceph_bluestore_onode_misses
-      - ceph_bluestore_onode_reshard
-      - ceph_bluestore_onode_shard_hits
-      - ceph_bluestore_onode_shard_misses
-      - ceph_bluestore_onode_spanning_blobs
-      - ceph_bluestore_onodes
-      - ceph_bluestore_onodes_pinned
-      charts:
-      - title: Onode Blobs
-        context: blob_state
-        units: blobs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_blobs
-          name: onode_blobs
-        - selector: ceph_bluestore_onode_spanning_blobs
-          name: onode_spanning_blobs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Onode Extents
-        context: extent_state
-        units: extents
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_extents
-          name: onode_extents
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Onodes
-        context: onode_state
-        units: onodes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onodes
-          name: onodes
-        - selector: ceph_bluestore_onodes_pinned
-          name: onodes_pinned
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_reshard
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Onode Lookup Outcomes
-        context: onode_lookup_outcomes
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_hits
-          name: hits
-        - selector: ceph_bluestore_onode_misses
-          name: misses
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Onode Shard Lookup Outcomes
-        context: shard_lookup_outcomes
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_shard_hits
-          name: shard_hits
-        - selector: ceph_bluestore_onode_shard_misses
-          name: shard_misses
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Data
-      context_namespace: priority_cache_data
-      metrics:
-      - ceph_bluestore_pricache:data_committed_bytes
-      - ceph_bluestore_pricache:data_pri0_bytes
-      - ceph_bluestore_pricache:data_pri10_bytes
-      - ceph_bluestore_pricache:data_pri11_bytes
-      - ceph_bluestore_pricache:data_pri1_bytes
-      - ceph_bluestore_pricache:data_pri2_bytes
-      - ceph_bluestore_pricache:data_pri3_bytes
-      - ceph_bluestore_pricache:data_pri4_bytes
-      - ceph_bluestore_pricache:data_pri5_bytes
-      - ceph_bluestore_pricache:data_pri6_bytes
-      - ceph_bluestore_pricache:data_pri7_bytes
-      - ceph_bluestore_pricache:data_pri8_bytes
-      - ceph_bluestore_pricache:data_pri9_bytes
-      - ceph_bluestore_pricache:data_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache:data_committed_bytes
-          name: committed_bytes
-        - selector: ceph_bluestore_pricache:data_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_bluestore_pricache:data_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_bluestore_pricache:data_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_bluestore_pricache:data_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_bluestore_pricache:data_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_bluestore_pricache:data_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_bluestore_pricache:data_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_bluestore_pricache:data_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_bluestore_pricache:data_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_bluestore_pricache:data_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_bluestore_pricache:data_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_bluestore_pricache:data_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_bluestore_pricache:data_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache KV
-      context_namespace: priority_cache_kv
-      metrics:
-      - ceph_bluestore_pricache:kv_committed_bytes
-      - ceph_bluestore_pricache:kv_pri0_bytes
-      - ceph_bluestore_pricache:kv_pri10_bytes
-      - ceph_bluestore_pricache:kv_pri11_bytes
-      - ceph_bluestore_pricache:kv_pri1_bytes
-      - ceph_bluestore_pricache:kv_pri2_bytes
-      - ceph_bluestore_pricache:kv_pri3_bytes
-      - ceph_bluestore_pricache:kv_pri4_bytes
-      - ceph_bluestore_pricache:kv_pri5_bytes
-      - ceph_bluestore_pricache:kv_pri6_bytes
-      - ceph_bluestore_pricache:kv_pri7_bytes
-      - ceph_bluestore_pricache:kv_pri8_bytes
-      - ceph_bluestore_pricache:kv_pri9_bytes
-      - ceph_bluestore_pricache:kv_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache:kv_committed_bytes
-          name: committed_bytes
-        - selector: ceph_bluestore_pricache:kv_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_bluestore_pricache:kv_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_bluestore_pricache:kv_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_bluestore_pricache:kv_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_bluestore_pricache:kv_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_bluestore_pricache:kv_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_bluestore_pricache:kv_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_bluestore_pricache:kv_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_bluestore_pricache:kv_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_bluestore_pricache:kv_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_bluestore_pricache:kv_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_bluestore_pricache:kv_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_bluestore_pricache:kv_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache KV Onode
-      context_namespace: priority_cache_kv_onode
-      metrics:
-      - ceph_bluestore_pricache:kv_onode_committed_bytes
-      - ceph_bluestore_pricache:kv_onode_pri0_bytes
-      - ceph_bluestore_pricache:kv_onode_pri10_bytes
-      - ceph_bluestore_pricache:kv_onode_pri11_bytes
-      - ceph_bluestore_pricache:kv_onode_pri1_bytes
-      - ceph_bluestore_pricache:kv_onode_pri2_bytes
-      - ceph_bluestore_pricache:kv_onode_pri3_bytes
-      - ceph_bluestore_pricache:kv_onode_pri4_bytes
-      - ceph_bluestore_pricache:kv_onode_pri5_bytes
-      - ceph_bluestore_pricache:kv_onode_pri6_bytes
-      - ceph_bluestore_pricache:kv_onode_pri7_bytes
-      - ceph_bluestore_pricache:kv_onode_pri8_bytes
-      - ceph_bluestore_pricache:kv_onode_pri9_bytes
-      - ceph_bluestore_pricache:kv_onode_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache:kv_onode_committed_bytes
-          name: committed_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Metadata
-      context_namespace: priority_cache_metadata
-      metrics:
-      - ceph_bluestore_pricache:meta_committed_bytes
-      - ceph_bluestore_pricache:meta_pri0_bytes
-      - ceph_bluestore_pricache:meta_pri10_bytes
-      - ceph_bluestore_pricache:meta_pri11_bytes
-      - ceph_bluestore_pricache:meta_pri1_bytes
-      - ceph_bluestore_pricache:meta_pri2_bytes
-      - ceph_bluestore_pricache:meta_pri3_bytes
-      - ceph_bluestore_pricache:meta_pri4_bytes
-      - ceph_bluestore_pricache:meta_pri5_bytes
-      - ceph_bluestore_pricache:meta_pri6_bytes
-      - ceph_bluestore_pricache:meta_pri7_bytes
-      - ceph_bluestore_pricache:meta_pri8_bytes
-      - ceph_bluestore_pricache:meta_pri9_bytes
-      - ceph_bluestore_pricache:meta_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache:meta_committed_bytes
-          name: committed_bytes
-        - selector: ceph_bluestore_pricache:meta_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_bluestore_pricache:meta_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_bluestore_pricache:meta_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_bluestore_pricache:meta_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_bluestore_pricache:meta_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_bluestore_pricache:meta_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_bluestore_pricache:meta_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_bluestore_pricache:meta_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_bluestore_pricache:meta_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_bluestore_pricache:meta_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_bluestore_pricache:meta_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_bluestore_pricache:meta_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_bluestore_pricache:meta_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Runtime
-      context_namespace: priority_cache_runtime
-      metrics:
-      - ceph_bluestore_pricache_cache_bytes
-      - ceph_bluestore_pricache_heap_bytes
-      - ceph_bluestore_pricache_mapped_bytes
-      - ceph_bluestore_pricache_target_bytes
-      - ceph_bluestore_pricache_unmapped_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache_cache_bytes
-          name: cache_bytes
-        - selector: ceph_bluestore_pricache_heap_bytes
-          name: heap_bytes
-        - selector: ceph_bluestore_pricache_mapped_bytes
-          name: mapped_bytes
-        - selector: ceph_bluestore_pricache_target_bytes
-          name: target_bytes
-        - selector: ceph_bluestore_pricache_unmapped_bytes
-          name: unmapped_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Space and Core State
-      context_namespace: space_and_core_state
-      metrics:
-      - ceph_bluestore_blob_split
-      - ceph_bluestore_buffer_bytes
-      - ceph_bluestore_buffer_hit_bytes
-      - ceph_bluestore_buffer_miss_bytes
-      - ceph_bluestore_buffers
-      - ceph_bluestore_clist_lat_count
-      - ceph_bluestore_clist_lat_sum
-      - ceph_bluestore_fragmentation_micros
-      - ceph_bluestore_gc_merged
-      - ceph_bluestore_kv_commit_lat_count
-      - ceph_bluestore_kv_commit_lat_sum
-      - ceph_bluestore_kv_final_lat_count
-      - ceph_bluestore_kv_final_lat_sum
-      - ceph_bluestore_kv_flush_lat_count
-      - ceph_bluestore_kv_flush_lat_sum
-      - ceph_bluestore_kv_sync_lat_count
-      - ceph_bluestore_kv_sync_lat_sum
-      - ceph_bluestore_slow_committed_kv_count
-      - ceph_bluestore_stored
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_clist_lat_count
-          name: clist_lat
-        - selector: ceph_bluestore_kv_commit_lat_count
-          name: kv_commit_lat
-        - selector: ceph_bluestore_kv_final_lat_count
-          name: kv_final_lat
-        - selector: ceph_bluestore_kv_flush_lat_count
-          name: kv_flush_lat
-        - selector: ceph_bluestore_kv_sync_lat_count
-          name: kv_sync_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_clist_lat_sum
-          name: clist_lat
-        - selector: ceph_bluestore_kv_commit_lat_sum
-          name: kv_commit_lat
-        - selector: ceph_bluestore_kv_final_lat_sum
-          name: kv_final_lat
-        - selector: ceph_bluestore_kv_flush_lat_sum
-          name: kv_flush_lat
-        - selector: ceph_bluestore_kv_sync_lat_sum
-          name: kv_sync_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_buffer_hit_bytes
-          name: hit_bytes
-        - selector: ceph_bluestore_buffer_miss_bytes
-          name: miss_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Current Work
-        context: current_work
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_buffers
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Blob Splits
-        context: blob_splits
-        units: blobs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_blob_split
-          name: blob_split
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Garbage-Collection Merge Throughput
-        context: gc_merge_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_gc_merged
-          name: gc_merged
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_slow_committed_kv_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Fragmentation
-        context: fragmentation
-        units: per mille
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_fragmentation_micros
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Buffer Cache Residency
-        context: buffer_cache_residency
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_buffer_bytes
-          name: buffer_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Logical Stored Data
-        context: logical_stored_data
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_stored
-          name: stored
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Transaction Pipeline
-      context_namespace: transaction_pipeline
-      metrics:
-      - ceph_bluestore_state_aio_wait_lat_count
-      - ceph_bluestore_state_aio_wait_lat_sum
-      - ceph_bluestore_state_deferred_aio_wait_lat_count
-      - ceph_bluestore_state_deferred_aio_wait_lat_sum
-      - ceph_bluestore_state_deferred_cleanup_lat_count
-      - ceph_bluestore_state_deferred_cleanup_lat_sum
-      - ceph_bluestore_state_deferred_queued_lat_count
-      - ceph_bluestore_state_deferred_queued_lat_sum
-      - ceph_bluestore_state_done_lat_count
-      - ceph_bluestore_state_done_lat_sum
-      - ceph_bluestore_state_finishing_lat_count
-      - ceph_bluestore_state_finishing_lat_sum
-      - ceph_bluestore_state_io_done_lat_count
-      - ceph_bluestore_state_io_done_lat_sum
-      - ceph_bluestore_state_kv_commiting_lat_count
-      - ceph_bluestore_state_kv_commiting_lat_sum
-      - ceph_bluestore_state_kv_done_lat_count
-      - ceph_bluestore_state_kv_done_lat_sum
-      - ceph_bluestore_state_kv_queued_lat_count
-      - ceph_bluestore_state_kv_queued_lat_sum
-      - ceph_bluestore_state_prepare_lat_count
-      - ceph_bluestore_state_prepare_lat_sum
-      - ceph_bluestore_txc_commit_lat_count
-      - ceph_bluestore_txc_commit_lat_sum
-      - ceph_bluestore_txc_count
-      - ceph_bluestore_txc_submit_lat_count
-      - ceph_bluestore_txc_submit_lat_sum
-      - ceph_bluestore_txc_throttle_lat_count
-      - ceph_bluestore_txc_throttle_lat_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_state_aio_wait_lat_count
-          name: state_aio_wait_lat
-        - selector: ceph_bluestore_state_deferred_aio_wait_lat_count
-          name: state_deferred_aio_wait_lat
-        - selector: ceph_bluestore_state_deferred_cleanup_lat_count
-          name: state_deferred_cleanup_lat
-        - selector: ceph_bluestore_state_deferred_queued_lat_count
-          name: state_deferred_queued_lat
-        - selector: ceph_bluestore_state_done_lat_count
-          name: state_done_lat
-        - selector: ceph_bluestore_state_finishing_lat_count
-          name: state_finishing_lat
-        - selector: ceph_bluestore_state_io_done_lat_count
-          name: state_io_done_lat
-        - selector: ceph_bluestore_state_kv_commiting_lat_count
-          name: state_kv_commiting_lat
-        - selector: ceph_bluestore_state_kv_done_lat_count
-          name: state_kv_done_lat
-        - selector: ceph_bluestore_state_kv_queued_lat_count
-          name: state_kv_queued_lat
-        - selector: ceph_bluestore_state_prepare_lat_count
-          name: state_prepare_lat
-        - selector: ceph_bluestore_txc_commit_lat_count
-          name: txc_commit_lat
-        - selector: ceph_bluestore_txc_submit_lat_count
-          name: txc_submit_lat
-        - selector: ceph_bluestore_txc_throttle_lat_count
-          name: txc_throttle_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_state_aio_wait_lat_sum
-          name: state_aio_wait_lat
-        - selector: ceph_bluestore_state_deferred_aio_wait_lat_sum
-          name: state_deferred_aio_wait_lat
-        - selector: ceph_bluestore_state_deferred_cleanup_lat_sum
-          name: state_deferred_cleanup_lat
-        - selector: ceph_bluestore_state_deferred_queued_lat_sum
-          name: state_deferred_queued_lat
-        - selector: ceph_bluestore_state_done_lat_sum
-          name: state_done_lat
-        - selector: ceph_bluestore_state_finishing_lat_sum
-          name: state_finishing_lat
-        - selector: ceph_bluestore_state_io_done_lat_sum
-          name: state_io_done_lat
-        - selector: ceph_bluestore_state_kv_commiting_lat_sum
-          name: state_kv_commiting_lat
-        - selector: ceph_bluestore_state_kv_done_lat_sum
-          name: state_kv_done_lat
-        - selector: ceph_bluestore_state_kv_queued_lat_sum
-          name: state_kv_queued_lat
-        - selector: ceph_bluestore_state_prepare_lat_sum
-          name: state_prepare_lat
-        - selector: ceph_bluestore_txc_commit_lat_sum
-          name: txc_commit_lat
-        - selector: ceph_bluestore_txc_submit_lat_sum
-          name: txc_submit_lat
-        - selector: ceph_bluestore_txc_throttle_lat_sum
-          name: txc_throttle_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_txc_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: CephFS MDS
-    context_namespace: cephfs_mds
-    groups:
-    - family: Attribute and Layout Mutation Latency
-      context_namespace: attribute_and_layout_mutation_latency
-      metrics:
-      - ceph_mds_server_req_rmxattr_latency_count
-      - ceph_mds_server_req_rmxattr_latency_sum
-      - ceph_mds_server_req_setattr_latency_count
-      - ceph_mds_server_req_setattr_latency_sum
-      - ceph_mds_server_req_setdirlayout_latency_count
-      - ceph_mds_server_req_setdirlayout_latency_sum
-      - ceph_mds_server_req_setfilelock_latency_count
-      - ceph_mds_server_req_setfilelock_latency_sum
-      - ceph_mds_server_req_setlayout_latency_count
-      - ceph_mds_server_req_setlayout_latency_sum
-      - ceph_mds_server_req_setxattr_latency_count
-      - ceph_mds_server_req_setxattr_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_rmxattr_latency_count
-          name: rmxattr_latency
-        - selector: ceph_mds_server_req_setattr_latency_count
-          name: setattr_latency
-        - selector: ceph_mds_server_req_setdirlayout_latency_count
-          name: setdirlayout_latency
-        - selector: ceph_mds_server_req_setfilelock_latency_count
-          name: setfilelock_latency
-        - selector: ceph_mds_server_req_setlayout_latency_count
-          name: setlayout_latency
-        - selector: ceph_mds_server_req_setxattr_latency_count
-          name: setxattr_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_rmxattr_latency_sum
-          name: rmxattr_latency
-        - selector: ceph_mds_server_req_setattr_latency_sum
-          name: setattr_latency
-        - selector: ceph_mds_server_req_setdirlayout_latency_sum
-          name: setdirlayout_latency
-        - selector: ceph_mds_server_req_setfilelock_latency_sum
-          name: setfilelock_latency
-        - selector: ceph_mds_server_req_setlayout_latency_sum
-          name: setlayout_latency
-        - selector: ceph_mds_server_req_setxattr_latency_sum
-          name: setxattr_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Capabilities
-      context_namespace: capabilities
-      metrics:
-      - ceph_mds_caps
-      - ceph_mds_ceph_cap_op_flush_ack
-      - ceph_mds_ceph_cap_op_flushsnap_ack
-      - ceph_mds_ceph_cap_op_grant
-      - ceph_mds_ceph_cap_op_revoke
-      - ceph_mds_ceph_cap_op_trunc
-      - ceph_mds_handle_client_cap_release
-      - ceph_mds_handle_client_caps
-      - ceph_mds_handle_client_caps_dirty
-      - ceph_mds_handle_inode_file_caps
-      - ceph_mds_inodes_with_caps
-      - ceph_mds_process_request_cap_release
-      - ceph_mds_server_cap_acquisition_throttle
-      - ceph_mds_server_cap_revoke_eviction
-      charts:
-      - title: Capabilities
-        context: capability_state
-        units: capabilities
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_caps
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Capability Messages
-        context: capability_messages
-        units: messages/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_handle_client_cap_release
-          name: handle_client_cap_release
-        - selector: ceph_mds_handle_client_caps
-          name: handle_client_caps
-        - selector: ceph_mds_handle_client_caps_dirty
-          name: handle_client_caps_dirty
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Capability-Throttled Requests
-        context: throttled_requests
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_cap_acquisition_throttle
-          name: server_cap_acquisition_throttle
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Capability-Revoke Evictions
-        context: evicted_clients
-        units: clients/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_cap_revoke_eviction
-          name: server_cap_revoke_eviction
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inodes
-        context: inode_state
-        units: inodes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_inodes_with_caps
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inode Work
-        context: inode_work
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_handle_inode_file_caps
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_ceph_cap_op_flush_ack
-          name: ceph_cap_op_flush_ack
-        - selector: ceph_mds_ceph_cap_op_flushsnap_ack
-          name: ceph_cap_op_flushsnap_ack
-        - selector: ceph_mds_ceph_cap_op_grant
-          name: ceph_cap_op_grant
-        - selector: ceph_mds_ceph_cap_op_revoke
-          name: ceph_cap_op_revoke
-        - selector: ceph_mds_ceph_cap_op_trunc
-          name: ceph_cap_op_trunc
-        - selector: ceph_mds_process_request_cap_release
-          name: process_request_cap_release
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Journal
-      context_namespace: journal
-      metrics:
-      - ceph_mds_log_ev
-      - ceph_mds_log_evadd
-      - ceph_mds_log_evex
-      - ceph_mds_log_evexd
-      - ceph_mds_log_evexg
-      - ceph_mds_log_evlrg
-      - ceph_mds_log_evtrm
-      - ceph_mds_log_expos
-      - ceph_mds_log_jlat_count
-      - ceph_mds_log_jlat_sum
-      - ceph_mds_log_rdpos
-      - ceph_mds_log_replayed
-      - ceph_mds_log_seg
-      - ceph_mds_log_segadd
-      - ceph_mds_log_segex
-      - ceph_mds_log_segexd
-      - ceph_mds_log_segexg
-      - ceph_mds_log_segmjr
-      - ceph_mds_log_segtrm
-      - ceph_mds_log_wrpos
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_jlat_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_jlat_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Current Journal Events
-        context: events_current
-        units: events
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_ev
-          name: ev
-        - selector: ceph_mds_log_evexd
-          name: evexd
-        - selector: ceph_mds_log_evexg
-          name: evexg
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Large Journal Events
-        context: large_events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_evlrg
-          name: evlrg
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Journal Events
-        context: journal_events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_evadd
-          name: evadd
-        - selector: ceph_mds_log_evex
-          name: evex
-        - selector: ceph_mds_log_evtrm
-          name: evtrm
-        - selector: ceph_mds_log_replayed
-          name: replayed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Journal Positions
-        context: journal_positions
-        units: position
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_expos
-          name: expos
-        - selector: ceph_mds_log_rdpos
-          name: rdpos
-        - selector: ceph_mds_log_wrpos
-          name: wrpos
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Journal Segments
-        context: journal_segments
-        units: segments/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_segadd
-          name: segadd
-        - selector: ceph_mds_log_segex
-          name: segex
-        - selector: ceph_mds_log_segtrm
-          name: segtrm
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Journal Segments
-        context: segments_current
-        units: segments
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_seg
-          name: seg
-        - selector: ceph_mds_log_segexd
-          name: segexd
-        - selector: ceph_mds_log_segexg
-          name: segexg
-        - selector: ceph_mds_log_segmjr
-          name: segmjr
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Metadata Cache Directory
-      context_namespace: metadata_cache_directory
-      metrics:
-      - ceph_mds_cache_dir_handle_discover
-      - ceph_mds_cache_dir_send_discover
-      - ceph_mds_cache_dir_try_discover
-      - ceph_mds_cache_dir_update
-      - ceph_mds_cache_dir_update_receipt
-      charts:
-      - title: Discovery Messages
-        context: discovery_messages
-        units: messages/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_dir_handle_discover
-          name: handle_discover
-        - selector: ceph_mds_cache_dir_send_discover
-          name: send_discover
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Discovery Attempts
-        context: discovery_attempts
-        units: attempts/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_dir_try_discover
-          name: try_discover
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Replication Directives
-        context: replication_directives
-        units: directives/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_dir_update
-          name: update
-        - selector: ceph_mds_cache_dir_update_receipt
-          name: update_receipt
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Metadata Cache Internal Requests
-      context_namespace: metadata_cache_internal_requests
-      metrics:
-      - ceph_mds_cache_ireq_enqueue_scrub
-      - ceph_mds_cache_ireq_exportdir
-      - ceph_mds_cache_ireq_flush
-      - ceph_mds_cache_ireq_fragmentdir
-      - ceph_mds_cache_ireq_fragstats
-      - ceph_mds_cache_ireq_inodestats
-      - ceph_mds_cache_ireq_quiesce_inode
-      - ceph_mds_cache_ireq_quiesce_path
-      charts:
-      - title: Inode Work
-        context: inode_work
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_ireq_inodestats
-          name: inodestats
-        - selector: ceph_mds_cache_ireq_quiesce_inode
-          name: quiesce_inode
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_ireq_exportdir
-          name: exportdir
-        - selector: ceph_mds_cache_ireq_flush
-          name: flush
-        - selector: ceph_mds_cache_ireq_fragmentdir
-          name: fragmentdir
-        - selector: ceph_mds_cache_ireq_fragstats
-          name: fragstats
-        - selector: ceph_mds_cache_ireq_quiesce_path
-          name: quiesce_path
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Scrub Work
-        context: scrub_work
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_ireq_enqueue_scrub
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Metadata Cache Recovery
-      context_namespace: metadata_cache_recovery
-      metrics:
-      - ceph_mds_cache_num_recovering_enqueued
-      - ceph_mds_cache_num_recovering_prioritized
-      - ceph_mds_cache_num_recovering_processing
-      - ceph_mds_cache_num_strays
-      - ceph_mds_cache_num_strays_delayed
-      - ceph_mds_cache_num_strays_enqueuing
-      - ceph_mds_cache_recovery_completed
-      - ceph_mds_cache_recovery_started
-      - ceph_mds_cache_strays_created
-      - ceph_mds_cache_strays_enqueued
-      - ceph_mds_cache_strays_migrated
-      - ceph_mds_cache_strays_reintegrated
-      charts:
-      - title: Current Work
-        context: current_work
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_num_strays
-          name: strays
-        - selector: ceph_mds_cache_num_strays_delayed
-          name: delayed
-        - selector: ceph_mds_cache_num_strays_enqueuing
-          name: enqueuing
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_strays_created
-          name: created
-        - selector: ceph_mds_cache_strays_enqueued
-          name: enqueued
-        - selector: ceph_mds_cache_strays_migrated
-          name: migrated
-        - selector: ceph_mds_cache_strays_reintegrated
-          name: reintegrated
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Files
-        context: file_state
-        units: files
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_num_recovering_enqueued
-          name: enqueued
-        - selector: ceph_mds_cache_num_recovering_prioritized
-          name: prioritized
-        - selector: ceph_mds_cache_num_recovering_processing
-          name: processing
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: File Work
-        context: file_work
-        units: files/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_recovery_completed
-          name: completed
-        - selector: ceph_mds_cache_recovery_started
-          name: started
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Metadata Cache Uninline
-      context_namespace: metadata_cache_uninline
-      metrics:
-      - ceph_mds_cache_uninline_started
-      - ceph_mds_cache_uninline_succeeded
-      - ceph_mds_cache_uninline_write_failed
-      charts:
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_uninline_started
-          name: started
-        - selector: ceph_mds_cache_uninline_succeeded
-          name: succeeded
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_uninline_write_failed
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Namespace Mutation Latency
-      context_namespace: namespace_mutation_latency
-      metrics:
-      - ceph_mds_server_req_create_latency_count
-      - ceph_mds_server_req_create_latency_sum
-      - ceph_mds_server_req_link_latency_count
-      - ceph_mds_server_req_link_latency_sum
-      - ceph_mds_server_req_mkdir_latency_count
-      - ceph_mds_server_req_mkdir_latency_sum
-      - ceph_mds_server_req_mknod_latency_count
-      - ceph_mds_server_req_mknod_latency_sum
-      - ceph_mds_server_req_rename_latency_count
-      - ceph_mds_server_req_rename_latency_sum
-      - ceph_mds_server_req_rmdir_latency_count
-      - ceph_mds_server_req_rmdir_latency_sum
-      - ceph_mds_server_req_symlink_latency_count
-      - ceph_mds_server_req_symlink_latency_sum
-      - ceph_mds_server_req_unlink_latency_count
-      - ceph_mds_server_req_unlink_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_create_latency_count
-          name: create_latency
-        - selector: ceph_mds_server_req_link_latency_count
-          name: link_latency
-        - selector: ceph_mds_server_req_mkdir_latency_count
-          name: mkdir_latency
-        - selector: ceph_mds_server_req_mknod_latency_count
-          name: mknod_latency
-        - selector: ceph_mds_server_req_rename_latency_count
-          name: rename_latency
-        - selector: ceph_mds_server_req_rmdir_latency_count
-          name: rmdir_latency
-        - selector: ceph_mds_server_req_symlink_latency_count
-          name: symlink_latency
-        - selector: ceph_mds_server_req_unlink_latency_count
-          name: unlink_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_create_latency_sum
-          name: create_latency
-        - selector: ceph_mds_server_req_link_latency_sum
-          name: link_latency
-        - selector: ceph_mds_server_req_mkdir_latency_sum
-          name: mkdir_latency
-        - selector: ceph_mds_server_req_mknod_latency_sum
-          name: mknod_latency
-        - selector: ceph_mds_server_req_rename_latency_sum
-          name: rename_latency
-        - selector: ceph_mds_server_req_rmdir_latency_sum
-          name: rmdir_latency
-        - selector: ceph_mds_server_req_symlink_latency_sum
-          name: symlink_latency
-        - selector: ceph_mds_server_req_unlink_latency_sum
-          name: unlink_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Namespace Traversal
-      context_namespace: namespace_traversal
-      metrics:
-      - ceph_mds_dir_commit
-      - ceph_mds_dir_fetch_complete
-      - ceph_mds_dir_fetch_keys
-      - ceph_mds_dir_merge
-      - ceph_mds_dir_split
-      - ceph_mds_openino_backtrace_fetch
-      - ceph_mds_openino_dir_fetch
-      - ceph_mds_openino_peer_discover
-      - ceph_mds_traverse
-      - ceph_mds_traverse_dir_fetch
-      - ceph_mds_traverse_discover
-      - ceph_mds_traverse_forward
-      - ceph_mds_traverse_hit
-      - ceph_mds_traverse_lock
-      - ceph_mds_traverse_remote_ino
-      charts:
-      - title: Directory-Fragment Lifecycle
-        context: dirfrag_lifecycle
-        units: dirfrags/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_dir_fetch_complete
-          name: dir_fetch_complete
-        - selector: ceph_mds_dir_merge
-          name: dir_merge
-        - selector: ceph_mds_dir_split
-          name: dir_split
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Namespace Traversals
-        context: traversals
-        units: traversals/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_traverse
-          name: traverse
-        - selector: ceph_mds_traverse_dir_fetch
-          name: traverse_dir_fetch
-        - selector: ceph_mds_traverse_discover
-          name: traverse_discover
-        - selector: ceph_mds_traverse_forward
-          name: traverse_forward
-        - selector: ceph_mds_traverse_lock
-          name: traverse_lock
-        - selector: ceph_mds_traverse_remote_ino
-          name: traverse_remote_ino
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inode Work
-        context: inode_work
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_openino_peer_discover
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Key Work
-        context: key_work
-        units: keys/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_dir_fetch_keys
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Lookup Outcomes
-        context: lookup_outcomes
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_traverse_hit
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_dir_commit
-          name: dir_commit
-        - selector: ceph_mds_openino_backtrace_fetch
-          name: openino_backtrace_fetch
-        - selector: ceph_mds_openino_dir_fetch
-          name: openino_dir_fetch
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Purge Queue
-      context_namespace: purge_queue
-      metrics:
-      - ceph_purge_queue_pq_executed
-      - ceph_purge_queue_pq_executed_ops
-      - ceph_purge_queue_pq_executing
-      - ceph_purge_queue_pq_executing_high_water
-      - ceph_purge_queue_pq_executing_ops
-      - ceph_purge_queue_pq_executing_ops_high_water
-      - ceph_purge_queue_pq_item_in_journal
-      charts:
-      - title: Current Work
-        context: current_work
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_item_in_journal
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Executed Purge Operations
-        context: purge_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_executed_ops
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Purge Operations in Flight
-        context: purge_operations_state
-        units: operations
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_executing_ops
-          name: ops
-        - selector: ceph_purge_queue_pq_executing_ops_high_water
-          name: high_water
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Executed Purge Tasks
-        context: purge_tasks
-        units: tasks/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_executed
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Purge Tasks in Flight
-        context: purge_tasks_state
-        units: tasks
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_executing
-          name: executing
-        - selector: ceph_purge_queue_pq_executing_high_water
-          name: high_water
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Rank Migration
-      context_namespace: rank_migration
-      metrics:
-      - ceph_mds_exported
-      - ceph_mds_exported_inodes
-      - ceph_mds_imported
-      - ceph_mds_imported_inodes
-      charts:
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_exported
-          name: exported
-        - selector: ceph_mds_imported
-          name: imported
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inode Work
-        context: inode_work
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_exported_inodes
-          name: exported_inodes
-        - selector: ceph_mds_imported_inodes
-          name: imported_inodes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Read Request Latency
-      context_namespace: read_request_latency
-      metrics:
-      - ceph_mds_server_req_blockdiff_latency_count
-      - ceph_mds_server_req_blockdiff_latency_sum
-      - ceph_mds_server_req_getattr_latency_count
-      - ceph_mds_server_req_getattr_latency_sum
-      - ceph_mds_server_req_getfilelock_latency_count
-      - ceph_mds_server_req_getfilelock_latency_sum
-      - ceph_mds_server_req_getvxattr_latency_count
-      - ceph_mds_server_req_getvxattr_latency_sum
-      - ceph_mds_server_req_lookup_latency_count
-      - ceph_mds_server_req_lookup_latency_sum
-      - ceph_mds_server_req_lookuphash_latency_count
-      - ceph_mds_server_req_lookuphash_latency_sum
-      - ceph_mds_server_req_lookupino_latency_count
-      - ceph_mds_server_req_lookupino_latency_sum
-      - ceph_mds_server_req_lookupname_latency_count
-      - ceph_mds_server_req_lookupname_latency_sum
-      - ceph_mds_server_req_lookupparent_latency_count
-      - ceph_mds_server_req_lookupparent_latency_sum
-      - ceph_mds_server_req_lookupsnap_latency_count
-      - ceph_mds_server_req_lookupsnap_latency_sum
-      - ceph_mds_server_req_open_latency_count
-      - ceph_mds_server_req_open_latency_sum
-      - ceph_mds_server_req_readdir_latency_count
-      - ceph_mds_server_req_readdir_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_blockdiff_latency_count
-          name: blockdiff_latency
-        - selector: ceph_mds_server_req_getattr_latency_count
-          name: getattr_latency
-        - selector: ceph_mds_server_req_getfilelock_latency_count
-          name: getfilelock_latency
-        - selector: ceph_mds_server_req_getvxattr_latency_count
-          name: getvxattr_latency
-        - selector: ceph_mds_server_req_lookup_latency_count
-          name: lookup_latency
-        - selector: ceph_mds_server_req_lookuphash_latency_count
-          name: lookuphash_latency
-        - selector: ceph_mds_server_req_lookupino_latency_count
-          name: lookupino_latency
-        - selector: ceph_mds_server_req_lookupname_latency_count
-          name: lookupname_latency
-        - selector: ceph_mds_server_req_lookupparent_latency_count
-          name: lookupparent_latency
-        - selector: ceph_mds_server_req_lookupsnap_latency_count
-          name: lookupsnap_latency
-        - selector: ceph_mds_server_req_open_latency_count
-          name: open_latency
-        - selector: ceph_mds_server_req_readdir_latency_count
-          name: readdir_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_blockdiff_latency_sum
-          name: blockdiff_latency
-        - selector: ceph_mds_server_req_getattr_latency_sum
-          name: getattr_latency
-        - selector: ceph_mds_server_req_getfilelock_latency_sum
-          name: getfilelock_latency
-        - selector: ceph_mds_server_req_getvxattr_latency_sum
-          name: getvxattr_latency
-        - selector: ceph_mds_server_req_lookup_latency_sum
-          name: lookup_latency
-        - selector: ceph_mds_server_req_lookuphash_latency_sum
-          name: lookuphash_latency
-        - selector: ceph_mds_server_req_lookupino_latency_sum
-          name: lookupino_latency
-        - selector: ceph_mds_server_req_lookupname_latency_sum
-          name: lookupname_latency
-        - selector: ceph_mds_server_req_lookupparent_latency_sum
-          name: lookupparent_latency
-        - selector: ceph_mds_server_req_lookupsnap_latency_sum
-          name: lookupsnap_latency
-        - selector: ceph_mds_server_req_open_latency_sum
-          name: open_latency
-        - selector: ceph_mds_server_req_readdir_latency_sum
-          name: readdir_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Request Handling and State
-      context_namespace: request_handling_and_state
-      metrics:
-      - ceph_mds_client_metrics_num_clients
-      - ceph_mds_forward
-      - ceph_mds_inodes
-      - ceph_mds_inodes_bottom
-      - ceph_mds_inodes_expired
-      - ceph_mds_inodes_pin_tail
-      - ceph_mds_inodes_pinned
-      - ceph_mds_inodes_top
-      - ceph_mds_load_cent
-      - ceph_mds_q
-      - ceph_mds_reply
-      - ceph_mds_reply_latency_count
-      - ceph_mds_reply_latency_sum
-      - ceph_mds_request
-      - ceph_mds_root_rbytes
-      - ceph_mds_root_rfiles
-      - ceph_mds_root_rsnaps
-      - ceph_mds_server_dispatch_client_request
-      - ceph_mds_server_dispatch_server_request
-      - ceph_mds_server_handle_client_request
-      - ceph_mds_server_handle_client_session
-      - ceph_mds_server_handle_peer_request
-      - ceph_mds_slow_reply
-      - ceph_mds_subtrees
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_reply_latency_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_reply_latency_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Connected Clients
-        context: connected_clients
-        units: clients
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_client_metrics_num_clients
-          name: client_metrics_num_clients
-        instances:
-          by_labels:
-          - ceph_daemon
-          - fs_name
-          - id
-          optional_by_labels: []
-      - title: Queued Requests
-        context: queued_requests
-        units: requests
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_q
-          name: q
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_reply
-          name: reply
-        - selector: ceph_mds_server_handle_client_session
-          name: server_handle_client_session
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_slow_reply
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Files
-        context: file_state
-        units: files
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_root_rfiles
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inodes
-        context: inode_state
-        units: inodes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_inodes
-          name: inodes
-        - selector: ceph_mds_inodes_bottom
-          name: bottom
-        - selector: ceph_mds_inodes_pin_tail
-          name: pin_tail
-        - selector: ceph_mds_inodes_pinned
-          name: pinned
-        - selector: ceph_mds_inodes_top
-          name: top
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Expired Inodes
-        context: expired_inodes
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_inodes_expired
-          name: expired
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Load
-        context: load
-        units: load
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_load_cent
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_forward
-          name: forward
-        - selector: ceph_mds_request
-          name: request
-        - selector: ceph_mds_server_dispatch_client_request
-          name: server_dispatch_client_request
-        - selector: ceph_mds_server_dispatch_server_request
-          name: server_dispatch_server_request
-        - selector: ceph_mds_server_handle_client_request
-          name: server_handle_client_request
-        - selector: ceph_mds_server_handle_peer_request
-          name: server_handle_peer_request
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Snapshots
-        context: snapshot_state
-        units: snapshots
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_root_rsnaps
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_root_rbytes
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Subtrees
-        context: subtrees
-        units: subtrees
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_subtrees
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Scrubbing
-      context_namespace: scrubbing
-      metrics:
-      - ceph_mds_scrub_backtrace_fetch
-      - ceph_mds_scrub_backtrace_repaired
-      - ceph_mds_scrub_dir_base_inodes
-      - ceph_mds_scrub_dir_inodes
-      - ceph_mds_scrub_dirfrag_rstats
-      - ceph_mds_scrub_file_inodes
-      - ceph_mds_scrub_inotable_repaired
-      - ceph_mds_scrub_set_tag
-      charts:
-      - title: Scrubbed Inodes
-        context: scrubbed_inodes
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_dir_base_inodes
-          name: dir_base_inodes
-        - selector: ceph_mds_scrub_dir_inodes
-          name: dir_inodes
-        - selector: ceph_mds_scrub_file_inodes
-          name: file_inodes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Backtrace Work
-        context: backtrace_work
-        units: backtraces/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_backtrace_fetch
-          name: backtrace_fetch
-        - selector: ceph_mds_scrub_backtrace_repaired
-          name: backtrace_repaired
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Repaired Inotables
-        context: repaired_inotables
-        units: inotables/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_inotable_repaired
-          name: inotable_repaired
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Applied Scrub Tags
-        context: applied_tags
-        units: tags/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_set_tag
-          name: set_tag
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Directory-Fragment Recursive-Stat Updates
-        context: dirfrag_rstat_updates
-        units: dirfrags/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_dirfrag_rstats
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Snapshot Mutation Latency
-      context_namespace: snapshot_mutation_latency
-      metrics:
-      - ceph_mds_server_req_lssnap_latency_count
-      - ceph_mds_server_req_lssnap_latency_sum
-      - ceph_mds_server_req_mksnap_latency_count
-      - ceph_mds_server_req_mksnap_latency_sum
-      - ceph_mds_server_req_renamesnap_latency_count
-      - ceph_mds_server_req_renamesnap_latency_sum
-      - ceph_mds_server_req_rmsnap_latency_count
-      - ceph_mds_server_req_rmsnap_latency_sum
-      - ceph_mds_server_req_snapdiff_latency_count
-      - ceph_mds_server_req_snapdiff_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_lssnap_latency_count
-          name: lssnap_latency
-        - selector: ceph_mds_server_req_mksnap_latency_count
-          name: mksnap_latency
-        - selector: ceph_mds_server_req_renamesnap_latency_count
-          name: renamesnap_latency
-        - selector: ceph_mds_server_req_rmsnap_latency_count
-          name: rmsnap_latency
-        - selector: ceph_mds_server_req_snapdiff_latency_count
-          name: snapdiff_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_lssnap_latency_sum
-          name: lssnap_latency
-        - selector: ceph_mds_server_req_mksnap_latency_sum
-          name: mksnap_latency
-        - selector: ceph_mds_server_req_renamesnap_latency_sum
-          name: renamesnap_latency
-        - selector: ceph_mds_server_req_rmsnap_latency_sum
-          name: rmsnap_latency
-        - selector: ceph_mds_server_req_snapdiff_latency_sum
-          name: snapdiff_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-  - family: CephFS MDS Memory
-    context_namespace: cephfs_mds_memory
-    metrics:
-    - ceph_mds_mem_cap
-    - ceph_mds_mem_cap_minus
-    - ceph_mds_mem_cap_plus
-    - ceph_mds_mem_dir
-    - ceph_mds_mem_dir_minus
-    - ceph_mds_mem_dir_plus
-    - ceph_mds_mem_dn
-    - ceph_mds_mem_dn_minus
-    - ceph_mds_mem_dn_plus
-    - ceph_mds_mem_heap
-    - ceph_mds_mem_ino
-    - ceph_mds_mem_ino_minus
-    - ceph_mds_mem_ino_plus
-    - ceph_mds_mem_rss
-    charts:
-    - title: Capabilities
-      context: capability_state
-      units: capabilities
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_cap
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Capability Work
-      context: capability_work
-      units: capabilities/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_cap_minus
-        name: minus
-      - selector: ceph_mds_mem_cap_plus
-        name: plus
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Dentries
-      context: dentry_state
-      units: dentries
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_dn
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Dentry Cache Churn
-      context: dentry_work
-      units: dentries/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_dn_minus
-        name: minus
-      - selector: ceph_mds_mem_dn_plus
-        name: plus
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Directories
-      context: directory_state
-      units: directories
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_dir
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Directory Cache Churn
-      context: directory_work
-      units: directories/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_dir_minus
-        name: minus
-      - selector: ceph_mds_mem_dir_plus
-        name: plus
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Inodes
-      context: inode_state
-      units: inodes
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_ino
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Inode Work
-      context: inode_work
-      units: inodes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_ino_minus
-        name: minus
-      - selector: ceph_mds_mem_ino_plus
-        name: plus
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Space and Memory
-      context: space
-      units: bytes
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_heap
-        name: heap
-      - selector: ceph_mds_mem_rss
-        name: rss
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: CephFS MDS Sessions
-    context_namespace: cephfs_mds_sessions
-    metrics:
-    - ceph_mds_sessions_average_load
-    - ceph_mds_sessions_avg_session_uptime
-    - ceph_mds_sessions_mdthresh_evicted
-    - ceph_mds_sessions_session_add
-    - ceph_mds_sessions_session_count
-    - ceph_mds_sessions_session_remove
-    - ceph_mds_sessions_sessions_open
-    - ceph_mds_sessions_sessions_stale
-    - ceph_mds_sessions_total_load
-    charts:
-    - title: Duration and Time
-      context: duration
-      units: seconds
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_avg_session_uptime
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Events
-      context: events
-      units: events/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_session_add
-        name: add
-      - selector: ceph_mds_sessions_session_remove
-        name: remove
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Average Session Load
-      context: average_load
-      units: load
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_average_load
-        name: average_load
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Total Session Load
-      context: total_load
-      units: load
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_total_load
-        name: total_load
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Metadata-Threshold Evictions
-      context: metadata_threshold_evictions
-      units: sessions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_mdthresh_evicted
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Sessions
-      context: session_state
-      units: sessions
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_session_count
-        name: session
-      - selector: ceph_mds_sessions_sessions_open
-        name: sessions_open
-      - selector: ceph_mds_sessions_sessions_stale
-        name: sessions_stale
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: CephFS MDS Clients
-    context_namespace: cephfs_mds_clients
-    metrics:
-    - ceph_mds_per_client_avg_metadata_latency
-    - ceph_mds_per_client_avg_read_latency
-    - ceph_mds_per_client_avg_write_latency
-    - ceph_mds_per_client_cap_hits
-    - ceph_mds_per_client_cap_miss
-    - ceph_mds_per_client_dentry_lease_hits
-    - ceph_mds_per_client_dentry_lease_miss
-    - ceph_mds_per_client_opened_files
-    - ceph_mds_per_client_opened_inodes
-    - ceph_mds_per_client_pinned_icaps
-    - ceph_mds_per_client_total_inodes
-    - ceph_mds_per_client_total_read_ops
-    - ceph_mds_per_client_total_read_size
-    - ceph_mds_per_client_total_write_ops
-    - ceph_mds_per_client_total_write_size
-    charts:
-    - title: Capability Access Outcomes
-      context: capability_outcomes
-      units: accesses/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_cap_hits
-        name: hits
-      - selector: ceph_mds_per_client_cap_miss
-        name: misses
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-      algorithm: incremental
-    - title: Dentry Lease Lookup Outcomes
-      context: dentry_lease_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_dentry_lease_hits
-        name: hits
-      - selector: ceph_mds_per_client_dentry_lease_miss
-        name: misses
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-      algorithm: incremental
-    - title: Average Operation Latency
-      context: average_operation_latency
-      units: seconds
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_avg_read_latency
-        name: read
-      - selector: ceph_mds_per_client_avg_write_latency
-        name: write
-      - selector: ceph_mds_per_client_avg_metadata_latency
-        name: metadata
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-    - title: Open Files
-      context: open_files
-      units: files
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_opened_files
-        name: open
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-    - title: Inode State
-      context: inode_state
-      units: inodes
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_opened_inodes
-        name: open
-      - selector: ceph_mds_per_client_total_inodes
-        name: total
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-    - title: Pinned Inode Capabilities
-      context: pinned_inode_capabilities
-      units: capabilities
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_pinned_icaps
-        name: pinned
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-    - title: Reported I/O Operations
-      context: reported_io_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_total_read_ops
-        name: read
-      - selector: ceph_mds_per_client_total_write_ops
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-      algorithm: incremental
-    - title: Reported I/O Volume
-      context: reported_io_volume
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_total_read_size
-        name: read
-      - selector: ceph_mds_per_client_total_write_size
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-      algorithm: incremental
-  - family: Exporter and Process Runtime
-    context_namespace: exporter_and_process_runtime
-    groups:
-    - family: Collection
-      context_namespace: collection
-      metrics:
-      - ceph_exporter_scrape_time
-      charts:
-      - title: Collection Duration
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_scrape_time
-          name: duration
-        instances:
-          by_labels:
-          - function
-          - host
-          optional_by_labels: []
-    - family: Daemon Availability
-      context_namespace: daemon_availability
-      metrics:
-      - ceph_daemon_socket_up
-      charts:
-      - title: Daemon Socket State
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_daemon_socket_up
-          name: reachable
-        instances:
-          by_labels:
-          - ceph_daemon
-          - hostname
-          optional_by_labels: []
-    - family: Daemon Processes
-      context_namespace: daemon_processes
-      metrics:
-      - ceph_exporter_cpu_total
-      - ceph_exporter_cpu_usage
-      - ceph_exporter_majflt_total
-      - ceph_exporter_minflt_total
-      - ceph_exporter_num_threads
-      - ceph_exporter_resident_size
-      - ceph_exporter_vm_size
-      charts:
-      - title: Page Faults
-        context: page_faults
-        units: faults/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_minflt_total
-          name: minor
-        - selector: ceph_exporter_majflt_total
-          name: major
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Threads
-        context: threads
-        units: threads
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_num_threads
-          name: threads
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: CPU Utilization
-        context: cpu_utilization
-        units: percentage
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_cpu_usage
-          name: utilization
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: CPU Time
-        context: cpu_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_cpu_total
-          name_from_label: mode
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Memory
-        context: memory
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_vm_size
-          name: virtual
-        - selector: ceph_exporter_resident_size
-          name: resident
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Manager Daemons
-    context_namespace: manager_daemons
-    metrics:
-    - ceph_mgr_cache_hit
-    - ceph_mgr_cache_miss
-    charts:
-    - title: Lookup Outcomes
-      context: lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mgr_cache_hit
-        name: hit
-      - selector: ceph_mgr_cache_miss
-        name: miss
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: Messenger
-    context_namespace: messenger
-    metrics:
-    - ceph_AsyncMessenger_RDMADispatcher_active_queue_pair
-    - ceph_AsyncMessenger_RDMADispatcher_async_last_wqe_events
-    - ceph_AsyncMessenger_RDMADispatcher_created_queue_pair
-    - ceph_AsyncMessenger_RDMADispatcher_handshake_errors
-    - ceph_AsyncMessenger_RDMADispatcher_inflight_tx_chunks
-    - ceph_AsyncMessenger_RDMADispatcher_polling
-    - ceph_AsyncMessenger_RDMADispatcher_rx_bufs_in_use
-    - ceph_AsyncMessenger_RDMADispatcher_rx_bufs_total
-    - ceph_AsyncMessenger_RDMADispatcher_rx_fin
-    - ceph_AsyncMessenger_RDMADispatcher_rx_total_wc
-    - ceph_AsyncMessenger_RDMADispatcher_rx_total_wc_errors
-    - ceph_AsyncMessenger_RDMADispatcher_total_async_events
-    - ceph_AsyncMessenger_RDMADispatcher_tx_retry_errors
-    - ceph_AsyncMessenger_RDMADispatcher_tx_total_wc
-    - ceph_AsyncMessenger_RDMADispatcher_tx_total_wc_errors
-    - ceph_AsyncMessenger_RDMADispatcher_tx_wr_flush_errors
-    - ceph_AsyncMessenger_Worker_msgr_connection_idle_timeouts
-    - ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
-    charts:
-    - title: RDMA Errors
-      context: rdma_errors
-      units: errors/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_handshake_errors
-        name: rdmadispatcher_handshake_errors
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_total_wc_errors
-        name: rdmadispatcher_rx_total_wc_errors
-      - selector: ceph_AsyncMessenger_RDMADispatcher_tx_retry_errors
-        name: rdmadispatcher_tx_retry_errors
-      - selector: ceph_AsyncMessenger_RDMADispatcher_tx_total_wc_errors
-        name: rdmadispatcher_tx_total_wc_errors
-      - selector: ceph_AsyncMessenger_RDMADispatcher_tx_wr_flush_errors
-        name: rdmadispatcher_tx_wr_flush_errors
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Connection Timeouts
-      context: connection_timeouts
-      units: connections/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_Worker_msgr_connection_idle_timeouts
-        name: worker_msgr_connection_idle_timeouts
-      - selector: ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
-        name: worker_msgr_connection_ready_timeouts
-      instances:
-        by_labels:
-        - ceph_daemon
-        - id
-        - instance_id
-        optional_by_labels: []
-    - title: Active Queue Pairs
-      context: active_queue_pairs
-      units: queue pairs
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_active_queue_pair
-        name: active_queue_pair
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: absolute
-    - title: Created Queue Pairs
-      context: created_queue_pairs
-      units: queue pairs/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_created_queue_pair
-        name: created_queue_pair
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: In-Flight Transmit Chunks
-      context: inflight_tx_chunks
-      units: chunks
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_inflight_tx_chunks
-        name: inflight_tx_chunks
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: absolute
-    - title: Polling State
-      context: polling_state
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_polling
-        name: polling
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: absolute
-    - title: Receive Buffers
-      context: receive_buffers
-      units: buffers
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_bufs_in_use
-        name: rx_bufs_in_use
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_bufs_total
-        name: rx_bufs
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: absolute
-    - title: Asynchronous Events
-      context: async_events
-      units: events/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_async_last_wqe_events
-        name: async_last_wqe_events
-      - selector: ceph_AsyncMessenger_RDMADispatcher_total_async_events
-        name: total_async_events
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Work Completions
-      context: work_completions
-      units: completions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_total_wc
-        name: rx_total_wc
-      - selector: ceph_AsyncMessenger_RDMADispatcher_tx_total_wc
-        name: tx_total_wc
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Received FIN Messages
-      context: received_fin_messages
-      units: messages/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_fin
-        name: rx_fin
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: Monitor Daemons
-    context_namespace: monitor_daemons
-    metrics:
-    - ceph_mon_election_call
-    - ceph_mon_election_lose
-    - ceph_mon_election_win
-    - ceph_mon_num_elections
-    - ceph_mon_num_sessions
-    - ceph_mon_session_add
-    - ceph_mon_session_rm
-    - ceph_mon_session_trim
-    charts:
-    - title: Elections
-      context: elections
-      units: elections/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mon_election_call
-        name: election_call
-      - selector: ceph_mon_election_lose
-        name: election_lose
-      - selector: ceph_mon_election_win
-        name: election_win
-      - selector: ceph_mon_num_elections
-        name: num_elections
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Sessions
-      context: session_state
-      units: sessions
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mon_num_sessions
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Session Churn
-      context: session_work
-      units: sessions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mon_session_add
-        name: add
-      - selector: ceph_mon_session_rm
-        name: rm
-      - selector: ceph_mon_session_trim
-        name: trim
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: OSD Client I/O
-    context_namespace: osd_client_i_o
-    metrics:
-    - ceph_osd_op
-    - ceph_osd_op_before_dequeue_op_lat_count
-    - ceph_osd_op_before_dequeue_op_lat_sum
-    - ceph_osd_op_before_queue_op_lat_count
-    - ceph_osd_op_before_queue_op_lat_sum
-    - ceph_osd_op_cache_hit
-    - ceph_osd_op_delayed_degraded
-    - ceph_osd_op_delayed_unreadable
-    - ceph_osd_op_in_bytes
-    - ceph_osd_op_latency_count
-    - ceph_osd_op_latency_sum
-    - ceph_osd_op_out_bytes
-    - ceph_osd_op_prepare_latency_count
-    - ceph_osd_op_prepare_latency_sum
-    - ceph_osd_op_process_latency_count
-    - ceph_osd_op_process_latency_sum
-    - ceph_osd_op_r
-    - ceph_osd_op_r_latency_count
-    - ceph_osd_op_r_latency_sum
-    - ceph_osd_op_r_out_bytes
-    - ceph_osd_op_r_prepare_latency_count
-    - ceph_osd_op_r_prepare_latency_sum
-    - ceph_osd_op_r_process_latency_count
-    - ceph_osd_op_r_process_latency_sum
-    - ceph_osd_op_rw
-    - ceph_osd_op_rw_in_bytes
-    - ceph_osd_op_rw_latency_count
-    - ceph_osd_op_rw_latency_sum
-    - ceph_osd_op_rw_out_bytes
-    - ceph_osd_op_rw_prepare_latency_count
-    - ceph_osd_op_rw_prepare_latency_sum
-    - ceph_osd_op_rw_process_latency_count
-    - ceph_osd_op_rw_process_latency_sum
-    - ceph_osd_op_w
-    - ceph_osd_op_w_in_bytes
-    - ceph_osd_op_w_latency_count
-    - ceph_osd_op_w_latency_sum
-    - ceph_osd_op_w_prepare_latency_count
-    - ceph_osd_op_w_prepare_latency_sum
-    - ceph_osd_op_w_process_latency_count
-    - ceph_osd_op_w_process_latency_sum
-    - ceph_osd_op_wip
-    - ceph_osd_replica_read
-    - ceph_osd_replica_read_redirect_conflict
-    - ceph_osd_replica_read_redirect_missing
-    - ceph_osd_replica_read_served
-    - ceph_osd_slow_ops_slow_ops_count
-    - ceph_osd_subop_in_bytes
-    - ceph_osd_subop_latency_count
-    - ceph_osd_subop_latency_sum
-    - ceph_osd_subop_pull
-    - ceph_osd_subop_pull_latency_count
-    - ceph_osd_subop_pull_latency_sum
-    - ceph_osd_subop_push
-    - ceph_osd_subop_push_in_bytes
-    - ceph_osd_subop_push_latency_count
-    - ceph_osd_subop_push_latency_sum
-    - ceph_osd_subop_w
-    - ceph_osd_subop_w_in_bytes
-    - ceph_osd_subop_w_latency_count
-    - ceph_osd_subop_w_latency_sum
-    - ceph_osd_tier_proxy_read
-    - ceph_osd_tier_proxy_write
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_before_dequeue_op_lat_count
-        name: op_before_dequeue_op_lat
-      - selector: ceph_osd_op_before_queue_op_lat_count
-        name: op_before_queue_op_lat
-      - selector: ceph_osd_op_latency_count
-        name: op_latency
-      - selector: ceph_osd_op_prepare_latency_count
-        name: op_prepare_latency
-      - selector: ceph_osd_op_process_latency_count
-        name: op_process_latency
-      - selector: ceph_osd_op_r_latency_count
-        name: op_r_latency
-      - selector: ceph_osd_op_r_prepare_latency_count
-        name: op_r_prepare_latency
-      - selector: ceph_osd_op_r_process_latency_count
-        name: op_r_process_latency
-      - selector: ceph_osd_op_rw_latency_count
-        name: op_rw_latency
-      - selector: ceph_osd_op_rw_prepare_latency_count
-        name: op_rw_prepare_latency
-      - selector: ceph_osd_op_rw_process_latency_count
-        name: op_rw_process_latency
-      - selector: ceph_osd_op_w_latency_count
-        name: op_w_latency
-      - selector: ceph_osd_op_w_prepare_latency_count
-        name: op_w_prepare_latency
-      - selector: ceph_osd_op_w_process_latency_count
-        name: op_w_process_latency
-      - selector: ceph_osd_subop_latency_count
-        name: subop_latency
-      - selector: ceph_osd_subop_pull_latency_count
-        name: subop_pull_latency
-      - selector: ceph_osd_subop_push_latency_count
-        name: subop_push_latency
-      - selector: ceph_osd_subop_w_latency_count
-        name: subop_w_latency
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_before_dequeue_op_lat_sum
-        name: op_before_dequeue_op_lat
-      - selector: ceph_osd_op_before_queue_op_lat_sum
-        name: op_before_queue_op_lat
-      - selector: ceph_osd_op_latency_sum
-        name: op_latency
-      - selector: ceph_osd_op_prepare_latency_sum
-        name: op_prepare_latency
-      - selector: ceph_osd_op_process_latency_sum
-        name: op_process_latency
-      - selector: ceph_osd_op_r_latency_sum
-        name: op_r_latency
-      - selector: ceph_osd_op_r_prepare_latency_sum
-        name: op_r_prepare_latency
-      - selector: ceph_osd_op_r_process_latency_sum
-        name: op_r_process_latency
-      - selector: ceph_osd_op_rw_latency_sum
-        name: op_rw_latency
-      - selector: ceph_osd_op_rw_prepare_latency_sum
-        name: op_rw_prepare_latency
-      - selector: ceph_osd_op_rw_process_latency_sum
-        name: op_rw_process_latency
-      - selector: ceph_osd_op_w_latency_sum
-        name: op_w_latency
-      - selector: ceph_osd_op_w_prepare_latency_sum
-        name: op_w_prepare_latency
-      - selector: ceph_osd_op_w_process_latency_sum
-        name: op_w_process_latency
-      - selector: ceph_osd_subop_latency_sum
-        name: subop_latency
-      - selector: ceph_osd_subop_pull_latency_sum
-        name: subop_pull_latency
-      - selector: ceph_osd_subop_push_latency_sum
-        name: subop_push_latency
-      - selector: ceph_osd_subop_w_latency_sum
-        name: subop_w_latency
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Byte Throughput
-      context: byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_in_bytes
-        name: op_in_bytes
-      - selector: ceph_osd_op_out_bytes
-        name: op_out_bytes
-      - selector: ceph_osd_op_r_out_bytes
-        name: op_r_out_bytes
-      - selector: ceph_osd_op_rw_in_bytes
-        name: op_rw_in_bytes
-      - selector: ceph_osd_op_rw_out_bytes
-        name: op_rw_out_bytes
-      - selector: ceph_osd_op_w_in_bytes
-        name: op_w_in_bytes
-      - selector: ceph_osd_subop_in_bytes
-        name: subop_in_bytes
-      - selector: ceph_osd_subop_push_in_bytes
-        name: subop_push_in_bytes
-      - selector: ceph_osd_subop_w_in_bytes
-        name: subop_w_in_bytes
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Operations in Progress
-      context: current_operations
-      units: operations
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_wip
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Events
-      context: events
-      units: events/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_subop_push
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Failure and Delay Outcomes
-      context: failure_outcomes
-      units: events/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_slow_ops_slow_ops_count
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Lookup Outcomes
-      context: lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_cache_hit
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Object Work
-      context: object_work
-      units: objects/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_delayed_degraded
-        name: op_delayed_degraded
-      - selector: ceph_osd_op_delayed_unreadable
-        name: op_delayed_unreadable
-      - selector: ceph_osd_replica_read_redirect_missing
-        name: replica_read_redirect_missing
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Operations
-      context: operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op
-        name: op
-      - selector: ceph_osd_op_r
-        name: op_r
-      - selector: ceph_osd_op_rw
-        name: op_rw
-      - selector: ceph_osd_op_w
-        name: op_w
-      - selector: ceph_osd_replica_read
-        name: replica_read
-      - selector: ceph_osd_replica_read_redirect_conflict
-        name: replica_read_redirect_conflict
-      - selector: ceph_osd_replica_read_served
-        name: replica_read_served
-      - selector: ceph_osd_subop_pull
-        name: subop_pull
-      - selector: ceph_osd_subop_w
-        name: subop_w
-      - selector: ceph_osd_tier_proxy_read
-        name: tier_proxy_read
-      - selector: ceph_osd_tier_proxy_write
-        name: tier_proxy_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: OSD Recovery
-    context_namespace: osd_recovery
-    metrics:
-    - ceph_osd_l_osd_recovery_backfill_queue_latency_count
-    - ceph_osd_l_osd_recovery_backfill_queue_latency_sum
-    - ceph_osd_l_osd_recovery_backfill_remove_queue_latency_count
-    - ceph_osd_l_osd_recovery_backfill_remove_queue_latency_sum
-    - ceph_osd_l_osd_recovery_context_queue_latency_count
-    - ceph_osd_l_osd_recovery_context_queue_latency_sum
-    - ceph_osd_l_osd_recovery_pull_queue_latency_count
-    - ceph_osd_l_osd_recovery_pull_queue_latency_sum
-    - ceph_osd_l_osd_recovery_push_queue_latency_count
-    - ceph_osd_l_osd_recovery_push_queue_latency_sum
-    - ceph_osd_l_osd_recovery_push_reply_queue_latency_count
-    - ceph_osd_l_osd_recovery_push_reply_queue_latency_sum
-    - ceph_osd_l_osd_recovery_queue_latency_count
-    - ceph_osd_l_osd_recovery_queue_latency_sum
-    - ceph_osd_l_osd_recovery_scan_queue_latency_count
-    - ceph_osd_l_osd_recovery_scan_queue_latency_sum
-    - ceph_osd_recovery_bytes
-    - ceph_osd_recovery_ops
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_l_osd_recovery_backfill_queue_latency_count
-        name: backfill_queue_latency
-      - selector: ceph_osd_l_osd_recovery_backfill_remove_queue_latency_count
-        name: backfill_remove_queue_latency
-      - selector: ceph_osd_l_osd_recovery_context_queue_latency_count
-        name: context_queue_latency
-      - selector: ceph_osd_l_osd_recovery_pull_queue_latency_count
-        name: pull_queue_latency
-      - selector: ceph_osd_l_osd_recovery_push_queue_latency_count
-        name: push_queue_latency
-      - selector: ceph_osd_l_osd_recovery_push_reply_queue_latency_count
-        name: push_reply_queue_latency
-      - selector: ceph_osd_l_osd_recovery_queue_latency_count
-        name: queue_latency
-      - selector: ceph_osd_l_osd_recovery_scan_queue_latency_count
-        name: scan_queue_latency
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_l_osd_recovery_backfill_queue_latency_sum
-        name: backfill_queue_latency
-      - selector: ceph_osd_l_osd_recovery_backfill_remove_queue_latency_sum
-        name: backfill_remove_queue_latency
-      - selector: ceph_osd_l_osd_recovery_context_queue_latency_sum
-        name: context_queue_latency
-      - selector: ceph_osd_l_osd_recovery_pull_queue_latency_sum
-        name: pull_queue_latency
-      - selector: ceph_osd_l_osd_recovery_push_queue_latency_sum
-        name: push_queue_latency
-      - selector: ceph_osd_l_osd_recovery_push_reply_queue_latency_sum
-        name: push_reply_queue_latency
-      - selector: ceph_osd_l_osd_recovery_queue_latency_sum
-        name: queue_latency
-      - selector: ceph_osd_l_osd_recovery_scan_queue_latency_sum
-        name: scan_queue_latency
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Byte Throughput
-      context: byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_recovery_bytes
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Operations
-      context: operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_recovery_ops
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: OSD Runtime
-    context_namespace: osd_runtime
-    metrics:
-    - ceph_osd_agent_evict
-    - ceph_osd_agent_flush
-    - ceph_osd_agent_skip
-    - ceph_osd_agent_wake
-    - ceph_osd_cached_crc
-    - ceph_osd_cached_crc_adjusted
-    - ceph_osd_copyfrom
-    - ceph_osd_heartbeat_to_peers
-    - ceph_osd_loadavg
-    - ceph_osd_map_message_epoch_dups
-    - ceph_osd_map_message_epochs
-    - ceph_osd_map_messages
-    - ceph_osd_messages_delayed_for_map
-    - ceph_osd_missed_crc
-    - ceph_osd_numpg
-    - ceph_osd_numpg_primary
-    - ceph_osd_numpg_removing
-    - ceph_osd_numpg_replica
-    - ceph_osd_numpg_stray
-    - ceph_osd_object_ctx_cache_hit
-    - ceph_osd_object_ctx_cache_total
-    - ceph_osd_osd_map_bl_cache_hit
-    - ceph_osd_osd_map_bl_cache_miss
-    - ceph_osd_osd_map_cache_hit
-    - ceph_osd_osd_map_cache_miss
-    - ceph_osd_osd_map_cache_miss_low
-    - ceph_osd_osd_map_cache_miss_low_avg_count
-    - ceph_osd_osd_map_cache_miss_low_avg_sum
-    - ceph_osd_osd_pg_biginfo
-    - ceph_osd_osd_pg_fastinfo
-    - ceph_osd_osd_pg_info
-    - ceph_osd_osd_tier_flush_lat_count
-    - ceph_osd_osd_tier_flush_lat_sum
-    - ceph_osd_osd_tier_promote_lat_count
-    - ceph_osd_osd_tier_promote_lat_sum
-    - ceph_osd_osd_tier_r_lat_count
-    - ceph_osd_osd_tier_r_lat_sum
-    - ceph_osd_pull
-    - ceph_osd_push
-    - ceph_osd_push_out_bytes
-    - ceph_osd_stat_bytes
-    - ceph_osd_stat_bytes_avail
-    - ceph_osd_stat_bytes_used
-    - ceph_osd_subop
-    - ceph_osd_tier_clean
-    - ceph_osd_tier_delay
-    - ceph_osd_tier_dirty
-    - ceph_osd_tier_evict
-    - ceph_osd_tier_flush
-    - ceph_osd_tier_flush_fail
-    - ceph_osd_tier_promote
-    - ceph_osd_tier_try_flush
-    - ceph_osd_tier_try_flush_fail
-    - ceph_osd_tier_whiteout
-    - ceph_osd_watch_timeouts
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_tier_flush_lat_count
-        name: flush_lat
-      - selector: ceph_osd_osd_tier_promote_lat_count
-        name: promote_lat
-      - selector: ceph_osd_osd_tier_r_lat_count
-        name: r_lat
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_tier_flush_lat_sum
-        name: flush_lat
-      - selector: ceph_osd_osd_tier_promote_lat_sum
-        name: promote_lat
-      - selector: ceph_osd_osd_tier_r_lat_sum
-        name: r_lat
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Value Measurement Measurements
-      context: value_measurements
-      units: measurements/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_map_cache_miss_low_avg_count
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Value Measurement
-      context: accumulated_value
-      units: value/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_map_cache_miss_low_avg_sum
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Byte Throughput
-      context: byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_push_out_bytes
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: CRC Cache Lookup Outcomes
-      context: crc_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_cached_crc
-        name: cached_crc
-      - selector: ceph_osd_cached_crc_adjusted
-        name: cached_crc_adjusted
-      - selector: ceph_osd_missed_crc
-        name: missed_crc
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Tier-Agent Actions
-      context: tier_agent_actions
-      units: actions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_agent_evict
-        name: agent_evict
-      - selector: ceph_osd_agent_wake
-        name: agent_wake
-      - selector: ceph_osd_tier_clean
-        name: tier_clean
-      - selector: ceph_osd_tier_delay
-        name: tier_delay
-      - selector: ceph_osd_tier_dirty
-        name: tier_dirty
-      - selector: ceph_osd_tier_evict
-        name: tier_evict
-      - selector: ceph_osd_tier_promote
-        name: tier_promote
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Copy-From Operations
-      context: copyfrom_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_copyfrom
-        name: copyfrom
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: OSD-Map Messages
-      context: map_messages
-      units: messages/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_map_messages
-        name: map_messages
-      - selector: ceph_osd_messages_delayed_for_map
-        name: messages_delayed_for_map
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: OSD-Map Epochs
-      context: map_epochs
-      units: epochs/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_map_message_epochs
-        name: map_message_epochs
-      - selector: ceph_osd_map_message_epoch_dups
-        name: map_message_epoch_dups
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Placement-Group Updates
-      context: pg_updates
-      units: updates/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_pg_biginfo
-        name: osd_pg_biginfo
-      - selector: ceph_osd_osd_pg_fastinfo
-        name: osd_pg_fastinfo
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Total Placement-Group Updates
-      context: pg_updates_total
-      units: placement group updates/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_pg_info
-        name: total
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Pushes
-      context: pushes
-      units: pushes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_push
-        name: push
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Suboperations
-      context: suboperations
-      units: suboperations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_subop
-        name: subop
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Failed Tier Flush Attempts
-      context: failed_tier_flush_attempts
-      units: attempts/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_tier_flush_fail
-        name: tier_flush_fail
-      - selector: ceph_osd_tier_try_flush_fail
-        name: tier_try_flush_fail
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Watch Timeouts
-      context: watch_timeouts
-      units: watches/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_watch_timeouts
-        name: watch_timeouts
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: OSD-Map Buffer-Cache Lookup Outcomes
-      context: map_buffer_cache_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_map_bl_cache_hit
-        name: osd_map_bl_cache_hit
-      - selector: ceph_osd_osd_map_bl_cache_miss
-        name: osd_map_bl_cache_miss
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Decoded OSD-Map Cache Lookup Outcomes
-      context: map_cache_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_map_cache_hit
-        name: osd_map_cache_hit
-      - selector: ceph_osd_osd_map_cache_miss
-        name: osd_map_cache_miss
-      - selector: ceph_osd_osd_map_cache_miss_low
-        name: osd_map_cache_miss_low
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Tier Whiteouts
-      context: tier_whiteouts
-      units: whiteouts/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_tier_whiteout
-        name: tier_whiteout
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Skipped Objects
-      context: skipped_objects
-      units: objects/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_agent_skip
-        name: agent_skip
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Object-Context Cache Lookup Outcomes
-      context: object_context_cache_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_object_ctx_cache_hit
-        name: object_ctx_cache_hit
-      - selector: ceph_osd_object_ctx_cache_total
-        name: object_ctx_cache
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Tier Flush Attempts
-      context: tier_flush_attempts
-      units: attempts/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_agent_flush
-        name: agent_flush
-      - selector: ceph_osd_tier_flush
-        name: tier_flush
-      - selector: ceph_osd_tier_try_flush
-        name: tier_try_flush
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Pulls
-      context: pulls
-      units: pulls/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_pull
-        name: pull
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Placement Groups
-      context: pg_state
-      units: PGs
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_numpg
-        name: numpg
-      - selector: ceph_osd_numpg_primary
-        name: primary
-      - selector: ceph_osd_numpg_removing
-        name: removing
-      - selector: ceph_osd_numpg_replica
-        name: replica
-      - selector: ceph_osd_numpg_stray
-        name: stray
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Space and Memory
-      context: space
-      units: bytes
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_stat_bytes
-        name: bytes
-      - selector: ceph_osd_stat_bytes_avail
-        name: avail
-      - selector: ceph_osd_stat_bytes_used
-        name: used
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Heartbeat Peers
-      context: heartbeat_peers
-      units: peers
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_heartbeat_to_peers
-        name: heartbeat_to_peers
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: OSD Load Average
-      context: load_average
-      units: load
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_loadavg
-        name: loadavg
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: OSD Scrubbing - Ceph 19
-    context_namespace: osd_scrubbing_ceph_19
-    groups:
-    - family: Elapsed Time
-      context_namespace: elapsed_time
-      metrics:
-      - ceph_osd_scrub_dp_ec_failed_reservations_elapsed_count
-      - ceph_osd_scrub_dp_ec_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_count
-      - ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_sum
-      - ceph_osd_scrub_dp_ec_successful_reservations_elapsed_count
-      - ceph_osd_scrub_dp_ec_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_count
-      - ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_sum
-      - ceph_osd_scrub_dp_repl_failed_reservations_elapsed_count
-      - ceph_osd_scrub_dp_repl_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_count
-      - ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_sum
-      - ceph_osd_scrub_dp_repl_successful_reservations_elapsed_count
-      - ceph_osd_scrub_dp_repl_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_count
-      - ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_sum
-      - ceph_osd_scrub_sh_ec_failed_reservations_elapsed_count
-      - ceph_osd_scrub_sh_ec_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_count
-      - ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_sum
-      - ceph_osd_scrub_sh_ec_successful_reservations_elapsed_count
-      - ceph_osd_scrub_sh_ec_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_count
-      - ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_sum
-      - ceph_osd_scrub_sh_repl_failed_reservations_elapsed_count
-      - ceph_osd_scrub_sh_repl_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_count
-      - ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_sum
-      - ceph_osd_scrub_sh_repl_successful_reservations_elapsed_count
-      - ceph_osd_scrub_sh_repl_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_count
-      - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
-      charts:
-      - title: Scrub Elapsed-Time Measurements
-        context: scrub_latency_measurements
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_count
-          name: dp_ec_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_count
-          name: dp_ec_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_count
-          name: dp_repl_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_count
-          name: dp_repl_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_count
-          name: sh_ec_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_count
-          name: sh_ec_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_count
-          name: sh_repl_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_count
-          name: sh_repl_successful_scrubs_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Reservation Elapsed-Time Measurements
-        context: reservation_latency_measurements
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_reservations_elapsed_count
-          name: dp_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_ec_successful_reservations_elapsed_count
-          name: dp_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_repl_failed_reservations_elapsed_count
-          name: dp_repl_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_repl_successful_reservations_elapsed_count
-          name: dp_repl_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_ec_failed_reservations_elapsed_count
-          name: sh_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_ec_successful_reservations_elapsed_count
-          name: sh_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_repl_failed_reservations_elapsed_count
-          name: sh_repl_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_repl_successful_reservations_elapsed_count
-          name: sh_repl_successful_reservations_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Accumulated Scrub Elapsed Time
-        context: accumulated_scrub_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_sum
-          name: dp_ec_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_sum
-          name: dp_ec_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_sum
-          name: dp_repl_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_sum
-          name: dp_repl_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_sum
-          name: sh_ec_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_sum
-          name: sh_ec_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_sum
-          name: sh_repl_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
-          name: sh_repl_successful_scrubs_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Reservation Elapsed Time
-        context: accumulated_reservation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_reservations_elapsed_sum
-          name: dp_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_ec_successful_reservations_elapsed_sum
-          name: dp_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_repl_failed_reservations_elapsed_sum
-          name: dp_repl_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_repl_successful_reservations_elapsed_sum
-          name: dp_repl_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_ec_failed_reservations_elapsed_sum
-          name: sh_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_ec_successful_reservations_elapsed_sum
-          name: sh_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_repl_failed_reservations_elapsed_sum
-          name: sh_repl_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_repl_successful_reservations_elapsed_sum
-          name: sh_repl_successful_reservations_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Outcomes
-      context_namespace: outcomes
-      metrics:
-      - ceph_osd_scrub_dp_ec_failed_scrubs
-      - ceph_osd_scrub_dp_ec_num_scrubs_started
-      - ceph_osd_scrub_dp_ec_successful_scrubs
-      - ceph_osd_scrub_dp_repl_failed_scrubs
-      - ceph_osd_scrub_dp_repl_num_scrubs_started
-      - ceph_osd_scrub_dp_repl_successful_scrubs
-      - ceph_osd_scrub_sh_ec_failed_scrubs
-      - ceph_osd_scrub_sh_ec_num_scrubs_started
-      - ceph_osd_scrub_sh_ec_successful_scrubs
-      - ceph_osd_scrub_sh_repl_failed_scrubs
-      - ceph_osd_scrub_sh_repl_num_scrubs_started
-      - ceph_osd_scrub_sh_repl_successful_scrubs
-      charts:
-      - title: Scrub Work
-        context: scrub_work
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_scrubs
-          name: dp_ec_failed_scrubs
-        - selector: ceph_osd_scrub_dp_ec_num_scrubs_started
-          name: dp_ec_num_scrubs_started
-        - selector: ceph_osd_scrub_dp_ec_successful_scrubs
-          name: dp_ec_successful_scrubs
-        - selector: ceph_osd_scrub_dp_repl_failed_scrubs
-          name: dp_repl_failed_scrubs
-        - selector: ceph_osd_scrub_dp_repl_num_scrubs_started
-          name: dp_repl_num_scrubs_started
-        - selector: ceph_osd_scrub_dp_repl_successful_scrubs
-          name: dp_repl_successful_scrubs
-        - selector: ceph_osd_scrub_sh_ec_failed_scrubs
-          name: sh_ec_failed_scrubs
-        - selector: ceph_osd_scrub_sh_ec_num_scrubs_started
-          name: sh_ec_num_scrubs_started
-        - selector: ceph_osd_scrub_sh_ec_successful_scrubs
-          name: sh_ec_successful_scrubs
-        - selector: ceph_osd_scrub_sh_repl_failed_scrubs
-          name: sh_repl_failed_scrubs
-        - selector: ceph_osd_scrub_sh_repl_num_scrubs_started
-          name: sh_repl_num_scrubs_started
-        - selector: ceph_osd_scrub_sh_repl_successful_scrubs
-          name: sh_repl_successful_scrubs
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-    - family: Reservations
-      context_namespace: reservations
-      metrics:
-      - ceph_osd_scrub_dp_ec_num_scrubs_past_reservation
-      - ceph_osd_scrub_dp_ec_replicas_in_reservation
-      - ceph_osd_scrub_dp_ec_reservation_process_aborted
-      - ceph_osd_scrub_dp_ec_reservation_process_failure
-      - ceph_osd_scrub_dp_ec_reservation_process_skipped
-      - ceph_osd_scrub_dp_repl_num_scrubs_past_reservation
-      - ceph_osd_scrub_dp_repl_replicas_in_reservation
-      - ceph_osd_scrub_dp_repl_reservation_process_aborted
-      - ceph_osd_scrub_dp_repl_reservation_process_failure
-      - ceph_osd_scrub_dp_repl_reservation_process_skipped
-      - ceph_osd_scrub_sh_ec_num_scrubs_past_reservation
-      - ceph_osd_scrub_sh_ec_replicas_in_reservation
-      - ceph_osd_scrub_sh_ec_reservation_process_aborted
-      - ceph_osd_scrub_sh_ec_reservation_process_failure
-      - ceph_osd_scrub_sh_ec_reservation_process_skipped
-      - ceph_osd_scrub_sh_repl_num_scrubs_past_reservation
-      - ceph_osd_scrub_sh_repl_replicas_in_reservation
-      - ceph_osd_scrub_sh_repl_reservation_process_aborted
-      - ceph_osd_scrub_sh_repl_reservation_process_failure
-      - ceph_osd_scrub_sh_repl_reservation_process_skipped
-      charts:
-      - title: Replicas in Reservation
-        context: replicas_in_reservation
-        units: replicas
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_replicas_in_reservation
-          name: dp_ec_replicas_in_reservation
-        - selector: ceph_osd_scrub_dp_repl_replicas_in_reservation
-          name: dp_repl_replicas_in_reservation
-        - selector: ceph_osd_scrub_sh_ec_replicas_in_reservation
-          name: sh_ec_replicas_in_reservation
-        - selector: ceph_osd_scrub_sh_repl_replicas_in_reservation
-          name: sh_repl_replicas_in_reservation
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Scrubs Past Reservation
-        context: scrubs_past_reservation
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_num_scrubs_past_reservation
-          name: dp_ec_num_scrubs_past_reservation
-        - selector: ceph_osd_scrub_dp_repl_num_scrubs_past_reservation
-          name: dp_repl_num_scrubs_past_reservation
-        - selector: ceph_osd_scrub_sh_ec_num_scrubs_past_reservation
-          name: sh_ec_num_scrubs_past_reservation
-        - selector: ceph_osd_scrub_sh_repl_num_scrubs_past_reservation
-          name: sh_repl_num_scrubs_past_reservation
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Reservation Process Outcomes
-        context: reservation_process_outcomes
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_reservation_process_aborted
-          name: dp_ec_reservation_process_aborted
-        - selector: ceph_osd_scrub_dp_ec_reservation_process_failure
-          name: dp_ec_reservation_process_failure
-        - selector: ceph_osd_scrub_dp_ec_reservation_process_skipped
-          name: dp_ec_reservation_process_skipped
-        - selector: ceph_osd_scrub_dp_repl_reservation_process_aborted
-          name: dp_repl_reservation_process_aborted
-        - selector: ceph_osd_scrub_dp_repl_reservation_process_failure
-          name: dp_repl_reservation_process_failure
-        - selector: ceph_osd_scrub_dp_repl_reservation_process_skipped
-          name: dp_repl_reservation_process_skipped
-        - selector: ceph_osd_scrub_sh_ec_reservation_process_aborted
-          name: sh_ec_reservation_process_aborted
-        - selector: ceph_osd_scrub_sh_ec_reservation_process_failure
-          name: sh_ec_reservation_process_failure
-        - selector: ceph_osd_scrub_sh_ec_reservation_process_skipped
-          name: sh_ec_reservation_process_skipped
-        - selector: ceph_osd_scrub_sh_repl_reservation_process_aborted
-          name: sh_repl_reservation_process_aborted
-        - selector: ceph_osd_scrub_sh_repl_reservation_process_failure
-          name: sh_repl_reservation_process_failure
-        - selector: ceph_osd_scrub_sh_repl_reservation_process_skipped
-          name: sh_repl_reservation_process_skipped
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-  - family: OSD Scrubbing - Ceph 20
-    context_namespace: osd_scrubbing_ceph_20
-    groups:
-    - family: Elapsed Time
-      context_namespace: elapsed_time
-      metrics:
-      - ceph_osd_failed_scrubs_ec_elapsed_count
-      - ceph_osd_failed_scrubs_ec_elapsed_sum
-      - ceph_osd_failed_scrubs_replicated_elapsed_count
-      - ceph_osd_failed_scrubs_replicated_elapsed_sum
-      - ceph_osd_scrub_ec_failed_reservations_elapsed_count
-      - ceph_osd_scrub_ec_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_ec_successful_reservations_elapsed_count
-      - ceph_osd_scrub_ec_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_replicated_failed_reservations_elapsed_count
-      - ceph_osd_scrub_replicated_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_replicated_successful_reservations_elapsed_count
-      - ceph_osd_scrub_replicated_successful_reservations_elapsed_sum
-      - ceph_osd_successful_scrubs_ec_elapsed_count
-      - ceph_osd_successful_scrubs_ec_elapsed_sum
-      - ceph_osd_successful_scrubs_replicated_elapsed_count
-      - ceph_osd_successful_scrubs_replicated_elapsed_sum
-      charts:
-      - title: Scrub Elapsed-Time Measurements
-        context: scrub_latency_measurements
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_failed_scrubs_ec_elapsed_count
-          name: failed_scrubs_ec_elapsed
-        - selector: ceph_osd_failed_scrubs_replicated_elapsed_count
-          name: failed_scrubs_replicated_elapsed
-        - selector: ceph_osd_successful_scrubs_ec_elapsed_count
-          name: successful_scrubs_ec_elapsed
-        - selector: ceph_osd_successful_scrubs_replicated_elapsed_count
-          name: successful_scrubs_replicated_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Reservation Elapsed-Time Measurements
-        context: reservation_latency_measurements
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_failed_reservations_elapsed_count
-          name: scrub_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_ec_successful_reservations_elapsed_count
-          name: scrub_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_replicated_failed_reservations_elapsed_count
-          name: scrub_replicated_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_replicated_successful_reservations_elapsed_count
-          name: scrub_replicated_successful_reservations_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Scrub Elapsed Time
-        context: accumulated_scrub_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_failed_scrubs_ec_elapsed_sum
-          name: failed_scrubs_ec_elapsed
-        - selector: ceph_osd_failed_scrubs_replicated_elapsed_sum
-          name: failed_scrubs_replicated_elapsed
-        - selector: ceph_osd_successful_scrubs_ec_elapsed_sum
-          name: successful_scrubs_ec_elapsed
-        - selector: ceph_osd_successful_scrubs_replicated_elapsed_sum
-          name: successful_scrubs_replicated_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Reservation Elapsed Time
-        context: accumulated_reservation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_failed_reservations_elapsed_sum
-          name: scrub_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_ec_successful_reservations_elapsed_sum
-          name: scrub_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_replicated_failed_reservations_elapsed_sum
-          name: scrub_replicated_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_replicated_successful_reservations_elapsed_sum
-          name: scrub_replicated_successful_reservations_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Interference and Scheduling
-      context_namespace: interference_and_scheduling
-      metrics:
-      - ceph_osd_scrub_ec_io_blocked
-      - ceph_osd_scrub_ec_io_intersects
-      - ceph_osd_scrub_replicated_io_blocked
-      - ceph_osd_scrub_replicated_io_intersects
-      charts:
-      - title: Client Write Interference
-        context: client_write_interference
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_io_blocked
-          name: ec_io_blocked
-        - selector: ceph_osd_scrub_ec_io_intersects
-          name: ec_io_intersects
-        - selector: ceph_osd_scrub_replicated_io_blocked
-          name: replicated_io_blocked
-        - selector: ceph_osd_scrub_replicated_io_intersects
-          name: replicated_io_intersects
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Outcomes
-      context_namespace: outcomes
-      metrics:
-      - ceph_osd_failed_scrubs_ec
-      - ceph_osd_failed_scrubs_replicated
-      - ceph_osd_num_scrubs_started_ec
-      - ceph_osd_num_scrubs_started_replicated
-      - ceph_osd_successful_scrubs_ec
-      - ceph_osd_successful_scrubs_replicated
-      charts:
-      - title: Scrub Work
-        context: scrub_work
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_failed_scrubs_ec
-          name: failed_scrubs_ec
-        - selector: ceph_osd_failed_scrubs_replicated
-          name: failed_scrubs_replicated
-        - selector: ceph_osd_num_scrubs_started_ec
-          name: num_scrubs_started_ec
-        - selector: ceph_osd_num_scrubs_started_replicated
-          name: num_scrubs_started_replicated
-        - selector: ceph_osd_successful_scrubs_ec
-          name: successful_scrubs_ec
-        - selector: ceph_osd_successful_scrubs_replicated
-          name: successful_scrubs_replicated
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Reservations
-      context_namespace: reservations
-      metrics:
-      - ceph_osd_num_scrubs_past_reservation_ec
-      - ceph_osd_num_scrubs_past_reservation_replicated
-      - ceph_osd_scrub_ec_replicas_in_reservation
-      - ceph_osd_scrub_ec_reservation_process_aborted
-      - ceph_osd_scrub_ec_reservation_process_failure
-      - ceph_osd_scrub_ec_reservation_process_skipped
-      - ceph_osd_scrub_ec_reservations_completed
-      - ceph_osd_scrub_replicated_replicas_in_reservation
-      - ceph_osd_scrub_replicated_reservation_process_aborted
-      - ceph_osd_scrub_replicated_reservation_process_failure
-      - ceph_osd_scrub_replicated_reservation_process_skipped
-      - ceph_osd_scrub_replicated_scrub_reservations_completed
-      charts:
-      - title: Replicas in Reservation
-        context: replicas_in_reservation
-        units: replicas
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_replicas_in_reservation
-          name: ec_replicas_in_reservation
-        - selector: ceph_osd_scrub_replicated_replicas_in_reservation
-          name: replicated_replicas_in_reservation
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Scrubs Past Reservation
-        context: scrubs_past_reservation
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_num_scrubs_past_reservation_ec
-          name: num_scrubs_past_reservation_ec
-        - selector: ceph_osd_num_scrubs_past_reservation_replicated
-          name: num_scrubs_past_reservation_replicated
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Reservation Process Outcomes
-        context: reservation_process_outcomes
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_reservation_process_aborted
-          name: scrub_ec_reservation_process_aborted
-        - selector: ceph_osd_scrub_ec_reservation_process_failure
-          name: scrub_ec_reservation_process_failure
-        - selector: ceph_osd_scrub_ec_reservation_process_skipped
-          name: scrub_ec_reservation_process_skipped
-        - selector: ceph_osd_scrub_ec_reservations_completed
-          name: scrub_ec_reservations_completed
-        - selector: ceph_osd_scrub_replicated_reservation_process_aborted
-          name: scrub_replicated_reservation_process_aborted
-        - selector: ceph_osd_scrub_replicated_reservation_process_failure
-          name: scrub_replicated_reservation_process_failure
-        - selector: ceph_osd_scrub_replicated_reservation_process_skipped
-          name: scrub_replicated_reservation_process_skipped
-        - selector: ceph_osd_scrub_replicated_scrub_reservations_completed
-          name: scrub_replicated_scrub_reservations_completed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Scrub Work
-      context_namespace: scrub_work
-      metrics:
-      - ceph_osd_scrub_ec_getattr_cnt
-      - ceph_osd_scrub_ec_read_bytes
-      - ceph_osd_scrub_ec_read_cnt
-      - ceph_osd_scrub_ec_stats_cnt
-      - ceph_osd_scrub_replicated_getattr_cnt
-      - ceph_osd_scrub_replicated_read_bytes
-      - ceph_osd_scrub_replicated_read_cnt
-      - ceph_osd_scrub_replicated_stats_cnt
-      charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_read_bytes
-          name: ec_read_bytes
-        - selector: ceph_osd_scrub_replicated_read_bytes
-          name: replicated_read_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Scrub Calls
-        context: scrub_calls
-        units: calls/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_getattr_cnt
-          name: ec_getattr_cnt
-        - selector: ceph_osd_scrub_ec_read_cnt
-          name: ec_read_cnt
-        - selector: ceph_osd_scrub_ec_stats_cnt
-          name: ec_stats_cnt
-        - selector: ceph_osd_scrub_replicated_getattr_cnt
-          name: replicated_getattr_cnt
-        - selector: ceph_osd_scrub_replicated_read_cnt
-          name: replicated_read_cnt
-        - selector: ceph_osd_scrub_replicated_stats_cnt
-          name: replicated_stats_cnt
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: OSD Scrubbing - Common Work
-    context_namespace: osd_scrubbing_common_work
-    groups:
-    - family: Interference and Scheduling
-      context_namespace: interference_and_scheduling
-      metrics:
-      - ceph_osd_scrub_dp_ec_chunk_busy
-      - ceph_osd_scrub_dp_ec_chunk_selected
-      - ceph_osd_scrub_dp_ec_locked_object
-      - ceph_osd_scrub_dp_ec_preemptions
-      - ceph_osd_scrub_dp_ec_write_blocked_by_scrub
-      - ceph_osd_scrub_dp_repl_chunk_busy
-      - ceph_osd_scrub_dp_repl_chunk_selected
-      - ceph_osd_scrub_dp_repl_locked_object
-      - ceph_osd_scrub_dp_repl_preemptions
-      - ceph_osd_scrub_dp_repl_write_blocked_by_scrub
-      - ceph_osd_scrub_sh_ec_chunk_busy
-      - ceph_osd_scrub_sh_ec_chunk_selected
-      - ceph_osd_scrub_sh_ec_locked_object
-      - ceph_osd_scrub_sh_ec_preemptions
-      - ceph_osd_scrub_sh_ec_write_blocked_by_scrub
-      - ceph_osd_scrub_sh_repl_chunk_busy
-      - ceph_osd_scrub_sh_repl_chunk_selected
-      - ceph_osd_scrub_sh_repl_locked_object
-      - ceph_osd_scrub_sh_repl_preemptions
-      - ceph_osd_scrub_sh_repl_write_blocked_by_scrub
-      charts:
-      - title: Object-Lock Waits
-        context: object_lock_waits
-        units: waits/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_locked_object
-          name: dp_ec_locked_object
-        - selector: ceph_osd_scrub_dp_repl_locked_object
-          name: dp_repl_locked_object
-        - selector: ceph_osd_scrub_sh_ec_locked_object
-          name: sh_ec_locked_object
-        - selector: ceph_osd_scrub_sh_repl_locked_object
-          name: sh_repl_locked_object
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Chunk Selection Outcomes
-        context: chunk_selection_outcomes
-        units: chunks/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_chunk_busy
-          name: dp_ec_chunk_busy
-        - selector: ceph_osd_scrub_dp_ec_chunk_selected
-          name: dp_ec_chunk_selected
-        - selector: ceph_osd_scrub_dp_repl_chunk_busy
-          name: dp_repl_chunk_busy
-        - selector: ceph_osd_scrub_dp_repl_chunk_selected
-          name: dp_repl_chunk_selected
-        - selector: ceph_osd_scrub_sh_ec_chunk_busy
-          name: sh_ec_chunk_busy
-        - selector: ceph_osd_scrub_sh_ec_chunk_selected
-          name: sh_ec_chunk_selected
-        - selector: ceph_osd_scrub_sh_repl_chunk_busy
-          name: sh_repl_chunk_busy
-        - selector: ceph_osd_scrub_sh_repl_chunk_selected
-          name: sh_repl_chunk_selected
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Scrub Preemptions
-        context: preemptions
-        units: preemptions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_preemptions
-          name: dp_ec_preemptions
-        - selector: ceph_osd_scrub_dp_repl_preemptions
-          name: dp_repl_preemptions
-        - selector: ceph_osd_scrub_sh_ec_preemptions
-          name: sh_ec_preemptions
-        - selector: ceph_osd_scrub_sh_repl_preemptions
-          name: sh_repl_preemptions
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Client Writes Blocked by Scrub
-        context: blocked_client_writes
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_write_blocked_by_scrub
-          name: dp_ec_write_blocked_by_scrub
-        - selector: ceph_osd_scrub_dp_repl_write_blocked_by_scrub
-          name: dp_repl_write_blocked_by_scrub
-        - selector: ceph_osd_scrub_sh_ec_write_blocked_by_scrub
-          name: sh_ec_write_blocked_by_scrub
-        - selector: ceph_osd_scrub_sh_repl_write_blocked_by_scrub
-          name: sh_repl_write_blocked_by_scrub
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-    - family: Reservations
-      context_namespace: reservations
-      metrics:
-      - ceph_osd_scrub_dp_ec_scrub_reservations_completed
-      - ceph_osd_scrub_dp_repl_scrub_reservations_completed
-      - ceph_osd_scrub_sh_ec_scrub_reservations_completed
-      - ceph_osd_scrub_sh_repl_scrub_reservations_completed
-      charts:
-      - title: Completed Scrub Reservations
-        context: completed_reservations
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_scrub_reservations_completed
-          name: dp_ec_scrub_reservations_completed
-        - selector: ceph_osd_scrub_dp_repl_scrub_reservations_completed
-          name: dp_repl_scrub_reservations_completed
-        - selector: ceph_osd_scrub_sh_ec_scrub_reservations_completed
-          name: sh_ec_scrub_reservations_completed
-        - selector: ceph_osd_scrub_sh_repl_scrub_reservations_completed
-          name: sh_repl_scrub_reservations_completed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-    - family: Scrub Work
-      context_namespace: scrub_work
-      metrics:
-      - ceph_osd_scrub_omapget_bytes
-      - ceph_osd_scrub_omapget_cnt
-      - ceph_osd_scrub_omapgetheader_bytes
-      - ceph_osd_scrub_omapgetheader_cnt
-      charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_omapget_bytes
-          name: omapget_bytes
-        - selector: ceph_osd_scrub_omapgetheader_bytes
-          name: omapgetheader_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OMAP Scrub Calls
-        context: omap_calls
-        units: calls/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_omapget_cnt
-          name: omapget_cnt
-        - selector: ceph_osd_scrub_omapgetheader_cnt
-          name: omapgetheader_cnt
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Object Gateway
-    context_namespace: object_gateway
-    groups:
-    - family: Lifecycle
-      context_namespace: lifecycle
-      metrics:
-      - ceph_rgw_lc_abort_mpu
-      - ceph_rgw_lc_expire_current
-      - ceph_rgw_lc_expire_dm
-      - ceph_rgw_lc_expire_noncurrent
-      - ceph_rgw_lc_transition_current
-      - ceph_rgw_lc_transition_noncurrent
-      charts:
-      - title: Lifecycle Actions
-        context: lifecycle_actions
-        units: actions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_lc_expire_current
-          name: expire_current
-        - selector: ceph_rgw_lc_expire_dm
-          name: expire_dm
-        - selector: ceph_rgw_lc_expire_noncurrent
-          name: expire_noncurrent
-        - selector: ceph_rgw_lc_transition_current
-          name: transition_current
-        - selector: ceph_rgw_lc_transition_noncurrent
-          name: transition_noncurrent
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Aborted Multipart Uploads
-        context: aborted_multipart_uploads
-        units: uploads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_lc_abort_mpu
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-    - family: Lua
-      context_namespace: lua
-      metrics:
-      - ceph_rgw_lua_current_vms
-      - ceph_rgw_lua_script_fail
-      - ceph_rgw_lua_script_ok
-      charts:
-      - title: Current Lua Virtual Machines
-        context: current_vms
-        units: VMs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_lua_current_vms
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Lua Script Executions
-        context: script_executions
-        units: executions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_lua_script_ok
-          name: success
-        - selector: ceph_rgw_lua_script_fail
-          name: failure
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-    - family: Notifications
-      context_namespace: notifications
-      metrics:
-      - ceph_rgw_pubsub_event_lost
-      - ceph_rgw_pubsub_event_triggered
-      - ceph_rgw_pubsub_events
-      - ceph_rgw_pubsub_missing_conf
-      - ceph_rgw_pubsub_push_failed
-      - ceph_rgw_pubsub_push_ok
-      - ceph_rgw_pubsub_push_pending
-      - ceph_rgw_pubsub_store_fail
-      - ceph_rgw_pubsub_store_ok
-      charts:
-      - title: Pending Notification Events
-        context: pending_events
-        units: events
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_push_pending
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Stored Events
-        context: event_state
-        units: events
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_events
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_event_lost
-          name: event_lost
-        - selector: ceph_rgw_pubsub_event_triggered
-          name: event_triggered
-        - selector: ceph_rgw_pubsub_push_ok
-          name: push_ok
-        - selector: ceph_rgw_pubsub_store_ok
-          name: store_ok
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_push_failed
-          name: push_failed
-        - selector: ceph_rgw_pubsub_store_fail
-          name: store_fail
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Missing Notification Configurations
-        context: missing_configurations
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_missing_conf
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-    - family: Requests and Queue
-      context_namespace: requests_and_queue
-      metrics:
-      - ceph_rgw_failed_req
-      - ceph_rgw_gc_retire_object
-      - ceph_rgw_get
-      - ceph_rgw_get_b
-      - ceph_rgw_get_initial_lat_count
-      - ceph_rgw_get_initial_lat_sum
-      - ceph_rgw_put
-      - ceph_rgw_put_b
-      - ceph_rgw_put_initial_lat_count
-      - ceph_rgw_put_initial_lat_sum
-      - ceph_rgw_qactive
-      - ceph_rgw_qlen
-      - ceph_rgw_req
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_get_initial_lat_count
-          name: get_initial_lat
-        - selector: ceph_rgw_put_initial_lat_count
-          name: put_initial_lat
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_get_initial_lat_sum
-          name: get_initial_lat
-        - selector: ceph_rgw_put_initial_lat_sum
-          name: put_initial_lat
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_get_b
-          name: get_b
-        - selector: ceph_rgw_put_b
-          name: put_b
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Queued and Active Requests
-        context: current_requests
-        units: requests
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_qactive
-          name: qactive
-        - selector: ceph_rgw_qlen
-          name: qlen
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Failed Requests
-        context: failed_requests
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_failed_req
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Object Work
-        context: object_work
-        units: objects/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_gc_retire_object
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Requests
-        context: requests
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_get
-          name: get
-        - selector: ceph_rgw_put
-          name: put
-        - selector: ceph_rgw_req
-          name: req
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-  - family: Object Gateway Cache
-    context_namespace: object_gateway_cache
-    metrics:
-    - ceph_rgw_cache_hit
-    - ceph_rgw_cache_miss
-    - ceph_rgw_keystone_token_cache_hit
-    - ceph_rgw_keystone_token_cache_miss
-    charts:
-    - title: Keystone Token Cache Lookup Outcomes
-      context: keystone_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rgw_keystone_token_cache_hit
-        name: hit
-      - selector: ceph_rgw_keystone_token_cache_miss
-        name: miss
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels: []
-    - title: Lookup Outcomes
-      context: lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rgw_cache_hit
-        name: cache_hit
-      - selector: ceph_rgw_cache_miss
-        name: cache_miss
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels: []
-  - family: Object Gateway Multisite
-    context_namespace: object_gateway_multisite
-    metrics:
-    - ceph_data_sync_from_zone_fetch_bytes_count
-    - ceph_data_sync_from_zone_fetch_bytes_sum
-    - ceph_data_sync_from_zone_fetch_errors
-    - ceph_data_sync_from_zone_fetch_not_modified
-    - ceph_data_sync_from_zone_lock_latency_count
-    - ceph_data_sync_from_zone_lock_latency_sum
-    - ceph_data_sync_from_zone_poll_errors
-    - ceph_data_sync_from_zone_poll_latency_count
-    - ceph_data_sync_from_zone_poll_latency_sum
-    charts:
-    - title: Replicated Objects
-      context: replicated_objects
-      units: objects/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_fetch_bytes_count
-        name: value
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-    - title: Accumulated Byte Measurement
-      context: accumulated_bytes
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_fetch_bytes_sum
-        name: value
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-      algorithm: incremental
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_lock_latency_count
-        name: lock_latency
-      - selector: ceph_data_sync_from_zone_poll_latency_count
-        name: poll_latency
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_lock_latency_sum
-        name: lock_latency
-      - selector: ceph_data_sync_from_zone_poll_latency_sum
-        name: poll_latency
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-      algorithm: incremental
-    - title: Replication-Log Request Errors
-      context: replication_log_request_errors
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_poll_errors
-        name: value
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-    - title: Object Work
-      context: object_work
-      units: objects/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_fetch_errors
-        name: errors
-      - selector: ceph_data_sync_from_zone_fetch_not_modified
-        name: not_modified
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-  - family: Objecter
-    context_namespace: objecter
-    metrics:
-    - ceph_objecter_command_active
-    - ceph_objecter_command_resend
-    - ceph_objecter_command_send
-    - ceph_objecter_linger_active
-    - ceph_objecter_linger_ping
-    - ceph_objecter_linger_resend
-    - ceph_objecter_linger_send
-    - ceph_objecter_map_epoch
-    - ceph_objecter_map_full
-    - ceph_objecter_map_inc
-    - ceph_objecter_omap_del
-    - ceph_objecter_omap_rd
-    - ceph_objecter_omap_wr
-    - ceph_objecter_op
-    - ceph_objecter_op_active
-    - ceph_objecter_op_inflight
-    - ceph_objecter_op_laggy
-    - ceph_objecter_op_latency_count
-    - ceph_objecter_op_latency_sum
-    - ceph_objecter_op_pg
-    - ceph_objecter_op_r
-    - ceph_objecter_op_reply
-    - ceph_objecter_op_resend
-    - ceph_objecter_op_rmw
-    - ceph_objecter_op_send
-    - ceph_objecter_op_send_bytes
-    - ceph_objecter_op_w
-    - ceph_objecter_oplen_avg_count
-    - ceph_objecter_oplen_avg_sum
-    - ceph_objecter_osd_laggy
-    - ceph_objecter_osd_session_close
-    - ceph_objecter_osd_session_open
-    - ceph_objecter_osd_sessions
-    - ceph_objecter_osdop_append
-    - ceph_objecter_osdop_call
-    - ceph_objecter_osdop_clonerange
-    - ceph_objecter_osdop_cmpxattr
-    - ceph_objecter_osdop_create
-    - ceph_objecter_osdop_delete
-    - ceph_objecter_osdop_getxattr
-    - ceph_objecter_osdop_mapext
-    - ceph_objecter_osdop_notify
-    - ceph_objecter_osdop_other
-    - ceph_objecter_osdop_pgls
-    - ceph_objecter_osdop_pgls_filter
-    - ceph_objecter_osdop_read
-    - ceph_objecter_osdop_resetxattrs
-    - ceph_objecter_osdop_rmxattr
-    - ceph_objecter_osdop_setxattr
-    - ceph_objecter_osdop_sparse_read
-    - ceph_objecter_osdop_src_cmpxattr
-    - ceph_objecter_osdop_stat
-    - ceph_objecter_osdop_truncate
-    - ceph_objecter_osdop_watch
-    - ceph_objecter_osdop_write
-    - ceph_objecter_osdop_writefull
-    - ceph_objecter_osdop_writesame
-    - ceph_objecter_osdop_zero
-    - ceph_objecter_poolop_active
-    - ceph_objecter_poolop_resend
-    - ceph_objecter_poolop_send
-    - ceph_objecter_poolstat_active
-    - ceph_objecter_poolstat_resend
-    - ceph_objecter_poolstat_send
-    - ceph_objecter_replica_read_bounced
-    - ceph_objecter_replica_read_completed
-    - ceph_objecter_replica_read_sent
-    - ceph_objecter_statfs_active
-    - ceph_objecter_statfs_resend
-    - ceph_objecter_statfs_send
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_op_latency_count
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_op_latency_sum
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      algorithm: incremental
-      aggregation: sum
-    - title: Submitted Top-Level Operations
-      context: submitted_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_oplen_avg_count
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Operation-Vector Entries
-      context: operation_vector_entries
-      units: entries/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_oplen_avg_sum
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      algorithm: incremental
-      aggregation: sum
-    - title: Byte Throughput
-      context: byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_op_send_bytes
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active Commands
-      context: active_commands
-      units: commands
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_command_active
-        name: command_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active Lingering Operations
-      context: active_lingering_operations
-      units: operations
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_linger_active
-        name: linger_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: OSD-Map Epoch
-      context: map_epoch
-      units: epoch
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_map_epoch
-        name: map_epoch
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: min
-    - title: Objecter Operations
-      context: active_operations
-      units: operations
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_op_active
-        name: op_active
-      - selector: ceph_objecter_op_inflight
-        name: op_inflight
-      - selector: ceph_objecter_op_laggy
-        name: op_laggy
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active Pool Operations
-      context: active_pool_operations
-      units: operations
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_poolop_active
-        name: poolop_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active Pool-Stat Requests
-      context: active_poolstat_requests
-      units: requests
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_poolstat_active
-        name: poolstat_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active StatFS Requests
-      context: active_statfs_requests
-      units: requests
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_statfs_active
-        name: statfs_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Commands
-      context: commands
-      units: commands/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_command_resend
-        name: command_resend
-      - selector: ceph_objecter_command_send
-        name: command_send
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Lingering Operations
-      context: lingering_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_linger_ping
-        name: linger_ping
-      - selector: ceph_objecter_linger_resend
-        name: linger_resend
-      - selector: ceph_objecter_linger_send
-        name: linger_send
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: OSD Maps
-      context: maps
-      units: maps/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_map_full
-        name: map_full
-      - selector: ceph_objecter_map_inc
-        name: map_inc
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Object Operations
-      context: operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_omap_del
-        name: omap_del
-      - selector: ceph_objecter_omap_rd
-        name: omap_rd
-      - selector: ceph_objecter_omap_wr
-        name: omap_wr
-      - selector: ceph_objecter_op
-        name: op
-      - selector: ceph_objecter_op_pg
-        name: op_pg
-      - selector: ceph_objecter_op_r
-        name: op_r
-      - selector: ceph_objecter_op_reply
-        name: op_reply
-      - selector: ceph_objecter_op_resend
-        name: op_resend
-      - selector: ceph_objecter_op_rmw
-        name: op_rmw
-      - selector: ceph_objecter_op_send
-        name: op_send
-      - selector: ceph_objecter_op_w
-        name: op_w
-      - selector: ceph_objecter_osdop_append
-        name: osdop_append
-      - selector: ceph_objecter_osdop_call
-        name: osdop_call
-      - selector: ceph_objecter_osdop_clonerange
-        name: osdop_clonerange
-      - selector: ceph_objecter_osdop_cmpxattr
-        name: osdop_cmpxattr
-      - selector: ceph_objecter_osdop_create
-        name: osdop_create
-      - selector: ceph_objecter_osdop_delete
-        name: osdop_delete
-      - selector: ceph_objecter_osdop_getxattr
-        name: osdop_getxattr
-      - selector: ceph_objecter_osdop_mapext
-        name: osdop_mapext
-      - selector: ceph_objecter_osdop_notify
-        name: osdop_notify
-      - selector: ceph_objecter_osdop_other
-        name: osdop_other
-      - selector: ceph_objecter_osdop_pgls
-        name: osdop_pgls
-      - selector: ceph_objecter_osdop_pgls_filter
-        name: osdop_pgls_filter
-      - selector: ceph_objecter_osdop_read
-        name: osdop_read
-      - selector: ceph_objecter_osdop_resetxattrs
-        name: osdop_resetxattrs
-      - selector: ceph_objecter_osdop_rmxattr
-        name: osdop_rmxattr
-      - selector: ceph_objecter_osdop_setxattr
-        name: osdop_setxattr
-      - selector: ceph_objecter_osdop_sparse_read
-        name: osdop_sparse_read
-      - selector: ceph_objecter_osdop_src_cmpxattr
-        name: osdop_src_cmpxattr
-      - selector: ceph_objecter_osdop_stat
-        name: osdop_stat
-      - selector: ceph_objecter_osdop_truncate
-        name: osdop_truncate
-      - selector: ceph_objecter_osdop_watch
-        name: osdop_watch
-      - selector: ceph_objecter_osdop_write
-        name: osdop_write
-      - selector: ceph_objecter_osdop_writefull
-        name: osdop_writefull
-      - selector: ceph_objecter_osdop_writesame
-        name: osdop_writesame
-      - selector: ceph_objecter_osdop_zero
-        name: osdop_zero
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Replica Reads
-      context: replica_reads
-      units: reads/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_replica_read_sent
-        name: replica_read_sent
-      - selector: ceph_objecter_replica_read_bounced
-        name: replica_read_bounced
-      - selector: ceph_objecter_replica_read_completed
-        name: replica_read_completed
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: OSD Sessions
-      context: osd_sessions
-      units: sessions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_osd_session_close
-        name: osd_session_close
-      - selector: ceph_objecter_osd_session_open
-        name: osd_session_open
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Pool Operations
-      context: pool_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_poolop_resend
-        name: poolop_resend
-      - selector: ceph_objecter_poolop_send
-        name: poolop_send
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Pool-Stat and StatFS Requests
-      context: stat_requests
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_poolstat_resend
-        name: poolstat_resend
-      - selector: ceph_objecter_poolstat_send
-        name: poolstat_send
-      - selector: ceph_objecter_statfs_resend
-        name: statfs_resend
-      - selector: ceph_objecter_statfs_send
-        name: statfs_send
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Sessions
-      context: session_state
-      units: sessions
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_osd_laggy
-        name: laggy
-      - selector: ceph_objecter_osd_sessions
-        name: sessions
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-  - family: RBD Client Images
-    context_namespace: rbd_client_images
-    metrics:
-    - ceph_rbd_librbd_image_cmp
-    - ceph_rbd_librbd_image_cmp_bytes
-    - ceph_rbd_librbd_image_cmp_latency_count
-    - ceph_rbd_librbd_image_cmp_latency_sum
-    - ceph_rbd_librbd_image_discard
-    - ceph_rbd_librbd_image_discard_bytes
-    - ceph_rbd_librbd_image_discard_latency_count
-    - ceph_rbd_librbd_image_discard_latency_sum
-    - ceph_rbd_librbd_image_flush
-    - ceph_rbd_librbd_image_flush_latency_count
-    - ceph_rbd_librbd_image_flush_latency_sum
-    - ceph_rbd_librbd_image_invalidate_cache
-    - ceph_rbd_librbd_image_lock_acquired_time
-    - ceph_rbd_librbd_image_notify
-    - ceph_rbd_librbd_image_opened_time
-    - ceph_rbd_librbd_image_rd
-    - ceph_rbd_librbd_image_rd_bytes
-    - ceph_rbd_librbd_image_rd_latency_count
-    - ceph_rbd_librbd_image_rd_latency_sum
-    - ceph_rbd_librbd_image_readahead
-    - ceph_rbd_librbd_image_readahead_bytes
-    - ceph_rbd_librbd_image_resize
-    - ceph_rbd_librbd_image_snap_create
-    - ceph_rbd_librbd_image_snap_remove
-    - ceph_rbd_librbd_image_snap_rename
-    - ceph_rbd_librbd_image_snap_rollback
-    - ceph_rbd_librbd_image_wr
-    - ceph_rbd_librbd_image_wr_bytes
-    - ceph_rbd_librbd_image_wr_latency_count
-    - ceph_rbd_librbd_image_wr_latency_sum
-    - ceph_rbd_librbd_image_ws
-    - ceph_rbd_librbd_image_ws_bytes
-    - ceph_rbd_librbd_image_ws_latency_count
-    - ceph_rbd_librbd_image_ws_latency_sum
-    charts:
-    - title: I/O Operations
-      context: io_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_rd
-        name: read
-      - selector: ceph_rbd_librbd_image_wr
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: I/O Byte Throughput
-      context: io_byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_rd_bytes
-        name: read
-      - selector: ceph_rbd_librbd_image_wr_bytes
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: I/O Latency Measurements
-      context: io_latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_rd_latency_count
-        name: read
-      - selector: ceph_rbd_librbd_image_wr_latency_count
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Accumulated I/O Latency
-      context: accumulated_io_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_rd_latency_sum
-        name: read
-      - selector: ceph_rbd_librbd_image_wr_latency_sum
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-      algorithm: incremental
-    - title: Lifecycle Timestamps
-      context: lifecycle_timestamps
-      units: seconds since epoch
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_opened_time
-        name: opened
-      - selector: ceph_rbd_librbd_image_lock_acquired_time
-        name: lock_acquired
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Data Operations
-      context: data_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_discard
-        name: discard
-      - selector: ceph_rbd_librbd_image_ws
-        name: write_same
-      - selector: ceph_rbd_librbd_image_cmp
-        name: compare_and_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Data Operation Byte Throughput
-      context: data_operation_byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_discard_bytes
-        name: discard
-      - selector: ceph_rbd_librbd_image_ws_bytes
-        name: write_same
-      - selector: ceph_rbd_librbd_image_cmp_bytes
-        name: compare_and_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Data Operation Latency Measurements
-      context: data_operation_latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_discard_latency_count
-        name: discard
-      - selector: ceph_rbd_librbd_image_ws_latency_count
-        name: write_same
-      - selector: ceph_rbd_librbd_image_cmp_latency_count
-        name: compare_and_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Accumulated Data Operation Latency
-      context: accumulated_data_operation_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_discard_latency_sum
-        name: discard
-      - selector: ceph_rbd_librbd_image_ws_latency_sum
-        name: write_same
-      - selector: ceph_rbd_librbd_image_cmp_latency_sum
-        name: compare_and_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-      algorithm: incremental
-    - title: Flush Operations
-      context: flush_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_flush
-        name: flush
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Flush Latency Measurements
-      context: flush_latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_flush_latency_count
-        name: flush
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Accumulated Flush Latency
-      context: accumulated_flush_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_flush_latency_sum
-        name: flush
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-      algorithm: incremental
-    - title: Snapshot Mutations
-      context: snapshot_mutations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_snap_create
-        name: create
-      - selector: ceph_rbd_librbd_image_snap_remove
-        name: remove
-      - selector: ceph_rbd_librbd_image_snap_rollback
-        name: rollback
-      - selector: ceph_rbd_librbd_image_snap_rename
-        name: rename
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Maintenance Operations
-      context: maintenance_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_notify
-        name: notify
-      - selector: ceph_rbd_librbd_image_resize
-        name: resize
-      - selector: ceph_rbd_librbd_image_readahead
-        name: readahead
-      - selector: ceph_rbd_librbd_image_invalidate_cache
-        name: invalidate_cache
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Readahead Byte Throughput
-      context: readahead_byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_readahead_bytes
-        name: readahead
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-  - family: RBD Mirror
-    context_namespace: rbd_mirror
-    groups:
-    - family: Journal
-      context_namespace: journal
-      metrics:
-      - ceph_rbd_mirror_journal_entries
-      - ceph_rbd_mirror_journal_image_entries
-      - ceph_rbd_mirror_journal_image_replay_bytes
-      - ceph_rbd_mirror_journal_image_replay_latency_count
-      - ceph_rbd_mirror_journal_image_replay_latency_sum
-      - ceph_rbd_mirror_journal_replay_bytes
-      - ceph_rbd_mirror_journal_replay_latency_count
-      - ceph_rbd_mirror_journal_replay_latency_sum
-      charts:
-      - title: Journal Replay Latency Measurements
-        context: latency_measurements
-        units: entries/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_replay_latency_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Image Journal Replay Latency Measurements
-        context: image_latency_measurements
-        units: entries/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_image_replay_latency_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_replay_latency_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Image Journal Replay Latency
-        context: image_accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_image_replay_latency_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_replay_bytes
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Image Journal Replay Byte Throughput
-        context: image_byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_image_replay_bytes
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Journal Entries
-        context: journal_entries
-        units: entries/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_entries
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Journal Entries Queued for Replay
-        context: image_journal_entries
-        units: entries/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_image_entries
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-    - family: Snapshot Replication
-      context_namespace: snapshot_replication
-      metrics:
-      - ceph_rbd_mirror_snapshot_image_last_sync_bytes
-      - ceph_rbd_mirror_snapshot_image_last_sync_time
-      - ceph_rbd_mirror_snapshot_image_local_timestamp
-      - ceph_rbd_mirror_snapshot_image_remote_timestamp
-      - ceph_rbd_mirror_snapshot_image_snapshots
-      - ceph_rbd_mirror_snapshot_image_sync_bytes
-      - ceph_rbd_mirror_snapshot_image_sync_time_count
-      - ceph_rbd_mirror_snapshot_image_sync_time_sum
-      - ceph_rbd_mirror_snapshot_snapshots
-      - ceph_rbd_mirror_snapshot_sync_bytes
-      - ceph_rbd_mirror_snapshot_sync_time_count
-      - ceph_rbd_mirror_snapshot_sync_time_sum
-      charts:
-      - title: Snapshot Sync Latency Measurements — Image Sync Time
-        context: latency_measurements_image_sync_time
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_sync_time_count
-          name: image_sync_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Snapshot Sync Latency Measurements — Sync Time
-        context: latency_measurements_sync_time
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_sync_time_count
-          name: sync_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency — Image Sync Time
-        context: accumulated_latency_image_sync_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_sync_time_sum
-          name: image_sync_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Latency — Sync Time
-        context: accumulated_latency_sync_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_sync_time_sum
-          name: sync_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput — Image Sync Bytes
-        context: byte_throughput_image_sync_bytes
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_sync_bytes
-          name: image_sync_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Byte Throughput — Sync Bytes
-        context: byte_throughput_sync_bytes
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_sync_bytes
-          name: sync_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Last Snapshot Sync Duration
-        context: last_sync_duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_last_sync_time
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Last Snapshot Sync Size
-        context: last_sync_size
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_last_sync_bytes
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Snapshot Work — Image Snapshots
-        context: snapshot_work_image_snapshots
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_snapshots
-          name: image_snapshots
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Snapshot Work — Snapshots
-        context: snapshot_work_snapshots
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_snapshots
-          name: snapshots
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Timestamps
-        context: timestamp
-        units: seconds since epoch
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_local_timestamp
-          name: local_timestamp
-        - selector: ceph_rbd_mirror_snapshot_image_remote_timestamp
-          name: remote_timestamp
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-  - family: Runtime
-    context_namespace: runtime
-    groups:
-    - family: Shared Daemon
-      context_namespace: shared_daemon
-      metrics:
-      - ceph_KStore_state_done_lat_count
-      - ceph_KStore_state_done_lat_sum
-      - ceph_KStore_state_finishing_lat_count
-      - ceph_KStore_state_finishing_lat_sum
-      - ceph_KStore_state_kv_done_lat_count
-      - ceph_KStore_state_kv_done_lat_sum
-      - ceph_KStore_state_kv_queued_lat_count
-      - ceph_KStore_state_kv_queued_lat_sum
-      - ceph_KStore_state_prepare_lat_count
-      - ceph_KStore_state_prepare_lat_sum
-      - ceph_cct_total_workers
-      - ceph_cct_unhealthy_workers
-      - ceph_client_fsync_count
-      - ceph_client_fsync_sum
-      - ceph_client_lat_count
-      - ceph_client_lat_sum
-      - ceph_client_mdavg
-      - ceph_client_mdsqsum
-      - ceph_client_rdlat_count
-      - ceph_client_rdlat_sum
-      - ceph_client_readavg
-      - ceph_client_readsqsum
-      - ceph_client_reply_count
-      - ceph_client_reply_sum
-      - ceph_client_writeavg
-      - ceph_client_writesqsum
-      - ceph_client_wrlat_count
-      - ceph_client_wrlat_sum
-      - ceph_cluster_num_bytes
-      - ceph_cluster_num_mon
-      - ceph_cluster_num_mon_quorum
-      - ceph_cluster_num_object
-      - ceph_cluster_num_object_degraded
-      - ceph_cluster_num_object_misplaced
-      - ceph_cluster_num_object_unfound
-      - ceph_cluster_num_osd
-      - ceph_cluster_num_osd_in
-      - ceph_cluster_num_osd_up
-      - ceph_cluster_num_pg
-      - ceph_cluster_num_pg_active
-      - ceph_cluster_num_pg_active_clean
-      - ceph_cluster_num_pg_peering
-      - ceph_cluster_num_pool
-      - ceph_cluster_osd_bytes
-      - ceph_cluster_osd_bytes_avail
-      - ceph_cluster_osd_bytes_used
-      - ceph_cluster_osd_epoch
-      - ceph_ipv4_dpdk_ip_linearize_operations
-      - ceph_libcephsqlite_vfs_op_access_count
-      - ceph_libcephsqlite_vfs_op_access_sum
-      - ceph_libcephsqlite_vfs_op_currenttime_count
-      - ceph_libcephsqlite_vfs_op_currenttime_sum
-      - ceph_libcephsqlite_vfs_op_delete_count
-      - ceph_libcephsqlite_vfs_op_delete_sum
-      - ceph_libcephsqlite_vfs_op_fullpathname_count
-      - ceph_libcephsqlite_vfs_op_fullpathname_sum
-      - ceph_libcephsqlite_vfs_op_open_count
-      - ceph_libcephsqlite_vfs_op_open_sum
-      - ceph_libcephsqlite_vfs_opf_checkreservedlock_count
-      - ceph_libcephsqlite_vfs_opf_checkreservedlock_sum
-      - ceph_libcephsqlite_vfs_opf_close_count
-      - ceph_libcephsqlite_vfs_opf_close_sum
-      - ceph_libcephsqlite_vfs_opf_devicecharacteristics_count
-      - ceph_libcephsqlite_vfs_opf_devicecharacteristics_sum
-      - ceph_libcephsqlite_vfs_opf_filecontrol_count
-      - ceph_libcephsqlite_vfs_opf_filecontrol_sum
-      - ceph_libcephsqlite_vfs_opf_filesize_count
-      - ceph_libcephsqlite_vfs_opf_filesize_sum
-      - ceph_libcephsqlite_vfs_opf_lock_count
-      - ceph_libcephsqlite_vfs_opf_lock_sum
-      - ceph_libcephsqlite_vfs_opf_read_count
-      - ceph_libcephsqlite_vfs_opf_read_sum
-      - ceph_libcephsqlite_vfs_opf_sectorsize_count
-      - ceph_libcephsqlite_vfs_opf_sectorsize_sum
-      - ceph_libcephsqlite_vfs_opf_sync_count
-      - ceph_libcephsqlite_vfs_opf_sync_sum
-      - ceph_libcephsqlite_vfs_opf_truncate_count
-      - ceph_libcephsqlite_vfs_opf_truncate_sum
-      - ceph_libcephsqlite_vfs_opf_unlock_count
-      - ceph_libcephsqlite_vfs_opf_unlock_sum
-      - ceph_libcephsqlite_vfs_opf_write_count
-      - ceph_libcephsqlite_vfs_opf_write_sum
-      - ceph_oft_omap_total_kv_pairs
-      - ceph_oft_omap_total_objs
-      - ceph_oft_omap_total_removes
-      - ceph_oft_omap_total_updates
-      - ceph_recoverystate_perf_activating_latency_count
-      - ceph_recoverystate_perf_activating_latency_sum
-      - ceph_recoverystate_perf_active_latency_count
-      - ceph_recoverystate_perf_active_latency_sum
-      - ceph_recoverystate_perf_backfilling_latency_count
-      - ceph_recoverystate_perf_backfilling_latency_sum
-      - ceph_recoverystate_perf_clean_latency_count
-      - ceph_recoverystate_perf_clean_latency_sum
-      - ceph_recoverystate_perf_down_latency_count
-      - ceph_recoverystate_perf_down_latency_sum
-      - ceph_recoverystate_perf_getinfo_latency_count
-      - ceph_recoverystate_perf_getinfo_latency_sum
-      - ceph_recoverystate_perf_getlog_latency_count
-      - ceph_recoverystate_perf_getlog_latency_sum
-      - ceph_recoverystate_perf_getmissing_latency_count
-      - ceph_recoverystate_perf_getmissing_latency_sum
-      - ceph_recoverystate_perf_incomplete_latency_count
-      - ceph_recoverystate_perf_incomplete_latency_sum
-      - ceph_recoverystate_perf_initial_latency_count
-      - ceph_recoverystate_perf_initial_latency_sum
-      - ceph_recoverystate_perf_notbackfilling_latency_count
-      - ceph_recoverystate_perf_notbackfilling_latency_sum
-      - ceph_recoverystate_perf_notrecovering_latency_count
-      - ceph_recoverystate_perf_notrecovering_latency_sum
-      - ceph_recoverystate_perf_peering_latency_count
-      - ceph_recoverystate_perf_peering_latency_sum
-      - ceph_recoverystate_perf_primary_latency_count
-      - ceph_recoverystate_perf_primary_latency_sum
-      - ceph_recoverystate_perf_recovered_latency_count
-      - ceph_recoverystate_perf_recovered_latency_sum
-      - ceph_recoverystate_perf_recovering_latency_count
-      - ceph_recoverystate_perf_recovering_latency_sum
-      - ceph_recoverystate_perf_replicaactive_latency_count
-      - ceph_recoverystate_perf_replicaactive_latency_sum
-      - ceph_recoverystate_perf_repnotrecovering_latency_count
-      - ceph_recoverystate_perf_repnotrecovering_latency_sum
-      - ceph_recoverystate_perf_reprecovering_latency_count
-      - ceph_recoverystate_perf_reprecovering_latency_sum
-      - ceph_recoverystate_perf_repwaitbackfillreserved_latency_count
-      - ceph_recoverystate_perf_repwaitbackfillreserved_latency_sum
-      - ceph_recoverystate_perf_repwaitrecoveryreserved_latency_count
-      - ceph_recoverystate_perf_repwaitrecoveryreserved_latency_sum
-      - ceph_recoverystate_perf_reset_latency_count
-      - ceph_recoverystate_perf_reset_latency_sum
-      - ceph_recoverystate_perf_start_latency_count
-      - ceph_recoverystate_perf_start_latency_sum
-      - ceph_recoverystate_perf_started_latency_count
-      - ceph_recoverystate_perf_started_latency_sum
-      - ceph_recoverystate_perf_stats_invalidated
-      - ceph_recoverystate_perf_stray_latency_count
-      - ceph_recoverystate_perf_stray_latency_sum
-      - ceph_recoverystate_perf_waitactingchange_latency_count
-      - ceph_recoverystate_perf_waitactingchange_latency_sum
-      - ceph_recoverystate_perf_waitlocalbackfillreserved_latency_count
-      - ceph_recoverystate_perf_waitlocalbackfillreserved_latency_sum
-      - ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_count
-      - ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_sum
-      - ceph_recoverystate_perf_waitremotebackfillreserved_latency_count
-      - ceph_recoverystate_perf_waitremotebackfillreserved_latency_sum
-      - ceph_recoverystate_perf_waitremoterecoveryreserved_latency_count
-      - ceph_recoverystate_perf_waitremoterecoveryreserved_latency_sum
-      - ceph_recoverystate_perf_waitupthru_latency_count
-      - ceph_recoverystate_perf_waitupthru_latency_sum
-      charts:
-      - title: KStore Transaction Latency Measurements
-        context: kstore_latency_measurements
-        units: transactions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_KStore_state_done_lat_count
-          name: kstore_state_done_lat
-        - selector: ceph_KStore_state_finishing_lat_count
-          name: kstore_state_finishing_lat
-        - selector: ceph_KStore_state_kv_done_lat_count
-          name: kstore_state_kv_done_lat
-        - selector: ceph_KStore_state_kv_queued_lat_count
-          name: kstore_state_kv_queued_lat
-        - selector: ceph_KStore_state_prepare_lat_count
-          name: kstore_state_prepare_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Client Request Latency Measurements
-        context: client_latency_measurements
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_lat_count
-          name: client_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Recovery-State Transition Latency Measurements
-        context: recovery_state_latency_measurements
-        units: state transitions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_recoverystate_perf_activating_latency_count
-          name: recoverystate_perf_activating_latency
-        - selector: ceph_recoverystate_perf_active_latency_count
-          name: recoverystate_perf_active_latency
-        - selector: ceph_recoverystate_perf_backfilling_latency_count
-          name: recoverystate_perf_backfilling_latency
-        - selector: ceph_recoverystate_perf_clean_latency_count
-          name: recoverystate_perf_clean_latency
-        - selector: ceph_recoverystate_perf_down_latency_count
-          name: recoverystate_perf_down_latency
-        - selector: ceph_recoverystate_perf_getinfo_latency_count
-          name: recoverystate_perf_getinfo_latency
-        - selector: ceph_recoverystate_perf_getlog_latency_count
-          name: recoverystate_perf_getlog_latency
-        - selector: ceph_recoverystate_perf_getmissing_latency_count
-          name: recoverystate_perf_getmissing_latency
-        - selector: ceph_recoverystate_perf_incomplete_latency_count
-          name: recoverystate_perf_incomplete_latency
-        - selector: ceph_recoverystate_perf_initial_latency_count
-          name: recoverystate_perf_initial_latency
-        - selector: ceph_recoverystate_perf_notbackfilling_latency_count
-          name: recoverystate_perf_notbackfilling_latency
-        - selector: ceph_recoverystate_perf_notrecovering_latency_count
-          name: recoverystate_perf_notrecovering_latency
-        - selector: ceph_recoverystate_perf_peering_latency_count
-          name: recoverystate_perf_peering_latency
-        - selector: ceph_recoverystate_perf_primary_latency_count
-          name: recoverystate_perf_primary_latency
-        - selector: ceph_recoverystate_perf_recovered_latency_count
-          name: recoverystate_perf_recovered_latency
-        - selector: ceph_recoverystate_perf_recovering_latency_count
-          name: recoverystate_perf_recovering_latency
-        - selector: ceph_recoverystate_perf_replicaactive_latency_count
-          name: recoverystate_perf_replicaactive_latency
-        - selector: ceph_recoverystate_perf_repnotrecovering_latency_count
-          name: recoverystate_perf_repnotrecovering_latency
-        - selector: ceph_recoverystate_perf_reprecovering_latency_count
-          name: recoverystate_perf_reprecovering_latency
-        - selector: ceph_recoverystate_perf_repwaitbackfillreserved_latency_count
-          name: recoverystate_perf_repwaitbackfillreserved_latency
-        - selector: ceph_recoverystate_perf_repwaitrecoveryreserved_latency_count
-          name: recoverystate_perf_repwaitrecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_reset_latency_count
-          name: recoverystate_perf_reset_latency
-        - selector: ceph_recoverystate_perf_start_latency_count
-          name: recoverystate_perf_start_latency
-        - selector: ceph_recoverystate_perf_started_latency_count
-          name: recoverystate_perf_started_latency
-        - selector: ceph_recoverystate_perf_stray_latency_count
-          name: recoverystate_perf_stray_latency
-        - selector: ceph_recoverystate_perf_waitactingchange_latency_count
-          name: recoverystate_perf_waitactingchange_latency
-        - selector: ceph_recoverystate_perf_waitlocalbackfillreserved_latency_count
-          name: recoverystate_perf_waitlocalbackfillreserved_latency
-        - selector: ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_count
-          name: recoverystate_perf_waitlocalrecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_waitremotebackfillreserved_latency_count
-          name: recoverystate_perf_waitremotebackfillreserved_latency
-        - selector: ceph_recoverystate_perf_waitremoterecoveryreserved_latency_count
-          name: recoverystate_perf_waitremoterecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_waitupthru_latency_count
-          name: recoverystate_perf_waitupthru_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated KStore Transaction Latency
-        context: accumulated_kstore_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_KStore_state_done_lat_sum
-          name: kstore_state_done_lat
-        - selector: ceph_KStore_state_finishing_lat_sum
-          name: kstore_state_finishing_lat
-        - selector: ceph_KStore_state_kv_done_lat_sum
-          name: kstore_state_kv_done_lat
-        - selector: ceph_KStore_state_kv_queued_lat_sum
-          name: kstore_state_kv_queued_lat
-        - selector: ceph_KStore_state_prepare_lat_sum
-          name: kstore_state_prepare_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Client Request Latency
-        context: accumulated_client_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_lat_sum
-          name: client_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Recovery-State Transition Latency
-        context: accumulated_recovery_state_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_recoverystate_perf_activating_latency_sum
-          name: recoverystate_perf_activating_latency
-        - selector: ceph_recoverystate_perf_active_latency_sum
-          name: recoverystate_perf_active_latency
-        - selector: ceph_recoverystate_perf_backfilling_latency_sum
-          name: recoverystate_perf_backfilling_latency
-        - selector: ceph_recoverystate_perf_clean_latency_sum
-          name: recoverystate_perf_clean_latency
-        - selector: ceph_recoverystate_perf_down_latency_sum
-          name: recoverystate_perf_down_latency
-        - selector: ceph_recoverystate_perf_getinfo_latency_sum
-          name: recoverystate_perf_getinfo_latency
-        - selector: ceph_recoverystate_perf_getlog_latency_sum
-          name: recoverystate_perf_getlog_latency
-        - selector: ceph_recoverystate_perf_getmissing_latency_sum
-          name: recoverystate_perf_getmissing_latency
-        - selector: ceph_recoverystate_perf_incomplete_latency_sum
-          name: recoverystate_perf_incomplete_latency
-        - selector: ceph_recoverystate_perf_initial_latency_sum
-          name: recoverystate_perf_initial_latency
-        - selector: ceph_recoverystate_perf_notbackfilling_latency_sum
-          name: recoverystate_perf_notbackfilling_latency
-        - selector: ceph_recoverystate_perf_notrecovering_latency_sum
-          name: recoverystate_perf_notrecovering_latency
-        - selector: ceph_recoverystate_perf_peering_latency_sum
-          name: recoverystate_perf_peering_latency
-        - selector: ceph_recoverystate_perf_primary_latency_sum
-          name: recoverystate_perf_primary_latency
-        - selector: ceph_recoverystate_perf_recovered_latency_sum
-          name: recoverystate_perf_recovered_latency
-        - selector: ceph_recoverystate_perf_recovering_latency_sum
-          name: recoverystate_perf_recovering_latency
-        - selector: ceph_recoverystate_perf_replicaactive_latency_sum
-          name: recoverystate_perf_replicaactive_latency
-        - selector: ceph_recoverystate_perf_repnotrecovering_latency_sum
-          name: recoverystate_perf_repnotrecovering_latency
-        - selector: ceph_recoverystate_perf_reprecovering_latency_sum
-          name: recoverystate_perf_reprecovering_latency
-        - selector: ceph_recoverystate_perf_repwaitbackfillreserved_latency_sum
-          name: recoverystate_perf_repwaitbackfillreserved_latency
-        - selector: ceph_recoverystate_perf_repwaitrecoveryreserved_latency_sum
-          name: recoverystate_perf_repwaitrecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_reset_latency_sum
-          name: recoverystate_perf_reset_latency
-        - selector: ceph_recoverystate_perf_start_latency_sum
-          name: recoverystate_perf_start_latency
-        - selector: ceph_recoverystate_perf_started_latency_sum
-          name: recoverystate_perf_started_latency
-        - selector: ceph_recoverystate_perf_stray_latency_sum
-          name: recoverystate_perf_stray_latency
-        - selector: ceph_recoverystate_perf_waitactingchange_latency_sum
-          name: recoverystate_perf_waitactingchange_latency
-        - selector: ceph_recoverystate_perf_waitlocalbackfillreserved_latency_sum
-          name: recoverystate_perf_waitlocalbackfillreserved_latency
-        - selector: ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_sum
-          name: recoverystate_perf_waitlocalrecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_waitremotebackfillreserved_latency_sum
-          name: recoverystate_perf_waitremotebackfillreserved_latency
-        - selector: ceph_recoverystate_perf_waitremoterecoveryreserved_latency_sum
-          name: recoverystate_perf_waitremoterecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_waitupthru_latency_sum
-          name: recoverystate_perf_waitupthru_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Client Operation Latency Measurements
-        context: client_operation_latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_fsync_count
-          name: client_fsync
-        - selector: ceph_client_rdlat_count
-          name: client_rdlat
-        - selector: ceph_client_reply_count
-          name: client_reply
-        - selector: ceph_client_wrlat_count
-          name: client_wrlat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: SQLite VFS Operation Latency Measurements
-        context: sqlite_vfs_latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_libcephsqlite_vfs_op_access_count
-          name: libcephsqlite_vfs_op_access
-        - selector: ceph_libcephsqlite_vfs_op_currenttime_count
-          name: libcephsqlite_vfs_op_currenttime
-        - selector: ceph_libcephsqlite_vfs_op_delete_count
-          name: libcephsqlite_vfs_op_delete
-        - selector: ceph_libcephsqlite_vfs_op_fullpathname_count
-          name: libcephsqlite_vfs_op_fullpathname
-        - selector: ceph_libcephsqlite_vfs_op_open_count
-          name: libcephsqlite_vfs_op_open
-        - selector: ceph_libcephsqlite_vfs_opf_checkreservedlock_count
-          name: libcephsqlite_vfs_opf_checkreservedlock
-        - selector: ceph_libcephsqlite_vfs_opf_close_count
-          name: libcephsqlite_vfs_opf_close
-        - selector: ceph_libcephsqlite_vfs_opf_devicecharacteristics_count
-          name: libcephsqlite_vfs_opf_devicecharacteristics
-        - selector: ceph_libcephsqlite_vfs_opf_filecontrol_count
-          name: libcephsqlite_vfs_opf_filecontrol
-        - selector: ceph_libcephsqlite_vfs_opf_filesize_count
-          name: libcephsqlite_vfs_opf_filesize
-        - selector: ceph_libcephsqlite_vfs_opf_lock_count
-          name: libcephsqlite_vfs_opf_lock
-        - selector: ceph_libcephsqlite_vfs_opf_read_count
-          name: libcephsqlite_vfs_opf_read
-        - selector: ceph_libcephsqlite_vfs_opf_sectorsize_count
-          name: libcephsqlite_vfs_opf_sectorsize
-        - selector: ceph_libcephsqlite_vfs_opf_sync_count
-          name: libcephsqlite_vfs_opf_sync
-        - selector: ceph_libcephsqlite_vfs_opf_truncate_count
-          name: libcephsqlite_vfs_opf_truncate
-        - selector: ceph_libcephsqlite_vfs_opf_unlock_count
-          name: libcephsqlite_vfs_opf_unlock
-        - selector: ceph_libcephsqlite_vfs_opf_write_count
-          name: libcephsqlite_vfs_opf_write
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Client Operation Latency
-        context: accumulated_client_operation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_fsync_sum
-          name: client_fsync
-        - selector: ceph_client_rdlat_sum
-          name: client_rdlat
-        - selector: ceph_client_reply_sum
-          name: client_reply
-        - selector: ceph_client_wrlat_sum
-          name: client_wrlat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated SQLite VFS Operation Latency
-        context: accumulated_sqlite_vfs_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_libcephsqlite_vfs_op_access_sum
-          name: libcephsqlite_vfs_op_access
-        - selector: ceph_libcephsqlite_vfs_op_currenttime_sum
-          name: libcephsqlite_vfs_op_currenttime
-        - selector: ceph_libcephsqlite_vfs_op_delete_sum
-          name: libcephsqlite_vfs_op_delete
-        - selector: ceph_libcephsqlite_vfs_op_fullpathname_sum
-          name: libcephsqlite_vfs_op_fullpathname
-        - selector: ceph_libcephsqlite_vfs_op_open_sum
-          name: libcephsqlite_vfs_op_open
-        - selector: ceph_libcephsqlite_vfs_opf_checkreservedlock_sum
-          name: libcephsqlite_vfs_opf_checkreservedlock
-        - selector: ceph_libcephsqlite_vfs_opf_close_sum
-          name: libcephsqlite_vfs_opf_close
-        - selector: ceph_libcephsqlite_vfs_opf_devicecharacteristics_sum
-          name: libcephsqlite_vfs_opf_devicecharacteristics
-        - selector: ceph_libcephsqlite_vfs_opf_filecontrol_sum
-          name: libcephsqlite_vfs_opf_filecontrol
-        - selector: ceph_libcephsqlite_vfs_opf_filesize_sum
-          name: libcephsqlite_vfs_opf_filesize
-        - selector: ceph_libcephsqlite_vfs_opf_lock_sum
-          name: libcephsqlite_vfs_opf_lock
-        - selector: ceph_libcephsqlite_vfs_opf_read_sum
-          name: libcephsqlite_vfs_opf_read
-        - selector: ceph_libcephsqlite_vfs_opf_sectorsize_sum
-          name: libcephsqlite_vfs_opf_sectorsize
-        - selector: ceph_libcephsqlite_vfs_opf_sync_sum
-          name: libcephsqlite_vfs_opf_sync
-        - selector: ceph_libcephsqlite_vfs_opf_truncate_sum
-          name: libcephsqlite_vfs_opf_truncate
-        - selector: ceph_libcephsqlite_vfs_opf_unlock_sum
-          name: libcephsqlite_vfs_opf_unlock
-        - selector: ceph_libcephsqlite_vfs_opf_write_sum
-          name: libcephsqlite_vfs_opf_write
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Monitors
-        context: monitor_state
-        units: monitors
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_mon
-          name: num_mon
-        - selector: ceph_cluster_num_mon_quorum
-          name: cluster_num_mon_quorum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OSDs
-        context: osd_state
-        units: OSDs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_osd
-          name: num_osd
-        - selector: ceph_cluster_num_osd_in
-          name: cluster_num_osd_in
-        - selector: ceph_cluster_num_osd_up
-          name: cluster_num_osd_up
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Pools
-        context: pool_state
-        units: pools
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_pool
-          name: num_pool
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OSD-Map Epoch
-        context: osd_map_epoch
-        units: epoch
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_osd_epoch
-          name: osd_epoch
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Duration and Time
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_mdavg
-          name: mdavg
-        - selector: ceph_client_readavg
-          name: readavg
-        - selector: ceph_client_writeavg
-          name: writeavg
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Invalidated Recovery Statistics
-        context: invalidations
-        units: invalidations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_recoverystate_perf_stats_invalidated
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_object
-          name: object
-        - selector: ceph_cluster_num_object_degraded
-          name: degraded
-        - selector: ceph_cluster_num_object_misplaced
-          name: misplaced
-        - selector: ceph_cluster_num_object_unfound
-          name: unfound
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_ipv4_dpdk_ip_linearize_operations
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_bytes
-          name: num_bytes
-        - selector: ceph_cluster_osd_bytes
-          name: osd_bytes
-        - selector: ceph_cluster_osd_bytes_avail
-          name: osd_bytes_avail
-        - selector: ceph_cluster_osd_bytes_used
-          name: osd_bytes_used
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_pg
-          name: cluster_num_pg
-        - selector: ceph_cluster_num_pg_active
-          name: cluster_num_pg_active
-        - selector: ceph_cluster_num_pg_active_clean
-          name: cluster_num_pg_active_clean
-        - selector: ceph_cluster_num_pg_peering
-          name: cluster_num_pg_peering
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Client Latency Squared-Deviation Accumulators
-        context: client_latency_sqsum
-        units: microseconds²/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_mdsqsum
-          name: client_mdsqsum
-        - selector: ceph_client_readsqsum
-          name: client_readsqsum
-        - selector: ceph_client_writesqsum
-          name: client_writesqsum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: OpenFileTable OMAP Mutations
-        context: oft_omap_mutations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_oft_omap_total_updates
-          name: oft_omap_total_updates
-        - selector: ceph_oft_omap_total_removes
-          name: oft_omap_total_removes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Context Workers
-        context: worker_state
-        units: workers
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cct_total_workers
-          name: cct_total_workers
-        - selector: ceph_cct_unhealthy_workers
-          name: cct_unhealthy_workers
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OpenFileTable Objects
-        context: oft_object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_oft_omap_total_objs
-          name: oft_omap_total_objs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OpenFileTable Key-Value Pairs
-        context: oft_entry_state
-        units: entries
-        label_promotion: []
-        dimensions:
-        - selector: ceph_oft_omap_total_kv_pairs
-          name: oft_omap_total_kv_pairs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Slow Operations
-      context_namespace: slow_operations
-      metrics:
-      - ceph_trackedop_slow_ops_count
-      charts:
-      - title: Slow Operations
-        context: slow_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_trackedop_slow_ops_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Storage Engine
-    context_namespace: storage_engine
-    groups:
-    - family: Priority Cache Full
-      context_namespace: priority_cache_full
-      metrics:
-      - ceph_prioritycache:full_committed_bytes
-      - ceph_prioritycache:full_pri0_bytes
-      - ceph_prioritycache:full_pri10_bytes
-      - ceph_prioritycache:full_pri11_bytes
-      - ceph_prioritycache:full_pri1_bytes
-      - ceph_prioritycache:full_pri2_bytes
-      - ceph_prioritycache:full_pri3_bytes
-      - ceph_prioritycache:full_pri4_bytes
-      - ceph_prioritycache:full_pri5_bytes
-      - ceph_prioritycache:full_pri6_bytes
-      - ceph_prioritycache:full_pri7_bytes
-      - ceph_prioritycache:full_pri8_bytes
-      - ceph_prioritycache:full_pri9_bytes
-      - ceph_prioritycache:full_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_prioritycache:full_committed_bytes
-          name: committed_bytes
-        - selector: ceph_prioritycache:full_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_prioritycache:full_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_prioritycache:full_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_prioritycache:full_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_prioritycache:full_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_prioritycache:full_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_prioritycache:full_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_prioritycache:full_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_prioritycache:full_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_prioritycache:full_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_prioritycache:full_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_prioritycache:full_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_prioritycache:full_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Incremental
-      context_namespace: priority_cache_incremental
-      metrics:
-      - ceph_prioritycache:inc_committed_bytes
-      - ceph_prioritycache:inc_pri0_bytes
-      - ceph_prioritycache:inc_pri10_bytes
-      - ceph_prioritycache:inc_pri11_bytes
-      - ceph_prioritycache:inc_pri1_bytes
-      - ceph_prioritycache:inc_pri2_bytes
-      - ceph_prioritycache:inc_pri3_bytes
-      - ceph_prioritycache:inc_pri4_bytes
-      - ceph_prioritycache:inc_pri5_bytes
-      - ceph_prioritycache:inc_pri6_bytes
-      - ceph_prioritycache:inc_pri7_bytes
-      - ceph_prioritycache:inc_pri8_bytes
-      - ceph_prioritycache:inc_pri9_bytes
-      - ceph_prioritycache:inc_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_prioritycache:inc_committed_bytes
-          name: committed_bytes
-        - selector: ceph_prioritycache:inc_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_prioritycache:inc_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_prioritycache:inc_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_prioritycache:inc_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_prioritycache:inc_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_prioritycache:inc_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_prioritycache:inc_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_prioritycache:inc_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_prioritycache:inc_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_prioritycache:inc_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_prioritycache:inc_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_prioritycache:inc_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_prioritycache:inc_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache KV
-      context_namespace: priority_cache_kv
-      metrics:
-      - ceph_prioritycache:kv_committed_bytes
-      - ceph_prioritycache:kv_pri0_bytes
-      - ceph_prioritycache:kv_pri10_bytes
-      - ceph_prioritycache:kv_pri11_bytes
-      - ceph_prioritycache:kv_pri1_bytes
-      - ceph_prioritycache:kv_pri2_bytes
-      - ceph_prioritycache:kv_pri3_bytes
-      - ceph_prioritycache:kv_pri4_bytes
-      - ceph_prioritycache:kv_pri5_bytes
-      - ceph_prioritycache:kv_pri6_bytes
-      - ceph_prioritycache:kv_pri7_bytes
-      - ceph_prioritycache:kv_pri8_bytes
-      - ceph_prioritycache:kv_pri9_bytes
-      - ceph_prioritycache:kv_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_prioritycache:kv_committed_bytes
-          name: committed_bytes
-        - selector: ceph_prioritycache:kv_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_prioritycache:kv_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_prioritycache:kv_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_prioritycache:kv_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_prioritycache:kv_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_prioritycache:kv_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_prioritycache:kv_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_prioritycache:kv_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_prioritycache:kv_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_prioritycache:kv_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_prioritycache:kv_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_prioritycache:kv_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_prioritycache:kv_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Runtime
-      context_namespace: priority_cache_runtime
-      metrics:
-      - ceph_prioritycache_cache_bytes
-      - ceph_prioritycache_heap_bytes
-      - ceph_prioritycache_mapped_bytes
-      - ceph_prioritycache_target_bytes
-      - ceph_prioritycache_unmapped_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_prioritycache_cache_bytes
-          name: cache_bytes
-        - selector: ceph_prioritycache_heap_bytes
-          name: heap_bytes
-        - selector: ceph_prioritycache_mapped_bytes
-          name: mapped_bytes
-        - selector: ceph_prioritycache_target_bytes
-          name: target_bytes
-        - selector: ceph_prioritycache_unmapped_bytes
-          name: unmapped_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: RocksDB Compaction
-      context_namespace: rocksdb_compaction
-      metrics:
-      - ceph_rocksdb_compact
-      - ceph_rocksdb_compact_completed
-      - ceph_rocksdb_compact_lasted
-      - ceph_rocksdb_compact_queue_len
-      - ceph_rocksdb_compact_queue_merge
-      - ceph_rocksdb_compact_running
-      charts:
-      - title: Compaction Work
-        context: compaction_state
-        units: compactions
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_compact_queue_len
-          name: queue_len
-        - selector: ceph_rocksdb_compact_running
-          name: running
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: absolute
-      - title: Duration and Time
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_compact_lasted
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Compactions
-        context: compactions
-        units: compactions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_compact
-          name: compact
-        - selector: ceph_rocksdb_compact_completed
-          name: completed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Compaction Queue Merges
-        context: queue_merges
-        units: merges/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_compact_queue_merge
-          name: queue_merge
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: RocksDB Requests
-      context_namespace: rocksdb_requests
-      metrics:
-      - ceph_rocksdb_get_latency_count
-      - ceph_rocksdb_get_latency_sum
-      - ceph_rocksdb_submit_latency_count
-      - ceph_rocksdb_submit_latency_sum
-      - ceph_rocksdb_submit_sync_latency_count
-      - ceph_rocksdb_submit_sync_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_get_latency_count
-          name: get_latency
-        - selector: ceph_rocksdb_submit_latency_count
-          name: submit_latency
-        - selector: ceph_rocksdb_submit_sync_latency_count
-          name: submit_sync_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_get_latency_sum
-          name: get_latency
-        - selector: ceph_rocksdb_submit_latency_sum
-          name: submit_latency
-        - selector: ceph_rocksdb_submit_sync_latency_sum
-          name: submit_sync_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: RocksDB Write Path
-      context_namespace: rocksdb_write_path
-      metrics:
-      - ceph_rocksdb_rocksdb_write_delay_time_count
-      - ceph_rocksdb_rocksdb_write_delay_time_sum
-      - ceph_rocksdb_rocksdb_write_memtable_time_count
-      - ceph_rocksdb_rocksdb_write_memtable_time_sum
-      - ceph_rocksdb_rocksdb_write_pre_and_post_time_count
-      - ceph_rocksdb_rocksdb_write_pre_and_post_time_sum
-      - ceph_rocksdb_rocksdb_write_wal_time_count
-      - ceph_rocksdb_rocksdb_write_wal_time_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_rocksdb_write_delay_time_count
-          name: delay_time
-        - selector: ceph_rocksdb_rocksdb_write_memtable_time_count
-          name: memtable_time
-        - selector: ceph_rocksdb_rocksdb_write_pre_and_post_time_count
-          name: pre_and_post_time
-        - selector: ceph_rocksdb_rocksdb_write_wal_time_count
-          name: wal_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_rocksdb_write_delay_time_sum
-          name: delay_time
-        - selector: ceph_rocksdb_rocksdb_write_memtable_time_sum
-          name: memtable_time
-        - selector: ceph_rocksdb_rocksdb_write_pre_and_post_time_sum
-          name: pre_and_post_time
-        - selector: ceph_rocksdb_rocksdb_write_wal_time_sum
-          name: wal_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-  - family: Runtime and Client Components
-    context_namespace: runtime_and_client_components
-    groups:
-    - family: RBD Persistent Write Log
-      context_namespace: rbd_persistent_write_log
-      metrics:
-      - ceph_rbd_librbd_pwl_aio_flush
-      - ceph_rbd_librbd_pwl_aio_flush_def
-      - ceph_rbd_librbd_pwl_aio_flush_lat_count
-      - ceph_rbd_librbd_pwl_aio_flush_lat_sum
-      - ceph_rbd_librbd_pwl_append_tx_lat_count
-      - ceph_rbd_librbd_pwl_append_tx_lat_sum
-      - ceph_rbd_librbd_pwl_caller_wr_latency_count
-      - ceph_rbd_librbd_pwl_caller_wr_latency_nw_count
-      - ceph_rbd_librbd_pwl_caller_wr_latency_nw_sum
-      - ceph_rbd_librbd_pwl_caller_wr_latency_sum
-      - ceph_rbd_librbd_pwl_cmp
-      - ceph_rbd_librbd_pwl_cmp_bytes
-      - ceph_rbd_librbd_pwl_cmp_fails
-      - ceph_rbd_librbd_pwl_cmp_lat_count
-      - ceph_rbd_librbd_pwl_cmp_lat_sum
-      - ceph_rbd_librbd_pwl_discard
-      - ceph_rbd_librbd_pwl_discard_bytes
-      - ceph_rbd_librbd_pwl_discard_lat_count
-      - ceph_rbd_librbd_pwl_discard_lat_sum
-      - ceph_rbd_librbd_pwl_hit_rd
-      - ceph_rbd_librbd_pwl_hit_rd_latency_count
-      - ceph_rbd_librbd_pwl_hit_rd_latency_sum
-      - ceph_rbd_librbd_pwl_internal_flush
-      - ceph_rbd_librbd_pwl_invalidate
-      - ceph_rbd_librbd_pwl_log_op_bytes_count
-      - ceph_rbd_librbd_pwl_log_op_bytes_sum
-      - ceph_rbd_librbd_pwl_log_ops
-      - ceph_rbd_librbd_pwl_op_alloc_t_count
-      - ceph_rbd_librbd_pwl_op_alloc_t_sum
-      - ceph_rbd_librbd_pwl_op_app_to_appc_t_count
-      - ceph_rbd_librbd_pwl_op_app_to_appc_t_sum
-      - ceph_rbd_librbd_pwl_op_app_to_cmp_t_count
-      - ceph_rbd_librbd_pwl_op_app_to_cmp_t_sum
-      - ceph_rbd_librbd_pwl_op_buf_to_app_t_count
-      - ceph_rbd_librbd_pwl_op_buf_to_app_t_sum
-      - ceph_rbd_librbd_pwl_op_buf_to_bufc_t_count
-      - ceph_rbd_librbd_pwl_op_buf_to_bufc_t_sum
-      - ceph_rbd_librbd_pwl_op_dis_to_app_t_count
-      - ceph_rbd_librbd_pwl_op_dis_to_app_t_sum
-      - ceph_rbd_librbd_pwl_op_dis_to_buf_t_count
-      - ceph_rbd_librbd_pwl_op_dis_to_buf_t_sum
-      - ceph_rbd_librbd_pwl_op_dis_to_cmp_t_count
-      - ceph_rbd_librbd_pwl_op_dis_to_cmp_t_sum
-      - ceph_rbd_librbd_pwl_part_hit_rd
-      - ceph_rbd_librbd_pwl_rd
-      - ceph_rbd_librbd_pwl_rd_bytes
-      - ceph_rbd_librbd_pwl_rd_hit_bytes
-      - ceph_rbd_librbd_pwl_rd_latency_count
-      - ceph_rbd_librbd_pwl_rd_latency_sum
-      - ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_count
-      - ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_sum
-      - ceph_rbd_librbd_pwl_req_all_to_dis_t_count
-      - ceph_rbd_librbd_pwl_req_all_to_dis_t_sum
-      - ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_count
-      - ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_sum
-      - ceph_rbd_librbd_pwl_req_arr_to_all_t_count
-      - ceph_rbd_librbd_pwl_req_arr_to_all_t_sum
-      - ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_count
-      - ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
-      - ceph_rbd_librbd_pwl_req_arr_to_dis_t_count
-      - ceph_rbd_librbd_pwl_req_arr_to_dis_t_sum
-      - ceph_rbd_librbd_pwl_retire_tx_lat_count
-      - ceph_rbd_librbd_pwl_retire_tx_lat_sum
-      - ceph_rbd_librbd_pwl_wr
-      - ceph_rbd_librbd_pwl_wr_bytes
-      - ceph_rbd_librbd_pwl_wr_def
-      - ceph_rbd_librbd_pwl_wr_def_buf
-      - ceph_rbd_librbd_pwl_wr_def_lanes
-      - ceph_rbd_librbd_pwl_wr_def_log
-      - ceph_rbd_librbd_pwl_wr_latency_count
-      - ceph_rbd_librbd_pwl_wr_latency_nw_count
-      - ceph_rbd_librbd_pwl_wr_latency_nw_sum
-      - ceph_rbd_librbd_pwl_wr_latency_sum
-      - ceph_rbd_librbd_pwl_wr_overlap
-      - ceph_rbd_librbd_pwl_wr_q_barrier
-      - ceph_rbd_librbd_pwl_writeback_lat_count
-      - ceph_rbd_librbd_pwl_writeback_lat_sum
-      - ceph_rbd_librbd_pwl_ws
-      - ceph_rbd_librbd_pwl_ws_bytes
-      - ceph_rbd_librbd_pwl_ws_lat_count
-      - ceph_rbd_librbd_pwl_ws_lat_sum
-      charts:
-      - title: Reads
-        context: reads
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_rd
-          name: rd
-        - selector: ceph_rbd_librbd_pwl_hit_rd
-          name: hit_rd
-        - selector: ceph_rbd_librbd_pwl_part_hit_rd
-          name: part_hit_rd
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Writes
-        context: writes
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_wr
-          name: wr
-        - selector: ceph_rbd_librbd_pwl_wr_def
-          name: wr_def
-        - selector: ceph_rbd_librbd_pwl_wr_def_lanes
-          name: wr_def_lanes
-        - selector: ceph_rbd_librbd_pwl_wr_def_log
-          name: wr_def_log
-        - selector: ceph_rbd_librbd_pwl_wr_def_buf
-          name: wr_def_buf
-        - selector: ceph_rbd_librbd_pwl_wr_overlap
-          name: wr_overlap
-        - selector: ceph_rbd_librbd_pwl_wr_q_barrier
-          name: wr_q_barrier
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Log Appends
-        context: log_appends
-        units: appends/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_log_ops
-          name: log_ops
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Cache and Image Operations
-        context: cache_image_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_discard
-          name: discard
-        - selector: ceph_rbd_librbd_pwl_aio_flush
-          name: aio_flush
-        - selector: ceph_rbd_librbd_pwl_aio_flush_def
-          name: aio_flush_def
-        - selector: ceph_rbd_librbd_pwl_ws
-          name: ws
-        - selector: ceph_rbd_librbd_pwl_cmp
-          name: cmp
-        - selector: ceph_rbd_librbd_pwl_cmp_fails
-          name: cmp_fails
-        - selector: ceph_rbd_librbd_pwl_internal_flush
-          name: internal_flush
-        - selector: ceph_rbd_librbd_pwl_invalidate
-          name: invalidate
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Read Throughput
-        context: read_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_rd_bytes
-          name: rd_bytes
-        - selector: ceph_rbd_librbd_pwl_rd_hit_bytes
-          name: rd_hit_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Write Throughput
-        context: write_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_wr_bytes
-          name: wr_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Data-Operation Throughput
-        context: data_operation_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_discard_bytes
-          name: discard_bytes
-        - selector: ceph_rbd_librbd_pwl_ws_bytes
-          name: ws_bytes
-        - selector: ceph_rbd_librbd_pwl_cmp_bytes
-          name: cmp_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Log-Append Throughput
-        context: log_append_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_log_op_bytes_sum
-          name: log_op_bytes_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Read Request Latency Measurements
-        context: read_latency_measurements
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_rd_latency_count
-          name: rd_latency_count
-        - selector: ceph_rbd_librbd_pwl_hit_rd_latency_count
-          name: hit_rd_latency_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Log-Append Size Measurements
-        context: log_append_size_measurements
-        units: appends/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_log_op_bytes_count
-          name: log_op_bytes_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Write Request Latency Measurements
-        context: write_latency_measurements
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_all_t_count
-          name: req_arr_to_all_t_count
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_t_count
-          name: req_arr_to_dis_t_count
-        - selector: ceph_rbd_librbd_pwl_req_all_to_dis_t_count
-          name: req_all_to_dis_t_count
-        - selector: ceph_rbd_librbd_pwl_wr_latency_count
-          name: wr_latency_count
-        - selector: ceph_rbd_librbd_pwl_caller_wr_latency_count
-          name: caller_wr_latency_count
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_count
-          name: req_arr_to_all_nw_t_count
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_count
-          name: req_arr_to_dis_nw_t_count
-        - selector: ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_count
-          name: req_all_to_dis_nw_t_count
-        - selector: ceph_rbd_librbd_pwl_wr_latency_nw_count
-          name: wr_latency_nw_count
-        - selector: ceph_rbd_librbd_pwl_caller_wr_latency_nw_count
-          name: caller_wr_latency_nw_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Log Operation Latency Measurements
-        context: log_operation_latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_op_alloc_t_count
-          name: op_alloc_t_count
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_buf_t_count
-          name: op_dis_to_buf_t_count
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_app_t_count
-          name: op_dis_to_app_t_count
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_cmp_t_count
-          name: op_dis_to_cmp_t_count
-        - selector: ceph_rbd_librbd_pwl_op_buf_to_app_t_count
-          name: op_buf_to_app_t_count
-        - selector: ceph_rbd_librbd_pwl_op_buf_to_bufc_t_count
-          name: op_buf_to_bufc_t_count
-        - selector: ceph_rbd_librbd_pwl_op_app_to_cmp_t_count
-          name: op_app_to_cmp_t_count
-        - selector: ceph_rbd_librbd_pwl_op_app_to_appc_t_count
-          name: op_app_to_appc_t_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Data Operation Latency Measurements
-        context: data_operation_latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_discard_lat_count
-          name: discard_lat_count
-        - selector: ceph_rbd_librbd_pwl_aio_flush_lat_count
-          name: aio_flush_lat_count
-        - selector: ceph_rbd_librbd_pwl_ws_lat_count
-          name: ws_lat_count
-        - selector: ceph_rbd_librbd_pwl_cmp_lat_count
-          name: cmp_lat_count
-        - selector: ceph_rbd_librbd_pwl_writeback_lat_count
-          name: writeback_lat_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Transaction Latency Measurements
-        context: transaction_latency_measurements
-        units: transactions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_append_tx_lat_count
-          name: append_tx_lat_count
-        - selector: ceph_rbd_librbd_pwl_retire_tx_lat_count
-          name: retire_tx_lat_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Accumulated Read Request Latency
-        context: accumulated_read_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_rd_latency_sum
-          name: rd_latency_sum
-        - selector: ceph_rbd_librbd_pwl_hit_rd_latency_sum
-          name: hit_rd_latency_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Accumulated Write Request Latency
-        context: accumulated_write_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_all_t_sum
-          name: req_arr_to_all_t_sum
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_t_sum
-          name: req_arr_to_dis_t_sum
-        - selector: ceph_rbd_librbd_pwl_req_all_to_dis_t_sum
-          name: req_all_to_dis_t_sum
-        - selector: ceph_rbd_librbd_pwl_wr_latency_sum
-          name: wr_latency_sum
-        - selector: ceph_rbd_librbd_pwl_caller_wr_latency_sum
-          name: caller_wr_latency_sum
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_sum
-          name: req_arr_to_all_nw_t_sum
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
-          name: req_arr_to_dis_nw_t_sum
-        - selector: ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_sum
-          name: req_all_to_dis_nw_t_sum
-        - selector: ceph_rbd_librbd_pwl_wr_latency_nw_sum
-          name: wr_latency_nw_sum
-        - selector: ceph_rbd_librbd_pwl_caller_wr_latency_nw_sum
-          name: caller_wr_latency_nw_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Accumulated Log Operation Latency
-        context: accumulated_log_operation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_op_alloc_t_sum
-          name: op_alloc_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_buf_t_sum
-          name: op_dis_to_buf_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_app_t_sum
-          name: op_dis_to_app_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_cmp_t_sum
-          name: op_dis_to_cmp_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_buf_to_app_t_sum
-          name: op_buf_to_app_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_buf_to_bufc_t_sum
-          name: op_buf_to_bufc_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_app_to_cmp_t_sum
-          name: op_app_to_cmp_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_app_to_appc_t_sum
-          name: op_app_to_appc_t_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Accumulated Data Operation Latency
-        context: accumulated_data_operation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_discard_lat_sum
-          name: discard_lat_sum
-        - selector: ceph_rbd_librbd_pwl_aio_flush_lat_sum
-          name: aio_flush_lat_sum
-        - selector: ceph_rbd_librbd_pwl_ws_lat_sum
-          name: ws_lat_sum
-        - selector: ceph_rbd_librbd_pwl_cmp_lat_sum
-          name: cmp_lat_sum
-        - selector: ceph_rbd_librbd_pwl_writeback_lat_sum
-          name: writeback_lat_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Accumulated Transaction Latency
-        context: accumulated_transaction_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_append_tx_lat_sum
-          name: append_tx_lat_sum
-        - selector: ceph_rbd_librbd_pwl_retire_tx_lat_sum
-          name: retire_tx_lat_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-    - family: Object Caches
-      context_namespace: object_caches
-      metrics:
-      - ceph_objectcacher_cache_bytes_hit
-      - ceph_objectcacher_cache_bytes_miss
-      - ceph_objectcacher_cache_ops_hit
-      - ceph_objectcacher_cache_ops_miss
-      - ceph_objectcacher_data_flushed
-      - ceph_objectcacher_data_overwritten_while_flushing
-      - ceph_objectcacher_data_read
-      - ceph_objectcacher_data_written
-      - ceph_objectcacher_write_bytes_blocked
-      - ceph_objectcacher_write_ops_blocked
-      - ceph_objectcacher_write_time_blocked
-      charts:
-      - title: Cache Outcomes
-        context: cache_outcomes
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_cache_ops_hit
-          name: hit
-        - selector: ceph_objectcacher_cache_ops_miss
-          name: miss
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Cache Byte Outcomes
-        context: cache_byte_outcomes
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_cache_bytes_hit
-          name: hit
-        - selector: ceph_objectcacher_cache_bytes_miss
-          name: miss
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Data Throughput
-        context: data_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_data_read
-          name: read
-        - selector: ceph_objectcacher_data_written
-          name: written
-        - selector: ceph_objectcacher_data_flushed
-          name: flushed
-        - selector: ceph_objectcacher_data_overwritten_while_flushing
-          name: overwritten_while_flushing
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Blocked Writes
-        context: blocked_writes
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_write_ops_blocked
-          name: operations
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Blocked Write Throughput
-        context: blocked_write_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_write_bytes_blocked
-          name: bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Blocked Write Time
-        context: blocked_write_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_write_time_blocked
-          name: time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-        algorithm: incremental
-    - family: Finishers
-      context_namespace: finishers
-      metrics:
-      - ceph_finisher_complete_latency_count
-      - ceph_finisher_complete_latency_sum
-      - ceph_finisher_queue_len
-      charts:
-      - title: Queued Callbacks
-        context: queue_depth
-        units: callbacks
-        label_promotion: []
-        dimensions:
-        - selector: ceph_finisher_queue_len
-          name: queued
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - finisher_key
-      - title: Drained Completion Batches
-        context: completions
-        units: batches/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_finisher_complete_latency_count
-          name: completed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - finisher_key
-      - title: Accumulated Completion Latency
-        context: accumulated_completion_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_finisher_complete_latency_sum
-          name: latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - finisher_key
-        algorithm: incremental
-    - family: Throttles
-      context_namespace: throttles
-      metrics:
-      - ceph_throttle_get
-      - ceph_throttle_get_or_fail_fail
-      - ceph_throttle_get_or_fail_success
-      - ceph_throttle_get_started
-      - ceph_throttle_get_sum
-      - ceph_throttle_max
-      - ceph_throttle_put
-      - ceph_throttle_put_sum
-      - ceph_throttle_take
-      - ceph_throttle_take_sum
-      - ceph_throttle_val
-      - ceph_throttle_wait_count
-      - ceph_throttle_wait_sum
-      charts:
-      - title: Utilization
-        context: utilization
-        units: slots
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_val
-          name: val
-        - selector: ceph_throttle_max
-          name: max
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - throttle_key
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_get_started
-          name: get_started
-        - selector: ceph_throttle_get
-          name: get
-        - selector: ceph_throttle_get_or_fail_fail
-          name: get_or_fail_fail
-        - selector: ceph_throttle_get_or_fail_success
-          name: get_or_fail_success
-        - selector: ceph_throttle_take
-          name: take
-        - selector: ceph_throttle_put
-          name: put
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - throttle_key
-      - title: Slot Throughput
-        context: slot_throughput
-        units: slots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_get_sum
-          name: get_sum
-        - selector: ceph_throttle_take_sum
-          name: take_sum
-        - selector: ceph_throttle_put_sum
-          name: put_sum
-        instances:
-          by_labels: []
-          optional_by_labels:
-          - throttle_key
-      - title: Waits
-        context: wait_measurements
-        units: waits/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_wait_count
-          name: waits
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - throttle_key
-      - title: Accumulated Wait Time
-        context: accumulated_wait_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_wait_sum
-          name: wait
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - throttle_key
-        algorithm: incremental
-    - family: Kernel Devices
-      context_namespace: kernel_devices
-      metrics:
-      - ceph_kernel_device_discard_op
-      - ceph_kernel_device_discard_threads
-      charts:
-      - title: Discard Operations
-        context: discard_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_kernel_device_discard_op
-          name: discard
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - kernel_device_key
-      - title: Discard Threads
-        context: discard_threads
-        units: threads
-        label_promotion: []
-        dimensions:
-        - selector: ceph_kernel_device_discard_threads
-          name: threads
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - kernel_device_key
-        algorithm: absolute
-    - family: mClock Shards
-      context_namespace: mclock_shards
-      metrics:
-      - ceph_mclock_shard_mclock_all_type_queue_len
-      - ceph_mclock_shard_mclock_best_effort_queue_len
-      - ceph_mclock_shard_mclock_client_queue_len
-      - ceph_mclock_shard_mclock_immediate_queue_len
-      - ceph_mclock_shard_mclock_recovery_queue_len
-      charts:
-      - title: Queue Depth
-        context: queue_depth
-        units: operations
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mclock_shard_mclock_immediate_queue_len
-          name: immediate
-        - selector: ceph_mclock_shard_mclock_client_queue_len
-          name: client
-        - selector: ceph_mclock_shard_mclock_recovery_queue_len
-          name: recovery
-        - selector: ceph_mclock_shard_mclock_best_effort_queue_len
-          name: best_effort
-        - selector: ceph_mclock_shard_mclock_all_type_queue_len
-          name: all_type
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - mclock_shard
-        algorithm: absolute
-    - family: Messenger Workers
-      context_namespace: messenger_workers
-      metrics:
-      - ceph_async_messenger_worker_msgr_active_connections
-      - ceph_async_messenger_worker_msgr_created_connections
-      - ceph_async_messenger_worker_msgr_handle_ack_lat_count
-      - ceph_async_messenger_worker_msgr_handle_ack_lat_sum
-      - ceph_async_messenger_worker_msgr_recv_bytes
-      - ceph_async_messenger_worker_msgr_recv_encrypted_bytes
-      - ceph_async_messenger_worker_msgr_recv_messages
-      - ceph_async_messenger_worker_msgr_running_fast_dispatch_time
-      - ceph_async_messenger_worker_msgr_running_recv_time
-      - ceph_async_messenger_worker_msgr_running_send_time
-      - ceph_async_messenger_worker_msgr_running_total_time
-      - ceph_async_messenger_worker_msgr_send_bytes
-      - ceph_async_messenger_worker_msgr_send_encrypted_bytes
-      - ceph_async_messenger_worker_msgr_send_messages
-      - ceph_async_messenger_worker_msgr_send_messages_queue_lat_count
-      - ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
-      charts:
-      - title: Messages
-        context: messages
-        units: messages/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_recv_messages
-          name: recv
-        - selector: ceph_async_messenger_worker_msgr_send_messages
-          name: send
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_recv_bytes
-          name: recv
-        - selector: ceph_async_messenger_worker_msgr_send_bytes
-          name: send
-        - selector: ceph_async_messenger_worker_msgr_recv_encrypted_bytes
-          name: recv_encrypted
-        - selector: ceph_async_messenger_worker_msgr_send_encrypted_bytes
-          name: send_encrypted
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Connections
-        context: connections
-        units: connections
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_active_connections
-          name: active
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-        algorithm: absolute
-      - title: Created Connections
-        context: created_connections
-        units: connections/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_created_connections
-          name: created
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Accumulated Worker Time
-        context: accumulated_worker_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_running_total_time
-          name: total
-        - selector: ceph_async_messenger_worker_msgr_running_send_time
-          name: send
-        - selector: ceph_async_messenger_worker_msgr_running_recv_time
-          name: recv
-        - selector: ceph_async_messenger_worker_msgr_running_fast_dispatch_time
-          name: fast_dispatch
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-        algorithm: incremental
-      - title: Send-Queue Latency Measurements
-        context: send_queue_latency_measurements
-        units: messages/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_send_messages_queue_lat_count
-          name: send_messages_queue
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Acknowledgement Latency Measurements
-        context: ack_latency_measurements
-        units: acknowledgements/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_handle_ack_lat_count
-          name: handle_ack
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Accumulated Send-Queue Latency
-        context: accumulated_send_queue_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
-          name: send_messages_queue
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-        algorithm: incremental
-      - title: Accumulated Acknowledgement Latency
-        context: accumulated_ack_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_handle_ack_lat_sum
-          name: handle_ack
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-        algorithm: incremental
-    - family: RDMA Workers
-      context_namespace: rdma_workers
-      metrics:
-      - ceph_async_messenger_rdma_worker_pending_sent_conns
-      - ceph_async_messenger_rdma_worker_rx_bytes
-      - ceph_async_messenger_rdma_worker_rx_chunks
-      - ceph_async_messenger_rdma_worker_tx_bytes
-      - ceph_async_messenger_rdma_worker_tx_chunks
-      - ceph_async_messenger_rdma_worker_tx_failed_post
-      - ceph_async_messenger_rdma_worker_tx_no_mem
-      - ceph_async_messenger_rdma_worker_tx_parital_mem
-      charts:
-      - title: RDMA Transfer Errors
-        context: transfer_errors
-        units: errors/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_rdma_worker_tx_no_mem
-          name: tx_no_mem
-        - selector: ceph_async_messenger_rdma_worker_tx_parital_mem
-          name: tx_parital_mem
-        - selector: ceph_async_messenger_rdma_worker_tx_failed_post
-          name: tx_failed_post
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rdma_worker
-      - title: Chunk Throughput
-        context: chunk_throughput
-        units: chunks/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_rdma_worker_tx_chunks
-          name: tx
-        - selector: ceph_async_messenger_rdma_worker_rx_chunks
-          name: rx
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rdma_worker
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_rdma_worker_tx_bytes
-          name: tx
-        - selector: ceph_async_messenger_rdma_worker_rx_bytes
-          name: rx
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rdma_worker
-      - title: Pending Connections
-        context: pending_connections
-        units: connections
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_rdma_worker_pending_sent_conns
-          name: pending
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rdma_worker
-        algorithm: absolute
-    - family: DPDK Queues
-      context_namespace: dpdk_queues
-      metrics:
-      - ceph_dpdk_queue_dpdk_receive_bad_checksum_errors
-      - ceph_dpdk_queue_dpdk_receive_bytes
-      - ceph_dpdk_queue_dpdk_receive_copy_bytes
-      - ceph_dpdk_queue_dpdk_receive_copy_ops
-      - ceph_dpdk_queue_dpdk_receive_fragments
-      - ceph_dpdk_queue_dpdk_receive_last_bunch
-      - ceph_dpdk_queue_dpdk_receive_linearize_ops
-      - ceph_dpdk_queue_dpdk_receive_no_memory_errors
-      - ceph_dpdk_queue_dpdk_receive_packets
-      - ceph_dpdk_queue_dpdk_send_bytes
-      - ceph_dpdk_queue_dpdk_send_copy_bytes
-      - ceph_dpdk_queue_dpdk_send_copy_ops
-      - ceph_dpdk_queue_dpdk_send_fragments
-      - ceph_dpdk_queue_dpdk_send_last_bunch
-      - ceph_dpdk_queue_dpdk_send_linearize_ops
-      - ceph_dpdk_queue_dpdk_send_packets
-      - ceph_dpdk_queue_dpdk_send_queue_length
-      charts:
-      - title: Packets
-        context: packets
-        units: packets/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_packets
-          name: receive
-        - selector: ceph_dpdk_queue_dpdk_send_packets
-          name: send
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_bytes
-          name: receive
-        - selector: ceph_dpdk_queue_dpdk_send_bytes
-          name: send
-        - selector: ceph_dpdk_queue_dpdk_receive_copy_bytes
-          name: receive_copy
-        - selector: ceph_dpdk_queue_dpdk_send_copy_bytes
-          name: send_copy
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Packet Fragments
-        context: packet_fragments
-        units: fragments/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_fragments
-          name: receive_fragments
-        - selector: ceph_dpdk_queue_dpdk_send_fragments
-          name: send_fragments
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Copy and Linearize Operations
-        context: copy_linearize_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_copy_ops
-          name: receive_copy_ops
-        - selector: ceph_dpdk_queue_dpdk_send_copy_ops
-          name: send_copy_ops
-        - selector: ceph_dpdk_queue_dpdk_receive_linearize_ops
-          name: receive_linearize_ops
-        - selector: ceph_dpdk_queue_dpdk_send_linearize_ops
-          name: send_linearize_ops
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Receive Errors
-        context: receive_errors
-        units: errors/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_bad_checksum_errors
-          name: bad_checksum
-        - selector: ceph_dpdk_queue_dpdk_receive_no_memory_errors
-          name: no_memory
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Last Batch Size
-        context: last_batch_size
-        units: packets
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_last_bunch
-          name: receive
-        - selector: ceph_dpdk_queue_dpdk_send_last_bunch
-          name: send
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-        algorithm: absolute
-      - title: Send Queue Depth
-        context: send_queue_depth
-        units: packets
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_send_queue_length
-          name: queued
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-        algorithm: absolute
-    - family: DPDK Ports
-      context_namespace: dpdk_ports
-      metrics:
-      - ceph_dpdk_port_dpdk_device_receive_badcrc_errors
-      - ceph_dpdk_port_dpdk_device_receive_dropped_errors
-      - ceph_dpdk_port_dpdk_device_receive_multicast_packets
-      - ceph_dpdk_port_dpdk_device_receive_nombuf_errors
-      - ceph_dpdk_port_dpdk_device_receive_total_errors
-      - ceph_dpdk_port_dpdk_device_send_total_errors
-      charts:
-      - title: Multicast Packets
-        context: multicast_packets
-        units: packets/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_port_dpdk_device_receive_multicast_packets
-          name: received
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_port
-      - title: Receive Errors
-        context: receive_errors
-        units: errors/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_port_dpdk_device_receive_badcrc_errors
-          name: badcrc
-        - selector: ceph_dpdk_port_dpdk_device_receive_total_errors
-          name: total
-        - selector: ceph_dpdk_port_dpdk_device_receive_dropped_errors
-          name: dropped
-        - selector: ceph_dpdk_port_dpdk_device_receive_nombuf_errors
-          name: nombuf
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_port
-      - title: Send Errors
-        context: send_errors
-        units: errors/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_port_dpdk_device_send_total_errors
-          name: total
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_port
-    - family: Service Identity
-      context_namespace: service_identity
-      metrics:
-      - ceph_service_unique_id
-      charts:
-      - title: Service Identity Metadata Sentinel
-        context: identity_metadata
-        units: identifier
-        label_promotion: []
-        dimensions:
-        - selector: ceph_service_unique_id
-          name: present
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - service_unique_id
-    - family: RADOS Striper
-      context_namespace: rados_striper
-      metrics:
-      - ceph_libcephsqlite_striper_lock
-      - ceph_libcephsqlite_striper_shrink
-      - ceph_libcephsqlite_striper_shrink_bytes
-      - ceph_libcephsqlite_striper_unlock
-      - ceph_libcephsqlite_striper_update_allocated
-      - ceph_libcephsqlite_striper_update_metadata
-      - ceph_libcephsqlite_striper_update_size
-      - ceph_libcephsqlite_striper_update_version
-      charts:
-      - title: Metadata and Lock Work
-        context: metadata_and_lock_work
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_libcephsqlite_striper_update_metadata
-          name: update_metadata
-        - selector: ceph_libcephsqlite_striper_update_allocated
-          name: update_allocated
-        - selector: ceph_libcephsqlite_striper_update_size
-          name: update_size
-        - selector: ceph_libcephsqlite_striper_update_version
-          name: update_version
-        - selector: ceph_libcephsqlite_striper_shrink
-          name: shrink
-        - selector: ceph_libcephsqlite_striper_lock
-          name: lock
-        - selector: ceph_libcephsqlite_striper_unlock
-          name: unlock
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Shrink Throughput
-        context: shrink_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_libcephsqlite_striper_shrink_bytes
-          name: bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Memory Pools
-      context_namespace: memory_pools
-      metrics:
-      - ceph_mempool_bloom_filter_bytes
-      - ceph_mempool_bloom_filter_items
-      - ceph_mempool_bluefs_bytes
-      - ceph_mempool_bluefs_file_reader_bytes
-      - ceph_mempool_bluefs_file_reader_items
-      - ceph_mempool_bluefs_file_writer_bytes
-      - ceph_mempool_bluefs_file_writer_items
-      - ceph_mempool_bluefs_items
-      - ceph_mempool_bluestore_alloc_bytes
-      - ceph_mempool_bluestore_alloc_items
-      - ceph_mempool_bluestore_blob_bytes
-      - ceph_mempool_bluestore_blob_items
-      - ceph_mempool_bluestore_cache_buffer_bytes
-      - ceph_mempool_bluestore_cache_buffer_items
-      - ceph_mempool_bluestore_cache_data_bytes
-      - ceph_mempool_bluestore_cache_data_items
-      - ceph_mempool_bluestore_cache_meta_bytes
-      - ceph_mempool_bluestore_cache_meta_items
-      - ceph_mempool_bluestore_cache_onode_bytes
-      - ceph_mempool_bluestore_cache_onode_items
-      - ceph_mempool_bluestore_cache_other_bytes
-      - ceph_mempool_bluestore_cache_other_items
-      - ceph_mempool_bluestore_extent_bytes
-      - ceph_mempool_bluestore_extent_items
-      - ceph_mempool_bluestore_fsck_bytes
-      - ceph_mempool_bluestore_fsck_items
-      - ceph_mempool_bluestore_inline_bl_bytes
-      - ceph_mempool_bluestore_inline_bl_items
-      - ceph_mempool_bluestore_shared_blob_bytes
-      - ceph_mempool_bluestore_shared_blob_items
-      - ceph_mempool_bluestore_txc_bytes
-      - ceph_mempool_bluestore_txc_items
-      - ceph_mempool_bluestore_writing_bytes
-      - ceph_mempool_bluestore_writing_deferred_bytes
-      - ceph_mempool_bluestore_writing_deferred_items
-      - ceph_mempool_bluestore_writing_items
-      - ceph_mempool_buffer_anon_bytes
-      - ceph_mempool_buffer_anon_items
-      - ceph_mempool_buffer_meta_bytes
-      - ceph_mempool_buffer_meta_items
-      - ceph_mempool_ec_extent_cache_bytes
-      - ceph_mempool_ec_extent_cache_items
-      - ceph_mempool_mds_co_bytes
-      - ceph_mempool_mds_co_items
-      - ceph_mempool_osd_bytes
-      - ceph_mempool_osd_items
-      - ceph_mempool_osd_mapbl_bytes
-      - ceph_mempool_osd_mapbl_items
-      - ceph_mempool_osd_pglog_bytes
-      - ceph_mempool_osd_pglog_items
-      - ceph_mempool_osdmap_bytes
-      - ceph_mempool_osdmap_items
-      - ceph_mempool_osdmap_mapping_bytes
-      - ceph_mempool_osdmap_mapping_items
-      - ceph_mempool_pgmap_bytes
-      - ceph_mempool_pgmap_items
-      - ceph_mempool_unittest_1_bytes
-      - ceph_mempool_unittest_1_items
-      - ceph_mempool_unittest_2_bytes
-      - ceph_mempool_unittest_2_items
-      charts:
-      - title: Memory Use
-        context: memory_use
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mempool_bloom_filter_bytes
-          name: bloom_filter
-        - selector: ceph_mempool_bluestore_alloc_bytes
-          name: bluestore_alloc
-        - selector: ceph_mempool_bluestore_cache_data_bytes
-          name: bluestore_cache_data
-        - selector: ceph_mempool_bluestore_cache_onode_bytes
-          name: bluestore_cache_onode
-        - selector: ceph_mempool_bluestore_cache_meta_bytes
-          name: bluestore_cache_meta
-        - selector: ceph_mempool_bluestore_cache_other_bytes
-          name: bluestore_cache_other
-        - selector: ceph_mempool_bluestore_cache_buffer_bytes
-          name: bluestore_cache_buffer
-        - selector: ceph_mempool_bluestore_extent_bytes
-          name: bluestore_extent
-        - selector: ceph_mempool_bluestore_blob_bytes
-          name: bluestore_blob
-        - selector: ceph_mempool_bluestore_shared_blob_bytes
-          name: bluestore_shared_blob
-        - selector: ceph_mempool_bluestore_inline_bl_bytes
-          name: bluestore_inline_bl
-        - selector: ceph_mempool_bluestore_fsck_bytes
-          name: bluestore_fsck
-        - selector: ceph_mempool_bluestore_txc_bytes
-          name: bluestore_txc
-        - selector: ceph_mempool_bluestore_writing_deferred_bytes
-          name: bluestore_writing_deferred
-        - selector: ceph_mempool_bluestore_writing_bytes
-          name: bluestore_writing
-        - selector: ceph_mempool_bluefs_bytes
-          name: bluefs
-        - selector: ceph_mempool_bluefs_file_reader_bytes
-          name: bluefs_file_reader
-        - selector: ceph_mempool_bluefs_file_writer_bytes
-          name: bluefs_file_writer
-        - selector: ceph_mempool_buffer_anon_bytes
-          name: buffer_anon
-        - selector: ceph_mempool_buffer_meta_bytes
-          name: buffer_meta
-        - selector: ceph_mempool_osd_bytes
-          name: osd
-        - selector: ceph_mempool_osd_mapbl_bytes
-          name: osd_mapbl
-        - selector: ceph_mempool_osd_pglog_bytes
-          name: osd_pglog
-        - selector: ceph_mempool_osdmap_bytes
-          name: osdmap
-        - selector: ceph_mempool_osdmap_mapping_bytes
-          name: osdmap_mapping
-        - selector: ceph_mempool_pgmap_bytes
-          name: pgmap
-        - selector: ceph_mempool_mds_co_bytes
-          name: mds_co
-        - selector: ceph_mempool_unittest_1_bytes
-          name: unittest_1
-        - selector: ceph_mempool_unittest_2_bytes
-          name: unittest_2
-        - selector: ceph_mempool_ec_extent_cache_bytes
-          name: ec_extent_cache
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Item Count
-        context: item_count
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mempool_bloom_filter_items
-          name: bloom_filter
-        - selector: ceph_mempool_bluestore_alloc_items
-          name: bluestore_alloc
-        - selector: ceph_mempool_bluestore_cache_data_items
-          name: bluestore_cache_data
-        - selector: ceph_mempool_bluestore_cache_onode_items
-          name: bluestore_cache_onode
-        - selector: ceph_mempool_bluestore_cache_meta_items
-          name: bluestore_cache_meta
-        - selector: ceph_mempool_bluestore_cache_other_items
-          name: bluestore_cache_other
-        - selector: ceph_mempool_bluestore_cache_buffer_items
-          name: bluestore_cache_buffer
-        - selector: ceph_mempool_bluestore_extent_items
-          name: bluestore_extent
-        - selector: ceph_mempool_bluestore_blob_items
-          name: bluestore_blob
-        - selector: ceph_mempool_bluestore_shared_blob_items
-          name: bluestore_shared_blob
-        - selector: ceph_mempool_bluestore_inline_bl_items
-          name: bluestore_inline_bl
-        - selector: ceph_mempool_bluestore_fsck_items
-          name: bluestore_fsck
-        - selector: ceph_mempool_bluestore_txc_items
-          name: bluestore_txc
-        - selector: ceph_mempool_bluestore_writing_deferred_items
-          name: bluestore_writing_deferred
-        - selector: ceph_mempool_bluestore_writing_items
-          name: bluestore_writing
-        - selector: ceph_mempool_bluefs_items
-          name: bluefs
-        - selector: ceph_mempool_bluefs_file_reader_items
-          name: bluefs_file_reader
-        - selector: ceph_mempool_bluefs_file_writer_items
-          name: bluefs_file_writer
-        - selector: ceph_mempool_buffer_anon_items
-          name: buffer_anon
-        - selector: ceph_mempool_buffer_meta_items
-          name: buffer_meta
-        - selector: ceph_mempool_osd_items
-          name: osd
-        - selector: ceph_mempool_osd_mapbl_items
-          name: osd_mapbl
-        - selector: ceph_mempool_osd_pglog_items
-          name: osd_pglog
-        - selector: ceph_mempool_osdmap_items
-          name: osdmap
-        - selector: ceph_mempool_osdmap_mapping_items
-          name: osdmap_mapping
-        - selector: ceph_mempool_pgmap_items
-          name: pgmap
-        - selector: ceph_mempool_mds_co_items
-          name: mds_co
-        - selector: ceph_mempool_unittest_1_items
-          name: unittest_1
-        - selector: ceph_mempool_unittest_2_items
-          name: unittest_2
-        - selector: ceph_mempool_ec_extent_cache_items
-          name: ec_extent_cache
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: CephFS Mirror
-    context_namespace: cephfs_mirror
-    groups:
-    - family: Service
-      context_namespace: service
-      metrics:
-      - ceph_cephfs_mirror_mirror_enable_failures
-      - ceph_cephfs_mirror_mirrored_filesystems
-      charts:
-      - title: Mirrored Filesystems
-        context: filesystems
-        units: filesystems
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_mirrored_filesystems
-          name: mirrored
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Mirroring Enable Failures
-        context: enable_failures
-        units: failures/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_mirror_enable_failures
-          name: failures
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Filesystems
-      context_namespace: filesystems
-      metrics:
-      - ceph_cephfs_mirror_mirrored_filesystems_directory_count
-      - ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
-      charts:
-      - title: Mirroring Peers
-        context: peers
-        units: peers
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
-          name: peers
-        instances:
-          by_labels:
-          - ceph_daemon
-          - filesystem
-          optional_by_labels: []
-      - title: Mirrored Directories
-        context: directories
-        units: directories
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_mirrored_filesystems_directory_count
-          name: directories
-        instances:
-          by_labels:
-          - ceph_daemon
-          - filesystem
-          optional_by_labels: []
-    - family: Peers
-      context_namespace: peers
-      metrics:
-      - ceph_cephfs_mirror_peers_avg_sync_time_count
-      - ceph_cephfs_mirror_peers_avg_sync_time_sum
-      - ceph_cephfs_mirror_peers_last_synced_bytes
-      - ceph_cephfs_mirror_peers_last_synced_duration
-      - ceph_cephfs_mirror_peers_last_synced_end
-      - ceph_cephfs_mirror_peers_last_synced_start
-      - ceph_cephfs_mirror_peers_snaps_deleted
-      - ceph_cephfs_mirror_peers_snaps_renamed
-      - ceph_cephfs_mirror_peers_snaps_synced
-      - ceph_cephfs_mirror_peers_sync_bytes
-      - ceph_cephfs_mirror_peers_sync_failures
-      charts:
-      - title: Snapshot Outcomes
-        context: snapshot_outcomes
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_snaps_synced
-          name: synced
-        - selector: ceph_cephfs_mirror_peers_snaps_deleted
-          name: deleted
-        - selector: ceph_cephfs_mirror_peers_snaps_renamed
-          name: renamed
-        - selector: ceph_cephfs_mirror_peers_sync_failures
-          name: failed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Sync-Time Measurements
-        context: sync_time_measurements
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_avg_sync_time_count
-          name: snapshots
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Accumulated Sync Time
-        context: accumulated_sync_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_avg_sync_time_sum
-          name: time
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Sync Throughput
-        context: sync_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_sync_bytes
-          name: bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Last Sync Timestamps
-        context: last_sync_timestamps
-        units: seconds since epoch
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_last_synced_start
-          name: started
-        - selector: ceph_cephfs_mirror_peers_last_synced_end
-          name: ended
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Last Sync Duration
-        context: last_sync_duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_last_synced_duration
-          name: duration
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Last Sync Size
-        context: last_sync_size
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_last_synced_bytes
-          name: bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-        algorithm: absolute
-  - family: Object Gateway Scheduling
-    context_namespace: object_gateway_scheduling
-    metrics:
-    - ceph_dmclock_admin_cancel
-    - ceph_dmclock_admin_cancel_cost
-    - ceph_dmclock_admin_cost
-    - ceph_dmclock_admin_limit
-    - ceph_dmclock_admin_limit_cost
-    - ceph_dmclock_admin_prio
-    - ceph_dmclock_admin_prio_cost
-    - ceph_dmclock_admin_prio_latency_count
-    - ceph_dmclock_admin_prio_latency_sum
-    - ceph_dmclock_admin_qlen
-    - ceph_dmclock_admin_res
-    - ceph_dmclock_admin_res_cost
-    - ceph_dmclock_admin_res_latency_count
-    - ceph_dmclock_admin_res_latency_sum
-    - ceph_dmclock_auth_cancel
-    - ceph_dmclock_auth_cancel_cost
-    - ceph_dmclock_auth_cost
-    - ceph_dmclock_auth_limit
-    - ceph_dmclock_auth_limit_cost
-    - ceph_dmclock_auth_prio
-    - ceph_dmclock_auth_prio_cost
-    - ceph_dmclock_auth_prio_latency_count
-    - ceph_dmclock_auth_prio_latency_sum
-    - ceph_dmclock_auth_qlen
-    - ceph_dmclock_auth_res
-    - ceph_dmclock_auth_res_cost
-    - ceph_dmclock_auth_res_latency_count
-    - ceph_dmclock_auth_res_latency_sum
-    - ceph_dmclock_data_cancel
-    - ceph_dmclock_data_cancel_cost
-    - ceph_dmclock_data_cost
-    - ceph_dmclock_data_limit
-    - ceph_dmclock_data_limit_cost
-    - ceph_dmclock_data_prio
-    - ceph_dmclock_data_prio_cost
-    - ceph_dmclock_data_prio_latency_count
-    - ceph_dmclock_data_prio_latency_sum
-    - ceph_dmclock_data_qlen
-    - ceph_dmclock_data_res
-    - ceph_dmclock_data_res_cost
-    - ceph_dmclock_data_res_latency_count
-    - ceph_dmclock_data_res_latency_sum
-    - ceph_dmclock_metadata_cancel
-    - ceph_dmclock_metadata_cancel_cost
-    - ceph_dmclock_metadata_cost
-    - ceph_dmclock_metadata_limit
-    - ceph_dmclock_metadata_limit_cost
-    - ceph_dmclock_metadata_prio
-    - ceph_dmclock_metadata_prio_cost
-    - ceph_dmclock_metadata_prio_latency_count
-    - ceph_dmclock_metadata_prio_latency_sum
-    - ceph_dmclock_metadata_qlen
-    - ceph_dmclock_metadata_res
-    - ceph_dmclock_metadata_res_cost
-    - ceph_dmclock_metadata_res_latency_count
-    - ceph_dmclock_metadata_res_latency_sum
-    - ceph_dmclock_scheduler_outstanding
-    - ceph_dmclock_scheduler_throttle
-    charts:
-    - title: Queue Depth
-      context: queue_depth
-      units: requests
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_qlen
-        name: admin
-      - selector: ceph_dmclock_auth_qlen
-        name: auth
-      - selector: ceph_dmclock_data_qlen
-        name: data
-      - selector: ceph_dmclock_metadata_qlen
-        name: metadata
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Queued Request Cost
-      context: queue_cost
-      units: cost
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_cost
-        name: admin
-      - selector: ceph_dmclock_auth_cost
-        name: auth
-      - selector: ceph_dmclock_data_cost
-        name: data
-      - selector: ceph_dmclock_metadata_cost
-        name: metadata
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Scheduled Requests
-      context: scheduled_requests
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_res
-        name: admin_reservation
-      - selector: ceph_dmclock_admin_prio
-        name: admin_priority
-      - selector: ceph_dmclock_auth_res
-        name: auth_reservation
-      - selector: ceph_dmclock_auth_prio
-        name: auth_priority
-      - selector: ceph_dmclock_data_res
-        name: data_reservation
-      - selector: ceph_dmclock_data_prio
-        name: data_priority
-      - selector: ceph_dmclock_metadata_res
-        name: metadata_reservation
-      - selector: ceph_dmclock_metadata_prio
-        name: metadata_priority
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Rejected and Cancelled Requests
-      context: rejected_and_cancelled_requests
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_limit
-        name: admin_limited
-      - selector: ceph_dmclock_admin_cancel
-        name: admin_cancelled
-      - selector: ceph_dmclock_auth_limit
-        name: auth_limited
-      - selector: ceph_dmclock_auth_cancel
-        name: auth_cancelled
-      - selector: ceph_dmclock_data_limit
-        name: data_limited
-      - selector: ceph_dmclock_data_cancel
-        name: data_cancelled
-      - selector: ceph_dmclock_metadata_limit
-        name: metadata_limited
-      - selector: ceph_dmclock_metadata_cancel
-        name: metadata_cancelled
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Scheduled and Rejected Cost
-      context: scheduled_and_rejected_cost
-      units: cost/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_res_cost
-        name: admin_reservation
-      - selector: ceph_dmclock_admin_prio_cost
-        name: admin_priority
-      - selector: ceph_dmclock_admin_limit_cost
-        name: admin_limited
-      - selector: ceph_dmclock_admin_cancel_cost
-        name: admin_cancelled
-      - selector: ceph_dmclock_auth_res_cost
-        name: auth_reservation
-      - selector: ceph_dmclock_auth_prio_cost
-        name: auth_priority
-      - selector: ceph_dmclock_auth_limit_cost
-        name: auth_limited
-      - selector: ceph_dmclock_auth_cancel_cost
-        name: auth_cancelled
-      - selector: ceph_dmclock_data_res_cost
-        name: data_reservation
-      - selector: ceph_dmclock_data_prio_cost
-        name: data_priority
-      - selector: ceph_dmclock_data_limit_cost
-        name: data_limited
-      - selector: ceph_dmclock_data_cancel_cost
-        name: data_cancelled
-      - selector: ceph_dmclock_metadata_res_cost
-        name: metadata_reservation
-      - selector: ceph_dmclock_metadata_prio_cost
-        name: metadata_priority
-      - selector: ceph_dmclock_metadata_limit_cost
-        name: metadata_limited
-      - selector: ceph_dmclock_metadata_cancel_cost
-        name: metadata_cancelled
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Scheduling-Latency Measurements
-      context: latency_measurements
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_res_latency_count
-        name: admin_reservation
-      - selector: ceph_dmclock_admin_prio_latency_count
-        name: admin_priority
-      - selector: ceph_dmclock_auth_res_latency_count
-        name: auth_reservation
-      - selector: ceph_dmclock_auth_prio_latency_count
-        name: auth_priority
-      - selector: ceph_dmclock_data_res_latency_count
-        name: data_reservation
-      - selector: ceph_dmclock_data_prio_latency_count
-        name: data_priority
-      - selector: ceph_dmclock_metadata_res_latency_count
-        name: metadata_reservation
-      - selector: ceph_dmclock_metadata_prio_latency_count
-        name: metadata_priority
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Scheduling Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_res_latency_sum
-        name: admin_reservation
-      - selector: ceph_dmclock_admin_prio_latency_sum
-        name: admin_priority
-      - selector: ceph_dmclock_auth_res_latency_sum
-        name: auth_reservation
-      - selector: ceph_dmclock_auth_prio_latency_sum
-        name: auth_priority
-      - selector: ceph_dmclock_data_res_latency_sum
-        name: data_reservation
-      - selector: ceph_dmclock_data_prio_latency_sum
-        name: data_priority
-      - selector: ceph_dmclock_metadata_res_latency_sum
-        name: metadata_reservation
-      - selector: ceph_dmclock_metadata_prio_latency_sum
-        name: metadata_priority
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Throttled Requests
-      context: throttled_requests
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_scheduler_throttle
-        name: throttled
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Outstanding Requests
-      context: outstanding_requests
-      units: requests
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_scheduler_outstanding
-        name: outstanding
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: Storage Engine Extensions
-    context_namespace: storage_engine_extensions
-    groups:
-    - family: RocksDB Binned Cache
-      context_namespace: rocksdb_binned_cache
-      metrics:
-      - ceph_rocksdb_binned_cache_capacity
-      - ceph_rocksdb_binned_cache_elems
-      - ceph_rocksdb_binned_cache_hits
-      - ceph_rocksdb_binned_cache_inserts
-      - ceph_rocksdb_binned_cache_lookups
-      - ceph_rocksdb_binned_cache_misses
-      - ceph_rocksdb_binned_cache_pinned
-      - ceph_rocksdb_binned_cache_usage
-      charts:
-      - title: Cache Memory
-        context: memory
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_capacity
-          name: capacity
-        - selector: ceph_rocksdb_binned_cache_usage
-          name: used
-        - selector: ceph_rocksdb_binned_cache_pinned
-          name: pinned
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-      - title: Cache Entries
-        context: entries
-        units: entries
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_elems
-          name: items
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-      - title: Cache Insertions
-        context: insertions
-        units: insertions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_inserts
-          name: insertions
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-        algorithm: incremental
-      - title: Cache Lookups
-        context: lookups
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_lookups
-          name: lookups
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-        algorithm: incremental
-      - title: Cache Lookup Outcomes
-        context: lookup_outcomes
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_hits
-          name: hits
-        - selector: ceph_rocksdb_binned_cache_misses
-          name: misses
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-        algorithm: incremental
-    - family: External Block Devices
-      context_namespace: external_block_devices
-      metrics:
-      - ceph_extblkdev_dev_log_size
-      - ceph_extblkdev_dev_log_util
-      - ceph_extblkdev_dev_phy_size
-      - ceph_extblkdev_dev_phy_util
-      - ceph_extblkdev_fcm
-      - ceph_extblkdev_part_log_avail
-      - ceph_extblkdev_part_log_size
-      - ceph_extblkdev_part_phy_avail
-      - ceph_extblkdev_part_phy_size
-      charts:
-      - title: FCM Plugin State
-        context: plugin_state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_extblkdev_fcm
-          name: fcm
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Device Size
-        context: device_size
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_extblkdev_dev_phy_size
-          name: physical
-        - selector: ceph_extblkdev_dev_log_size
-          name: logical
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Device Utilization
-        context: device_utilization
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_extblkdev_dev_phy_util
-          name: physical
-        - selector: ceph_extblkdev_dev_log_util
-          name: logical
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Partition Space
-        context: partition_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_extblkdev_part_phy_size
-          name: physical_size
-        - selector: ceph_extblkdev_part_log_size
-          name: logical_size
-        - selector: ceph_extblkdev_part_phy_avail
-          name: physical_available
-        - selector: ceph_extblkdev_part_log_avail
-          name: logical_available
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Ceph Clients
-    context_namespace: ceph_clients
-    metrics:
-    - ceph_client_mdops
-    - ceph_client_rdops
-    - ceph_client_wrops
-    charts:
-    - title: Client I/O Operations
-      context: io_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_client_mdops
-        name: metadata
-      - selector: ceph_client_rdops
-        name: read
-      - selector: ceph_client_wrops
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-  - family: NVMe-oF
-    context_namespace: nvme_of
-    groups:
-    - family: Block Devices
-      context_namespace: block_devices
-      metrics:
-      - ceph_nvmeof_bdev_capacity_bytes
-      - ceph_nvmeof_bdev_metadata
-      - ceph_nvmeof_bdev_read_bytes_total
-      - ceph_nvmeof_bdev_read_seconds_total
-      - ceph_nvmeof_bdev_reads_completed_total
-      - ceph_nvmeof_bdev_write_seconds_total
-      - ceph_nvmeof_bdev_writes_completed_total
-      - ceph_nvmeof_bdev_written_bytes_total
-      charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_read_bytes_total
-          name: read_bytes
-        - selector: ceph_nvmeof_bdev_written_bytes_total
-          name: written_bytes
-        instances:
-          by_labels:
-          - bdev_name
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_reads_completed_total
-          name: reads_completed
-        - selector: ceph_nvmeof_bdev_writes_completed_total
-          name: writes_completed
-        instances:
-          by_labels:
-          - bdev_name
-          - ceph_instance
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_capacity_bytes
-          name: value
-        instances:
-          by_labels:
-          - bdev_name
-          optional_by_labels: []
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_metadata
-          name: value
-        instances:
-          by_labels:
-          - bdev_name
-          - block_size
-          - ceph_instance
-          - namespace
-          - pool_name
-          - rbd_name
-          optional_by_labels: []
-      - title: Accumulated Time
-        context: time_accumulation
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_read_seconds_total
-          name: read_seconds
-        - selector: ceph_nvmeof_bdev_write_seconds_total
-          name: write_seconds
-        instances:
-          by_labels:
-          - bdev_name
-          - ceph_instance
-          optional_by_labels: []
-    - family: Gateways
-      context_namespace: gateways
-      metrics:
-      - ceph_nvmeof_reactor_seconds_total
-      - ceph_nvmeof_rpc_method_seconds
-      charts:
-      - title: Collection Duration
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_rpc_method_seconds
-          name: value
-        instances:
-          by_labels:
-          - method
-          optional_by_labels: []
-      - title: Accumulated Time
-        context: time_accumulation
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_reactor_seconds_total
-          name: value
-        instances:
-          by_labels:
-          - ceph_instance
-          - mode
-          - name
-          optional_by_labels: []
-    - family: Hosts
-      context_namespace: hosts
-      metrics:
-      - ceph_nvmeof_host_connection_state
-      - ceph_nvmeof_host_keepalive_timeout
-      charts:
-      - title: Host Connection State
-        context: connection_state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_host_connection_state
-          name: value
-        instances:
-          by_labels:
-          - gw_name
-          - host_addr
-          - host_nqn
-          - nqn
-          optional_by_labels: []
-      - title: Keepalive Timeout State
-        context: keepalive_timeout_state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_host_keepalive_timeout
-          name: value
-        instances:
-          by_labels:
-          - ceph_instance
-          - gw_name
-          - host_nqn
-          - nqn
-          optional_by_labels: []
-    - family: Subsystems
-      context_namespace: subsystems
-      metrics:
-      - ceph_nvmeof_subsystem_host_count
-      - ceph_nvmeof_subsystem_listener_count
-      - ceph_nvmeof_subsystem_listener_iface_speed_bytes
-      - ceph_nvmeof_subsystem_metadata
-      - ceph_nvmeof_subsystem_namespace_count
-      - ceph_nvmeof_subsystem_namespace_limit
-      - ceph_nvmeof_subsystem_namespace_metadata
-      charts:
-      - title: Configured Hosts
-        context: host_state
-        units: hosts
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_host_count
-          name: value
-        instances:
-          by_labels:
-          - nqn
-          optional_by_labels: []
-      - title: Listener Interface Link Speed
-        context: link_speed
-        units: Mbps
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_listener_iface_speed_bytes
-          name: value
-        instances:
-          by_labels:
-          - device
-          optional_by_labels: []
-      - title: Listener Addresses
-        context: listener_state
-        units: listeners
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_listener_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_instance
-          - nqn
-          optional_by_labels: []
-      - title: Namespaces
-        context: namespace_count
-        units: namespaces
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_namespace_count
-          name: nvmeof_subsystem_namespace_count
-        instances:
-          by_labels:
-          - ceph_instance
-          - nqn
-          optional_by_labels: []
-      - title: Namespace Limit
-        context: namespace_limit
-        units: namespaces
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_namespace_limit
-          name: limit
-        instances:
-          by_labels:
-          - nqn
-          optional_by_labels: []
-      - title: State and Metadata — Metadata
-        context: state_metadata
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_metadata
-          name: metadata
-        instances:
-          by_labels:
-          - allow_any_host
-          - ceph_instance
-          - group
-          - ha_enabled
-          - model_number
-          - nqn
-          - serial_number
-          optional_by_labels: []
-      - title: State and Metadata — Namespace Metadata
-        context: state_namespace_metadata
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_namespace_metadata
-          name: namespace_metadata
-        instances:
-          by_labels:
-          - anagrpid
-          - bdev_name
-          - ceph_instance
-          - nqn
-          - nsid
-          - rados_namespace_name
-          optional_by_labels: []
+        - title: Client I/O Operations
+          context: io_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_client_mdops
+              name: metadata
+            - selector: ceph_client_rdops
+              name: read
+            - selector: ceph_client_wrops
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+    - family: NVMe-oF
+      context_namespace: nvme_of
+      groups:
+        - family: Block Devices
+          context_namespace: block_devices
+          metrics:
+            - ceph_nvmeof_bdev_capacity_bytes
+            - ceph_nvmeof_bdev_metadata
+            - ceph_nvmeof_bdev_read_bytes_total
+            - ceph_nvmeof_bdev_read_seconds_total
+            - ceph_nvmeof_bdev_reads_completed_total
+            - ceph_nvmeof_bdev_write_seconds_total
+            - ceph_nvmeof_bdev_writes_completed_total
+            - ceph_nvmeof_bdev_written_bytes_total
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_read_bytes_total
+                  name: read_bytes
+                - selector: ceph_nvmeof_bdev_written_bytes_total
+                  name: written_bytes
+              instances:
+                by_labels:
+                  - bdev_name
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_reads_completed_total
+                  name: reads_completed
+                - selector: ceph_nvmeof_bdev_writes_completed_total
+                  name: writes_completed
+              instances:
+                by_labels:
+                  - bdev_name
+                  - ceph_instance
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_capacity_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - bdev_name
+                optional_by_labels: []
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - bdev_name
+                  - block_size
+                  - ceph_instance
+                  - namespace
+                  - pool_name
+                  - rbd_name
+                optional_by_labels: []
+            - title: Accumulated Time
+              context: time_accumulation
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_read_seconds_total
+                  name: read_seconds
+                - selector: ceph_nvmeof_bdev_write_seconds_total
+                  name: write_seconds
+              instances:
+                by_labels:
+                  - bdev_name
+                  - ceph_instance
+                optional_by_labels: []
+        - family: Gateways
+          context_namespace: gateways
+          metrics:
+            - ceph_nvmeof_reactor_seconds_total
+            - ceph_nvmeof_rpc_method_seconds
+          charts:
+            - title: Collection Duration
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_rpc_method_seconds
+                  name: value
+              instances:
+                by_labels:
+                  - method
+                optional_by_labels: []
+            - title: Accumulated Time
+              context: time_accumulation
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_reactor_seconds_total
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_instance
+                  - mode
+                  - name
+                optional_by_labels: []
+        - family: Hosts
+          context_namespace: hosts
+          metrics:
+            - ceph_nvmeof_host_connection_state
+            - ceph_nvmeof_host_keepalive_timeout
+          charts:
+            - title: Host Connection State
+              context: connection_state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_host_connection_state
+                  name: value
+              instances:
+                by_labels:
+                  - gw_name
+                  - host_addr
+                  - host_nqn
+                  - nqn
+                optional_by_labels: []
+            - title: Keepalive Timeout State
+              context: keepalive_timeout_state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_host_keepalive_timeout
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_instance
+                  - gw_name
+                  - host_nqn
+                  - nqn
+                optional_by_labels: []
+        - family: Subsystems
+          context_namespace: subsystems
+          metrics:
+            - ceph_nvmeof_subsystem_host_count
+            - ceph_nvmeof_subsystem_listener_count
+            - ceph_nvmeof_subsystem_listener_iface_speed_bytes
+            - ceph_nvmeof_subsystem_metadata
+            - ceph_nvmeof_subsystem_namespace_count
+            - ceph_nvmeof_subsystem_namespace_limit
+            - ceph_nvmeof_subsystem_namespace_metadata
+          charts:
+            - title: Configured Hosts
+              context: host_state
+              units: hosts
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_host_count
+                  name: value
+              instances:
+                by_labels:
+                  - nqn
+                optional_by_labels: []
+            - title: Listener Interface Link Speed
+              context: link_speed
+              units: Mbps
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_listener_iface_speed_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - device
+                optional_by_labels: []
+            - title: Listener Addresses
+              context: listener_state
+              units: listeners
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_listener_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_instance
+                  - nqn
+                optional_by_labels: []
+            - title: Namespaces
+              context: namespace_count
+              units: namespaces
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_namespace_count
+                  name: nvmeof_subsystem_namespace_count
+              instances:
+                by_labels:
+                  - ceph_instance
+                  - nqn
+                optional_by_labels: []
+            - title: Namespace Limit
+              context: namespace_limit
+              units: namespaces
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_namespace_limit
+                  name: limit
+              instances:
+                by_labels:
+                  - nqn
+                optional_by_labels: []
+            - title: State and Metadata — Metadata
+              context: state_metadata
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_metadata
+                  name: metadata
+              instances:
+                by_labels:
+                  - allow_any_host
+                  - ceph_instance
+                  - group
+                  - ha_enabled
+                  - model_number
+                  - nqn
+                  - serial_number
+                optional_by_labels: []
+            - title: State and Metadata — Namespace Metadata
+              context: state_namespace_metadata
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_namespace_metadata
+                  name: namespace_metadata
+              instances:
+                by_labels:
+                  - anagrpid
+                  - bdev_name
+                  - ceph_instance
+                  - nqn
+                  - nsid
+                  - rados_namespace_name
+                optional_by_labels: []

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml
@@ -4,1703 +4,1703 @@ app: haproxy
 autogen:
   selector:
     deny:
-    - haproxy_backend_agg_server_check_status
-    - haproxy_process_description
-    - haproxy_process_node
-    - haproxy_process_start_time_seconds
+      - haproxy_backend_agg_server_check_status
+      - haproxy_process_description
+      - haproxy_process_node
+      - haproxy_process_start_time_seconds
 template:
   family: HAProxy
   context_namespace: haproxy
   groups:
-  - family: Process
-    groups:
-    - family: Activity
-      metrics:
-      - haproxy_process_nbproc
-      - haproxy_process_nbthread
-      - haproxy_process_recv_logs_total
-      - haproxy_process_relative_process_id
-      - haproxy_process_requests_total
-      charts:
-      - title: Received Logs
-        context: process_recv_logs_total
-        units: logs/s
-        dimensions:
-        - selector: haproxy_process_recv_logs_total
-          name: value
-      - title: Relative Process ID
-        context: process_relative_process_id
-        units: process id
-        dimensions:
-        - selector: haproxy_process_relative_process_id
-          name: value
-      - title: Requests
-        context: process_requests_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_process_requests_total
-          name: value
-      - title: Threads
-        context: process_nbthread
-        units: threads
-        dimensions:
-        - selector: haproxy_process_nbthread
-          name: value
-      - title: Worker Processes
-        context: process_nbproc
-        units: processes
-        dimensions:
-        - selector: haproxy_process_nbproc
-          name: value
-    - family: Compression
-      metrics:
-      - haproxy_process_current_zlib_memory
-      - haproxy_process_limit_http_comp
-      - haproxy_process_max_zlib_memory
-      charts:
-      - title: Current Zlib Memory
-        context: process_current_zlib_memory
-        units: bytes
-        dimensions:
-        - selector: haproxy_process_current_zlib_memory
-          name: value
-      - title: HTTP Compression Limit
-        context: process_limit_http_comp
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_process_limit_http_comp
-          name: value
-      - title: Max Zlib Memory
-        context: process_max_zlib_memory
-        units: bytes
-        dimensions:
-        - selector: haproxy_process_max_zlib_memory
-          name: value
-    - family: Connections
-      metrics:
-      - haproxy_process_connections_total
-      - haproxy_process_current_connection_rate
-      - haproxy_process_current_connections
-      - haproxy_process_hard_max_connections
-      - haproxy_process_limit_connection_rate
-      - haproxy_process_max_connection_rate
-      - haproxy_process_max_connections
-      - haproxy_process_max_fds
-      - haproxy_process_max_pipes
-      - haproxy_process_max_sockets
-      - haproxy_process_pipes_free_total
-      - haproxy_process_pipes_used_total
-      charts:
-      - title: Connections
-        context: process_connections_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_process_connections_total
-          name: value
-      - title: Current Connection Rate
-        context: process_current_connection_rate
-        units: connections/s
-        dimensions:
-        - selector: haproxy_process_current_connection_rate
-          name: value
-      - title: Current Connections
-        context: process_current_connections
-        units: connections
-        dimensions:
-        - selector: haproxy_process_current_connections
-          name: value
-      - title: Hard Max Connections
-        context: process_hard_max_connections
-        units: connections
-        dimensions:
-        - selector: haproxy_process_hard_max_connections
-          name: value
-      - title: Limit Connection Rate
-        context: process_limit_connection_rate
-        units: connections/s
-        dimensions:
-        - selector: haproxy_process_limit_connection_rate
-          name: value
-      - title: Max Connection Rate
-        context: process_max_connection_rate
-        units: connections/s
-        dimensions:
-        - selector: haproxy_process_max_connection_rate
-          name: value
-      - title: Max Connections
-        context: process_max_connections
-        units: connections
-        dimensions:
-        - selector: haproxy_process_max_connections
-          name: value
-      - title: Max FDs
-        context: process_max_fds
-        units: file descriptors
-        dimensions:
-        - selector: haproxy_process_max_fds
-          name: value
-      - title: Max Pipes
-        context: process_max_pipes
-        units: pipes
-        dimensions:
-        - selector: haproxy_process_max_pipes
-          name: value
-      - title: Max Sockets
-        context: process_max_sockets
-        units: sockets
-        dimensions:
-        - selector: haproxy_process_max_sockets
-          name: value
-      - title: Pipes
-        context: process_pipes
-        units: pipes
-        algorithm: absolute
-        dimensions:
-        - selector: haproxy_process_pipes_used_total
-          name: used
-        - selector: haproxy_process_pipes_free_total
-          name: free
-    - family: Errors
-      metrics:
-      - haproxy_process_dropped_logs_total
-      - haproxy_process_failed_resolutions
-      - haproxy_process_total_warnings
-      charts:
-      - title: Dropped Logs
-        context: process_dropped_logs_total
-        units: logs/s
-        dimensions:
-        - selector: haproxy_process_dropped_logs_total
-          name: value
-      - title: Failed Resolutions
-        context: process_failed_resolutions
-        units: errors/s
-        dimensions:
-        - selector: haproxy_process_failed_resolutions
-          name: value
-      - title: Warnings
-        context: process_total_warnings
-        units: warnings/s
-        dimensions:
-        - selector: haproxy_process_total_warnings
-          name: value
-    - family: Health
-      metrics:
-      - haproxy_process_active_peers
-      charts:
-      - title: Active Peers
-        context: process_active_peers
-        units: peers
-        dimensions:
-        - selector: haproxy_process_active_peers
-          name: value
-    - family: Memory
-      metrics:
-      - haproxy_process_max_memory_bytes
-      - haproxy_process_pool_allocated_bytes
-      - haproxy_process_pool_failures_total
-      - haproxy_process_pool_used_bytes
-      charts:
-      - title: Max Memory Bytes
-        context: process_max_memory_bytes
-        units: bytes
-        dimensions:
-        - selector: haproxy_process_max_memory_bytes
-          name: value
-      - title: Pool Allocated Bytes
-        context: process_pool_allocated_bytes
-        units: bytes
-        dimensions:
-        - selector: haproxy_process_pool_allocated_bytes
-          name: value
-      - title: Pool Failures
-        context: process_pool_failures_total
-        units: failures/s
-        dimensions:
-        - selector: haproxy_process_pool_failures_total
-          name: value
-      - title: Pool Used Bytes
-        context: process_pool_used_bytes
-        units: bytes
-        dimensions:
-        - selector: haproxy_process_pool_used_bytes
-          name: value
-    - family: Queue
-      metrics:
-      - haproxy_process_current_run_queue
-      charts:
-      - title: Current Run Queue
-        context: process_current_run_queue
-        units: tasks
-        dimensions:
-        - selector: haproxy_process_current_run_queue
-          name: value
-    - family: SSL
-      metrics:
-      - haproxy_process_current_backend_ssl_key_rate
-      - haproxy_process_current_frontend_ssl_key_rate
-      - haproxy_process_current_ssl_connections
-      - haproxy_process_current_ssl_rate
-      - haproxy_process_frontend_ssl_reuse
-      - haproxy_process_limit_ssl_rate
-      - haproxy_process_max_backend_ssl_key_rate
-      - haproxy_process_max_frontend_ssl_key_rate
-      - haproxy_process_max_ssl_connections
-      - haproxy_process_max_ssl_rate
-      - haproxy_process_ssl_cache_lookups_total
-      - haproxy_process_ssl_cache_misses_total
-      - haproxy_process_ssl_connections_total
-      charts:
-      - title: Current Backend SSL Key Rate
-        context: process_current_backend_ssl_key_rate
-        units: keys/s
-        dimensions:
-        - selector: haproxy_process_current_backend_ssl_key_rate
-          name: value
-      - title: Current Frontend SSL Key Rate
-        context: process_current_frontend_ssl_key_rate
-        units: keys/s
-        dimensions:
-        - selector: haproxy_process_current_frontend_ssl_key_rate
-          name: value
-      - title: Current SSL Connections
-        context: process_current_ssl_connections
-        units: connections
-        dimensions:
-        - selector: haproxy_process_current_ssl_connections
-          name: value
-      - title: Current SSL Rate
-        context: process_current_ssl_rate
-        units: connections/s
-        dimensions:
-        - selector: haproxy_process_current_ssl_rate
-          name: value
-      - title: Frontend SSL Reuse
-        context: process_frontend_ssl_reuse
-        units: percentage
-        dimensions:
-        - selector: haproxy_process_frontend_ssl_reuse
-          name: value
-      - title: Limit SSL Rate
-        context: process_limit_ssl_rate
-        units: connections/s
-        dimensions:
-        - selector: haproxy_process_limit_ssl_rate
-          name: value
-      - title: Max Backend SSL Key Rate
-        context: process_max_backend_ssl_key_rate
-        units: keys/s
-        dimensions:
-        - selector: haproxy_process_max_backend_ssl_key_rate
-          name: value
-      - title: Max Frontend SSL Key Rate
-        context: process_max_frontend_ssl_key_rate
-        units: keys/s
-        dimensions:
-        - selector: haproxy_process_max_frontend_ssl_key_rate
-          name: value
-      - title: Max SSL Connections
-        context: process_max_ssl_connections
-        units: connections
-        dimensions:
-        - selector: haproxy_process_max_ssl_connections
-          name: value
-      - title: Max SSL Rate
-        context: process_max_ssl_rate
-        units: connections/s
-        dimensions:
-        - selector: haproxy_process_max_ssl_rate
-          name: value
-      - title: SSL Cache Lookups
-        context: process_ssl_cache_lookups_total
-        units: lookups/s
-        dimensions:
-        - selector: haproxy_process_ssl_cache_lookups_total
-          name: value
-      - title: SSL Cache Misses
-        context: process_ssl_cache_misses_total
-        units: events/s
-        dimensions:
-        - selector: haproxy_process_ssl_cache_misses_total
-          name: value
-      - title: SSL Connections
-        context: process_ssl_connections_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_process_ssl_connections_total
-          name: value
-    - family: Scheduler
-      metrics:
-      - haproxy_process_connected_peers
-      - haproxy_process_current_tasks
-      - haproxy_process_jobs
-      - haproxy_process_listeners
-      - haproxy_process_unstoppable_jobs
-      charts:
-      - title: Connected Peers
-        context: process_connected_peers
-        units: peers
-        dimensions:
-        - selector: haproxy_process_connected_peers
-          name: value
-      - title: Current Tasks
-        context: process_current_tasks
-        units: tasks
-        dimensions:
-        - selector: haproxy_process_current_tasks
-          name: value
-      - title: Jobs
-        context: process_jobs
-        units: jobs
-        dimensions:
-        - selector: haproxy_process_jobs
-          name: value
-      - title: Listeners
-        context: process_listeners
-        units: listeners
-        dimensions:
-        - selector: haproxy_process_listeners
-          name: value
-      - title: Unstoppable Jobs
-        context: process_unstoppable_jobs
-        units: jobs
-        dimensions:
-        - selector: haproxy_process_unstoppable_jobs
-          name: value
-    - family: Sessions
-      metrics:
-      - haproxy_process_current_session_rate
-      - haproxy_process_limit_session_rate
-      - haproxy_process_max_session_rate
-      charts:
-      - title: Current Session Rate
-        context: process_current_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_process_current_session_rate
-          name: value
-      - title: Limit Session Rate
-        context: process_limit_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_process_limit_session_rate
-          name: value
-      - title: Max Session Rate
-        context: process_max_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_process_max_session_rate
-          name: value
-    - family: Status
-      metrics:
-      - haproxy_process_busy_polling_enabled
-      - haproxy_process_stopping
-      charts:
-      - title: Busy Polling Enabled
-        context: process_busy_polling_enabled
-        units: '{status}'
-        dimensions:
-        - selector: haproxy_process_busy_polling_enabled
-          name: value
-      - title: Stopping
-        context: process_stopping
-        units: '{status}'
-        dimensions:
-        - selector: haproxy_process_stopping
-          name: value
-    - family: Timing
-      metrics:
-      - haproxy_process_idle_time_percent
-      - haproxy_process_uptime_seconds
-      charts:
-      - title: Idle Time Percent
-        context: process_idle_time_percent
-        units: percentage
-        dimensions:
-        - selector: haproxy_process_idle_time_percent
-          name: value
-      - title: Uptime Seconds
-        context: process_uptime_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_process_uptime_seconds
-          name: value
-    - family: Traffic
-      metrics:
-      - haproxy_process_bytes_out_rate
-      - haproxy_process_bytes_out_total
-      - haproxy_process_http_comp_bytes_in_total
-      - haproxy_process_http_comp_bytes_out_total
-      - haproxy_process_spliced_bytes_out_total
-      charts:
-      - title: Bytes Out
-        context: process_bytes_out_total
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_process_bytes_out_total
-          name: value
-      - title: Bytes Out Rate
-        context: process_bytes_out_rate
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_process_bytes_out_rate
-          name: value
-      - title: HTTP Compression Bytes In
-        context: process_http_comp_bytes_in_total
-        units: bytes/s
-        algorithm: absolute
-        dimensions:
-        - selector: haproxy_process_http_comp_bytes_in_total
-          name: value
-      - title: HTTP Compression Bytes Out
-        context: process_http_comp_bytes_out_total
-        units: bytes/s
-        algorithm: absolute
-        dimensions:
-        - selector: haproxy_process_http_comp_bytes_out_total
-          name: value
-      - title: Spliced Bytes Out
-        context: process_spliced_bytes_out_total
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_process_spliced_bytes_out_total
-          name: value
-  - family: Frontends
-    chart_defaults:
-      instances:
-        by_labels:
-        - proxy
-    groups:
-    - family: Compression
-      metrics:
-      - haproxy_frontend_http_comp_responses_total
-      charts:
-      - title: HTTP Compression Responses
-        context: frontend_http_comp_responses_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_frontend_http_comp_responses_total
-          name: value
-    - family: Connections
-      metrics:
-      - haproxy_frontend_connections_rate_max
-      - haproxy_frontend_connections_total
-      - haproxy_frontend_denied_connections_total
-      charts:
-      - title: Connections
-        context: frontend_connections_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_frontend_connections_total
-          name: value
-      - title: Connections Rate Max
-        context: frontend_connections_rate_max
-        units: connections/s
-        dimensions:
-        - selector: haproxy_frontend_connections_rate_max
-          name: value
-      - title: Denied Connections
-        context: frontend_denied_connections_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_frontend_denied_connections_total
-          name: value
-    - family: Errors
-      metrics:
-      - haproxy_frontend_failed_header_rewriting_total
-      - haproxy_frontend_internal_errors_total
-      - haproxy_frontend_request_errors_total
-      - haproxy_frontend_requests_denied_total
-      - haproxy_frontend_responses_denied_total
-      charts:
-      - title: Errors
-        context: frontend_errors
-        units: errors/s
-        dimensions:
-        - selector: haproxy_frontend_request_errors_total
-          name: request
-        - selector: haproxy_frontend_failed_header_rewriting_total
-          name: header_rewriting
-        - selector: haproxy_frontend_internal_errors_total
-          name: internal
-      - title: Requests Denied
-        context: frontend_requests_denied_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_frontend_requests_denied_total
-          name: value
-      - title: Responses Denied
-        context: frontend_responses_denied_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_frontend_responses_denied_total
-          name: value
-    - family: HTTP
-      metrics:
-      - haproxy_frontend_http_cache_hits_total
-      - haproxy_frontend_http_cache_lookups_total
-      - haproxy_frontend_http_requests_rate_max
-      - haproxy_frontend_http_requests_total
-      - haproxy_frontend_http_responses_total
-      - haproxy_frontend_intercepted_requests_total
-      charts:
-      - title: HTTP Cache Hits
-        context: frontend_http_cache_hits_total
-        units: hits/s
-        dimensions:
-        - selector: haproxy_frontend_http_cache_hits_total
-          name: value
-      - title: HTTP Cache Lookups
-        context: frontend_http_cache_lookups_total
-        units: lookups/s
-        dimensions:
-        - selector: haproxy_frontend_http_cache_lookups_total
-          name: value
-      - title: HTTP Requests
-        context: frontend_http_requests_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_frontend_http_requests_total
-          name: value
-      - title: HTTP Requests Rate Max
-        context: frontend_http_requests_rate_max
-        units: requests/s
-        dimensions:
-        - selector: haproxy_frontend_http_requests_rate_max
-          name: value
-      - title: HTTP Responses
-        context: frontend_http_responses_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_frontend_http_responses_total
-          name_from_label: code
-      - title: Intercepted Requests
-        context: frontend_intercepted_requests_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_frontend_intercepted_requests_total
-          name: value
-    - family: Sessions
-      metrics:
-      - haproxy_frontend_current_session_rate
-      - haproxy_frontend_current_sessions
-      - haproxy_frontend_denied_sessions_total
-      - haproxy_frontend_limit_session_rate
-      - haproxy_frontend_limit_sessions
-      - haproxy_frontend_max_session_rate
-      - haproxy_frontend_max_sessions
-      - haproxy_frontend_sessions_total
-      charts:
-      - title: Current Session Rate
-        context: frontend_current_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_frontend_current_session_rate
-          name: value
-      - title: Current Sessions
-        context: frontend_current_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_frontend_current_sessions
-          name: value
-      - title: Denied Sessions
-        context: frontend_denied_sessions_total
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_frontend_denied_sessions_total
-          name: value
-      - title: Limit Session Rate
-        context: frontend_limit_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_frontend_limit_session_rate
-          name: value
-      - title: Limit Sessions
-        context: frontend_limit_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_frontend_limit_sessions
-          name: value
-      - title: Max Session Rate
-        context: frontend_max_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_frontend_max_session_rate
-          name: value
-      - title: Max Sessions
-        context: frontend_max_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_frontend_max_sessions
-          name: value
-      - title: Sessions
-        context: frontend_sessions_total
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_frontend_sessions_total
-          name: value
-    - family: Status
-      metrics:
-      - haproxy_frontend_status
-      charts:
-      - title: Status
-        context: frontend_status
-        units: '{status}'
-        dimensions:
-        - selector: haproxy_frontend_status
-          name_from_label: state
-    - family: Traffic
-      metrics:
-      - haproxy_frontend_bytes_in_total
-      - haproxy_frontend_bytes_out_total
-      - haproxy_frontend_http_comp_bytes_bypassed_total
-      - haproxy_frontend_http_comp_bytes_in_total
-      - haproxy_frontend_http_comp_bytes_out_total
-      charts:
-      - title: HTTP Compression Bytes Bypassed
-        context: frontend_http_comp_bytes_bypassed_total
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_frontend_http_comp_bytes_bypassed_total
-          name: value
-      - title: HTTP Compression Bytes In
-        context: frontend_http_comp_bytes_in_total
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_frontend_http_comp_bytes_in_total
-          name: value
-      - title: HTTP Compression Bytes Out
-        context: frontend_http_comp_bytes_out_total
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_frontend_http_comp_bytes_out_total
-          name: value
-      - title: Traffic
-        context: frontend_traffic
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_frontend_bytes_in_total
-          name: in
-        - selector: haproxy_frontend_bytes_out_total
-          name: out
-  - family: Listeners
-    chart_defaults:
-      instances:
-        by_labels:
-        - proxy
-        - listener
-    groups:
-    - family: Connections
-      metrics:
-      - haproxy_listener_connections_total
-      - haproxy_listener_denied_connections_total
-      charts:
-      - title: Connections
-        context: listener_connections_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_listener_connections_total
-          name: value
-      - title: Denied Connections
-        context: listener_denied_connections_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_listener_denied_connections_total
-          name: value
-    - family: Errors
-      metrics:
-      - haproxy_listener_failed_header_rewriting_total
-      - haproxy_listener_internal_errors_total
-      - haproxy_listener_request_errors_total
-      - haproxy_listener_requests_denied_total
-      - haproxy_listener_responses_denied_total
-      charts:
-      - title: Errors
-        context: listener_errors
-        units: errors/s
-        dimensions:
-        - selector: haproxy_listener_request_errors_total
-          name: request
-        - selector: haproxy_listener_failed_header_rewriting_total
-          name: header_rewriting
-        - selector: haproxy_listener_internal_errors_total
-          name: internal
-      - title: Requests Denied
-        context: listener_requests_denied_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_listener_requests_denied_total
-          name: value
-      - title: Responses Denied
-        context: listener_responses_denied_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_listener_responses_denied_total
-          name: value
-    - family: Sessions
-      metrics:
-      - haproxy_listener_current_sessions
-      - haproxy_listener_denied_sessions_total
-      - haproxy_listener_limit_sessions
-      - haproxy_listener_max_sessions
-      - haproxy_listener_sessions_total
-      charts:
-      - title: Current Sessions
-        context: listener_current_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_listener_current_sessions
-          name: value
-      - title: Denied Sessions
-        context: listener_denied_sessions_total
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_listener_denied_sessions_total
-          name: value
-      - title: Limit Sessions
-        context: listener_limit_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_listener_limit_sessions
-          name: value
-      - title: Max Sessions
-        context: listener_max_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_listener_max_sessions
-          name: value
-      - title: Sessions
-        context: listener_sessions_total
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_listener_sessions_total
-          name: value
-    - family: Status
-      metrics:
-      - haproxy_listener_status
-      charts:
-      - title: Status
-        context: listener_status
-        units: '{status}'
-        dimensions:
-        - selector: haproxy_listener_status
-          name_from_label: state
-    - family: Traffic
-      metrics:
-      - haproxy_listener_bytes_in_total
-      - haproxy_listener_bytes_out_total
-      charts:
-      - title: Traffic
-        context: listener_traffic
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_listener_bytes_in_total
-          name: in
-        - selector: haproxy_listener_bytes_out_total
-          name: out
-  - family: Backends
-    chart_defaults:
-      instances:
-        by_labels:
-        - proxy
-    groups:
-    - family: Compression
-      metrics:
-      - haproxy_backend_http_comp_responses_total
-      charts:
-      - title: HTTP Compression Responses
-        context: backend_http_comp_responses_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_backend_http_comp_responses_total
-          name: value
-    - family: Connections
-      metrics:
-      - haproxy_backend_connection_attempts_total
-      - haproxy_backend_connection_reuses_total
-      charts:
-      - title: Connection Attempts
-        context: backend_connection_attempts_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_backend_connection_attempts_total
-          name: value
-      - title: Connection Reuses
-        context: backend_connection_reuses_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_backend_connection_reuses_total
-          name: value
-    - family: Errors
-      metrics:
-      - haproxy_backend_client_aborts_total
-      - haproxy_backend_connection_errors_total
-      - haproxy_backend_failed_header_rewriting_total
-      - haproxy_backend_internal_errors_total
-      - haproxy_backend_redispatch_warnings_total
-      - haproxy_backend_requests_denied_total
-      - haproxy_backend_response_errors_total
-      - haproxy_backend_responses_denied_total
-      - haproxy_backend_retry_warnings_total
-      - haproxy_backend_server_aborts_total
-      charts:
-      - title: Aborts
-        context: backend_aborts
-        units: aborts/s
-        dimensions:
-        - selector: haproxy_backend_client_aborts_total
-          name: client
-        - selector: haproxy_backend_server_aborts_total
-          name: server
-      - title: Errors
-        context: backend_errors
-        units: errors/s
-        dimensions:
-        - selector: haproxy_backend_response_errors_total
-          name: response
-        - selector: haproxy_backend_connection_errors_total
-          name: connection
-        - selector: haproxy_backend_failed_header_rewriting_total
-          name: header_rewriting
-        - selector: haproxy_backend_internal_errors_total
-          name: internal
-      - title: Requests Denied
-        context: backend_requests_denied_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_backend_requests_denied_total
-          name: value
-      - title: Responses Denied
-        context: backend_responses_denied_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_backend_responses_denied_total
-          name: value
-      - title: Warnings
-        context: backend_warnings
-        units: warnings/s
-        dimensions:
-        - selector: haproxy_backend_retry_warnings_total
-          name: retry
-        - selector: haproxy_backend_redispatch_warnings_total
-          name: redispatch
-    - family: HTTP
-      metrics:
-      - haproxy_backend_http_cache_hits_total
-      - haproxy_backend_http_cache_lookups_total
-      - haproxy_backend_http_requests_total
-      - haproxy_backend_http_responses_total
-      charts:
-      - title: HTTP Cache Hits
-        context: backend_http_cache_hits_total
-        units: hits/s
-        dimensions:
-        - selector: haproxy_backend_http_cache_hits_total
-          name: value
-      - title: HTTP Cache Lookups
-        context: backend_http_cache_lookups_total
-        units: lookups/s
-        dimensions:
-        - selector: haproxy_backend_http_cache_lookups_total
-          name: value
-      - title: HTTP Requests
-        context: backend_http_requests_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_backend_http_requests_total
-          name: value
-      - title: HTTP Responses
-        context: backend_http_responses_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_backend_http_responses_total
-          name_from_label: code
-    - family: Health
-      metrics:
-      - haproxy_backend_active_servers
-      - haproxy_backend_backup_servers
-      - haproxy_backend_check_last_change_seconds
-      - haproxy_backend_check_up_down_total
-      - haproxy_backend_downtime_seconds_total
-      - haproxy_backend_loadbalanced_total
-      - haproxy_backend_uweight
-      - haproxy_backend_weight
-      charts:
-      - title: Available Servers
-        context: backend_servers
-        units: servers
-        dimensions:
-        - selector: haproxy_backend_active_servers
-          name: active
-        - selector: haproxy_backend_backup_servers
-          name: backup
-      - title: Check Last Change Seconds
-        context: backend_check_last_change_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_check_last_change_seconds
-          name: value
-      - title: Downtime Seconds
-        context: backend_downtime_seconds_total
-        units: seconds/s
-        dimensions:
-        - selector: haproxy_backend_downtime_seconds_total
-          name: value
-      - title: Failed Check State Transitions
-        context: backend_check_up_down_total
-        units: transitions/s
-        dimensions:
-        - selector: haproxy_backend_check_up_down_total
-          name: value
-      - title: Load-Balanced Requests
-        context: backend_loadbalanced_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_backend_loadbalanced_total
-          name: value
-      - title: User Weight
-        context: backend_uweight
-        units: weight
-        dimensions:
-        - selector: haproxy_backend_uweight
-          name: value
-      - title: Weight
-        context: backend_weight
-        units: weight
-        dimensions:
-        - selector: haproxy_backend_weight
-          name: value
-    - family: Queue
-      metrics:
-      - haproxy_backend_current_queue
-      - haproxy_backend_max_queue
-      - haproxy_backend_max_queue_time_seconds
-      - haproxy_backend_queue_time_average_seconds
-      charts:
-      - title: Current Queue
-        context: backend_current_queue
-        units: requests
-        dimensions:
-        - selector: haproxy_backend_current_queue
-          name: value
-      - title: Max Queue
-        context: backend_max_queue
-        units: requests
-        dimensions:
-        - selector: haproxy_backend_max_queue
-          name: value
-      - title: Max Queue Time Seconds
-        context: backend_max_queue_time_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_max_queue_time_seconds
-          name: value
-      - title: Queue Time Average Seconds
-        context: backend_queue_time_average_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_queue_time_average_seconds
-          name: value
-    - family: Sessions
-      metrics:
-      - haproxy_backend_current_session_rate
-      - haproxy_backend_current_sessions
-      - haproxy_backend_last_session_seconds
-      - haproxy_backend_limit_sessions
-      - haproxy_backend_max_session_rate
-      - haproxy_backend_max_sessions
-      - haproxy_backend_sessions_total
-      charts:
-      - title: Current Session Rate
-        context: backend_current_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_backend_current_session_rate
-          name: value
-      - title: Current Sessions
-        context: backend_current_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_backend_current_sessions
-          name: value
-      - title: Last Session Seconds
-        context: backend_last_session_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_last_session_seconds
-          name: value
-      - title: Limit Sessions
-        context: backend_limit_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_backend_limit_sessions
-          name: value
-      - title: Max Session Rate
-        context: backend_max_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_backend_max_session_rate
-          name: value
-      - title: Max Sessions
-        context: backend_max_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_backend_max_sessions
-          name: value
-      - title: Sessions
-        context: backend_sessions_total
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_backend_sessions_total
-          name: value
-    - family: Status
-      metrics:
-      - haproxy_backend_agg_check_status
-      - haproxy_backend_agg_server_status
-      - haproxy_backend_status
-      charts:
-      - title: Aggregated Check Status
-        context: backend_agg_check_status
-        units: servers
-        dimensions:
-        - selector: haproxy_backend_agg_check_status
-          name_from_label: state
-      - title: Aggregated Server Status
-        context: backend_agg_server_status
-        units: servers
-        dimensions:
-        - selector: haproxy_backend_agg_server_status
-          name_from_label: state
-      - title: Status
-        context: backend_status
-        units: '{status}'
-        dimensions:
-        - selector: haproxy_backend_status
-          name_from_label: state
-    - family: Timing
-      metrics:
-      - haproxy_backend_connect_time_average_seconds
-      - haproxy_backend_max_connect_time_seconds
-      - haproxy_backend_max_response_time_seconds
-      - haproxy_backend_max_total_time_seconds
-      - haproxy_backend_response_time_average_seconds
-      - haproxy_backend_total_time_average_seconds
-      charts:
-      - title: Average Total Time
-        context: backend_total_time_average_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_total_time_average_seconds
-          name: value
-      - title: Connect Time Average Seconds
-        context: backend_connect_time_average_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_connect_time_average_seconds
-          name: value
-      - title: Max Connect Time Seconds
-        context: backend_max_connect_time_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_max_connect_time_seconds
-          name: value
-      - title: Max Response Time Seconds
-        context: backend_max_response_time_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_max_response_time_seconds
-          name: value
-      - title: Maximum Total Time
-        context: backend_max_total_time_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_max_total_time_seconds
-          name: value
-      - title: Response Time Average Seconds
-        context: backend_response_time_average_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_backend_response_time_average_seconds
-          name: value
-    - family: Traffic
-      metrics:
-      - haproxy_backend_bytes_in_total
-      - haproxy_backend_bytes_out_total
-      - haproxy_backend_http_comp_bytes_bypassed_total
-      - haproxy_backend_http_comp_bytes_in_total
-      - haproxy_backend_http_comp_bytes_out_total
-      charts:
-      - title: HTTP Compression Bytes Bypassed
-        context: backend_http_comp_bytes_bypassed_total
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_backend_http_comp_bytes_bypassed_total
-          name: value
-      - title: HTTP Compression Bytes In
-        context: backend_http_comp_bytes_in_total
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_backend_http_comp_bytes_in_total
-          name: value
-      - title: HTTP Compression Bytes Out
-        context: backend_http_comp_bytes_out_total
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_backend_http_comp_bytes_out_total
-          name: value
-      - title: Traffic
-        context: backend_traffic
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_backend_bytes_in_total
-          name: in
-        - selector: haproxy_backend_bytes_out_total
-          name: out
-  - family: Servers
-    chart_defaults:
-      instances:
-        by_labels:
-        - proxy
-        - server
-    groups:
-    - family: Connections
-      metrics:
-      - haproxy_server_connection_attempts_total
-      - haproxy_server_connection_reuses_total
-      - haproxy_server_idle_connections_current
-      - haproxy_server_idle_connections_limit
-      - haproxy_server_need_connections_current
-      - haproxy_server_safe_idle_connections_current
-      - haproxy_server_unsafe_idle_connections_current
-      - haproxy_server_used_connections_current
-      charts:
-      - title: Connection Attempts
-        context: server_connection_attempts_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_server_connection_attempts_total
-          name: value
-      - title: Connection Reuses
-        context: server_connection_reuses_total
-        units: connections/s
-        dimensions:
-        - selector: haproxy_server_connection_reuses_total
-          name: value
-      - title: Current Idle Connections
-        context: server_idle_connections_current
-        units: connections
-        dimensions:
-        - selector: haproxy_server_idle_connections_current
-          name: value
-      - title: Current Used Connections
-        context: server_used_connections_current
-        units: connections
-        dimensions:
-        - selector: haproxy_server_used_connections_current
-          name: value
-      - title: Idle Connection Limit
-        context: server_idle_connections_limit
-        units: connections
-        dimensions:
-        - selector: haproxy_server_idle_connections_limit
-          name: value
-      - title: Idle Connection Safety
-        context: server_idle_connection_safety
-        units: connections
-        dimensions:
-        - selector: haproxy_server_safe_idle_connections_current
-          name: safe
-        - selector: haproxy_server_unsafe_idle_connections_current
-          name: unsafe
-      - title: Needed Connections
-        context: server_need_connections_current
-        units: connections
-        dimensions:
-        - selector: haproxy_server_need_connections_current
-          name: value
-    - family: Errors
-      metrics:
-      - haproxy_server_check_failures_total
-      - haproxy_server_client_aborts_total
-      - haproxy_server_connection_errors_total
-      - haproxy_server_failed_header_rewriting_total
-      - haproxy_server_internal_errors_total
-      - haproxy_server_redispatch_warnings_total
-      - haproxy_server_response_errors_total
-      - haproxy_server_responses_denied_total
-      - haproxy_server_retry_warnings_total
-      - haproxy_server_server_aborts_total
-      charts:
-      - title: Aborts
-        context: server_aborts
-        units: aborts/s
-        dimensions:
-        - selector: haproxy_server_client_aborts_total
-          name: client
-        - selector: haproxy_server_server_aborts_total
-          name: server
-      - title: Check Failures
-        context: server_check_failures_total
-        units: failures/s
-        dimensions:
-        - selector: haproxy_server_check_failures_total
-          name: value
-      - title: Errors
-        context: server_errors
-        units: errors/s
-        dimensions:
-        - selector: haproxy_server_response_errors_total
-          name: response
-        - selector: haproxy_server_connection_errors_total
-          name: connection
-        - selector: haproxy_server_failed_header_rewriting_total
-          name: header_rewriting
-        - selector: haproxy_server_internal_errors_total
-          name: internal
-      - title: Responses Denied
-        context: server_responses_denied_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_server_responses_denied_total
-          name: value
-      - title: Warnings
-        context: server_warnings
-        units: warnings/s
-        dimensions:
-        - selector: haproxy_server_retry_warnings_total
-          name: retry
-        - selector: haproxy_server_redispatch_warnings_total
-          name: redispatch
-    - family: HTTP
-      metrics:
-      - haproxy_server_http_requests_total
-      - haproxy_server_http_responses_total
-      charts:
-      - title: HTTP Requests
-        context: server_http_requests_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_server_http_requests_total
-          name: value
-      - title: HTTP Responses
-        context: server_http_responses_total
-        units: responses/s
-        dimensions:
-        - selector: haproxy_server_http_responses_total
-          name_from_label: code
-    - family: Health
-      metrics:
-      - haproxy_server_active
-      - haproxy_server_agent_code
-      - haproxy_server_agent_duration_seconds
-      - haproxy_server_backup
-      - haproxy_server_check_code
-      - haproxy_server_check_duration_seconds
-      - haproxy_server_check_last_change_seconds
-      - haproxy_server_check_up_down_total
-      - haproxy_server_current_throttle
-      - haproxy_server_downtime_seconds_total
-      - haproxy_server_loadbalanced_total
-      - haproxy_server_uweight
-      - haproxy_server_weight
-      charts:
-      - title: Agent Code
-        context: server_agent_code
-        units: code
-        dimensions:
-        - selector: haproxy_server_agent_code
-          name: value
-      - title: Agent Duration Seconds
-        context: server_agent_duration_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_agent_duration_seconds
-          name: value
-      - title: Check Code
-        context: server_check_code
-        units: code
-        dimensions:
-        - selector: haproxy_server_check_code
-          name: value
-      - title: Check Duration Seconds
-        context: server_check_duration_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_check_duration_seconds
-          name: value
-      - title: Check Last Change Seconds
-        context: server_check_last_change_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_check_last_change_seconds
-          name: value
-      - title: Current Throttle
-        context: server_current_throttle
-        units: percentage
-        dimensions:
-        - selector: haproxy_server_current_throttle
-          name: value
-      - title: Downtime Seconds
-        context: server_downtime_seconds_total
-        units: seconds/s
-        dimensions:
-        - selector: haproxy_server_downtime_seconds_total
-          name: value
-      - title: Failed Check State Transitions
-        context: server_check_up_down_total
-        units: transitions/s
-        dimensions:
-        - selector: haproxy_server_check_up_down_total
-          name: value
-      - title: Load-Balanced Requests
-        context: server_loadbalanced_total
-        units: requests/s
-        dimensions:
-        - selector: haproxy_server_loadbalanced_total
-          name: value
-      - title: Server Role
-        context: server_role
-        units: servers
-        dimensions:
-        - selector: haproxy_server_active
-          name: active
-        - selector: haproxy_server_backup
-          name: backup
-      - title: User Weight
-        context: server_uweight
-        units: weight
-        dimensions:
-        - selector: haproxy_server_uweight
-          name: value
-      - title: Weight
-        context: server_weight
-        units: weight
-        dimensions:
-        - selector: haproxy_server_weight
-          name: value
-    - family: Queue
-      metrics:
-      - haproxy_server_current_queue
-      - haproxy_server_max_queue
-      - haproxy_server_max_queue_time_seconds
-      - haproxy_server_queue_limit
-      - haproxy_server_queue_time_average_seconds
-      charts:
-      - title: Current Queue
-        context: server_current_queue
-        units: requests
-        dimensions:
-        - selector: haproxy_server_current_queue
-          name: value
-      - title: Max Queue
-        context: server_max_queue
-        units: requests
-        dimensions:
-        - selector: haproxy_server_max_queue
-          name: value
-      - title: Max Queue Time Seconds
-        context: server_max_queue_time_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_max_queue_time_seconds
-          name: value
-      - title: Queue Limit
-        context: server_queue_limit
-        units: requests
-        dimensions:
-        - selector: haproxy_server_queue_limit
-          name: value
-      - title: Queue Time Average Seconds
-        context: server_queue_time_average_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_queue_time_average_seconds
-          name: value
-    - family: Sessions
-      metrics:
-      - haproxy_server_current_session_rate
-      - haproxy_server_current_sessions
-      - haproxy_server_last_session_seconds
-      - haproxy_server_limit_sessions
-      - haproxy_server_max_session_rate
-      - haproxy_server_max_sessions
-      - haproxy_server_sessions_total
-      charts:
-      - title: Current Session Rate
-        context: server_current_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_server_current_session_rate
-          name: value
-      - title: Current Sessions
-        context: server_current_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_server_current_sessions
-          name: value
-      - title: Last Session Seconds
-        context: server_last_session_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_last_session_seconds
-          name: value
-      - title: Limit Sessions
-        context: server_limit_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_server_limit_sessions
-          name: value
-      - title: Max Session Rate
-        context: server_max_session_rate
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_server_max_session_rate
-          name: value
-      - title: Max Sessions
-        context: server_max_sessions
-        units: sessions
-        dimensions:
-        - selector: haproxy_server_max_sessions
-          name: value
-      - title: Sessions
-        context: server_sessions_total
-        units: sessions/s
-        dimensions:
-        - selector: haproxy_server_sessions_total
-          name: value
-    - family: Status
-      metrics:
-      - haproxy_server_agent_status
-      - haproxy_server_check_status
-      - haproxy_server_status
-      charts:
-      - title: Agent Status
-        context: server_agent_status
-        units: '{status}'
-        dimensions:
-        - selector: haproxy_server_agent_status
-          name_from_label: state
-      - title: Check Status
-        context: server_check_status
-        units: '{status}'
-        dimensions:
-        - selector: haproxy_server_check_status
-          name_from_label: state
-      - title: Status
-        context: server_status
-        units: '{status}'
-        dimensions:
-        - selector: haproxy_server_status
-          name_from_label: state
-    - family: Timing
-      metrics:
-      - haproxy_server_connect_time_average_seconds
-      - haproxy_server_max_connect_time_seconds
-      - haproxy_server_max_response_time_seconds
-      - haproxy_server_max_total_time_seconds
-      - haproxy_server_response_time_average_seconds
-      - haproxy_server_total_time_average_seconds
-      charts:
-      - title: Average Total Time
-        context: server_total_time_average_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_total_time_average_seconds
-          name: value
-      - title: Connect Time Average Seconds
-        context: server_connect_time_average_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_connect_time_average_seconds
-          name: value
-      - title: Max Connect Time Seconds
-        context: server_max_connect_time_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_max_connect_time_seconds
-          name: value
-      - title: Max Response Time Seconds
-        context: server_max_response_time_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_max_response_time_seconds
-          name: value
-      - title: Maximum Total Time
-        context: server_max_total_time_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_max_total_time_seconds
-          name: value
-      - title: Response Time Average Seconds
-        context: server_response_time_average_seconds
-        units: seconds
-        dimensions:
-        - selector: haproxy_server_response_time_average_seconds
-          name: value
-    - family: Traffic
-      metrics:
-      - haproxy_server_bytes_in_total
-      - haproxy_server_bytes_out_total
-      charts:
-      - title: Traffic
-        context: server_traffic
-        units: bytes/s
-        dimensions:
-        - selector: haproxy_server_bytes_in_total
-          name: in
-        - selector: haproxy_server_bytes_out_total
-          name: out
-  - family: Resolvers
-    chart_defaults:
-      instances:
-        by_labels:
-        - resolver
-        - nameserver
-    groups:
-    - family: DNS
-      metrics:
-      - haproxy_resolver_any_err
-      - haproxy_resolver_cname
-      - haproxy_resolver_cname_error
-      - haproxy_resolver_invalid
-      - haproxy_resolver_nx
-      - haproxy_resolver_other
-      - haproxy_resolver_outdated
-      - haproxy_resolver_refused
-      - haproxy_resolver_send_error
-      - haproxy_resolver_sent
-      - haproxy_resolver_timeout
-      - haproxy_resolver_too_big
-      - haproxy_resolver_truncated
-      - haproxy_resolver_update
-      - haproxy_resolver_valid
-      charts:
-      - title: Any Errors
-        context: resolver_any_err
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_any_err
-          name: value
-      - title: CNAME
-        context: resolver_cname
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_cname
-          name: value
-      - title: CNAME Error
-        context: resolver_cname_error
-        units: errors/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_cname_error
-          name: value
-      - title: Invalid
-        context: resolver_invalid
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_invalid
-          name: value
-      - title: NX
-        context: resolver_nx
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_nx
-          name: value
-      - title: Other
-        context: resolver_other
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_other
-          name: value
-      - title: Outdated
-        context: resolver_outdated
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_outdated
-          name: value
-      - title: Refused
-        context: resolver_refused
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_refused
-          name: value
-      - title: Send Error
-        context: resolver_send_error
-        units: errors/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_send_error
-          name: value
-      - title: Sent
-        context: resolver_sent
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_sent
-          name: value
-      - title: Timeout
-        context: resolver_timeout
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_timeout
-          name: value
-      - title: Too Big
-        context: resolver_too_big
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_too_big
-          name: value
-      - title: Truncated
-        context: resolver_truncated
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_truncated
-          name: value
-      - title: Update
-        context: resolver_update
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_update
-          name: value
-      - title: Valid
-        context: resolver_valid
-        units: queries/s
-        algorithm: incremental
-        dimensions:
-        - selector: haproxy_resolver_valid
-          name: value
-  - family: Stick Tables
-    chart_defaults:
-      instances:
-        by_labels:
-        - name
-        - type
-    groups:
-    - family: Entries
-      metrics:
-      - haproxy_sticktable_size
-      - haproxy_sticktable_used
-      charts:
-      - title: Size
-        context: sticktable_size
-        units: entries
-        dimensions:
-        - selector: haproxy_sticktable_size
-          name: value
-      - title: Used
-        context: sticktable_used
-        units: entries
-        dimensions:
-        - selector: haproxy_sticktable_used
-          name: value
+    - family: Process
+      groups:
+        - family: Activity
+          metrics:
+            - haproxy_process_nbproc
+            - haproxy_process_nbthread
+            - haproxy_process_recv_logs_total
+            - haproxy_process_relative_process_id
+            - haproxy_process_requests_total
+          charts:
+            - title: Received Logs
+              context: process_recv_logs_total
+              units: logs/s
+              dimensions:
+                - selector: haproxy_process_recv_logs_total
+                  name: value
+            - title: Relative Process ID
+              context: process_relative_process_id
+              units: process id
+              dimensions:
+                - selector: haproxy_process_relative_process_id
+                  name: value
+            - title: Requests
+              context: process_requests_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_process_requests_total
+                  name: value
+            - title: Threads
+              context: process_nbthread
+              units: threads
+              dimensions:
+                - selector: haproxy_process_nbthread
+                  name: value
+            - title: Worker Processes
+              context: process_nbproc
+              units: processes
+              dimensions:
+                - selector: haproxy_process_nbproc
+                  name: value
+        - family: Compression
+          metrics:
+            - haproxy_process_current_zlib_memory
+            - haproxy_process_limit_http_comp
+            - haproxy_process_max_zlib_memory
+          charts:
+            - title: Current Zlib Memory
+              context: process_current_zlib_memory
+              units: bytes
+              dimensions:
+                - selector: haproxy_process_current_zlib_memory
+                  name: value
+            - title: HTTP Compression Limit
+              context: process_limit_http_comp
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_process_limit_http_comp
+                  name: value
+            - title: Max Zlib Memory
+              context: process_max_zlib_memory
+              units: bytes
+              dimensions:
+                - selector: haproxy_process_max_zlib_memory
+                  name: value
+        - family: Connections
+          metrics:
+            - haproxy_process_connections_total
+            - haproxy_process_current_connection_rate
+            - haproxy_process_current_connections
+            - haproxy_process_hard_max_connections
+            - haproxy_process_limit_connection_rate
+            - haproxy_process_max_connection_rate
+            - haproxy_process_max_connections
+            - haproxy_process_max_fds
+            - haproxy_process_max_pipes
+            - haproxy_process_max_sockets
+            - haproxy_process_pipes_free_total
+            - haproxy_process_pipes_used_total
+          charts:
+            - title: Connections
+              context: process_connections_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_process_connections_total
+                  name: value
+            - title: Current Connection Rate
+              context: process_current_connection_rate
+              units: connections/s
+              dimensions:
+                - selector: haproxy_process_current_connection_rate
+                  name: value
+            - title: Current Connections
+              context: process_current_connections
+              units: connections
+              dimensions:
+                - selector: haproxy_process_current_connections
+                  name: value
+            - title: Hard Max Connections
+              context: process_hard_max_connections
+              units: connections
+              dimensions:
+                - selector: haproxy_process_hard_max_connections
+                  name: value
+            - title: Limit Connection Rate
+              context: process_limit_connection_rate
+              units: connections/s
+              dimensions:
+                - selector: haproxy_process_limit_connection_rate
+                  name: value
+            - title: Max Connection Rate
+              context: process_max_connection_rate
+              units: connections/s
+              dimensions:
+                - selector: haproxy_process_max_connection_rate
+                  name: value
+            - title: Max Connections
+              context: process_max_connections
+              units: connections
+              dimensions:
+                - selector: haproxy_process_max_connections
+                  name: value
+            - title: Max FDs
+              context: process_max_fds
+              units: file descriptors
+              dimensions:
+                - selector: haproxy_process_max_fds
+                  name: value
+            - title: Max Pipes
+              context: process_max_pipes
+              units: pipes
+              dimensions:
+                - selector: haproxy_process_max_pipes
+                  name: value
+            - title: Max Sockets
+              context: process_max_sockets
+              units: sockets
+              dimensions:
+                - selector: haproxy_process_max_sockets
+                  name: value
+            - title: Pipes
+              context: process_pipes
+              units: pipes
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_pipes_used_total
+                  name: used
+                - selector: haproxy_process_pipes_free_total
+                  name: free
+        - family: Errors
+          metrics:
+            - haproxy_process_dropped_logs_total
+            - haproxy_process_failed_resolutions
+            - haproxy_process_total_warnings
+          charts:
+            - title: Dropped Logs
+              context: process_dropped_logs_total
+              units: logs/s
+              dimensions:
+                - selector: haproxy_process_dropped_logs_total
+                  name: value
+            - title: Failed Resolutions
+              context: process_failed_resolutions
+              units: errors/s
+              dimensions:
+                - selector: haproxy_process_failed_resolutions
+                  name: value
+            - title: Warnings
+              context: process_total_warnings
+              units: warnings/s
+              dimensions:
+                - selector: haproxy_process_total_warnings
+                  name: value
+        - family: Health
+          metrics:
+            - haproxy_process_active_peers
+          charts:
+            - title: Active Peers
+              context: process_active_peers
+              units: peers
+              dimensions:
+                - selector: haproxy_process_active_peers
+                  name: value
+        - family: Memory
+          metrics:
+            - haproxy_process_max_memory_bytes
+            - haproxy_process_pool_allocated_bytes
+            - haproxy_process_pool_failures_total
+            - haproxy_process_pool_used_bytes
+          charts:
+            - title: Max Memory Bytes
+              context: process_max_memory_bytes
+              units: bytes
+              dimensions:
+                - selector: haproxy_process_max_memory_bytes
+                  name: value
+            - title: Pool Allocated Bytes
+              context: process_pool_allocated_bytes
+              units: bytes
+              dimensions:
+                - selector: haproxy_process_pool_allocated_bytes
+                  name: value
+            - title: Pool Failures
+              context: process_pool_failures_total
+              units: failures/s
+              dimensions:
+                - selector: haproxy_process_pool_failures_total
+                  name: value
+            - title: Pool Used Bytes
+              context: process_pool_used_bytes
+              units: bytes
+              dimensions:
+                - selector: haproxy_process_pool_used_bytes
+                  name: value
+        - family: Queue
+          metrics:
+            - haproxy_process_current_run_queue
+          charts:
+            - title: Current Run Queue
+              context: process_current_run_queue
+              units: tasks
+              dimensions:
+                - selector: haproxy_process_current_run_queue
+                  name: value
+        - family: SSL
+          metrics:
+            - haproxy_process_current_backend_ssl_key_rate
+            - haproxy_process_current_frontend_ssl_key_rate
+            - haproxy_process_current_ssl_connections
+            - haproxy_process_current_ssl_rate
+            - haproxy_process_frontend_ssl_reuse
+            - haproxy_process_limit_ssl_rate
+            - haproxy_process_max_backend_ssl_key_rate
+            - haproxy_process_max_frontend_ssl_key_rate
+            - haproxy_process_max_ssl_connections
+            - haproxy_process_max_ssl_rate
+            - haproxy_process_ssl_cache_lookups_total
+            - haproxy_process_ssl_cache_misses_total
+            - haproxy_process_ssl_connections_total
+          charts:
+            - title: Current Backend SSL Key Rate
+              context: process_current_backend_ssl_key_rate
+              units: keys/s
+              dimensions:
+                - selector: haproxy_process_current_backend_ssl_key_rate
+                  name: value
+            - title: Current Frontend SSL Key Rate
+              context: process_current_frontend_ssl_key_rate
+              units: keys/s
+              dimensions:
+                - selector: haproxy_process_current_frontend_ssl_key_rate
+                  name: value
+            - title: Current SSL Connections
+              context: process_current_ssl_connections
+              units: connections
+              dimensions:
+                - selector: haproxy_process_current_ssl_connections
+                  name: value
+            - title: Current SSL Rate
+              context: process_current_ssl_rate
+              units: connections/s
+              dimensions:
+                - selector: haproxy_process_current_ssl_rate
+                  name: value
+            - title: Frontend SSL Reuse
+              context: process_frontend_ssl_reuse
+              units: percentage
+              dimensions:
+                - selector: haproxy_process_frontend_ssl_reuse
+                  name: value
+            - title: Limit SSL Rate
+              context: process_limit_ssl_rate
+              units: connections/s
+              dimensions:
+                - selector: haproxy_process_limit_ssl_rate
+                  name: value
+            - title: Max Backend SSL Key Rate
+              context: process_max_backend_ssl_key_rate
+              units: keys/s
+              dimensions:
+                - selector: haproxy_process_max_backend_ssl_key_rate
+                  name: value
+            - title: Max Frontend SSL Key Rate
+              context: process_max_frontend_ssl_key_rate
+              units: keys/s
+              dimensions:
+                - selector: haproxy_process_max_frontend_ssl_key_rate
+                  name: value
+            - title: Max SSL Connections
+              context: process_max_ssl_connections
+              units: connections
+              dimensions:
+                - selector: haproxy_process_max_ssl_connections
+                  name: value
+            - title: Max SSL Rate
+              context: process_max_ssl_rate
+              units: connections/s
+              dimensions:
+                - selector: haproxy_process_max_ssl_rate
+                  name: value
+            - title: SSL Cache Lookups
+              context: process_ssl_cache_lookups_total
+              units: lookups/s
+              dimensions:
+                - selector: haproxy_process_ssl_cache_lookups_total
+                  name: value
+            - title: SSL Cache Misses
+              context: process_ssl_cache_misses_total
+              units: events/s
+              dimensions:
+                - selector: haproxy_process_ssl_cache_misses_total
+                  name: value
+            - title: SSL Connections
+              context: process_ssl_connections_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_process_ssl_connections_total
+                  name: value
+        - family: Scheduler
+          metrics:
+            - haproxy_process_connected_peers
+            - haproxy_process_current_tasks
+            - haproxy_process_jobs
+            - haproxy_process_listeners
+            - haproxy_process_unstoppable_jobs
+          charts:
+            - title: Connected Peers
+              context: process_connected_peers
+              units: peers
+              dimensions:
+                - selector: haproxy_process_connected_peers
+                  name: value
+            - title: Current Tasks
+              context: process_current_tasks
+              units: tasks
+              dimensions:
+                - selector: haproxy_process_current_tasks
+                  name: value
+            - title: Jobs
+              context: process_jobs
+              units: jobs
+              dimensions:
+                - selector: haproxy_process_jobs
+                  name: value
+            - title: Listeners
+              context: process_listeners
+              units: listeners
+              dimensions:
+                - selector: haproxy_process_listeners
+                  name: value
+            - title: Unstoppable Jobs
+              context: process_unstoppable_jobs
+              units: jobs
+              dimensions:
+                - selector: haproxy_process_unstoppable_jobs
+                  name: value
+        - family: Sessions
+          metrics:
+            - haproxy_process_current_session_rate
+            - haproxy_process_limit_session_rate
+            - haproxy_process_max_session_rate
+          charts:
+            - title: Current Session Rate
+              context: process_current_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_process_current_session_rate
+                  name: value
+            - title: Limit Session Rate
+              context: process_limit_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_process_limit_session_rate
+                  name: value
+            - title: Max Session Rate
+              context: process_max_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_process_max_session_rate
+                  name: value
+        - family: Status
+          metrics:
+            - haproxy_process_busy_polling_enabled
+            - haproxy_process_stopping
+          charts:
+            - title: Busy Polling Enabled
+              context: process_busy_polling_enabled
+              units: '{status}'
+              dimensions:
+                - selector: haproxy_process_busy_polling_enabled
+                  name: value
+            - title: Stopping
+              context: process_stopping
+              units: '{status}'
+              dimensions:
+                - selector: haproxy_process_stopping
+                  name: value
+        - family: Timing
+          metrics:
+            - haproxy_process_idle_time_percent
+            - haproxy_process_uptime_seconds
+          charts:
+            - title: Idle Time Percent
+              context: process_idle_time_percent
+              units: percentage
+              dimensions:
+                - selector: haproxy_process_idle_time_percent
+                  name: value
+            - title: Uptime Seconds
+              context: process_uptime_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_process_uptime_seconds
+                  name: value
+        - family: Traffic
+          metrics:
+            - haproxy_process_bytes_out_rate
+            - haproxy_process_bytes_out_total
+            - haproxy_process_http_comp_bytes_in_total
+            - haproxy_process_http_comp_bytes_out_total
+            - haproxy_process_spliced_bytes_out_total
+          charts:
+            - title: Bytes Out
+              context: process_bytes_out_total
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_process_bytes_out_total
+                  name: value
+            - title: Bytes Out Rate
+              context: process_bytes_out_rate
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_process_bytes_out_rate
+                  name: value
+            - title: HTTP Compression Bytes In
+              context: process_http_comp_bytes_in_total
+              units: bytes/s
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_http_comp_bytes_in_total
+                  name: value
+            - title: HTTP Compression Bytes Out
+              context: process_http_comp_bytes_out_total
+              units: bytes/s
+              algorithm: absolute
+              dimensions:
+                - selector: haproxy_process_http_comp_bytes_out_total
+                  name: value
+            - title: Spliced Bytes Out
+              context: process_spliced_bytes_out_total
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_process_spliced_bytes_out_total
+                  name: value
+    - family: Frontends
+      chart_defaults:
+        instances:
+          by_labels:
+            - proxy
+      groups:
+        - family: Compression
+          metrics:
+            - haproxy_frontend_http_comp_responses_total
+          charts:
+            - title: HTTP Compression Responses
+              context: frontend_http_comp_responses_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_frontend_http_comp_responses_total
+                  name: value
+        - family: Connections
+          metrics:
+            - haproxy_frontend_connections_rate_max
+            - haproxy_frontend_connections_total
+            - haproxy_frontend_denied_connections_total
+          charts:
+            - title: Connections
+              context: frontend_connections_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_frontend_connections_total
+                  name: value
+            - title: Connections Rate Max
+              context: frontend_connections_rate_max
+              units: connections/s
+              dimensions:
+                - selector: haproxy_frontend_connections_rate_max
+                  name: value
+            - title: Denied Connections
+              context: frontend_denied_connections_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_frontend_denied_connections_total
+                  name: value
+        - family: Errors
+          metrics:
+            - haproxy_frontend_failed_header_rewriting_total
+            - haproxy_frontend_internal_errors_total
+            - haproxy_frontend_request_errors_total
+            - haproxy_frontend_requests_denied_total
+            - haproxy_frontend_responses_denied_total
+          charts:
+            - title: Errors
+              context: frontend_errors
+              units: errors/s
+              dimensions:
+                - selector: haproxy_frontend_request_errors_total
+                  name: request
+                - selector: haproxy_frontend_failed_header_rewriting_total
+                  name: header_rewriting
+                - selector: haproxy_frontend_internal_errors_total
+                  name: internal
+            - title: Requests Denied
+              context: frontend_requests_denied_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_frontend_requests_denied_total
+                  name: value
+            - title: Responses Denied
+              context: frontend_responses_denied_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_frontend_responses_denied_total
+                  name: value
+        - family: HTTP
+          metrics:
+            - haproxy_frontend_http_cache_hits_total
+            - haproxy_frontend_http_cache_lookups_total
+            - haproxy_frontend_http_requests_rate_max
+            - haproxy_frontend_http_requests_total
+            - haproxy_frontend_http_responses_total
+            - haproxy_frontend_intercepted_requests_total
+          charts:
+            - title: HTTP Cache Hits
+              context: frontend_http_cache_hits_total
+              units: hits/s
+              dimensions:
+                - selector: haproxy_frontend_http_cache_hits_total
+                  name: value
+            - title: HTTP Cache Lookups
+              context: frontend_http_cache_lookups_total
+              units: lookups/s
+              dimensions:
+                - selector: haproxy_frontend_http_cache_lookups_total
+                  name: value
+            - title: HTTP Requests
+              context: frontend_http_requests_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_frontend_http_requests_total
+                  name: value
+            - title: HTTP Requests Rate Max
+              context: frontend_http_requests_rate_max
+              units: requests/s
+              dimensions:
+                - selector: haproxy_frontend_http_requests_rate_max
+                  name: value
+            - title: HTTP Responses
+              context: frontend_http_responses_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_frontend_http_responses_total
+                  name_from_label: code
+            - title: Intercepted Requests
+              context: frontend_intercepted_requests_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_frontend_intercepted_requests_total
+                  name: value
+        - family: Sessions
+          metrics:
+            - haproxy_frontend_current_session_rate
+            - haproxy_frontend_current_sessions
+            - haproxy_frontend_denied_sessions_total
+            - haproxy_frontend_limit_session_rate
+            - haproxy_frontend_limit_sessions
+            - haproxy_frontend_max_session_rate
+            - haproxy_frontend_max_sessions
+            - haproxy_frontend_sessions_total
+          charts:
+            - title: Current Session Rate
+              context: frontend_current_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_frontend_current_session_rate
+                  name: value
+            - title: Current Sessions
+              context: frontend_current_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_frontend_current_sessions
+                  name: value
+            - title: Denied Sessions
+              context: frontend_denied_sessions_total
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_frontend_denied_sessions_total
+                  name: value
+            - title: Limit Session Rate
+              context: frontend_limit_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_frontend_limit_session_rate
+                  name: value
+            - title: Limit Sessions
+              context: frontend_limit_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_frontend_limit_sessions
+                  name: value
+            - title: Max Session Rate
+              context: frontend_max_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_frontend_max_session_rate
+                  name: value
+            - title: Max Sessions
+              context: frontend_max_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_frontend_max_sessions
+                  name: value
+            - title: Sessions
+              context: frontend_sessions_total
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_frontend_sessions_total
+                  name: value
+        - family: Status
+          metrics:
+            - haproxy_frontend_status
+          charts:
+            - title: Status
+              context: frontend_status
+              units: '{status}'
+              dimensions:
+                - selector: haproxy_frontend_status
+                  name_from_label: state
+        - family: Traffic
+          metrics:
+            - haproxy_frontend_bytes_in_total
+            - haproxy_frontend_bytes_out_total
+            - haproxy_frontend_http_comp_bytes_bypassed_total
+            - haproxy_frontend_http_comp_bytes_in_total
+            - haproxy_frontend_http_comp_bytes_out_total
+          charts:
+            - title: HTTP Compression Bytes Bypassed
+              context: frontend_http_comp_bytes_bypassed_total
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_frontend_http_comp_bytes_bypassed_total
+                  name: value
+            - title: HTTP Compression Bytes In
+              context: frontend_http_comp_bytes_in_total
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_frontend_http_comp_bytes_in_total
+                  name: value
+            - title: HTTP Compression Bytes Out
+              context: frontend_http_comp_bytes_out_total
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_frontend_http_comp_bytes_out_total
+                  name: value
+            - title: Traffic
+              context: frontend_traffic
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_frontend_bytes_in_total
+                  name: in
+                - selector: haproxy_frontend_bytes_out_total
+                  name: out
+    - family: Listeners
+      chart_defaults:
+        instances:
+          by_labels:
+            - proxy
+            - listener
+      groups:
+        - family: Connections
+          metrics:
+            - haproxy_listener_connections_total
+            - haproxy_listener_denied_connections_total
+          charts:
+            - title: Connections
+              context: listener_connections_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_listener_connections_total
+                  name: value
+            - title: Denied Connections
+              context: listener_denied_connections_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_listener_denied_connections_total
+                  name: value
+        - family: Errors
+          metrics:
+            - haproxy_listener_failed_header_rewriting_total
+            - haproxy_listener_internal_errors_total
+            - haproxy_listener_request_errors_total
+            - haproxy_listener_requests_denied_total
+            - haproxy_listener_responses_denied_total
+          charts:
+            - title: Errors
+              context: listener_errors
+              units: errors/s
+              dimensions:
+                - selector: haproxy_listener_request_errors_total
+                  name: request
+                - selector: haproxy_listener_failed_header_rewriting_total
+                  name: header_rewriting
+                - selector: haproxy_listener_internal_errors_total
+                  name: internal
+            - title: Requests Denied
+              context: listener_requests_denied_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_listener_requests_denied_total
+                  name: value
+            - title: Responses Denied
+              context: listener_responses_denied_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_listener_responses_denied_total
+                  name: value
+        - family: Sessions
+          metrics:
+            - haproxy_listener_current_sessions
+            - haproxy_listener_denied_sessions_total
+            - haproxy_listener_limit_sessions
+            - haproxy_listener_max_sessions
+            - haproxy_listener_sessions_total
+          charts:
+            - title: Current Sessions
+              context: listener_current_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_listener_current_sessions
+                  name: value
+            - title: Denied Sessions
+              context: listener_denied_sessions_total
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_listener_denied_sessions_total
+                  name: value
+            - title: Limit Sessions
+              context: listener_limit_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_listener_limit_sessions
+                  name: value
+            - title: Max Sessions
+              context: listener_max_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_listener_max_sessions
+                  name: value
+            - title: Sessions
+              context: listener_sessions_total
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_listener_sessions_total
+                  name: value
+        - family: Status
+          metrics:
+            - haproxy_listener_status
+          charts:
+            - title: Status
+              context: listener_status
+              units: '{status}'
+              dimensions:
+                - selector: haproxy_listener_status
+                  name_from_label: state
+        - family: Traffic
+          metrics:
+            - haproxy_listener_bytes_in_total
+            - haproxy_listener_bytes_out_total
+          charts:
+            - title: Traffic
+              context: listener_traffic
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_listener_bytes_in_total
+                  name: in
+                - selector: haproxy_listener_bytes_out_total
+                  name: out
+    - family: Backends
+      chart_defaults:
+        instances:
+          by_labels:
+            - proxy
+      groups:
+        - family: Compression
+          metrics:
+            - haproxy_backend_http_comp_responses_total
+          charts:
+            - title: HTTP Compression Responses
+              context: backend_http_comp_responses_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_backend_http_comp_responses_total
+                  name: value
+        - family: Connections
+          metrics:
+            - haproxy_backend_connection_attempts_total
+            - haproxy_backend_connection_reuses_total
+          charts:
+            - title: Connection Attempts
+              context: backend_connection_attempts_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_backend_connection_attempts_total
+                  name: value
+            - title: Connection Reuses
+              context: backend_connection_reuses_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_backend_connection_reuses_total
+                  name: value
+        - family: Errors
+          metrics:
+            - haproxy_backend_client_aborts_total
+            - haproxy_backend_connection_errors_total
+            - haproxy_backend_failed_header_rewriting_total
+            - haproxy_backend_internal_errors_total
+            - haproxy_backend_redispatch_warnings_total
+            - haproxy_backend_requests_denied_total
+            - haproxy_backend_response_errors_total
+            - haproxy_backend_responses_denied_total
+            - haproxy_backend_retry_warnings_total
+            - haproxy_backend_server_aborts_total
+          charts:
+            - title: Aborts
+              context: backend_aborts
+              units: aborts/s
+              dimensions:
+                - selector: haproxy_backend_client_aborts_total
+                  name: client
+                - selector: haproxy_backend_server_aborts_total
+                  name: server
+            - title: Errors
+              context: backend_errors
+              units: errors/s
+              dimensions:
+                - selector: haproxy_backend_response_errors_total
+                  name: response
+                - selector: haproxy_backend_connection_errors_total
+                  name: connection
+                - selector: haproxy_backend_failed_header_rewriting_total
+                  name: header_rewriting
+                - selector: haproxy_backend_internal_errors_total
+                  name: internal
+            - title: Requests Denied
+              context: backend_requests_denied_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_backend_requests_denied_total
+                  name: value
+            - title: Responses Denied
+              context: backend_responses_denied_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_backend_responses_denied_total
+                  name: value
+            - title: Warnings
+              context: backend_warnings
+              units: warnings/s
+              dimensions:
+                - selector: haproxy_backend_retry_warnings_total
+                  name: retry
+                - selector: haproxy_backend_redispatch_warnings_total
+                  name: redispatch
+        - family: HTTP
+          metrics:
+            - haproxy_backend_http_cache_hits_total
+            - haproxy_backend_http_cache_lookups_total
+            - haproxy_backend_http_requests_total
+            - haproxy_backend_http_responses_total
+          charts:
+            - title: HTTP Cache Hits
+              context: backend_http_cache_hits_total
+              units: hits/s
+              dimensions:
+                - selector: haproxy_backend_http_cache_hits_total
+                  name: value
+            - title: HTTP Cache Lookups
+              context: backend_http_cache_lookups_total
+              units: lookups/s
+              dimensions:
+                - selector: haproxy_backend_http_cache_lookups_total
+                  name: value
+            - title: HTTP Requests
+              context: backend_http_requests_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_backend_http_requests_total
+                  name: value
+            - title: HTTP Responses
+              context: backend_http_responses_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_backend_http_responses_total
+                  name_from_label: code
+        - family: Health
+          metrics:
+            - haproxy_backend_active_servers
+            - haproxy_backend_backup_servers
+            - haproxy_backend_check_last_change_seconds
+            - haproxy_backend_check_up_down_total
+            - haproxy_backend_downtime_seconds_total
+            - haproxy_backend_loadbalanced_total
+            - haproxy_backend_uweight
+            - haproxy_backend_weight
+          charts:
+            - title: Available Servers
+              context: backend_servers
+              units: servers
+              dimensions:
+                - selector: haproxy_backend_active_servers
+                  name: active
+                - selector: haproxy_backend_backup_servers
+                  name: backup
+            - title: Check Last Change Seconds
+              context: backend_check_last_change_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_check_last_change_seconds
+                  name: value
+            - title: Downtime Seconds
+              context: backend_downtime_seconds_total
+              units: seconds/s
+              dimensions:
+                - selector: haproxy_backend_downtime_seconds_total
+                  name: value
+            - title: Failed Check State Transitions
+              context: backend_check_up_down_total
+              units: transitions/s
+              dimensions:
+                - selector: haproxy_backend_check_up_down_total
+                  name: value
+            - title: Load-Balanced Requests
+              context: backend_loadbalanced_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_backend_loadbalanced_total
+                  name: value
+            - title: User Weight
+              context: backend_uweight
+              units: weight
+              dimensions:
+                - selector: haproxy_backend_uweight
+                  name: value
+            - title: Weight
+              context: backend_weight
+              units: weight
+              dimensions:
+                - selector: haproxy_backend_weight
+                  name: value
+        - family: Queue
+          metrics:
+            - haproxy_backend_current_queue
+            - haproxy_backend_max_queue
+            - haproxy_backend_max_queue_time_seconds
+            - haproxy_backend_queue_time_average_seconds
+          charts:
+            - title: Current Queue
+              context: backend_current_queue
+              units: requests
+              dimensions:
+                - selector: haproxy_backend_current_queue
+                  name: value
+            - title: Max Queue
+              context: backend_max_queue
+              units: requests
+              dimensions:
+                - selector: haproxy_backend_max_queue
+                  name: value
+            - title: Max Queue Time Seconds
+              context: backend_max_queue_time_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_max_queue_time_seconds
+                  name: value
+            - title: Queue Time Average Seconds
+              context: backend_queue_time_average_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_queue_time_average_seconds
+                  name: value
+        - family: Sessions
+          metrics:
+            - haproxy_backend_current_session_rate
+            - haproxy_backend_current_sessions
+            - haproxy_backend_last_session_seconds
+            - haproxy_backend_limit_sessions
+            - haproxy_backend_max_session_rate
+            - haproxy_backend_max_sessions
+            - haproxy_backend_sessions_total
+          charts:
+            - title: Current Session Rate
+              context: backend_current_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_backend_current_session_rate
+                  name: value
+            - title: Current Sessions
+              context: backend_current_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_backend_current_sessions
+                  name: value
+            - title: Last Session Seconds
+              context: backend_last_session_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_last_session_seconds
+                  name: value
+            - title: Limit Sessions
+              context: backend_limit_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_backend_limit_sessions
+                  name: value
+            - title: Max Session Rate
+              context: backend_max_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_backend_max_session_rate
+                  name: value
+            - title: Max Sessions
+              context: backend_max_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_backend_max_sessions
+                  name: value
+            - title: Sessions
+              context: backend_sessions_total
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_backend_sessions_total
+                  name: value
+        - family: Status
+          metrics:
+            - haproxy_backend_agg_check_status
+            - haproxy_backend_agg_server_status
+            - haproxy_backend_status
+          charts:
+            - title: Aggregated Check Status
+              context: backend_agg_check_status
+              units: servers
+              dimensions:
+                - selector: haproxy_backend_agg_check_status
+                  name_from_label: state
+            - title: Aggregated Server Status
+              context: backend_agg_server_status
+              units: servers
+              dimensions:
+                - selector: haproxy_backend_agg_server_status
+                  name_from_label: state
+            - title: Status
+              context: backend_status
+              units: '{status}'
+              dimensions:
+                - selector: haproxy_backend_status
+                  name_from_label: state
+        - family: Timing
+          metrics:
+            - haproxy_backend_connect_time_average_seconds
+            - haproxy_backend_max_connect_time_seconds
+            - haproxy_backend_max_response_time_seconds
+            - haproxy_backend_max_total_time_seconds
+            - haproxy_backend_response_time_average_seconds
+            - haproxy_backend_total_time_average_seconds
+          charts:
+            - title: Average Total Time
+              context: backend_total_time_average_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_total_time_average_seconds
+                  name: value
+            - title: Connect Time Average Seconds
+              context: backend_connect_time_average_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_connect_time_average_seconds
+                  name: value
+            - title: Max Connect Time Seconds
+              context: backend_max_connect_time_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_max_connect_time_seconds
+                  name: value
+            - title: Max Response Time Seconds
+              context: backend_max_response_time_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_max_response_time_seconds
+                  name: value
+            - title: Maximum Total Time
+              context: backend_max_total_time_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_max_total_time_seconds
+                  name: value
+            - title: Response Time Average Seconds
+              context: backend_response_time_average_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_backend_response_time_average_seconds
+                  name: value
+        - family: Traffic
+          metrics:
+            - haproxy_backend_bytes_in_total
+            - haproxy_backend_bytes_out_total
+            - haproxy_backend_http_comp_bytes_bypassed_total
+            - haproxy_backend_http_comp_bytes_in_total
+            - haproxy_backend_http_comp_bytes_out_total
+          charts:
+            - title: HTTP Compression Bytes Bypassed
+              context: backend_http_comp_bytes_bypassed_total
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_backend_http_comp_bytes_bypassed_total
+                  name: value
+            - title: HTTP Compression Bytes In
+              context: backend_http_comp_bytes_in_total
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_backend_http_comp_bytes_in_total
+                  name: value
+            - title: HTTP Compression Bytes Out
+              context: backend_http_comp_bytes_out_total
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_backend_http_comp_bytes_out_total
+                  name: value
+            - title: Traffic
+              context: backend_traffic
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_backend_bytes_in_total
+                  name: in
+                - selector: haproxy_backend_bytes_out_total
+                  name: out
+    - family: Servers
+      chart_defaults:
+        instances:
+          by_labels:
+            - proxy
+            - server
+      groups:
+        - family: Connections
+          metrics:
+            - haproxy_server_connection_attempts_total
+            - haproxy_server_connection_reuses_total
+            - haproxy_server_idle_connections_current
+            - haproxy_server_idle_connections_limit
+            - haproxy_server_need_connections_current
+            - haproxy_server_safe_idle_connections_current
+            - haproxy_server_unsafe_idle_connections_current
+            - haproxy_server_used_connections_current
+          charts:
+            - title: Connection Attempts
+              context: server_connection_attempts_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_server_connection_attempts_total
+                  name: value
+            - title: Connection Reuses
+              context: server_connection_reuses_total
+              units: connections/s
+              dimensions:
+                - selector: haproxy_server_connection_reuses_total
+                  name: value
+            - title: Current Idle Connections
+              context: server_idle_connections_current
+              units: connections
+              dimensions:
+                - selector: haproxy_server_idle_connections_current
+                  name: value
+            - title: Current Used Connections
+              context: server_used_connections_current
+              units: connections
+              dimensions:
+                - selector: haproxy_server_used_connections_current
+                  name: value
+            - title: Idle Connection Limit
+              context: server_idle_connections_limit
+              units: connections
+              dimensions:
+                - selector: haproxy_server_idle_connections_limit
+                  name: value
+            - title: Idle Connection Safety
+              context: server_idle_connection_safety
+              units: connections
+              dimensions:
+                - selector: haproxy_server_safe_idle_connections_current
+                  name: safe
+                - selector: haproxy_server_unsafe_idle_connections_current
+                  name: unsafe
+            - title: Needed Connections
+              context: server_need_connections_current
+              units: connections
+              dimensions:
+                - selector: haproxy_server_need_connections_current
+                  name: value
+        - family: Errors
+          metrics:
+            - haproxy_server_check_failures_total
+            - haproxy_server_client_aborts_total
+            - haproxy_server_connection_errors_total
+            - haproxy_server_failed_header_rewriting_total
+            - haproxy_server_internal_errors_total
+            - haproxy_server_redispatch_warnings_total
+            - haproxy_server_response_errors_total
+            - haproxy_server_responses_denied_total
+            - haproxy_server_retry_warnings_total
+            - haproxy_server_server_aborts_total
+          charts:
+            - title: Aborts
+              context: server_aborts
+              units: aborts/s
+              dimensions:
+                - selector: haproxy_server_client_aborts_total
+                  name: client
+                - selector: haproxy_server_server_aborts_total
+                  name: server
+            - title: Check Failures
+              context: server_check_failures_total
+              units: failures/s
+              dimensions:
+                - selector: haproxy_server_check_failures_total
+                  name: value
+            - title: Errors
+              context: server_errors
+              units: errors/s
+              dimensions:
+                - selector: haproxy_server_response_errors_total
+                  name: response
+                - selector: haproxy_server_connection_errors_total
+                  name: connection
+                - selector: haproxy_server_failed_header_rewriting_total
+                  name: header_rewriting
+                - selector: haproxy_server_internal_errors_total
+                  name: internal
+            - title: Responses Denied
+              context: server_responses_denied_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_server_responses_denied_total
+                  name: value
+            - title: Warnings
+              context: server_warnings
+              units: warnings/s
+              dimensions:
+                - selector: haproxy_server_retry_warnings_total
+                  name: retry
+                - selector: haproxy_server_redispatch_warnings_total
+                  name: redispatch
+        - family: HTTP
+          metrics:
+            - haproxy_server_http_requests_total
+            - haproxy_server_http_responses_total
+          charts:
+            - title: HTTP Requests
+              context: server_http_requests_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_server_http_requests_total
+                  name: value
+            - title: HTTP Responses
+              context: server_http_responses_total
+              units: responses/s
+              dimensions:
+                - selector: haproxy_server_http_responses_total
+                  name_from_label: code
+        - family: Health
+          metrics:
+            - haproxy_server_active
+            - haproxy_server_agent_code
+            - haproxy_server_agent_duration_seconds
+            - haproxy_server_backup
+            - haproxy_server_check_code
+            - haproxy_server_check_duration_seconds
+            - haproxy_server_check_last_change_seconds
+            - haproxy_server_check_up_down_total
+            - haproxy_server_current_throttle
+            - haproxy_server_downtime_seconds_total
+            - haproxy_server_loadbalanced_total
+            - haproxy_server_uweight
+            - haproxy_server_weight
+          charts:
+            - title: Agent Code
+              context: server_agent_code
+              units: code
+              dimensions:
+                - selector: haproxy_server_agent_code
+                  name: value
+            - title: Agent Duration Seconds
+              context: server_agent_duration_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_agent_duration_seconds
+                  name: value
+            - title: Check Code
+              context: server_check_code
+              units: code
+              dimensions:
+                - selector: haproxy_server_check_code
+                  name: value
+            - title: Check Duration Seconds
+              context: server_check_duration_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_check_duration_seconds
+                  name: value
+            - title: Check Last Change Seconds
+              context: server_check_last_change_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_check_last_change_seconds
+                  name: value
+            - title: Current Throttle
+              context: server_current_throttle
+              units: percentage
+              dimensions:
+                - selector: haproxy_server_current_throttle
+                  name: value
+            - title: Downtime Seconds
+              context: server_downtime_seconds_total
+              units: seconds/s
+              dimensions:
+                - selector: haproxy_server_downtime_seconds_total
+                  name: value
+            - title: Failed Check State Transitions
+              context: server_check_up_down_total
+              units: transitions/s
+              dimensions:
+                - selector: haproxy_server_check_up_down_total
+                  name: value
+            - title: Load-Balanced Requests
+              context: server_loadbalanced_total
+              units: requests/s
+              dimensions:
+                - selector: haproxy_server_loadbalanced_total
+                  name: value
+            - title: Server Role
+              context: server_role
+              units: servers
+              dimensions:
+                - selector: haproxy_server_active
+                  name: active
+                - selector: haproxy_server_backup
+                  name: backup
+            - title: User Weight
+              context: server_uweight
+              units: weight
+              dimensions:
+                - selector: haproxy_server_uweight
+                  name: value
+            - title: Weight
+              context: server_weight
+              units: weight
+              dimensions:
+                - selector: haproxy_server_weight
+                  name: value
+        - family: Queue
+          metrics:
+            - haproxy_server_current_queue
+            - haproxy_server_max_queue
+            - haproxy_server_max_queue_time_seconds
+            - haproxy_server_queue_limit
+            - haproxy_server_queue_time_average_seconds
+          charts:
+            - title: Current Queue
+              context: server_current_queue
+              units: requests
+              dimensions:
+                - selector: haproxy_server_current_queue
+                  name: value
+            - title: Max Queue
+              context: server_max_queue
+              units: requests
+              dimensions:
+                - selector: haproxy_server_max_queue
+                  name: value
+            - title: Max Queue Time Seconds
+              context: server_max_queue_time_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_max_queue_time_seconds
+                  name: value
+            - title: Queue Limit
+              context: server_queue_limit
+              units: requests
+              dimensions:
+                - selector: haproxy_server_queue_limit
+                  name: value
+            - title: Queue Time Average Seconds
+              context: server_queue_time_average_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_queue_time_average_seconds
+                  name: value
+        - family: Sessions
+          metrics:
+            - haproxy_server_current_session_rate
+            - haproxy_server_current_sessions
+            - haproxy_server_last_session_seconds
+            - haproxy_server_limit_sessions
+            - haproxy_server_max_session_rate
+            - haproxy_server_max_sessions
+            - haproxy_server_sessions_total
+          charts:
+            - title: Current Session Rate
+              context: server_current_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_server_current_session_rate
+                  name: value
+            - title: Current Sessions
+              context: server_current_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_server_current_sessions
+                  name: value
+            - title: Last Session Seconds
+              context: server_last_session_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_last_session_seconds
+                  name: value
+            - title: Limit Sessions
+              context: server_limit_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_server_limit_sessions
+                  name: value
+            - title: Max Session Rate
+              context: server_max_session_rate
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_server_max_session_rate
+                  name: value
+            - title: Max Sessions
+              context: server_max_sessions
+              units: sessions
+              dimensions:
+                - selector: haproxy_server_max_sessions
+                  name: value
+            - title: Sessions
+              context: server_sessions_total
+              units: sessions/s
+              dimensions:
+                - selector: haproxy_server_sessions_total
+                  name: value
+        - family: Status
+          metrics:
+            - haproxy_server_agent_status
+            - haproxy_server_check_status
+            - haproxy_server_status
+          charts:
+            - title: Agent Status
+              context: server_agent_status
+              units: '{status}'
+              dimensions:
+                - selector: haproxy_server_agent_status
+                  name_from_label: state
+            - title: Check Status
+              context: server_check_status
+              units: '{status}'
+              dimensions:
+                - selector: haproxy_server_check_status
+                  name_from_label: state
+            - title: Status
+              context: server_status
+              units: '{status}'
+              dimensions:
+                - selector: haproxy_server_status
+                  name_from_label: state
+        - family: Timing
+          metrics:
+            - haproxy_server_connect_time_average_seconds
+            - haproxy_server_max_connect_time_seconds
+            - haproxy_server_max_response_time_seconds
+            - haproxy_server_max_total_time_seconds
+            - haproxy_server_response_time_average_seconds
+            - haproxy_server_total_time_average_seconds
+          charts:
+            - title: Average Total Time
+              context: server_total_time_average_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_total_time_average_seconds
+                  name: value
+            - title: Connect Time Average Seconds
+              context: server_connect_time_average_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_connect_time_average_seconds
+                  name: value
+            - title: Max Connect Time Seconds
+              context: server_max_connect_time_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_max_connect_time_seconds
+                  name: value
+            - title: Max Response Time Seconds
+              context: server_max_response_time_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_max_response_time_seconds
+                  name: value
+            - title: Maximum Total Time
+              context: server_max_total_time_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_max_total_time_seconds
+                  name: value
+            - title: Response Time Average Seconds
+              context: server_response_time_average_seconds
+              units: seconds
+              dimensions:
+                - selector: haproxy_server_response_time_average_seconds
+                  name: value
+        - family: Traffic
+          metrics:
+            - haproxy_server_bytes_in_total
+            - haproxy_server_bytes_out_total
+          charts:
+            - title: Traffic
+              context: server_traffic
+              units: bytes/s
+              dimensions:
+                - selector: haproxy_server_bytes_in_total
+                  name: in
+                - selector: haproxy_server_bytes_out_total
+                  name: out
+    - family: Resolvers
+      chart_defaults:
+        instances:
+          by_labels:
+            - resolver
+            - nameserver
+      groups:
+        - family: DNS
+          metrics:
+            - haproxy_resolver_any_err
+            - haproxy_resolver_cname
+            - haproxy_resolver_cname_error
+            - haproxy_resolver_invalid
+            - haproxy_resolver_nx
+            - haproxy_resolver_other
+            - haproxy_resolver_outdated
+            - haproxy_resolver_refused
+            - haproxy_resolver_send_error
+            - haproxy_resolver_sent
+            - haproxy_resolver_timeout
+            - haproxy_resolver_too_big
+            - haproxy_resolver_truncated
+            - haproxy_resolver_update
+            - haproxy_resolver_valid
+          charts:
+            - title: Any Errors
+              context: resolver_any_err
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_any_err
+                  name: value
+            - title: CNAME
+              context: resolver_cname
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_cname
+                  name: value
+            - title: CNAME Error
+              context: resolver_cname_error
+              units: errors/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_cname_error
+                  name: value
+            - title: Invalid
+              context: resolver_invalid
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_invalid
+                  name: value
+            - title: NX
+              context: resolver_nx
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_nx
+                  name: value
+            - title: Other
+              context: resolver_other
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_other
+                  name: value
+            - title: Outdated
+              context: resolver_outdated
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_outdated
+                  name: value
+            - title: Refused
+              context: resolver_refused
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_refused
+                  name: value
+            - title: Send Error
+              context: resolver_send_error
+              units: errors/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_send_error
+                  name: value
+            - title: Sent
+              context: resolver_sent
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_sent
+                  name: value
+            - title: Timeout
+              context: resolver_timeout
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_timeout
+                  name: value
+            - title: Too Big
+              context: resolver_too_big
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_too_big
+                  name: value
+            - title: Truncated
+              context: resolver_truncated
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_truncated
+                  name: value
+            - title: Update
+              context: resolver_update
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_update
+                  name: value
+            - title: Valid
+              context: resolver_valid
+              units: queries/s
+              algorithm: incremental
+              dimensions:
+                - selector: haproxy_resolver_valid
+                  name: value
+    - family: Stick Tables
+      chart_defaults:
+        instances:
+          by_labels:
+            - name
+            - type
+      groups:
+        - family: Entries
+          metrics:
+            - haproxy_sticktable_size
+            - haproxy_sticktable_used
+          charts:
+            - title: Size
+              context: sticktable_size
+              units: entries
+              dimensions:
+                - selector: haproxy_sticktable_size
+                  name: value
+            - title: Used
+              context: sticktable_used
+              units: entries
+              dimensions:
+                - selector: haproxy_sticktable_used
+                  name: value


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats Prometheus YAML profiles and profile proofs for `go.d` to a consistent style (indentation and list alignment). No schema or runtime behavior changes; this reduces noise in future diffs.

- Touches `ceph`, `haproxy`, `litellm`, and `vllm` profile proofs and default profiles under `src/go/plugin/go.d/.../prometheus.profiles/...`.
- Changes are whitespace-only; no keys or values were added or removed.
- Review by spot-checking a few files to confirm structure is unchanged and YAML parses.

**Rollout**
- No migration required; existing configurations continue to work.

<sup>Written for commit 0d6fcdabf1498fc7f6a2c4fe931f348061b0e502. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Ceph monitoring validation for Reef and Tentacle fixtures, covering additional objecter and replica-read metrics, including established, removed, and decreased values.

- **Style**
  - Standardized configuration formatting for HAProxy, LiteLLM, and vLLM profiles without changing settings or observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->