### PR TITLE
ci: avoid package builds for Go-only changes

### DIFF
--- a/.github/scripts/test-ci-workflow-file-selection.py
+++ b/.github/scripts/test-ci-workflow-file-selection.py
@@ -8,14 +8,15 @@ from pathlib import Path, PurePosixPath
 
 ROOT = Path(__file__).resolve().parents[2]
 REVIEW_WORKFLOW = ROOT / ".github/workflows/review.yml"
-GO_WORKFLOW_STEPS = (
+GO_TESTS_WORKFLOW = ROOT / ".github/workflows/go-tests.yml"
+BUILD_WORKFLOW_STEPS = (
     (ROOT / ".github/workflows/build.yml", "Check build files"),
     (ROOT / ".github/workflows/docker.yml", "Check build system files"),
 )
 
 SHELL_PATH_RE = re.compile(r"\.sh(?:\.in)?$")
 SHELL_FIND_PATTERNS = ("*.sh", "*.sh.in")
-GO_PATH_PATTERNS = (
+BROAD_GO_PATH_PATTERNS = (
     "*.go",
     "go.mod",
     "go.sum",
@@ -32,11 +33,6 @@ def shell_trigger_matches(path: str) -> bool:
 def shell_scanner_matches(path: str) -> bool:
     name = PurePosixPath(path).name
     return any(fnmatch.fnmatchcase(name, pattern) for pattern in SHELL_FIND_PATTERNS)
-
-
-def go_group_matches(path: str) -> bool:
-    candidate = PurePosixPath(path)
-    return any(candidate.match(pattern) for pattern in GO_PATH_PATTERNS)
 
 
 def workflow_step(workflow: str, name: str) -> list[str]:
@@ -124,29 +120,6 @@ class WorkflowFileSelectionTest(unittest.TestCase):
         )
         self.assertFalse(any(shell_trigger_matches(path) for path in paths))
 
-    def test_go_group_covers_root_and_nested_go_inputs(self) -> None:
-        accepted = (
-            "main.go",
-            "go.mod",
-            "go.sum",
-            "src/go/main.go",
-            "src/go/go.mod",
-            "src/go/go.sum",
-        )
-        rejected = (
-            "main.go.md",
-            "docs/go.mod.md",
-            "src/generated/golang.txt",
-        )
-
-        for path in accepted:
-            with self.subTest(path=path):
-                self.assertTrue(go_group_matches(path))
-
-        for path in rejected:
-            with self.subTest(path=path):
-                self.assertFalse(go_group_matches(path))
-
     def test_workflows_use_the_tested_shell_contract(self) -> None:
         workflow = REVIEW_WORKFLOW.read_text(encoding="utf-8")
         shellcheck_step = workflow_step(workflow, "Run shellcheck")
@@ -155,8 +128,8 @@ class WorkflowFileSelectionTest(unittest.TestCase):
         self.assertEqual(literal_block(shellcheck_step, "pattern"), {"*.sh", "*.sh.in"})
         self.assertNotIn('pattern: "*.sh*"', workflow)
 
-    def test_go_decisions_do_not_consume_filename_inventories(self) -> None:
-        for workflow_path, build_step_name in GO_WORKFLOW_STEPS:
+    def test_build_decisions_avoid_broad_go_triggers_and_filename_inventories(self) -> None:
+        for workflow_path, build_step_name in BUILD_WORKFLOW_STEPS:
             workflow = workflow_path.read_text(encoding="utf-8")
             build_files_step = workflow_step(workflow, build_step_name)
             check_run_step = workflow_step(workflow, "Check Run")
@@ -170,7 +143,25 @@ class WorkflowFileSelectionTest(unittest.TestCase):
                     any("steps.check-build-files.outputs.any_modified" in line for line in check_go_step)
                 )
                 self.assertNotIn("other_changed_files", workflow)
-                self.assertTrue(set(GO_PATH_PATTERNS) <= literal_block(build_files_step, "files"))
+                self.assertTrue(
+                    set(BROAD_GO_PATH_PATTERNS).isdisjoint(literal_block(build_files_step, "files"))
+                )
+
+    def test_go_workflow_owns_agent_go_validation(self) -> None:
+        workflow = GO_TESTS_WORKFLOW.read_text(encoding="utf-8")
+        check_files_step = workflow_step(workflow, "Check files")
+
+        self.assertTrue(
+            {
+                "src/go/**",
+                "src/collectors/cgroups.plugin/cgroup-name/**",
+                "src/collectors/ebpf.plugin/ebpfgo.plugin/**",
+            }
+            <= literal_block(check_files_step, "files")
+        )
+        self.assertIn("CGO_ENABLED=0 go build", workflow)
+        self.assertIn("go test -json ./... -race", workflow)
+        self.assertIn("name: Go build tests", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,6 @@ jobs:
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
           files: |
-            *.go
-            go.mod
-            go.sum
-            **/*.go
-            **/go.mod
-            **/go.sum
             **/*.cmake
             CMakeLists.txt
             netdata-installer.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,12 +69,6 @@ jobs:
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
           files: |
-            *.go
-            go.mod
-            go.sum
-            **/*.go
-            **/go.mod
-            **/go.sum
             .dockerignore
             CMakeLists.txt
             netdata-installer.sh


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips package builds when a PR only changes Go files. Previously, any `*.go`/`go.mod`/`go.sum` change triggered `build.yml` and `docker.yml`; now only build-system changes do, and Go changes are validated in `go-tests.yml`.

- Remove Go file patterns from the "Check build files" steps in `build.yml` and `docker.yml`.
- Add tests that forbid broad Go triggers in package workflows and assert `go-tests.yml` checks `src/go/**`, `src/collectors/cgroups.plugin/cgroup-name/**`, and `src/collectors/ebpf.plugin/ebpfgo.plugin/**`, and runs `go build` and `go test -race`.
- Result: faster CI and no package artifacts for Go-only PRs; non-Go build triggers are unchanged.

<sup>Written for commit 9ae8a094e81f4fee014c5f4fffaea0f837de647f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI workflow selection so Go source and module changes are validated by the Go test workflow.
  * Prevented build and Docker workflows from running for changes limited to Go files or module metadata.
  * Added validation to ensure Go-specific paths and commands remain correctly assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->