### PR TITLE
docs(mcp): fix stale netdata-build-mcp setup/auth docs

### DIFF
--- a/.agents/ENV.md
+++ b/.agents/ENV.md
@@ -40,11 +40,18 @@ Used by the build/run MCP server under `packaging/tools/automation/mcp`. When
 launches claims itself to Cloud as an ephemeral node named `mcp-<agent_id>`.
 Leave the token blank to launch unclaimed (local + MCP access still work).
 
+This server also requires `NETDATA_CLOUD_TOKEN` (see the table above) --
+`scripts/setup_mcp.py` / `ninja setup-mcp` fail without it, and at runtime it
+mints a per-agent Cloud bearer for the `netdata_agent_<name>` tools that
+forward calls into a running agent's own `/mcp`.
+
 | Key | Role | Where to find it | Sample format |
 |---|---|---|---|
 | `NETDATA_CLAIM_TOKEN` | Space claim token; enables auto-claim when set | app.netdata.cloud -> Space settings -> Connect Nodes -> the `--claim-token` value | long opaque token |
 | `NETDATA_CLAIM_ROOMS` | comma-separated Room id(s) for the node (optional) | same Connect Nodes dialog -> the `--claim-rooms` value | UUID[,UUID...] |
 | `NETDATA_CLAIM_URL` | Cloud base URL (optional) | defaults to `https://app.netdata.cloud` agent-side | URL |
+| `NETDATA_CLOUD_TOKEN` | Cloud REST token; required for setup and for the agent-forwarding tools | see the "Netdata Cloud + agents" table above | 36-char UUID-shaped token |
+| `NETDATA_CLOUD_HOSTNAME` | Cloud REST API host (optional) | see the table above; defaults to `app.netdata.cloud` | `app.netdata.cloud` |
 
 ### agent-events ingestion node
 
@@ -116,6 +123,13 @@ auth` instead.
 - `AGENT_EVENTS_HOSTNAME`
 - `AGENT_EVENTS_NODE_ID`
 - `AGENT_EVENTS_MACHINE_GUID`
+
+### netdata-build-mcp (ninja setup-mcp)
+
+- `NETDATA_CLAIM_TOKEN` (required)
+- `NETDATA_CLOUD_TOKEN` (required)
+- `NETDATA_CLAIM_ROOMS` / `NETDATA_CLAIM_URL` (optional)
+- `NETDATA_CLOUD_HOSTNAME` (optional; defaults to `app.netdata.cloud`)
 
 ### mirror-netdata-repos
 

--- a/.env.template
+++ b/.env.template
@@ -13,7 +13,10 @@
 # Netdata Cloud REST API
 # ---------------------------------------------------------------
 # Used by: query-netdata-cloud, query-netdata-agents,
-#          query-agent-events.
+#          query-agent-events, packaging/tools/automation/mcp
+#          (the build/run MCP server -- required by setup_mcp.py /
+#          ninja setup-mcp, and at runtime to mint per-agent bearers
+#          for the netdata_agent_<name> forwarding tools).
 #
 # NETDATA_CLOUD_TOKEN -- long-lived Cloud REST token.
 #   Get one at: https://app.netdata.cloud
@@ -36,6 +39,12 @@ NETDATA_CLOUD_HOSTNAME="app.netdata.cloud"
 #          ephemeral node named mcp-<agent_id>. Leave blank to
 #          launch unclaimed (local + MCP access still work).
 #          Must be present in the MCP server's environment.
+#
+#          NOTE: this server also requires NETDATA_CLOUD_TOKEN
+#          (above) -- setup_mcp.py / `ninja setup-mcp` fails
+#          without it, and it's used at runtime to mint per-agent
+#          Cloud bearers for the netdata_agent_<name> forwarding
+#          tools.
 #
 # NETDATA_CLAIM_TOKEN -- a Space claim token.
 #   Get one at: https://app.netdata.cloud -> Space settings

--- a/packaging/tools/automation/mcp/README.md
+++ b/packaging/tools/automation/mcp/README.md
@@ -112,7 +112,11 @@ netdata_agent_query_metrics(agent_id="agent", metric="system.cpu", after=-60, be
   argument, or `find_anomalous_metrics` which needs ML — off in these profiles).
 - The tool schemas are **vendored** (`agent_tools.py`, snapshotted via
   `scripts/snapshot_agent_tools.py`); a pinned surface, refreshed on demand.
-- No auth/claim needed — localhost `/mcp` is open; forwarding is per-call.
+- Every forwarded call requires `NETDATA_CLOUD_TOKEN` in the server's
+  environment: it mints and attaches a per-agent Cloud bearer before
+  forwarding (agent functions stay access-gated even on localhost once the
+  agent is claimed). A missing token, or a failed mint, is a hard error —
+  there is no anonymous path.
 
 ## OTel logs: configure, feed, query
 
@@ -216,22 +220,27 @@ Wire the server into your agent client in one step (configures **opencode** and
 **Claude Code** in your **global** config, pointing at this checkout, over stdio):
 
 ```sh
-# claim creds are required (launched agents auto-claim to Cloud):
-export NETDATA_CLAIM_TOKEN=…   # and optionally NETDATA_CLAIM_ROOMS
+# both tokens are required (claim creds so launched agents auto-claim to
+# Cloud; the Cloud token so the server can mint per-agent bearers):
+export NETDATA_CLAIM_TOKEN=…   # and optionally NETDATA_CLAIM_ROOMS/NETDATA_CLAIM_URL
+export NETDATA_CLOUD_TOKEN=…   # and optionally NETDATA_CLOUD_HOSTNAME
 ninja setup-mcp                 # from your build dir, or:
 python3 packaging/tools/automation/mcp/scripts/setup_mcp.py --tool all
 # …or pass them explicitly (CLI beats env):
-#   setup_mcp.py --claim-token … [--claim-rooms …] [--claim-url …]
+#   setup_mcp.py --claim-token … [--claim-rooms …] [--claim-url …] \
+#                --cloud-token … [--cloud-hostname …]
 ```
 
 - It mutates **your** global config (`~/.config/opencode/opencode.json` via a
   safe merge; Claude via `claude mcp add --scope user`) — never the repo. It
   adds only the `netdata-build` server and is idempotent.
-- **Claim creds are wired into the client's per-server env** (opencode
-  `environment`, Claude `--env`), so launched agents auto-claim. The **token is
-  required** — `--claim-token` or `NETDATA_CLAIM_TOKEN`; setup **fails** if
-  neither is set. This writes the token into your global client config (the
-  intended cost of pinning it per-server).
+- **Both credentials are wired into the client's per-server env** (opencode
+  `environment`, Claude `--env`), so launched agents auto-claim and the
+  "Querying a running agent" tools (below) can mint bearers. **Both tokens
+  are required** — `--claim-token`/`NETDATA_CLAIM_TOKEN` and
+  `--cloud-token`/`NETDATA_CLOUD_TOKEN`; setup **fails** if either is unset.
+  This writes both tokens into your global client config (the intended cost
+  of pinning them per-server).
 - `--tool opencode|claude|all` selects which to configure; a missing client is
   skipped, not an error.
 - Global config points the server at **this checkout's code**, but the server
@@ -281,7 +290,7 @@ project regardless of the client's cwd):
 ## Development
 
 ```sh
-uv run pytest          # unit tests (profiles, runner, job registry)
+uv run pytest          # unit tests (build/run lifecycle, agent forwarding + bearer auth, OTel, setup_mcp)
 ```
 
 Layout — a transport-free core with no `mcp` imports, plus a thin MCP layer:
@@ -296,7 +305,9 @@ netdata_mcp/
   runtime.py       # agent run dir + netdata.conf gen, port, readiness probe ── core
   agents.py        # AgentRegistry (agent-id -> worktree/profile)  ── core
   run.py           # Run + RunRegistry (launch/readiness/stop)     ── core
-  bearer.py        # Cloud per-agent bearer minting/cache (otel-logs auth) ── core
+  bearer.py        # Cloud per-agent bearer minting/cache (agent forwarding + otel-logs auth) ── core
+  agentmcp.py      # forward a call to a running agent's own /mcp  ── core
+  agent_tools.py   # vendored agent /mcp tool schemas (AGENT_TOOLS) ── core
   agentfn.py       # call a netdata function over HTTP (otel-logs) ── core
   streams.py       # Stream + StreamRegistry, synth/stream cargo runners ── core
   journal.py       # /proc PID resolution + read-only journalctl wrapper ── core
@@ -308,6 +319,9 @@ netdata_mcp/
     agents.py      # netdata_agent_declare
     run.py         # netdata_run_start / _status / _logs / _stop
     logs.py        # netdata_agent_logs (journalctl wrapper; journald hosts only)
+    agent_mcp.py   # netdata_agent_<name> forwarding tools (Querying a running agent)
+    models.py      # shared response models (JobInfo, RunInfo, AgentLogs, ...)
+    vendored.py    # register_forwarding_tool() (vendored-schema tool registration)
     mint_bearer.py # netdata_agent_mint_bearer (per-agent bearer for the Playwright MCP)
     otel_config.py # netdata_agent_otel_config
     otel_logs.py   # netdata_agent_otel_logs


### PR DESCRIPTION
## Summary
- README.md's "No auth/claim needed" claim for the `netdata_agent_<name>` forwarding tools was wrong — every forwarded call now hard-requires `NETDATA_CLOUD_TOKEN` to mint and attach a per-agent Cloud bearer (`netdata_mcp/tools/agent_mcp.py`).
- The "Quick setup" section only documented `NETDATA_CLAIM_TOKEN` as required; `scripts/setup_mcp.py` also hard-requires `NETDATA_CLOUD_TOKEN` and fails without it.
- The README's `Layout` file tree was missing 5 real files (`agentmcp.py`, `agent_tools.py`, `tools/agent_mcp.py`, `tools/models.py`, `tools/vendored.py`), and the `pytest`/`bearer.py` one-liners understated current coverage.
- `.env.template` and `.agents/ENV.md` didn't mention `NETDATA_CLOUD_TOKEN` as required for this tool's setup, and `ENV.md`'s per-skill checklist had no entry for it at all.

All of these trace back to the same root cause: the OTel-logs PR (`9e447641a`) hardened the server's auth model but the docs it shipped alongside were never updated to match. Found via a 4-way parallel audit comparing every README/env claim against the current code; each correction cites the exact file:line that contradicted the prior text.

Documentation-only change — no code, schema, or behavior touched.

## Test plan
- [x] `bash .agents/sow/scan-sensitive.sh` on all 3 changed files — clean
- [x] Manually re-verified each corrected claim against the cited source (`netdata_mcp/tools/agent_mcp.py`, `scripts/setup_mcp.py`, `ls netdata_mcp/ netdata_mcp/tools/`)
- [ ] A teammate follows the corrected "Quick setup" section end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale auth/setup docs for the `netdata-build` MCP server. Old docs said agent forwarding needed no auth and setup only required a claim token; now setup and every forwarded call require a Cloud token to mint per‑agent bearers, with no anonymous path.

- Updated `packaging/tools/automation/mcp/README.md`: removed “no auth/claim” claim, documented that `NETDATA_CLOUD_TOKEN` is required for forwarding and setup, added `--cloud-token/--cloud-hostname` flags, and expanded test coverage notes. The Layout now includes the missing files (`agentmcp.py`, `agent_tools.py`, `tools/agent_mcp.py`, `tools/models.py`, `tools/vendored.py`).
- Updated `.env.template` and `.agents/ENV.md`: list `NETDATA_CLOUD_TOKEN` as required for `ninja setup-mcp`/`scripts/setup_mcp.py` and for runtime forwarding, and add optional `NETDATA_CLOUD_HOSTNAME`. Added a per-skill checklist entry for the MCP build server.
- Documentation-only change; no code or behavior modifications.

**Migration**
- Set both `NETDATA_CLAIM_TOKEN` and `NETDATA_CLOUD_TOKEN` before running `ninja setup-mcp` or `scripts/setup_mcp.py`, or pass them via `--claim-token` and `--cloud-token`.
- Ensure the MCP server’s environment includes `NETDATA_CLOUD_TOKEN` at runtime; agent forwarding tools will hard-fail without it.

<sup>Written for commit a2c4b7f187b38d799611e1511eb2bb69bd2cf0df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP setup instructions to require `NETDATA_CLOUD_TOKEN`.
  * Clarified which configuration values are needed for setup and runtime agent forwarding.
  * Documented authentication behavior, including errors when the token is missing or credentials cannot be created.
  * Expanded setup guidance with command-line and environment configuration examples.
  * Added a checklist covering required, optional, and default configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->