### PR TITLE
Fix typo in clickhouse.replicas_max_absolute_delay

### DIFF
--- a/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
+++ b/src/go/plugin/go.d/collector/clickhouse/metadata.yaml
@@ -542,7 +542,7 @@ modules:
                 - name: fetch
                 - name: send
                 - name: check
-            - name: clickhouse.replicas_max_absolute_dela
+            - name: clickhouse.replicas_max_absolute_delay
               description: Replicas max absolute delay
               unit: seconds
               chart_type: line


### PR DESCRIPTION
##### Summary

metadata.yaml lists it as `clickhouse.replicas_max_absolute_dela`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects a misspelled metric name in the ClickHouse collector metadata to align with the actual metric. Old: clickhouse.replicas_max_absolute_dela. New: clickhouse.replicas_max_absolute_delay.

- No runtime/code behavior change; only `src/go/plugin/go.d/collector/clickhouse/metadata.yaml` updated. If any dashboards or alerts referenced the misspelled name from metadata, update them to `clickhouse.replicas_max_absolute_delay`.

<sup>Written for commit f357d2ad1845a53965d36baee639ae98fc762bad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ClickHouse metric name to `clickhouse.replicas_max_absolute_delay`, ensuring accurate metric identification and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->