### PR TITLE
fix(rrdcalc): clarify health initialization flag behavior on child disconnect

### DIFF
--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -577,10 +577,11 @@ void rrdcalc_child_disconnected(RRDHOST *host) {
     // This is the initialization flag rather than the label-recheck one on purpose: the alert lists
     // are now empty, so the incremental apply path is correct and cheaper than detach-and-reattach.
     //
-    // The flags stay pending, inert, for as long as the child is away: our caller sets
-    // host->health.enabled = false right after us, so rrdhost_should_run_health() is false and
-    // nothing consumes them. They are consumed on the first health pass after the host is online
-    // again, whichever path brings it back.
+    // The flags stay pending, inert, for as long as the child is away: our caller clears
+    // RRDHOST_FLAG_COLLECTOR_ONLINE before calling us, so rrdhost_should_run_health() is already
+    // false by the time we raise them and nothing consumes them (health.enabled = false, set later
+    // in the same caller, only reinforces this). They are consumed on the first health pass after
+    // the host is online again, whichever path brings it back.
     RRDSET *st;
     rrdset_foreach_read(st, host) {
         rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);


### PR DESCRIPTION
##### Summary
- Clarify why pending health-initialization flags remain inert while a child is disconnected.
- Document that the collector-online flag is cleared before the flags are raised.
- Note that disabling health later in the same caller is additional protection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified health-status behavior while a child component is offline.
  * Documented that pending health flags are processed when the host comes back online.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->