### PR TITLE
apps.plugin: add system.processes_state chart on macOS and FreeBSD (#23296, #23535)

### DIFF
--- a/src/collectors/apps.plugin/apps_os_freebsd.c
+++ b/src/collectors/apps.plugin/apps_os_freebsd.c
@@ -321,9 +321,10 @@ cleanup:
 
 // FreeBSD maintains ki_stat for every process. SSLEEP covers both
 // interruptible and uninterruptible sleep, distinguished by TDF_SINTR in
-// ki_tdflags (ps shows uninterruptible sleep as 'D'); SWAIT and SLOCK are
-// interruptible wait states (ps shows 'W' and 'L'). Zombies are present in
-// the KERN_PROC_PROC data and are counted like any other process.
+// ki_tdflags (ps shows uninterruptible sleep as 'D'); SWAIT (waiting for an
+// interrupt) and SLOCK (blocked on a lock) are handled per-case below.
+// Zombies are present in the KERN_PROC_PROC data and are counted like any
+// other process.
 static inline void update_proc_state_count_freebsd(char ki_stat, long ki_tdflags) {
     switch (ki_stat) {
         case SRUN:
@@ -336,11 +337,16 @@ static inline void update_proc_state_count_freebsd(char ki_stat, long ki_tdflags
                 proc_state_count[PROC_STATUS_SLEEPING_D] += 1;
             break;
         case SWAIT:
-        case SLOCK:
-            // freebsd wait states (ps shows 'W' and 'L'); they are not
-            // uninterruptible sleep (that is SSLEEP without TDF_SINTR, shown as
-            // 'D'), so count them as interruptible sleep instead of dropping them.
+            // Waiting for an interrupt to wake it (ps shows 'W'); on live
+            // systems these are idle kernel threads (clock, intr), so they are
+            // interruptible by definition.
             proc_state_count[PROC_STATUS_SLEEPING] += 1;
+            break;
+        case SLOCK:
+            // Blocked on a kernel lock (TD_ON_LOCK turnstile wait), not
+            // signal-interruptible; FreeBSD's own linprocfs maps SLOCK to
+            // Linux 'D', so count it as uninterruptible sleep.
+            proc_state_count[PROC_STATUS_SLEEPING_D] += 1;
             break;
         case SZOMB:
             proc_state_count[PROC_STATUS_ZOMBIE] += 1;

--- a/src/collectors/apps.plugin/apps_os_freebsd.c
+++ b/src/collectors/apps.plugin/apps_os_freebsd.c
@@ -319,9 +319,10 @@ cleanup:
     return false;
 }
 
-// FreeBSD maintains ki_stat for every process; SSLEEP covers both
+// FreeBSD maintains ki_stat for every process. SSLEEP covers both
 // interruptible and uninterruptible sleep, distinguished by TDF_SINTR in
-// ki_tdflags (ps shows uninterruptible sleep as 'D'). Zombies are present in
+// ki_tdflags (ps shows uninterruptible sleep as 'D'); SWAIT and SLOCK are
+// interruptible wait states (ps shows 'W' and 'L'). Zombies are present in
 // the KERN_PROC_PROC data and are counted like any other process.
 static inline void update_proc_state_count_freebsd(char ki_stat, long ki_tdflags) {
     switch (ki_stat) {
@@ -333,6 +334,13 @@ static inline void update_proc_state_count_freebsd(char ki_stat, long ki_tdflags
                 proc_state_count[PROC_STATUS_SLEEPING] += 1;
             else
                 proc_state_count[PROC_STATUS_SLEEPING_D] += 1;
+            break;
+        case SWAIT:
+        case SLOCK:
+            // freebsd wait states (ps shows 'W' and 'L'); they are not
+            // uninterruptible sleep (that is SSLEEP without TDF_SINTR, shown as
+            // 'D'), so count them as interruptible sleep instead of dropping them.
+            proc_state_count[PROC_STATUS_SLEEPING] += 1;
             break;
         case SZOMB:
             proc_state_count[PROC_STATUS_ZOMBIE] += 1;

--- a/src/collectors/apps.plugin/apps_os_freebsd.c
+++ b/src/collectors/apps.plugin/apps_os_freebsd.c
@@ -319,16 +319,20 @@ cleanup:
     return false;
 }
 
-// FreeBSD maintains ki_stat for every process, including sleeping (SSLEEP),
-// stopped (SSTOP) and zombie (SZOMB) states. Zombies are present in the
-// KERN_PROC_PROC data and are counted like any other process.
-static inline void update_proc_state_count_freebsd(char ki_stat) {
+// FreeBSD maintains ki_stat for every process; SSLEEP covers both
+// interruptible and uninterruptible sleep, distinguished by TDF_SINTR in
+// ki_tdflags (ps shows uninterruptible sleep as 'D'). Zombies are present in
+// the KERN_PROC_PROC data and are counted like any other process.
+static inline void update_proc_state_count_freebsd(char ki_stat, long ki_tdflags) {
     switch (ki_stat) {
         case SRUN:
             proc_state_count[PROC_STATUS_RUNNING] += 1;
             break;
         case SSLEEP:
-            proc_state_count[PROC_STATUS_SLEEPING] += 1;
+            if (ki_tdflags & TDF_SINTR)
+                proc_state_count[PROC_STATUS_SLEEPING] += 1;
+            else
+                proc_state_count[PROC_STATUS_SLEEPING_D] += 1;
             break;
         case SZOMB:
             proc_state_count[PROC_STATUS_ZOMBIE] += 1;
@@ -394,7 +398,7 @@ bool apps_os_collect_all_pids_freebsd(void) {
         pid_t pid = procbase[i].ki_pid;
         if (pid <= 0) continue;
 
-        update_proc_state_count_freebsd(procbase[i].ki_stat);
+        update_proc_state_count_freebsd(procbase[i].ki_stat, procbase[i].ki_tdflags);
 
         incrementally_collect_data_for_pid(pid, &procbase[i]);
     }

--- a/src/collectors/apps.plugin/apps_os_freebsd.c
+++ b/src/collectors/apps.plugin/apps_os_freebsd.c
@@ -319,7 +319,36 @@ cleanup:
     return false;
 }
 
+// FreeBSD maintains ki_stat for every process, including sleeping (SSLEEP),
+// stopped (SSTOP) and zombie (SZOMB) states. Zombies are present in the
+// KERN_PROC_PROC data and are counted like any other process.
+static inline void update_proc_state_count_freebsd(char ki_stat) {
+    switch (ki_stat) {
+        case SRUN:
+            proc_state_count[PROC_STATUS_RUNNING] += 1;
+            break;
+        case SSLEEP:
+            proc_state_count[PROC_STATUS_SLEEPING] += 1;
+            break;
+        case SZOMB:
+            proc_state_count[PROC_STATUS_ZOMBIE] += 1;
+            break;
+        case SSTOP:
+            proc_state_count[PROC_STATUS_STOPPED] += 1;
+            break;
+        default:
+            // SIDL (still being created) and any unrecognized states are not
+            // counted, mirroring the Linux default case.
+            break;
+    }
+}
+
 bool apps_os_collect_all_pids_freebsd(void) {
+#if (PROCESSES_HAVE_STATE == 1)
+    // clear process state counter
+    memset(proc_state_count, 0, sizeof proc_state_count);
+#endif
+
     // Mark all processes as unread before collecting new data
     struct pid_stat *p = NULL;
     int i, procnum;
@@ -364,6 +393,9 @@ bool apps_os_collect_all_pids_freebsd(void) {
     for (i = 0 ; i < procnum ; ++i) {
         pid_t pid = procbase[i].ki_pid;
         if (pid <= 0) continue;
+
+        update_proc_state_count_freebsd(procbase[i].ki_stat);
+
         incrementally_collect_data_for_pid(pid, &procbase[i]);
     }
 

--- a/src/collectors/apps.plugin/apps_os_macos.c
+++ b/src/collectors/apps.plugin/apps_os_macos.c
@@ -420,8 +420,8 @@ bool apps_os_read_pid_stat_macos(struct pid_stat *p, void *ptr) {
                       p->values[PDF_THREADS]);
     }
 
-    // MacOS doesn't have a direct concept of process state like Linux,
-    // so updating process state count might need a different approach.
+    // p->state is not set on macOS; process state counting happens in
+    // apps_os_collect_all_pids_macos() from kinfo_proc.p_stat.
 
     return true;
 }

--- a/src/collectors/apps.plugin/apps_os_macos.c
+++ b/src/collectors/apps.plugin/apps_os_macos.c
@@ -426,9 +426,40 @@ bool apps_os_read_pid_stat_macos(struct pid_stat *p, void *ptr) {
     return true;
 }
 
+// On macOS the kernel only distinguishes the stopped (SSTOP) and zombie (SZOMB)
+// states in p_stat; every live process reports SRUN whether it is running or
+// sleeping, so "running" counts all live (non-zombie, non-stopped) processes
+// and SSLEEP never fires. Zombies must be counted here, because they are
+// skipped from per-process metrics (they have no Mach task).
+static inline void update_proc_state_count_macos(char p_stat) {
+    switch (p_stat) {
+        case SRUN:
+            proc_state_count[PROC_STATUS_RUNNING] += 1;
+            break;
+        case SSLEEP:
+            proc_state_count[PROC_STATUS_SLEEPING] += 1;
+            break;
+        case SZOMB:
+            proc_state_count[PROC_STATUS_ZOMBIE] += 1;
+            break;
+        case SSTOP:
+            proc_state_count[PROC_STATUS_STOPPED] += 1;
+            break;
+        default:
+            // SIDL (still being created) and any future states are not counted,
+            // mirroring the Linux default case.
+            break;
+    }
+}
+
 bool apps_os_collect_all_pids_macos(void) {
     static pid_t *pids = NULL;
     static int allocatedProcessCount = 0;
+
+#if (PROCESSES_HAVE_STATE == 1)
+    // clear process state counter
+    memset(proc_state_count, 0, sizeof proc_state_count);
+#endif
 
     // Get the number of processes
     int numberOfProcesses = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
@@ -472,6 +503,11 @@ bool apps_os_collect_all_pids_macos(void) {
         }
         if(procSize == 0) // no such process
             continue;
+
+        // count the process state before skipping zombies, so that
+        // system.processes_state includes zombies even though they are
+        // excluded from per-process metrics (they have no Mach task)
+        update_proc_state_count_macos(pi.proc.kp_proc.p_stat);
 
         // zombies have no Mach task and proc_pidinfo() resolves pids via proc_find(),
         // which skips SZOMB entries - so every proc_pidinfo() flavor below returns

--- a/src/collectors/apps.plugin/apps_os_macos.c
+++ b/src/collectors/apps.plugin/apps_os_macos.c
@@ -431,6 +431,8 @@ bool apps_os_read_pid_stat_macos(struct pid_stat *p, void *ptr) {
 // sleeping, so "running" counts all live (non-zombie, non-stopped) processes
 // and SSLEEP never fires. Zombies must be counted here, because they are
 // skipped from per-process metrics (they have no Mach task).
+// Counts one process into proc_state_count[] according to its kinfo_proc
+// p_stat value. Called once per collected process, before per-process metrics.
 static inline void update_proc_state_count_macos(char p_stat) {
     switch (p_stat) {
         case SRUN:

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -103,7 +103,7 @@ NETDATA_DOUBLE
 
 int update_every = 1;
 
-#if defined(OS_LINUX)
+#if (PROCESSES_HAVE_STATE == 1)
 proc_state proc_state_count[PROC_STATUS_END];
 const char *proc_states[] = {
     [PROC_STATUS_RUNNING] = "running",

--- a/src/collectors/apps.plugin/apps_plugin.h
+++ b/src/collectors/apps.plugin/apps_plugin.h
@@ -96,7 +96,7 @@ struct pid_info {
 #define PROCESSES_HAVE_CMDLINE               1
 #define PROCESSES_HAVE_PID_LIMITS            0
 #define PROCESSES_HAVE_COMM_AND_NAME         0
-#define PROCESSES_HAVE_STATE                 0
+#define PROCESSES_HAVE_STATE                 1
 #define PPID_SHOULD_BE_RUNNING               1
 #define INCREMENTAL_DATA_COLLECTION          1
 #define CPU_TO_NANOSECONDCORES (1) // already in nanoseconds

--- a/src/collectors/apps.plugin/apps_plugin.h
+++ b/src/collectors/apps.plugin/apps_plugin.h
@@ -48,7 +48,7 @@ struct apps_ebpf_cachestat_totals {
 #define PROCESSES_HAVE_CMDLINE               1
 #define PROCESSES_HAVE_PID_LIMITS            0
 #define PROCESSES_HAVE_COMM_AND_NAME         0
-#define PROCESSES_HAVE_STATE                 0
+#define PROCESSES_HAVE_STATE                 1
 #define PPID_SHOULD_BE_RUNNING               1
 #define INCREMENTAL_DATA_COLLECTION          1
 #define CPU_TO_NANOSECONDCORES (1)


### PR DESCRIPTION
### Summary

Implements a `system.processes_state` chart (running / sleeping_interruptible / sleeping_uninterruptible / zombie / stopped) on **macOS** and **FreeBSD**, matching the existing Linux chart shape. Closes #23296 and #23535.

- Enable `PROCESSES_HAVE_STATE` on macOS and FreeBSD; map `kinfo_proc.p_stat` (macOS) / `kinfo_proc.ki_stat` (FreeBSD) to process states (SRUN/SSLEEP/SSTOP/SZOMB; SIDL and unknown states ignored, mirroring Linux).
- macOS: count zombies **before** they are skipped from per-process metrics, so zombies are visible again without regressing the #23293/#23297 log-flood fix (zombies still excluded from `proc_pidinfo` — they have no Mach task).
- FreeBSD: `ki_stat` is kernel-maintained for every process, so the chart carries a real breakdown (sleeping included).
- Define `proc_state_count`/`proc_states` under `PROCESSES_HAVE_STATE` instead of `OS_LINUX`, so any flag-enabled platform links the shared emit path.

### Platform notes

- macOS (verified on macOS 26.5 / Darwin 25.5): the BSD `p_stat` field only distinguishes stopped (SSTOP) and zombie (SZOMB); every live process reports SRUN whether running or sleeping. So `running` counts all live processes and the two `sleeping_*` dimensions stay at 0 on this kernel — documented in a code comment. `zombie`/`stopped` carry the real signal.
- FreeBSD (verified on FreeBSD 14.1): `ki_stat` distinguishes SRUN/SSLEEP/SSTOP/SZOMB, and `ki_tdflags & TDF_SINTR` splits interruptible vs uninterruptible sleep exactly like `ps` (which shows `D`): `sleeping_uninterruptible` is populated. Live test: `running=2, sleeping_interruptible=32, sleeping_uninterruptible=14, zombie=5, stopped=2` (the 14 are kernel daemons in D state).
- Windows: **not supported** — no process-level state exists in perflib/the public APIs (only per-thread `ThreadState`/`WaitReason`), and Windows has no zombies. `PROCESSES_HAVE_STATE` stays 0 there.

### Testing

- macOS (arm64): build clean; live run with 5 spawned zombies + a SIGSTOP'd process verified counts; zombie PIDs produce no `Failed to get task info` log lines.
- FreeBSD 14.1: build clean (`apps.plugin` only); live run with 5 zombies + SIGSTOP plus D-state kernel daemons verified the chart block above; no new errors.

Closes #23296, #23535


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process-state reporting on macOS and FreeBSD.
  - Zombie processes are now included in aggregate state metrics.
  - Added more accurate classification for running, sleeping, stopped, waiting, and locked processes.
  - Process-state counters are reset consistently before each collection cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->