### PR TITLE
fix(smartctl): sanitize device name with spaces for chart ID compatibility

### DIFF
--- a/src/go/plugin/go.d/collector/smartctl/scan.go
+++ b/src/go/plugin/go.d/collector/smartctl/scan.go
@@ -20,7 +20,7 @@ func (s *scanDevice) key() string {
 }
 
 func (s *scanDevice) shortName() string {
-	return strings.TrimPrefix(s.name, "/dev/")
+	return cleanDeviceName(strings.TrimPrefix(s.name, "/dev/"))
 }
 
 func (c *Collector) scanDevices() (map[string]*scanDevice, error) {

--- a/src/go/plugin/go.d/collector/smartctl/smart_device.go
+++ b/src/go/plugin/go.d/collector/smartctl/smart_device.go
@@ -20,7 +20,7 @@ type smartDevice struct {
 
 func (d *smartDevice) deviceName() string {
 	v := d.data.Get("device.name").String()
-	return strings.TrimPrefix(v, "/dev/")
+	return cleanDeviceName(strings.TrimPrefix(v, "/dev/"))
 }
 
 func (d *smartDevice) deviceType() string {
@@ -116,4 +116,8 @@ func (a *smartAttribute) rawValue() string {
 
 func (a *smartAttribute) rawString() string {
 	return a.data.Get("raw.string").String()
+}
+
+func cleanDeviceName(name string) string {
+	return strings.NewReplacer(" ", "_", "/", "_").Replace(name)
 }


### PR DESCRIPTION
### Problem

On macOS, some USB-to-SATA drive enclosures report a bridge chip name that has a space in it (e.g. "easystore 25FB"). The smartctl collector finds these devices and reads SMART data, but chart creation fails silently because chart IDs cannot contain spaces. The device simply never appears on the dashboard.

### Fix

Add `cleanDeviceName()` helper that replaces spaces and slashes with underscores, mirroring the existing `cleanAttributeName()` pattern and the postgres collector's `removeSpaces()` (#17968). Apply it to:

- `smartDevice.deviceName()` — used in chart IDs, dimension IDs, and metric keys
- `scanDevice.shortName()` — used in `removeDeviceCharts()` prefix matching

### Related

- Fixes #23474
- Reference: #17968 (same fix pattern for postgres collector)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes device names in `smartctl` so charts are created and managed correctly. Previously, names with spaces (e.g., "easystore 25FB") produced invalid chart IDs and the device never appeared; now spaces and slashes are replaced with underscores.

- Add cleanDeviceName() and apply to smartDevice.deviceName() and scanDevice.shortName() (affects chart/dimension IDs and removeDeviceCharts prefix).
- No migration needed; previously affected devices had no charts.

<sup>Written for commit e6a27ba4caec4e80232d2aefb9c127111c7a06f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage device name formatting in monitoring results.
  * Device names are now consistently normalized, including names containing spaces or slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->