### PR TITLE
fix(mrg): avoid UUID map create/free churn during metric lookups

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -524,6 +524,9 @@ int netdata_main(int argc, char **argv) {
                             if (unittest_waiting_queue()) return 1;
                             if (rw_spinlock_unittest()) return 1;
                             if (uuidmap_unittest()) return 1;
+#ifdef ENABLE_DBENGINE
+                            if (mrg_unittest()) return 1;
+#endif
                             if (paths_unittest()) return 1;
 #ifdef HAVE_LIBBACKTRACE
                             if (stacktrace_unittest()) return 1;

--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -401,7 +401,7 @@ struct mrg_uuid_race {
     size_t churn_hits;
     size_t churn_misses;
     size_t mismatches;
-    size_t deletes;
+    size_t deletes;        // deletions actually performed, by whichever side won
 };
 
 struct mrg_uuid_race_writer_ctx {
@@ -477,7 +477,12 @@ static void mrg_uuid_race_reader(void *ptr) {
         else
             __atomic_add_fetch(churned ? &t->churn_hits : &t->stable_hits, 1, __ATOMIC_RELAXED);
 
-        mrg_metric_release(t->mrg, metric);
+        // If the writer retired this metric while we held it, the writer's
+        // release could not delete it and OUR release performs the deletion.
+        // Counting only the writer side would undercount, and could report zero
+        // deletions - a false failure - in a run where readers always won.
+        if(mrg_metric_release(t->mrg, metric))
+            __atomic_add_fetch(&t->deletes, 1, __ATOMIC_RELAXED);
     }
 }
 
@@ -514,7 +519,7 @@ static int mrg_uuid_lookup_delete_race_unittest(void) {
             .latest_update_every_s = 1,
         };
         METRIC *m = mrg_metric_add_and_acquire(mrg, entry, &added);
-        mrg_metric_release(mrg, m);
+        if(m) mrg_metric_release(mrg, m);
     }
 
     ND_THREAD *th[MRG_UUID_RACE_READERS + MRG_UUID_RACE_WRITERS];
@@ -626,8 +631,13 @@ static int mrg_stale_peeked_id_unittest(void) {
     // 2. borrow the id exactly as the production lookup does - no reference taken
     UUIDMAP_ID borrowed = uuidmap_peek_id(victim);
     if(!borrowed) {
+        // Without a borrowed id there is nothing that can go stale, and the
+        // assertion below would look up id 0 and pass vacuously. Stop here.
         fprintf(stderr, "ERROR: peek could not resolve a uuid that has a metric\n");
-        errors++;
+        mrg_metric_release_and_delete(mrg, metric);
+        (void)mrg_destroy(mrg);
+        fprintf(stderr, "Stale peeked id test: 1 ERROR(S)\n");
+        return 1;
     }
 
     // 3. delete the metric. metric_release() also drops the METRIC's uuidmap
@@ -674,7 +684,14 @@ static int mrg_stale_peeked_id_unittest(void) {
         mrg_metric_release(mrg, ghost);
     }
 
-    (void)mrg_destroy(mrg);
+    // A non-zero result means metrics were still referenced and the MRG was left
+    // alive - i.e. this test leaked a reference. Ignoring it would let a cleanup
+    // regression pass silently.
+    size_t referenced = mrg_destroy(mrg);
+    if(referenced) {
+        fprintf(stderr, "ERROR: %zu metrics still referenced - the MRG was not destroyed\n", referenced);
+        errors++;
+    }
 
     if(errors)
         fprintf(stderr, "Stale peeked id test: %d ERROR(S)\n", errors);

--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -366,9 +366,181 @@ static int mrg_entries_acquired_counter_unittest(MRG *mrg) {
     return errors;
 }
 
+// ----------------------------------------------------------------------------
+// Concurrent lookup-vs-delete on the uuid path.
+//
+// mrg_metric_get_and_acquire_by_uuid() resolves the uuid with uuidmap_peek_id(),
+// which returns an id it holds NO reference on. That is only safe because every
+// METRIC owns a uuidmap reference for its whole lifetime, so an id that resolves
+// to a metric is necessarily still alive, and because ids are never reused, so a
+// stale id can only miss -- never alias a different uuid.
+//
+// This exercises exactly that window: readers look metrics up by uuid while
+// writers add and delete metrics for the same uuid pool. Any mismatch between the
+// uuid asked for and the uuid of the metric returned means the id aliased, which
+// is the failure mode the contract forbids.
+
+#define MRG_UUID_RACE_ENTRIES 512
+#define MRG_UUID_RACE_SECS 3
+#define MRG_UUID_RACE_READERS 4
+#define MRG_UUID_RACE_WRITERS 4
+
+struct mrg_uuid_race {
+    MRG *mrg;
+    nd_uuid_t *uuids;
+    size_t entries;
+    size_t churn_from;      // uuids below this index are stable, above they churn
+    bool stop;
+    size_t lookups_ok;
+    size_t lookups_miss;
+    size_t mismatches;
+    size_t deletes;
+};
+
+static void mrg_uuid_race_writer(void *ptr) {
+    struct mrg_uuid_race *t = ptr;
+    size_t span = t->entries - t->churn_from;
+    size_t i = 0;
+
+    while(!__atomic_load_n(&t->stop, __ATOMIC_RELAXED)) {
+        i = t->churn_from + ((i + 1) % span);
+
+        bool added = false;
+        // no retention on purpose: metric_release() only deletes a metric that
+        // has none (acquired_metric_has_retention()), and this test needs the
+        // delete path to actually run
+        MRG_ENTRY entry = {
+            .uuid = &t->uuids[i],
+            .section = (Word_t)&test_ctx_0,
+            .first_time_s = 0,
+            .last_time_s = 0,
+            .latest_update_every_s = 0,
+        };
+
+        METRIC *metric = mrg_metric_add_and_acquire(t->mrg, entry, &added);
+        if(mrg_metric_release_and_delete(t->mrg, metric))
+            __atomic_add_fetch(&t->deletes, 1, __ATOMIC_RELAXED);
+    }
+}
+
+static void mrg_uuid_race_reader(void *ptr) {
+    struct mrg_uuid_race *t = ptr;
+    size_t i = 0;
+
+    while(!__atomic_load_n(&t->stop, __ATOMIC_RELAXED)) {
+        i = (i + 1) % t->entries;
+
+        METRIC *metric = mrg_metric_get_and_acquire_by_uuid(t->mrg, &t->uuids[i], (Word_t)&test_ctx_0);
+        if(!metric) {
+            // a miss is a legitimate outcome here - the writers delete constantly
+            __atomic_add_fetch(&t->lookups_miss, 1, __ATOMIC_RELAXED);
+            continue;
+        }
+
+        // we hold the metric, so its uuidmap entry cannot go away underneath us
+        nd_uuid_t *got = mrg_metric_uuid(t->mrg, metric);
+        if(!got || uuid_compare(*got, t->uuids[i]) != 0)
+            __atomic_add_fetch(&t->mismatches, 1, __ATOMIC_RELAXED);
+        else
+            __atomic_add_fetch(&t->lookups_ok, 1, __ATOMIC_RELAXED);
+
+        mrg_metric_release(t->mrg, metric);
+    }
+}
+
+static int mrg_uuid_lookup_delete_race_unittest(void) {
+    fprintf(stderr, "\nTesting concurrent MRG lookup-by-uuid vs delete (%d readers, %d writers, %ds)...\n",
+            MRG_UUID_RACE_READERS, MRG_UUID_RACE_WRITERS, MRG_UUID_RACE_SECS);
+
+    int errors = 0;
+
+    // isolated MRG so the churn cannot disturb the accounting the other tests check
+    MRG *mrg = mrg_create_for_unittest();
+
+    struct mrg_uuid_race t = {
+        .mrg = mrg,
+        .entries = MRG_UUID_RACE_ENTRIES,
+        .uuids = callocz(MRG_UUID_RACE_ENTRIES, sizeof(nd_uuid_t)),
+    };
+    for(size_t i = 0; i < t.entries ;i++)
+        uuid_generate_random(t.uuids[i]);
+
+    // Seed the lower half with metrics that HAVE retention. metric_release()
+    // refuses to delete those, so they stay put and give the readers something
+    // they must reliably find; the upper half is left to the writers to churn.
+    // Without both halves the test proves nothing: all-stable means the delete
+    // path never runs, all-churn means the lookup path never succeeds.
+    t.churn_from = t.entries / 2;
+    for(size_t i = 0; i < t.churn_from ;i++) {
+        bool added = false;
+        MRG_ENTRY entry = {
+            .uuid = &t.uuids[i],
+            .section = (Word_t)&test_ctx_0,
+            .first_time_s = 2,
+            .last_time_s = 3,
+            .latest_update_every_s = 1,
+        };
+        METRIC *m = mrg_metric_add_and_acquire(mrg, entry, &added);
+        mrg_metric_release(mrg, m);
+    }
+
+    ND_THREAD *th[MRG_UUID_RACE_READERS + MRG_UUID_RACE_WRITERS];
+    size_t n = 0;
+    for(size_t i = 0; i < MRG_UUID_RACE_WRITERS ;i++) {
+        char buf[15 + 1];
+        snprintfz(buf, sizeof(buf) - 1, "MRGRW[%zu]", i);
+        th[n++] = nd_thread_create(buf, NETDATA_THREAD_OPTION_DONT_LOG, mrg_uuid_race_writer, &t);
+    }
+    for(size_t i = 0; i < MRG_UUID_RACE_READERS ;i++) {
+        char buf[15 + 1];
+        snprintfz(buf, sizeof(buf) - 1, "MRGRD[%zu]", i);
+        th[n++] = nd_thread_create(buf, NETDATA_THREAD_OPTION_DONT_LOG, mrg_uuid_race_reader, &t);
+    }
+
+    sleep_usec(MRG_UUID_RACE_SECS * USEC_PER_SEC);
+    __atomic_store_n(&t.stop, true, __ATOMIC_RELAXED);
+
+    for(size_t i = 0; i < n ;i++)
+        nd_thread_join(th[i]);
+
+    fprintf(stderr, "  lookups: %zu hit, %zu miss, %zu deletes, %zu MISMATCHES\n",
+            t.lookups_ok, t.lookups_miss, t.deletes, t.mismatches);
+
+    if(t.mismatches) {
+        fprintf(stderr, "ERROR: %zu lookups returned a metric for the wrong UUID\n", t.mismatches);
+        errors++;
+    }
+
+    // both outcomes must actually have happened, or the test proved nothing
+    if(!t.lookups_ok) {
+        fprintf(stderr, "ERROR: no successful lookup - the race was never exercised\n");
+        errors++;
+    }
+    if(!t.deletes) {
+        fprintf(stderr, "ERROR: no deletion happened - the race was never exercised\n");
+        errors++;
+    }
+
+    freez(t.uuids);
+
+    size_t referenced = mrg_destroy(mrg);
+    if(referenced) {
+        fprintf(stderr, "ERROR: %zu metrics still referenced after the race (leaked reference)\n", referenced);
+        errors++;
+    }
+
+    if(errors)
+        fprintf(stderr, "MRG uuid lookup/delete race test: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "MRG uuid lookup/delete race test: OK\n");
+
+    return errors;
+}
+
 int mrg_unittest(void) {
     int errors = dbengine_accounting_helpers_unittest();
     errors += mrg_destroy_referenced_metric_unittest();
+    errors += mrg_uuid_lookup_delete_race_unittest();
 
     // Use mrg_create_for_unittest to avoid pre-loaded metrics that block deletion
     MRG *mrg = mrg_create_for_unittest();

--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -393,36 +393,64 @@ struct mrg_uuid_race {
     size_t entries;
     size_t churn_from;      // uuids below this index are stable, above they churn
     bool stop;
-    size_t lookups_ok;
-    size_t lookups_miss;
+    // counted per region: an aggregate hit counter cannot distinguish "a reader
+    // queried a churning uuid while it was being deleted" from "a reader only
+    // ever hit the stable half", which is the whole point of the test
+    size_t stable_hits;
+    size_t stable_misses;
+    size_t churn_hits;
+    size_t churn_misses;
     size_t mismatches;
     size_t deletes;
 };
 
+struct mrg_uuid_race_writer_ctx {
+    struct mrg_uuid_race *t;
+    size_t from, to;            // this writer's exclusive slice of the churn region
+};
+
 static void mrg_uuid_race_writer(void *ptr) {
-    struct mrg_uuid_race *t = ptr;
-    size_t span = t->entries - t->churn_from;
+    struct mrg_uuid_race_writer_ctx *w = ptr;
+    struct mrg_uuid_race *t = w->t;
+
+    size_t span = w->to - w->from;
+    METRIC **held = callocz(span, sizeof(METRIC *));
     size_t i = 0;
 
+    // Each writer owns its slice exclusively, and keeps every metric it creates
+    // alive until its next sweep over that slot. Without that window the
+    // add/delete pair is back-to-back and readers can only ever miss - the churn
+    // region then contributes nothing and the race is not actually exercised.
     while(!__atomic_load_n(&t->stop, __ATOMIC_RELAXED)) {
-        i = t->churn_from + ((i + 1) % span);
+        i = (i + 1) % span;
+        size_t idx = w->from + i;
+
+        if(held[i]) {
+            // it has been visible to readers for a full sweep - retire it now
+            if(mrg_metric_release_and_delete(t->mrg, held[i]))
+                __atomic_add_fetch(&t->deletes, 1, __ATOMIC_RELAXED);
+            held[i] = NULL;
+        }
 
         bool added = false;
         // no retention on purpose: metric_release() only deletes a metric that
         // has none (acquired_metric_has_retention()), and this test needs the
         // delete path to actually run
         MRG_ENTRY entry = {
-            .uuid = &t->uuids[i],
+            .uuid = &t->uuids[idx],
             .section = (Word_t)&test_ctx_0,
             .first_time_s = 0,
             .last_time_s = 0,
             .latest_update_every_s = 0,
         };
+        held[i] = mrg_metric_add_and_acquire(t->mrg, entry, &added);
+    }
 
-        METRIC *metric = mrg_metric_add_and_acquire(t->mrg, entry, &added);
-        if(mrg_metric_release_and_delete(t->mrg, metric))
+    for(size_t k = 0; k < span ;k++) {
+        if(held[k] && mrg_metric_release_and_delete(t->mrg, held[k]))
             __atomic_add_fetch(&t->deletes, 1, __ATOMIC_RELAXED);
     }
+    freez(held);
 }
 
 static void mrg_uuid_race_reader(void *ptr) {
@@ -432,10 +460,13 @@ static void mrg_uuid_race_reader(void *ptr) {
     while(!__atomic_load_n(&t->stop, __ATOMIC_RELAXED)) {
         i = (i + 1) % t->entries;
 
+        bool churned = (i >= t->churn_from);
+
         METRIC *metric = mrg_metric_get_and_acquire_by_uuid(t->mrg, &t->uuids[i], (Word_t)&test_ctx_0);
         if(!metric) {
-            // a miss is a legitimate outcome here - the writers delete constantly
-            __atomic_add_fetch(&t->lookups_miss, 1, __ATOMIC_RELAXED);
+            // a miss is legitimate in the churn region - the writers delete constantly.
+            // In the stable region it is a defect: those metrics are never deleted.
+            __atomic_add_fetch(churned ? &t->churn_misses : &t->stable_misses, 1, __ATOMIC_RELAXED);
             continue;
         }
 
@@ -444,7 +475,7 @@ static void mrg_uuid_race_reader(void *ptr) {
         if(!got || uuid_compare(*got, t->uuids[i]) != 0)
             __atomic_add_fetch(&t->mismatches, 1, __ATOMIC_RELAXED);
         else
-            __atomic_add_fetch(&t->lookups_ok, 1, __ATOMIC_RELAXED);
+            __atomic_add_fetch(churned ? &t->churn_hits : &t->stable_hits, 1, __ATOMIC_RELAXED);
 
         mrg_metric_release(t->mrg, metric);
     }
@@ -487,11 +518,16 @@ static int mrg_uuid_lookup_delete_race_unittest(void) {
     }
 
     ND_THREAD *th[MRG_UUID_RACE_READERS + MRG_UUID_RACE_WRITERS];
+    struct mrg_uuid_race_writer_ctx wctx[MRG_UUID_RACE_WRITERS];
     size_t n = 0;
+    size_t churn_span = t.entries - t.churn_from;
     for(size_t i = 0; i < MRG_UUID_RACE_WRITERS ;i++) {
         char buf[15 + 1];
         snprintfz(buf, sizeof(buf) - 1, "MRGRW[%zu]", i);
-        th[n++] = nd_thread_create(buf, NETDATA_THREAD_OPTION_DONT_LOG, mrg_uuid_race_writer, &t);
+        wctx[i].t = &t;
+        wctx[i].from = t.churn_from + (churn_span * i) / MRG_UUID_RACE_WRITERS;
+        wctx[i].to   = t.churn_from + (churn_span * (i + 1)) / MRG_UUID_RACE_WRITERS;
+        th[n++] = nd_thread_create(buf, NETDATA_THREAD_OPTION_DONT_LOG, mrg_uuid_race_writer, &wctx[i]);
     }
     for(size_t i = 0; i < MRG_UUID_RACE_READERS ;i++) {
         char buf[15 + 1];
@@ -505,17 +541,34 @@ static int mrg_uuid_lookup_delete_race_unittest(void) {
     for(size_t i = 0; i < n ;i++)
         nd_thread_join(th[i]);
 
-    fprintf(stderr, "  lookups: %zu hit, %zu miss, %zu deletes, %zu MISMATCHES\n",
-            t.lookups_ok, t.lookups_miss, t.deletes, t.mismatches);
+    fprintf(stderr, "  stable: %zu hit / %zu miss   churn: %zu hit / %zu miss   deletes: %zu   MISMATCHES: %zu\n",
+            t.stable_hits, t.stable_misses, t.churn_hits, t.churn_misses, t.deletes, t.mismatches);
 
     if(t.mismatches) {
         fprintf(stderr, "ERROR: %zu lookups returned a metric for the wrong UUID\n", t.mismatches);
         errors++;
     }
 
-    // both outcomes must actually have happened, or the test proved nothing
-    if(!t.lookups_ok) {
-        fprintf(stderr, "ERROR: no successful lookup - the race was never exercised\n");
+    // stable metrics are never deleted, so they must always be findable
+    if(t.stable_misses) {
+        fprintf(stderr, "ERROR: %zu lookups missed a metric that is never deleted\n", t.stable_misses);
+        errors++;
+    }
+    if(!t.stable_hits) {
+        fprintf(stderr, "ERROR: no stable lookup succeeded - the readers did not run\n");
+        errors++;
+    }
+
+    // The real requirement: readers must have queried CHURNING uuids and seen
+    // them both present and absent. Hits alone could all come from the stable
+    // half, and deletes alone say nothing about what the readers were doing --
+    // neither would prove a lookup overlapped an in-flight deletion.
+    if(!t.churn_hits) {
+        fprintf(stderr, "ERROR: no churn-region hit - readers never caught a churning metric alive\n");
+        errors++;
+    }
+    if(!t.churn_misses) {
+        fprintf(stderr, "ERROR: no churn-region miss - readers never caught a churning metric deleted\n");
         errors++;
     }
     if(!t.deletes) {
@@ -539,9 +592,102 @@ static int mrg_uuid_lookup_delete_race_unittest(void) {
     return errors;
 }
 
+// Deterministic proof of the property the race test can only sample: an id
+// borrowed by uuidmap_peek_id() and then invalidated must MISS, never alias.
+//
+// This reproduces the exact handoff mrg_metric_get_and_acquire_by_uuid() performs
+// -- peek the id, then use it as a bare MRG key -- but drives the invalidation by
+// hand instead of hoping threads interleave, so it cannot pass vacuously.
+static int mrg_stale_peeked_id_unittest(void) {
+    fprintf(stderr, "\nTesting stale peeked id cannot alias (deterministic)...\n");
+    int errors = 0;
+
+    MRG *mrg = mrg_create_for_unittest();
+
+    nd_uuid_t victim;
+    uuid_generate_random(victim);
+
+    // 1. a metric exists for `victim`, so its uuid is in the uuidmap
+    bool added = false;
+    MRG_ENTRY entry = {
+        .uuid = &victim,
+        .section = (Word_t)&test_ctx_0,
+        .first_time_s = 0,          // no retention, so it is deletable on release
+        .last_time_s = 0,
+        .latest_update_every_s = 0,
+    };
+    METRIC *metric = mrg_metric_add_and_acquire(mrg, entry, &added);
+    if(!metric) {
+        fprintf(stderr, "ERROR: cannot add the victim metric\n");
+        mrg_destroy(mrg);
+        return 1;
+    }
+
+    // 2. borrow the id exactly as the production lookup does - no reference taken
+    UUIDMAP_ID borrowed = uuidmap_peek_id(victim);
+    if(!borrowed) {
+        fprintf(stderr, "ERROR: peek could not resolve a uuid that has a metric\n");
+        errors++;
+    }
+
+    // 3. delete the metric. metric_release() also drops the METRIC's uuidmap
+    //    reference, so the uuidmap entry goes away and `borrowed` becomes stale.
+    if(!mrg_metric_release_and_delete(mrg, metric)) {
+        fprintf(stderr, "ERROR: the victim metric was not deleted\n");
+        errors++;
+    }
+
+    if(uuidmap_peek_id(victim) != 0) {
+        fprintf(stderr, "ERROR: peek still resolves a uuid whose only metric was deleted\n");
+        errors++;
+    }
+
+    // 4. churn plenty of new metrics through the same section. If ids were ever
+    //    recycled, one of these would land on `borrowed`.
+    enum { DECOYS = 4096 };
+    for(size_t i = 0; i < DECOYS ;i++) {
+        nd_uuid_t decoy;
+        uuid_generate_random(decoy);
+        decoy[15] = victim[15];     // same partition => same id sequence
+        bool decoy_added = false;
+        MRG_ENTRY d = {
+            .uuid = &decoy,
+            .section = (Word_t)&test_ctx_0,
+            .first_time_s = 2,
+            .last_time_s = 3,
+            .latest_update_every_s = 1,
+        };
+        METRIC *dm = mrg_metric_add_and_acquire(mrg, d, &decoy_added);
+        if(dm) mrg_metric_release(mrg, dm);
+    }
+
+    // 5. THE assertion: the stale id must not resolve to anything at all.
+    //    A non-NULL result here is the aliasing bug the contract forbids.
+    METRIC *ghost = mrg_metric_get_and_acquire_by_id(mrg, borrowed, (Word_t)&test_ctx_0);
+    if(ghost) {
+        nd_uuid_t *ghost_uuid = mrg_metric_uuid(mrg, ghost);
+        char b[UUID_STR_LEN] = "?";
+        if(ghost_uuid) uuid_unparse_lower(*ghost_uuid, b);
+        fprintf(stderr, "ERROR: stale borrowed id %u resolved to a metric (uuid %s) - it aliased\n",
+                borrowed, b);
+        errors++;
+        mrg_metric_release(mrg, ghost);
+    }
+
+    (void)mrg_destroy(mrg);
+
+    if(errors)
+        fprintf(stderr, "Stale peeked id test: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "Stale peeked id test: OK\n");
+
+    return errors;
+}
+
 int mrg_unittest(void) {
     int errors = dbengine_accounting_helpers_unittest();
     errors += mrg_destroy_referenced_metric_unittest();
+    errors += mrg_stale_peeked_id_unittest();
     errors += mrg_uuid_lookup_delete_race_unittest();
 
     // Use mrg_create_for_unittest to avoid pre-loaded metrics that block deletion

--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -372,8 +372,10 @@ static int mrg_entries_acquired_counter_unittest(MRG *mrg) {
 // mrg_metric_get_and_acquire_by_uuid() resolves the uuid with uuidmap_peek_id(),
 // which returns an id it holds NO reference on. That is only safe because every
 // METRIC owns a uuidmap reference for its whole lifetime, so an id that resolves
-// to a metric is necessarily still alive, and because ids are never reused, so a
-// stale id can only miss -- never alias a different uuid.
+// to a metric is necessarily still alive, and because ids are unique for the
+// lifetime of the uuidmap, so a stale id can only miss -- never alias a different
+// uuid. (uuidmap_destroy() restarts the sequence, but it cannot succeed while a
+// METRIC holds a reference.)
 //
 // This exercises exactly that window: readers look metrics up by uuid while
 // writers add and delete metrics for the same uuid pool. Any mismatch between the

--- a/src/database/engine/mrg.c
+++ b/src/database/engine/mrg.c
@@ -187,10 +187,28 @@ METRIC *mrg_metric_add_and_acquire(MRG *mrg, MRG_ENTRY entry, bool *ret) {
 
 ALWAYS_INLINE
 METRIC *mrg_metric_get_and_acquire_by_uuid(MRG *mrg, nd_uuid_t *uuid, Word_t section) {
-    UUIDMAP_ID id = uuidmap_create(*uuid);
-    METRIC *metric = metric_get_and_acquire_by_id(mrg, id, section);
-    uuidmap_free(id);
-    return metric;
+    // This is a pure lookup, so resolve the uuid to its id WITHOUT creating it
+    // and WITHOUT taking a reference on it.
+    //
+    // It used to call uuidmap_create()/uuidmap_free() around the lookup, which
+    // was wrong twice over. Functionally, a miss inserted the uuid into the
+    // uuidmap only for the matching free to delete it again -- create/delete
+    // churn for something we only ever used as a search key. And for
+    // performance, uuidmap_free() takes the partition WRITE lock on every call,
+    // so every metric lookup serialized on it; during MRG population that is one
+    // exclusive acquisition per metric per journal file across only
+    // UUIDMAP_PARTITIONS partitions.
+    //
+    // Using the id as a bare key is safe here: every METRIC in the MRG holds its
+    // own uuidmap reference for its whole lifetime (metric_add_and_acquire()
+    // takes it, metric_del() releases it), so an id that resolves to a metric is
+    // necessarily still alive. If the uuid is unknown there can be no metric for
+    // it, and if the entry died the lookup simply misses -- ids are never reused,
+    // so a stale id cannot alias a different uuid.
+    UUIDMAP_ID id = uuidmap_peek_id(*uuid);
+    if(!id) return NULL;
+
+    return metric_get_and_acquire_by_id(mrg, id, section);
 }
 
 ALWAYS_INLINE

--- a/src/database/engine/mrg.c
+++ b/src/database/engine/mrg.c
@@ -203,8 +203,10 @@ METRIC *mrg_metric_get_and_acquire_by_uuid(MRG *mrg, nd_uuid_t *uuid, Word_t sec
     // own uuidmap reference for its whole lifetime (metric_add_and_acquire()
     // takes it, metric_del() releases it), so an id that resolves to a metric is
     // necessarily still alive. If the uuid is unknown there can be no metric for
-    // it, and if the entry died the lookup simply misses -- ids are never reused,
-    // so a stale id cannot alias a different uuid.
+    // it, and if the entry died the lookup simply misses -- ids are unique for the
+    // lifetime of the uuidmap, so a stale id cannot alias a different uuid. (The
+    // sequence only restarts on a successful uuidmap_destroy(), which cannot
+    // happen while any METRIC still holds its reference.)
     UUIDMAP_ID id = uuidmap_peek_id(*uuid);
     if(!id) return NULL;
 

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -67,7 +67,8 @@ static UUIDMAP_ID get_next_id_unsafe(struct uuidmap_partition *partition) {
         fatal("UUIDMAP: Maximum ID limit reached for partition %u. UUIDs exhausted.",
               (unsigned int)(partition - uuid_map.p));
 
-    // IDs are never reused, so the sequence space is lifetime capacity.
+    // IDs are never reused while the map lives (uuidmap_destroy() restarts the
+    // sequence), so the sequence space is this map's lifetime capacity.
     // next_id is monotonic and only changes under the partition write lock,
     // so the equality check fires exactly once per partition.
     if (unlikely(partition->next_id == (UUIDMAP_ID_SEQ_MASK / 10) * 9))
@@ -82,23 +83,30 @@ static UUIDMAP_ID get_next_id_unsafe(struct uuidmap_partition *partition) {
     return uuidmap_make_id(partition - uuid_map.p, ++partition->next_id);
 }
 
-static inline UUIDMAP_ID uuidmap_acquire_by_uuid(const nd_uuid_t uuid) {
-    UUIDMAP_ID id = 0;
+// Resolves uuid -> id through the uuid_to_id index. The caller MUST already hold
+// the partition lock. Returns 0 when the uuid is not indexed.
+//
+// This does no refcount work at all: on its own the returned id is only a key,
+// not a handle. Callers that need the entry to stay alive must acquire a
+// reference themselves while still holding the lock.
+static ALWAYS_INLINE UUIDMAP_ID uuidmap_id_by_uuid_locked(const nd_uuid_t uuid, uint8_t partition) {
+    Pvoid_t *PValue = JudyHSGet(uuid_map.p[partition].uuid_to_id, (void *)uuid, sizeof(nd_uuid_t));
+    if(unlikely(PValue == PJERR))
+        fatal("UUIDMAP: corrupted JudyHS array");
 
+    return (PValue && *PValue) ? *(UUIDMAP_ID *)PValue : 0;
+}
+
+static inline UUIDMAP_ID uuidmap_acquire_by_uuid(const nd_uuid_t uuid) {
     uint8_t partition = uuid_to_uuidmap_partition(uuid);
 
     // try to find it in the JudyHS - we may have it already
     rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
-    Pvoid_t *PValue = JudyHSGet(uuid_map.p[partition].uuid_to_id, (void *)uuid, sizeof(nd_uuid_t));
-    if(PValue == PJERR)
-        fatal("UUIDMAP: corrupted JudyHS array");
 
-    if(PValue && *PValue) {
-        // it is found
-
-        id = *(UUIDMAP_ID *)PValue;
-
-        PValue = JudyLGet(uuid_map.p[partition].id_to_uuid, id, PJE0);
+    UUIDMAP_ID id = uuidmap_id_by_uuid_locked(uuid, partition);
+    if(id) {
+        // it is found - take a reference before we drop the lock
+        Pvoid_t *PValue = JudyLGet(uuid_map.p[partition].id_to_uuid, id, PJE0);
         if (!PValue || PValue == PJERR)
             fatal("UUIDMAP: corrupted JudyL array");
 
@@ -112,19 +120,10 @@ static inline UUIDMAP_ID uuidmap_acquire_by_uuid(const nd_uuid_t uuid) {
 }
 
 UUIDMAP_ID uuidmap_peek_id(const nd_uuid_t uuid) {
-    UUIDMAP_ID id = 0;
-
     uint8_t partition = uuid_to_uuidmap_partition(uuid);
 
     rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
-
-    Pvoid_t *PValue = JudyHSGet(uuid_map.p[partition].uuid_to_id, (void *)uuid, sizeof(nd_uuid_t));
-    if(unlikely(PValue == PJERR))
-        fatal("UUIDMAP: corrupted JudyHS array");
-
-    if(PValue && *PValue)
-        id = *(UUIDMAP_ID *)PValue;
-
+    UUIDMAP_ID id = uuidmap_id_by_uuid_locked(uuid, partition);
     rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
 
     return id;
@@ -482,6 +481,23 @@ static int uuidmap_destroy_referenced_entry_unittest(void) {
         errors++;
     }
 
+    // A destroy that could not proceed must ALSO not have restarted the id
+    // sequence. This is the guarantee that makes a borrowed, unreferenced id
+    // (uuidmap_peek_id) safe: ids are unique per map lifetime, and a map cannot
+    // be torn down underneath a live reference. If a failed destroy reset
+    // next_id, the id issued below would collide with the one still held above.
+    nd_uuid_t same_partition_uuid;
+    uuid_generate_random(same_partition_uuid);
+    same_partition_uuid[15] = test_uuid[15];    // same partition => same id sequence
+
+    UUIDMAP_ID id2 = uuidmap_create(same_partition_uuid);
+    if(id2 == id) {
+        fprintf(stderr, "ERROR: id sequence restarted despite a failed destroy - "
+                        "id %u was issued twice for different UUIDs\n", id);
+        errors++;
+    }
+    uuidmap_free(id2);
+
     uuidmap_free(id);
 
     referenced = uuidmap_destroy();
@@ -792,8 +808,10 @@ static int uuidmap_peek_id_unittest(void) {
         errors++;
     }
 
-    // 5. ids are never reused - this is what makes a stale peeked id safe to use
-    //    as a bare lookup key: it can only ever miss, never alias another uuid
+    // 5. within a map lifetime ids are never reused - this is what makes a stale
+    //    peeked id safe as a bare lookup key: it can only miss, never alias.
+    //    (uuidmap_destroy() does restart the sequence, but cannot succeed while
+    //    anything holds a reference - covered by the destroy test above.)
     UUIDMAP_ID recreated = uuidmap_create(uuid);
     if(recreated == created) {
         fprintf(stderr, "ERROR: recreate reused id %u - ids must never be reused\n", created);

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -735,11 +735,86 @@ static int uuidmap_concurrent_unittest(void) {
     return errors;
 }
 
+// Verifies the uuidmap_peek_id() contract: it resolves a uuid to its id WITHOUT
+// creating it and WITHOUT taking a reference. Both halves matter -- a leaked
+// reference would keep entries alive forever, and a created-on-miss entry would
+// reintroduce the create/delete churn peek exists to avoid.
+static int uuidmap_peek_id_unittest(void) {
+    fprintf(stderr, "\nTesting UUID Map peek (non-owning lookup)...\n");
+    int errors = 0;
+
+    nd_uuid_t uuid;
+    uuid_generate_random(uuid);
+
+    // 1. an unknown uuid must miss, and must NOT be inserted as a side effect
+    UUIDMAP_ID id = uuidmap_peek_id(uuid);
+    if(id != 0) {
+        fprintf(stderr, "ERROR: peek returned id %u for an unknown UUID (expected 0)\n", id);
+        errors++;
+    }
+    if(uuidmap_peek_id(uuid) != 0) {
+        fprintf(stderr, "ERROR: peek created the UUID it was asked to look up\n");
+        errors++;
+    }
+
+    // 2. a known uuid must resolve to exactly the id create() handed out
+    UUIDMAP_ID created = uuidmap_create(uuid);
+    if(!created) {
+        fprintf(stderr, "ERROR: cannot create UUID for the peek test\n");
+        return errors + 1;
+    }
+
+    if((id = uuidmap_peek_id(uuid)) != created) {
+        fprintf(stderr, "ERROR: peek returned %u, expected %u\n", id, created);
+        errors++;
+    }
+
+    // 3. peek must take no reference: after many peeks, the SINGLE outstanding
+    //    reference from create() must still be enough to delete the entry
+    for(size_t i = 0; i < 1000 ;i++) {
+        if(uuidmap_peek_id(uuid) != created) {
+            fprintf(stderr, "ERROR: peek became unstable at iteration %zu\n", i);
+            errors++;
+            break;
+        }
+    }
+
+    uuidmap_free(created);
+
+    if(uuidmap_uuid_ptr(created) != NULL) {
+        fprintf(stderr, "ERROR: entry survived its last free - peek leaked a reference\n");
+        errors++;
+    }
+
+    // 4. peek must not report (or resurrect) a deleted entry
+    if((id = uuidmap_peek_id(uuid)) != 0) {
+        fprintf(stderr, "ERROR: peek returned id %u for a deleted UUID (expected 0)\n", id);
+        errors++;
+    }
+
+    // 5. ids are never reused - this is what makes a stale peeked id safe to use
+    //    as a bare lookup key: it can only ever miss, never alias another uuid
+    UUIDMAP_ID recreated = uuidmap_create(uuid);
+    if(recreated == created) {
+        fprintf(stderr, "ERROR: recreate reused id %u - ids must never be reused\n", created);
+        errors++;
+    }
+    uuidmap_free(recreated);
+
+    if(errors)
+        fprintf(stderr, "UUID Map peek test: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "UUID Map peek test: OK\n");
+
+    return errors;
+}
+
 int uuidmap_unittest(void) {
     fprintf(stderr, "\nTesting UUID Map...\n");
 
     const size_t ENTRIES = 100000;
     int errors = uuidmap_destroy_referenced_entry_unittest();
+    errors += uuidmap_peek_id_unittest();
     errors += uuidmap_locked_lookup_delete_interleaving_unittest();
     errors += uuidmap_concurrent_unittest();
 

--- a/src/libnetdata/uuid/uuidmap.c
+++ b/src/libnetdata/uuid/uuidmap.c
@@ -111,6 +111,25 @@ static inline UUIDMAP_ID uuidmap_acquire_by_uuid(const nd_uuid_t uuid) {
     return id;
 }
 
+UUIDMAP_ID uuidmap_peek_id(const nd_uuid_t uuid) {
+    UUIDMAP_ID id = 0;
+
+    uint8_t partition = uuid_to_uuidmap_partition(uuid);
+
+    rw_spinlock_read_lock(&uuid_map.p[partition].spinlock);
+
+    Pvoid_t *PValue = JudyHSGet(uuid_map.p[partition].uuid_to_id, (void *)uuid, sizeof(nd_uuid_t));
+    if(unlikely(PValue == PJERR))
+        fatal("UUIDMAP: corrupted JudyHS array");
+
+    if(PValue && *PValue)
+        id = *(UUIDMAP_ID *)PValue;
+
+    rw_spinlock_read_unlock(&uuid_map.p[partition].spinlock);
+
+    return id;
+}
+
 UUIDMAP_ID uuidmap_create(const nd_uuid_t uuid) {
     UUIDMAP_ID id = uuidmap_acquire_by_uuid(uuid);
     if(id != 0) return id;

--- a/src/libnetdata/uuid/uuidmap.h
+++ b/src/libnetdata/uuid/uuidmap.h
@@ -43,6 +43,16 @@ size_t uuidmap_destroy(void);
 // delete a uuid from the map
 void uuidmap_free(UUIDMAP_ID id);
 
+// Look up the id of a uuid WITHOUT creating it and WITHOUT taking a reference,
+// so it needs no matching uuidmap_free(). Returns 0 when the uuid is unknown.
+//
+// The returned id is a key, not a handle: it must NOT be used to reach the
+// uuidmap entry (uuidmap_uuid(), uuidmap_uuid_ptr(), uuidmap_dup(), ...), because
+// nothing keeps that entry alive. It is safe to use as a lookup key in a
+// structure whose own entries hold uuidmap references -- ids are never reused,
+// so a stale id can only ever miss, never alias a different uuid.
+UUIDMAP_ID uuidmap_peek_id(const nd_uuid_t uuid);
+
 // returns true if found, false if not found
 // UUID is copied to out_uuid if found
 bool uuidmap_uuid(UUIDMAP_ID id, nd_uuid_t out_uuid);

--- a/src/libnetdata/uuid/uuidmap.h
+++ b/src/libnetdata/uuid/uuidmap.h
@@ -8,7 +8,8 @@
 typedef uint32_t UUIDMAP_ID;
 
 // 2^UUIDMAP_PARTITION_BITS partitions; the remaining bits of UUIDMAP_ID are
-// the per-partition ID sequence space. IDs are never reused, so raising the
+// the per-partition ID sequence space. IDs are never reused within the lifetime
+// of the map (uuidmap_destroy() restarts the sequence), so raising the
 // partition count proportionally lowers the per-partition lifetime ID
 // capacity - total lifetime capacity stays at 2^32 and random UUIDs
 // distribute evenly across partitions. The partition is also reused by MRG
@@ -49,8 +50,17 @@ void uuidmap_free(UUIDMAP_ID id);
 // The returned id is a key, not a handle: it must NOT be used to reach the
 // uuidmap entry (uuidmap_uuid(), uuidmap_uuid_ptr(), uuidmap_dup(), ...), because
 // nothing keeps that entry alive. It is safe to use as a lookup key in a
-// structure whose own entries hold uuidmap references -- ids are never reused,
-// so a stale id can only ever miss, never alias a different uuid.
+// structure whose own entries hold uuidmap references: ids are unique for the
+// LIFETIME OF THE MAP, so a stale id can only ever miss, never alias a different
+// uuid.
+//
+// Uniqueness is per map lifetime, NOT global: uuidmap_destroy() restarts the
+// per-partition sequence, so ids handed out before it can be issued again after.
+// That is not a hazard for the borrowing pattern above only because a destroy
+// cannot succeed while anything still holds a reference (it returns the
+// referenced count and leaves the map intact), and any structure keyed by these
+// ids holds references for exactly as long as it keeps the keys. A caller that
+// stores a borrowed id across a successful uuidmap_destroy() WOULD alias.
 UUIDMAP_ID uuidmap_peek_id(const nd_uuid_t uuid);
 
 // returns true if found, false if not found


### PR DESCRIPTION
##### Summary
- Add uuidmap_peek_id() for non-owning UUID-to-ID lookups.
- Use it in MRG metric lookups instead of creating and immediately freeing UUID map entries.
- Avoid unnecessary UUID-map mutations and partition write-lock contention during MRG population.
- Preserve lookup safety: unknown or stale UUID IDs cleanly miss and cannot alias another UUID.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UUID-based metric lookups without creating unnecessary temporary mappings.
  * Unknown UUIDs are handled cleanly without creating new entries.
  * Reduced lock contention during metric retrieval.
  * Improved reliability during concurrent lookups and metric deletion.
  * Prevented stale identifiers from resolving to a different metric after deletion and UUID changes.
* **Tests**
  * Expanded coverage for lookup behavior, deletion, concurrency, and identifier stability.
  * Added metric lookup validation to supported full test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->