### PR TITLE
Add Ceph monitoring and alert coverage (Phase 1)

### DIFF
--- a/.agents/skills/project-health-alert-authoring/SKILL.md
+++ b/.agents/skills/project-health-alert-authoring/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: project-health-alert-authoring
+description: Author, adapt, modify, or review Netdata health alerts and alert templates. Use when translating alerts from another system; changing `src/health/health.d/*.conf`, lookup/calc/warn/crit expressions, lifecycle, timing, routing, ownership, or missing-data behavior; writing health-config tests; or selecting an alert's chart/context/label identity.
+---
+
+# Author Netdata Health Alerts
+
+Use this skill before changing a health-alert definition. Alerts are production policy: a syntactically valid expression
+can still page incorrectly, manufacture a recovery, duplicate an incident owner, or make a disappearing entity look healthy.
+
+The normal goal when translating an alert from another system is **Netdata-adapted operational equivalence**, not
+execution-engine emulation. Preserve the operator-visible incident as closely as Netdata can express it through NIDL
+instances, alert beats, database lookups, native gap behavior, and chart obsoletion. Treat differences from the source
+engine as explicit design facts to document and test, not as defects by default.
+
+## Read The Right Sources
+
+1. Read `AGENTS.md`, the active SOW, the target alert file, and its collector/profile source.
+2. Read `docs/NIDL-Framework.md`, `src/health/REFERENCE.md`, `src/health/README.md`, and
+   `src/health/alert-configuration-ordering.md`.
+3. Read the existing alert owner and search for duplicate names, contexts, metric prefixes, and equivalent generic alerts.
+4. When lifecycle, missing-data, expression, or lookup semantics matter, confirm them in current runtime source:
+   - `src/health/health_event_loop.c`
+   - `src/health/health_variable.c`
+   - `src/web/api/queries/query-execute.c`
+   - the selected grouping implementation below `src/web/api/queries/`
+   - `src/libnetdata/eval/eval-evaluate.c`
+5. When the source is a go.d collector or Prometheus profile, also load the matching collector/profile skill and its required
+   references. Do not treat this skill as a replacement for collector or profile authoring guidance.
+
+Never query or reconfigure a live Agent merely to validate an alert unless the user has explicitly authorized that access.
+
+## Establish The Alert Contract Before Editing
+
+Write down the following in the active SOW before changing a non-trivial alert:
+
+- **Incident and owner:** What real incident does this alert represent? Which one source owns it? Do not create a
+  product-named duplicate of an existing collection-failure, component-failure, or generic host alert just to change
+  routing or severity.
+- **Signal contract:** Identify every source value and its meanings, including zero, non-zero, tri-state values, absent
+  dimensions, temporary collection failure, and known entity disappearance.
+- **Source intent and adaptation:** Separate the source alert's operator intent from its engine syntax. Record which
+  condition, scope, severity, persistence intent, identity, and recovery semantics Netdata preserves; record every
+  deliberate difference. Use `NETDATA-ADAPTED` as the normal classification. Reserve `EXACT` for a proven coincidental
+  match across timing, gaps, identity, recovery, and removal—not merely a similar expression.
+- **NIDL instance map:** Record the monitored component, context, one instance type, RRDSET/chart ID identity, dimensions,
+  stable identity labels, current metadata labels, and the collector's obsoletion condition. An alert attaches to one
+  RRDSET/chart instance; a template applies that same rule independently to matching instances in one context.
+- **Identity:** Choose an `alarm` only for a specific chart instance; choose a `template` for a context-wide rule. An
+  identity label MUST identify the same monitored entity across its intended lifetime. A label whose source value can
+  change for that entity is current metadata, not RRDSET identity: preserve the chart ID and update/promote the label.
+  Confirm labels preserve the incident identity and do not create unbounded instances.
+  Prove whether each promoted source label is live metadata, creation-time metadata, or source-frozen history. Do not
+  describe a label as "current" merely because Netdata can update labels.
+- **Variables and aggregation:** An unqualified variable resolves in the alert's local monitored component/instance before
+  broader candidates. Use a fully qualified chart/dimension reference only after proving the other chart is the matching
+  instance and labels select it unambiguously. Never synthesize an infrastructure-level alert by combining multiple
+  RRDSET instances in alert configuration; require a source-owned aggregate RRDSET at the higher component level instead.
+  The alert `component:` classification field does not replace this NIDL mapping.
+- **Lifecycle:** Specify expected `UNINITIALIZED`, `CLEAR`, `WARNING`/`CRITICAL`, `UNDEFINED`, and `REMOVED` behavior.
+  State whether an ordinary recovery emits a zero or whether the chart/dimension disappears instead.
+- **Timing:** State the source update cadence, explicit alert cadence, lookup window, source persistence intent, selected
+  Netdata adaptation, startup behavior, partial-gap behavior, stale-chart behavior, and notification policy. Do not call
+  a lookup window an implementation of another engine's `for:` state machine.
+- **Validation:** List the boundary, transition, missing-data, recovery, and duplicate-ownership tests that prove the
+  contract.
+
+Pause for a user decision when the change creates a public alert contract, changes default notification policy, changes
+the owner of an incident, needs shared health/query framework work, or cannot preserve the approved operator-visible
+incident closely enough with Netdata-native behavior. A difference from Prometheus execution alone is not such a blocker.
+
+## Model The Lifecycle Truthfully
+
+| Source situation | Alert-lifecycle consequence |
+|---|---|
+| Valid numeric input and both conditions are false | `CLEAR` |
+| Valid numeric input and warning/critical condition is true | `WARNING` or `CRITICAL` |
+| Some values exist in a lookup window and some are NULL | The lookup continues using numeric values; NULL is not automatically a failed condition |
+| Collector misses a collection while the chart remains live | A runnable alert may evaluate a lookup based on stored data; no fresh sample is fabricated |
+| Lookup runs and its selected window has no usable values | `$this` is `NaN`; the final state is `UNDEFINED` only when the condition preserves it |
+| A lookup's newest stored sample is too old for its runnable-history gate | The health loop skips that evaluation; it does not manufacture `CLEAR` or guarantee an `UNDEFINED` transition |
+| Collector knows the entity is gone and obsoletes the chart | The alert enters `REMOVED`, not an ordinary zero/CLEAR recovery |
+
+Important rules:
+
+- **A collection failure is not disappearance.** Collectors MUST preserve a gap when they cannot measure and MUST obsolete
+  only an entity they know is gone. Do not add a false zero to make an alert recover.
+- **A chart can remain alert-eligible during a gap.** The health loop skips an obsolete chart, but does not require a
+  newly collected value for every scheduled evaluation. `$last_collected_t` and `$update_every` expose freshness when an
+  alert is the deliberate stale-collection owner.
+- **A live chart does not guarantee every lookup remains runnable forever.** For a relative database lookup, the health
+  loop eventually skips evaluation when the newest stored point is too old for the requested window plus its bounded
+  update-interval tolerance. Skipping evaluation preserves the prior alert state; it is different from evaluating an
+  all-null result to `UNDEFINED`.
+- **Obsoletion ends the instance alert.** Once the collector knows an entity is gone and obsoletes its RRDSET, the health
+  rule no longer evaluates that instance. Do not attempt to emulate an infrastructure-level continuation in another
+  alert; collect a source-owned aggregate instance if that is the required product signal.
+- **A null result does not fabricate healthy state.** The health loop assigns `NaN` to an empty lookup result. A condition
+  that itself evaluates to `NaN` is `UNDEFINED`.
+- **Comparisons can consume `NaN`.** In the expression evaluator, `NaN` is false in boolean contexts and a comparison
+  such as `$this == 0` produces a finite false result. That can yield `CLEAR`, not `UNDEFINED`. If the contract requires
+  `UNDEFINED`, make and test an expression path that preserves `NaN`; never assume a comparison does so.
+- **Some NULLs are not all NULLs.** Query aggregation accepts numeric points and omits non-numeric ones. Do not assume a
+  partial collection gap invalidates a window unless the current runtime and the approved product contract say it does.
+  A general strict-coverage rule is shared-framework work, not an alert-file shortcut.
+- **Do not duplicate freshness ownership.** Use `$now - $last_collected_t` for an explicit collection/staleness alert only
+  when no existing generic collection-failure alert already owns the incident. A data-state alert normally owns the
+  measured condition, not the collector outage.
+
+For a data-state alert that MUST become `UNDEFINED` when its lookup is non-finite, use and test this condition shape:
+
+```text
+warn: ($this == nan or $this == inf) ? (nan) : (<numeric predicate>)
+```
+
+Use `crit:` in the same way. This preserves the non-finite result only; it does not turn a partial-null window into a
+collection-failure alert or replace a known-obsolete chart's `REMOVED` lifecycle.
+
+## Adapt Timing To Netdata
+
+### Current State
+
+Use `calc` when the source's current value is the full condition. Test start-up, missing input, normal recovery, and chart
+obsoletion separately. `delay:` controls Netdata alert transition/notification hysteresis; it is not a general substitute
+for a Prometheus `for:` duration.
+
+### Persistence Intent
+
+Treat another system's `for: D` as an operator intent to suppress transient conditions. It is not a requirement to emulate
+that system's pending-state machine. Choose the closest safe Netdata-native behavior from the source's actual numeric
+state space, set an explicit `every:`, and disclose the differences:
+
+- For a binary source where **1 means the active fault**, `min -5m unaligned` with an active predicate is true only when
+  every **observed numeric value** in the selected window is active. This is a Netdata observation-window adaptation, not
+  Prometheus `for: 5m`.
+- For a binary source where **0 means the active fault**, use the complementary aggregation/predicate that requires all
+  observed values to be zero; consult the lookup reference and prove it with state-sequence tests.
+- For a tri-state or enumerated source, do not apply a binary `min`/`max` rule by analogy. Use an exact predicate over the
+  full state space. For example, `countif(!=target)` returns the percentage of observed values outside `target`; zero means
+  every observed value matched.
+- `min`, `max`, and `countif` operate on the numeric samples they receive. Test active-to-other-state transitions in both
+  directions and record the intended partial-gap behavior.
+- A new chart may become runnable with up to one chart update interval less history than the requested lookup window.
+  Therefore an already-active condition can raise up to roughly one source beat before `D` after chart creation. Do not
+  conceal this with a hand-authored "window complete" flag.
+- A missing sample does not reset an observation window. Values before and after a partial gap may contribute to the same
+  lookup. Collection-failure ownership remains separate unless the alert contract explicitly owns freshness.
+- One health rule has one historical database lookup. A predicate combining multiple dimensions cannot gain exact
+  historical persistence by looking up one dimension and combining it with the others' current values. Prefer, in order:
+  a source-owned derived dimension when the persisted compound condition is essential; otherwise a truthful current-state
+  adaptation; never a mixed-time formula that changes the incident meaning.
+- Do not lengthen the window mechanically by one assumed collector interval. Collector cadence is configurable, and that
+  does not repair partial gaps or create a source-engine pending state.
+
+For every persistence adaptation, prove: chart startup, observed active history, each recovery state, each higher/lower
+enumerated state, a partial source gap, a stale non-runnable lookup, collection resumption, chart obsoletion, and the
+configured evaluation cadence. Never invent a `pending` state that Netdata does not expose, and never declare fidelity
+from the look of an expression alone.
+
+## Keep Ownership And Identity Non-Duplicating
+
+- Search existing stock alerts before adding one. Reuse an existing alert only when it really owns the same logical
+  incident; disclose routing/severity/lifecycle differences rather than silently relabeling it.
+- Keep source collection failure, component/API collection failure, source data-state failure, and client-observed failure
+  as separate owners when they identify different operator actions.
+- Filter templates with chart labels only when they select the intended RRDSET instance without changing its identity.
+  A current metadata label may be used as a filter only when the alert contract explicitly wants that current metadata;
+  do not turn it into `instances.by_labels` merely to make filtering convenient. Exclude known named rules from generic
+  fallbacks, including special sources whose recovery is chart removal rather than zero.
+- Preserve ordinary zero recovery. Do not convert an active-to-zero source into disappearance, and do not treat a
+  disappearing source as a normal CLEAR.
+- Use the ordering guide for template/alarm precedence and user-versus-stock override behavior. Same-name definitions are
+  an override mechanism; different names coexist and can therefore duplicate incidents.
+
+## Validate The Actual Contract
+
+Run the smallest relevant tests first, then the full affected suite. A complete alert change normally needs all applicable
+items below:
+
+1. Run `/usr/sbin/netdata -W healthconfigtest` for the built-in health parser and lookup suite.
+2. Add or update a focused test that reads the shipped alert template and asserts its context, labels, lookup, units,
+   cadence, expressions, routing, source ownership, and declared fidelity—not merely a copied expected string.
+3. Test the signal's lifecycle through the real query/health runtime where practical. If a lower-level deterministic model
+   is necessary, derive it directly from runtime timestamps and numeric-point selection; do not pass an arbitrary
+   `windowComplete` flag or label skipped NULLs as continuous evaluation. Cover startup, active transition, normal zero
+   recovery, a true all-null query, partial-null behavior, stale non-runnable behavior, collection resumption, known
+   disappearance/`REMOVED`, and label identity.
+4. For an expression that relies on `NaN`, test the evaluator result directly. Check both direct `NaN` propagation and any
+   comparison/conditional branch; do not infer the result from ordinary floating-point intuition.
+5. Run collector/profile validation when the alert depends on a collector or profile change. Include source absence and
+   collision-bearing labels where relevant.
+6. Search for same-incident alerts, duplicate contexts, old names, fallback overlap, and generated artifacts. Record the
+   result in the SOW.
+7. For an externally sourced alert pack, commit a source-pinned mapping that records the original condition, scope,
+   severity, persistence intent, supported releases, Netdata owner, adaptation, and known differences. Tests MUST consume
+   that mapping rather than restating the intended result independently.
+8. Validate every published configuration example through the same job-construction prerequisites users need. In
+   particular, a job referencing `vnode:` is incomplete unless the example defines or clearly links the required vnode.
+9. Run `git diff --check` and the project-required validation/review gate before claiming completion.
+
+`healthconfigtest` runs built-in health parser and lookup cases. It does not load every stock health template, prove that a
+template attaches to the intended chart, or prove the runtime lifecycle. Cover those separately with source-aware contract
+and transition tests.
+
+## Completion Check
+
+Before requesting review, confirm all of the following:
+
+- The alert has exactly one logical owner and a stable scope.
+- Its NIDL instance map shows one monitored component and one instance-level alert target; any required aggregate is a
+  source-owned higher-level RRDSET, not an alert-side merge.
+- Its source state values, gaps, absence, and recovery have been tested rather than assumed.
+- Its `NaN`, `UNDEFINED`, `CLEAR`, and `REMOVED` transitions match the recorded contract.
+- Its timing is the closest safe Netdata adaptation, with startup/gap/stale differences disclosed; `delay:` is not
+  standing in for another engine's persistence state machine.
+- Notification defaults follow the approved product policy.
+- No shared health/query behavior was added or assumed without the required separate scope approval.
+
+## Authoritative References
+
+- Syntax, variables, lookups, and stock patterns: `src/health/REFERENCE.md`
+- State model and missing-data summary: `src/health/README.md`
+- NIDL component/instance/dimension/label model: `docs/NIDL-Framework.md`
+- Template/alarm and user/stock precedence: `src/health/alert-configuration-ordering.md`
+- Alert eligibility, lookup execution, and `REMOVED`: `src/health/health_event_loop.c`
+- `$now`, `$last_collected_t`, `$update_every`, and dimension freshness: `src/health/health_variable.c`
+- Query gaps and grouping: `src/web/api/queries/query-execute.c` and the relevant grouping implementation
+- `NaN` expression semantics: `src/libnetdata/eval/eval-evaluate.c`

--- a/.agents/skills/project-health-alert-authoring/SKILL.md
+++ b/.agents/skills/project-health-alert-authoring/SKILL.md
@@ -69,6 +69,103 @@ Pause for a user decision when the change creates a public alert contract, chang
 the owner of an incident, needs shared health/query framework work, or cannot preserve the approved operator-visible
 incident closely enough with Netdata-native behavior. A difference from Prometheus execution alone is not such a blocker.
 
+## Combine Values Across Dimensions, Charts, And Alerts
+
+Choose the smallest pattern that can express the condition truthfully. Do not introduce cross-chart or intermediate-alert
+plumbing when the required values already share the alert's chart.
+
+### Pattern 1 — dimensions on the alert's chart
+
+Use unqualified dimension variables in `calc`, `warn`, or `crit` when every required value is a dimension on the chart
+named by `on:`:
+
+```text
+template: example_ratio
+      on: app.state
+     calc: $total - $used
+```
+
+Runtime facts:
+
+- Matching is by dimension ID or name in the alert's own chart.
+- The default dimension value is `collector.last_stored_value`: the latest database-stored value after interpolation, not
+  a database-window aggregate and not necessarily the raw last collector sample.
+- A missing dimension makes the expression fail with an unknown variable and the alert value become `NaN`.
+- Prefer explicit non-finite guards when `UNDEFINED` is the required missing-input state; do not rely on arithmetic or
+  comparisons to preserve `NaN`.
+
+Use `$dimension_raw` only when the contract specifically needs the last collected value before interpolation/storage
+presentation, and `$dimension_last_collected_t` only when it needs that dimension's collection timestamp.
+
+### Pattern 2 — dimensions from another chart or context
+
+Use a dotted chart/context reference when values live on different charts:
+
+```text
+template: example_cross_chart
+      on: app.usage
+     calc: $this * 100 / ${app.capacity.total}
+```
+
+The dotted prefix is interpreted from right to left as chart/context plus the final dimension name. Runtime resolution:
+
+1. An exact chart ID is checked first.
+2. A chart name may match.
+3. If the prefix is a context, every chart instance in that context contributes candidates for the final dimension.
+4. Every candidate is scored against the alert's chart labels by counting equal key/value labels.
+5. The candidate with the highest score wins. Equal scores are resolved by candidate traversal order, so avoid designs
+   where a tie is possible.
+
+Consequences:
+
+- This is the natural way to compare related chart instances, but the matching labels must make the intended instance
+  unique. A generic shared label such as only `component=ceph` is usually insufficient across many cluster instances.
+- Like Pattern 1, the selected dimension value is the latest stored value, not a query over a time window.
+- Fully qualified names containing punctuation must use `${...}` braces.
+- A reference that resolves to no candidate fails as an unknown variable and produces `NaN`.
+
+### Pattern 3 — an intermediate alert as a computed variable
+
+Create a non-notifying helper alert when the required value itself needs a database lookup or multi-stage computation,
+then reference that alert by name from the consuming alert:
+
+```text
+template: example_window
+      on: app.work
+   lookup: average -1h of requests
+     calc: $this
+      to: silent
+
+template: example_consumes
+      on: app.current
+   lookup: average -1m of requests
+     calc: $this / $example_window
+     warn: $this > 1
+      to: sysadmin
+```
+
+Runtime facts:
+
+- Every running alert with the referenced name is a candidate.
+- Candidates are selected by the same equal-label score used for cross-chart variables.
+- The selected candidate contributes its current alert value (`rc->value`), after that helper's own lookup and `calc`.
+- This is the only one of the three patterns that can combine database-window results such as “max of the last hour of X
+  with the average of the last minute of Y”.
+- Health evaluates all lookup/calculation phases before warning/critical phases, but helper snapshots are published as
+  each alert completes. A consumer with a different cadence can therefore read the helper's previous published value on
+  its first beat or after cadence drift. Align `every:` or disclose this timing difference.
+- Prefer `to: silent` on helpers and document why they exist; a helper is instrumentation, not a second incident owner.
+
+### Choosing a pattern
+
+- Same chart, latest values: Pattern 1.
+- Different charts/contexts, latest values: Pattern 2.
+- Any input needs a database window or a staged calculation: Pattern 3.
+- Never use Pattern 3 merely to avoid a qualified dotted reference; its added timing and lifecycle coupling must earn its
+  place.
+- Never combine multiple RRDSET instances into one infrastructure-level alert on the alert side. If no source-owned chart
+  provides the required aggregate, that is a collector/profile/framework gap, not an alert-expression workaround.
+
 ## Model The Lifecycle Truthfully
 
 | Source situation | Alert-lifecycle consequence |
@@ -223,6 +320,8 @@ Before requesting review, confirm all of the following:
 - NIDL component/instance/dimension/label model: `docs/NIDL-Framework.md`
 - Template/alarm and user/stock precedence: `src/health/alert-configuration-ordering.md`
 - Alert eligibility, lookup execution, and `REMOVED`: `src/health/health_event_loop.c`
-- `$now`, `$last_collected_t`, `$update_every`, and dimension freshness: `src/health/health_variable.c`
+- `$now`, `$last_collected_t`, `$update_every`, dimension freshness, same-chart variables, cross-chart/context
+  variables, alert variables, and label-score selection: `src/health/health_variable.c`
+- Equal-label score implementation: `src/database/rrdlabels.c:rrdlabels_common_count()`
 - Query gaps and grouping: `src/web/api/queries/query-execute.c` and the relevant grouping implementation
 - `NaN` expression semantics: `src/libnetdata/eval/eval-evaluate.c`

--- a/.agents/skills/project-health-alert-authoring/SKILL.md
+++ b/.agents/skills/project-health-alert-authoring/SKILL.md
@@ -221,6 +221,80 @@ Use `calc` when the source's current value is the full condition. Test start-up,
 obsoletion separately. `delay:` controls Netdata alert transition/notification hysteresis; it is not a general substitute
 for a Prometheus `for:` duration.
 
+## Control Flapping With Three Combinable Layers
+
+Stability is a signal-shaping problem, a threshold-boundary problem, and a transition-confirmation problem. Address them
+deliberately in that order. Do not label every anti-flapping technique “hysteresis”: only `delay:` postpones an alert
+transition.
+
+### Layer 1 — stabilize the queried value
+
+Use `lookup:` to make `$this` a stable aggregate over an explicit observation window:
+
+```text
+lookup: average -5m unaligned of latency
+```
+
+- `average` smooths noisy utilization, rate, latency, and utilization-like signals.
+- `min` requires every observed numeric sample to remain active, appropriate for persisted binary fault states.
+- `max` preserves worst-case excursions when the incident is defined by peaks.
+- `countif` expresses percent-of-observed-time semantics.
+
+This reduces noise but cannot prevent a stable aggregate from hovering near one threshold. A 5-minute average near 100 ms
+can still cross a 100 ms threshold repeatedly.
+
+### Layer 2 — separate raise and clear thresholds
+
+For policy thresholds whose signal may hover near the boundary, use a state-dependent predicate:
+
+```text
+warn: $this > (($status >= $WARNING) ? (90) : (100))
+crit: $this > (($status == $CRITICAL) ? (95) : (99))
+```
+
+This changes one threshold into two thresholds:
+
+- clear-to-warning raises above 100;
+- active-warning clears below 90;
+- critical can independently use another raise/clear pair.
+
+Important semantics:
+
+- This is **not hysteresis** and does not delay any transition.
+- The alert continues evaluating at its normal `every:` cadence.
+- It only changes the boundary used by the current status, so a genuine crossing of the recovery threshold acts
+  immediately.
+- Preserve a non-finite guard around the complete expression when `UNDEFINED` must remain possible.
+
+Prefer this when independent raise/clear boundaries are meaningful and the signal is expected to linger near one boundary.
+Do not use it to redefine a categorical exact condition into a policy band.
+
+### Layer 3 — confirm transitions with true hysteresis
+
+Use `delay:` only when a transition must remain selected for a duration before Netdata executes the transition
+notification:
+
+```text
+delay: down 5m multiplier 1.5 max 1h
+```
+
+- `up` delays a state escalation; `down` delays a recovery/de-escalation.
+- `multiplier` grows the delay when the state changes during the delay.
+- `max` caps the accumulated delay.
+
+This is the only layer that postpones an alert transition notification. It can suppress rapid clear/reactivate
+notification cycles, but it can also postpone a real transition. Use it sparingly and record the expected transition
+delay in the alert contract.
+
+### Selection procedure
+
+1. Establish whether the incident is categorical, threshold policy, or derived arithmetic.
+2. Select the smallest truthful `lookup:` window and aggregation first.
+3. For a noisy policy threshold, choose explicit raise/clear thresholds before adding transition delay.
+4. Add `delay:` only when rapid transition notifications are independently harmful and later notification is acceptable.
+5. Test each layer: input noise, boundary crossing, recovery, reactivation, non-finite input, partial gap, and the exact
+   expected notification time.
+
 ### Persistence Intent
 
 Treat another system's `for: D` as an operator intent to suppress transient conditions. It is not a requirement to emulate

--- a/.agents/skills/project-health-alert-authoring/agents/openai.yaml
+++ b/.agents/skills/project-health-alert-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Health Alert Authoring"
+  short_description: "Author correct Netdata health alerts"
+  default_prompt: "Use $project-health-alert-authoring to add or review a Netdata health alert."

--- a/.agents/skills/project-prometheus-profiles/SKILL.md
+++ b/.agents/skills/project-prometheus-profiles/SKILL.md
@@ -30,8 +30,9 @@ Repository architecture and runtime documents are the final authority when the s
 - `src/go/plugin/go.d/collector/prometheus/relabel/README.md`
 - `src/go/plugin/framework/charttpl/README.md`
 
-Do not require the generic NIDL guide as an authoring prerequisite. Prometheus chart templates have a narrower identity,
-label, aggregation, and hierarchy contract described in the chart-template reference.
+Read `docs/NIDL-Framework.md` when choosing or reviewing a monitored component, instance grain, dimension set, or label
+role. Then use the chart-template reference for the Prometheus-specific identity, label-promotion, aggregation, and
+hierarchy contract that realizes that NIDL model.
 
 ## Authoring workflow
 

--- a/.agents/skills/project-prometheus-profiles/SKILL.md
+++ b/.agents/skills/project-prometheus-profiles/SKILL.md
@@ -177,6 +177,26 @@ declared by its proof cases.
 source semantics, cardinality outside the evidence, or that a relationship is additive. Resolve warnings with evidence;
 do not mechanically silence them.
 
+Before semantic review, render the actual family table of contents:
+
+```bash
+.agents/skills/project-prometheus-profiles/scripts/profile-toc.py \
+  /path/to/profile.yaml \
+  --app application-name
+```
+
+The helper prints the operator-visible family tree with contexts and effective priorities, then emits advisory UX
+warnings. It is not a gate and does not make design decisions. Investigate each warning and either repair the hierarchy
+or record why the warning is intentional:
+
+- all top-level families sharing a prefix usually repeat the application/root;
+- a leaf with more than 15 contexts usually needs intermediate owner structure;
+- a one-context leaf may be unnecessary structure or a merge candidate;
+- a one-character family segment is often a slash-containing label such as `I/O` split accidentally into `I` and `O`.
+
+Do not remove structure solely to silence the warning when the parent is an operator entity, a module boundary, or a
+release contract; do not add structure solely to divide by metric type.
+
 ### 8. Perform semantic review
 
 After objective validation, review the result as an operator:
@@ -224,4 +244,5 @@ repository workflow. Integration files under `integrations/` are generated and s
 - `how-tos/build-synthetic-fixture.md` — public source-complete fixture construction.
 - `sqlite-metadata-reset.md` — destructive metadata-reset boundary.
 - `scripts/validate-profile.py` — compatibility launcher for the authoritative Go validator.
+- `scripts/profile-toc.py` — render the operator family ToC and report advisory hierarchy UX warnings.
 - `scripts/proof-bundle.py` — stock proof catalog and replay wrapper.

--- a/.agents/skills/project-prometheus-profiles/scripts/profile-toc.py
+++ b/.agents/skills/project-prometheus-profiles/scripts/profile-toc.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Render the operator-facing chart-family table of contents for a Prometheus profile.
+
+This is a design-review helper, not a validator gate. It intentionally reports UX warnings
+that require human judgement.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+import sys
+
+import yaml
+
+DEFAULT_PRIORITY = 70000
+LARGE_LEAF_CONTEXTS = 15
+
+
+@dataclass
+class Chart:
+    context: str
+    priority: int
+
+
+@dataclass
+class Node:
+    name: str
+    charts: list[Chart] = field(default_factory=list)
+    children: dict[str, "Node"] = field(default_factory=dict)
+
+    @property
+    def context_count(self) -> int:
+        return len({chart.context for chart in self.charts})
+
+
+def normalize(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def build_tree(profile: dict) -> Node:
+    template = profile.get("template")
+    if not isinstance(template, dict):
+        raise ValueError("profile has no template mapping")
+
+    root = Node(normalize(template.get("family")) or "(root)")
+    groups = template.get("groups")
+    if not isinstance(groups, list):
+        return root
+
+    def add_group(group: object, parent: Node, context_parts: list[str]) -> None:
+        if not isinstance(group, dict):
+            return
+
+        family = normalize(group.get("family"))
+        node = parent.children.setdefault(family, Node(family))
+        namespace = normalize(group.get("context_namespace"))
+        child_context_parts = context_parts + ([namespace] if namespace else [])
+
+        for chart in group.get("charts") or []:
+            if not isinstance(chart, dict):
+                continue
+            context = ".".join(part for part in (*child_context_parts, normalize(chart.get("context"))) if part)
+            if not context:
+                context = "(no context)"
+            node.charts.append(Chart(context, int(chart.get("priority") or DEFAULT_PRIORITY)))
+
+        for child in group.get("groups") or []:
+            add_group(child, node, child_context_parts)
+
+    for group in groups:
+        add_group(group, root, [])
+    return root
+
+
+def sort_key(item: tuple[str, Node]) -> tuple[int, int, str]:
+    name, node = item
+    priorities = [chart.priority for chart in node.charts]
+    minimum = min(priorities, default=DEFAULT_PRIORITY)
+    return (minimum, -len(name), name)
+
+
+def render(node: Node, depth: int = 0) -> list[str]:
+    lines: list[str] = []
+    indent = "  " * depth
+    if depth == 0:
+        display_name = node.name or "(application root)"
+    else:
+        display_name = node.name or "(unnamed)"
+    leaf_contexts = node.context_count
+
+    if depth == 0:
+        title = f"{display_name} [contexts={leaf_contexts}]"
+    elif node.children:
+        title = f"{indent}{display_name}/ [leaf-contexts={leaf_contexts}]"
+    else:
+        title = f"{indent}{display_name} [contexts={leaf_contexts}]"
+    lines.append(title)
+
+    for chart in sorted(node.charts, key=lambda chart: (chart.priority, chart.context)):
+        lines.append(f"{indent}  . {chart.context} @{chart.priority}")
+
+    for _, child in sorted(node.children.items(), key=sort_key):
+        lines.extend(render(child, depth + 1))
+    return lines
+
+
+def warnings(root: Node, app_name: str | None = None) -> list[str]:
+    results: list[str] = []
+    top_names = [name.strip("/") for name in root.children]
+    application = (app_name or "").strip()
+
+    # One-character family segments, including the accidental split of names such as I/O.
+    def walk(node: Node, path: tuple[str, ...] = ()) -> None:
+        current = (*path, node.name) if depth_visible(node, path) else path
+        for segment in (node.name.split("/") if node.name else []):
+            if len(segment) == 1:
+                rendered = "/".join(part for part in current if part and part != "(root)")
+                results.append(
+                    f"one-character family segment {segment!r} in {rendered or '(root)'}: "
+                    "a slash-containing label such as I/O may have split into I/O path segments"
+                )
+        for child in node.children.values():
+            walk(child, current)
+
+    def depth_visible(node: Node, path: tuple[str, ...]) -> bool:
+        return bool(path) or bool(node.name)
+
+    walk(root)
+
+    # Common prefix on all top-level families.
+    if len(top_names) >= 2:
+        first, *rest = top_names
+        common: list[str] = []
+        for characters in zip(*(name for name in top_names if name)):
+            if len(set(characters)) == 1:
+                common.append(characters[0])
+            else:
+                break
+        prefix = "".join(common).strip()
+        words = first.split()
+        usable_prefix = ""
+        for index in range(1, len(words) + 1):
+            candidate = " ".join(words[:index]).strip()
+            if candidate and all(name == candidate or name.startswith(candidate + " ") for name in top_names):
+                usable_prefix = candidate
+        selected = max((prefix, usable_prefix), key=len)
+        if selected and len(selected) >= 2:
+            results.append(
+                f"all top-level families share prefix {selected!r}: remove the common/application prefix if it is redundant"
+            )
+
+    if application:
+        lowered = application.casefold()
+        exact_names = {name.casefold() for name in top_names}
+        for name in top_names:
+            # CephFS-style product names legitimately begin with the same letters as the
+            # application; only flag an exact application token, not a longer product word.
+            exact_application_prefix = name.casefold() == lowered or name.casefold().startswith(lowered + " ")
+            if exact_application_prefix and name.casefold() not in exact_names:
+                results.append(
+                    f"top-level family {name!r} starts with application name {application!r}: remove the redundant prefix"
+                )
+
+    # Oversized and single-context leaves.
+    def leaves(node: Node, path: tuple[str, ...] = ()) -> None:
+        current = path + ((node.name,) if node.name else ())
+        if not node.children and current:
+            rendered = "/".join(part for part in current if part and part != "(root)")
+            if node.context_count > LARGE_LEAF_CONTEXTS:
+                results.append(
+                    f"leaf {rendered!r} contains {node.context_count} contexts (> {LARGE_LEAF_CONTEXTS}): add structure"
+                )
+            elif node.context_count == 1:
+                results.append(f"leaf {rendered!r} contains one context: remove unnecessary structure or merge siblings")
+        for child in node.children.values():
+            leaves(child, current)
+
+    leaves(root)
+
+    return sorted(dict.fromkeys(results))
+
+
+def parse_arguments(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profile", type=Path, help="profile YAML path")
+    parser.add_argument("--app", help="application name used to detect redundant application prefixes")
+    parser.add_argument("--quiet", action="store_true", help="print ToC without warnings")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_arguments(argv)
+    try:
+        document = yaml.safe_load(args.profile.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as error:
+        print(f"error: cannot read profile {args.profile}: {error}", file=sys.stderr)
+        return 2
+    if not isinstance(document, dict):
+        print(f"error: profile {args.profile} is not a YAML mapping", file=sys.stderr)
+        return 2
+
+    try:
+        tree = build_tree(document)
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    print("\n".join(render(tree)))
+    if not args.quiet:
+        design_warnings = warnings(tree, args.app or normalize(document.get("app")))
+        print("\nUX warnings (not validation failures):")
+        if design_warnings:
+            for index, warning in enumerate(design_warnings, 1):
+                print(f"{index}. {warning}")
+        else:
+            print("none")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.agents/skills/project-prometheus-profiles/scripts/test_profile_toc.py
+++ b/.agents/skills/project-prometheus-profiles/scripts/test_profile_toc.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Tests for the profile table-of-contents design helper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+SCRIPT = Path(__file__).with_name("profile-toc.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("profile_toc", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+profile_toc = load_module()
+
+
+def tree_from_yaml(text: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as stream:
+        stream.write(text)
+        path = Path(stream.name)
+    try:
+        return profile_toc.build_tree(yaml.safe_load(path.read_text()))
+    finally:
+        path.unlink()
+
+
+class ProfileTocWarningsTest(unittest.TestCase):
+    def test_common_prefix_warning(self) -> None:
+        root = tree_from_yaml(
+            """
+app: service
+template:
+  family: Service
+  groups:
+  - family: Service API
+    charts: [{title: a, context: a, units: x, dimensions: []}]
+  - family: Service Workers
+    charts: [{title: b, context: b, units: x, dimensions: []}]
+"""
+        )
+        warnings = profile_toc.warnings(root, "service")
+        self.assertIn("all top-level families share prefix 'Service'", "\n".join(warnings))
+
+    def test_one_character_segment_warning(self) -> None:
+        root = profile_toc.Node("I/O")
+        child = profile_toc.Node("O")
+        root.children["O"] = child
+        child.charts.append(profile_toc.Chart("ctx", 1))
+        self.assertTrue(any("one-character family segment" in warning for warning in profile_toc.warnings(root)))
+
+    def test_large_leaf_warning(self) -> None:
+        root = profile_toc.Node("(root)")
+        node = profile_toc.Node("Large")
+        root.children["Large"] = node
+        for index in range(16):
+            node.charts.append(profile_toc.Chart(f"context{index}", index))
+        self.assertTrue(any("contains 16 contexts" in warning for warning in profile_toc.warnings(root)))
+
+    def test_single_context_leaf_warning(self) -> None:
+        root = profile_toc.Node("(root)")
+        node = profile_toc.Node("Single")
+        root.children["Single"] = node
+        node.charts.append(profile_toc.Chart("context", 1))
+        self.assertTrue(any("contains one context" in warning for warning in profile_toc.warnings(root)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/project-writing-collectors/SKILL.md
+++ b/.agents/skills/project-writing-collectors/SKILL.md
@@ -727,7 +727,7 @@ Internal C plugins under `src/collectors/`. Reuse shared metric definitions from
 | Topology library | topology producers in Go | `src/go/pkg/topology/v1` |
 | netipc cross-plugin enrichment | C / Go / Rust | `src/libnetdata/netipc/`, `src/go/pkg/netipc/`, `src/crates/netipc/` |
 | DYNCFG protocol | dynamic configuration | `src/plugins.d/DYNCFG.md`, `docs/developer-and-contributor-corner/dyncfg.md` |
-| Health alerts reference | alert template authoring | `src/health/REFERENCE.md`, `src/health/alert-configuration-ordering.md` |
+| Health alerts | adding, changing, or reviewing an alert/template | `.agents/skills/project-health-alert-authoring/SKILL.md` |
 | Integrations pipeline | doc generation from `metadata.yaml` | `integrations/README.md` |
 | Go framework changes | changing shared Go collector/runtime framework code | `src/go/plugin/framework/docs/changing-framework-code.md` |
 | go.d V1-to-V2 migration | migrating existing go.d collectors | `src/go/plugin/go.d/docs/migrate-v1-to-v2.md` |

--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -533,7 +533,7 @@ sidebar:
       - meta:
           label: Ceph
           edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/ceph/README.md
-          description: Deploy distributed Ceph monitoring with the MGR Prometheus module, ceph-exporter, the Dashboard API collector, alerts, Parents, retention, and integrations.
+          description: Deploy distributed Ceph monitoring with the MGR Prometheus module, ceph-exporter, the NVMe-oF gateway exporter, the Dashboard API collector, alerts, Parents, retention, and integrations.
           keywords: [ceph, prometheus, mgr, exporter, dashboard, alerts, retention, parent, rgw, nvme-of]
       - type: integration_placeholder
         integration_kind: collectors

--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -529,6 +529,12 @@ sidebar:
           edit_url: https://github.com/netdata/netdata/edit/master/src/go/plugin/go.d/collector/prometheus/relabel/README.md
           description: Rewrite, derive, or drop scraped Prometheus metrics and labels with Prometheus-compatible metric_relabel_configs rules before charts are built.
           keywords: [prometheus, relabeling, metric_relabel_configs, labels, collectors]
+
+      - meta:
+          label: Ceph
+          edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/ceph/README.md
+          description: Deploy distributed Ceph monitoring with the MGR Prometheus module, ceph-exporter, the native Dashboard API collector, Phase 1 alerts, Parents, retention, and integrations.
+          keywords: [ceph, prometheus, mgr, exporter, dashboard, alerts, retention, parent, rgw, nvme-of]
       - type: integration_placeholder
         integration_kind: collectors
   # Exporting Metrics

--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -533,7 +533,7 @@ sidebar:
       - meta:
           label: Ceph
           edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/ceph/README.md
-          description: Deploy distributed Ceph monitoring with the MGR Prometheus module, ceph-exporter, the native Dashboard API collector, Phase 1 alerts, Parents, retention, and integrations.
+          description: Deploy distributed Ceph monitoring with the MGR Prometheus module, ceph-exporter, the Dashboard API collector, alerts, Parents, retention, and integrations.
           keywords: [ceph, prometheus, mgr, exporter, dashboard, alerts, retention, parent, rgw, nvme-of]
       - type: integration_placeholder
         integration_kind: collectors

--- a/docs/guides/ceph/README.md
+++ b/docs/guides/ceph/README.md
@@ -1,6 +1,6 @@
 # Monitor Ceph
 
-Netdata gives you a complete operational view of Ceph by collecting three complementary telemetry surfaces: the MGR Prometheus module, official `ceph-exporter`, and the Ceph Dashboard API. Deploy one Agent close to each Ceph node to monitor cluster state, daemon health, host resources, RGW traffic, and local hardware together.
+Netdata gives you a complete operational view of Ceph by collecting four complementary telemetry surfaces: the MGR Prometheus module, official `ceph-exporter`, the NVMe-oF gateway exporter, and the Ceph Dashboard API. Deploy one Agent close to each Ceph node to monitor cluster state, daemon health, host resources, RGW traffic, and local hardware together.
 
 ## What you can monitor
 
@@ -17,10 +17,11 @@ Netdata gives you a complete operational view of Ceph by collecting three comple
 
 ## Ceph telemetry and Netdata
 
-Ceph natively exposes metrics in the Prometheus exposition format through two interfaces:
+Ceph natively exposes metrics in the Prometheus exposition format through three interfaces:
 
 - The **Ceph Manager Prometheus module** is the cluster-level surface. The active Manager periodically builds a metric cache from cluster state and publishes it at an HTTP metrics endpoint.
 - The official **`ceph-exporter`** is the host-local surface. It gathers daemon and admin-socket telemetry on each Ceph node and publishes it in the same format.
+- The **NVMe-oF gateway exporter** is the gateway-local surface. Each gateway daemon publishes its own Prometheus endpoint, normally on port 10008.
 
 The word “Prometheus” here refers to the exposition wire format, not the Prometheus monitoring stack. Netdata reads Ceph's native endpoints directly, recognizes the official metric families with its built-in Ceph profile, and creates charts and alerts from that state. You do not need to install Prometheus Server, Alertmanager, or another database for this monitoring to work. If you already operate Prometheus, it can continue reading Ceph independently; coexistence is optional.
 
@@ -81,8 +82,9 @@ Run one Agent on each Ceph node. Each Agent monitors the Ceph services and host 
 
 | Surface | Deployment | What it provides |
 |---|---|---|
-| MGR Prometheus module | One logical job per Ceph cluster | Cluster health, quorum, capacity, placement groups, pools, RGW aggregate telemetry, and exporter-local NVMe-oF telemetry |
+| MGR Prometheus module | One logical job per Ceph cluster | Cluster health, quorum, capacity, placement groups, pools, and RGW aggregate telemetry |
 | `ceph-exporter` | One job on each node whose daemon telemetry you need | Host-local daemon performance and daemon inventory |
+| NVMe-oF gateway exporter | One job on each gateway endpoint | Gateway-local runtime, block-device, host, subsystem, and namespace telemetry |
 | Ceph Dashboard API | One logical job per Ceph cluster | Dashboard API component integrity and Ceph investigation Functions |
 | Host collectors | Every Agent | Node disks, filesystems, network interfaces, processes, and logs |
 
@@ -103,6 +105,10 @@ For high availability, put a stable address in front of the active MGR and keep 
 ### ceph-exporter
 
 Deploy or enable official `ceph-exporter` on each Ceph node whose daemon telemetry you need. Collect from each exporter on its own host. Use the exporter priority limit to select the daemon counters published, and size `max_time_series` and `max_time_series_per_metric` for that surface.
+
+### NVMe-oF gateway exporter
+
+Enable the exporter in each Ceph NVMe-oF gateway deployment and collect every gateway endpoint whose local state you need. Preserve one stable job identity per gateway endpoint. The default gateway metrics port is 10008, but the deployment may configure a different port. Size each local job for that gateway's series surface.
 
 ### Ceph Dashboard API
 
@@ -157,12 +163,13 @@ Size the deployment from measured behavior:
 
 ## Alert ownership and routing
 
-The MGR Prometheus profile owns cluster and exporter-local Ceph alerts:
+The built-in Ceph profile recognizes all three Prometheus interfaces. Alert ownership follows the configured endpoint: one MGR job owns cluster-level alerts, and each gateway-exporter job owns its gateway-local alerts. The covered incidents are:
 
 - cluster health and manager-module health;
 - monitor quorum and OSD population summaries;
 - placement group, pool, capacity, and recovery conditions;
-- hardware and NVMe-oF conditions exposed by supported exporters;
+- node-proxy hardware conditions exposed by MGR;
+- gateway-local NVMe-oF conditions exposed by each gateway-exporter job;
 - RGW notification, Lua, request-fallback, queue-pressure, and multisite retry conditions.
 
 The native Dashboard collector owns API component collection failures. Generic Netdata collectors own host-local and endpoint checks:

--- a/docs/guides/ceph/README.md
+++ b/docs/guides/ceph/README.md
@@ -1,162 +1,162 @@
 # Monitor Ceph
 
-Deploy Netdata close to each Ceph node, then collect the three complementary Ceph telemetry surfaces: the MGR Prometheus module, `ceph-exporter`, and the native Ceph Dashboard API collector. This guide describes the Phase 1 deployment, ownership boundaries, alert behavior, retention planning, and integration paths.
+Netdata gives you a complete operational view of Ceph by collecting three complementary telemetry surfaces: the MGR Prometheus module, official `ceph-exporter`, and the Ceph Dashboard API. Deploy one Agent close to each Ceph node to monitor cluster state, daemon health, host resources, RGW traffic, and local hardware together.
+
+## What you can monitor
+
+- Cluster health, manager health, monitor quorum, and cluster capacity.
+- OSD populations, placement groups, pools, recovery, and scrub activity.
+- CephFS/MDS, RBD, RBD Mirror, SMB, and client I/O telemetry exposed by your Ceph release.
+- Host-local daemon performance from official `ceph-exporter`.
+- RGW requests, Lua execution, notifications, queues, retries, and access logs.
+- RGW endpoint availability and TLS certificate health.
+- NVMe-oF gateway, block-device, host, subsystem, and namespace telemetry from supported exporters.
+- Node hardware health, cooling, power, memory, processors, storage, and temperature reporting on Tentacle.
+- Dashboard API component integrity and on-demand Ceph investigation Functions.
+- Per-node disks, filesystems, network interfaces, processes, and logs through Netdata's host collectors.
 
 ## Deployment model
 
-Run one Agent on each Ceph node. Ceph telemetry is distributed: a single Agent cannot observe every daemon's admin socket or every host's disks, interfaces, logs, and processes.
+Run one Agent on each Ceph node. Each Agent monitors the Ceph services and host resources on its own node, preserving local admin-socket, disk, interface, process, and log context.
 
-| Surface | Deployment | Ownership |
+| Surface | Deployment | What it provides |
 |---|---|---|
-| MGR Prometheus module | One logical job per Ceph cluster | Cluster health, quorum, capacity, placement groups, pools, RGW aggregate telemetry, and NVMe-oF exporter-local telemetry |
-| `ceph-exporter` | One job on each node that should expose daemon/admin-socket telemetry | Host-local daemon performance and daemon inventory |
-| Native Ceph Dashboard API | One logical job per Ceph cluster | Dashboard API component integrity and Ceph RCA Functions |
+| MGR Prometheus module | One logical job per Ceph cluster | Cluster health, quorum, capacity, placement groups, pools, RGW aggregate telemetry, and exporter-local NVMe-oF telemetry |
+| `ceph-exporter` | One job on each node whose daemon telemetry you need | Host-local daemon performance and daemon inventory |
+| Ceph Dashboard API | One logical job per Ceph cluster | Dashboard API component integrity and Ceph investigation Functions |
 | Host collectors | Every Agent | Node disks, filesystems, network interfaces, processes, and logs |
 
-Use one stable Prometheus job identity for the MGR surface. If the active MGR moves, update DNS or the reverse proxy to the current active endpoint rather than creating one job for each possible MGR. Multiple active MGR jobs for the same cluster create duplicate cluster alert owners.
+Use one stable job identity for the MGR surface. If the active MGR moves, update DNS or the reverse proxy to the current active endpoint rather than creating one job for every possible MGR. Multiple active MGR jobs for the same cluster create duplicate cluster alert owners.
 
-For `ceph-exporter`, preserve each node's own job or vnode identity. Do not merge exporter jobs across hosts; their signals are host-local.
+For `ceph-exporter`, preserve each node's own job or virtual-node identity. Keep exporter jobs host-local rather than merging them across hosts.
 
-A Parent can receive streams from all Ceph Agents. Parenting changes where data is stored and queried, not the identity of each Ceph node: child charts retain their node scope, labels, and alert instances. Organize Cloud rooms by site, cluster, or role, and use the combined view when you need an infrastructure-wide investigation.
+A Parent can receive streams from every Ceph Agent. Parenting changes where data is stored and queried, not the identity of each Ceph node: child charts retain their node scope, labels, and alert instances. Organize Netdata Cloud rooms by site, cluster, or role, then use the combined view for infrastructure-wide investigation.
 
-## Enable the telemetry surfaces
+## Enable telemetry
 
 ### MGR Prometheus module
 
-Enable the Ceph MGR Prometheus module and expose one stable HTTPS or HTTP endpoint for the cluster. Configure the Netdata Prometheus collector to scrape that endpoint. The built-in Ceph profile matches the official Ceph metric surfaces automatically.
+Enable the Ceph MGR Prometheus module and expose one stable HTTP or HTTPS endpoint for the cluster. Configure the Netdata Prometheus collector to scrape that endpoint. The built-in Ceph profile recognizes the official metric surface automatically.
 
-For high availability, put a stable address in front of the active MGR and keep the Netdata job name and vnode identity stable. Do not create duplicate jobs for standby MGR endpoints.
+For high availability, put a stable address in front of the active MGR and keep the Netdata job name and virtual-node identity stable.
 
 ### ceph-exporter
 
-On Reef and later, deploy or enable `ceph-exporter` on each Ceph node whose daemon telemetry you need. Collect from each exporter on its own host. The exporter's priority limit controls which daemon counters it publishes; size `max_time_series` and `max_time_series_per_metric` for the selected surface.
+Deploy or enable official `ceph-exporter` on each Ceph node whose daemon telemetry you need. Collect from each exporter on its own host. Use the exporter priority limit to select the daemon counters published, and size `max_time_series` and `max_time_series_per_metric` for that surface.
 
-### Native Ceph Dashboard API
+### Ceph Dashboard API
 
-Enable the Ceph Dashboard module, secure it with TLS, and create a read-only Dashboard user. Configure one native Ceph collector job per Ceph cluster. This collector complements Prometheus rather than replacing it: it owns API component integrity and provides Ceph RCA Functions.
+Enable the Ceph Dashboard module, secure it with TLS, and create a read-only Dashboard user. Configure one native Ceph collector job per cluster. The Dashboard collector complements Prometheus: it owns API component integrity and provides Ceph investigation Functions.
 
-## Supported release surfaces
+## Supported releases
 
-Phase 1 covers the public metric surfaces of:
+Netdata's built-in Ceph profile recognizes the metric surfaces of:
 
 - Reef 18.2.8
 - Squid 19.2.5
 - Tentacle 20.2.3
 
-The profiles and alerts are source-pinned to these releases. Some telemetry is release-specific:
+Release-specific charts follow the telemetry exposed by each Ceph release. For example, node hardware and local NVMe-oF gateway charts appear when Tentacle exports those series.
 
-- Reef and Squid provide the core MGR and exporter surfaces.
-- Tentacle adds node-proxy hardware, NVMe-oF local gateway signals, and other newer metrics.
-- Tentacle-only charts and alerts do not appear on Reef or Squid when those series are absent.
+## Authentication, TLS, and routing
 
-## Permissions, TLS, and routing
-
-- Give the Dashboard user read access to the required Ceph scopes. The built-in read-only Dashboard role is sufficient for the native collector.
+- Give the Dashboard user read access to the required Ceph scopes. The built-in read-only Dashboard role is sufficient.
 - Use TLS for Dashboard and MGR endpoints where practical.
-- Do not point a job at a generic reverse-proxy login page. The URL must reach the Ceph API or metrics endpoint directly.
+- Point each job directly at the Ceph API or metrics endpoint, not a generic reverse-proxy login page.
 - Preserve stable job identity through redirects and failover. Chart identity and alert ownership depend on it.
 - If Ceph redirects HTTP to HTTPS, configure the final HTTPS URL explicitly rather than relying on redirect following.
 
-## Collection cadence and limits
+## Collection cadence and cardinality
 
 Netdata scrape frequency does not control Ceph producer refresh frequency.
 
-- The MGR Prometheus module refreshes its metric cache on its own Ceph-side interval.
-- `ceph-exporter` refreshes daemon metrics on its own configured interval.
+- The MGR Prometheus module refreshes its metric cache on its configured Ceph-side interval.
+- `ceph-exporter` refreshes daemon metrics on its configured interval.
 - Netdata samples the exposed current cache at the job's `update_every`.
 
-Match the Netdata interval to the producer cache interval when redundant samples are undesirable. A faster scrape does not force Ceph to perform more work or refresh more often.
+Match the Netdata interval to the producer cache interval when you want to avoid redundant samples. A faster scrape does not force Ceph to refresh more often.
 
-The Ceph profile can expose a large metric surface. Set job-level `max_time_series` and `max_time_series_per_metric` after measuring your release and exporter configuration. Do not enable broad optional debug or detail surfaces unless you have sized the resulting chart and dimension cardinality.
+Ceph can expose a large metric surface. Set job-level `max_time_series` and `max_time_series_per_metric` after measuring your release and exporter configuration. Enable broad optional debug or detail surfaces only after sizing the resulting chart and dimension cardinality.
 
-## Telemetry and alert ownership
+## Alert ownership and routing
 
-The MGR Prometheus profile owns the cluster-level Phase 1 alerts:
+The MGR Prometheus profile owns cluster and exporter-local Ceph alerts:
 
-- cluster health and MGR module health;
+- cluster health and manager-module health;
 - monitor quorum and OSD population summaries;
 - placement group, pool, capacity, and recovery conditions;
-- Tentacle hardware and NVMe-oF local conditions;
-- RGW notification, Lua, request-fallback, queue-pressure, and multisite retry alerts.
+- hardware and NVMe-oF conditions exposed by supported exporters;
+- RGW notification, Lua, request-fallback, queue-pressure, and multisite retry conditions.
 
-The native Dashboard API collector owns component collection failure and does not duplicate MGR data-state alerts. Generic collectors remain the single owners of host-local and endpoint checks:
+The native Dashboard collector owns API component collection failures. Generic Netdata collectors own host-local and endpoint checks:
 
 - host disks, filesystems, and network interfaces;
-- `httpcheck` for basic unauthenticated RGW endpoint liveness;
+- `httpcheck` for unauthenticated RGW endpoint liveness;
 - `x509check` for RGW certificate expiration and revocation;
-- `weblog` for complete RGW access logs, including the `total_time` numeric field in milliseconds.
+- `web_log` for complete RGW access logs, including request outcomes and latency.
 
-`httpcheck` does not prove authenticated S3 correctness. For authenticated object PUT/GET/LIST/DELETE verification, use the Phase 2 S3 check capability.
+### Silent and notifying alerts
 
-### Silent and notifying defaults
-
-Many Phase 1 conditions are silent by default because their threshold is workload policy rather than a categorical error. Examples include:
+Policy-dependent conditions are silent by default so you can tune them to your workload. Examples include:
 
 - queue depth and notification backlog pressure;
-- storage capacity policy;
+- storage-capacity policy;
 - traffic anomalies;
 - client-error rates;
-- some hardware temperature thresholds.
+- selected hardware temperature thresholds.
 
-Categorical or hard-failure conditions notify by default. Route silent alerts explicitly only after tuning their thresholds for your environment. Override routing without changing stock thresholds by copying the health template into the local health configuration.
+Categorical failures notify by default. Enable silent alerts after tuning their thresholds for your environment. To change routing without changing stock thresholds, copy the health template into the local health configuration.
 
-### Collection gaps and disappearance
+### Collection gaps and disappearing charts
 
-A failed scrape does not fabricate a healthy value. Data-state alerts may continue to evaluate the last stored value, while the generic collection alert owns the scrape failure. When Ceph removes a chart and the collector obsoletes it, its instance alerts are removed rather than falsely clearing.
+The collection alert reports scrape failures, while data-state alerts continue to use the latest stored values. When Ceph withdraws an entity and its chart becomes obsolete, Netdata removes that instance alert.
 
-## RGW and S3 monitoring
+## RGW and S3 observability
 
-For RGW, the MGR profile provides aggregate telemetry for requests, aborted requests, Lua scripts, notifications, queues, and multisite errors.
+The MGR profile provides aggregate RGW telemetry for requests, aborted requests, Lua scripts, notifications, queues, and multisite retries.
 
-For HTTP outcomes and latency, collect the RGW access log with `weblog`. The Ceph JSON log example maps request, status, size, and client fields, and declares `total_time` as a numeric custom field in milliseconds. This preserves the exact Ceph duration field instead of misusing the standard integer request-time field.
+Collect the RGW access log with `web_log` to analyze HTTP outcomes, bytes, clients, and latency. The Ceph JSON example maps request, status, size, and client fields, and declares `total_time` as a numeric custom field in milliseconds, preserving Ceph's exact duration field.
 
-Use `httpcheck` for unauthenticated endpoint liveness and `x509check` for certificate expiry or revocation. For authenticated S3 correctness, multisite payload checks, and delete propagation, use the Phase 2 capabilities rather than approximating them from counters.
+Use `httpcheck` for unauthenticated endpoint liveness and `x509check` for certificate expiration or revocation.
 
-### Phase 1 limits
+## Investigation Functions
 
-- Per-topic persistent notification backlog has no source-published Prometheus numeric family in the covered releases.
-- Selected tenant, user, and bucket detail is not enabled automatically because those optional surfaces can be high-cardinality.
-- Quota, sync lag, recovery shards, RPO, lifecycle health, and garbage-collection age require the Phase 2 native or probe surfaces.
+The native Ceph Dashboard collector provides Functions for detailed health, OSD, pool, and incident investigation. Functions run on demand and do not create charts by themselves.
 
-## RCA Functions
-
-The native Ceph Dashboard collector provides Functions for detailed health, OSD, pool, and incident investigation. These Functions are on-demand API calls; they do not create charts or alerts by themselves.
-
-Use Functions when you need detailed current inventory or component state. Use charts and alerts for continuous monitoring. If a Function requires the Ceph orchestrator, ensure the Dashboard configuration exposes it.
+Use Functions when you need current inventory or component detail. Use charts and alerts for continuous monitoring. If a Function requires the Ceph orchestrator, ensure the Dashboard configuration exposes it.
 
 ## Retention and capacity planning
 
 Plan retention separately on Children and Parents.
 
-1. Deploy one Agent per Ceph node and run a representative workload for days.
-2. Measure the number of charts and dimensions actually produced for your Ceph release, optional exporter surfaces, and collectors.
+1. Deploy one Agent per Ceph node and run a representative workload for several days.
+2. Measure the charts and dimensions produced by your Ceph release, selected exporter surfaces, and collectors.
 3. Decide where long retention lives:
    - keep short high-resolution retention locally on each Child;
    - stream longer retention to one or more Parents.
-4. Use the measured chart and dimension counts, sample interval, tiering mode, and intended retention horizon to estimate disk requirements.
-5. Validate the estimate after several days and again after several weeks.
-6. For multi-year storage, export to Prometheus, Grafana-compatible storage, or another external system rather than storing every sample in the Agent database.
+4. Estimate disk requirements from measured chart and dimension counts, sample interval, tiering mode, and retention horizon.
+5. Revalidate the estimate after several days and again after several weeks.
+6. For multi-year storage, export to Prometheus remote storage, Grafana-compatible storage, or another external system rather than storing every sample in the Agent database.
 
-Do not extrapolate from a single quiet day: hardware inventories, failover, optional exporter surfaces, and incident activity change cardinality. Do not assume linear growth from Ceph capacity alone; chart cardinality follows enabled telemetry surfaces and their labels.
+Do not extrapolate from a single quiet day: hardware inventories, failover, optional exporter surfaces, and incident activity change cardinality. Chart cardinality follows enabled telemetry surfaces and labels, not Ceph storage capacity alone.
 
-Phase 1 does not forecast storage growth or capacity exhaustion. Use the measured charts and exported long-term data for trend analysis until a supported prediction capability exists.
+Use measured charts and exported long-term data for trend analysis.
 
-## Cloud, rooms, and sites
+## Netdata Cloud, rooms, and sites
 
 Connect each Agent to Netdata Cloud unless you operate a fully on-prem deployment. Organize rooms by site, cluster, or operational responsibility. A room is a navigation and access boundary, not a data aggregation layer.
 
-Parents preserve child identity. A Parent can provide long retention, unified querying, and a single TLS ingress, while each Ceph node remains independently visible in Cloud.
+Parents preserve child identity. A Parent can provide long retention, unified querying, and a single TLS ingress while every Ceph node remains independently visible in Cloud.
 
-For on-prem-only deployments, streaming and local dashboards remain available. You lose Cloud-managed rooms, centralized silencing, and Cloud notifications, but local Agent health and notification mechanisms still work.
+For on-prem-only deployments, streaming and local dashboards remain available. Local Agent health and notification mechanisms continue to work.
 
 ## Grafana, Prometheus, Zabbix, and exporting
 
-The Ceph collectors coexist with existing monitoring:
+Netdata coexists with your existing monitoring:
 
 - Keep or deploy Grafana dashboards independently.
-- Keep existing Prometheus exporters; the Prometheus collector reads Ceph's official endpoints but does not replace them.
-- Keep an existing Zabbix deployment independently and collect Ceph through Zabbix's own integrations. Netdata does not
-  provide a direct Zabbix exporting connector.
+- Keep existing Prometheus exporters; Netdata can read the same official Ceph endpoints without replacing that workflow.
+- Keep an existing Zabbix deployment independently and collect Ceph through Zabbix's own integrations.
 - Export Netdata metrics to external systems with the exporting engine.
 - Send selected Netdata alerts to external systems through supported notification integrations.
 
@@ -164,9 +164,9 @@ Do not point multiple Netdata jobs at the same logical Ceph cluster MGR endpoint
 
 ## Notifications
 
-Route alert notifications centrally through Netdata Cloud when your Agents are connected, or configure notifications per Agent for on-prem deployments. Start with the notifying categorical alerts, then enable and tune silent policy alerts only where you have measured a meaningful threshold.
+Route notifications centrally through Netdata Cloud when your Agents are connected, or configure notifications per Agent for on-prem deployments. Start with notifying categorical alerts, then enable and tune policy alerts where you have measured meaningful thresholds.
 
-## Incident guide
+## Incident and configuration references
 
 For the native physical-capacity alert, see the [Ceph cluster space usage](/src/health/guides/ceph/ceph_cluster_space_usage.md) incident guide.
 
@@ -175,7 +175,7 @@ For collector configuration details, see:
 - [Ceph](/src/go/plugin/go.d/collector/ceph/integrations/ceph.md)
 - [Ceph Prometheus](/src/go/plugin/go.d/collector/prometheus/integrations/ceph_prometheus.md)
 
-For Agent deployment and streaming, see:
+For Agent deployment, streaming, retention, exporting, and notifications, see:
 
 - [Deployment with centralization points](/docs/deployment-guides/deployment-with-centralization-points.md)
 - [Metrics centralization points](/docs/observability-centralization-points/metrics-centralization-points/README.md)

--- a/docs/guides/ceph/README.md
+++ b/docs/guides/ceph/README.md
@@ -15,6 +15,50 @@ Netdata gives you a complete operational view of Ceph by collecting three comple
 - Dashboard API component integrity and on-demand Ceph investigation Functions.
 - Per-node disks, filesystems, network interfaces, processes, and logs through Netdata's host collectors.
 
+## Operational coverage map
+
+Use this map to identify the Netdata surface that owns the operational question you are investigating.
+
+| Operational need | What Netdata monitors | Primary owner | Operator behavior |
+|---|---|---|---|
+| Cluster health | Overall health, named Ceph health checks, daemon crashes, slow operations | MGR Prometheus | Categorical failures notify; workload-specific checks can be tuned |
+| Monitor availability | MON quorum and quorum risk | MGR Prometheus | Investigate monitor membership and elections |
+| Data integrity | Unfound objects, damaged PGs, scrub errors | MGR Prometheus | Treat as priority data-safety conditions |
+| Placement groups | Active/clean PG counts, scrub status, PG density, recovery blockers | MGR Prometheus | Inspect affected pool and recovery progress |
+| Capacity | Cluster physical capacity plus OSD/pool thresholds | Ceph Dashboard API and MGR Prometheus | Dashboard provides physical utilization; MGR exposes Ceph threshold states |
+| OSD availability | Down OSDs, down OSD hosts, and down-OSD percentage | MGR Prometheus | Identify the affected daemon or host |
+| Recovery and rebalance | Backfill/recovery blockers and recovery work | MGR Prometheus | Watch conditions that prevent repair or rebalance |
+| CephFS | MDS damage, degradation, standby availability, and rank health | MGR Prometheus | Investigate the affected filesystem and MDS rank |
+| RBD mirroring | Local/remote snapshot timestamp synchronization | MGR Prometheus | Identify mirrored images that have diverged |
+| RGW service health | Notifications, Lua execution, queue pressure, retries, aborted requests | MGR Prometheus | Inspect aggregate gateway behavior |
+| RGW request outcomes | Status classes, bytes, clients, and request duration | `web_log` | Analyze complete RGW access logs |
+| RGW endpoint reachability | Unauthenticated HTTP liveness | `httpcheck` | Verify the selected endpoint is reachable |
+| RGW certificates | Certificate expiration and revocation | `x509check` | Track certificate lifecycle independently of RGW traffic |
+| Node health | CPU, memory, disk I/O, filesystems, network interfaces, and processes | Standard Netdata collectors | Continue using normal Agent monitoring for each Ceph node |
+| API component integrity | Dashboard API collection status | Ceph Dashboard API | Detect component-specific collection failures |
+| Incident investigation | Detailed health, OSD, pool, and daemon inventory | Ceph Dashboard Functions | Run on demand during an investigation |
+
+### How Netdata maps Ceph health directives
+
+Ceph publishes its own health-check directives. Netdata maps the directives that have a stable public metric signal to named alerts and charts, so operators can use Ceph's operational vocabulary while working in Netdata.
+
+Examples:
+
+| Ceph directive | Netdata operator view |
+|---|---|
+| `RECENT_CRASH` | Recent Ceph daemon crash |
+| `RECENT_MGR_MODULE_CRASH` | Recent manager-module crash |
+| `MON_DOWN` | Monitor down and monitor-quorum summaries |
+| `OSD_DOWN` | Down OSD and OSD-host conditions |
+| `OBJECT_UNFOUND` | Unfound object condition |
+| `PG_DAMAGED` | Damaged placement-group condition |
+| `PG_NOT_SCRUBBED` | Placement groups overdue for scrub |
+| `POOL_FULL` | Full pool condition |
+| `MDS_ALL_DOWN` | CephFS unavailable |
+| `FS_WITH_FAILED_MDS` | CephFS MDS rank has failed with no standby |
+
+Netdata's standard system alerts remain the owners of node-level conditions such as filesystem usage and packet drops. Ceph-specific alerts do not duplicate those incidents; they add cluster, daemon, and storage-service state that Ceph itself publishes.
+
 ## Deployment model
 
 Run one Agent on each Ceph node. Each Agent monitors the Ceph services and host resources on its own node, preserving local admin-socket, disk, interface, process, and log context.

--- a/docs/guides/ceph/README.md
+++ b/docs/guides/ceph/README.md
@@ -38,7 +38,7 @@ Use this map to identify the Netdata surface that owns the operational question 
 
 | Operational need | What Netdata monitors | Primary owner | Operator behavior |
 |---|---|---|---|
-| Cluster health | Overall health, named Ceph health checks, daemon crashes, slow operations | MGR Prometheus | Categorical failures notify; workload-specific checks can be tuned |
+| Cluster health | Overall health, named Ceph health checks, daemon crashes, slow operations | MGR Prometheus | HEALTH_ERR and other categorical failures notify; HEALTH_WARN and workload-specific checks are silent until enabled and tuned |
 | Monitor availability | MON quorum and quorum risk | MGR Prometheus | Investigate monitor membership and elections |
 | Data integrity | Unfound objects, damaged PGs, scrub errors | MGR Prometheus | Treat as priority data-safety conditions |
 | Placement groups | Active/clean PG counts, scrub status, PG density, recovery blockers | MGR Prometheus | Inspect affected pool and recovery progress |
@@ -199,7 +199,7 @@ The collection alert reports scrape failures, while data-state alerts continue t
 
 The MGR profile provides aggregate RGW telemetry for requests, aborted requests, Lua scripts, notifications, queues, and multisite retries.
 
-Collect the RGW access log with `web_log` to analyze HTTP outcomes, bytes, clients, and latency. The Ceph JSON example maps request, status, size, and client fields, and declares `total_time` as a numeric custom field in milliseconds, preserving Ceph's exact duration field.
+Collect the RGW JSON access log with `web_log` to analyze HTTP outcomes, bytes, clients, and latency. Configure RGW to emit its access log in JSON format and make that file available to the Agent. The Ceph JSON example maps request, status, size, and client fields, and declares `total_time` as a numeric custom field in milliseconds, preserving Ceph's exact duration field.
 
 Use `httpcheck` for unauthenticated endpoint liveness and `x509check` for certificate expiration or revocation.
 

--- a/docs/guides/ceph/README.md
+++ b/docs/guides/ceph/README.md
@@ -1,0 +1,184 @@
+# Monitor Ceph
+
+Deploy Netdata close to each Ceph node, then collect the three complementary Ceph telemetry surfaces: the MGR Prometheus module, `ceph-exporter`, and the native Ceph Dashboard API collector. This guide describes the Phase 1 deployment, ownership boundaries, alert behavior, retention planning, and integration paths.
+
+## Deployment model
+
+Run one Agent on each Ceph node. Ceph telemetry is distributed: a single Agent cannot observe every daemon's admin socket or every host's disks, interfaces, logs, and processes.
+
+| Surface | Deployment | Ownership |
+|---|---|---|
+| MGR Prometheus module | One logical job per Ceph cluster | Cluster health, quorum, capacity, placement groups, pools, RGW aggregate telemetry, and NVMe-oF exporter-local telemetry |
+| `ceph-exporter` | One job on each node that should expose daemon/admin-socket telemetry | Host-local daemon performance and daemon inventory |
+| Native Ceph Dashboard API | One logical job per Ceph cluster | Dashboard API component integrity and Ceph RCA Functions |
+| Host collectors | Every Agent | Node disks, filesystems, network interfaces, processes, and logs |
+
+Use one stable Prometheus job identity for the MGR surface. If the active MGR moves, update DNS or the reverse proxy to the current active endpoint rather than creating one job for each possible MGR. Multiple active MGR jobs for the same cluster create duplicate cluster alert owners.
+
+For `ceph-exporter`, preserve each node's own job or vnode identity. Do not merge exporter jobs across hosts; their signals are host-local.
+
+A Parent can receive streams from all Ceph Agents. Parenting changes where data is stored and queried, not the identity of each Ceph node: child charts retain their node scope, labels, and alert instances. Organize Cloud rooms by site, cluster, or role, and use the combined view when you need an infrastructure-wide investigation.
+
+## Enable the telemetry surfaces
+
+### MGR Prometheus module
+
+Enable the Ceph MGR Prometheus module and expose one stable HTTPS or HTTP endpoint for the cluster. Configure the Netdata Prometheus collector to scrape that endpoint. The built-in Ceph profile matches the official Ceph metric surfaces automatically.
+
+For high availability, put a stable address in front of the active MGR and keep the Netdata job name and vnode identity stable. Do not create duplicate jobs for standby MGR endpoints.
+
+### ceph-exporter
+
+On Reef and later, deploy or enable `ceph-exporter` on each Ceph node whose daemon telemetry you need. Collect from each exporter on its own host. The exporter's priority limit controls which daemon counters it publishes; size `max_time_series` and `max_time_series_per_metric` for the selected surface.
+
+### Native Ceph Dashboard API
+
+Enable the Ceph Dashboard module, secure it with TLS, and create a read-only Dashboard user. Configure one native Ceph collector job per Ceph cluster. This collector complements Prometheus rather than replacing it: it owns API component integrity and provides Ceph RCA Functions.
+
+## Supported release surfaces
+
+Phase 1 covers the public metric surfaces of:
+
+- Reef 18.2.8
+- Squid 19.2.5
+- Tentacle 20.2.3
+
+The profiles and alerts are source-pinned to these releases. Some telemetry is release-specific:
+
+- Reef and Squid provide the core MGR and exporter surfaces.
+- Tentacle adds node-proxy hardware, NVMe-oF local gateway signals, and other newer metrics.
+- Tentacle-only charts and alerts do not appear on Reef or Squid when those series are absent.
+
+## Permissions, TLS, and routing
+
+- Give the Dashboard user read access to the required Ceph scopes. The built-in read-only Dashboard role is sufficient for the native collector.
+- Use TLS for Dashboard and MGR endpoints where practical.
+- Do not point a job at a generic reverse-proxy login page. The URL must reach the Ceph API or metrics endpoint directly.
+- Preserve stable job identity through redirects and failover. Chart identity and alert ownership depend on it.
+- If Ceph redirects HTTP to HTTPS, configure the final HTTPS URL explicitly rather than relying on redirect following.
+
+## Collection cadence and limits
+
+Netdata scrape frequency does not control Ceph producer refresh frequency.
+
+- The MGR Prometheus module refreshes its metric cache on its own Ceph-side interval.
+- `ceph-exporter` refreshes daemon metrics on its own configured interval.
+- Netdata samples the exposed current cache at the job's `update_every`.
+
+Match the Netdata interval to the producer cache interval when redundant samples are undesirable. A faster scrape does not force Ceph to perform more work or refresh more often.
+
+The Ceph profile can expose a large metric surface. Set job-level `max_time_series` and `max_time_series_per_metric` after measuring your release and exporter configuration. Do not enable broad optional debug or detail surfaces unless you have sized the resulting chart and dimension cardinality.
+
+## Telemetry and alert ownership
+
+The MGR Prometheus profile owns the cluster-level Phase 1 alerts:
+
+- cluster health and MGR module health;
+- monitor quorum and OSD population summaries;
+- placement group, pool, capacity, and recovery conditions;
+- Tentacle hardware and NVMe-oF local conditions;
+- RGW notification, Lua, request-fallback, queue-pressure, and multisite retry alerts.
+
+The native Dashboard API collector owns component collection failure and does not duplicate MGR data-state alerts. Generic collectors remain the single owners of host-local and endpoint checks:
+
+- host disks, filesystems, and network interfaces;
+- `httpcheck` for basic unauthenticated RGW endpoint liveness;
+- `x509check` for RGW certificate expiration and revocation;
+- `weblog` for complete RGW access logs, including the `total_time` numeric field in milliseconds.
+
+`httpcheck` does not prove authenticated S3 correctness. For authenticated object PUT/GET/LIST/DELETE verification, use the Phase 2 S3 check capability.
+
+### Silent and notifying defaults
+
+Many Phase 1 conditions are silent by default because their threshold is workload policy rather than a categorical error. Examples include:
+
+- queue depth and notification backlog pressure;
+- storage capacity policy;
+- traffic anomalies;
+- client-error rates;
+- some hardware temperature thresholds.
+
+Categorical or hard-failure conditions notify by default. Route silent alerts explicitly only after tuning their thresholds for your environment. Override routing without changing stock thresholds by copying the health template into the local health configuration.
+
+### Collection gaps and disappearance
+
+A failed scrape does not fabricate a healthy value. Data-state alerts may continue to evaluate the last stored value, while the generic collection alert owns the scrape failure. When Ceph removes a chart and the collector obsoletes it, its instance alerts are removed rather than falsely clearing.
+
+## RGW and S3 monitoring
+
+For RGW, the MGR profile provides aggregate telemetry for requests, aborted requests, Lua scripts, notifications, queues, and multisite errors.
+
+For HTTP outcomes and latency, collect the RGW access log with `weblog`. The Ceph JSON log example maps request, status, size, and client fields, and declares `total_time` as a numeric custom field in milliseconds. This preserves the exact Ceph duration field instead of misusing the standard integer request-time field.
+
+Use `httpcheck` for unauthenticated endpoint liveness and `x509check` for certificate expiry or revocation. For authenticated S3 correctness, multisite payload checks, and delete propagation, use the Phase 2 capabilities rather than approximating them from counters.
+
+### Phase 1 limits
+
+- Per-topic persistent notification backlog has no source-published Prometheus numeric family in the covered releases.
+- Selected tenant, user, and bucket detail is not enabled automatically because those optional surfaces can be high-cardinality.
+- Quota, sync lag, recovery shards, RPO, lifecycle health, and garbage-collection age require the Phase 2 native or probe surfaces.
+
+## RCA Functions
+
+The native Ceph Dashboard collector provides Functions for detailed health, OSD, pool, and incident investigation. These Functions are on-demand API calls; they do not create charts or alerts by themselves.
+
+Use Functions when you need detailed current inventory or component state. Use charts and alerts for continuous monitoring. If a Function requires the Ceph orchestrator, ensure the Dashboard configuration exposes it.
+
+## Retention and capacity planning
+
+Plan retention separately on Children and Parents.
+
+1. Deploy one Agent per Ceph node and run a representative workload for days.
+2. Measure the number of charts and dimensions actually produced for your Ceph release, optional exporter surfaces, and collectors.
+3. Decide where long retention lives:
+   - keep short high-resolution retention locally on each Child;
+   - stream longer retention to one or more Parents.
+4. Use the measured chart and dimension counts, sample interval, tiering mode, and intended retention horizon to estimate disk requirements.
+5. Validate the estimate after several days and again after several weeks.
+6. For multi-year storage, export to Prometheus, Grafana-compatible storage, or another external system rather than storing every sample in the Agent database.
+
+Do not extrapolate from a single quiet day: hardware inventories, failover, optional exporter surfaces, and incident activity change cardinality. Do not assume linear growth from Ceph capacity alone; chart cardinality follows enabled telemetry surfaces and their labels.
+
+Phase 1 does not forecast storage growth or capacity exhaustion. Use the measured charts and exported long-term data for trend analysis until a supported prediction capability exists.
+
+## Cloud, rooms, and sites
+
+Connect each Agent to Netdata Cloud unless you operate a fully on-prem deployment. Organize rooms by site, cluster, or operational responsibility. A room is a navigation and access boundary, not a data aggregation layer.
+
+Parents preserve child identity. A Parent can provide long retention, unified querying, and a single TLS ingress, while each Ceph node remains independently visible in Cloud.
+
+For on-prem-only deployments, streaming and local dashboards remain available. You lose Cloud-managed rooms, centralized silencing, and Cloud notifications, but local Agent health and notification mechanisms still work.
+
+## Grafana, Prometheus, Zabbix, and exporting
+
+The Ceph collectors coexist with existing monitoring:
+
+- Keep or deploy Grafana dashboards independently.
+- Keep existing Prometheus exporters; the Prometheus collector reads Ceph's official endpoints but does not replace them.
+- Keep an existing Zabbix deployment independently and collect Ceph through Zabbix's own integrations. Netdata does not
+  provide a direct Zabbix exporting connector.
+- Export Netdata metrics to external systems with the exporting engine.
+- Send selected Netdata alerts to external systems through supported notification integrations.
+
+Do not point multiple Netdata jobs at the same logical Ceph cluster MGR endpoint under different identities unless you intentionally want separate alert owners.
+
+## Notifications
+
+Route alert notifications centrally through Netdata Cloud when your Agents are connected, or configure notifications per Agent for on-prem deployments. Start with the notifying categorical alerts, then enable and tune silent policy alerts only where you have measured a meaningful threshold.
+
+## Incident guide
+
+For the native physical-capacity alert, see the [Ceph cluster space usage](/src/health/guides/ceph/ceph_cluster_space_usage.md) incident guide.
+
+For collector configuration details, see:
+
+- [Ceph](/src/go/plugin/go.d/collector/ceph/integrations/ceph.md)
+- [Ceph Prometheus](/src/go/plugin/go.d/collector/prometheus/integrations/ceph_prometheus.md)
+
+For Agent deployment and streaming, see:
+
+- [Deployment with centralization points](/docs/deployment-guides/deployment-with-centralization-points.md)
+- [Metrics centralization points](/docs/observability-centralization-points/metrics-centralization-points/README.md)
+- [Sizing Netdata Parents](/docs/netdata-agent/sizing-netdata-agents/disk-requirements-and-retention.md)
+- [Exporting reference](/src/exporting/README.md)
+- [Notifications](/docs/alerts-and-notifications/notifications/README.md)

--- a/docs/guides/ceph/README.md
+++ b/docs/guides/ceph/README.md
@@ -15,6 +15,22 @@ Netdata gives you a complete operational view of Ceph by collecting three comple
 - Dashboard API component integrity and on-demand Ceph investigation Functions.
 - Per-node disks, filesystems, network interfaces, processes, and logs through Netdata's host collectors.
 
+## Ceph telemetry and Netdata
+
+Ceph natively exposes metrics in the Prometheus exposition format through two interfaces:
+
+- The **Ceph Manager Prometheus module** is the cluster-level surface. The active Manager periodically builds a metric cache from cluster state and publishes it at an HTTP metrics endpoint.
+- The official **`ceph-exporter`** is the host-local surface. It gathers daemon and admin-socket telemetry on each Ceph node and publishes it in the same format.
+
+The word “Prometheus” here refers to the exposition wire format, not the Prometheus monitoring stack. Netdata reads Ceph's native endpoints directly, recognizes the official metric families with its built-in Ceph profile, and creates charts and alerts from that state. You do not need to install Prometheus Server, Alertmanager, or another database for this monitoring to work. If you already operate Prometheus, it can continue reading Ceph independently; coexistence is optional.
+
+Telemetry freshness has two independent clocks:
+
+1. **Producer interval:** Ceph controls how often the MGR metric cache or `ceph-exporter` daemon metrics are refreshed.
+2. **Consumer interval:** Netdata controls how often it reads the currently exposed cache through the job's `update_every`.
+
+Matching the Netdata interval to the producer interval normally produces one useful observation per Ceph refresh. Reading more frequently can repeat the same cached state, while reading less frequently can skip producer updates. Choose the interval according to the observation you need: every producer update, periodic trend sampling, lower endpoint traffic, or tighter visibility for a selected surface.
+
 ## Operational coverage map
 
 Use this map to identify the Netdata surface that owns the operational question you are investigating.
@@ -80,7 +96,7 @@ A Parent can receive streams from every Ceph Agent. Parenting changes where data
 
 ### MGR Prometheus module
 
-Enable the Ceph MGR Prometheus module and expose one stable HTTP or HTTPS endpoint for the cluster. Configure the Netdata Prometheus collector to scrape that endpoint. The built-in Ceph profile recognizes the official metric surface automatically.
+Enable the Ceph MGR Prometheus module and expose one stable HTTP or HTTPS endpoint for the cluster. Configure the Netdata Prometheus collector to read that endpoint. The built-in Ceph profile recognizes the official metric surface automatically.
 
 For high availability, put a stable address in front of the active MGR and keep the Netdata job name and virtual-node identity stable.
 
@@ -90,7 +106,7 @@ Deploy or enable official `ceph-exporter` on each Ceph node whose daemon telemet
 
 ### Ceph Dashboard API
 
-Enable the Ceph Dashboard module, secure it with TLS, and create a read-only Dashboard user. Configure one native Ceph collector job per cluster. The Dashboard collector complements Prometheus: it owns API component integrity and provides Ceph investigation Functions.
+Enable the Ceph Dashboard module, secure it with TLS, and create a read-only Dashboard user. Configure one native Ceph collector job per cluster. The Dashboard collector complements the metric endpoints: it owns API component integrity and provides Ceph investigation Functions.
 
 ## Supported releases
 
@@ -110,17 +126,34 @@ Release-specific charts follow the telemetry exposed by each Ceph release. For e
 - Preserve stable job identity through redirects and failover. Chart identity and alert ownership depend on it.
 - If Ceph redirects HTTP to HTTPS, configure the final HTTPS URL explicitly rather than relying on redirect following.
 
-## Collection cadence and cardinality
+## Sizing and Ceph impact
 
-Netdata scrape frequency does not control Ceph producer refresh frequency.
+Monitoring workload has four components:
 
-- The MGR Prometheus module refreshes its metric cache on its configured Ceph-side interval.
-- `ceph-exporter` refreshes daemon metrics on its configured interval.
-- Netdata samples the exposed current cache at the job's `update_every`.
+1. **Ceph producer work:** the Manager refreshes its metric cache, and `ceph-exporter` gathers daemon counters. Ceph controls this work through its own configuration.
+2. **Endpoint serving work:** each collection request reads and transfers the current exposition. Cost scales with the enabled metric surface.
+3. **Netdata processing work:** parsing, chart planning, and health evaluation scale with the selected families and resulting chart cardinality.
+4. **Storage and retention:** chart and dimension counts drive database volume; the streaming topology determines where long retention is stored.
 
-Match the Netdata interval to the producer cache interval when you want to avoid redundant samples. A faster scrape does not force Ceph to refresh more often.
+Use the collection model to choose scope:
 
-Ceph can expose a large metric surface. Set job-level `max_time_series` and `max_time_series_per_metric` after measuring your release and exporter configuration. Enable broad optional debug or detail surfaces only after sizing the resulting chart and dimension cardinality.
+- Collect one logical MGR job per Ceph cluster, use a stable active-MGR endpoint or failover target, and align its interval with the Manager cache interval.
+- Collect each `ceph-exporter` on the host whose daemon detail you need, and align its interval with the exporter refresh interval.
+- Choose a Dashboard interval appropriate for cluster size, and use selectors and entity caps when complete OSD or pool detail is unnecessary.
+- Enable broad optional diagnostic surfaces after measuring the resulting cardinality.
+- Treat tenant, user, and bucket detail as a separate capacity decision: those surfaces can grow with the object-storage environment.
+- Use hardware telemetry knowing that it scales with the reported component inventory.
+- Run investigation Functions on demand during an incident rather than as a continuous inventory process.
+
+Use job-level `max_time_series` and `max_time_series_per_metric` to bound an exposed surface. These limits do not reduce Ceph's producer cost, but they control Netdata's processing and storage boundary.
+
+Size the deployment from measured behavior:
+
+1. Enable the intended telemetry surfaces.
+2. Run a representative workload for several days.
+3. Measure charts, dimensions, labels, endpoint response size, collection duration, Agent CPU and memory, and storage growth.
+4. Select local retention and Parent placement.
+5. Export to long-term storage when multi-year history is required.
 
 ## Alert ownership and routing
 

--- a/src/go/internal/promprofile/semantics/units.go
+++ b/src/go/internal/promprofile/semantics/units.go
@@ -99,6 +99,13 @@ var displayRegistry = map[string]registeredDisplay{
 		unit:          "requests/min",
 		scale:         newRationalScale(60, 1),
 	},
+	"fan_revolutions_per_minute": {
+		quantity:      "count",
+		object:        "fan_revolutions",
+		effectiveRate: "per_second",
+		unit:          "fan revolutions per minute",
+		scale:         newRationalScale(60, 1),
+	},
 	"tokens_per_minute": {
 		quantity:      "count",
 		object:        "tokens",

--- a/src/go/internal/promprofile/validation/ceph_health_lifecycle_test.go
+++ b/src/go/internal/promprofile/validation/ceph_health_lifecycle_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package promvalidation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
+	promcollector "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus"
+)
+
+func TestCephHealthDetailKeepsNameIdentityAcrossObservedLabelChangesThenExpires(t *testing.T) {
+	const active = `
+# TYPE ceph_health_status gauge
+ceph_health_status 1
+# TYPE ceph_health_detail gauge
+ceph_health_detail{name="RECENT_CRASH",severity="HEALTH_WARN"} 1
+`
+	const resolved = `
+# TYPE ceph_health_status gauge
+ceph_health_status 0
+# TYPE ceph_health_detail gauge
+ceph_health_detail{name="RECENT_CRASH",severity="HEALTH_WARN"} 0
+`
+	// Ceph's supported health-history implementation records severity when a named
+	// entry is created. This synthetic change proves profile identity if a source
+	// version ever updates that metadata; it is not a claimed Ceph transition.
+	const changedMetadata = `
+# TYPE ceph_health_status gauge
+ceph_health_status 2
+# TYPE ceph_health_detail gauge
+ceph_health_detail{name="RECENT_CRASH",severity="HEALTH_ERR"} 1
+`
+	const absent = `
+# TYPE ceph_health_status gauge
+ceph_health_status 0
+`
+
+	var input struct {
+		sync.RWMutex
+		body string
+	}
+	input.body = active
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		input.RLock()
+		defer input.RUnlock()
+		_, _ = w.Write([]byte(input.body))
+	}))
+	defer server.Close()
+
+	collector := promcollector.New()
+	collector.URL = server.URL
+	collector.Profiles = promcollector.ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collector.Init(context.Background()))
+	require.NoError(t, collector.Check(context.Background()))
+	defer collector.Cleanup(context.Background())
+
+	engine, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, engine.LoadYAML([]byte(collector.ChartTemplateYAML()), 1))
+	cycles, ok := metrix.AsCycleManagedStore(collector.MetricStore())
+	require.True(t, ok)
+
+	collectPlan := func(body string) chartengine.Plan {
+		input.Lock()
+		input.body = body
+		input.Unlock()
+		cycles.CycleController().BeginCycle()
+		require.NoError(t, collector.Collect(context.Background()))
+		require.NoError(t, cycles.CycleController().CommitCycleSuccess())
+		attempt, err := engine.PreparePlan(collector.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+		require.NoError(t, err)
+		plan := attempt.Plan()
+		require.NoError(t, attempt.Commit())
+		return plan
+	}
+
+	activePlan := collectPlan(active)
+	chartID := cephHealthLifecycleChartID(t, activePlan)
+	if got := cephHealthLifecycleUpdate(t, activePlan, chartID); got != 1 {
+		t.Fatalf("active health-detail value = %v, want 1", got)
+	}
+
+	changedMetadataPlan := collectPlan(changedMetadata)
+	if cephHealthLifecycleHasRemove(changedMetadataPlan, chartID) {
+		t.Fatalf("observed label change removed the named health-check chart: %#v", changedMetadataPlan.Actions)
+	}
+	cephHealthLifecycleHasNoCreate(t, changedMetadataPlan)
+	require.Equal(t, map[string]string{
+		"name":     "RECENT_CRASH",
+		"severity": "HEALTH_ERR",
+	}, cephHealthLifecycleLabelUpdate(t, changedMetadataPlan, chartID))
+	if got := cephHealthLifecycleUpdate(t, changedMetadataPlan, chartID); got != 1 {
+		t.Fatalf("health-detail value after observed label change = %v, want 1", got)
+	}
+
+	resolvedPlan := collectPlan(resolved)
+	if cephHealthLifecycleHasRemove(resolvedPlan, chartID) {
+		t.Fatalf("resolved ordinary health check removed its chart instead of emitting zero: %#v", resolvedPlan.Actions)
+	}
+	if got := cephHealthLifecycleUpdate(t, resolvedPlan, chartID); got != 0 {
+		t.Fatalf("resolved health-detail value = %v, want 0", got)
+	}
+
+	for cycle := 1; cycle < 5; cycle++ {
+		plan := collectPlan(absent)
+		if cephHealthLifecycleHasRemove(plan, chartID) {
+			t.Fatalf("absent health check expired early at successful cycle %d: %#v", cycle, plan.Actions)
+		}
+	}
+	finalPlan := collectPlan(absent)
+	if !cephHealthLifecycleHasRemove(finalPlan, chartID) {
+		t.Fatalf("absent health check did not expire after five successful cycles: %#v", finalPlan.Actions)
+	}
+}
+
+func cephHealthLifecycleChartID(t *testing.T, plan chartengine.Plan) string {
+	t.Helper()
+	for _, item := range plan.Actions {
+		if action, ok := item.(chartengine.CreateChartAction); ok && action.Meta.Context == "prometheus.ceph.health.health_checks.state" {
+			return action.ChartID
+		}
+	}
+	t.Fatalf("initial fixture did not create the Ceph health-detail chart: %#v", plan.Actions)
+	return ""
+}
+
+func cephHealthLifecycleUpdate(t *testing.T, plan chartengine.Plan, chartID string) float64 {
+	t.Helper()
+	for _, item := range plan.Actions {
+		action, ok := item.(chartengine.UpdateChartAction)
+		if !ok || action.ChartID != chartID {
+			continue
+		}
+		for _, value := range action.Values {
+			if value.Name != "value" {
+				continue
+			}
+			if !value.IsFloat || value.IsEmpty {
+				t.Fatalf("health-detail update is not a concrete float value: %#v", value)
+			}
+			return value.Float64
+		}
+	}
+	t.Fatalf("plan has no health-detail update for chart %q: %#v", chartID, plan.Actions)
+	return 0
+}
+
+func cephHealthLifecycleLabelUpdate(t *testing.T, plan chartengine.Plan, chartID string) map[string]string {
+	t.Helper()
+	for _, item := range plan.Actions {
+		action, ok := item.(chartengine.UpdateChartLabelsAction)
+		if ok && action.ChartID == chartID {
+			return action.Labels
+		}
+	}
+	t.Fatalf("plan has no health-detail label update for chart %q: %#v", chartID, plan.Actions)
+	return nil
+}
+
+func cephHealthLifecycleHasNoCreate(t *testing.T, plan chartengine.Plan) {
+	t.Helper()
+	for _, item := range plan.Actions {
+		if action, ok := item.(chartengine.CreateChartAction); ok && action.Meta.Context == "prometheus.ceph.health.health_checks.state" {
+			t.Fatalf("severity change created a second named health-check chart: %#v", plan.Actions)
+		}
+	}
+}
+
+func cephHealthLifecycleHasRemove(plan chartengine.Plan, chartID string) bool {
+	for _, item := range plan.Actions {
+		if action, ok := item.(chartengine.RemoveChartAction); ok && action.ChartID == chartID {
+			return true
+		}
+	}
+	return false
+}

--- a/src/go/internal/promprofile/validation/ceph_source_contract_test.go
+++ b/src/go/internal/promprofile/validation/ceph_source_contract_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package promvalidation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	promsemantics "github.com/netdata/netdata/go/plugins/internal/promprofile/semantics"
+	"github.com/netdata/netdata/go/plugins/internal/promprofile/testutil"
+)
+
+func TestCephTentacleHardwareFanRPMSourceUnit(t *testing.T) {
+	source, err := promsemantics.LoadSourceSemantics(
+		promtestutil.Require(t, "prometheus/profiles/ceph/SOURCE-SEMANTICS.yaml"),
+	)
+	require.NoError(t, err)
+
+	signal, ok := source.Signals["hardware_fan_rpm"]
+	require.True(t, ok)
+	component, ok := signal.Components["value"]
+	require.True(t, ok)
+	require.Equal(t, "count", component.Unit.Quantity)
+	require.Equal(t, "one", component.Unit.Base)
+	require.Equal(t, "per_minute", component.Unit.Rate)
+	require.Equal(t, "fan_revolutions", component.Unit.Object)
+}

--- a/src/go/plugin/go.d/collector/ceph/collector_test.go
+++ b/src/go/plugin/go.d/collector/ceph/collector_test.go
@@ -834,6 +834,25 @@ func TestCollector_ChartTemplateContract(t *testing.T) {
 	assert.Equal(t, expectedChartFamilies(), actualFamilies)
 }
 
+func TestCollector_PhysicalCapacityAlertContract(t *testing.T) {
+	alert, err := os.ReadFile("../../../../../health/health.d/ceph.conf")
+	require.NoError(t, err)
+
+	config := string(alert)
+	start := strings.Index(config, "template: ceph_cluster_physical_capacity_utilization")
+	require.NotEqual(t, -1, start)
+	block := config[start:]
+	if end := strings.Index(block, "\n template:"); end >= 0 {
+		block = block[:end]
+	}
+	assert.Contains(t, block, "on: ceph.cluster_physical_capacity_utilization")
+	assert.Contains(t, block, "calc: $utilization")
+	assert.Contains(t, block, "to: silent")
+	assert.Contains(t, block, "silent by default")
+	assert.Contains(t, block, "warn: $this > (($status >= $WARNING ) ? (85) : (90))")
+	assert.Contains(t, block, "crit: $this > (($status == $CRITICAL) ? (90) : (98))")
+}
+
 func TestCollector_ComponentCollectionAlertContract(t *testing.T) {
 	alert, err := os.ReadFile("../../../../../health/health.d/ceph.conf")
 	require.NoError(t, err)

--- a/src/go/plugin/go.d/collector/ceph/collector_test.go
+++ b/src/go/plugin/go.d/collector/ceph/collector_test.go
@@ -859,6 +859,65 @@ func TestCollector_PhysicalCapacityAlertContract(t *testing.T) {
 	assert.Contains(t, block, "crit: $this > (($status == $CRITICAL) ? (90) : (98))")
 }
 
+func cephHealthTemplates(t *testing.T) map[string]map[string]string {
+	t.Helper()
+	content, err := os.ReadFile("../../../../../health/health.d/ceph.conf")
+	require.NoError(t, err)
+
+	templates := make(map[string]map[string]string)
+	var current map[string]string
+	for source := range strings.SplitSeq(string(content), "\n") {
+		line := strings.TrimSpace(source)
+		if name, ok := strings.CutPrefix(line, "template:"); ok {
+			current = make(map[string]string)
+			templates[strings.TrimSpace(name)] = current
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "info:"); ok {
+			current["info"] = strings.TrimSpace(value)
+		}
+	}
+	return templates
+}
+
+func TestCollector_PublicAlertInfoMatchesHealthTemplates(t *testing.T) {
+	templates := cephHealthTemplates(t)
+
+	var metadata struct {
+		Modules []struct {
+			Meta struct {
+				ModuleName string `yaml:"module_name"`
+			} `yaml:"meta"`
+			Alerts []struct {
+				Name string `yaml:"name"`
+				Info string `yaml:"info"`
+			} `yaml:"alerts"`
+		} `yaml:"modules"`
+	}
+	content, err := os.ReadFile("metadata.yaml")
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(content, &metadata))
+
+	var public []struct {
+		Name string `yaml:"name"`
+		Info string `yaml:"info"`
+	}
+	for _, module := range metadata.Modules {
+		if module.Meta.ModuleName == "ceph" {
+			public = module.Alerts
+			break
+		}
+	}
+	require.Len(t, public, 2)
+	for _, alert := range public {
+		assert.Equalf(t, templates[alert.Name]["info"], alert.Info,
+			"metadata alert %q does not exactly match its shipped health-template info", alert.Name)
+	}
+}
+
 func TestCollector_ComponentCollectionAlertContract(t *testing.T) {
 	block := cephHealthAlertBlock(t, "ceph_component_collection_failed")
 	assert.Contains(t, block, "on: ceph.component_collection_status")

--- a/src/go/plugin/go.d/collector/ceph/collector_test.go
+++ b/src/go/plugin/go.d/collector/ceph/collector_test.go
@@ -834,17 +834,23 @@ func TestCollector_ChartTemplateContract(t *testing.T) {
 	assert.Equal(t, expectedChartFamilies(), actualFamilies)
 }
 
-func TestCollector_PhysicalCapacityAlertContract(t *testing.T) {
+func cephHealthAlertBlock(t *testing.T, template string) string {
+	t.Helper()
 	alert, err := os.ReadFile("../../../../../health/health.d/ceph.conf")
 	require.NoError(t, err)
 
 	config := string(alert)
-	start := strings.Index(config, "template: ceph_cluster_physical_capacity_utilization")
+	start := strings.Index(config, "template: "+template)
 	require.NotEqual(t, -1, start)
 	block := config[start:]
 	if end := strings.Index(block, "\n template:"); end >= 0 {
 		block = block[:end]
 	}
+	return block
+}
+
+func TestCollector_PhysicalCapacityAlertContract(t *testing.T) {
+	block := cephHealthAlertBlock(t, "ceph_cluster_physical_capacity_utilization")
 	assert.Contains(t, block, "on: ceph.cluster_physical_capacity_utilization")
 	assert.Contains(t, block, "calc: $utilization")
 	assert.Contains(t, block, "to: silent")
@@ -854,16 +860,7 @@ func TestCollector_PhysicalCapacityAlertContract(t *testing.T) {
 }
 
 func TestCollector_ComponentCollectionAlertContract(t *testing.T) {
-	alert, err := os.ReadFile("../../../../../health/health.d/ceph.conf")
-	require.NoError(t, err)
-
-	config := string(alert)
-	start := strings.Index(config, "template: ceph_component_collection_failed")
-	require.NotEqual(t, -1, start)
-	block := config[start:]
-	if end := strings.Index(block, "\n template:"); end >= 0 {
-		block = block[:end]
-	}
+	block := cephHealthAlertBlock(t, "ceph_component_collection_failed")
 	assert.Contains(t, block, "on: ceph.component_collection_status")
 	assert.Contains(t, block, "calc: $failed")
 	assert.Contains(t, block, "${label:component}")

--- a/src/go/plugin/go.d/collector/ceph/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ceph/metadata.yaml
@@ -320,9 +320,11 @@ modules:
           - name: More preconfigured Ceph alerts are expected
             description: |
               This integration ships alerts for collection failures and native capacity utilization.
-              Health Function rows are on-demand tables and do not create alerts. Keep Ceph mixin/Alertmanager rules for
-              PG states, OSD down/out, MON quorum, slow operations, scrub errors, and RGW conditions unless equivalent
-              Netdata alerts are explicitly implemented and tested. Slack, webhook, and PagerDuty are notification
+              Health Function rows are on-demand tables and do not create alerts. When the Ceph Prometheus profile is
+              configured, its MGR-owned alert layer supplies tested cluster health, crash, slow-operation, and cephadm
+              conditions; this native collector remains the owner of Dashboard API component-collection failures. Keep Ceph
+              mixin/Alertmanager rules for conditions without an explicitly implemented and tested Netdata equivalent,
+              including any required PG, OSD, MON, scrub, or RGW policy. Slack, webhook, and PagerDuty are notification
               transports, not Ceph threshold definitions.
     alerts:
       - name: ceph_component_collection_failed

--- a/src/go/plugin/go.d/collector/ceph/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ceph/metadata.yaml
@@ -319,7 +319,9 @@ modules:
               automatically compatible. On-demand Function tables are not Prometheus time series.
           - name: More preconfigured Ceph alerts are expected
             description: |
-              This integration ships alerts for collection failures and native capacity utilization.
+              This integration ships a notifying collection-failure alert and a silent-by-default native capacity-utilization
+              policy. Existing installations that relied on automatic capacity notifications must explicitly route the
+              capacity alert after upgrade.
               Health Function rows are on-demand tables and do not create alerts. When the Ceph Prometheus profile is
               configured, its MGR-owned alert layer supplies tested cluster health, crash, slow-operation, and cephadm
               conditions; this native collector remains the owner of Dashboard API component-collection failures. Keep Ceph
@@ -334,7 +336,7 @@ modules:
       - name: ceph_cluster_physical_capacity_utilization
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: ceph.cluster_physical_capacity_utilization
-        info: 'Ceph cluster ${label:fsid} disk space utilization'
+        info: 'Ceph cluster ${label:fsid} disk space utilization. This stock capacity policy is silent by default; explicitly route it when notifications are required.'
     metrics:
       folding:
         title: Metrics

--- a/src/go/plugin/go.d/collector/ceph/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ceph/metadata.yaml
@@ -332,7 +332,7 @@ modules:
       - name: ceph_component_collection_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: ceph.component_collection_status
-        info: 'Ceph ${label:component} metric collection for cluster ${label:fsid} is failing'
+        info: "Metric collection for the Ceph ${label:component} component is failing while other Ceph metrics continue to be collected"
       - name: ceph_cluster_physical_capacity_utilization
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: ceph.cluster_physical_capacity_utilization

--- a/src/go/plugin/go.d/collector/httpcheck/metadata.yaml
+++ b/src/go/plugin/go.d/collector/httpcheck/metadata.yaml
@@ -207,6 +207,17 @@ modules:
             title: Config
             enabled: true
           list:
+            - name: Ceph RGW endpoint liveness
+              description: Basic unauthenticated liveness check for a Ceph RGW HTTP endpoint. This does not verify authenticated S3 operations.
+              config: |
+                jobs:
+                  - name: ceph-rgw-local
+                    url: http://127.0.0.1:8080
+                    status_accepted:
+                      - 200
+                      - 204
+                      - 403
+                      - 405
             - name: Basic
               description: A basic example configuration.
               config: |

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1890,6 +1890,101 @@ func TestCollector_CephNVMeoFAlertBoundaries(t *testing.T) {
 	}
 }
 
+func TestCollector_CephRGWAlertChartsMaterialize(t *testing.T) {
+	input, err := os.ReadFile(promtestutil.Require(t,
+		"prometheus/profiles/ceph/fixtures/ceph_reef_ceph_exporter_limit11.prom"))
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(input)
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	defer collr.Cleanup(context.Background())
+
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	eng, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+	require.NoError(t, attempt.Commit())
+
+	created := make(map[string]int)
+	for _, action := range plan.Actions {
+		if create, ok := action.(chartengine.CreateChartAction); ok {
+			created[create.Meta.Context]++
+		}
+	}
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway.notifications.events"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway.notifications.missing_configurations"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway.lua.script_executions"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway.requests_and_queue.failed_requests"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway.notifications.failure_outcomes"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway.notifications.pending_events"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway.notifications.event_state"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway.requests_and_queue.current_requests"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway_multisite.object_work"])
+	require.Equal(t, 1, created["prometheus.ceph.object_gateway_multisite.replication_log_request_errors"])
+}
+
+func TestCollector_CephRGWAlertBoundaries(t *testing.T) {
+	templates := cephHealthAlertTemplates(t)
+	want := map[string]struct {
+		lookup    string
+		condition string
+	}{
+		"rgw_notification_event_lost":             {"min -1m unaligned of event_lost", "crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
+		"rgw_notification_missing_configuration":  {"min -1m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
+		"rgw_lua_script_failed":                   {"min -1m unaligned of failure", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
+		"rgw_failed_request_rate_fallback":        {"min -5m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
+		"rgw_notification_push_or_store_failures": {"min -5m unaligned of push_failed,store_fail", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
+		"rgw_notification_inflight_pressure":      {"min -5m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)"},
+		"rgw_notification_store_backlog":          {"min -5m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)"},
+		"rgw_request_queue_pressure":              {"min -5m unaligned of qlen", "warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)"},
+		"rgw_multisite_fetch_errors":              {"min -5m unaligned of errors", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
+		"rgw_multisite_poll_errors":               {"min -5m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
+	}
+	for name, expected := range want {
+		t.Run(name, func(t *testing.T) {
+			block, ok := templates[name]
+			require.Truef(t, ok, "template %s is absent", name)
+			assert.Equal(t, expected.lookup, block["lookup"])
+			assert.Equal(t, expected.condition, block["condition"])
+			assert.Equal(t, "silent", block["to"])
+		})
+	}
+
+	// min is the all-observed-samples time grouping: one recovery sample clears
+	// the rule even when earlier samples in the same window were active.
+	allSamples := func(samples []float64) float64 {
+		if len(samples) == 0 {
+			return math.NaN()
+		}
+		minimum := samples[0]
+		for _, sample := range samples[1:] {
+			if sample < minimum {
+				minimum = sample
+			}
+		}
+		return minimum
+	}
+	assert.InDelta(t, 0, allSamples([]float64{.1, 0, 0}), 1e-12)
+	assert.InDelta(t, 999, allSamples([]float64{1001, 1000, 999}), 1e-12)
+	assert.True(t, math.IsNaN(allSamples(nil)))
+}
+
 func TestCollector_CephMGRAlertContract(t *testing.T) {
 	manifest := loadCephAlertManifest(t)
 	templates := cephHealthAlertTemplates(t)
@@ -1932,10 +2027,34 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		"CEPH-082-HELPER-READ-OPS", "CEPH-083", "CEPH-083-HELPER-WRITE-TIME", "CEPH-083-HELPER-WRITE-OPS",
 		"CEPH-084", "CEPH-092", "CEPH-094", "CEPH-094-HELPER-GATEWAY",
 	}, cephManifestSOWIDs(manifest.Alerts))
-	require.ElementsMatch(t, []string{"CEPH-ND-001", "CEPH-ND-002", "RGW-M-01", "RGW-M-02"},
-		cephManifestExtensionSOWIDs(manifest.NetdataExtensions))
+	require.ElementsMatch(t, []string{
+		"CEPH-ND-001", "CEPH-ND-002", "RGW-M-01", "RGW-M-02", "RGW-M-08", "RGW-M-09", "RGW-M-10",
+		"RGW-S-04", "RGW-S-12", "RGW-S-16", "RGW-S-17", "RGW-S-18", "RGW-S-19", "RGW-S-20", "RGW-S-20",
+		"RGW-M-03", "RGW-M-04", "RGW-S-01", "RGW-S-02", "RGW-S-03", "RGW-S-09", "RGW-S-13", "RGW-S-14",
+		"RGW-S-15",
+	}, cephManifestExtensionSOWIDs(manifest.NetdataExtensions))
 	for name, extension := range manifest.NetdataExtensions {
 		require.NotEmptyf(t, extension.Reason, "%s has no extension rationale", name)
+		if extension.Fidelity == "UNSUPPORTED" {
+			require.Empty(t, extension.Context)
+			require.NotContains(t, templates, name)
+			continue
+		}
+		block, hasTemplate := templates[name]
+		if hasTemplate && extension.Condition != "" {
+			require.NotEmpty(t, extension.Context)
+			assert.Equal(t, extension.Context, block["on"])
+			assert.Equal(t, extension.Lookup, block["lookup"])
+			assert.Equal(t, extension.Calc, block["calc"])
+			assert.Equal(t, extension.Units, block["units"])
+			assert.Equal(t, extension.Condition, block["condition"])
+			assert.Equal(t, extension.Recipient, block["to"])
+		} else {
+			require.Empty(t, extension.Lookup)
+			require.Empty(t, extension.Calc)
+			require.Empty(t, extension.Condition)
+			require.Empty(t, extension.Recipient)
+		}
 		require.NotEmptyf(t, extension.Fidelity, "%s has no extension fidelity", name)
 		require.NotEmptyf(t, extension.Owner, "%s has no extension owner", name)
 		if extension.Adaptation != "" {
@@ -2063,6 +2182,72 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 	assert.Equal(t, manifest.NetdataExtensions["ceph_component_collection_failed"].Context,
 		templates["ceph_component_collection_failed"]["on"])
 	assert.NotContains(t, templates, "ceph_mgr_prometheus_module_inactive")
+}
+
+func TestCollector_CephRGWGenericOwnerExamples(t *testing.T) {
+	var metadata struct {
+		Modules []struct {
+			Setup struct {
+				Configuration struct {
+					Examples struct {
+						List []struct {
+							Name        string `yaml:"name"`
+							Description string `yaml:"description"`
+							Config      string `yaml:"config"`
+						} `yaml:"list"`
+					} `yaml:"examples"`
+				} `yaml:"configuration"`
+			} `yaml:"setup"`
+		} `yaml:"modules"`
+	}
+
+	for _, tc := range []struct {
+		module   string
+		example  string
+		contains string
+	}{
+		{module: "httpcheck", example: "Ceph RGW endpoint liveness", contains: "ceph-rgw-local"},
+		{module: "x509check", example: "Ceph RGW certificate", contains: "ceph_rgw_cert"},
+		{module: "weblog", example: "Ceph RGW access log", contains: "custom_numeric_fields"},
+	} {
+		t.Run(tc.module, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join("..", tc.module, "metadata.yaml"))
+			require.NoError(t, err)
+
+			require.NoError(t, yaml.Unmarshal(content, &metadata))
+			require.NotEmpty(t, metadata.Modules)
+
+			found := false
+			for _, module := range metadata.Modules {
+				for _, example := range module.Setup.Configuration.Examples.List {
+					if example.Name != tc.example {
+						continue
+					}
+					found = true
+					assert.Contains(t, example.Config, tc.contains)
+					assert.Contains(t, example.Description, "Ceph RGW")
+					if tc.module == "x509check" {
+						assert.Contains(t, example.Config, "check_revocation_status: yes")
+					}
+				}
+			}
+			require.Truef(t, found, "%s example %q not found", tc.module, tc.example)
+		})
+	}
+
+	manifest := loadCephAlertManifest(t)
+	require.Equal(t, "x509check.revocation_status", manifest.NetdataExtensions["rgw_tls_certificate_revoked"].Context)
+	require.Equal(t, "httpcheck.status", manifest.NetdataExtensions["rgw_basic_endpoint_unavailable"].Context)
+	require.Equal(t,
+		"web_log.custom_numeric_field_total_time_summary",
+		manifest.NetdataExtensions["rgw_overall_request_latency"].Context)
+
+	x509Templates := healthAlertTemplatesFromFile(t, filepath.Join("..", "..", "..", "..", "..", "health", "health.d", "x509check.conf"))
+	require.Equal(t, "x509check.revocation_status", x509Templates["x509check_revocation_status"]["on"])
+	httpcheckTemplates := healthAlertTemplatesFromFile(t, filepath.Join("..", "..", "..", "..", "..", "health", "health.d", "httpcheck.conf"))
+	require.Equal(t, "httpcheck.status", httpcheckTemplates["httpcheck_web_service_up"]["on"])
+	weblogTemplates := healthAlertTemplatesFromFile(t, filepath.Join("..", "..", "..", "..", "..", "health", "health.d", "web_log.conf"))
+	require.Equal(t, "web_log.request_processing_time", weblogTemplates["web_log_web_slow"]["on"])
 }
 
 func TestCollector_CephMGRAlertSourcePins(t *testing.T) {
@@ -2458,6 +2643,11 @@ func TestCollector_CephMetadataAlertsMatchMGRAlertTemplates(t *testing.T) {
 		}
 	}
 	expected["ceph_unknown_health_check"] = manifest.NetdataExtensions["ceph_unknown_health_check"].Context
+	for name, extension := range manifest.NetdataExtensions {
+		if extension.Context != "" && extension.Condition != "" {
+			expected[name] = extension.Context
+		}
+	}
 	assert.Equal(t, expected, actual)
 	for name, metadataInfo := range info {
 		if name == "ceph_unknown_health_check" {
@@ -2502,6 +2692,7 @@ type cephNetdataExtension struct {
 	Context      string `yaml:"context"`
 	LabelsPolicy string `yaml:"labels_policy"`
 	Lookup       string `yaml:"lookup"`
+	Calc         string `yaml:"calc"`
 	Units        string `yaml:"units"`
 	Condition    string `yaml:"condition"`
 	Recipient    string `yaml:"recipient"`

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1047,32 +1047,7 @@ func TestCollector_CephMGRReleaseFixturesMaterializeM01AlertIdentities(t *testin
 			input, err := os.ReadFile(promtestutil.Require(t, fixture))
 			require.NoError(t, err)
 
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				_, _ = w.Write(input)
-			}))
-			defer srv.Close()
-
-			collr := New()
-			collr.URL = srv.URL
-			collr.Profiles = ProfilesConfig{Mode: "auto"}
-			require.NoError(t, collr.Init(context.Background()))
-			require.NoError(t, collr.Check(context.Background()))
-			defer collr.Cleanup(context.Background())
-
-			cc := cycle(t, collr.MetricStore())
-			cc.BeginCycle()
-			require.NoError(t, collr.Collect(context.Background()))
-			require.NoError(t, cc.CommitCycleSuccess())
-
-			eng, err := chartengine.New()
-			require.NoError(t, err)
-			require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
-			attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
-			require.NoError(t, err)
-			defer attempt.Abort()
-			plan := attempt.Plan()
-			require.NoError(t, attempt.Commit())
-
+			plan := collectCephPlan(t, input).plan
 			var healthCheckNames, daemonHealthTypes []string
 			for _, item := range plan.Actions {
 				create, ok := item.(chartengine.CreateChartAction)
@@ -1111,31 +1086,7 @@ func TestCollector_CephMGRNamedHealthCheckIdentities(t *testing.T) {
 	for _, name := range want {
 		fmt.Fprintf(&input, "ceph_health_detail{name=\"%s\",severity=\"HEALTH_WARN\"} 1\n", name)
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(input.String()))
-	}))
-	defer srv.Close()
-
-	collr := New()
-	collr.URL = srv.URL
-	collr.Profiles = ProfilesConfig{Mode: "auto"}
-	require.NoError(t, collr.Init(context.Background()))
-	require.NoError(t, collr.Check(context.Background()))
-	defer collr.Cleanup(context.Background())
-
-	cc := cycle(t, collr.MetricStore())
-	cc.BeginCycle()
-	require.NoError(t, collr.Collect(context.Background()))
-	require.NoError(t, cc.CommitCycleSuccess())
-
-	eng, err := chartengine.New()
-	require.NoError(t, err)
-	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
-	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
-	require.NoError(t, err)
-	defer attempt.Abort()
-	plan := attempt.Plan()
-	require.NoError(t, attempt.Commit())
+	plan := collectCephPlan(t, []byte(input.String())).plan
 
 	var actual []string
 	for _, action := range plan.Actions {
@@ -1172,32 +1123,7 @@ func TestCollector_CephMGRClusterSummaries(t *testing.T) {
 		fmt.Fprintf(&input, "ceph_osd_up{ceph_daemon=\"osd.%d\"} %d\n", i, up)
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(input.String()))
-	}))
-	defer srv.Close()
-
-	collr := New()
-	collr.URL = srv.URL
-	collr.Profiles = ProfilesConfig{Mode: "auto"}
-	require.NoError(t, collr.Init(context.Background()))
-	require.NoError(t, collr.Check(context.Background()))
-	defer collr.Cleanup(context.Background())
-
-	cc := cycle(t, collr.MetricStore())
-	cc.BeginCycle()
-	require.NoError(t, collr.Collect(context.Background()))
-	require.NoError(t, cc.CommitCycleSuccess())
-
-	eng, err := chartengine.New()
-	require.NoError(t, err)
-	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
-	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
-	require.NoError(t, err)
-	defer attempt.Abort()
-	plan := attempt.Plan()
-	require.NoError(t, attempt.Commit())
-
+	plan := collectCephPlan(t, []byte(input.String())).plan
 	const (
 		monSummary  = "prometheus.ceph.control_plane.monitor.cluster_summary"
 		monMetadata = "prometheus.ceph.control_plane.monitor.state_metadata"
@@ -1230,15 +1156,7 @@ func TestCollector_CephMGRClusterSummaries(t *testing.T) {
 		t.Helper()
 		update, ok := updates[chart.ChartID]
 		require.Truef(t, ok, "chart %q has no update", chart.ChartID)
-		actual := make(map[string]float64)
-		for _, value := range update.Values {
-			if value.IsFloat {
-				actual[value.Name] = value.Float64
-			} else {
-				actual[value.Name] = float64(value.Int64)
-			}
-		}
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, expected, chartUpdateValues(t, update))
 	}
 	requireChartValues(creates[monSummary][0], map[string]float64{"total": 3, "in_quorum": 2})
 	requireChartValues(creates[osdSummary][0], map[string]float64{"total": 10, "up": 9})
@@ -1290,32 +1208,7 @@ func TestCollector_CephM05RBDMirrorTimestampMaterialization(t *testing.T) {
 	input.WriteString("ceph_rbd_mirror_snapshot_image_local_timestamp{ceph_daemon=\"rbd-mirror.a\",image=\"behind\",namespace=\"other\",pool=\"other\"} 99\n")
 	input.WriteString("ceph_rbd_mirror_snapshot_image_remote_timestamp{ceph_daemon=\"rbd-mirror.a\",image=\"behind\",namespace=\"other\",pool=\"other\"} 100\n")
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(input.String()))
-	}))
-	defer srv.Close()
-
-	collr := New()
-	collr.URL = srv.URL
-	collr.Profiles = ProfilesConfig{Mode: "auto"}
-	require.NoError(t, collr.Init(context.Background()))
-	require.NoError(t, collr.Check(context.Background()))
-	defer collr.Cleanup(context.Background())
-
-	cc := cycle(t, collr.MetricStore())
-	cc.BeginCycle()
-	require.NoError(t, collr.Collect(context.Background()))
-	require.NoError(t, cc.CommitCycleSuccess())
-
-	eng, err := chartengine.New()
-	require.NoError(t, err)
-	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
-	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
-	require.NoError(t, err)
-	defer attempt.Abort()
-	plan := attempt.Plan()
-	require.NoError(t, attempt.Commit())
-
+	plan := collectCephPlan(t, []byte(input.String())).plan
 	const context = "prometheus.ceph.rbd_mirror.snapshot_replication.timestamp"
 	chartContexts := make(map[string]string)
 	updates := make(map[string]chartengine.UpdateChartAction)
@@ -1332,14 +1225,7 @@ func TestCollector_CephM05RBDMirrorTimestampMaterialization(t *testing.T) {
 	require.Len(t, updates, 3, "each mirrored image retains its own chart identity")
 
 	for chartID, update := range updates {
-		actual := make(map[string]float64)
-		for _, value := range update.Values {
-			if value.IsFloat {
-				actual[value.Name] = value.Float64
-			} else {
-				actual[value.Name] = float64(value.Int64)
-			}
-		}
+		actual := chartUpdateValues(t, update)
 		require.Len(t, actual, 2, "chart %q must expose both timestamps", chartID)
 		switch actual["local_timestamp"] {
 		case 100:
@@ -1475,32 +1361,7 @@ func TestCollector_CephM04PoolDifferenceMaterialization(t *testing.T) {
 		fmt.Fprintf(&input, "ceph_pg_total{pool_id=%q} %v\n", pool, values[2])
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(input.String()))
-	}))
-	defer srv.Close()
-
-	collr := New()
-	collr.URL = srv.URL
-	collr.Profiles = ProfilesConfig{Mode: "auto"}
-	require.NoError(t, collr.Init(context.Background()))
-	require.NoError(t, collr.Check(context.Background()))
-	defer collr.Cleanup(context.Background())
-
-	cc := cycle(t, collr.MetricStore())
-	cc.BeginCycle()
-	require.NoError(t, collr.Collect(context.Background()))
-	require.NoError(t, cc.CommitCycleSuccess())
-
-	eng, err := chartengine.New()
-	require.NoError(t, err)
-	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
-	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
-	require.NoError(t, err)
-	defer attempt.Abort()
-	plan := attempt.Plan()
-	require.NoError(t, attempt.Commit())
-
+	plan := collectCephPlan(t, []byte(input.String())).plan
 	const context = "prometheus.ceph.placement_groups_and_recovery.healthy_state.pg_state"
 	chartContexts := make(map[string]string)
 	updates := make(map[string]chartengine.UpdateChartAction)
@@ -1515,14 +1376,7 @@ func TestCollector_CephM04PoolDifferenceMaterialization(t *testing.T) {
 	}
 	require.Len(t, updates, 3, "one PG chart instance must remain per pool")
 	for chartID, update := range updates {
-		actual := make(map[string]float64)
-		for _, value := range update.Values {
-			if value.IsFloat {
-				actual[value.Name] = value.Float64
-			} else {
-				actual[value.Name] = float64(value.Int64)
-			}
-		}
+		actual := chartUpdateValues(t, update)
 		switch actual["pg_total"] {
 		case 100:
 			switch actual["clean"] {
@@ -1553,32 +1407,7 @@ func TestCollector_CephHardwareProfileReleaseGating(t *testing.T) {
 			input, err := os.ReadFile(promtestutil.Require(t, fixturePath))
 			require.NoError(t, err)
 
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				_, _ = w.Write(input)
-			}))
-			defer srv.Close()
-
-			collr := New()
-			collr.URL = srv.URL
-			collr.Profiles = ProfilesConfig{Mode: "auto"}
-			require.NoError(t, collr.Init(context.Background()))
-			require.NoError(t, collr.Check(context.Background()))
-			defer collr.Cleanup(context.Background())
-
-			cc := cycle(t, collr.MetricStore())
-			cc.BeginCycle()
-			require.NoError(t, collr.Collect(context.Background()))
-			require.NoError(t, cc.CommitCycleSuccess())
-
-			eng, err := chartengine.New()
-			require.NoError(t, err)
-			require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
-			attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
-			require.NoError(t, err)
-			defer attempt.Abort()
-			plan := attempt.Plan()
-			require.NoError(t, attempt.Commit())
-
+			plan := collectCephPlan(t, input).plan
 			healthIDs := make(map[string]chartengine.CreateChartAction)
 			temperatureIDs := make(map[string]chartengine.CreateChartAction)
 			for _, action := range plan.Actions {
@@ -1715,32 +1544,7 @@ func TestCollector_CephNVMeoFMaterializesLocalAlertIdentities(t *testing.T) {
 	input, err := os.ReadFile(promtestutil.Require(t, "prometheus/profiles/ceph/fixtures/ceph_nvmeof.prom"))
 	require.NoError(t, err)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(input)
-	}))
-	defer srv.Close()
-
-	collr := New()
-	collr.URL = srv.URL
-	collr.Profiles = ProfilesConfig{Mode: "auto"}
-	require.NoError(t, collr.Init(context.Background()))
-	require.NoError(t, collr.Check(context.Background()))
-	defer collr.Cleanup(context.Background())
-
-	cc := cycle(t, collr.MetricStore())
-	cc.BeginCycle()
-	require.NoError(t, collr.Collect(context.Background()))
-	require.NoError(t, cc.CommitCycleSuccess())
-
-	eng, err := chartengine.New()
-	require.NoError(t, err)
-	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
-	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
-	require.NoError(t, err)
-	defer attempt.Abort()
-	plan := attempt.Plan()
-	require.NoError(t, attempt.Commit())
-
+	plan := collectCephPlan(t, input).plan
 	byContext := make(map[string][]chartengine.CreateChartAction)
 	updates := make(map[string]chartengine.UpdateChartAction)
 	for _, action := range plan.Actions {
@@ -1774,15 +1578,7 @@ func TestCollector_CephNVMeoFMaterializesLocalAlertIdentities(t *testing.T) {
 		t.Helper()
 		update, ok := updates[chart.ChartID]
 		require.Truef(t, ok, "chart %q has no update", chart.ChartID)
-		values := make(map[string]float64)
-		for _, value := range update.Values {
-			if value.IsFloat {
-				values[value.Name] = value.Float64
-			} else {
-				values[value.Name] = float64(value.Int64)
-			}
-		}
-		return values
+		return chartUpdateValues(t, update)
 	}
 	for _, reactor := range byContext["prometheus.ceph.nvme_of.gateways.time_accumulation"] {
 		require.Contains(t, chartValues(reactor), "busy")
@@ -1905,32 +1701,7 @@ func TestCollector_CephRGWAlertChartsMaterialize(t *testing.T) {
 		"prometheus/profiles/ceph/fixtures/ceph_reef_ceph_exporter_limit11.prom"))
 	require.NoError(t, err)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(input)
-	}))
-	defer srv.Close()
-
-	collr := New()
-	collr.URL = srv.URL
-	collr.Profiles = ProfilesConfig{Mode: "auto"}
-	require.NoError(t, collr.Init(context.Background()))
-	require.NoError(t, collr.Check(context.Background()))
-	defer collr.Cleanup(context.Background())
-
-	cc := cycle(t, collr.MetricStore())
-	cc.BeginCycle()
-	require.NoError(t, collr.Collect(context.Background()))
-	require.NoError(t, cc.CommitCycleSuccess())
-
-	eng, err := chartengine.New()
-	require.NoError(t, err)
-	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
-	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
-	require.NoError(t, err)
-	defer attempt.Abort()
-	plan := attempt.Plan()
-	require.NoError(t, attempt.Commit())
-
+	plan := collectCephPlan(t, input).plan
 	created := make(map[string]int)
 	for _, action := range plan.Actions {
 		if create, ok := action.(chartengine.CreateChartAction); ok {
@@ -2809,6 +2580,54 @@ func cephManifestExtensionSOWIDs(extensions map[string]cephNetdataExtension) []s
 func cephHealthAlertTemplates(t *testing.T) map[string]map[string]string {
 	t.Helper()
 	return healthAlertTemplatesFromFile(t, "../../../../../health/health.d/ceph.conf")
+}
+
+type cephCollectorPlan struct {
+	collector *Collector
+	plan      chartengine.Plan
+}
+
+func collectCephPlan(t *testing.T, body []byte) cephCollectorPlan {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	t.Cleanup(func() { collr.Cleanup(context.Background()) })
+
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	eng, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+	require.NoError(t, attempt.Commit())
+	return cephCollectorPlan{collector: collr, plan: plan}
+}
+
+func chartUpdateValues(t *testing.T, update chartengine.UpdateChartAction) map[string]float64 {
+	t.Helper()
+	values := make(map[string]float64)
+	for _, value := range update.Values {
+		if value.IsFloat {
+			values[value.Name] = value.Float64
+		} else {
+			values[value.Name] = float64(value.Int64)
+		}
+	}
+	return values
 }
 
 func healthAlertTemplatesFromFile(t *testing.T, path string) map[string]map[string]string {

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1244,6 +1244,116 @@ func TestCollector_CephMGRClusterSummaries(t *testing.T) {
 	requireChartValues(creates[osdSummary][0], map[string]float64{"total": 10, "up": 9})
 }
 
+func TestCollector_CephM05RBDMirrorTimestampBoundaries(t *testing.T) {
+	drift := func(local, remote float64) float64 {
+		if math.IsNaN(local) || math.IsInf(local, 0) || math.IsNaN(remote) || math.IsInf(remote, 0) ||
+			local < 0 || remote < 0 {
+			return math.NaN()
+		}
+		return local - remote
+	}
+	for _, tc := range []struct {
+		name      string
+		local     float64
+		remote    float64
+		want      float64
+		unsynced  bool
+		undefined bool
+	}{
+		{name: "invalid NaN local", local: math.NaN(), remote: 1, undefined: true},
+		{name: "invalid infinite remote", local: 1, remote: math.Inf(1), undefined: true},
+		{name: "negative local timestamp", local: -1, remote: 1, undefined: true},
+		{name: "synchronized", local: 100, remote: 100},
+		{name: "local behind", local: 99, remote: 100, want: -1, unsynced: true},
+		{name: "local ahead", local: 101, remote: 100, want: 1, unsynced: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := drift(tc.local, tc.remote)
+			if tc.undefined {
+				assert.True(t, math.IsNaN(got))
+				return
+			}
+			assert.InDelta(t, tc.want, got, 1e-12)
+			assert.Equal(t, tc.unsynced, got != 0)
+		})
+	}
+}
+
+func TestCollector_CephM05RBDMirrorTimestampMaterialization(t *testing.T) {
+	var input strings.Builder
+	input.WriteString("# TYPE ceph_rbd_mirror_snapshot_image_local_timestamp gauge\n")
+	input.WriteString("# TYPE ceph_rbd_mirror_snapshot_image_remote_timestamp gauge\n")
+	input.WriteString("ceph_rbd_mirror_snapshot_image_local_timestamp{ceph_daemon=\"rbd-mirror.a\",image=\"synced\",namespace=\"ns\",pool=\"pool\"} 100\n")
+	input.WriteString("ceph_rbd_mirror_snapshot_image_remote_timestamp{ceph_daemon=\"rbd-mirror.a\",image=\"synced\",namespace=\"ns\",pool=\"pool\"} 100\n")
+	input.WriteString("ceph_rbd_mirror_snapshot_image_local_timestamp{ceph_daemon=\"rbd-mirror.a\",image=\"ahead\",namespace=\"ns\",pool=\"pool\"} 101\n")
+	input.WriteString("ceph_rbd_mirror_snapshot_image_remote_timestamp{ceph_daemon=\"rbd-mirror.a\",image=\"ahead\",namespace=\"ns\",pool=\"pool\"} 100\n")
+	input.WriteString("ceph_rbd_mirror_snapshot_image_local_timestamp{ceph_daemon=\"rbd-mirror.a\",image=\"behind\",namespace=\"other\",pool=\"other\"} 99\n")
+	input.WriteString("ceph_rbd_mirror_snapshot_image_remote_timestamp{ceph_daemon=\"rbd-mirror.a\",image=\"behind\",namespace=\"other\",pool=\"other\"} 100\n")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input.String()))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	defer collr.Cleanup(context.Background())
+
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	eng, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+	require.NoError(t, attempt.Commit())
+
+	const context = "prometheus.ceph.rbd_mirror.snapshot_replication.timestamp"
+	chartContexts := make(map[string]string)
+	updates := make(map[string]chartengine.UpdateChartAction)
+	for _, action := range plan.Actions {
+		create, ok := action.(chartengine.CreateChartAction)
+		if ok {
+			chartContexts[create.ChartID] = create.Meta.Context
+		}
+		update, ok := action.(chartengine.UpdateChartAction)
+		if ok && chartContexts[update.ChartID] == context {
+			updates[update.ChartID] = update
+		}
+	}
+	require.Len(t, updates, 3, "each mirrored image retains its own chart identity")
+
+	for chartID, update := range updates {
+		actual := make(map[string]float64)
+		for _, value := range update.Values {
+			if value.IsFloat {
+				actual[value.Name] = value.Float64
+			} else {
+				actual[value.Name] = float64(value.Int64)
+			}
+		}
+		require.Len(t, actual, 2, "chart %q must expose both timestamps", chartID)
+		switch actual["local_timestamp"] {
+		case 100:
+			assert.EqualValues(t, 100, actual["remote_timestamp"])
+		case 101:
+			assert.EqualValues(t, 100, actual["remote_timestamp"])
+		case 99:
+			assert.EqualValues(t, 100, actual["remote_timestamp"])
+		default:
+			t.Fatalf("unexpected timestamp chart values %q: %v", chartID, actual)
+		}
+	}
+}
+
 func TestCollector_CephM04DerivedBoundaries(t *testing.T) {
 	difference := func(total, partial float64) float64 {
 		if math.IsNaN(total) || math.IsInf(total, 0) || math.IsNaN(partial) || math.IsInf(partial, 0) ||
@@ -1625,7 +1735,8 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		"CEPH-037", "CEPH-038", "CEPH-039", "CEPH-063", "CEPH-064", "CEPH-065", "CEPH-066", "CEPH-067",
 		"CEPH-068", "CEPH-069", "CEPH-070", "CEPH-071", "CEPH-072", "CEPH-073", "CEPH-074", "CEPH-075",
 		"CEPH-076", "CEPH-077", "CEPH-098", "CEPH-099", "CEPH-100", "CEPH-101", "CEPH-102", "CEPH-103",
-		"CEPH-104", "CEPH-040", "CEPH-040-HELPER", "CEPH-041", "CEPH-043", "CEPH-044", "CEPH-045",
+		"CEPH-006", "CEPH-007", "CEPH-008", "CEPH-009", "CEPH-010", "CEPH-011", "CEPH-012", "CEPH-055",
+		"CEPH-056", "CEPH-057", "CEPH-058", "CEPH-104", "CEPH-040", "CEPH-040-HELPER", "CEPH-041", "CEPH-043", "CEPH-044", "CEPH-045",
 		"CEPH-046", "CEPH-046-HELPER", "CEPH-047", "CEPH-047-HELPER", "CEPH-048", "CEPH-049", "CEPH-050",
 		"CEPH-051", "CEPH-052", "CEPH-054", "CEPH-059", "CEPH-060", "CEPH-061", "CEPH-062",
 	}, cephManifestSOWIDs(manifest.Alerts))
@@ -1672,6 +1783,13 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		require.NotEmpty(t, adaptation.Preserved)
 		require.NotEmpty(t, adaptation.Differences)
 
+		if mapping.Netdata.Disposition == "reject" {
+			require.Equal(t, "UNSUPPORTED", mapping.Netdata.Fidelity)
+			require.Empty(t, mapping.Netdata.Context)
+			require.NotEmptyf(t, mapping.Netdata.Reason, "%s has no rejection rationale", name)
+			require.NotContains(t, templates, name, "%s rejected rule must not ship an alert template")
+			continue
+		}
 		if mapping.Netdata.Disposition == "internal-helper" {
 			require.Equalf(t, "silent", mapping.Netdata.Recipient, "%s internal helper must be silent", name)
 			require.Containsf(t, templates, name, "internal helper template is absent")
@@ -1763,7 +1881,7 @@ func TestCollector_CephMGRAlertSourcePins(t *testing.T) {
 
 			rules := parseCephSourceAlertRules(t, content)
 			for name, mapping := range manifest.Alerts {
-				if mapping.Netdata.Disposition == "internal-helper" || mapping.Netdata.Disposition == "subsumed-helper" {
+				if slices.Contains([]string{"internal-helper", "subsumed-helper"}, mapping.Netdata.Disposition) {
 					continue
 				}
 				if !slices.Contains(mapping.Source.Releases, release) {
@@ -2137,7 +2255,7 @@ func TestCollector_CephMetadataAlertsMatchMGRAlertTemplates(t *testing.T) {
 	}
 	expected := make(map[string]string)
 	for name, mapping := range manifest.Alerts {
-		if mapping.Netdata.Disposition != "reuse" {
+		if mapping.Netdata.Disposition != "reuse" && mapping.Netdata.Disposition != "reject" {
 			expected[name] = mapping.Netdata.Context
 		}
 	}
@@ -2216,6 +2334,7 @@ type cephAlertMapping struct {
 		Units       string   `yaml:"units"`
 		Condition   string   `yaml:"condition"`
 		Recipient   string   `yaml:"recipient"`
+		Reason      string   `yaml:"reason"`
 		Adaptation  string   `yaml:"adaptation"`
 		OwnerFile   string   `yaml:"owner_file"`
 		OwnerAlerts []string `yaml:"owner_alerts"`

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1701,6 +1701,195 @@ func TestCollector_CephMGRClusterAlertBoundaries(t *testing.T) {
 	}
 }
 
+func TestCollector_CephNVMeoFMaterializesLocalAlertIdentities(t *testing.T) {
+	input, err := os.ReadFile(promtestutil.Require(t, "prometheus/profiles/ceph/fixtures/ceph_nvmeof.prom"))
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(input)
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	defer collr.Cleanup(context.Background())
+
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	eng, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+	require.NoError(t, attempt.Commit())
+
+	byContext := make(map[string][]chartengine.CreateChartAction)
+	updates := make(map[string]chartengine.UpdateChartAction)
+	for _, action := range plan.Actions {
+		switch action := action.(type) {
+		case chartengine.CreateChartAction:
+			byContext[action.Meta.Context] = append(byContext[action.Meta.Context], action)
+		case chartengine.UpdateChartAction:
+			updates[action.ChartID] = action
+		}
+	}
+
+	require.Len(t, byContext["prometheus.ceph.nvme_of.subsystems.state_metadata"], 3)
+	require.Len(t, byContext["prometheus.ceph.nvme_of.gateways.time_accumulation"], 2)
+	require.Len(t, byContext["prometheus.ceph.nvme_of.block_devices.operations"], 2)
+	require.Len(t, byContext["prometheus.ceph.nvme_of.block_devices.time_accumulation"], 2)
+	require.Len(t, byContext["prometheus.ceph.nvme_of.hosts.keepalive_timeout_state"], 2)
+	require.Len(t, byContext["prometheus.ceph.nvme_of.subsystems.state_namespace_metadata"], 4)
+	require.Len(t, byContext["prometheus.ceph.nvme_of.subsystems.namespace_capacity"], 2)
+	require.Len(t, byContext["prometheus.ceph.nvme_of.subsystems.namespace_count"], 2)
+	require.Len(t, byContext["prometheus.ceph.nvme_of.gateways.namespace_count"], 1)
+
+	open := byContext["prometheus.ceph.nvme_of.subsystems.state_metadata"][0]
+	for _, create := range byContext["prometheus.ceph.nvme_of.subsystems.state_metadata"] {
+		if create.Labels["allow_any_host"] == "yes" {
+			open = create
+		}
+	}
+	require.Equal(t, "yes", open.Labels["allow_any_host"])
+
+	chartValues := func(chart chartengine.CreateChartAction) map[string]float64 {
+		t.Helper()
+		update, ok := updates[chart.ChartID]
+		require.Truef(t, ok, "chart %q has no update", chart.ChartID)
+		values := make(map[string]float64)
+		for _, value := range update.Values {
+			if value.IsFloat {
+				values[value.Name] = value.Float64
+			} else {
+				values[value.Name] = float64(value.Int64)
+			}
+		}
+		return values
+	}
+	for _, reactor := range byContext["prometheus.ceph.nvme_of.gateways.time_accumulation"] {
+		require.Contains(t, chartValues(reactor), "busy")
+		require.Contains(t, chartValues(reactor), "idle")
+	}
+
+	for _, bdev := range byContext["prometheus.ceph.nvme_of.block_devices.operations"] {
+		values := chartValues(bdev)
+		require.Contains(t, values, "reads_completed")
+		require.Contains(t, values, "writes_completed")
+		require.Greater(t, values["reads_completed"], float64(0))
+	}
+
+	gatewayNamespaces := make(map[string]float64)
+	for _, gateway := range byContext["prometheus.ceph.nvme_of.gateways.namespace_count"] {
+		gatewayNamespaces[gateway.ChartID] = chartValues(gateway)["namespace_count"]
+	}
+	assert.InDeltaMapValues(t, map[string]float64{"prometheus_ceph_nvme_of_gateways_namespace_count": 3}, gatewayNamespaces, 1e-12)
+}
+
+func TestCollector_CephNVMeoFAlertBoundaries(t *testing.T) {
+	cpuPercent := func(minimumBusyRate float64) float64 {
+		if math.IsNaN(minimumBusyRate) || math.IsInf(minimumBusyRate, 0) || minimumBusyRate < 0 || minimumBusyRate > 1 {
+			return math.NaN()
+		}
+		return minimumBusyRate * 100
+	}
+	for _, tc := range []struct {
+		name  string
+		busy  float64
+		want  float64
+		actor bool
+		undef bool
+	}{
+		{name: "invalid NaN busy", busy: math.NaN(), undef: true},
+		{name: "negative busy", busy: -0.01, undef: true},
+		{name: "busy above one core", busy: 1.01, undef: true},
+		{name: "exactly eighty does not act", busy: .8, want: 80},
+		{name: "above eighty acts", busy: .81, want: 81, actor: true},
+	} {
+		t.Run("cpu "+tc.name, func(t *testing.T) {
+			value := cpuPercent(tc.busy)
+			if tc.undef {
+				assert.True(t, math.IsNaN(value))
+				return
+			}
+			assert.InDelta(t, tc.want, value, 1e-12)
+			assert.Equal(t, tc.actor, value > 80)
+		})
+	}
+
+	latency := func(secondsPerSecond, operationsPerSecond float64) float64 {
+		if math.IsNaN(secondsPerSecond) || math.IsInf(secondsPerSecond, 0) ||
+			math.IsNaN(operationsPerSecond) || math.IsInf(operationsPerSecond, 0) || operationsPerSecond <= 0 {
+			return math.NaN()
+		}
+		return secondsPerSecond / operationsPerSecond
+	}
+	for _, tc := range []struct {
+		name                           string
+		secondsPerSecond, opsPerSecond float64
+		want                           float64
+		read, write                    bool
+		undef                          bool
+	}{
+		{name: "invalid NaN time", secondsPerSecond: math.NaN(), opsPerSecond: 1, undef: true},
+		{name: "zero denominator", secondsPerSecond: 1, opsPerSecond: 0, undef: true},
+		{name: "normal read", secondsPerSecond: .005, opsPerSecond: 1, want: .005},
+		{name: "read boundary", secondsPerSecond: .01, opsPerSecond: 1, want: .01},
+		{name: "normal write", secondsPerSecond: .015, opsPerSecond: 1, want: .015, read: true},
+		{name: "write threshold", secondsPerSecond: .021, opsPerSecond: 1, want: .021, read: true, write: true},
+	} {
+		t.Run("latency "+tc.name, func(t *testing.T) {
+			value := latency(tc.secondsPerSecond, tc.opsPerSecond)
+			if tc.undef {
+				assert.True(t, math.IsNaN(value))
+				return
+			}
+			assert.InDelta(t, tc.want, value, 1e-12)
+			assert.Equal(t, tc.read, value > .01)
+			assert.Equal(t, tc.write, value > .02)
+		})
+	}
+
+	namespaceLimit := func(count, limit float64) (float64, bool) {
+		if math.IsNaN(count) || math.IsInf(count, 0) || math.IsNaN(limit) || math.IsInf(limit, 0) ||
+			count < 0 || limit < 0 {
+			return math.NaN(), false
+		}
+		return count, count >= limit
+	}
+	for _, tc := range []struct {
+		name    string
+		count   float64
+		limit   float64
+		want    float64
+		reached bool
+		undef   bool
+	}{
+		{name: "invalid negative count", count: -1, limit: 1, undef: true},
+		{name: "invalid negative limit", count: 1, limit: -1, undef: true},
+		{name: "below limit", count: 1, limit: 2, want: 1},
+		{name: "at limit", count: 2, limit: 2, want: 2, reached: true},
+		{name: "above limit", count: 3, limit: 2, want: 3, reached: true},
+	} {
+		t.Run("namespace "+tc.name, func(t *testing.T) {
+			value, reached := namespaceLimit(tc.count, tc.limit)
+			if tc.undef {
+				assert.True(t, math.IsNaN(value))
+				return
+			}
+			assert.InDelta(t, tc.want, value, 1e-12)
+			assert.Equal(t, tc.reached, reached)
+		})
+	}
+}
+
 func TestCollector_CephMGRAlertContract(t *testing.T) {
 	manifest := loadCephAlertManifest(t)
 	templates := cephHealthAlertTemplates(t)
@@ -1739,6 +1928,9 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		"CEPH-056", "CEPH-057", "CEPH-058", "CEPH-104", "CEPH-040", "CEPH-040-HELPER", "CEPH-041", "CEPH-043", "CEPH-044", "CEPH-045",
 		"CEPH-046", "CEPH-046-HELPER", "CEPH-047", "CEPH-047-HELPER", "CEPH-048", "CEPH-049", "CEPH-050",
 		"CEPH-051", "CEPH-052", "CEPH-054", "CEPH-059", "CEPH-060", "CEPH-061", "CEPH-062",
+		"CEPH-078", "CEPH-080", "CEPH-080-HELPER-PERSIST", "CEPH-082", "CEPH-082-HELPER-READ-TIME",
+		"CEPH-082-HELPER-READ-OPS", "CEPH-083", "CEPH-083-HELPER-WRITE-TIME", "CEPH-083-HELPER-WRITE-OPS",
+		"CEPH-084", "CEPH-092", "CEPH-094", "CEPH-094-HELPER-GATEWAY",
 	}, cephManifestSOWIDs(manifest.Alerts))
 	require.ElementsMatch(t, []string{"CEPH-ND-001", "CEPH-ND-002", "RGW-M-01", "RGW-M-02"},
 		cephManifestExtensionSOWIDs(manifest.NetdataExtensions))
@@ -1751,6 +1943,12 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 			require.Truef(t, ok, "%s references unknown adaptation %q", name, extension.Adaptation)
 		}
 	}
+
+	inventoryAdaptation := manifest.AdaptationContracts["local_nvmeof_inventory_limit"]
+	require.NotContains(t, strings.Join(inventoryAdaptation.Preserved, "\n"), "one-minute observation",
+		"current-only namespace-capacity rule must not claim a persisted observation window")
+	require.NotContains(t, strings.Join(inventoryAdaptation.Differences, "\n"), "persistence uses every available sample",
+		"current-only namespace-capacity rule must disclose that source persistence is not represented")
 
 	for name, mapping := range manifest.Alerts {
 		require.Truef(t, mapping.SourceAlert != "" || len(mapping.SourceAlerts) > 0,

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1067,7 +1067,7 @@ func TestCollector_CephProfileFamilySegments(t *testing.T) {
 	require.NotEmpty(t, families)
 
 	for _, family := range families {
-		for _, segment := range strings.Split(family, "/") {
+		for segment := range strings.SplitSeq(family, "/") {
 			require.NotContains(t, []string{"I", "O"}, segment,
 				"family %q uses the reserved path segment %q", family, segment)
 		}

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1330,9 +1330,9 @@ func TestCollector_CephM04DerivedBoundaries(t *testing.T) {
 		{name: "availability with OSD down", availability: 1, osd: 1},
 		{name: "availability without OSD down", availability: 1, osd: 0, want: 1},
 		{name: "no availability", availability: 0, osd: 1},
-		{name: "inactive condition with withdrawn OSD chart", availability: 0},
-		{name: "invalid OSD state", availability: 1, osd: math.NaN(), undefined: true},
-		{name: "active condition with withdrawn OSD chart", availability: 1, osd: math.NaN(), undefined: true},
+		{name: "inactive condition clears without evaluating OSD state", availability: 0, osd: math.NaN()},
+		{name: "active condition with unresolved OSD state", availability: 1, osd: math.NaN(), undefined: true},
+		{name: "active condition with infinite OSD state", availability: 1, osd: math.Inf(1), undefined: true},
 	} {
 		t.Run("blocking I/O "+tc.name, func(t *testing.T) {
 			got := blockingIO(tc.availability, tc.osd)
@@ -2498,8 +2498,9 @@ func TestCollector_CephMetadataAlertsMatchMGRAlertTemplates(t *testing.T) {
 		}
 	}
 	assert.Equal(t, expected, actual)
+	templates := cephHealthAlertTemplates(t)
 	for name, metadataInfo := range info {
-		assert.Equalf(t, cephHealthAlertTemplates(t)[name]["info"], metadataInfo,
+		assert.Equalf(t, templates[name]["info"], metadataInfo,
 			"metadata alert %q does not exactly match its shipped health-template info", name)
 	}
 }

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -9,11 +9,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1242,6 +1244,97 @@ func TestCollector_CephMGRClusterSummaries(t *testing.T) {
 	requireChartValues(creates[osdSummary][0], map[string]float64{"total": 10, "up": 9})
 }
 
+func TestCollector_CephHardwareProfileReleaseGating(t *testing.T) {
+	fixtures := []string{
+		"prometheus/profiles/ceph/fixtures/ceph_reef_mgr_limit11.prom",
+		"prometheus/profiles/ceph/fixtures/ceph_squid_mgr_limit11.prom",
+		"prometheus/profiles/ceph/fixtures/ceph_tentacle_mgr_limit11.prom",
+	}
+
+	for _, fixturePath := range fixtures {
+		t.Run(filepath.Base(fixturePath), func(t *testing.T) {
+			input, err := os.ReadFile(promtestutil.Require(t, fixturePath))
+			require.NoError(t, err)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(input)
+			}))
+			defer srv.Close()
+
+			collr := New()
+			collr.URL = srv.URL
+			collr.Profiles = ProfilesConfig{Mode: "auto"}
+			require.NoError(t, collr.Init(context.Background()))
+			require.NoError(t, collr.Check(context.Background()))
+			defer collr.Cleanup(context.Background())
+
+			cc := cycle(t, collr.MetricStore())
+			cc.BeginCycle()
+			require.NoError(t, collr.Collect(context.Background()))
+			require.NoError(t, cc.CommitCycleSuccess())
+
+			eng, err := chartengine.New()
+			require.NoError(t, err)
+			require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+			attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+			require.NoError(t, err)
+			defer attempt.Abort()
+			plan := attempt.Plan()
+			require.NoError(t, attempt.Commit())
+
+			healthIDs := make(map[string]chartengine.CreateChartAction)
+			temperatureIDs := make(map[string]chartengine.CreateChartAction)
+			for _, action := range plan.Actions {
+				create, ok := action.(chartengine.CreateChartAction)
+				if !ok {
+					continue
+				}
+				switch create.Meta.Context {
+				case "prometheus.ceph.node_hardware.health.state":
+					healthIDs[create.ChartID] = create
+				case "prometheus.ceph.node_hardware.temperature.temperature":
+					temperatureIDs[create.ChartID] = create
+				}
+			}
+
+			isTentacle := strings.Contains(fixturePath, "_tentacle_")
+			if !isTentacle {
+				assert.Empty(t, healthIDs, "Reef/Squid must not materialize Tentacle-only hardware charts")
+				assert.Empty(t, temperatureIDs, "Reef/Squid must not materialize Tentacle-only temperature charts")
+				return
+			}
+
+			assert.Len(t, healthIDs, 9, "each collision-bearing health component remains a separate instance")
+			assert.Len(t, temperatureIDs, 8, "each collision-bearing temperature sensor remains a separate instance")
+
+			wantHealth := []string{
+				"prometheus_ceph_node_hardware_health_state_node-a_storage_drive-0",
+				"prometheus_ceph_node_hardware_health_state_node-a_processors_cpu-0",
+				"prometheus_ceph_node_hardware_health_state_node-a_memory_dimm-0",
+				"prometheus_ceph_node_hardware_health_state_node-a_power_psu-0",
+				"prometheus_ceph_node_hardware_health_state_node-a_network_nic-0",
+				"prometheus_ceph_node_hardware_health_state_node-a_fans_fan-0",
+				"prometheus_ceph_node_hardware_health_state_node-a_temperatures_temp-0",
+				"prometheus_ceph_node_hardware_health_state_node-b_storage_drive-0",
+				"prometheus_ceph_node_hardware_health_state_node-b_storage_drive-1",
+			}
+			assert.ElementsMatch(t, wantHealth, slices.Collect(maps.Keys(healthIDs)))
+
+			wantTemperature := []string{
+				"prometheus_ceph_node_hardware_temperature_temperature_node-a_MB_TEMP_0",
+				"prometheus_ceph_node_hardware_temperature_temperature_node-a_DIMM_0_TEMP",
+				"prometheus_ceph_node_hardware_temperature_temperature_node-a_CPU_TEMP_0",
+				"prometheus_ceph_node_hardware_temperature_temperature_node-a_NVME_0_TEMP",
+				"prometheus_ceph_node_hardware_temperature_temperature_node-b_MB_TEMP_0",
+				"prometheus_ceph_node_hardware_temperature_temperature_node-b_DIMM_0_TEMP",
+				"prometheus_ceph_node_hardware_temperature_temperature_node-b_CPU_TEMP_0",
+				"prometheus_ceph_node_hardware_temperature_temperature_node-b_NVME_0_TEMP",
+			}
+			assert.ElementsMatch(t, wantTemperature, slices.Collect(maps.Keys(temperatureIDs)))
+		})
+	}
+}
+
 func TestCollector_CephMGRClusterAlertBoundaries(t *testing.T) {
 	monState := func(total, inQuorum float64) (down, atRisk float64) {
 		if math.IsNaN(total) || math.IsInf(total, 0) || math.IsNaN(inQuorum) || math.IsInf(inQuorum, 0) ||
@@ -1352,7 +1445,10 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		"CEPH-001", "CEPH-002", "CEPH-003", "CEPH-004", "CEPH-005", "CEPH-013", "CEPH-014", "CEPH-015",
 		"CEPH-016", "CEPH-017", "CEPH-018", "CEPH-019", "CEPH-020", "CEPH-021", "CEPH-025", "CEPH-027",
 		"CEPH-028", "CEPH-029", "CEPH-030", "CEPH-032", "CEPH-033", "CEPH-034", "CEPH-035", "CEPH-036",
-		"CEPH-037", "CEPH-038", "CEPH-039", "CEPH-059", "CEPH-060", "CEPH-061", "CEPH-062",
+		"CEPH-037", "CEPH-038", "CEPH-039", "CEPH-063", "CEPH-064", "CEPH-065", "CEPH-066", "CEPH-067",
+		"CEPH-068", "CEPH-069", "CEPH-070", "CEPH-071", "CEPH-072", "CEPH-073", "CEPH-074", "CEPH-075",
+		"CEPH-076", "CEPH-077", "CEPH-098", "CEPH-099", "CEPH-100", "CEPH-101", "CEPH-102", "CEPH-103",
+		"CEPH-104", "CEPH-059", "CEPH-060", "CEPH-061", "CEPH-062",
 	}, cephManifestSOWIDs(manifest.Alerts))
 	require.ElementsMatch(t, []string{"CEPH-ND-001", "CEPH-ND-002", "RGW-M-01", "RGW-M-02"},
 		cephManifestExtensionSOWIDs(manifest.NetdataExtensions))
@@ -1372,21 +1468,19 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		hasExpressions := len(mapping.Source.Expressions) > 0
 		require.NotEqualf(t, hasExpression, hasExpressions,
 			"%s must define exactly one of source expression or release expressions", name)
-		if hasExpressions {
-			require.Lenf(t, mapping.Source.Expressions, 3, "%s source expressions do not cover the supported releases", name)
-			for _, release := range []string{"reef", "squid", "tentacle"} {
+		require.NotEmptyf(t, mapping.Source.Releases, "%s has no supported-release set", name)
+		for _, release := range []string{"reef", "squid", "tentacle"} {
+			supported := slices.Contains(mapping.Source.Releases, release)
+			require.Equalf(t, supported, mapping.Source.Lines[release] > 0,
+				"%s release availability and line pin disagree for %s", name, release)
+			require.Equalf(t, supported, mapping.Source.DefinitionSHA256[release] != "",
+				"%s release availability and definition pin disagree for %s", name, release)
+			if hasExpressions {
 				require.Containsf(t, mapping.Source.Expressions, release,
 					"%s has no source expression for %s", name, release)
 			}
 		}
 		require.NotEmpty(t, mapping.Source.Severity)
-		require.Positive(t, mapping.Source.Lines["reef"])
-		require.Positive(t, mapping.Source.Lines["squid"])
-		require.Positive(t, mapping.Source.Lines["tentacle"])
-		for _, release := range []string{"reef", "squid", "tentacle"} {
-			digest := mapping.Source.DefinitionSHA256[release]
-			require.NotEmptyf(t, digest, "%s has no source-definition pin for %s", name, release)
-		}
 		adaptation, ok := manifest.AdaptationContracts[mapping.Netdata.Adaptation]
 		require.Truef(t, ok, "%s references unknown adaptation %q", name, mapping.Netdata.Adaptation)
 		require.NotEmpty(t, adaptation.Preserved)
@@ -1466,6 +1560,11 @@ func TestCollector_CephMGRAlertSourcePins(t *testing.T) {
 
 			rules := parseCephSourceAlertRules(t, content)
 			for name, mapping := range manifest.Alerts {
+				if !slices.Contains(mapping.Source.Releases, release) {
+					require.NotContainsf(t, rules, mapping.SourceAlert,
+						"%s is incorrectly present in %s", mapping.SourceAlert, release)
+					continue
+				}
 				t.Run(name, func(t *testing.T) {
 					rule, ok := rules[mapping.SourceAlert]
 					require.Truef(t, ok, "source alert %q is absent", mapping.SourceAlert)
@@ -1889,6 +1988,7 @@ type cephAlertMapping struct {
 	Source      struct {
 		Expression       string            `yaml:"expression"`
 		Expressions      map[string]string `yaml:"expressions"`
+		Releases         []string          `yaml:"releases"`
 		Persistence      string            `yaml:"persistence"`
 		Severity         string            `yaml:"severity"`
 		Lines            map[string]int    `yaml:"lines"`

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/prometheus/selector"
 	"github.com/netdata/netdata/go/plugins/pkg/web"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/chartengine"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/charttpl"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/promprofiles"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/prometheus/relabel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
@@ -1022,6 +1023,55 @@ ceph_healthcheck_slow_ops 1
 			"prometheus.ceph_healthcheck_slow_ops":  {"ceph_healthcheck_slow_ops"},
 		},
 	)
+}
+
+func TestCollector_CephProfileFamilySegments(t *testing.T) {
+	input, err := os.ReadFile(promtestutil.Require(t, "prometheus/profiles/ceph/fixtures/ceph_squid_mgr_limit11.prom"))
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(input)
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+
+	spec, _, err := charttpl.DecodeYAMLValidated([]byte(collr.ChartTemplateYAML()))
+	require.NoError(t, err)
+
+	var families []string
+	var collectFamilies func(charttpl.Group, []string)
+	collectFamilies = func(group charttpl.Group, parents []string) {
+		parts := parents
+		if family := strings.TrimSpace(group.Family); family != "" {
+			parts = append(append([]string(nil), parents...), family)
+		}
+		families = append(families, strings.Join(parts, "/"))
+		for _, chart := range group.Charts {
+			if family := strings.TrimSpace(chart.Family); family != "" {
+				families = append(families, strings.Join(append(append([]string(nil), parts...), family), "/"))
+			} else if len(parts) != 0 {
+				families = append(families, strings.Join(parts, "/"))
+			}
+		}
+		for _, child := range group.Groups {
+			collectFamilies(child, parts)
+		}
+	}
+	for _, group := range spec.Groups {
+		collectFamilies(group, nil)
+	}
+	require.NotEmpty(t, families)
+
+	for _, family := range families {
+		for _, segment := range strings.Split(family, "/") {
+			require.NotContains(t, []string{"I", "O"}, segment,
+				"family %q uses the reserved path segment %q", family, segment)
+		}
+	}
 }
 
 func TestCollector_CephMGRReleaseFixturesMaterializeM01AlertIdentities(t *testing.T) {

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -8,6 +8,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1089,6 +1091,236 @@ func TestCollector_CephMGRReleaseFixturesMaterializeM01AlertIdentities(t *testin
 	}
 }
 
+func TestCollector_CephMGRNamedHealthCheckIdentities(t *testing.T) {
+	manifest := loadCephAlertManifest(t)
+	var want []string
+	for _, mapping := range manifest.Alerts {
+		if mapping.Netdata.Disposition == "reuse" ||
+			mapping.Netdata.Context != "prometheus.ceph.health.health_checks.state" {
+			continue
+		}
+		name, ok := strings.CutPrefix(mapping.Netdata.Labels, "name=")
+		require.True(t, ok)
+		want = append(want, name)
+	}
+
+	var input strings.Builder
+	input.WriteString("# TYPE ceph_health_detail gauge\n")
+	for _, name := range want {
+		fmt.Fprintf(&input, "ceph_health_detail{name=\"%s\",severity=\"HEALTH_WARN\"} 1\n", name)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input.String()))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	defer collr.Cleanup(context.Background())
+
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	eng, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+	require.NoError(t, attempt.Commit())
+
+	var actual []string
+	for _, action := range plan.Actions {
+		create, ok := action.(chartengine.CreateChartAction)
+		if ok && create.Meta.Context == "prometheus.ceph.health.health_checks.state" {
+			actual = append(actual, create.Labels["name"])
+		}
+	}
+	assert.ElementsMatch(t, want, actual)
+}
+
+func TestCollector_CephMGRClusterSummaries(t *testing.T) {
+	var input strings.Builder
+	input.WriteString("# TYPE ceph_mon_metadata gauge\n# TYPE ceph_mon_quorum_status gauge\n")
+	for i := 0; i < 3; i++ {
+		fmt.Fprintf(&input,
+			"ceph_mon_metadata{ceph_daemon=\"mon.%c\",ceph_version=\"19.2.5\",hostname=\"mon-host-%d\",public_addr=\"192.0.2.%d:3300\",rank=\"%d\"} 1\n",
+			'a'+i, i, i+1, i)
+		quorum := 1
+		if i == 2 {
+			quorum = 0
+		}
+		fmt.Fprintf(&input, "ceph_mon_quorum_status{ceph_daemon=\"mon.%c\"} %d\n", 'a'+i, quorum)
+	}
+	input.WriteString("# TYPE ceph_osd_metadata gauge\n# TYPE ceph_osd_up gauge\n")
+	for i := 0; i < 10; i++ {
+		fmt.Fprintf(&input,
+			"ceph_osd_metadata{back_iface=\"back%d\",ceph_daemon=\"osd.%d\",ceph_version=\"19.2.5\",cluster_addr=\"192.0.2.%d:6800\",device_class=\"ssd\",front_iface=\"front%d\",hostname=\"osd-host-%d\",objectstore=\"bluestore\",public_addr=\"198.51.100.%d:6800\"} 1\n",
+			i, i, i+1, i, i, i+1)
+		up := 1
+		if i == 9 {
+			up = 0
+		}
+		fmt.Fprintf(&input, "ceph_osd_up{ceph_daemon=\"osd.%d\"} %d\n", i, up)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input.String()))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	defer collr.Cleanup(context.Background())
+
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	eng, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+	require.NoError(t, attempt.Commit())
+
+	const (
+		monSummary  = "prometheus.ceph.control_plane.monitor.cluster_summary"
+		monMetadata = "prometheus.ceph.control_plane.monitor.state_metadata"
+		monQuorum   = "prometheus.ceph.control_plane.monitor.state_quorum_status"
+		osdSummary  = "prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary"
+		osdMetadata = "prometheus.ceph.osd_capacity_and_state.metadata.state"
+		osdState    = "prometheus.ceph.osd_capacity_and_state.osd_state.state"
+	)
+	creates := make(map[string][]chartengine.CreateChartAction)
+	updates := make(map[string]chartengine.UpdateChartAction)
+	for _, action := range plan.Actions {
+		switch action := action.(type) {
+		case chartengine.CreateChartAction:
+			creates[action.Meta.Context] = append(creates[action.Meta.Context], action)
+		case chartengine.UpdateChartAction:
+			updates[action.ChartID] = action
+		}
+	}
+
+	require.Len(t, creates[monSummary], 1)
+	require.Len(t, creates[osdSummary], 1)
+	assert.Equal(t, "monitors", creates[monSummary][0].Meta.Units)
+	assert.Equal(t, "OSDs", creates[osdSummary][0].Meta.Units)
+	assert.Len(t, creates[monMetadata], 3, "cluster summary must not replace monitor member charts")
+	assert.Len(t, creates[monQuorum], 3, "cluster summary must not replace monitor quorum charts")
+	assert.Len(t, creates[osdMetadata], 10, "cluster summary must not replace OSD metadata charts")
+	assert.Len(t, creates[osdState], 10, "cluster summary must not replace OSD state charts")
+
+	requireChartValues := func(chart chartengine.CreateChartAction, expected map[string]float64) {
+		t.Helper()
+		update, ok := updates[chart.ChartID]
+		require.Truef(t, ok, "chart %q has no update", chart.ChartID)
+		actual := make(map[string]float64)
+		for _, value := range update.Values {
+			if value.IsFloat {
+				actual[value.Name] = value.Float64
+			} else {
+				actual[value.Name] = float64(value.Int64)
+			}
+		}
+		assert.Equal(t, expected, actual)
+	}
+	requireChartValues(creates[monSummary][0], map[string]float64{"total": 3, "in_quorum": 2})
+	requireChartValues(creates[osdSummary][0], map[string]float64{"total": 10, "up": 9})
+}
+
+func TestCollector_CephMGRClusterAlertBoundaries(t *testing.T) {
+	monState := func(total, inQuorum float64) (down, atRisk float64) {
+		if math.IsNaN(total) || math.IsInf(total, 0) || math.IsNaN(inQuorum) || math.IsInf(inQuorum, 0) ||
+			total <= 0 || inQuorum < 0 || inQuorum > total {
+			return math.NaN(), math.NaN()
+		}
+		if inQuorum < total && inQuorum*2 > total {
+			down = 1
+			if (inQuorum-1)*2 <= total {
+				atRisk = 1
+			}
+		}
+		return down, atRisk
+	}
+	for _, tc := range []struct {
+		name               string
+		total, inQuorum    float64
+		wantDown, wantRisk float64
+		undefined          bool
+	}{
+		{name: "invalid NaN total", total: math.NaN(), inQuorum: 2, undefined: true},
+		{name: "invalid infinite quorum", total: 3, inQuorum: math.Inf(1), undefined: true},
+		{name: "zero population", total: 0, inQuorum: 0, undefined: true},
+		{name: "negative quorum", total: 3, inQuorum: -1, undefined: true},
+		{name: "quorum exceeds population", total: 3, inQuorum: 4, undefined: true},
+		{name: "healthy odd population", total: 3, inQuorum: 3},
+		{name: "minimum odd majority", total: 3, inQuorum: 2, wantDown: 1, wantRisk: 1},
+		{name: "odd majority above minimum", total: 5, inQuorum: 4, wantDown: 1},
+		{name: "minimum five member majority", total: 5, inQuorum: 3, wantDown: 1, wantRisk: 1},
+		{name: "minimum even majority", total: 4, inQuorum: 3, wantDown: 1, wantRisk: 1},
+		{name: "quorum already lost", total: 4, inQuorum: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			down, risk := monState(tc.total, tc.inQuorum)
+			if tc.undefined {
+				assert.True(t, math.IsNaN(down))
+				assert.True(t, math.IsNaN(risk))
+				return
+			}
+			assert.Equal(t, tc.wantDown, down)
+			assert.Equal(t, tc.wantRisk, risk)
+		})
+	}
+
+	osdDownPercent := func(total, up float64) float64 {
+		if math.IsNaN(total) || math.IsInf(total, 0) || math.IsNaN(up) || math.IsInf(up, 0) ||
+			total <= 0 || up < 0 || up > total {
+			return math.NaN()
+		}
+		return (total - up) * 100 / total
+	}
+	for _, tc := range []struct {
+		name      string
+		total, up float64
+		want      float64
+		critical  bool
+		undefined bool
+	}{
+		{name: "invalid NaN up", total: 10, up: math.NaN(), undefined: true},
+		{name: "zero population", total: 0, up: 0, undefined: true},
+		{name: "negative up", total: 10, up: -1, undefined: true},
+		{name: "up exceeds population", total: 10, up: 11, undefined: true},
+		{name: "all OSDs up", total: 10, up: 10},
+		{name: "below threshold", total: 10000, up: 9001, want: 9.99},
+		{name: "at threshold", total: 10, up: 9, want: 10, critical: true},
+		{name: "above threshold", total: 10, up: 8, want: 20, critical: true},
+	} {
+		t.Run("osd "+tc.name, func(t *testing.T) {
+			value := osdDownPercent(tc.total, tc.up)
+			if tc.undefined {
+				assert.True(t, math.IsNaN(value))
+				return
+			}
+			assert.InDelta(t, tc.want, value, 1e-12)
+			assert.Equal(t, tc.critical, value >= 10)
+		})
+	}
+}
+
 func TestCollector_CephMGRAlertContract(t *testing.T) {
 	manifest := loadCephAlertManifest(t)
 	templates := cephHealthAlertTemplates(t)
@@ -1117,8 +1349,10 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		},
 	}, manifest.Sources)
 	require.ElementsMatch(t, []string{
-		"CEPH-001", "CEPH-002", "CEPH-013", "CEPH-014", "CEPH-015", "CEPH-016", "CEPH-059", "CEPH-060",
-		"CEPH-061", "CEPH-062",
+		"CEPH-001", "CEPH-002", "CEPH-003", "CEPH-004", "CEPH-005", "CEPH-013", "CEPH-014", "CEPH-015",
+		"CEPH-016", "CEPH-017", "CEPH-018", "CEPH-019", "CEPH-020", "CEPH-021", "CEPH-025", "CEPH-027",
+		"CEPH-028", "CEPH-029", "CEPH-030", "CEPH-032", "CEPH-033", "CEPH-034", "CEPH-035", "CEPH-036",
+		"CEPH-037", "CEPH-038", "CEPH-039", "CEPH-059", "CEPH-060", "CEPH-061", "CEPH-062",
 	}, cephManifestSOWIDs(manifest.Alerts))
 	require.ElementsMatch(t, []string{"CEPH-ND-001", "CEPH-ND-002", "RGW-M-01", "RGW-M-02"},
 		cephManifestExtensionSOWIDs(manifest.NetdataExtensions))
@@ -1134,8 +1368,17 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 
 	for name, mapping := range manifest.Alerts {
 		require.NotEmpty(t, mapping.SourceAlert)
-		require.NotEmpty(t, mapping.Source.Expression)
-		require.NotEmpty(t, mapping.Source.Persistence)
+		hasExpression := mapping.Source.Expression != ""
+		hasExpressions := len(mapping.Source.Expressions) > 0
+		require.NotEqualf(t, hasExpression, hasExpressions,
+			"%s must define exactly one of source expression or release expressions", name)
+		if hasExpressions {
+			require.Lenf(t, mapping.Source.Expressions, 3, "%s source expressions do not cover the supported releases", name)
+			for _, release := range []string{"reef", "squid", "tentacle"} {
+				require.Containsf(t, mapping.Source.Expressions, release,
+					"%s has no source expression for %s", name, release)
+			}
+		}
 		require.NotEmpty(t, mapping.Source.Severity)
 		require.Positive(t, mapping.Source.Lines["reef"])
 		require.Positive(t, mapping.Source.Lines["squid"])
@@ -1150,6 +1393,8 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		require.NotEmpty(t, adaptation.Differences)
 
 		if mapping.Netdata.Disposition == "reuse" {
+			require.NotEmptyf(t, mapping.Netdata.OwnerFile, "%s has no generic owner file", name)
+			require.NotEmptyf(t, mapping.Netdata.OwnerAlerts, "%s has no generic owner templates", name)
 			continue
 		}
 		t.Run(name, func(t *testing.T) {
@@ -1158,26 +1403,48 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 			assert.Equal(t, mapping.Netdata.Context, block["on"])
 			assert.Equal(t, mapping.Netdata.Labels, block["chart labels"])
 			assert.Equal(t, mapping.Netdata.Lookup, block["lookup"])
+			assert.Equal(t, mapping.Netdata.Calc, block["calc"])
+			if mapping.Netdata.Calc != "" {
+				assert.Empty(t, mapping.Netdata.Lookup, "current compound alert must not mix historical and current dimensions")
+				assert.NotContains(t, mapping.Netdata.Calc, "$last_collected_t",
+					"data-state alert must not duplicate generic collection-failure ownership")
+			}
 			assert.Equal(t, mapping.Netdata.Units, block["units"])
 			assert.Equal(t, manifest.NetdataAlertCadence, block["every"])
-			assert.Empty(t, block["delay"], "observation-window adaptation must not use notification delay")
+			assert.Empty(t, block["delay"], "source persistence adaptation must not use notification delay")
 			assert.Equal(t, mapping.Netdata.Condition, block["condition"])
 			assert.Equal(t, mapping.Netdata.Recipient, block["to"])
-			assert.Equal(t, "NETDATA-ADAPTED", mapping.Netdata.Fidelity)
+			assert.Contains(t, []string{"NETDATA-ADAPTED", "CORRECTED-INTENT"}, mapping.Netdata.Fidelity)
 			assert.True(t, strings.HasPrefix(block["on"], "prometheus.ceph."))
-			assert.Contains(t, block["info"], "available")
+			if mapping.Netdata.Calc == "" {
+				assert.Contains(t, block["info"], "available")
+			} else {
+				assert.Contains(t, block["info"], "current")
+			}
 			assert.NotContains(t, block["info"], "continuously")
 		})
 	}
 
+	for name, mapping := range manifest.Alerts {
+		if mapping.Netdata.Disposition != "reuse" {
+			continue
+		}
+		generic := healthAlertTemplatesFromFile(t, filepath.Join("../../../../../..", mapping.Netdata.OwnerFile))
+		for _, owner := range mapping.Netdata.OwnerAlerts {
+			block, ok := generic[owner]
+			require.Truef(t, ok, "%s generic owner %q is absent from %s", name, owner, mapping.Netdata.OwnerFile)
+			assert.Equal(t, mapping.Netdata.Context, block["on"])
+			assert.NotContains(t, templates, owner, "Ceph alert pack duplicates a generic owner")
+		}
+		assert.Equal(t, "CORRECTED-INTENT", mapping.Netdata.Fidelity)
+	}
+
 	reuse := manifest.Alerts["plugin_data_collection_status"].Netdata
-	generic := healthAlertTemplatesFromFile(t, "../../../../../health/health.d/go.d.plugin.conf")["plugin_data_collection_status"]
-	assert.Equal(t, reuse.Context, generic["on"])
+	generic := healthAlertTemplatesFromFile(t, filepath.Join("../../../../../..", reuse.OwnerFile))["plugin_data_collection_status"]
 	assert.Equal(t, reuse.Lookup, generic["lookup"])
 	assert.Equal(t, reuse.Units, generic["units"])
 	assert.Equal(t, reuse.Condition, generic["condition"])
 	assert.Equal(t, reuse.Recipient, generic["to"])
-	assert.Equal(t, "CORRECTED-INTENT", reuse.Fidelity)
 
 	// The Dashboard API collector owns this separate native collection-integrity alert.
 	assert.Equal(t, manifest.NetdataExtensions["ceph_component_collection_failed"].Context,
@@ -1203,7 +1470,11 @@ func TestCollector_CephMGRAlertSourcePins(t *testing.T) {
 					rule, ok := rules[mapping.SourceAlert]
 					require.Truef(t, ok, "source alert %q is absent", mapping.SourceAlert)
 
-					assert.Equal(t, mapping.Source.Expression, rule.Expression)
+					expression := mapping.Source.Expression
+					if len(mapping.Source.Expressions) > 0 {
+						expression = mapping.Source.Expressions[release]
+					}
+					assert.Equal(t, expression, rule.Expression)
 					assert.Equal(t, mapping.Source.Persistence, rule.Persistence)
 					assert.Equal(t, mapping.Source.Severity, rule.Severity)
 					assert.Equal(t, mapping.Source.Lines[release], rule.Line)
@@ -1526,6 +1797,7 @@ func TestCollector_CephMetadataVNodeExampleDeclaresPrerequisite(t *testing.T) {
 }
 
 func TestCollector_CephMetadataAlertsMatchMGRAlertTemplates(t *testing.T) {
+	manifest := loadCephAlertManifest(t)
 	var metadata struct {
 		Modules []struct {
 			Meta struct {
@@ -1554,18 +1826,14 @@ func TestCollector_CephMetadataAlertsMatchMGRAlertTemplates(t *testing.T) {
 		}
 		break
 	}
-	assert.Equal(t, map[string]string{
-		"ceph_health_error":         "prometheus.ceph.health.cluster_status.state",
-		"ceph_health_warning":       "prometheus.ceph.health.cluster_status.state",
-		"ceph_daemon_crash":         "prometheus.ceph.health.health_checks.state",
-		"ceph_mgr_module_crash":     "prometheus.ceph.health.health_checks.state",
-		"ceph_daemon_slow_ops":      "prometheus.ceph.health.daemon_health.item_count",
-		"ceph_slow_ops":             "prometheus.ceph.health.slow_operations.current_operations",
-		"cephadm_daemon_failed":     "prometheus.ceph.health.health_checks.state",
-		"cephadm_paused":            "prometheus.ceph.health.health_checks.state",
-		"cephadm_upgrade_failed":    "prometheus.ceph.health.health_checks.state",
-		"ceph_unknown_health_check": "prometheus.ceph.health.health_checks.state",
-	}, actual)
+	expected := make(map[string]string)
+	for name, mapping := range manifest.Alerts {
+		if mapping.Netdata.Disposition != "reuse" {
+			expected[name] = mapping.Netdata.Context
+		}
+	}
+	expected["ceph_unknown_health_check"] = manifest.NetdataExtensions["ceph_unknown_health_check"].Context
+	assert.Equal(t, expected, actual)
 	for name, metadataInfo := range info {
 		if name == "ceph_unknown_health_check" {
 			assert.Contains(t, metadataInfo, "available sample")
@@ -1620,22 +1888,26 @@ type cephAlertMapping struct {
 	SourceAlert string `yaml:"source_alert"`
 	Source      struct {
 		Expression       string            `yaml:"expression"`
+		Expressions      map[string]string `yaml:"expressions"`
 		Persistence      string            `yaml:"persistence"`
 		Severity         string            `yaml:"severity"`
 		Lines            map[string]int    `yaml:"lines"`
 		DefinitionSHA256 map[string]string `yaml:"definition_sha256"`
 	} `yaml:"source"`
 	Netdata struct {
-		Disposition string `yaml:"disposition"`
-		Fidelity    string `yaml:"fidelity"`
-		Owner       string `yaml:"owner"`
-		Context     string `yaml:"context"`
-		Labels      string `yaml:"labels"`
-		Lookup      string `yaml:"lookup"`
-		Units       string `yaml:"units"`
-		Condition   string `yaml:"condition"`
-		Recipient   string `yaml:"recipient"`
-		Adaptation  string `yaml:"adaptation"`
+		Disposition string   `yaml:"disposition"`
+		Fidelity    string   `yaml:"fidelity"`
+		Owner       string   `yaml:"owner"`
+		Context     string   `yaml:"context"`
+		Labels      string   `yaml:"labels"`
+		Lookup      string   `yaml:"lookup"`
+		Calc        string   `yaml:"calc"`
+		Units       string   `yaml:"units"`
+		Condition   string   `yaml:"condition"`
+		Recipient   string   `yaml:"recipient"`
+		Adaptation  string   `yaml:"adaptation"`
+		OwnerFile   string   `yaml:"owner_file"`
+		OwnerAlerts []string `yaml:"owner_alerts"`
 	} `yaml:"netdata"`
 }
 
@@ -1688,7 +1960,7 @@ func healthAlertTemplatesFromFile(t *testing.T, path string) map[string]map[stri
 		if current == nil {
 			continue
 		}
-		for _, field := range []string{"on", "chart labels", "lookup", "units", "every", "delay", "warn", "crit", "info", "to"} {
+		for _, field := range []string{"on", "chart labels", "lookup", "calc", "units", "every", "delay", "warn", "crit", "info", "to"} {
 			if value, ok := strings.CutPrefix(line, field+":"); ok {
 				key := field
 				if field == "warn" || field == "crit" {

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1150,7 +1150,7 @@ func TestCollector_CephMGRNamedHealthCheckIdentities(t *testing.T) {
 func TestCollector_CephMGRClusterSummaries(t *testing.T) {
 	var input strings.Builder
 	input.WriteString("# TYPE ceph_mon_metadata gauge\n# TYPE ceph_mon_quorum_status gauge\n")
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		fmt.Fprintf(&input,
 			"ceph_mon_metadata{ceph_daemon=\"mon.%c\",ceph_version=\"19.2.5\",hostname=\"mon-host-%d\",public_addr=\"192.0.2.%d:3300\",rank=\"%d\"} 1\n",
 			'a'+i, i, i+1, i)
@@ -1161,7 +1161,7 @@ func TestCollector_CephMGRClusterSummaries(t *testing.T) {
 		fmt.Fprintf(&input, "ceph_mon_quorum_status{ceph_daemon=\"mon.%c\"} %d\n", 'a'+i, quorum)
 	}
 	input.WriteString("# TYPE ceph_osd_metadata gauge\n# TYPE ceph_osd_up gauge\n")
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		fmt.Fprintf(&input,
 			"ceph_osd_metadata{back_iface=\"back%d\",ceph_daemon=\"osd.%d\",ceph_version=\"19.2.5\",cluster_addr=\"192.0.2.%d:6800\",device_class=\"ssd\",front_iface=\"front%d\",hostname=\"osd-host-%d\",objectstore=\"bluestore\",public_addr=\"198.51.100.%d:6800\"} 1\n",
 			i, i, i+1, i, i, i+1)
@@ -2819,7 +2819,7 @@ func healthAlertTemplatesFromFile(t *testing.T, path string) map[string]map[stri
 
 	templates := make(map[string]map[string]string)
 	var current map[string]string
-	for _, source := range strings.Split(string(content), "\n") {
+	for source := range strings.SplitSeq(string(content), "\n") {
 		line := strings.TrimSpace(source)
 		if name, ok := strings.CutPrefix(line, "template:"); ok {
 			current = make(map[string]string)

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -3,7 +3,11 @@
 package prometheus
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -990,14 +994,712 @@ func TestCollector_CephProfile(t *testing.T) {
 	const input = `
 # TYPE ceph_health_status gauge
 ceph_health_status 0
+# TYPE ceph_health_detail gauge
+ceph_health_detail{name="RECENT_CRASH",severity="HEALTH_WARN"} 1
+# TYPE ceph_daemon_health_metrics gauge
+ceph_daemon_health_metrics{ceph_daemon="osd.0",type="SLOW_OPS"} 1
+# TYPE ceph_healthcheck_slow_ops gauge
+ceph_healthcheck_slow_ops 1
 `
 	testCollectorStockProfileModes(
 		t,
 		"ceph",
 		input,
-		map[string][]string{"prometheus.ceph.health.cluster_status.state": {"value"}},
-		map[string][]string{"prometheus.ceph_health_status": {"ceph_health_status"}},
+		map[string][]string{
+			"prometheus.ceph.health.cluster_status.state":               {"value"},
+			"prometheus.ceph.health.health_checks.state":                {"value"},
+			"prometheus.ceph.health.daemon_health.item_count":           {"value"},
+			"prometheus.ceph.health.slow_operations.current_operations": {"value"},
+		},
+		map[string][]string{
+			"prometheus.ceph_health_status":         {"ceph_health_status"},
+			"prometheus.ceph_health_detail":         {"ceph_health_detail"},
+			"prometheus.ceph_daemon_health_metrics": {"ceph_daemon_health_metrics"},
+			"prometheus.ceph_healthcheck_slow_ops":  {"ceph_healthcheck_slow_ops"},
+		},
 	)
+}
+
+func TestCollector_CephMGRReleaseFixturesMaterializeM01AlertIdentities(t *testing.T) {
+	const (
+		healthChecksContext = "prometheus.ceph.health.health_checks.state"
+		daemonHealthContext = "prometheus.ceph.health.daemon_health.item_count"
+	)
+	wantHealthCheckNames := []string{
+		"RECENT_CRASH",
+		"RECENT_MGR_MODULE_CRASH",
+		"CEPHADM_FAILED_DAEMON",
+		"CEPHADM_PAUSED",
+		"UPGRADE_EXCEPTION",
+	}
+	fixtures := []string{
+		"prometheus/profiles/ceph/fixtures/ceph_reef_mgr_limit11.prom",
+		"prometheus/profiles/ceph/fixtures/ceph_squid_mgr_limit11.prom",
+		"prometheus/profiles/ceph/fixtures/ceph_tentacle_mgr_limit11.prom",
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(filepath.Base(fixture), func(t *testing.T) {
+			input, err := os.ReadFile(promtestutil.Require(t, fixture))
+			require.NoError(t, err)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(input)
+			}))
+			defer srv.Close()
+
+			collr := New()
+			collr.URL = srv.URL
+			collr.Profiles = ProfilesConfig{Mode: "auto"}
+			require.NoError(t, collr.Init(context.Background()))
+			require.NoError(t, collr.Check(context.Background()))
+			defer collr.Cleanup(context.Background())
+
+			cc := cycle(t, collr.MetricStore())
+			cc.BeginCycle()
+			require.NoError(t, collr.Collect(context.Background()))
+			require.NoError(t, cc.CommitCycleSuccess())
+
+			eng, err := chartengine.New()
+			require.NoError(t, err)
+			require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+			attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+			require.NoError(t, err)
+			defer attempt.Abort()
+			plan := attempt.Plan()
+			require.NoError(t, attempt.Commit())
+
+			var healthCheckNames, daemonHealthTypes []string
+			for _, item := range plan.Actions {
+				create, ok := item.(chartengine.CreateChartAction)
+				if !ok {
+					continue
+				}
+				switch create.Meta.Context {
+				case healthChecksContext:
+					healthCheckNames = append(healthCheckNames, create.Labels["name"])
+				case daemonHealthContext:
+					daemonHealthTypes = append(daemonHealthTypes, create.Labels["type"])
+				}
+			}
+
+			assert.ElementsMatch(t, wantHealthCheckNames, healthCheckNames)
+			assert.Equal(t, []string{"SLOW_OPS"}, daemonHealthTypes)
+		})
+	}
+}
+
+func TestCollector_CephMGRAlertContract(t *testing.T) {
+	manifest := loadCephAlertManifest(t)
+	templates := cephHealthAlertTemplates(t)
+
+	require.Equal(t, "v1", manifest.Version)
+	require.Equal(t, "source-alert-map", manifest.Kind)
+	require.Equal(t, "ceph", manifest.Profile)
+	require.Equal(t, "10s", manifest.NetdataAlertCadence)
+	require.Equal(t, "SHA-256 of the UTF-8 canonical JSON for the complete parsed source alert rule, with object keys sorted "+
+		"lexicographically, no insignificant whitespace, and non-ASCII characters preserved", manifest.DefinitionSHA256Contract)
+	require.Equal(t, map[string]cephAlertSource{
+		"reef": {
+			Tag: "v18.2.8", Commit: "efac5a54607c13fa50d4822e50242b86e6e446df",
+			Path:   "monitoring/ceph-mixin/prometheus_alerts.yml",
+			SHA256: "0325e5c481d00c674f7faf759e00f6c5c22028dbcc8bb95491404d600c6f3efd",
+		},
+		"squid": {
+			Tag: "v19.2.5", Commit: "abc7aa7f2701e5d46878fd5e6bb7e2955f1a395a",
+			Path:   "monitoring/ceph-mixin/prometheus_alerts.yml",
+			SHA256: "259ee363694d174f46427a443ba0a8952b28df0c17af2bb65a2378511bc321ba",
+		},
+		"tentacle": {
+			Tag: "v20.2.3", Commit: "06c2f9c35b67055a8a6fb99d1be236b3c4832ace",
+			Path:   "monitoring/ceph-mixin/prometheus_alerts.yml",
+			SHA256: "09308346d3d143ff128813f1142f1499142799174da4e0505ddad7144b8d8716",
+		},
+	}, manifest.Sources)
+	require.ElementsMatch(t, []string{
+		"CEPH-001", "CEPH-002", "CEPH-013", "CEPH-014", "CEPH-015", "CEPH-016", "CEPH-059", "CEPH-060",
+		"CEPH-061", "CEPH-062",
+	}, cephManifestSOWIDs(manifest.Alerts))
+	require.ElementsMatch(t, []string{"CEPH-ND-001", "CEPH-ND-002", "RGW-M-01", "RGW-M-02"},
+		cephManifestExtensionSOWIDs(manifest.NetdataExtensions))
+	for name, extension := range manifest.NetdataExtensions {
+		require.NotEmptyf(t, extension.Reason, "%s has no extension rationale", name)
+		require.NotEmptyf(t, extension.Fidelity, "%s has no extension fidelity", name)
+		require.NotEmptyf(t, extension.Owner, "%s has no extension owner", name)
+		if extension.Adaptation != "" {
+			_, ok := manifest.AdaptationContracts[extension.Adaptation]
+			require.Truef(t, ok, "%s references unknown adaptation %q", name, extension.Adaptation)
+		}
+	}
+
+	for name, mapping := range manifest.Alerts {
+		require.NotEmpty(t, mapping.SourceAlert)
+		require.NotEmpty(t, mapping.Source.Expression)
+		require.NotEmpty(t, mapping.Source.Persistence)
+		require.NotEmpty(t, mapping.Source.Severity)
+		require.Positive(t, mapping.Source.Lines["reef"])
+		require.Positive(t, mapping.Source.Lines["squid"])
+		require.Positive(t, mapping.Source.Lines["tentacle"])
+		for _, release := range []string{"reef", "squid", "tentacle"} {
+			digest := mapping.Source.DefinitionSHA256[release]
+			require.NotEmptyf(t, digest, "%s has no source-definition pin for %s", name, release)
+		}
+		adaptation, ok := manifest.AdaptationContracts[mapping.Netdata.Adaptation]
+		require.Truef(t, ok, "%s references unknown adaptation %q", name, mapping.Netdata.Adaptation)
+		require.NotEmpty(t, adaptation.Preserved)
+		require.NotEmpty(t, adaptation.Differences)
+
+		if mapping.Netdata.Disposition == "reuse" {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			block, ok := templates[name]
+			require.True(t, ok, "missing alert template")
+			assert.Equal(t, mapping.Netdata.Context, block["on"])
+			assert.Equal(t, mapping.Netdata.Labels, block["chart labels"])
+			assert.Equal(t, mapping.Netdata.Lookup, block["lookup"])
+			assert.Equal(t, mapping.Netdata.Units, block["units"])
+			assert.Equal(t, manifest.NetdataAlertCadence, block["every"])
+			assert.Empty(t, block["delay"], "observation-window adaptation must not use notification delay")
+			assert.Equal(t, mapping.Netdata.Condition, block["condition"])
+			assert.Equal(t, mapping.Netdata.Recipient, block["to"])
+			assert.Equal(t, "NETDATA-ADAPTED", mapping.Netdata.Fidelity)
+			assert.True(t, strings.HasPrefix(block["on"], "prometheus.ceph."))
+			assert.Contains(t, block["info"], "available")
+			assert.NotContains(t, block["info"], "continuously")
+		})
+	}
+
+	reuse := manifest.Alerts["plugin_data_collection_status"].Netdata
+	generic := healthAlertTemplatesFromFile(t, "../../../../../health/health.d/go.d.plugin.conf")["plugin_data_collection_status"]
+	assert.Equal(t, reuse.Context, generic["on"])
+	assert.Equal(t, reuse.Lookup, generic["lookup"])
+	assert.Equal(t, reuse.Units, generic["units"])
+	assert.Equal(t, reuse.Condition, generic["condition"])
+	assert.Equal(t, reuse.Recipient, generic["to"])
+	assert.Equal(t, "CORRECTED-INTENT", reuse.Fidelity)
+
+	// The Dashboard API collector owns this separate native collection-integrity alert.
+	assert.Equal(t, manifest.NetdataExtensions["ceph_component_collection_failed"].Context,
+		templates["ceph_component_collection_failed"]["on"])
+	assert.NotContains(t, templates, "ceph_mgr_prometheus_module_inactive")
+}
+
+func TestCollector_CephMGRAlertSourcePins(t *testing.T) {
+	manifest := loadCephAlertManifest(t)
+
+	for release, source := range manifest.Sources {
+		t.Run(release, func(t *testing.T) {
+			path := filepath.Join("testdata", "ceph_source_alerts", release+".yaml")
+			content, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			fileDigest := sha256.Sum256(content)
+			require.Equal(t, source.SHA256, hex.EncodeToString(fileDigest[:]), "pinned source file digest")
+
+			rules := parseCephSourceAlertRules(t, content)
+			for name, mapping := range manifest.Alerts {
+				t.Run(name, func(t *testing.T) {
+					rule, ok := rules[mapping.SourceAlert]
+					require.Truef(t, ok, "source alert %q is absent", mapping.SourceAlert)
+
+					assert.Equal(t, mapping.Source.Expression, rule.Expression)
+					assert.Equal(t, mapping.Source.Persistence, rule.Persistence)
+					assert.Equal(t, mapping.Source.Severity, rule.Severity)
+					assert.Equal(t, mapping.Source.Lines[release], rule.Line)
+					assert.Equal(t, mapping.Source.DefinitionSHA256[release], rule.DefinitionSHA256)
+				})
+			}
+		})
+	}
+}
+
+type cephSourceAlertRule struct {
+	Expression       string
+	Persistence      string
+	Severity         string
+	Line             int
+	DefinitionSHA256 string
+}
+
+func parseCephSourceAlertRules(t *testing.T, content []byte) map[string]cephSourceAlertRule {
+	t.Helper()
+
+	var source struct {
+		Groups []struct {
+			Rules []yaml.Node `yaml:"rules"`
+		} `yaml:"groups"`
+	}
+	require.NoError(t, yaml.Unmarshal(content, &source))
+
+	rules := make(map[string]cephSourceAlertRule)
+	for _, group := range source.Groups {
+		for _, node := range group.Rules {
+			var definition map[string]any
+			require.NoError(t, node.Decode(&definition))
+
+			name, ok := definition["alert"].(string)
+			if !ok {
+				continue
+			}
+			_, exists := rules[name]
+			require.Falsef(t, exists, "duplicate source alert %q", name)
+
+			labels, ok := definition["labels"].(map[string]any)
+			require.Truef(t, ok, "source alert %q has no labels mapping", name)
+			severity, ok := labels["severity"].(string)
+			require.Truef(t, ok, "source alert %q has no severity label", name)
+
+			rules[name] = cephSourceAlertRule{
+				Expression:       cephSourceString(t, name, definition, "expr"),
+				Persistence:      cephSourceOptionalString(t, name, definition, "for"),
+				Severity:         severity,
+				Line:             node.Line,
+				DefinitionSHA256: cephCanonicalDefinitionSHA256(t, name, definition),
+			}
+		}
+	}
+	return rules
+}
+
+func cephSourceString(t *testing.T, alertName string, definition map[string]any, field string) string {
+	t.Helper()
+
+	value, ok := definition[field].(string)
+	require.Truef(t, ok, "source alert %q has no string %q field", alertName, field)
+	return value
+}
+
+func cephSourceOptionalString(t *testing.T, alertName string, definition map[string]any, field string) string {
+	t.Helper()
+
+	value, exists := definition[field]
+	if !exists {
+		return ""
+	}
+	text, ok := value.(string)
+	require.Truef(t, ok, "source alert %q has non-string %q field", alertName, field)
+	return text
+}
+
+func cephCanonicalDefinitionSHA256(t *testing.T, alertName string, definition map[string]any) string {
+	t.Helper()
+
+	var canonical bytes.Buffer
+	encoder := json.NewEncoder(&canonical)
+	encoder.SetEscapeHTML(false)
+	require.NoErrorf(t, encoder.Encode(definition), "canonicalize source alert %q", alertName)
+
+	digest := sha256.Sum256(bytes.TrimSuffix(canonical.Bytes(), []byte{'\n'}))
+	return hex.EncodeToString(digest[:])
+}
+
+func TestCollector_CephMGRObservationWindowAdaptation(t *testing.T) {
+	active, healthy, warning, critical := 1, 0, 1, 2
+	const window, updateEvery = 30, 15
+
+	tests := []struct {
+		name             string
+		now, first, last int
+		obsolete         bool
+		points           []cephObservedPoint
+		matches          func(int) bool
+		want             string
+	}{
+		{
+			name: "new chart can raise with one update interval less history",
+			now:  15, first: 0, last: 15,
+			points:  []cephObservedPoint{{0, &active}, {15, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "active",
+		},
+		{
+			name: "prior healthy value remains in the observation window",
+			now:  30, first: 0, last: 30,
+			points:  []cephObservedPoint{{0, &healthy}, {15, &active}, {30, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "clear",
+		},
+		{
+			name: "active observed values fill the window after the healthy value expires",
+			now:  45, first: 0, last: 45,
+			points:  []cephObservedPoint{{0, &healthy}, {15, &active}, {30, &active}, {45, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "active",
+		},
+		{
+			name: "partial gap does not reset observed active values",
+			now:  45, first: 0, last: 45,
+			points:  []cephObservedPoint{{0, &healthy}, {15, &active}, {45, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "active",
+		},
+		{
+			name: "relative window remains anchored to evaluation time during a gap",
+			now:  45, first: 0, last: 30,
+			points:  []cephObservedPoint{{0, &healthy}, {15, &active}, {30, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "active",
+		},
+		{
+			name: "runnable all-null lookup is undefined",
+			now:  15, first: 0, last: 15,
+			points:  []cephObservedPoint{{0, nil}, {15, nil}},
+			matches: func(v int) bool { return v > 0 }, want: "undefined",
+		},
+		{
+			name: "gap becomes undefined when stored values leave a still-runnable window",
+			now:  60, first: 0, last: 15,
+			points:  []cephObservedPoint{{0, &active}, {15, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "undefined",
+		},
+		{
+			name: "stale lookup stops evaluating",
+			now:  61, first: 0, last: 15,
+			points:  []cephObservedPoint{{0, &active}, {15, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "not-run",
+		},
+		{
+			name: "collection resumption evaluates the new stored window",
+			now:  75, first: 0, last: 75,
+			points:  []cephObservedPoint{{0, &active}, {15, &active}, {75, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "active",
+		},
+		{
+			name: "ordinary zero recovery clears",
+			now:  45, first: 0, last: 45,
+			points:  []cephObservedPoint{{15, &active}, {30, &active}, {45, &healthy}},
+			matches: func(v int) bool { return v > 0 }, want: "clear",
+		},
+		{
+			name: "other enumerated state clears warning predicate",
+			now:  45, first: 0, last: 45,
+			points:  []cephObservedPoint{{15, &warning}, {30, &warning}, {45, &critical}},
+			matches: func(v int) bool { return v == 1 }, want: "clear",
+		},
+		{
+			name: "obsolete chart removes instance alert",
+			now:  45, first: 0, last: 45, obsolete: true,
+			points:  []cephObservedPoint{{15, &active}, {30, &active}, {45, &active}},
+			matches: func(v int) bool { return v > 0 }, want: "removed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, cephObservationWindowState(
+				tc.now, tc.first, tc.last, window, updateEvery, tc.obsolete, tc.points, tc.matches))
+		})
+	}
+}
+
+type cephObservedPoint struct {
+	at    int
+	value *int
+}
+
+// cephObservationWindowState mirrors the relevant gates in rrdcalc_isrunnable()
+// and the numeric-point selection of a relative unaligned health lookup. The
+// query window remains relative to the evaluation time, not the latest stored
+// sample. Tests pass timestamps; there is deliberately no synthetic "window
+// complete" or Prometheus-style pending state.
+func cephObservationWindowState(
+	now, first, last, window, updateEvery int,
+	obsolete bool,
+	points []cephObservedPoint,
+	matches func(int) bool,
+) string {
+	if obsolete {
+		return "removed"
+	}
+	if now-window+updateEvery < first || now-window-updateEvery > last {
+		return "not-run"
+	}
+
+	start := now - window
+	hasValue := false
+	for _, point := range points {
+		if point.at < start || point.at > now || point.value == nil {
+			continue
+		}
+		hasValue = true
+		if !matches(*point.value) {
+			return "clear"
+		}
+	}
+	if !hasValue {
+		return "undefined"
+	}
+	return "active"
+}
+
+func TestCollector_CephUnknownHealthCheckFallbackContract(t *testing.T) {
+	manifest := loadCephAlertManifest(t)
+	extension := manifest.NetdataExtensions["ceph_unknown_health_check"]
+	block := cephHealthAlertTemplates(t)["ceph_unknown_health_check"]
+	require.Equal(t, "NETDATA-ADAPTED", extension.Fidelity)
+	require.NotEmpty(t, extension.LabelsPolicy)
+	assert.Equal(t, extension.Context, block["on"])
+	assert.Equal(t, extension.Lookup, block["lookup"])
+	assert.Equal(t, extension.Units, block["units"])
+	assert.Equal(t, manifest.NetdataAlertCadence, block["every"])
+	assert.Empty(t, block["delay"])
+	assert.Equal(t, extension.Condition, block["condition"])
+	assert.Equal(t, extension.Recipient, block["to"])
+	labels, ok := strings.CutPrefix(block["chart labels"], "name=")
+	require.True(t, ok, "fallback must filter the health-check name label")
+	fields := strings.Fields(labels)
+	require.NotEmpty(t, fields)
+	require.Equal(t, "*", fields[len(fields)-1], "negative label matches require a final positive match")
+
+	got := make([]string, 0, len(fields)-1)
+	for _, field := range fields[:len(fields)-1] {
+		require.Truef(t, strings.HasPrefix(field, "!"), "fallback matcher %q is not a name exclusion", field)
+		got = append(got, strings.TrimPrefix(field, "!"))
+	}
+	assert.ElementsMatch(t, []string{
+		"BLUESTORE_DISK_SIZE_MISMATCH", "BLUESTORE_SPURIOUS_READ_ERRORS", "CEPHADM_CERT_ERROR",
+		"CEPHADM_CERT_WARNING", "CEPHADM_FAILED_DAEMON", "CEPHADM_PAUSED", "DEVICE_HEALTH",
+		"DEVICE_HEALTH_IN_USE", "DEVICE_HEALTH_TOOMANY", "FS_DEGRADED", "FS_WITH_FAILED_MDS",
+		"HARDWARE_FANS", "HARDWARE_MEMORY", "HARDWARE_NETWORK", "HARDWARE_POWER", "HARDWARE_PROCESSOR",
+		"HARDWARE_STORAGE", "MDS_ALL_DOWN", "MDS_DAMAGE", "MDS_HEALTH_READ_ONLY", "MDS_INSUFFICIENT_STANDBY",
+		"MDS_UP_LESS_THAN_MAX", "MON_CLOCK_SKEW", "MON_DISK_CRIT", "MON_DISK_LOW", "MON_DOWN",
+		"OBJECT_UNFOUND", "OSD_BACKFILLFULL", "OSD_DOWN", "OSD_FULL", "OSD_HOST_DOWN", "OSD_NEARFULL",
+		"OSD_SCRUB_ERRORS", "OSD_SLOW_PING_TIME_BACK", "OSD_SLOW_PING_TIME_FRONT", "OSD_TOO_MANY_REPAIRS",
+		"PG_AVAILABILITY", "PG_BACKFILL_FULL", "PG_DAMAGED", "PG_NOT_DEEP_SCRUBBED", "PG_NOT_SCRUBBED",
+		"PG_RECOVERY_FULL", "POOL_BACKFILLFULL", "POOL_FULL", "POOL_NEAR_FULL", "RECENT_CRASH",
+		"RECENT_MGR_MODULE_CRASH", "SLOW_OPS", "TOO_MANY_PGS", "UPGRADE_EXCEPTION",
+	}, got)
+}
+
+func TestCollector_CephMetadataModelsProducerScopes(t *testing.T) {
+	mgr := New()
+	configureProfileJobFromMetadata(t, mgr, "collector-go.d.plugin-prometheus-ceph", "ceph", "ceph-mgr")
+	assert.Empty(t, mgr.Vnode)
+	assert.Equal(t, 15, mgr.UpdateEvery)
+
+	mgrVNode := New()
+	configureProfileJobFromMetadata(t, mgrVNode, "collector-go.d.plugin-prometheus-ceph", "ceph", "ceph-mgr-vnode")
+	assert.Equal(t, "ceph-cluster", mgrVNode.Vnode)
+	assert.Equal(t, 15, mgrVNode.UpdateEvery)
+
+	exporter := New()
+	configureProfileJobFromMetadata(t, exporter, "collector-go.d.plugin-prometheus-ceph", "ceph", "ceph-exporter")
+	assert.Empty(t, exporter.Vnode)
+	assert.Equal(t, 5, exporter.UpdateEvery)
+}
+
+func TestCollector_CephMetadataVNodeExampleDeclaresPrerequisite(t *testing.T) {
+	var metadata struct {
+		Modules []struct {
+			Meta struct {
+				ID string `yaml:"id"`
+			} `yaml:"meta"`
+			Setup struct {
+				Configuration struct {
+					Examples struct {
+						List []struct {
+							Name        string `yaml:"name"`
+							Description string `yaml:"description"`
+							Config      string `yaml:"config"`
+						} `yaml:"list"`
+					} `yaml:"examples"`
+				} `yaml:"configuration"`
+			} `yaml:"setup"`
+		} `yaml:"modules"`
+	}
+	content, err := os.ReadFile("metadata.yaml")
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(content, &metadata))
+
+	for _, module := range metadata.Modules {
+		if module.Meta.ID != "collector-go.d.plugin-prometheus-ceph" {
+			continue
+		}
+		for _, example := range module.Setup.Configuration.Examples.List {
+			if example.Name != "Ceph MGR with virtual node" {
+				continue
+			}
+			require.Contains(t, example.Description, "/etc/netdata/vnodes/vnodes.conf")
+			require.Contains(t, example.Description, "hostname: ceph-cluster")
+			require.Contains(t, example.Description, "undefined vnode makes the job fail to start")
+			require.Contains(t, example.Config, "vnode: ceph-cluster")
+			return
+		}
+	}
+	t.Fatal("Ceph metadata has no self-contained virtual-node example")
+}
+
+func TestCollector_CephMetadataAlertsMatchMGRAlertTemplates(t *testing.T) {
+	var metadata struct {
+		Modules []struct {
+			Meta struct {
+				ID string `yaml:"id"`
+			} `yaml:"meta"`
+			Alerts []struct {
+				Name   string `yaml:"name"`
+				Metric string `yaml:"metric"`
+				Info   string `yaml:"info"`
+			} `yaml:"alerts"`
+		} `yaml:"modules"`
+	}
+	content, err := os.ReadFile("metadata.yaml")
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(content, &metadata))
+
+	actual := make(map[string]string)
+	info := make(map[string]string)
+	for _, module := range metadata.Modules {
+		if module.Meta.ID != "collector-go.d.plugin-prometheus-ceph" {
+			continue
+		}
+		for _, alert := range module.Alerts {
+			actual[alert.Name] = alert.Metric
+			info[alert.Name] = alert.Info
+		}
+		break
+	}
+	assert.Equal(t, map[string]string{
+		"ceph_health_error":         "prometheus.ceph.health.cluster_status.state",
+		"ceph_health_warning":       "prometheus.ceph.health.cluster_status.state",
+		"ceph_daemon_crash":         "prometheus.ceph.health.health_checks.state",
+		"ceph_mgr_module_crash":     "prometheus.ceph.health.health_checks.state",
+		"ceph_daemon_slow_ops":      "prometheus.ceph.health.daemon_health.item_count",
+		"ceph_slow_ops":             "prometheus.ceph.health.slow_operations.current_operations",
+		"cephadm_daemon_failed":     "prometheus.ceph.health.health_checks.state",
+		"cephadm_paused":            "prometheus.ceph.health.health_checks.state",
+		"cephadm_upgrade_failed":    "prometheus.ceph.health.health_checks.state",
+		"ceph_unknown_health_check": "prometheus.ceph.health.health_checks.state",
+	}, actual)
+	for name, metadataInfo := range info {
+		if name == "ceph_unknown_health_check" {
+			assert.Contains(t, metadataInfo, "available sample")
+			assert.Contains(t, cephHealthAlertTemplates(t)[name]["info"], "available sample")
+			continue
+		}
+		assert.Truef(t, strings.HasPrefix(cephHealthAlertTemplates(t)[name]["info"], metadataInfo),
+			"metadata alert %q does not match its shipped health-template info", name)
+	}
+}
+
+type cephAlertManifest struct {
+	Version                  string                            `yaml:"version"`
+	Kind                     string                            `yaml:"kind"`
+	Profile                  string                            `yaml:"profile"`
+	NetdataAlertCadence      string                            `yaml:"netdata_alert_cadence"`
+	DefinitionSHA256Contract string                            `yaml:"definition_sha256_contract"`
+	Sources                  map[string]cephAlertSource        `yaml:"sources"`
+	AdaptationContracts      map[string]cephAdaptationContract `yaml:"adaptation_contracts"`
+	Alerts                   map[string]cephAlertMapping       `yaml:"alerts"`
+	NetdataExtensions        map[string]cephNetdataExtension   `yaml:"netdata_extensions"`
+}
+
+type cephAlertSource struct {
+	Tag    string `yaml:"tag"`
+	Commit string `yaml:"commit"`
+	Path   string `yaml:"path"`
+	SHA256 string `yaml:"sha256"`
+}
+
+type cephAdaptationContract struct {
+	Preserved   []string `yaml:"preserved"`
+	Differences []string `yaml:"differences"`
+}
+
+type cephNetdataExtension struct {
+	SOWID        string `yaml:"sow_id"`
+	Reason       string `yaml:"reason"`
+	Fidelity     string `yaml:"fidelity"`
+	Owner        string `yaml:"owner"`
+	Context      string `yaml:"context"`
+	LabelsPolicy string `yaml:"labels_policy"`
+	Lookup       string `yaml:"lookup"`
+	Units        string `yaml:"units"`
+	Condition    string `yaml:"condition"`
+	Recipient    string `yaml:"recipient"`
+	Adaptation   string `yaml:"adaptation"`
+}
+
+type cephAlertMapping struct {
+	SOWID       string `yaml:"sow_id"`
+	SourceAlert string `yaml:"source_alert"`
+	Source      struct {
+		Expression       string            `yaml:"expression"`
+		Persistence      string            `yaml:"persistence"`
+		Severity         string            `yaml:"severity"`
+		Lines            map[string]int    `yaml:"lines"`
+		DefinitionSHA256 map[string]string `yaml:"definition_sha256"`
+	} `yaml:"source"`
+	Netdata struct {
+		Disposition string `yaml:"disposition"`
+		Fidelity    string `yaml:"fidelity"`
+		Owner       string `yaml:"owner"`
+		Context     string `yaml:"context"`
+		Labels      string `yaml:"labels"`
+		Lookup      string `yaml:"lookup"`
+		Units       string `yaml:"units"`
+		Condition   string `yaml:"condition"`
+		Recipient   string `yaml:"recipient"`
+		Adaptation  string `yaml:"adaptation"`
+	} `yaml:"netdata"`
+}
+
+func loadCephAlertManifest(t *testing.T) cephAlertManifest {
+	t.Helper()
+
+	content, err := os.ReadFile("testdata/ceph_alerts.yaml")
+	require.NoError(t, err)
+	var manifest cephAlertManifest
+	require.NoError(t, yaml.Unmarshal(content, &manifest))
+	return manifest
+}
+
+func cephManifestSOWIDs(alerts map[string]cephAlertMapping) []string {
+	ids := make([]string, 0, len(alerts))
+	for _, alert := range alerts {
+		ids = append(ids, alert.SOWID)
+	}
+	return ids
+}
+
+func cephManifestExtensionSOWIDs(extensions map[string]cephNetdataExtension) []string {
+	ids := make([]string, 0, len(extensions))
+	for _, extension := range extensions {
+		ids = append(ids, extension.SOWID)
+	}
+	return ids
+}
+
+func cephHealthAlertTemplates(t *testing.T) map[string]map[string]string {
+	t.Helper()
+	return healthAlertTemplatesFromFile(t, "../../../../../health/health.d/ceph.conf")
+}
+
+func healthAlertTemplatesFromFile(t *testing.T, path string) map[string]map[string]string {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	templates := make(map[string]map[string]string)
+	var current map[string]string
+	for _, source := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(source)
+		if name, ok := strings.CutPrefix(line, "template:"); ok {
+			current = make(map[string]string)
+			templates[strings.TrimSpace(name)] = current
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		for _, field := range []string{"on", "chart labels", "lookup", "units", "every", "delay", "warn", "crit", "info", "to"} {
+			if value, ok := strings.CutPrefix(line, field+":"); ok {
+				key := field
+				if field == "warn" || field == "crit" {
+					key = "condition"
+					value = field + ":" + value
+				}
+				current[key] = strings.TrimSpace(value)
+			}
+		}
+	}
+	return templates
 }
 
 func configureProfileJobFromMetadata(

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1420,29 +1420,39 @@ func TestCollector_CephM04DerivedBoundaries(t *testing.T) {
 		})
 	}
 
-	blockingIO := func(pgAvailability, osdDown float64) float64 {
-		if math.IsNaN(pgAvailability) || math.IsInf(pgAvailability, 0) ||
-			math.IsNaN(osdDown) || math.IsInf(osdDown, 0) {
+	blockingIO := func(pgAvailability, osdDown float64, osdDownResolved bool) float64 {
+		if math.IsNaN(pgAvailability) || math.IsInf(pgAvailability, 0) {
 			return math.NaN()
 		}
-		if pgAvailability == 1 && osdDown != 1 {
-			return 1
+		if pgAvailability != 1 {
+			// Ceph can withdraw an inactive OSD_DOWN health-check chart entirely.
+			// The inactive primary condition must clear without resolving that helper.
+			return 0
 		}
-		return 0
+		if osdDown == 1 {
+			return 0
+		}
+		if !osdDownResolved || math.IsNaN(osdDown) || math.IsInf(osdDown, 0) {
+			return math.NaN()
+		}
+		return 1
 	}
 	for _, tc := range []struct {
 		name              string
 		availability, osd float64
+		osdResolved       bool
 		want              float64
 		undefined         bool
 	}{
-		{name: "availability with OSD down", availability: 1, osd: 1},
-		{name: "availability without OSD down", availability: 1, osd: 0, want: 1},
-		{name: "no availability", availability: 0, osd: 1},
-		{name: "invalid OSD state", availability: 1, osd: math.NaN(), undefined: true},
+		{name: "availability with OSD down", availability: 1, osd: 1, osdResolved: true},
+		{name: "availability without OSD down", availability: 1, osd: 0, osdResolved: true, want: 1},
+		{name: "no availability", availability: 0, osd: 1, osdResolved: true},
+		{name: "inactive condition with withdrawn OSD chart", availability: 0},
+		{name: "invalid OSD state", availability: 1, osd: math.NaN(), osdResolved: true, undefined: true},
+		{name: "active condition with withdrawn OSD chart", availability: 1, undefined: true},
 	} {
 		t.Run("blocking I/O "+tc.name, func(t *testing.T) {
-			got := blockingIO(tc.availability, tc.osd)
+			got := blockingIO(tc.availability, tc.osd, tc.osdResolved)
 			if tc.undefined {
 				assert.True(t, math.IsNaN(got))
 				return

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1722,13 +1722,29 @@ func TestCollector_CephRGWAlertChartsMaterialize(t *testing.T) {
 
 func TestCollector_CephRGWAlertBoundaries(t *testing.T) {
 	templates := cephHealthAlertTemplates(t)
-	want := map[string]struct {
+	occurrence := map[string]struct {
+		lookup    string
+		condition string
+		recipient string
+	}{
+		"rgw_notification_event_lost":            {"max -1m unaligned of event_lost", "crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)", "sysadmin"},
+		"rgw_notification_missing_configuration": {"max -1m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)", "sysadmin"},
+		"rgw_lua_script_failed":                  {"max -1m unaligned of failure", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)", "sysadmin"},
+	}
+	for name, expected := range occurrence {
+		t.Run(name, func(t *testing.T) {
+			block, ok := templates[name]
+			require.Truef(t, ok, "template %s is absent", name)
+			assert.Equal(t, expected.lookup, block["lookup"])
+			assert.Equal(t, expected.condition, block["condition"])
+			assert.Equal(t, expected.recipient, block["to"])
+		})
+	}
+
+	sustained := map[string]struct {
 		lookup    string
 		condition string
 	}{
-		"rgw_notification_event_lost":             {"min -1m unaligned of event_lost", "crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
-		"rgw_notification_missing_configuration":  {"min -1m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
-		"rgw_lua_script_failed":                   {"min -1m unaligned of failure", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
 		"rgw_failed_request_rate_fallback":        {"min -5m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
 		"rgw_notification_push_or_store_failures": {"min -5m unaligned of push_failed,store_fail", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
 		"rgw_notification_inflight_pressure":      {"min -5m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)"},
@@ -1737,7 +1753,7 @@ func TestCollector_CephRGWAlertBoundaries(t *testing.T) {
 		"rgw_multisite_fetch_errors":              {"min -5m unaligned of errors", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
 		"rgw_multisite_poll_errors":               {"min -5m unaligned of value", "warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)"},
 	}
-	for name, expected := range want {
+	for name, expected := range sustained {
 		t.Run(name, func(t *testing.T) {
 			block, ok := templates[name]
 			require.Truef(t, ok, "template %s is absent", name)
@@ -1747,25 +1763,23 @@ func TestCollector_CephRGWAlertBoundaries(t *testing.T) {
 		})
 	}
 
-	// min is the all-observed-samples time grouping: one recovery sample clears
-	// the rule even when earlier samples in the same window were active.
-	allSamples := func(samples []float64) float64 {
+	// max preserves any failure occurrence in the window, independent of event volume.
+	anyOccurrence := func(samples []float64) float64 {
 		if len(samples) == 0 {
 			return math.NaN()
 		}
-		minimum := samples[0]
+		maximum := samples[0]
 		for _, sample := range samples[1:] {
-			if sample < minimum {
-				minimum = sample
+			if sample > maximum {
+				maximum = sample
 			}
 		}
-		return minimum
+		return maximum
 	}
-	assert.InDelta(t, 0, allSamples([]float64{.1, 0, 0}), 1e-12)
-	assert.InDelta(t, 999, allSamples([]float64{1001, 1000, 999}), 1e-12)
-	assert.True(t, math.IsNaN(allSamples(nil)))
+	assert.InDelta(t, .1, anyOccurrence([]float64{0, .1, 0}), 1e-12)
+	assert.InDelta(t, float64(0), anyOccurrence([]float64{0, 0, 0}), 1e-12)
+	assert.True(t, math.IsNaN(anyOccurrence(nil)))
 }
-
 func TestCollector_CephMGRAlertContract(t *testing.T) {
 	manifest := loadCephAlertManifest(t)
 	templates := cephHealthAlertTemplates(t)
@@ -1838,6 +1852,12 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		}
 		require.NotEmptyf(t, extension.Fidelity, "%s has no extension fidelity", name)
 		require.NotEmptyf(t, extension.Owner, "%s has no extension owner", name)
+		switch extension.SOWID {
+		case "RGW-M-08", "RGW-M-09", "RGW-M-10":
+			require.Equal(t, "rgw_categorical_counter_occurrence", extension.Adaptation)
+		case "RGW-S-04", "RGW-S-16":
+			require.Equal(t, "rgw_counter_rate_window", extension.Adaptation)
+		}
 		if extension.Adaptation != "" {
 			_, ok := manifest.AdaptationContracts[extension.Adaptation]
 			require.Truef(t, ok, "%s references unknown adaptation %q", name, extension.Adaptation)
@@ -2386,6 +2406,17 @@ func TestCollector_CephMetadataModelsProducerScopes(t *testing.T) {
 	assert.Equal(t, 5, exporter.UpdateEvery)
 }
 
+func TestCollector_CephNVMeoFAlertsAreOwnedByLocalExporter(t *testing.T) {
+	manifest := loadCephAlertManifest(t)
+	for _, mapping := range manifest.Alerts {
+		if !strings.HasPrefix(mapping.Netdata.Context, "prometheus.ceph.nvme_of.") {
+			continue
+		}
+		assert.Equalf(t, "nvmeof_exporter", mapping.Netdata.Owner,
+			"%s must name its local gateway-exporter owner", mapping.SOWID)
+	}
+}
+
 func TestCollector_CephMetadataVNodeExampleDeclaresPrerequisite(t *testing.T) {
 	var metadata struct {
 		Modules []struct {
@@ -2458,12 +2489,15 @@ func TestCollector_CephMetadataAlertsMatchMGRAlertTemplates(t *testing.T) {
 		break
 	}
 	expected := make(map[string]string)
+	publicMapping := func(disposition string) bool {
+		return disposition != "reuse" && disposition != "reject" &&
+			disposition != "internal-helper" && disposition != "subsumed-helper"
+	}
 	for name, mapping := range manifest.Alerts {
-		if mapping.Netdata.Disposition != "reuse" && mapping.Netdata.Disposition != "reject" {
+		if publicMapping(mapping.Netdata.Disposition) {
 			expected[name] = mapping.Netdata.Context
 		}
 	}
-	expected["ceph_unknown_health_check"] = manifest.NetdataExtensions["ceph_unknown_health_check"].Context
 	for name, extension := range manifest.NetdataExtensions {
 		if extension.Context != "" && extension.Condition != "" {
 			expected[name] = extension.Context
@@ -2471,13 +2505,8 @@ func TestCollector_CephMetadataAlertsMatchMGRAlertTemplates(t *testing.T) {
 	}
 	assert.Equal(t, expected, actual)
 	for name, metadataInfo := range info {
-		if name == "ceph_unknown_health_check" {
-			assert.Contains(t, metadataInfo, "available sample")
-			assert.Contains(t, cephHealthAlertTemplates(t)[name]["info"], "available sample")
-			continue
-		}
-		assert.Truef(t, strings.HasPrefix(cephHealthAlertTemplates(t)[name]["info"], metadataInfo),
-			"metadata alert %q does not match its shipped health-template info", name)
+		assert.Equalf(t, cephHealthAlertTemplates(t)[name]["info"], metadataInfo,
+			"metadata alert %q does not exactly match its shipped health-template info", name)
 	}
 }
 

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1306,19 +1306,17 @@ func TestCollector_CephM04DerivedBoundaries(t *testing.T) {
 		})
 	}
 
-	blockingIO := func(pgAvailability, osdDown float64, osdDownResolved bool) float64 {
+	blockingIO := func(pgAvailability, osdDown float64) float64 {
 		if math.IsNaN(pgAvailability) || math.IsInf(pgAvailability, 0) {
 			return math.NaN()
 		}
 		if pgAvailability != 1 {
-			// Ceph can withdraw an inactive OSD_DOWN health-check chart entirely.
-			// The inactive primary condition must clear without resolving that helper.
 			return 0
 		}
 		if osdDown == 1 {
 			return 0
 		}
-		if !osdDownResolved || math.IsNaN(osdDown) || math.IsInf(osdDown, 0) {
+		if math.IsNaN(osdDown) || math.IsInf(osdDown, 0) {
 			return math.NaN()
 		}
 		return 1
@@ -1326,19 +1324,18 @@ func TestCollector_CephM04DerivedBoundaries(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
 		availability, osd float64
-		osdResolved       bool
 		want              float64
 		undefined         bool
 	}{
-		{name: "availability with OSD down", availability: 1, osd: 1, osdResolved: true},
-		{name: "availability without OSD down", availability: 1, osd: 0, osdResolved: true, want: 1},
-		{name: "no availability", availability: 0, osd: 1, osdResolved: true},
+		{name: "availability with OSD down", availability: 1, osd: 1},
+		{name: "availability without OSD down", availability: 1, osd: 0, want: 1},
+		{name: "no availability", availability: 0, osd: 1},
 		{name: "inactive condition with withdrawn OSD chart", availability: 0},
-		{name: "invalid OSD state", availability: 1, osd: math.NaN(), osdResolved: true, undefined: true},
-		{name: "active condition with withdrawn OSD chart", availability: 1, undefined: true},
+		{name: "invalid OSD state", availability: 1, osd: math.NaN(), undefined: true},
+		{name: "active condition with withdrawn OSD chart", availability: 1, osd: math.NaN(), undefined: true},
 	} {
 		t.Run("blocking I/O "+tc.name, func(t *testing.T) {
-			got := blockingIO(tc.availability, tc.osd, tc.osdResolved)
+			got := blockingIO(tc.availability, tc.osd)
 			if tc.undefined {
 				assert.True(t, math.IsNaN(got))
 				return
@@ -1601,7 +1598,7 @@ func TestCollector_CephNVMeoFMaterializesLocalAlertIdentities(t *testing.T) {
 
 func TestCollector_CephNVMeoFAlertBoundaries(t *testing.T) {
 	cpuPercent := func(minimumBusyRate float64) float64 {
-		if math.IsNaN(minimumBusyRate) || math.IsInf(minimumBusyRate, 0) || minimumBusyRate < 0 || minimumBusyRate > 1 {
+		if math.IsNaN(minimumBusyRate) || math.IsInf(minimumBusyRate, 0) || minimumBusyRate < 0 {
 			return math.NaN()
 		}
 		return minimumBusyRate * 100
@@ -1615,7 +1612,6 @@ func TestCollector_CephNVMeoFAlertBoundaries(t *testing.T) {
 	}{
 		{name: "invalid NaN busy", busy: math.NaN(), undef: true},
 		{name: "negative busy", busy: -0.01, undef: true},
-		{name: "busy above one core", busy: 1.01, undef: true},
 		{name: "exactly eighty does not act", busy: .8, want: 80},
 		{name: "above eighty acts", busy: .81, want: 81, actor: true},
 	} {
@@ -1663,35 +1659,33 @@ func TestCollector_CephNVMeoFAlertBoundaries(t *testing.T) {
 		})
 	}
 
-	namespaceLimit := func(count, limit float64) (float64, bool) {
+	namespaceLimit := func(count, limit float64) bool {
 		if math.IsNaN(count) || math.IsInf(count, 0) || math.IsNaN(limit) || math.IsInf(limit, 0) ||
 			count < 0 || limit < 0 {
-			return math.NaN(), false
+			return false
 		}
-		return count, count >= limit
+		return count >= limit
 	}
 	for _, tc := range []struct {
 		name    string
 		count   float64
 		limit   float64
-		want    float64
 		reached bool
 		undef   bool
 	}{
 		{name: "invalid negative count", count: -1, limit: 1, undef: true},
 		{name: "invalid negative limit", count: 1, limit: -1, undef: true},
-		{name: "below limit", count: 1, limit: 2, want: 1},
-		{name: "at limit", count: 2, limit: 2, want: 2, reached: true},
-		{name: "above limit", count: 3, limit: 2, want: 3, reached: true},
+		{name: "below limit", count: 1, limit: 2},
+		{name: "at limit", count: 2, limit: 2, reached: true},
+		{name: "above limit", count: 3, limit: 2, reached: true},
 	} {
 		t.Run("namespace "+tc.name, func(t *testing.T) {
-			value, reached := namespaceLimit(tc.count, tc.limit)
+			got := namespaceLimit(tc.count, tc.limit)
 			if tc.undef {
-				assert.True(t, math.IsNaN(value))
+				assert.False(t, got)
 				return
 			}
-			assert.InDelta(t, tc.want, value, 1e-12)
-			assert.Equal(t, tc.reached, reached)
+			assert.Equal(t, tc.reached, got)
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -2250,6 +2250,46 @@ func TestCollector_CephRGWGenericOwnerExamples(t *testing.T) {
 	require.Equal(t, "web_log.request_processing_time", weblogTemplates["web_log_web_slow"]["on"])
 }
 
+func TestCollector_CephPhase1AlertMatrixComplete(t *testing.T) {
+	manifest := loadCephAlertManifest(t)
+	got := append(cephManifestSOWIDs(manifest.Alerts), cephManifestExtensionSOWIDs(manifest.NetdataExtensions)...)
+
+	// The native physical-capacity policy is owned directly by the native collector health
+	// configuration and metadata; it is not part of the Prometheus source-alert manifest.
+	got = append(got, "CEPH-ND-003")
+
+	want := []string{
+		// M01
+		"CEPH-001", "CEPH-002", "CEPH-013", "CEPH-014", "CEPH-015", "CEPH-016", "CEPH-059",
+		"CEPH-060", "CEPH-061", "CEPH-062", "CEPH-ND-001", "CEPH-ND-002", "RGW-M-01", "RGW-M-02",
+		// M02
+		"CEPH-003", "CEPH-004", "CEPH-005", "CEPH-017", "CEPH-018", "CEPH-019", "CEPH-020",
+		"CEPH-021", "CEPH-025", "CEPH-027", "CEPH-028", "CEPH-029", "CEPH-030", "CEPH-032",
+		"CEPH-033", "CEPH-034", "CEPH-035", "CEPH-036", "CEPH-037", "CEPH-038", "CEPH-039",
+		// M03
+		"CEPH-063", "CEPH-064", "CEPH-065", "CEPH-066", "CEPH-067", "CEPH-068", "CEPH-069",
+		"CEPH-070", "CEPH-071", "CEPH-072", "CEPH-073", "CEPH-074", "CEPH-075", "CEPH-076",
+		"CEPH-077", "CEPH-098", "CEPH-099", "CEPH-100", "CEPH-101", "CEPH-102", "CEPH-103", "CEPH-104",
+		// M04
+		"CEPH-040", "CEPH-040-HELPER", "CEPH-041", "CEPH-043", "CEPH-044", "CEPH-045", "CEPH-046",
+		"CEPH-046-HELPER", "CEPH-047", "CEPH-047-HELPER", "CEPH-048", "CEPH-049", "CEPH-050",
+		"CEPH-051", "CEPH-052", "CEPH-054", "CEPH-ND-003",
+		// M05
+		"CEPH-006", "CEPH-007", "CEPH-008", "CEPH-009", "CEPH-010", "CEPH-011", "CEPH-012",
+		"CEPH-055", "CEPH-056", "CEPH-057", "CEPH-058",
+		// M06
+		"CEPH-078", "CEPH-080", "CEPH-080-HELPER-PERSIST", "CEPH-082", "CEPH-082-HELPER-READ-TIME",
+		"CEPH-082-HELPER-READ-OPS", "CEPH-083", "CEPH-083-HELPER-WRITE-TIME", "CEPH-083-HELPER-WRITE-OPS",
+		"CEPH-084", "CEPH-092", "CEPH-094", "CEPH-094-HELPER-GATEWAY",
+		// M07
+		"RGW-M-03", "RGW-M-04", "RGW-M-08", "RGW-M-09", "RGW-M-10", "RGW-S-01", "RGW-S-02",
+		"RGW-S-03", "RGW-S-04", "RGW-S-09", "RGW-S-12", "RGW-S-13", "RGW-S-14", "RGW-S-15",
+		"RGW-S-16", "RGW-S-17", "RGW-S-18", "RGW-S-19", "RGW-S-20",
+	}
+
+	require.ElementsMatch(t, want, slices.Compact(slices.Sorted(slices.Values(got))))
+}
+
 func TestCollector_CephMGRAlertSourcePins(t *testing.T) {
 	manifest := loadCephAlertManifest(t)
 

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -1097,7 +1097,7 @@ func TestCollector_CephMGRNamedHealthCheckIdentities(t *testing.T) {
 	manifest := loadCephAlertManifest(t)
 	var want []string
 	for _, mapping := range manifest.Alerts {
-		if mapping.Netdata.Disposition == "reuse" ||
+		if mapping.Netdata.Disposition == "reuse" || mapping.Netdata.Disposition == "internal-helper" ||
 			mapping.Netdata.Context != "prometheus.ceph.health.health_checks.state" {
 			continue
 		}
@@ -1242,6 +1242,183 @@ func TestCollector_CephMGRClusterSummaries(t *testing.T) {
 	}
 	requireChartValues(creates[monSummary][0], map[string]float64{"total": 3, "in_quorum": 2})
 	requireChartValues(creates[osdSummary][0], map[string]float64{"total": 10, "up": 9})
+}
+
+func TestCollector_CephM04DerivedBoundaries(t *testing.T) {
+	difference := func(total, partial float64) float64 {
+		if math.IsNaN(total) || math.IsInf(total, 0) || math.IsNaN(partial) || math.IsInf(partial, 0) ||
+			total < 0 || partial < 0 || partial > total {
+			return math.NaN()
+		}
+		return total - partial
+	}
+	for _, tc := range []struct {
+		name           string
+		total, partial float64
+		want           float64
+		active         bool
+		undefined      bool
+	}{
+		{name: "invalid NaN total", total: math.NaN(), partial: 1, undefined: true},
+		{name: "invalid infinite partial", total: 10, partial: math.Inf(1), undefined: true},
+		{name: "negative total", total: -1, partial: 0, undefined: true},
+		{name: "partial exceeds total", total: 1, partial: 2, undefined: true},
+		{name: "zero pool", total: 0, partial: 0},
+		{name: "healthy pool", total: 100, partial: 100},
+		{name: "one inactive or unclean PG", total: 100, partial: 99, want: 1, active: true},
+		{name: "all inactive or unclean PGs", total: 100, partial: 0, want: 100, active: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := difference(tc.total, tc.partial)
+			if tc.undefined {
+				assert.True(t, math.IsNaN(got))
+				return
+			}
+			assert.InDelta(t, tc.want, got, 1e-12)
+			assert.Equal(t, tc.active, got > 0)
+		})
+	}
+
+	allUp := func(total, up float64) float64 {
+		if math.IsNaN(total) || math.IsInf(total, 0) || math.IsNaN(up) || math.IsInf(up, 0) ||
+			total <= 0 || up < 0 || up > total {
+			return math.NaN()
+		}
+		if up == total {
+			return 1
+		}
+		return 0
+	}
+	for _, tc := range []struct {
+		name      string
+		total, up float64
+		want      float64
+		undefined bool
+	}{
+		{name: "invalid NaN up", total: 10, up: math.NaN(), undefined: true},
+		{name: "zero population", total: 0, up: 0, undefined: true},
+		{name: "all OSDs up", total: 10, up: 10, want: 1},
+		{name: "one OSD down", total: 10, up: 9},
+	} {
+		t.Run("all up "+tc.name, func(t *testing.T) {
+			got := allUp(tc.total, tc.up)
+			if tc.undefined {
+				assert.True(t, math.IsNaN(got))
+				return
+			}
+			assert.InDelta(t, tc.want, got, 1e-12)
+		})
+	}
+
+	blockingIO := func(pgAvailability, osdDown float64) float64 {
+		if math.IsNaN(pgAvailability) || math.IsInf(pgAvailability, 0) ||
+			math.IsNaN(osdDown) || math.IsInf(osdDown, 0) {
+			return math.NaN()
+		}
+		if pgAvailability == 1 && osdDown != 1 {
+			return 1
+		}
+		return 0
+	}
+	for _, tc := range []struct {
+		name              string
+		availability, osd float64
+		want              float64
+		undefined         bool
+	}{
+		{name: "availability with OSD down", availability: 1, osd: 1},
+		{name: "availability without OSD down", availability: 1, osd: 0, want: 1},
+		{name: "no availability", availability: 0, osd: 1},
+		{name: "invalid OSD state", availability: 1, osd: math.NaN(), undefined: true},
+	} {
+		t.Run("blocking I/O "+tc.name, func(t *testing.T) {
+			got := blockingIO(tc.availability, tc.osd)
+			if tc.undefined {
+				assert.True(t, math.IsNaN(got))
+				return
+			}
+			assert.InDelta(t, tc.want, got, 1e-12)
+		})
+	}
+}
+
+func TestCollector_CephM04PoolDifferenceMaterialization(t *testing.T) {
+	var input strings.Builder
+	input.WriteString("# TYPE ceph_pg_active gauge\n# TYPE ceph_pg_clean gauge\n# TYPE ceph_pg_total gauge\n")
+	for pool, values := range map[string][3]float64{
+		"healthy": {100, 100, 100},
+		"partial": {100, 99, 100},
+		"zero":    {0, 0, 0},
+	} {
+		fmt.Fprintf(&input, "ceph_pg_active{pool_id=%q} %v\n", pool, values[0])
+		fmt.Fprintf(&input, "ceph_pg_clean{pool_id=%q} %v\n", pool, values[1])
+		fmt.Fprintf(&input, "ceph_pg_total{pool_id=%q} %v\n", pool, values[2])
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(input.String()))
+	}))
+	defer srv.Close()
+
+	collr := New()
+	collr.URL = srv.URL
+	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	defer collr.Cleanup(context.Background())
+
+	cc := cycle(t, collr.MetricStore())
+	cc.BeginCycle()
+	require.NoError(t, collr.Collect(context.Background()))
+	require.NoError(t, cc.CommitCycleSuccess())
+
+	eng, err := chartengine.New()
+	require.NoError(t, err)
+	require.NoError(t, eng.LoadYAML([]byte(collr.ChartTemplateYAML()), 1))
+	attempt, err := eng.PreparePlan(collr.MetricStore().Read(metrix.ReadRaw(), metrix.ReadFlatten()))
+	require.NoError(t, err)
+	defer attempt.Abort()
+	plan := attempt.Plan()
+	require.NoError(t, attempt.Commit())
+
+	const context = "prometheus.ceph.placement_groups_and_recovery.healthy_state.pg_state"
+	chartContexts := make(map[string]string)
+	updates := make(map[string]chartengine.UpdateChartAction)
+	for _, action := range plan.Actions {
+		if create, ok := action.(chartengine.CreateChartAction); ok {
+			chartContexts[create.ChartID] = create.Meta.Context
+		}
+		update, ok := action.(chartengine.UpdateChartAction)
+		if ok && chartContexts[update.ChartID] == context {
+			updates[update.ChartID] = update
+		}
+	}
+	require.Len(t, updates, 3, "one PG chart instance must remain per pool")
+	for chartID, update := range updates {
+		actual := make(map[string]float64)
+		for _, value := range update.Values {
+			if value.IsFloat {
+				actual[value.Name] = value.Float64
+			} else {
+				actual[value.Name] = float64(value.Int64)
+			}
+		}
+		switch actual["pg_total"] {
+		case 100:
+			switch actual["clean"] {
+			case 100:
+				assert.Equal(t, map[string]float64{"active": 100, "clean": 100, "pg_total": 100}, actual)
+			case 99:
+				assert.Equal(t, map[string]float64{"active": 100, "clean": 99, "pg_total": 100}, actual)
+			default:
+				t.Fatalf("unexpected healthy-total PG chart values %q: %v", chartID, actual)
+			}
+		case 0:
+			assert.Equal(t, map[string]float64{"active": 0, "clean": 0, "pg_total": 0}, actual)
+		default:
+			t.Fatalf("unexpected PG chart values %q: %v", chartID, actual)
+		}
+	}
 }
 
 func TestCollector_CephHardwareProfileReleaseGating(t *testing.T) {
@@ -1448,7 +1625,9 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		"CEPH-037", "CEPH-038", "CEPH-039", "CEPH-063", "CEPH-064", "CEPH-065", "CEPH-066", "CEPH-067",
 		"CEPH-068", "CEPH-069", "CEPH-070", "CEPH-071", "CEPH-072", "CEPH-073", "CEPH-074", "CEPH-075",
 		"CEPH-076", "CEPH-077", "CEPH-098", "CEPH-099", "CEPH-100", "CEPH-101", "CEPH-102", "CEPH-103",
-		"CEPH-104", "CEPH-059", "CEPH-060", "CEPH-061", "CEPH-062",
+		"CEPH-104", "CEPH-040", "CEPH-040-HELPER", "CEPH-041", "CEPH-043", "CEPH-044", "CEPH-045",
+		"CEPH-046", "CEPH-046-HELPER", "CEPH-047", "CEPH-047-HELPER", "CEPH-048", "CEPH-049", "CEPH-050",
+		"CEPH-051", "CEPH-052", "CEPH-054", "CEPH-059", "CEPH-060", "CEPH-061", "CEPH-062",
 	}, cephManifestSOWIDs(manifest.Alerts))
 	require.ElementsMatch(t, []string{"CEPH-ND-001", "CEPH-ND-002", "RGW-M-01", "RGW-M-02"},
 		cephManifestExtensionSOWIDs(manifest.NetdataExtensions))
@@ -1463,13 +1642,20 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 	}
 
 	for name, mapping := range manifest.Alerts {
-		require.NotEmpty(t, mapping.SourceAlert)
+		require.Truef(t, mapping.SourceAlert != "" || len(mapping.SourceAlerts) > 0,
+			"%s has no canonical or release source alert", name)
 		hasExpression := mapping.Source.Expression != ""
 		hasExpressions := len(mapping.Source.Expressions) > 0
 		require.NotEqualf(t, hasExpression, hasExpressions,
 			"%s must define exactly one of source expression or release expressions", name)
-		require.NotEmptyf(t, mapping.Source.Releases, "%s has no supported-release set", name)
+		isHelper := mapping.Netdata.Disposition == "internal-helper" || mapping.Netdata.Disposition == "subsumed-helper"
+		if !isHelper {
+			require.NotEmptyf(t, mapping.Source.Releases, "%s has no supported-release set", name)
+		}
 		for _, release := range []string{"reef", "squid", "tentacle"} {
+			if isHelper {
+				continue
+			}
 			supported := slices.Contains(mapping.Source.Releases, release)
 			require.Equalf(t, supported, mapping.Source.Lines[release] > 0,
 				"%s release availability and line pin disagree for %s", name, release)
@@ -1486,6 +1672,23 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 		require.NotEmpty(t, adaptation.Preserved)
 		require.NotEmpty(t, adaptation.Differences)
 
+		if mapping.Netdata.Disposition == "internal-helper" {
+			require.Equalf(t, "silent", mapping.Netdata.Recipient, "%s internal helper must be silent", name)
+			require.Containsf(t, templates, name, "internal helper template is absent")
+			assert.Equalf(t, mapping.Netdata.Context, templates[name]["on"], "%s helper context mismatch", name)
+			assert.Equalf(t, mapping.Netdata.Calc, templates[name]["calc"], "%s helper calc mismatch", name)
+			assert.Equalf(t, manifest.NetdataAlertCadence, templates[name]["every"], "%s helper cadence mismatch", name)
+			assert.Equalf(t, mapping.Netdata.Condition, templates[name]["condition"], "%s helper condition mismatch", name)
+			assert.Equalf(t, mapping.Netdata.Recipient, templates[name]["to"], "%s helper routing mismatch", name)
+			continue
+		}
+		if mapping.Netdata.Disposition == "subsumed-helper" {
+			require.Equalf(t, "silent", mapping.Netdata.Recipient, "%s subsumed helper must be silent", name)
+			require.NotEmptyf(t, mapping.Netdata.Owner, "%s has no owning alert", name)
+			_, ok := templates[mapping.Netdata.Owner]
+			require.Truef(t, ok, "%s owner %q is absent", name, mapping.Netdata.Owner)
+			continue
+		}
 		if mapping.Netdata.Disposition == "reuse" {
 			require.NotEmptyf(t, mapping.Netdata.OwnerFile, "%s has no generic owner file", name)
 			require.NotEmptyf(t, mapping.Netdata.OwnerAlerts, "%s has no generic owner templates", name)
@@ -1498,7 +1701,7 @@ func TestCollector_CephMGRAlertContract(t *testing.T) {
 			assert.Equal(t, mapping.Netdata.Labels, block["chart labels"])
 			assert.Equal(t, mapping.Netdata.Lookup, block["lookup"])
 			assert.Equal(t, mapping.Netdata.Calc, block["calc"])
-			if mapping.Netdata.Calc != "" {
+			if mapping.Netdata.Calc != "" && mapping.Netdata.Disposition == "correct" {
 				assert.Empty(t, mapping.Netdata.Lookup, "current compound alert must not mix historical and current dimensions")
 				assert.NotContains(t, mapping.Netdata.Calc, "$last_collected_t",
 					"data-state alert must not duplicate generic collection-failure ownership")
@@ -1560,14 +1763,21 @@ func TestCollector_CephMGRAlertSourcePins(t *testing.T) {
 
 			rules := parseCephSourceAlertRules(t, content)
 			for name, mapping := range manifest.Alerts {
+				if mapping.Netdata.Disposition == "internal-helper" || mapping.Netdata.Disposition == "subsumed-helper" {
+					continue
+				}
 				if !slices.Contains(mapping.Source.Releases, release) {
 					require.NotContainsf(t, rules, mapping.SourceAlert,
 						"%s is incorrectly present in %s", mapping.SourceAlert, release)
 					continue
 				}
 				t.Run(name, func(t *testing.T) {
-					rule, ok := rules[mapping.SourceAlert]
-					require.Truef(t, ok, "source alert %q is absent", mapping.SourceAlert)
+					sourceAlert := mapping.SourceAlert
+					if len(mapping.SourceAlerts) > 0 {
+						sourceAlert = mapping.SourceAlerts[release]
+					}
+					rule, ok := rules[sourceAlert]
+					require.Truef(t, ok, "source alert %q is absent", sourceAlert)
 
 					expression := mapping.Source.Expression
 					if len(mapping.Source.Expressions) > 0 {
@@ -1983,9 +2193,10 @@ type cephNetdataExtension struct {
 }
 
 type cephAlertMapping struct {
-	SOWID       string `yaml:"sow_id"`
-	SourceAlert string `yaml:"source_alert"`
-	Source      struct {
+	SOWID        string            `yaml:"sow_id"`
+	SourceAlert  string            `yaml:"source_alert"`
+	SourceAlerts map[string]string `yaml:"source_alerts"`
+	Source       struct {
 		Expression       string            `yaml:"expression"`
 		Expressions      map[string]string `yaml:"expressions"`
 		Releases         []string          `yaml:"releases"`

--- a/src/go/plugin/go.d/collector/prometheus/collector_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/collector_test.go
@@ -2671,6 +2671,7 @@ func collectCephPlan(t *testing.T, body []byte) cephCollectorPlan {
 	collr := New()
 	collr.URL = srv.URL
 	collr.Profiles = ProfilesConfig{Mode: "auto"}
+	collr.MaxTS = 20_000
 	require.NoError(t, collr.Init(context.Background()))
 	require.NoError(t, collr.Check(context.Background()))
 	t.Cleanup(func() { collr.Cleanup(context.Background()) })

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -4633,6 +4633,58 @@ modules:
                     max_time_series: 20000
                     max_time_series_per_metric: 4000
     alerts:
+      - name: ceph_nvmeof_subsystem_open_security
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.subsystems.state_metadata
+        info: 'Every available sample in the 5-minute observation window reports an NVMe-oF subsystem configured without host security.'
+      - name: ceph_nvmeof_gateway_cpu_10m
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.gateways.time_accumulation
+        info: 'Internal helper holding the lowest local reactor busy-rate sample observed over ten minutes; it does not notify.'
+      - name: ceph_nvmeof_gateway_cpu
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.gateways.time_accumulation
+        info: 'The current lowest local reactor busy-rate sample in the 10-minute observation window is above 80 percent.'
+      - name: ceph_nvmeof_read_latency_1m
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
+        info: 'Internal helper holding the local one-minute per-block-device read service-time rate; it does not notify.'
+      - name: ceph_nvmeof_read_operations_1m
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.block_devices.operations
+        info: 'Internal helper holding the local one-minute per-block-device completed-read rate; it does not notify.'
+      - name: ceph_nvmeof_high_read_latency
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
+        info: 'The current local one-minute read service-time ratio exceeds 10 milliseconds per completed read.'
+      - name: ceph_nvmeof_write_latency_1m
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
+        info: 'Internal helper holding the local one-minute per-block-device write service-time rate; it does not notify.'
+      - name: ceph_nvmeof_write_operations_1m
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.block_devices.operations
+        info: 'Internal helper holding the local one-minute per-block-device completed-write rate; it does not notify.'
+      - name: ceph_nvmeof_high_write_latency
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
+        info: 'The current local one-minute write service-time ratio exceeds 20 milliseconds per completed write.'
+      - name: ceph_nvmeof_host_keepalive_timeout
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.hosts.keepalive_timeout_state
+        info: 'The exporter currently reports a host disconnected by keepalive timeout. Exporter refresh reads and clears this one-shot state.'
+      - name: ceph_nvmeof_subsystem_namespace_limit
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.subsystems.namespace_capacity
+        info: 'The current subsystem namespace count is at or above its configured limit.'
+      - name: ceph_nvmeof_gateway_namespaces
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.gateways.namespace_count
+        info: 'Internal helper summing subsystem namespace counts inside the local exporter endpoint; it does not notify.'
+      - name: ceph_nvmeof_too_many_namespaces
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.nvme_of.gateways.namespace_count
+        info: 'The current local exporter namespace inventory is at or above the supported maximum of 4096.'
       - name: ceph_health_error
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.cluster_status.state

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -4546,7 +4546,20 @@ modules:
           Alert ownership is deliberately layered. Configure one logical MGR scrape scope per Ceph cluster for cluster-health
           alerts and use the native Ceph collector for its complementary Dashboard API collection-integrity alerts. Netdata's
           generic Prometheus collection alert covers a configured MGR job that cannot scrape; it is distinct from native API
-          component failures and does not report an unconfigured job.
+          component failures and does not report an unconfigured job. The monitor and OSD cluster-summary charts sum member
+          rows only within that MGR job or vnode; they are one cluster instance, not an infrastructure-level aggregation.
+          Use one stable endpoint or failover target that follows the active MGR and one stable job/vnode identity per logical
+          cluster. Separate jobs for active and standby endpoints can create duplicate cluster alert owners.
+
+          Cluster-summary alerts evaluate the latest stored dimensions on each Netdata health beat. A failed scrape does not
+          obsolete the chart or fabricate new values, so the data-state alert may continue evaluating the last stored state;
+          the generic collection alert owns that scrape failure. When the collector knows the chart has disappeared and
+          obsoletes it, its instance alerts are removed.
+
+          Ceph's node root-filesystem and packet-drop recommendations are owned by Netdata's generic per-filesystem and
+          per-interface host alerts on the Agents collecting each Ceph node, not by the MGR profile. Those stock policies use
+          Netdata's own thresholds, windows, directionality, hysteresis, and routing. They remain silent policy guidance where
+          applicable and are not duplicated under Ceph-specific names.
         method_description: |
           Netdata periodically scrapes the Ceph MGR Prometheus module or official `ceph-exporter` endpoint and applies the
           built-in `ceph` profile. The MGR module refreshes its enabled metric cache every 15 seconds by default, and standalone
@@ -4654,6 +4667,82 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
         info: 'Every available sample in the 30-second observation window reports a cephadm upgrade exception.'
+      - name: ceph_device_failure_predicted
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports a device predicted to fail.'
+      - name: ceph_device_failure_prediction_too_high
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports that removing all predicted failures would compromise availability.'
+      - name: ceph_device_failure_relocation_incomplete
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports blocked relocation from a predicted device failure.'
+      - name: ceph_mon_clock_skew
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports monitor clock skew.'
+      - name: ceph_mon_diskspace_critical
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports critically low monitor-store space.'
+      - name: ceph_mon_diskspace_low
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports low monitor-store space.'
+      - name: ceph_mon_down
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.control_plane.monitor.cluster_summary
+        info: 'The current MGR cluster summary reports fewer monitors in quorum than configured, while a majority still remains.'
+      - name: ceph_mon_quorum_at_risk
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.control_plane.monitor.cluster_summary
+        info: 'The current MGR cluster summary reports exactly the minimum surviving monitor majority; one more monitor loss would remove quorum.'
+      - name: ceph_osd_backfill_full
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports that an OSD has reached its backfill-full threshold and rebalance cannot complete.'
+      - name: ceph_osd_down
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports a down OSD.'
+      - name: ceph_osd_down_high
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
+        info: 'The current MGR cluster summary reports that at least 10% of configured OSDs are down.'
+      - name: ceph_osd_full
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports an OSD at its full threshold.'
+      - name: ceph_osd_host_down
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports an offline OSD host.'
+      - name: ceph_osd_internal_disk_size_mismatch
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports a BlueStore device-size mismatch that can cause the affected OSD to crash.'
+      - name: ceph_osd_near_full
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports an OSD at its near-full threshold.'
+      - name: ceph_osd_read_errors
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports BlueStore read errors that succeeded only after retries.'
+      - name: ceph_osd_timeouts_cluster_network
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports slow backend OSD heartbeats.'
+      - name: ceph_osd_timeouts_public_network
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports slow frontend OSD heartbeats.'
+      - name: ceph_osd_too_many_repairs
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports excessive repaired reads, which may indicate a failing drive.'
       - name: ceph_unknown_health_check
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -4518,26 +4518,20 @@ modules:
           different Dashboard REST API.
 
           The built-in profile separates cluster-wide MGR health, quorum, capacity, placement groups, pools, and OSD metadata
-          from host-local `ceph-exporter` daemon availability and MON, MGR, OSD, and RGW performance. Optional branches cover
+          from host-local `ceph-exporter` daemon availability and MON, MGR, OSD, and RGW performance. You can monitor
           CephFS/MDS and CephFS Mirror, RBD images, RBD Mirror, SMB, NVMe-oF, RGW user/bucket/topic/cache/multisite and dmClock
           scheduling, RocksDB binned caches, external block devices, and Ceph client I/O across Reef 18.2.8, Squid 19.2.5,
           and Tentacle 20.2.3. On Tentacle, the endpoints also expose primary-OSD PG-rebuild duration, while the MGR additionally
           exposes cephadm node-proxy CPU, memory, storage, cooling, temperature, and per-component health metrics. Firmware
-          remains source metadata and is not charted because Ceph exposes it as an info family. PG state flags and RGW
-          global/user/bucket views are overlapping diagnostic populations and are not additive totals. Profile relabeling
-          turns dynamic MDS-client, librbd ImageCtx/PWL, ObjectCacher, objecter, RocksDB cache, Finisher, Throttle, KernelDevice,
-          mClock, messenger, RDMA, DPDK, and service-identity family names into stable profile inputs while preserving their
-          source keys as identity labels. The source-complete profile materializes the entire declared release/producer union
-          with zero generic fallback. Unknown future Ceph families remain visible through generic fallback until their source
-          semantics can be curated; generic visibility is a forward-compatibility guard, not evidence that a known source
-          family was fully modeled. The profile drops only the source-proven raw MGR RGW source-zone aliases because the stable
-          normalized family is already charted.
+          inventory remains available as metadata. PG state flags and RGW global/user/bucket views provide diagnostic detail
+          rather than additive totals. The profile gives dynamic MDS-client, librbd ImageCtx/PWL, ObjectCacher, objecter,
+          RocksDB cache, Finisher, Throttle, KernelDevice, mClock, messenger, RDMA, DPDK, and service-identity families stable
+          chart identities while preserving their source keys.
 
-          The chart model follows the producer's source lifecycle rather than relying on Prometheus wire type alone. Current
-          populations that Ceph increments and decrements remain absolute, while cumulative work published through gauges is
-          rendered incrementally so Netdata performs rate calculation and reset detection. Shared charts compare only the same
-          counted or measured population: requests, objects, bytes, reservations, state transitions, and other unlike units
-          remain separate even when their wire type or numeric scale is similar.
+          Charts follow each producer's lifecycle. Current populations that Ceph increments and decrements remain absolute,
+          while cumulative work published through gauges is rendered incrementally so Netdata performs rate calculation and
+          reset detection. Shared charts compare only the same counted or measured population, keeping requests, objects,
+          bytes, reservations, and state transitions separate even when their numeric scales are similar.
 
           The profile also covers priority-0 daemon counters exposed when `ceph-exporter` is configured with
           `exporter_prio_limit=0`, conditional exporter process CPU, memory, thread, and page-fault metrics, and the official
@@ -4545,23 +4539,19 @@ modules:
           charted per reported component and temperature sensor with its hostname, category, component, or sensor identity.
           These families are absent on Reef and Squid; their absence creates no chart or alert there.
 
-          Alert ownership is deliberately layered. Configure one logical MGR scrape scope per Ceph cluster for cluster-health
-          alerts and use the native Ceph collector for its complementary Dashboard API collection-integrity alerts. Netdata's
-          generic Prometheus collection alert covers a configured MGR job that cannot scrape; it is distinct from native API
-          component failures and does not report an unconfigured job. The monitor and OSD cluster-summary charts sum member
-          rows only within that MGR job or vnode; they are one cluster instance, not an infrastructure-level aggregation.
-          Use one stable endpoint or failover target that follows the active MGR and one stable job/vnode identity per logical
-          cluster. Separate jobs for active and standby endpoints can create duplicate cluster alert owners.
+          Configure one logical MGR job per Ceph cluster for cluster-health alerts and one native Ceph Dashboard job for
+          API component integrity. The generic Prometheus collection alert reports a configured MGR job that cannot scrape;
+          the native collector reports Dashboard API component failures. Monitor and OSD cluster-summary charts represent
+          one cluster job or virtual node. Use one stable endpoint or failover target that follows the active MGR, and keep
+          one stable job or virtual-node identity per cluster.
 
           Cluster-summary alerts evaluate the latest stored dimensions on each Netdata health beat. A failed scrape does not
           obsolete the chart or fabricate new values, so the data-state alert may continue evaluating the last stored state;
           the generic collection alert owns that scrape failure. When the collector knows the chart has disappeared and
           obsoletes it, its instance alerts are removed.
 
-          Ceph's node root-filesystem and packet-drop recommendations are owned by Netdata's generic per-filesystem and
-          per-interface host alerts on the Agents collecting each Ceph node, not by the MGR profile. Those stock policies use
-          Netdata's own thresholds, windows, directionality, hysteresis, and routing. They remain silent policy guidance where
-          applicable and are not duplicated under Ceph-specific names.
+          Netdata's per-filesystem and per-interface host alerts monitor root-filesystem usage and packet drops on each Ceph
+          node. These host-wide policies use Netdata's thresholds, windows, directionality, hysteresis, and routing.
         method_description: |
           Netdata periodically scrapes the Ceph MGR Prometheus module or official `ceph-exporter` endpoint and applies the
           built-in `ceph` profile. The MGR module refreshes its enabled metric cache every 15 seconds by default, and standalone
@@ -4640,7 +4630,7 @@ modules:
       - name: ceph_nvmeof_gateway_cpu_10m
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.gateways.time_accumulation
-        info: 'Internal helper holding the lowest local reactor busy-rate sample observed over ten minutes; it does not notify.'
+        info: 'Holds the lowest local reactor busy-rate sample observed over ten minutes for the gateway CPU policy.'
       - name: ceph_nvmeof_gateway_cpu
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.gateways.time_accumulation
@@ -4648,11 +4638,11 @@ modules:
       - name: ceph_nvmeof_read_latency_1m
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
-        info: 'Internal helper holding the local one-minute per-block-device read service-time rate; it does not notify.'
+        info: 'Holds the local one-minute per-block-device read service-time rate.'
       - name: ceph_nvmeof_read_operations_1m
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.block_devices.operations
-        info: 'Internal helper holding the local one-minute per-block-device completed-read rate; it does not notify.'
+        info: 'Holds the local one-minute per-block-device completed-read rate.'
       - name: ceph_nvmeof_high_read_latency
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
@@ -4660,11 +4650,11 @@ modules:
       - name: ceph_nvmeof_write_latency_1m
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
-        info: 'Internal helper holding the local one-minute per-block-device write service-time rate; it does not notify.'
+        info: 'Holds the local one-minute per-block-device write service-time rate.'
       - name: ceph_nvmeof_write_operations_1m
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.block_devices.operations
-        info: 'Internal helper holding the local one-minute per-block-device completed-write rate; it does not notify.'
+        info: 'Holds the local one-minute per-block-device completed-write rate.'
       - name: ceph_nvmeof_high_write_latency
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
@@ -4680,7 +4670,7 @@ modules:
       - name: ceph_nvmeof_gateway_namespaces
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.gateways.namespace_count
-        info: 'Internal helper summing subsystem namespace counts inside the local exporter endpoint; it does not notify.'
+        info: 'Sums subsystem namespace counts inside the local exporter endpoint.'
       - name: ceph_nvmeof_too_many_namespaces
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.gateways.namespace_count
@@ -4896,7 +4886,7 @@ modules:
       - name: ceph_osd_all_up
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
-        info: 'Internal helper holding the current all-configured-OSDs-up state; it does not notify.'
+        info: 'Holds the current all-configured-OSDs-up state.'
       - name: ceph_object_missing
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
@@ -4920,7 +4910,7 @@ modules:
       - name: ceph_osd_down_current
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Internal helper holding the current OSD-down health state; it does not notify.'
+        info: 'Holds the current OSD-down health state.'
       - name: ceph_pg_unavailable_blocking_io
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -399,7 +399,11 @@ modules:
         list:
           - name: "Disappearing or sparse metrics not clearing alerts"
             description: |
-              When a metric disappears from the Prometheus endpoint response (for example, a gauge that is only exposed when its value is greater than 0), Netdata does not require any special value to stop tracking it. The Prometheus collector automatically detects metrics that are no longer present in the scrape response. After 10 consecutive collection cycles where the metric is absent, the associated chart is automatically removed and any alerts on that chart will clear. You do not need to send a special value (such as 0, NaN, or StaleNaN) — simply omitting the metric from the response is sufficient. Note that during the 10-cycle grace period, the last known value remains and alerts may not clear immediately.
+              The Prometheus collector detects metrics that disappear from a successful scrape response and profile-authored
+              charts expire after their configured successful-cycle lifetime. An expired chart makes its alerts `REMOVED`; it
+              is not a normal `CLEAR` transition and does not send a recovery notification. Export an explicit normal value
+              (for example `0`) whenever an alert needs a reliable recovery transition. A failed scrape does not advance the
+              expiry lifetime; use the generic collector collection-failure alert to detect that separate condition.
     alerts: []
     metrics:
       folding:
@@ -4538,9 +4542,17 @@ modules:
           The profile also covers priority-0 daemon counters exposed when `ceph-exporter` is configured with
           `exporter_prio_limit=0`, conditional exporter process CPU, memory, thread, and page-fault metrics, and the official
           NVMe-oF gateway's Python process runtime surface.
+
+          Alert ownership is deliberately layered. Configure one logical MGR scrape scope per Ceph cluster for cluster-health
+          alerts and use the native Ceph collector for its complementary Dashboard API collection-integrity alerts. Netdata's
+          generic Prometheus collection alert covers a configured MGR job that cannot scrape; it is distinct from native API
+          component failures and does not report an unconfigured job.
         method_description: |
           Netdata periodically scrapes the Ceph MGR Prometheus module or official `ceph-exporter` endpoint and applies the
-          built-in `ceph` profile.
+          built-in `ceph` profile. The MGR module refreshes its enabled metric cache every 15 seconds by default, and standalone
+          `ceph-exporter` refreshes daemon metrics every 5 seconds by default. Scrapes read those producer caches; choosing a
+          5-, 10-, 15-, or 60-second Netdata interval does not schedule Ceph producer refresh. Match the interval to the
+          configured producer cache period to avoid redundant samples, unless the MGR cache is deliberately disabled.
     setup:
       <<: *setup
       prerequisites:
@@ -4564,22 +4576,88 @@ modules:
               folding:
                 enabled: false
               description: |
-                Collect the cluster-wide MGR endpoint and a local official ceph-exporter endpoint with the automatically
-                matched Ceph and process-runtime profiles. Repeat the exporter job for every exporter endpoint. The Ceph
-                profile preserves source labels that collide with Netdata's Prometheus re-export labels under a `ceph_`
-                prefix, retains opaque dynamic group keys, and normalizes only source families whose suffix grammar is
-                unambiguous.
+                Collect one logical MGR endpoint per Ceph cluster and each local official ceph-exporter endpoint with the
+                automatically matched Ceph and process-runtime profiles. Configure one MGR job per cluster and do not scrape
+                multiple active MGR endpoints into the same job. Repeat the exporter job for every exporter endpoint, using
+                each host's own scope. The Ceph profile preserves source labels that collide with Netdata's Prometheus
+                re-export labels under a `ceph_` prefix, retains opaque dynamic group keys, and normalizes only source families
+                whose suffix grammar is unambiguous.
               config: |
                 jobs:
-                  - &ceph_job
-                    name: ceph-mgr
+                  - name: ceph-mgr
                     url: http://127.0.0.1:9283/metrics
+                    update_every: 15
                     expected_prefix: ceph_
                     max_time_series: 20000
                     max_time_series_per_metric: 4000
-                  - <<: *ceph_job
-                    name: ceph-exporter
+                  - name: ceph-exporter
                     url: http://127.0.0.1:9926/metrics
+                    update_every: 5
+                    expected_prefix: ceph_
+                    max_time_series: 20000
+                    max_time_series_per_metric: 4000
+            - name: Ceph MGR with virtual node
+              description: |
+                Use a virtual node when the cluster identity should remain independent of the Agent currently scraping its
+                active MGR. First define the vnode in `/etc/netdata/vnodes/vnodes.conf`:
+
+                ```yaml
+                - hostname: ceph-cluster
+                  guid: <your-uuid-here>
+                ```
+
+                Then reference that exact hostname in the MGR job. An undefined vnode makes the job fail to start. Keep one
+                logical MGR job and one stable vnode identity per Ceph cluster.
+              config: |
+                jobs:
+                  - name: ceph-mgr-vnode
+                    vnode: ceph-cluster
+                    url: http://127.0.0.1:9283/metrics
+                    update_every: 15
+                    expected_prefix: ceph_
+                    max_time_series: 20000
+                    max_time_series_per_metric: 4000
+    alerts:
+      - name: ceph_health_error
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.cluster_status.state
+        info: 'Every available Ceph MGR health sample in the 5-minute observation window is HEALTH_ERR.'
+      - name: ceph_health_warning
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.cluster_status.state
+        info: 'Every available Ceph MGR health sample in the 15-minute observation window is HEALTH_WARN.'
+      - name: ceph_daemon_crash
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports a recent daemon crash.'
+      - name: ceph_mgr_module_crash
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports a recent manager-module crash.'
+      - name: ceph_daemon_slow_ops
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.daemon_health.item_count
+        info: 'Every available sample in the 30-second observation window reports one or more slow operations for this daemon.'
+      - name: ceph_slow_ops
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.slow_operations.current_operations
+        info: 'Every available sample in the 30-second observation window reports one or more cluster slow operations.'
+      - name: cephadm_daemon_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports a failed cephadm daemon.'
+      - name: cephadm_paused
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports that cephadm is paused.'
+      - name: cephadm_upgrade_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports a cephadm upgrade exception.'
+      - name: ceph_unknown_health_check
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports an unclassified ordinary health check.'
 
   - <<: *module
     meta:

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -4521,7 +4521,7 @@ modules:
           from host-local `ceph-exporter` daemon availability and MON, MGR, OSD, and RGW performance. Optional branches cover
           CephFS/MDS and CephFS Mirror, RBD images, RBD Mirror, SMB, NVMe-oF, RGW user/bucket/topic/cache/multisite and dmClock
           scheduling, RocksDB binned caches, external block devices, and Ceph client I/O across Reef 18.2.8, Squid 19.2.5,
-          and Tentacle 20.2.2. On Tentacle, the endpoints also expose primary-OSD PG-rebuild duration, while the MGR additionally
+          and Tentacle 20.2.3. On Tentacle, the endpoints also expose primary-OSD PG-rebuild duration, while the MGR additionally
           exposes cephadm node-proxy CPU, memory, storage, cooling, temperature, and per-component health metrics. Firmware
           remains source metadata and is not charted because Ceph exposes it as an info family. PG state flags and RGW
           global/user/bucket views are overlapping diagnostic populations and are not additive totals. Profile relabeling
@@ -4541,7 +4541,9 @@ modules:
 
           The profile also covers priority-0 daemon counters exposed when `ceph-exporter` is configured with
           `exporter_prio_limit=0`, conditional exporter process CPU, memory, thread, and page-fault metrics, and the official
-          NVMe-oF gateway's Python process runtime surface.
+          NVMe-oF gateway's Python process runtime surface. On Tentacle, the optional MGR node-proxy hardware surface is
+          charted per reported component and temperature sensor with its hostname, category, component, or sensor identity.
+          These families are absent on Reef and Squid; their absence creates no chart or alert there.
 
           Alert ownership is deliberately layered. Configure one logical MGR scrape scope per Ceph cluster for cluster-health
           alerts and use the native Ceph collector for its complementary Dashboard API collection-integrity alerts. Netdata's
@@ -4679,6 +4681,94 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
         info: 'Every available sample in the 1-minute observation window reports blocked relocation from a predicted device failure.'
+      - name: ceph_cooling_degraded
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports warning health for a reported fan component.'
+      - name: ceph_cooling_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports error health for a reported fan component.'
+      - name: ceph_dimm_temperature_high
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.temperature.temperature
+        info: 'Every available sample in the 1-minute observation window reports a recognized DIMM temperature sensor above 80°C.'
+      - name: ceph_hardware_fan_error
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports a Ceph fan hardware error.'
+      - name: ceph_hardware_memory_error
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports a Ceph memory hardware error.'
+      - name: ceph_hardware_network_error
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports a Ceph network hardware error.'
+      - name: ceph_hardware_power_error
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports a Ceph power hardware error.'
+      - name: ceph_hardware_processor_error
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports a Ceph processor hardware error.'
+      - name: ceph_hardware_storage_error
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 30-second observation window reports a Ceph storage hardware error.'
+      - name: ceph_memory_degraded
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports warning health for a reported memory component.'
+      - name: ceph_memory_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports error health for a reported memory component.'
+      - name: ceph_motherboard_temperature_high
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.temperature.temperature
+        info: 'Every available sample in the 1-minute observation window reports a recognized motherboard temperature sensor above 60°C.'
+      - name: ceph_nvme_drive_degraded
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports warning health for a reported storage component.'
+      - name: ceph_nvme_drive_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports error health for a reported storage component.'
+      - name: ceph_nvme_temperature_high
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.temperature.temperature
+        info: 'Every available sample in the 1-minute observation window reports a recognized NVMe temperature sensor above 70°C.'
+      - name: ceph_network_degraded
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports warning health for a reported network component.'
+      - name: ceph_network_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports error health for a reported network component.'
+      - name: ceph_power_supply_degraded
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports warning health for a reported power component.'
+      - name: ceph_power_supply_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports error health for a reported power component.'
+      - name: ceph_processor_degraded
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports warning health for a reported processor component.'
+      - name: ceph_processor_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.health.state
+        info: 'Every available sample in the 1-minute observation window reports error health for a reported processor component.'
+      - name: ceph_processor_temperature_high
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.node_hardware.temperature.temperature
+        info: 'Every available sample in the 1-minute observation window reports a recognized processor temperature sensor above 80°C.'
       - name: ceph_mon_clock_skew
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -4685,6 +4685,46 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.gateways.namespace_count
         info: 'The current local exporter namespace inventory is at or above the supported maximum of 4096.'
+      - name: rgw_notification_event_lost
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway.notifications.events
+        info: 'Every available sample in the 1-minute observation window reports a non-zero final notification-event loss rate.'
+      - name: rgw_notification_missing_configuration
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway.notifications.missing_configurations
+        info: 'Every available sample in the 1-minute observation window reports a non-zero notification missing-configuration rate.'
+      - name: rgw_lua_script_failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway.lua.script_executions
+        info: 'Every available sample in the 1-minute observation window reports a non-zero Lua script failure rate.'
+      - name: rgw_failed_request_rate_fallback
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway.requests_and_queue.failed_requests
+        info: 'Every available sample in the 5-minute observation window reports a non-zero aborted-request rate. This is a fallback signal and does not identify HTTP 5xx responses.'
+      - name: rgw_notification_push_or_store_failures
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway.notifications.failure_outcomes
+        info: 'Every available sample in the 5-minute observation window reports non-zero retryable notification push or store failures.'
+      - name: rgw_notification_inflight_pressure
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway.notifications.pending_events
+        info: 'Every available sample in the 5-minute observation window reports at least 1000 notification events pending endpoint reply. Tune this policy threshold for the endpoint.'
+      - name: rgw_notification_store_backlog
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway.notifications.event_state
+        info: 'Every available sample in the 5-minute observation window reports at least 1000 events stored in the persistent notification store. Tune this policy threshold for the workload.'
+      - name: rgw_request_queue_pressure
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway.requests_and_queue.current_requests
+        info: 'Every available sample in the 5-minute observation window reports at least 1000 queued requests. Tune this policy threshold for the RGW instance.'
+      - name: rgw_multisite_fetch_errors
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway_multisite.object_work
+        info: 'Every available sample in the 5-minute observation window reports a non-zero multisite data-fetch error rate.'
+      - name: rgw_multisite_poll_errors
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.object_gateway_multisite.replication_log_request_errors
+        info: 'Every available sample in the 5-minute observation window reports a non-zero replication-log poll error rate.'
       - name: ceph_health_error
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.cluster_status.state

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -4769,6 +4769,38 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.temperature.temperature
         info: 'Every available sample in the 1-minute observation window reports a recognized processor temperature sensor above 80°C.'
+      - name: ceph_filesystem_damaged
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports filesystem metadata damage.'
+      - name: ceph_filesystem_degraded
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports a degraded Ceph filesystem.'
+      - name: ceph_filesystem_failure_no_standby
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports a failed MDS rank with no standby.'
+      - name: ceph_filesystem_insufficient_standby
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports insufficient CephFS standby daemons.'
+      - name: ceph_filesystem_mds_ranks_low
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports fewer active MDS ranks than configured.'
+      - name: ceph_filesystem_offline
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports all MDS ranks unavailable.'
+      - name: ceph_filesystem_read_only
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports a Ceph filesystem forced read-only.'
+      - name: ceph_rbd_mirror_images_not_in_sync
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.rbd_mirror.snapshot_replication.timestamp
+        info: 'The current local and remote snapshot timestamps differ for this mirrored image.'
       - name: ceph_osd_all_up
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -41,7 +41,7 @@ modules:
           description: ""
     setup: &setup
       prerequisites:
-        list: [ ]
+        list: []
       configuration: &prometheus_configuration
         file:
           name: go.d/prometheus.conf
@@ -429,13 +429,13 @@ modules:
         - As Histogram if it has 'le' label.
 
         **The rest are ignored**.
-      availability: [ ]
+      availability: []
       dynamic_context_prefixes:
         - prefix: prometheus.
           reason: >-
             Generic autogen and built-in profiles emit endpoint- and application-specific contexts under the prometheus
             namespace.
-      scopes: [ ]
+      scopes: []
   - <<: *module
     meta:
       <<: *meta
@@ -4564,8 +4564,9 @@ modules:
         list:
           - title: Enable an official Ceph Prometheus endpoint
             description: |
-              Enable the [Ceph MGR Prometheus module](https://docs.ceph.com/en/latest/mgr/prometheus/) for cluster metrics or
-              deploy the official `ceph-exporter` for host-local daemon performance metrics. The stock profile supports the
+              Enable the [Ceph MGR Prometheus module](https://docs.ceph.com/en/latest/mgr/prometheus/) for cluster metrics,
+              deploy the official `ceph-exporter` for host-local daemon performance metrics, or enable the Ceph NVMe-oF
+              gateway exporter on each gateway endpoint. The stock profile supports the
               default priority threshold and the complete priority-0 surface; use `exporter_prio_limit=0` when those diagnostic
               counters are required and size the job limits for the resulting series count. When cephadm node-proxy hardware
               reporting is enabled, hardware series scale with the cluster-wide component inventory; size both
@@ -4601,6 +4602,19 @@ modules:
                     expected_prefix: ceph_
                     max_time_series: 20000
                     max_time_series_per_metric: 4000
+            - name: Ceph NVMe-oF gateway exporter
+              description: |
+                Collect one local gateway endpoint per Ceph NVMe-oF gateway whose local state is required. The gateway
+                exporter is independent of the MGR endpoint and normally listens on port 10008. Preserve one stable job
+                identity for each gateway and size the local series limits independently.
+              config: |
+                jobs:
+                  - name: ceph-nvmeof-gateway-a
+                    url: http://127.0.0.1:10008/metrics
+                    update_every: 5
+                    expected_prefix: ceph_
+                    max_time_series: 10000
+                    max_time_series_per_metric: 2000
             - name: Ceph MGR with virtual node
               description: |
                 Use a virtual node when the cluster identity should remain independent of the Agent currently scraping its
@@ -4627,34 +4641,14 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.subsystems.state_metadata
         info: 'Every available sample in the 5-minute observation window reports an NVMe-oF subsystem configured without host security.'
-      - name: ceph_nvmeof_gateway_cpu_10m
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.nvme_of.gateways.time_accumulation
-        info: 'Holds the lowest local reactor busy-rate sample observed over ten minutes for the gateway CPU policy.'
       - name: ceph_nvmeof_gateway_cpu
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.gateways.time_accumulation
         info: 'The current lowest local reactor busy-rate sample in the 10-minute observation window is above 80 percent.'
-      - name: ceph_nvmeof_read_latency_1m
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
-        info: 'Holds the local one-minute per-block-device read service-time rate.'
-      - name: ceph_nvmeof_read_operations_1m
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.nvme_of.block_devices.operations
-        info: 'Holds the local one-minute per-block-device completed-read rate.'
       - name: ceph_nvmeof_high_read_latency
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
         info: 'The current local one-minute read service-time ratio exceeds 10 milliseconds per completed read.'
-      - name: ceph_nvmeof_write_latency_1m
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
-        info: 'Holds the local one-minute per-block-device write service-time rate.'
-      - name: ceph_nvmeof_write_operations_1m
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.nvme_of.block_devices.operations
-        info: 'Holds the local one-minute per-block-device completed-write rate.'
       - name: ceph_nvmeof_high_write_latency
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.block_devices.time_accumulation
@@ -4662,15 +4656,11 @@ modules:
       - name: ceph_nvmeof_host_keepalive_timeout
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.hosts.keepalive_timeout_state
-        info: 'The exporter currently reports a host disconnected by keepalive timeout. Exporter refresh reads and clears this one-shot state.'
+        info: 'The gateway exporter currently reports host ${label:host_nqn} disconnected from subsystem ${label:nqn}. Inspect the initiator link and reconnect behavior. Exporter refresh reads and clears this one-shot state.'
       - name: ceph_nvmeof_subsystem_namespace_limit
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.subsystems.namespace_capacity
         info: 'The current subsystem namespace count is at or above its configured limit.'
-      - name: ceph_nvmeof_gateway_namespaces
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.nvme_of.gateways.namespace_count
-        info: 'Sums subsystem namespace counts inside the local exporter endpoint.'
       - name: ceph_nvmeof_too_many_namespaces
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.nvme_of.gateways.namespace_count
@@ -4678,15 +4668,15 @@ modules:
       - name: rgw_notification_event_lost
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.object_gateway.notifications.events
-        info: 'Every available sample in the 1-minute observation window reports a non-zero final notification-event loss rate.'
+        info: 'One or more final notification-event losses occurred in the 1-minute observation window. Inspect the affected RGW instance and notification endpoint.'
       - name: rgw_notification_missing_configuration
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.object_gateway.notifications.missing_configurations
-        info: 'Every available sample in the 1-minute observation window reports a non-zero notification missing-configuration rate.'
+        info: 'One or more notifications were rejected for missing configuration in the 1-minute observation window. Inspect the affected RGW instance and notification configuration.'
       - name: rgw_lua_script_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.object_gateway.lua.script_executions
-        info: 'Every available sample in the 1-minute observation window reports a non-zero Lua script failure rate.'
+        info: 'One or more configured Lua request scripts failed in the 1-minute observation window. Inspect the affected RGW instance and script error logs.'
       - name: rgw_failed_request_rate_fallback
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.object_gateway.requests_and_queue.failed_requests
@@ -4718,19 +4708,19 @@ modules:
       - name: ceph_health_error
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.cluster_status.state
-        info: 'Every available Ceph MGR health sample in the 5-minute observation window is HEALTH_ERR.'
+        info: 'Every available Ceph MGR health sample in the 5-minute observation window is HEALTH_ERR. Review active cause-specific Ceph alerts and use `ceph health detail` for the current cause.'
       - name: ceph_health_warning
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.cluster_status.state
-        info: 'Every available Ceph MGR health sample in the 15-minute observation window is HEALTH_WARN.'
+        info: 'Every available Ceph MGR health sample in the 15-minute observation window is HEALTH_WARN. Use `ceph health detail` for the current cause.'
       - name: ceph_daemon_crash
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports a recent daemon crash.'
+        info: 'Every available sample in the 1-minute observation window reports a recent daemon crash. Use `ceph health detail` for the affected daemon and crash details.'
       - name: ceph_mgr_module_crash
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 5-minute observation window reports a recent manager-module crash.'
+        info: 'Every available sample in the 5-minute observation window reports a recent manager-module crash. Use `ceph health detail` for the affected module and crash details.'
       - name: ceph_daemon_slow_ops
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.daemon_health.item_count
@@ -4738,39 +4728,39 @@ modules:
       - name: ceph_slow_ops
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.slow_operations.current_operations
-        info: 'Every available sample in the 30-second observation window reports one or more cluster slow operations.'
+        info: 'Every available sample in the 30-second observation window reports one or more cluster slow operations. Use `ceph health detail` to identify the cause.'
       - name: cephadm_daemon_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 30-second observation window reports a failed cephadm daemon.'
+        info: 'Every available sample in the 30-second observation window reports a failed cephadm daemon. Use `ceph health detail` for the affected daemon and failure details.'
       - name: cephadm_paused
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports that cephadm is paused.'
+        info: 'Every available sample in the 1-minute observation window reports that cephadm is paused. Resume cephadm or use `ceph health detail` to determine why it was paused.'
       - name: cephadm_upgrade_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 30-second observation window reports a cephadm upgrade exception.'
+        info: 'Every available sample in the 30-second observation window reports a cephadm upgrade exception. Use `ceph health detail` for the failed upgrade step.'
       - name: ceph_device_failure_predicted
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports a device predicted to fail.'
+        info: 'Every available sample in the 1-minute observation window reports a device predicted to fail. Use `ceph health detail` and `ceph device ls` to identify it.'
       - name: ceph_device_failure_prediction_too_high
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports that removing all predicted failures would compromise availability.'
+        info: 'Every available sample in the 1-minute observation window reports that removing all predicted failures would compromise availability. Add capacity before relocating data.'
       - name: ceph_device_failure_relocation_incomplete
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports blocked relocation from a predicted device failure.'
+        info: 'Every available sample in the 1-minute observation window reports blocked relocation from a predicted device failure. Check free capacity and the balancer.'
       - name: ceph_cooling_degraded
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports warning health for a reported fan component.'
+        info: 'Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect fan health, airflow, and the system event log.'
       - name: ceph_cooling_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports error health for a reported fan component.'
+        info: 'Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect fan health, airflow, and the system event log.'
       - name: ceph_dimm_temperature_high
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.temperature.temperature
@@ -4802,11 +4792,11 @@ modules:
       - name: ceph_memory_degraded
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports warning health for a reported memory component.'
+        info: 'Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect DIMM health and memory errors.'
       - name: ceph_memory_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports error health for a reported memory component.'
+        info: 'Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect DIMM health and memory errors.'
       - name: ceph_motherboard_temperature_high
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.temperature.temperature
@@ -4814,11 +4804,11 @@ modules:
       - name: ceph_nvme_drive_degraded
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports warning health for a reported storage component.'
+        info: 'Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect drive health and kernel logs.'
       - name: ceph_nvme_drive_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports error health for a reported storage component.'
+        info: 'Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect drive health and kernel logs.'
       - name: ceph_nvme_temperature_high
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.temperature.temperature
@@ -4826,27 +4816,27 @@ modules:
       - name: ceph_network_degraded
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports warning health for a reported network component.'
+        info: 'Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect the interface, link state, and network errors.'
       - name: ceph_network_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports error health for a reported network component.'
+        info: 'Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect the interface, link state, and network errors.'
       - name: ceph_power_supply_degraded
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports warning health for a reported power component.'
+        info: 'Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect the host power supply and system event log.'
       - name: ceph_power_supply_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports error health for a reported power component.'
+        info: 'Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect the host power supply and system event log.'
       - name: ceph_processor_degraded
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports warning health for a reported processor component.'
+        info: 'Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect processor health and thermals.'
       - name: ceph_processor_failed
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.health.state
-        info: 'Every available sample in the 1-minute observation window reports error health for a reported processor component.'
+        info: 'Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect processor health and thermals.'
       - name: ceph_processor_temperature_high
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.temperature.temperature
@@ -4883,10 +4873,6 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.rbd_mirror.snapshot_replication.timestamp
         info: 'The current local and remote snapshot timestamps differ for this mirrored image.'
-      - name: ceph_osd_all_up
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
-        info: 'Holds the current all-configured-OSDs-up state.'
       - name: ceph_object_missing
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
@@ -4907,10 +4893,6 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
         info: 'Every available sample in the 1-minute observation window reports recovery blocked by OSD fullness.'
-      - name: ceph_osd_down_current
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.health.health_checks.state
-        info: 'Holds the current OSD-down health state.'
       - name: ceph_pg_unavailable_blocking_io
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
@@ -4919,10 +4901,6 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
         info: 'Every available sample in the 5-minute observation window reports damaged placement-group data.'
-      - name: ceph_osd_scrub_errors
-        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
-        metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 5-minute observation window reports scrub errors when PG-damage is not already active.'
       - name: ceph_pgs_high_per_osd
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
@@ -4950,15 +4928,15 @@ modules:
       - name: ceph_mon_clock_skew
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports monitor clock skew.'
+        info: 'Every available sample in the 1-minute observation window reports monitor clock skew. Use `ceph time-sync-status` and inspect the monitors'' time synchronization services.'
       - name: ceph_mon_diskspace_critical
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports critically low monitor-store space.'
+        info: 'Every available sample in the 1-minute observation window reports critically low monitor-store space. Use `ceph health detail` to identify the affected monitor.'
       - name: ceph_mon_diskspace_low
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 5-minute observation window reports low monitor-store space.'
+        info: 'Every available sample in the 5-minute observation window reports low monitor-store space. Use `ceph health detail` to identify the affected monitor.'
       - name: ceph_mon_down
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.control_plane.monitor.cluster_summary
@@ -4974,7 +4952,7 @@ modules:
       - name: ceph_osd_down
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 5-minute observation window reports a down OSD.'
+        info: 'Every available sample in the 5-minute observation window reports a down OSD. Use `ceph health detail` to identify affected OSDs and hosts.'
       - name: ceph_osd_down_high
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
@@ -4982,11 +4960,11 @@ modules:
       - name: ceph_osd_full
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports an OSD at its full threshold.'
+        info: 'Every available sample in the 1-minute observation window reports an OSD at its full threshold. Use `ceph health detail` and `ceph osd df` to identify it.'
       - name: ceph_osd_host_down
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 5-minute observation window reports an offline OSD host.'
+        info: 'Every available sample in the 5-minute observation window reports an offline OSD host. Use `ceph health detail` to identify the host and its OSDs.'
       - name: ceph_osd_internal_disk_size_mismatch
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
@@ -4994,19 +4972,19 @@ modules:
       - name: ceph_osd_near_full
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 5-minute observation window reports an OSD at its near-full threshold.'
+        info: 'Every available sample in the 5-minute observation window reports an OSD at its near-full threshold. Use `ceph health detail` and `ceph osd df` to identify it.'
       - name: ceph_osd_read_errors
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 30-second observation window reports BlueStore read errors that succeeded only after retries.'
+        info: 'Every available sample in the 30-second observation window reports BlueStore read errors that succeeded only after retries. Inspect the affected hardware and kernel.'
       - name: ceph_osd_timeouts_cluster_network
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports slow backend OSD heartbeats.'
+        info: 'Every available sample in the 1-minute observation window reports slow backend OSD heartbeats. Inspect the cluster network for latency or loss.'
       - name: ceph_osd_timeouts_public_network
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports slow frontend OSD heartbeats.'
+        info: 'Every available sample in the 1-minute observation window reports slow frontend OSD heartbeats. Inspect the public network for latency or loss.'
       - name: ceph_osd_too_many_repairs
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
@@ -5014,7 +4992,7 @@ modules:
       - name: ceph_unknown_health_check
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state
-        info: 'Every available sample in the 1-minute observation window reports an unclassified ordinary health check.'
+        info: 'Every available sample in the 1-minute observation window reports the unclassified health check ${label:name}. Use `ceph health detail` for its recorded explanation.'
 
   - <<: *module
     meta:

--- a/src/go/plugin/go.d/collector/prometheus/metadata.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/metadata.yaml
@@ -4769,6 +4769,70 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.node_hardware.temperature.temperature
         info: 'Every available sample in the 1-minute observation window reports a recognized processor temperature sensor above 80°C.'
+      - name: ceph_osd_all_up
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
+        info: 'Internal helper holding the current all-configured-OSDs-up state; it does not notify.'
+      - name: ceph_object_missing
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'The current unfound condition is active while every configured OSD is up; client I/O for affected objects can block.'
+      - name: ceph_pg_backfill_at_risk
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports placement-group backfill blocked by fullness.'
+      - name: ceph_pg_not_deep_scrubbed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports placement groups overdue for deep scrub.'
+      - name: ceph_pg_not_scrubbed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports placement groups overdue for scrub.'
+      - name: ceph_pg_recovery_at_risk
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports recovery blocked by OSD fullness.'
+      - name: ceph_osd_down_current
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Internal helper holding the current OSD-down health state; it does not notify.'
+      - name: ceph_pg_unavailable_blocking_io
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'The current PG-unavailable condition is active while the separate OSD-down condition is not.'
+      - name: ceph_pgs_damaged
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports damaged placement-group data.'
+      - name: ceph_osd_scrub_errors
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports scrub errors when PG-damage is not already active.'
+      - name: ceph_pgs_high_per_osd
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports excessive placement groups per OSD.'
+      - name: ceph_pgs_inactive
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.placement_groups_and_recovery.healthy_state.pg_state
+        info: 'The current per-pool count reports fewer active placement groups than the pool total.'
+      - name: ceph_pgs_unclean
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.placement_groups_and_recovery.healthy_state.pg_state
+        info: 'The current per-pool count reports fewer clean placement groups than the pool total.'
+      - name: ceph_pool_backfill_full
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 10-second observation window reports a pool at its backfill-full threshold.'
+      - name: ceph_pool_full
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 1-minute observation window reports a full pool.'
+      - name: ceph_pool_near_full
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
+        metric: prometheus.ceph.health.health_checks.state
+        info: 'Every available sample in the 5-minute observation window reports a near-full pool.'
       - name: ceph_mon_clock_skew
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/ceph.conf
         metric: prometheus.ceph.health.health_checks.state

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -1462,7 +1462,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.accumulated_latency:
-    family: Ceph/BlueFS/I/O and Files
+    family: Ceph/BlueFS/IO and Files
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1495,7 +1495,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.byte_throughput:
-    family: Ceph/BlueFS/I/O and Files
+    family: Ceph/BlueFS/IO and Files
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1556,7 +1556,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.latency_measurements:
-    family: Ceph/BlueFS/I/O and Files
+    family: Ceph/BlueFS/IO and Files
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1589,7 +1589,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.operations:
-    family: Ceph/BlueFS/I/O and Files
+    family: Ceph/BlueFS/IO and Files
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1642,7 +1642,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.zero_read_outcomes:
-    family: Ceph/BlueFS/I/O and Files
+    family: Ceph/BlueFS/IO and Files
     question: What is the zero-read outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1917,7 +1917,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.accumulated_latency:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1950,7 +1950,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.byte_throughput:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1987,7 +1987,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.latency_measurements:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2020,7 +2020,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.penalty_reads:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the penalty reads for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2033,7 +2033,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.read_outcomes:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the read outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2050,7 +2050,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.skipped_blobs:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the skipped blobs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2063,7 +2063,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.skipped_writes:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the skipped writes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2076,7 +2076,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.slow_aio_waits:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the slow aio waits for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2089,7 +2089,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.slow_reads:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the slow reads for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2106,7 +2106,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.write_operations:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the write operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2147,7 +2147,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.written_blobs:
-    family: Ceph/BlueStore/I/O
+    family: Ceph/BlueStore/IO
     question: What is the written blobs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7574,7 +7574,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.accumulated_latency:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7655,7 +7655,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.byte_throughput:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7700,7 +7700,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.current_operations:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the operations in progress for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7713,7 +7713,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.events:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7726,7 +7726,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.failure_outcomes:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7739,7 +7739,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.latency_measurements:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7820,7 +7820,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.lookup_outcomes:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7833,7 +7833,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.object_work:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the object work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7854,7 +7854,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.operations:
-    family: Ceph/OSD Client I/O
+    family: Ceph/OSD Client IO
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9651,7 +9651,7 @@ views:
       evidence:
       - ceph_display_conventions
   pools.client_i_o.byte_throughput:
-    family: Ceph/Pools/Client I/O
+    family: Ceph/Pools/Client IO
     question: What is the byte throughput for each pool id?
     entity: by_pool_id
     inputs:
@@ -9668,7 +9668,7 @@ views:
       promote: []
       omit: {}
   pools.client_i_o.operations:
-    family: Ceph/Pools/Client I/O
+    family: Ceph/Pools/Client IO
     question: What is the operations for each pool id?
     entity: by_pool_id
     inputs:
@@ -10065,7 +10065,7 @@ views:
       promote: []
       omit: {}
   rbd_images.i_o.byte_throughput:
-    family: Ceph/RBD Images/I/O
+    family: Ceph/RBD Images/IO
     question: What is the byte throughput for each image and namespace and pool?
     entity: by_image_and_namespace_and_pool
     inputs:
@@ -10082,7 +10082,7 @@ views:
       promote: []
       omit: {}
   rbd_images.i_o.operations:
-    family: Ceph/RBD Images/I/O
+    family: Ceph/RBD Images/IO
     question: What is the operations for each image and namespace and pool?
     entity: by_image_and_namespace_and_pool
     inputs:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -39,13 +39,13 @@ entities:
     grain: Ceph application and compression mode and description and name and pool id and type
     identity:
       required:
-      - application
       - compression_mode
       - description
       - name
       - pool_id
       - type
-      optional: []
+      optional:
+      - application
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -104,12 +104,12 @@ entities:
       required:
       - ceph_daemon
       - ceph_instance
-      - db_device
       - device
       - device_ids
       - devices
+      optional:
+      - db_device
       - wal_device
-      optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -260,13 +260,14 @@ entities:
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
-  by_ceph_daemon_and_id_and_instance_id:
-    grain: Ceph ceph daemon and id and instance id
+  by_id_and_daemon_owner_alternative:
+    grain: Ceph labeled worker ID with exactly one daemon-owner identity
     identity:
       required:
-      - ceph_daemon
       - id
-      - instance_id
+      alternatives:
+        - - ceph_daemon
+        - - instance_id
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -545,6 +546,51 @@ entities:
       - instance_id
       optional:
       - source_zone
+    high_cardinality_acceptance:
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
+        Netdata aggregation.
+  by_instance_id_and_user_and_tenant:
+    grain: Ceph instance id and user and tenant
+    identity:
+      required:
+      - instance_id
+      - user
+      optional:
+      - tenant
+    high_cardinality_acceptance:
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
+        Netdata aggregation.
+  by_instance_id_and_bucket_and_tenant:
+    grain: Ceph instance id and bucket and tenant
+    identity:
+      required:
+      - instance_id
+      - bucket
+      optional:
+      - tenant
+    high_cardinality_acceptance:
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
+        Netdata aggregation.
+  by_instance_id_and_local_zone_id_and_source_zone_id_and_shard_id_and_sync_shard:
+    grain: Ceph instance id, zone identities, shard id, and dynamic grammar identity
+    identity:
+      required:
+      - instance_id
+      - local_zone_id
+      - source_zone_id
+      - shard_id
+      optional:
+      - sync_shard
+    high_cardinality_acceptance:
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
+        Netdata aggregation.
+  by_instance_id_and_topic:
+    grain: Ceph instance id and topic
+    identity:
+      required:
+      - instance_id
+      optional:
+      - topic
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
@@ -857,6 +903,38 @@ normalizations:
       - label_objecter_handle
     evidence:
     - normalization_objecter_identity
+  rgw_topic_identity:
+    kind: embedded_identity_extract
+    registry_grammar: rgw_topic
+    target_label: topic
+    retain:
+      family: canonical_branch
+      captured_identity: true
+    output:
+      meaning: Persistent notification topic identity.
+      endpoint_cardinality:
+        kind: operational_population
+      stability: stable
+      evidence:
+      - labels_rgw_topic_persistent_topic_len
+    evidence:
+    - normalization_rgw_topic_identity
+  rgw_sync_delta_identity:
+    kind: embedded_identity_extract
+    registry_grammar: rgw_sync_delta
+    target_label: sync_shard
+    retain:
+      family: canonical_branch
+      captured_identity: true
+    output:
+      meaning: Dynamic multisite data-log shard identity.
+      endpoint_cardinality:
+        kind: operational_population
+      stability: dynamic
+      evidence:
+      - labels_rgw_sync_delta_sync_delta
+    evidence:
+    - normalization_rgw_sync_delta_identity
   rdma_worker_identity:
     kind: embedded_identity_extract
     registry_grammar: rdma_worker
@@ -5634,8 +5712,8 @@ views:
       omit: {}
   messenger.connection_timeouts:
     family: Ceph/Messenger
-    question: What is the connection timeouts for each ceph daemon and id and instance id?
-    entity: by_ceph_daemon_and_id_and_instance_id
+    question: What is the connection timeout rate for each worker and its daemon-owner alternative?
+    entity: by_id_and_daemon_owner_alternative
     inputs:
       worker_msgr_connection_idle_timeouts:
         signal: asyncmessenger_worker_msgr_connection_idle_timeouts
@@ -6878,6 +6956,513 @@ views:
       dimensions: {}
       promote: []
       omit: {}
+  object_gateway.global_operations.operations:
+    family: Ceph/Object Gateway/Global Operations
+    question: What is the operations for each instance id?
+    entity: by_instance_id
+    inputs:
+      copy_obj:
+        signal: rgw_op_copy_obj_ops
+        components:
+        - value
+      del_bucket:
+        signal: rgw_op_del_bucket_ops
+        components:
+        - value
+      del_obj:
+        signal: rgw_op_del_obj_ops
+        components:
+        - value
+      get_obj:
+        signal: rgw_op_get_obj_ops
+        components:
+        - value
+      list_buckets:
+        signal: rgw_op_list_buckets_ops
+        components:
+        - value
+      list_obj:
+        signal: rgw_op_list_obj_ops
+        components:
+        - value
+      put_obj:
+        signal: rgw_op_put_obj_ops
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.global_operations.object_bytes:
+    family: Ceph/Object Gateway/Global Operations
+    question: What is the object bytes for each instance id?
+    entity: by_instance_id
+    inputs:
+      copy_obj:
+        signal: rgw_op_copy_obj_bytes
+        components:
+        - value
+      del_obj:
+        signal: rgw_op_del_obj_bytes
+        components:
+        - value
+      get_obj:
+        signal: rgw_op_get_obj_bytes
+        components:
+        - value
+      put_obj:
+        signal: rgw_op_put_obj_bytes
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.global_operations.latency_measurements:
+    family: Ceph/Object Gateway/Global Operations
+    question: What is the latency measurements for each instance id?
+    entity: by_instance_id
+    inputs:
+      copy_obj:
+        signal: rgw_op_copy_obj_lat
+        components:
+        - value
+      del_bucket:
+        signal: rgw_op_del_bucket_lat
+        components:
+        - value
+      del_obj:
+        signal: rgw_op_del_obj_lat
+        components:
+        - value
+      get_obj:
+        signal: rgw_op_get_obj_lat
+        components:
+        - value
+      list_buckets:
+        signal: rgw_op_list_buckets_lat
+        components:
+        - value
+      list_obj:
+        signal: rgw_op_list_obj_lat
+        components:
+        - value
+      put_obj:
+        signal: rgw_op_put_obj_lat
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.global_operations.accumulated_latency:
+    family: Ceph/Object Gateway/Global Operations
+    question: What is the accumulated latency for each instance id?
+    entity: by_instance_id
+    inputs:
+      copy_obj:
+        signal: rgw_op_copy_obj_lat_sum
+        components:
+        - value
+      del_bucket:
+        signal: rgw_op_del_bucket_lat_sum
+        components:
+        - value
+      del_obj:
+        signal: rgw_op_del_obj_lat_sum
+        components:
+        - value
+      get_obj:
+        signal: rgw_op_get_obj_lat_sum
+        components:
+        - value
+      list_buckets:
+        signal: rgw_op_list_buckets_lat_sum
+        components:
+        - value
+      list_obj:
+        signal: rgw_op_list_obj_lat_sum
+        components:
+        - value
+      put_obj:
+        signal: rgw_op_put_obj_lat_sum
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.user_operations.operations:
+    family: Ceph/Object Gateway/User Operations
+    question: What is the operations for each instance id and user and tenant?
+    entity: by_instance_id_and_user_and_tenant
+    inputs:
+      copy_obj:
+        signal: rgw_user_op_copy_obj_ops
+        components:
+        - value
+      del_bucket:
+        signal: rgw_user_op_del_bucket_ops
+        components:
+        - value
+      del_obj:
+        signal: rgw_user_op_del_obj_ops
+        components:
+        - value
+      get_obj:
+        signal: rgw_user_op_get_obj_ops
+        components:
+        - value
+      list_buckets:
+        signal: rgw_user_op_list_buckets_ops
+        components:
+        - value
+      list_obj:
+        signal: rgw_user_op_list_obj_ops
+        components:
+        - value
+      put_obj:
+        signal: rgw_user_op_put_obj_ops
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.user_operations.object_bytes:
+    family: Ceph/Object Gateway/User Operations
+    question: What is the object bytes for each instance id and user and tenant?
+    entity: by_instance_id_and_user_and_tenant
+    inputs:
+      copy_obj:
+        signal: rgw_user_op_copy_obj_bytes
+        components:
+        - value
+      del_obj:
+        signal: rgw_user_op_del_obj_bytes
+        components:
+        - value
+      get_obj:
+        signal: rgw_user_op_get_obj_bytes
+        components:
+        - value
+      put_obj:
+        signal: rgw_user_op_put_obj_bytes
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.user_operations.latency_measurements:
+    family: Ceph/Object Gateway/User Operations
+    question: What is the latency measurements for each instance id and user and tenant?
+    entity: by_instance_id_and_user_and_tenant
+    inputs:
+      copy_obj:
+        signal: rgw_user_op_copy_obj_lat
+        components:
+        - value
+      del_bucket:
+        signal: rgw_user_op_del_bucket_lat
+        components:
+        - value
+      del_obj:
+        signal: rgw_user_op_del_obj_lat
+        components:
+        - value
+      get_obj:
+        signal: rgw_user_op_get_obj_lat
+        components:
+        - value
+      list_buckets:
+        signal: rgw_user_op_list_buckets_lat
+        components:
+        - value
+      list_obj:
+        signal: rgw_user_op_list_obj_lat
+        components:
+        - value
+      put_obj:
+        signal: rgw_user_op_put_obj_lat
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.user_operations.accumulated_latency:
+    family: Ceph/Object Gateway/User Operations
+    question: What is the accumulated latency for each instance id and user and tenant?
+    entity: by_instance_id_and_user_and_tenant
+    inputs:
+      copy_obj:
+        signal: rgw_user_op_copy_obj_lat_sum
+        components:
+        - value
+      del_bucket:
+        signal: rgw_user_op_del_bucket_lat_sum
+        components:
+        - value
+      del_obj:
+        signal: rgw_user_op_del_obj_lat_sum
+        components:
+        - value
+      get_obj:
+        signal: rgw_user_op_get_obj_lat_sum
+        components:
+        - value
+      list_buckets:
+        signal: rgw_user_op_list_buckets_lat_sum
+        components:
+        - value
+      list_obj:
+        signal: rgw_user_op_list_obj_lat_sum
+        components:
+        - value
+      put_obj:
+        signal: rgw_user_op_put_obj_lat_sum
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.bucket_operations.operations:
+    family: Ceph/Object Gateway/Bucket Operations
+    question: What is the operations for each instance id and bucket and tenant?
+    entity: by_instance_id_and_bucket_and_tenant
+    inputs:
+      copy_obj:
+        signal: rgw_bucket_op_copy_obj_ops
+        components:
+        - value
+      del_bucket:
+        signal: rgw_bucket_op_del_bucket_ops
+        components:
+        - value
+      del_obj:
+        signal: rgw_bucket_op_del_obj_ops
+        components:
+        - value
+      get_obj:
+        signal: rgw_bucket_op_get_obj_ops
+        components:
+        - value
+      list_buckets:
+        signal: rgw_bucket_op_list_buckets_ops
+        components:
+        - value
+      list_obj:
+        signal: rgw_bucket_op_list_obj_ops
+        components:
+        - value
+      put_obj:
+        signal: rgw_bucket_op_put_obj_ops
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.bucket_operations.object_bytes:
+    family: Ceph/Object Gateway/Bucket Operations
+    question: What is the object bytes for each instance id and bucket and tenant?
+    entity: by_instance_id_and_bucket_and_tenant
+    inputs:
+      copy_obj:
+        signal: rgw_bucket_op_copy_obj_bytes
+        components:
+        - value
+      del_obj:
+        signal: rgw_bucket_op_del_obj_bytes
+        components:
+        - value
+      get_obj:
+        signal: rgw_bucket_op_get_obj_bytes
+        components:
+        - value
+      put_obj:
+        signal: rgw_bucket_op_put_obj_bytes
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.bucket_operations.latency_measurements:
+    family: Ceph/Object Gateway/Bucket Operations
+    question: What is the latency measurements for each instance id and bucket and tenant?
+    entity: by_instance_id_and_bucket_and_tenant
+    inputs:
+      copy_obj:
+        signal: rgw_bucket_op_copy_obj_lat
+        components:
+        - value
+      del_bucket:
+        signal: rgw_bucket_op_del_bucket_lat
+        components:
+        - value
+      del_obj:
+        signal: rgw_bucket_op_del_obj_lat
+        components:
+        - value
+      get_obj:
+        signal: rgw_bucket_op_get_obj_lat
+        components:
+        - value
+      list_buckets:
+        signal: rgw_bucket_op_list_buckets_lat
+        components:
+        - value
+      list_obj:
+        signal: rgw_bucket_op_list_obj_lat
+        components:
+        - value
+      put_obj:
+        signal: rgw_bucket_op_put_obj_lat
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.bucket_operations.accumulated_latency:
+    family: Ceph/Object Gateway/Bucket Operations
+    question: What is the accumulated latency for each instance id and bucket and tenant?
+    entity: by_instance_id_and_bucket_and_tenant
+    inputs:
+      copy_obj:
+        signal: rgw_bucket_op_copy_obj_lat_sum
+        components:
+        - value
+      del_bucket:
+        signal: rgw_bucket_op_del_bucket_lat_sum
+        components:
+        - value
+      del_obj:
+        signal: rgw_bucket_op_del_obj_lat_sum
+        components:
+        - value
+      get_obj:
+        signal: rgw_bucket_op_get_obj_lat_sum
+        components:
+        - value
+      list_buckets:
+        signal: rgw_bucket_op_list_buckets_lat_sum
+        components:
+        - value
+      list_obj:
+        signal: rgw_bucket_op_list_obj_lat_sum
+        components:
+        - value
+      put_obj:
+        signal: rgw_bucket_op_put_obj_lat_sum
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway_multisite.data_log_shard_delay:
+    family: Ceph/Object Gateway/Multisite
+    question: What is the current data-log shard delay for each instance id and dynamic sync shard?
+    entity: by_instance_id_and_local_zone_id_and_source_zone_id_and_shard_id_and_sync_shard
+    inputs:
+      sync_delta:
+        signal: rgw_sync_delta_sync_delta
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+
+  object_gateway.persistent_topics.queue_length:
+    family: Ceph/Object Gateway/Persistent Topics
+    question: What is the persistent topic queue length for each instance id and topic?
+    entity: by_instance_id_and_topic
+    inputs:
+      entries:
+        signal: rgw_topic_persistent_topic_len
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway.persistent_topics.queue_size:
+    family: Ceph/Object Gateway/Persistent Topics
+    question: What is the persistent topic queue size for each instance id and topic?
+    entity: by_instance_id_and_topic
+    inputs:
+      bytes:
+        signal: rgw_topic_persistent_topic_size
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+
+  object_gateway_cache.d4n_lookup_outcomes:
+    family: Ceph/Object Gateway/Cache
+    question: What are the D4N cache lookup outcomes for each instance id?
+    entity: by_instance_id
+    inputs:
+      hit:
+        signal: rgw_d4n_cache_hits
+        components:
+        - value
+      miss:
+        signal: rgw_d4n_cache_misses
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway_cache.d4n_cache_evictions:
+    family: Ceph/Object Gateway/Cache
+    question: What is the D4N cache eviction rate for each instance id?
+    entity: by_instance_id
+    inputs:
+      eviction:
+        signal: rgw_d4n_cache_evictions
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+
+  object_gateway_scheduling.simple_throttler_outstanding:
+    family: Ceph/Object Gateway/Scheduling
+    question: What is the current simple throttler outstanding requests for each instance id?
+    entity: by_instance_id
+    inputs:
+      outstanding:
+        signal: simple_throttler_outstanding
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  object_gateway_scheduling.simple_throttler_rejections:
+    family: Ceph/Object Gateway/Scheduling
+    question: What is the cumulative simple throttler request rejections for each instance id?
+    entity: by_instance_id
+    inputs:
+      throttled:
+        signal: simple_throttler_throttle
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+
   objecter.accumulated_latency:
     family: Ceph/Runtime and Clients/Objecter
     question: What is the accumulated latency for each ceph daemon and instance id?

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -12,434 +12,434 @@ entities:
     grain: Ceph NVMe-oF subsystem security/group/HA/model/NQN/serial metadata
     identity:
       required:
-      - allow_any_host
-      - group
-      - ha_enabled
-      - model_number
-      - nqn
-      - serial_number
+        - allow_any_host
+        - group
+        - ha_enabled
+        - model_number
+        - nqn
+        - serial_number
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_anagrpid_and_bdev_name_and_nqn_and_nsid_and_rados_namespace_name:
     grain: Ceph NVMe-oF namespace metadata identity
     identity:
       required:
-      - anagrpid
-      - bdev_name
-      - nqn
-      - nsid
-      - rados_namespace_name
+        - anagrpid
+        - bdev_name
+        - nqn
+        - nsid
+        - rados_namespace_name
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_application_and_compression_mode_and_description_and_name_and_pool_id_and_type:
     grain: Ceph application and compression mode and description and name and pool id and type
     identity:
       required:
-      - compression_mode
-      - description
-      - name
-      - pool_id
-      - type
+        - compression_mode
+        - description
+        - name
+        - pool_id
+        - type
       optional:
-      - application
+        - application
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   ? by_back_iface_and_ceph_daemon_and_ceph_version_and_cluster_addr_and_device_class_and_front_iface_and_hostname_and_objectstore_and_public_addr
-  : grain: Ceph back iface and ceph daemon and ceph version and cluster addr and device class and front iface and hostname
-      and objectstore and public addr
+  : grain: Ceph back iface and ceph daemon and ceph version and cluster addr and device class and front iface and
+      hostname and objectstore and public addr
     identity:
       required:
-      - back_iface
-      - ceph_daemon
-      - ceph_version
-      - cluster_addr
-      - device_class
-      - front_iface
-      - hostname
-      - objectstore
-      - public_addr
+        - back_iface
+        - ceph_daemon
+        - ceph_version
+        - cluster_addr
+        - device_class
+        - front_iface
+        - hostname
+        - objectstore
+        - public_addr
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_bdev_name:
     grain: Ceph bdev name
     identity:
       required:
-      - bdev_name
+        - bdev_name
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_bdev_name_and_block_size_and_namespace_and_pool_name_and_rbd_name:
     grain: Ceph NVMe-oF bdev name, block size, namespace, pool name, and RBD name
     identity:
       required:
-      - bdev_name
-      - block_size
-      - namespace
-      - pool_name
-      - rbd_name
+        - bdev_name
+        - block_size
+        - namespace
+        - pool_name
+        - rbd_name
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon:
     grain: Ceph ceph daemon
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_ceph_instance_and_db_device_and_device_and_device_ids_and_devices_and_wal_device:
     grain: Ceph ceph daemon and ceph instance and db device and device and device ids and devices and wal device
     identity:
       required:
-      - ceph_daemon
-      - ceph_instance
-      - device
-      - device_ids
-      - devices
+        - ceph_daemon
+        - ceph_instance
+        - device
+        - device_ids
+        - devices
       optional:
-      - db_device
-      - wal_device
+        - db_device
+        - wal_device
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_ceph_instance_and_device:
     grain: Ceph ceph daemon and ceph instance and device
     identity:
       required:
-      - ceph_daemon
-      - ceph_instance
-      - device
+        - ceph_daemon
+        - ceph_instance
+        - device
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_ceph_version_and_fs_id_and_hostname_and_public_addr_and_rank:
     grain: Ceph ceph daemon and ceph version and fs id and hostname and public addr and rank
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - fs_id
-      - hostname
-      - public_addr
-      - rank
+        - ceph_daemon
+        - ceph_version
+        - fs_id
+        - hostname
+        - public_addr
+        - rank
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_ceph_version_and_hostname:
     grain: Ceph ceph daemon and ceph version and hostname
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - hostname
+        - ceph_daemon
+        - ceph_version
+        - hostname
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_ceph_version_and_hostname_and_id_and_instance_id:
     grain: Ceph ceph daemon and ceph version and hostname and id and instance id
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - hostname
-      - id
-      - instance_id
+        - ceph_daemon
+        - ceph_version
+        - hostname
+        - id
+        - instance_id
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_ceph_version_and_hostname_and_instance_id:
     grain: Ceph ceph daemon and ceph version and hostname and instance id
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - hostname
-      - instance_id
+        - ceph_daemon
+        - ceph_version
+        - hostname
+        - instance_id
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_ceph_version_and_hostname_and_public_addr_and_rank:
     grain: Ceph ceph daemon and ceph version and hostname and public addr and rank
     identity:
       required:
-      - ceph_daemon
-      - ceph_version
-      - hostname
-      - public_addr
-      - rank
+        - ceph_daemon
+        - ceph_version
+        - hostname
+        - public_addr
+        - rank
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key:
     grain: Ceph ceph daemon and client and rank and mds filesystem key
     identity:
       required:
-      - ceph_daemon
-      - client
-      - rank
+        - ceph_daemon
+        - client
+        - rank
       optional:
-      - mds_filesystem_key
+        - mds_filesystem_key
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_dpdk_port:
     grain: Ceph ceph daemon and dpdk port
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - dpdk_port
+        - dpdk_port
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_dpdk_queue:
     grain: Ceph ceph daemon and dpdk queue
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - dpdk_queue
+        - dpdk_queue
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_filesystem:
     grain: Ceph ceph daemon and filesystem
     identity:
       required:
-      - ceph_daemon
-      - filesystem
+        - ceph_daemon
+        - filesystem
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_finisher_key:
     grain: Ceph ceph daemon and finisher key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - finisher_key
+        - finisher_key
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_fs_name_and_id:
     grain: Ceph ceph daemon and fs name and id
     identity:
       required:
-      - ceph_daemon
-      - fs_name
-      - id
+        - ceph_daemon
+        - fs_name
+        - id
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_hostname:
     grain: Ceph ceph daemon and hostname
     identity:
       required:
-      - ceph_daemon
-      - hostname
+        - ceph_daemon
+        - hostname
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_id_and_daemon_owner_alternative:
     grain: Ceph labeled worker ID with exactly one daemon-owner identity
     identity:
       required:
-      - id
+        - id
       alternatives:
         - - ceph_daemon
         - - instance_id
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_image_and_namespace_and_pool:
     grain: Ceph ceph daemon and image and namespace and pool
     identity:
       required:
-      - ceph_daemon
-      - image
-      - namespace
-      - pool
+        - ceph_daemon
+        - image
+        - namespace
+        - pool
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_instance_id:
     grain: Ceph ceph daemon and instance id
     identity:
       required: []
       optional: []
       alternatives:
-      - - ceph_daemon
-      - - instance_id
+        - - ceph_daemon
+        - - instance_id
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_kernel_device_key:
     grain: Ceph ceph daemon and kernel device key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - kernel_device_key
+        - kernel_device_key
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_level_and_pooltype:
     grain: Ceph ceph daemon and level and pooltype
     identity:
       required:
-      - ceph_daemon
-      - level
-      - pooltype
+        - ceph_daemon
+        - level
+        - pooltype
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_librbd_image_key:
     grain: Ceph ceph daemon and librbd image key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - librbd_image_key
+        - librbd_image_key
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_librbd_pwl_key:
     grain: Ceph ceph daemon and librbd pwl key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - librbd_pwl_key
+        - librbd_pwl_key
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_mclock_shard:
     grain: Ceph ceph daemon and mclock shard
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - mclock_shard
+        - mclock_shard
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_messenger_worker:
     grain: Ceph ceph daemon and messenger worker
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - messenger_worker
+        - messenger_worker
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_objectcacher_key:
     grain: Ceph ceph daemon and objectcacher key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - objectcacher_key
+        - objectcacher_key
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid:
     grain: Ceph ceph daemon and peer cluster filesystem and peer cluster name and source filesystem and source fscid
     identity:
       required:
-      - ceph_daemon
-      - peer_cluster_filesystem
-      - peer_cluster_name
-      - source_filesystem
-      - source_fscid
+        - ceph_daemon
+        - peer_cluster_filesystem
+        - peer_cluster_name
+        - source_filesystem
+        - source_fscid
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_rdma_worker:
     grain: Ceph ceph daemon and rdma worker
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - rdma_worker
+        - rdma_worker
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_rocksdb_cache_key:
     grain: Ceph ceph daemon and rocksdb cache key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - rocksdb_cache_key
+        - rocksdb_cache_key
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_service_unique_id:
     grain: Ceph ceph daemon and service unique id
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - service_unique_id
+        - service_unique_id
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_throttle_key:
     grain: Ceph ceph daemon and throttle key
     identity:
       required:
-      - ceph_daemon
+        - ceph_daemon
       optional:
-      - throttle_key
+        - throttle_key
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_ceph_daemon_and_type:
     grain: Ceph ceph daemon and type
     identity:
       required:
-      - ceph_daemon
-      - type
+        - ceph_daemon
+        - type
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_gw_name_and_host_nqn_and_nqn:
     grain: Ceph NVMe-oF gateway name, host NQN, and subsystem NQN
     identity:
       required:
-      - gw_name
-      - host_nqn
-      - nqn
+        - gw_name
+        - host_nqn
+        - nqn
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   local_gateway_endpoint:
     grain: One direct NVMe-oF exporter endpoint selected by the collector job
     identity:
@@ -449,207 +449,207 @@ entities:
     grain: Ceph daemon name and hostname and service name and service type
     identity:
       required:
-      - daemon_name
-      - hostname
-      - service_name
-      - service_type
+        - daemon_name
+        - hostname
+        - service_name
+        - service_type
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_data_pools_and_fs_id_and_metadata_pool_and_name:
     grain: Ceph data pools and fs id and metadata pool and name
     identity:
       required:
-      - data_pools
-      - fs_id
-      - metadata_pool
-      - name
+        - data_pools
+        - fs_id
+        - metadata_pool
+        - name
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_device:
     grain: Ceph device
     identity:
       required:
-      - device
+        - device
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_device_class:
     grain: Ceph device class
     identity:
       required:
-      - device_class
+        - device_class
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_function_and_host:
     grain: Ceph function and host
     identity:
       required:
-      - function
-      - host
+        - function
+        - host
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_gw_name_and_host_addr_and_host_nqn_and_nqn:
     grain: Ceph gw name and host addr and host nqn and nqn
     identity:
       required:
-      - gw_name
-      - host_addr
-      - host_nqn
-      - nqn
+        - gw_name
+        - host_addr
+        - host_nqn
+        - nqn
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_image_and_namespace_and_pool:
     grain: Ceph image and namespace and pool
     identity:
       required:
-      - image
-      - namespace
-      - pool
+        - image
+        - namespace
+        - pool
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_image_name_and_pool_id:
     grain: Ceph image name and pool id
     identity:
       required:
-      - image_name
-      - pool_id
+        - image_name
+        - pool_id
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_instance_id:
     grain: Ceph instance id
     identity:
       required:
-      - instance_id
+        - instance_id
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_instance_id_and_source_zone:
     grain: Ceph instance id and source zone
     identity:
       required:
-      - instance_id
+        - instance_id
       optional:
-      - source_zone
+        - source_zone
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_instance_id_and_user_and_tenant:
     grain: Ceph instance id and user and tenant
     identity:
       required:
-      - instance_id
-      - user
+        - instance_id
+        - user
       optional:
-      - tenant
+        - tenant
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_instance_id_and_bucket_and_tenant:
     grain: Ceph instance id and bucket and tenant
     identity:
       required:
-      - instance_id
-      - bucket
+        - instance_id
+        - bucket
       optional:
-      - tenant
+        - tenant
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_instance_id_and_local_zone_id_and_source_zone_id_and_shard_id_and_sync_shard:
     grain: Ceph instance id, zone identities, shard id, and dynamic grammar identity
     identity:
       required:
-      - instance_id
-      - local_zone_id
-      - source_zone_id
-      - shard_id
+        - instance_id
+        - local_zone_id
+        - source_zone_id
+        - shard_id
       optional:
-      - sync_shard
+        - sync_shard
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_instance_id_and_topic:
     grain: Ceph instance id and topic
     identity:
       required:
-      - instance_id
+        - instance_id
       optional:
-      - topic
+        - topic
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_method:
     grain: Ceph method
     identity:
       required:
-      - method
+        - method
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_name:
     grain: Ceph name
     identity:
       required:
-      - name
+        - name
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_netbiosname_and_share_and_smb_version_and_subvolume_and_subvolume_group_and_volume:
     grain: Ceph netbiosname and share and smb version and subvolume and subvolume group and volume
     identity:
       required:
-      - netbiosname
-      - share
-      - smb_version
-      - subvolume
-      - subvolume_group
-      - volume
+        - netbiosname
+        - share
+        - smb_version
+        - subvolume
+        - subvolume_group
+        - volume
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_nqn:
     grain: Ceph nqn
     identity:
       required:
-      - nqn
+        - nqn
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_pool_id:
     grain: Ceph pool id
     identity:
       required:
-      - pool_id
+        - pool_id
       optional: []
     high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
+      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review
+        and broader Netdata aggregation.
   by_throttle_key:
     grain: Ceph throttle key
     identity:
       required: []
       optional:
-      - throttle_key
+        - throttle_key
   cluster:
     grain: Ceph cluster endpoint
     identity:
@@ -659,9 +659,9 @@ entities:
     grain: Ceph node hardware component
     identity:
       required:
-      - hostname
-      - category
-      - component
+        - hostname
+        - category
+        - component
       optional: []
     high_cardinality_acceptance:
       operator_value: Per-component identity preserves actionable hardware health observations exposed by Ceph node-proxy.
@@ -669,11 +669,11 @@ entities:
     grain: Ceph node CPU and processor inventory identity
     identity:
       required:
-      - hostname
-      - cpu
-      - manufacturer
-      - model
-      - total_threads
+        - hostname
+        - cpu
+        - manufacturer
+        - model
+        - total_threads
       optional: []
     high_cardinality_acceptance:
       operator_value: Per-CPU identity preserves processor capacity observations exposed by Ceph node-proxy.
@@ -681,8 +681,8 @@ entities:
     grain: Ceph node fan
     identity:
       required:
-      - hostname
-      - fan_name
+        - hostname
+        - fan_name
       optional: []
     high_cardinality_acceptance:
       operator_value: Per-fan identity preserves cooling observations exposed by Ceph node-proxy.
@@ -690,9 +690,9 @@ entities:
     grain: Ceph node memory module and type
     identity:
       required:
-      - hostname
-      - dimm
-      - type
+        - hostname
+        - dimm
+        - type
       optional: []
     high_cardinality_acceptance:
       operator_value: Per-DIMM identity preserves memory inventory exposed by Ceph node-proxy.
@@ -700,13 +700,13 @@ entities:
     grain: Ceph node storage device and inventory identity
     identity:
       required:
-      - hostname
-      - device
-      - model
-      - protocol
-      - firmware_version
-      - slot
-      - serial_number
+        - hostname
+        - device
+        - model
+        - protocol
+        - firmware_version
+        - slot
+        - serial_number
       optional: []
     high_cardinality_acceptance:
       operator_value: Per-device identity preserves storage inventory exposed by Ceph node-proxy.
@@ -714,8 +714,8 @@ entities:
     grain: Ceph node temperature sensor
     identity:
       required:
-      - hostname
-      - sensor_name
+        - hostname
+        - sensor_name
       optional: []
     high_cardinality_acceptance:
       operator_value: Per-sensor identity preserves thermal observations exposed by Ceph node-proxy.
@@ -740,9 +740,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_dpdk_port
+        - label_dpdk_port
     evidence:
-    - normalization_dpdk_port_identity
+      - normalization_dpdk_port_identity
   dpdk_queue_identity:
     kind: embedded_identity_extract
     registry_grammar: dpdk_queue
@@ -756,9 +756,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_dpdk_queue
+        - label_dpdk_queue
     evidence:
-    - normalization_dpdk_queue_identity
+      - normalization_dpdk_queue_identity
   finisher_identity:
     kind: embedded_identity_extract
     registry_grammar: finisher
@@ -772,9 +772,9 @@ normalizations:
         kind: bounded_configuration
       stability: restart_stable
       evidence:
-      - label_finisher_key
+        - label_finisher_key
     evidence:
-    - normalization_finisher_identity
+      - normalization_finisher_identity
   kernel_device_identity:
     kind: embedded_identity_extract
     registry_grammar: kernel_device
@@ -788,9 +788,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_kernel_device_key
+        - label_kernel_device_key
     evidence:
-    - normalization_kernel_device_identity
+      - normalization_kernel_device_identity
   librbd_image_identity:
     kind: embedded_identity_extract
     registry_grammar: librbd_image
@@ -804,9 +804,9 @@ normalizations:
         kind: operational_population
       stability: stable
       evidence:
-      - label_librbd_image_key
+        - label_librbd_image_key
     evidence:
-    - normalization_librbd_image_identity
+      - normalization_librbd_image_identity
   librbd_pwl_identity:
     kind: embedded_identity_extract
     registry_grammar: librbd_pwl
@@ -820,9 +820,9 @@ normalizations:
         kind: operational_population
       stability: stable
       evidence:
-      - label_librbd_pwl_key
+        - label_librbd_pwl_key
     evidence:
-    - normalization_librbd_pwl_identity
+      - normalization_librbd_pwl_identity
   mclock_shard_identity:
     kind: embedded_identity_extract
     registry_grammar: mclock_shard
@@ -836,9 +836,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_mclock_shard
+        - label_mclock_shard
     evidence:
-    - normalization_mclock_shard_identity
+      - normalization_mclock_shard_identity
   mds_client_identity:
     kind: embedded_identity_extract
     registry_grammar: mds_client
@@ -852,9 +852,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_mds_filesystem_key
+        - label_mds_filesystem_key
     evidence:
-    - normalization_mds_client_identity
+      - normalization_mds_client_identity
   messenger_worker_identity:
     kind: embedded_identity_extract
     registry_grammar: messenger_worker
@@ -868,9 +868,9 @@ normalizations:
         kind: bounded_configuration
       stability: restart_stable
       evidence:
-      - label_messenger_worker
+        - label_messenger_worker
     evidence:
-    - normalization_messenger_worker_identity
+      - normalization_messenger_worker_identity
   objectcacher_identity:
     kind: embedded_identity_extract
     registry_grammar: objectcacher
@@ -884,9 +884,9 @@ normalizations:
         kind: operational_population
       stability: restart_stable
       evidence:
-      - label_objectcacher_key
+        - label_objectcacher_key
     evidence:
-    - normalization_objectcacher_identity
+      - normalization_objectcacher_identity
   objecter_identity:
     kind: embedded_identity_extract
     registry_grammar: objecter
@@ -900,9 +900,9 @@ normalizations:
         kind: operational_population
       stability: dynamic
       evidence:
-      - label_objecter_handle
+        - label_objecter_handle
     evidence:
-    - normalization_objecter_identity
+      - normalization_objecter_identity
   rgw_topic_identity:
     kind: embedded_identity_extract
     registry_grammar: rgw_topic
@@ -916,9 +916,9 @@ normalizations:
         kind: operational_population
       stability: stable
       evidence:
-      - labels_rgw_topic_persistent_topic_len
+        - labels_rgw_topic_persistent_topic_len
     evidence:
-    - normalization_rgw_topic_identity
+      - normalization_rgw_topic_identity
   rgw_sync_delta_identity:
     kind: embedded_identity_extract
     registry_grammar: rgw_sync_delta
@@ -932,9 +932,9 @@ normalizations:
         kind: operational_population
       stability: dynamic
       evidence:
-      - labels_rgw_sync_delta_sync_delta
+        - labels_rgw_sync_delta_sync_delta
     evidence:
-    - normalization_rgw_sync_delta_identity
+      - normalization_rgw_sync_delta_identity
   rdma_worker_identity:
     kind: embedded_identity_extract
     registry_grammar: rdma_worker
@@ -948,9 +948,9 @@ normalizations:
         kind: bounded_configuration
       stability: restart_stable
       evidence:
-      - label_rdma_worker
+        - label_rdma_worker
     evidence:
-    - normalization_rdma_worker_identity
+      - normalization_rdma_worker_identity
   rgw_sync_identity:
     kind: embedded_identity_repair
     registry_grammar: rgw_sync
@@ -963,8 +963,8 @@ normalizations:
       capture: source_zone_fragment
     identity:
       operands:
-      - source_zone_fragment
-      - source_zone
+        - source_zone_fragment
+        - source_zone
       separator: _
       blank: omit_operand_and_separator
       sanitizer: prometheus_label_value
@@ -972,16 +972,16 @@ normalizations:
       when_identity_label: absent
       outcome: drop_before_writer
       evidence:
-      - rgw_sync_duplicate
+        - rgw_sync_duplicate
     output:
       meaning: Sanitized remote RGW source-zone identity reconstructed from the source family and label.
       endpoint_cardinality:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_rgw_sync_source_zone
+        - label_rgw_sync_source_zone
     evidence:
-    - normalization_rgw_sync_identity
+      - normalization_rgw_sync_identity
   rocksdb_cache_identity:
     kind: embedded_identity_extract
     registry_grammar: rocksdb_cache
@@ -995,9 +995,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_rocksdb_cache_key
+        - label_rocksdb_cache_key
     evidence:
-    - normalization_rocksdb_cache_identity
+      - normalization_rocksdb_cache_identity
   service_unique_id_identity:
     kind: embedded_identity_extract
     registry_grammar: service_unique_id
@@ -1011,9 +1011,9 @@ normalizations:
         kind: operational_population
       stability: restart_stable
       evidence:
-      - label_service_unique_id
+        - label_service_unique_id
     evidence:
-    - normalization_service_unique_id_identity
+      - normalization_service_unique_id_identity
   throttle_identity:
     kind: embedded_identity_extract
     registry_grammar: throttle
@@ -1027,9 +1027,9 @@ normalizations:
         kind: bounded_configuration
       stability: stable
       evidence:
-      - label_throttle_key
+        - label_throttle_key
     evidence:
-    - normalization_throttle_identity
+      - normalization_throttle_identity
 # `hardware_firmware_info` is a source-declared info family. The writer rejects it as
 # `writer_ineligible/info_family` before authored or autogen output, so it has no
 # exclusion. A future inventory presentation requires a deliberate writer-policy decision.
@@ -1039,355 +1039,355 @@ limitations:
   objecter.accumulated_latency#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.byte_throughput#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.commands#command_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.commands#command_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.latency_measurements#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.lingering_operations#linger_ping:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.lingering_operations#linger_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.lingering_operations#linger_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.maps#map_full:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.maps#map_inc:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operation_vector_entries#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#omap_del:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#omap_rd:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#omap_wr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_pg:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_r:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_reply:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_rmw:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#op_w:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_append:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_call:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_clonerange:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_cmpxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_create:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_delete:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_getxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_mapext:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_notify:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_other:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_pgls:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_pgls_filter:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_read:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_resetxattrs:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_rmxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_setxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_sparse_read:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_src_cmpxattr:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_stat:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_truncate:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_watch:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_write:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_writefull:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_writesame:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.operations#osdop_zero:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.osd_sessions#osd_session_close:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.osd_sessions#osd_session_open:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.pool_operations#poolop_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.pool_operations#poolop_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.replica_reads#replica_read_bounced:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: tentacle_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.replica_reads#replica_read_completed:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: tentacle_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.replica_reads#replica_read_sent:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: tentacle_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.stat_requests#poolstat_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.stat_requests#poolstat_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.stat_requests#statfs_resend:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.stat_requests#statfs_send:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
   objecter.submitted_operations#value:
     contributor_variant: objecter_handles
     evidence:
-    - objecter_handle_lifecycle
+      - objecter_handle_lifecycle
     proof_sequence: reef_ceph_exporter_objecter_churn
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
 views:
@@ -1399,15 +1399,15 @@ views:
       db_alloc_lat:
         signal: bluefs_db_alloc_lat_sum
         components:
-        - value
+          - value
       slow_alloc_lat:
         signal: bluefs_slow_alloc_lat_sum
         components:
-        - value
+          - value
       wal_alloc_lat:
         signal: bluefs_wal_alloc_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1420,15 +1420,15 @@ views:
       db:
         signal: bluefs_alloc_unit_db
         components:
-        - value
+          - value
       slow:
         signal: bluefs_alloc_unit_slow
         components:
-        - value
+          - value
       wal:
         signal: bluefs_alloc_unit_wal
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1441,15 +1441,15 @@ views:
       db_max_lat:
         signal: bluefs_alloc_db_max_lat
         components:
-        - value
+          - value
       slow_max_lat:
         signal: bluefs_alloc_slow_max_lat
         components:
-        - value
+          - value
       wal_max_lat:
         signal: bluefs_alloc_wal_max_lat
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1462,11 +1462,11 @@ views:
       fallback:
         signal: bluefs_alloc_slow_fallback
         components:
-        - value
+          - value
       size_fallback:
         signal: bluefs_alloc_slow_size_fallback
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1479,15 +1479,15 @@ views:
       db_alloc_lat:
         signal: bluefs_db_alloc_lat_count
         components:
-        - value
+          - value
       slow_alloc_lat:
         signal: bluefs_slow_alloc_lat_count
         components:
-        - value
+          - value
       wal_alloc_lat:
         signal: bluefs_wal_alloc_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1500,11 +1500,11 @@ views:
       lat:
         signal: bluefs_compact_lat_sum
         components:
-        - value
+          - value
       lock_lat:
         signal: bluefs_compact_lock_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1517,7 +1517,7 @@ views:
       value:
         signal: bluefs_log_compactions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1530,11 +1530,11 @@ views:
       lat:
         signal: bluefs_compact_lat_count
         components:
-        - value
+          - value
       lock_lat:
         signal: bluefs_compact_lock_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1547,27 +1547,27 @@ views:
       flush_lat:
         signal: bluefs_flush_lat_sum
         components:
-        - value
+          - value
       fsync_lat:
         signal: bluefs_fsync_lat_sum
         components:
-        - value
+          - value
       read_lat:
         signal: bluefs_read_lat_sum
         components:
-        - value
+          - value
       read_random_lat:
         signal: bluefs_read_random_lat_sum
         components:
-        - value
+          - value
       truncate_lat:
         signal: bluefs_truncate_lat_sum
         components:
-        - value
+          - value
       unlink_lat:
         signal: bluefs_unlink_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1580,55 +1580,55 @@ views:
       read_bytes:
         signal: bluefs_read_bytes
         components:
-        - value
+          - value
       read_disk_bytes:
         signal: bluefs_read_disk_bytes
         components:
-        - value
+          - value
       read_disk_bytes_db:
         signal: bluefs_read_disk_bytes_db
         components:
-        - value
+          - value
       read_disk_bytes_slow:
         signal: bluefs_read_disk_bytes_slow
         components:
-        - value
+          - value
       read_disk_bytes_wal:
         signal: bluefs_read_disk_bytes_wal
         components:
-        - value
+          - value
       read_prefetch_bytes:
         signal: bluefs_read_prefetch_bytes
         components:
-        - value
+          - value
       read_random_buffer_bytes:
         signal: bluefs_read_random_buffer_bytes
         components:
-        - value
+          - value
       read_random_bytes:
         signal: bluefs_read_random_bytes
         components:
-        - value
+          - value
       read_random_disk_bytes:
         signal: bluefs_read_random_disk_bytes
         components:
-        - value
+          - value
       read_random_disk_bytes_db:
         signal: bluefs_read_random_disk_bytes_db
         components:
-        - value
+          - value
       read_random_disk_bytes_slow:
         signal: bluefs_read_random_disk_bytes_slow
         components:
-        - value
+          - value
       read_random_disk_bytes_wal:
         signal: bluefs_read_random_disk_bytes_wal
         components:
-        - value
+          - value
       write_bytes:
         signal: bluefs_write_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1641,27 +1641,27 @@ views:
       flush_lat:
         signal: bluefs_flush_lat_count
         components:
-        - value
+          - value
       fsync_lat:
         signal: bluefs_fsync_lat_count
         components:
-        - value
+          - value
       read_lat:
         signal: bluefs_read_lat_count
         components:
-        - value
+          - value
       read_random_lat:
         signal: bluefs_read_random_lat_count
         components:
-        - value
+          - value
       truncate_lat:
         signal: bluefs_truncate_lat_count
         components:
-        - value
+          - value
       unlink_lat:
         signal: bluefs_unlink_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1674,47 +1674,47 @@ views:
       log_write:
         signal: bluefs_log_write_count
         components:
-        - value
+          - value
       read:
         signal: bluefs_read_count
         components:
-        - value
+          - value
       read_disk:
         signal: bluefs_read_disk_count
         components:
-        - value
+          - value
       read_prefetch:
         signal: bluefs_read_prefetch_count
         components:
-        - value
+          - value
       read_random_buffer:
         signal: bluefs_read_random_buffer_count
         components:
-        - value
+          - value
       read_random:
         signal: bluefs_read_random_count
         components:
-        - value
+          - value
       read_random_disk:
         signal: bluefs_read_random_disk_count
         components:
-        - value
+          - value
       write:
         signal: bluefs_write_count
         components:
-        - value
+          - value
       write_count_sst:
         signal: bluefs_write_count_sst
         components:
-        - value
+          - value
       write_count_wal:
         signal: bluefs_write_count_wal
         components:
-        - value
+          - value
       write_disk:
         signal: bluefs_write_disk_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1727,11 +1727,11 @@ views:
       candidate:
         signal: bluefs_read_zeros_candidate
         components:
-        - value
+          - value
       errors:
         signal: bluefs_read_zeros_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1744,15 +1744,15 @@ views:
       db:
         signal: bluefs_max_bytes_db
         components:
-        - value
+          - value
       slow:
         signal: bluefs_max_bytes_slow
         components:
-        - value
+          - value
       wal:
         signal: bluefs_max_bytes_wal
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1765,19 +1765,19 @@ views:
       bytes_written_slow:
         signal: bluefs_bytes_written_slow
         components:
-        - value
+          - value
       bytes_written_sst:
         signal: bluefs_bytes_written_sst
         components:
-        - value
+          - value
       bytes_written_wal:
         signal: bluefs_bytes_written_wal
         components:
-        - value
+          - value
       logged_bytes:
         signal: bluefs_logged_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1790,7 +1790,7 @@ views:
       value:
         signal: bluefs_num_files
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1803,11 +1803,11 @@ views:
       sst:
         signal: bluefs_files_written_sst
         components:
-        - value
+          - value
       wal:
         signal: bluefs_files_written_wal
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1820,31 +1820,31 @@ views:
       db_total_bytes:
         signal: bluefs_db_total_bytes
         components:
-        - value
+          - value
       db_used_bytes:
         signal: bluefs_db_used_bytes
         components:
-        - value
+          - value
       log_bytes:
         signal: bluefs_log_bytes
         components:
-        - value
+          - value
       slow_total_bytes:
         signal: bluefs_slow_total_bytes
         components:
-        - value
+          - value
       slow_used_bytes:
         signal: bluefs_slow_used_bytes
         components:
-        - value
+          - value
       wal_total_bytes:
         signal: bluefs_wal_total_bytes
         components:
-        - value
+          - value
       wal_used_bytes:
         signal: bluefs_wal_used_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1857,7 +1857,7 @@ views:
       value:
         signal: bluestore_allocator_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1870,7 +1870,7 @@ views:
       allocated:
         signal: bluestore_allocated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1883,7 +1883,7 @@ views:
       alloc_unit:
         signal: bluestore_alloc_unit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1896,7 +1896,7 @@ views:
       value:
         signal: bluestore_allocator_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1909,15 +1909,15 @@ views:
       compress_lat:
         signal: bluestore_compress_lat_sum
         components:
-        - value
+          - value
       csum_lat:
         signal: bluestore_csum_lat_sum
         components:
-        - value
+          - value
       decompress_lat:
         signal: bluestore_decompress_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1930,7 +1930,7 @@ views:
       extent_compress:
         signal: bluestore_extent_compress
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1943,11 +1943,11 @@ views:
       compress_rejected:
         signal: bluestore_compress_rejected_count
         components:
-        - value
+          - value
       compress_success:
         signal: bluestore_compress_success_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1960,15 +1960,15 @@ views:
       compress_lat:
         signal: bluestore_compress_lat_count
         components:
-        - value
+          - value
       csum_lat:
         signal: bluestore_csum_lat_count
         components:
-        - value
+          - value
       decompress_lat:
         signal: bluestore_decompress_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -1981,15 +1981,15 @@ views:
       compressed:
         signal: bluestore_compressed
         components:
-        - value
+          - value
       allocated:
         signal: bluestore_compressed_allocated
         components:
-        - value
+          - value
       original:
         signal: bluestore_compressed_original
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2002,27 +2002,27 @@ views:
       read_lat:
         signal: bluestore_read_lat_sum
         components:
-        - value
+          - value
       read_onode_meta_lat:
         signal: bluestore_read_onode_meta_lat_sum
         components:
-        - value
+          - value
       read_wait_aio_lat:
         signal: bluestore_read_wait_aio_lat_sum
         components:
-        - value
+          - value
       remove_lat:
         signal: bluestore_remove_lat_sum
         components:
-        - value
+          - value
       truncate_lat:
         signal: bluestore_truncate_lat_sum
         components:
-        - value
+          - value
       write_lat:
         signal: bluestore_write_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2035,31 +2035,31 @@ views:
       issued_deferred_write_bytes:
         signal: bluestore_issued_deferred_write_bytes
         components:
-        - value
+          - value
       submitted_deferred_write_bytes:
         signal: bluestore_submitted_deferred_write_bytes
         components:
-        - value
+          - value
       write_big_bytes:
         signal: bluestore_write_big_bytes
         components:
-        - value
+          - value
       write_big_skipped_bytes:
         signal: bluestore_write_big_skipped_bytes
         components:
-        - value
+          - value
       write_pad_bytes:
         signal: bluestore_write_pad_bytes
         components:
-        - value
+          - value
       write_small_bytes:
         signal: bluestore_write_small_bytes
         components:
-        - value
+          - value
       write_small_skipped_bytes:
         signal: bluestore_write_small_skipped_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2072,27 +2072,27 @@ views:
       read_lat:
         signal: bluestore_read_lat_count
         components:
-        - value
+          - value
       read_onode_meta_lat:
         signal: bluestore_read_onode_meta_lat_count
         components:
-        - value
+          - value
       read_wait_aio_lat:
         signal: bluestore_read_wait_aio_lat_count
         components:
-        - value
+          - value
       remove_lat:
         signal: bluestore_remove_lat_count
         components:
-        - value
+          - value
       truncate_lat:
         signal: bluestore_truncate_lat_count
         components:
-        - value
+          - value
       write_lat:
         signal: bluestore_write_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2105,7 +2105,7 @@ views:
       write_penalty_read_ops:
         signal: bluestore_write_penalty_read_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2118,11 +2118,11 @@ views:
       read_eio:
         signal: bluestore_read_eio
         components:
-        - value
+          - value
       reads_with_retries:
         signal: bluestore_reads_with_retries
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2135,7 +2135,7 @@ views:
       write_big_skipped_blobs:
         signal: bluestore_write_big_skipped_blobs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2148,7 +2148,7 @@ views:
       write_small_skipped:
         signal: bluestore_write_small_skipped
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2161,7 +2161,7 @@ views:
       slow_aio_wait:
         signal: bluestore_slow_aio_wait_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2174,11 +2174,11 @@ views:
       slow_read_onode_meta:
         signal: bluestore_slow_read_onode_meta_count
         components:
-        - value
+          - value
       slow_read_wait_aio:
         signal: bluestore_slow_read_wait_aio_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2191,35 +2191,35 @@ views:
       issued_deferred_writes:
         signal: bluestore_issued_deferred_writes
         components:
-        - value
+          - value
       submitted_deferred_writes:
         signal: bluestore_submitted_deferred_writes
         components:
-        - value
+          - value
       write_big:
         signal: bluestore_write_big
         components:
-        - value
+          - value
       write_big_deferred:
         signal: bluestore_write_big_deferred
         components:
-        - value
+          - value
       write_new:
         signal: bluestore_write_new
         components:
-        - value
+          - value
       write_small:
         signal: bluestore_write_small
         components:
-        - value
+          - value
       write_small_pre_read:
         signal: bluestore_write_small_pre_read
         components:
-        - value
+          - value
       write_small_unused:
         signal: bluestore_write_small_unused
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2232,7 +2232,7 @@ views:
       write_big_blobs:
         signal: bluestore_write_big_blobs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2245,31 +2245,31 @@ views:
       clear_lat:
         signal: bluestore_omap_clear_lat_sum
         components:
-        - value
+          - value
       get_keys_lat:
         signal: bluestore_omap_get_keys_lat_sum
         components:
-        - value
+          - value
       get_values_lat:
         signal: bluestore_omap_get_values_lat_sum
         components:
-        - value
+          - value
       lower_bound_lat:
         signal: bluestore_omap_lower_bound_lat_sum
         components:
-        - value
+          - value
       next_lat:
         signal: bluestore_omap_next_lat_sum
         components:
-        - value
+          - value
       seek_to_first_lat:
         signal: bluestore_omap_seek_to_first_lat_sum
         components:
-        - value
+          - value
       upper_bound_lat:
         signal: bluestore_omap_upper_bound_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2282,11 +2282,11 @@ views:
       setheader_bytes:
         signal: bluestore_omap_setheader_bytes
         components:
-        - value
+          - value
       setkeys_bytes:
         signal: bluestore_omap_setkeys_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2299,11 +2299,11 @@ views:
       rmkeys:
         signal: bluestore_omap_rmkeys_count
         components:
-        - value
+          - value
       setkeys_records:
         signal: bluestore_omap_setkeys_records
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2316,31 +2316,31 @@ views:
       clear_lat:
         signal: bluestore_omap_clear_lat_count
         components:
-        - value
+          - value
       get_keys_lat:
         signal: bluestore_omap_get_keys_lat_count
         components:
-        - value
+          - value
       get_values_lat:
         signal: bluestore_omap_get_values_lat_count
         components:
-        - value
+          - value
       lower_bound_lat:
         signal: bluestore_omap_lower_bound_lat_count
         components:
-        - value
+          - value
       next_lat:
         signal: bluestore_omap_next_lat_count
         components:
-        - value
+          - value
       seek_to_first_lat:
         signal: bluestore_omap_seek_to_first_lat_count
         components:
-        - value
+          - value
       upper_bound_lat:
         signal: bluestore_omap_upper_bound_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2353,11 +2353,11 @@ views:
       setheader:
         signal: bluestore_omap_setheader_count
         components:
-        - value
+          - value
       setkeys:
         signal: bluestore_omap_setkeys_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2370,7 +2370,7 @@ views:
       iterator:
         signal: bluestore_omap_iterator_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2383,7 +2383,7 @@ views:
       rmkey_range:
         signal: bluestore_omap_rmkey_range_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2396,11 +2396,11 @@ views:
       onode_blobs:
         signal: bluestore_onode_blobs
         components:
-        - value
+          - value
       onode_spanning_blobs:
         signal: bluestore_onode_spanning_blobs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2413,7 +2413,7 @@ views:
       value:
         signal: bluestore_onode_reshard
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2426,7 +2426,7 @@ views:
       onode_extents:
         signal: bluestore_onode_extents
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2439,11 +2439,11 @@ views:
       hits:
         signal: bluestore_onode_hits
         components:
-        - value
+          - value
       misses:
         signal: bluestore_onode_misses
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2456,11 +2456,11 @@ views:
       onodes:
         signal: bluestore_onodes
         components:
-        - value
+          - value
       onodes_pinned:
         signal: bluestore_onodes_pinned
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2473,11 +2473,11 @@ views:
       shard_hits:
         signal: bluestore_onode_shard_hits
         components:
-        - value
+          - value
       shard_misses:
         signal: bluestore_onode_shard_misses
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2490,59 +2490,59 @@ views:
       committed_bytes:
         signal: bluestore_pricache_data_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: bluestore_pricache_data_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: bluestore_pricache_data_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: bluestore_pricache_data_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: bluestore_pricache_data_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: bluestore_pricache_data_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: bluestore_pricache_data_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: bluestore_pricache_data_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: bluestore_pricache_data_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: bluestore_pricache_data_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: bluestore_pricache_data_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: bluestore_pricache_data_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: bluestore_pricache_data_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: bluestore_pricache_data_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2555,59 +2555,59 @@ views:
       committed_bytes:
         signal: bluestore_pricache_kv_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: bluestore_pricache_kv_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: bluestore_pricache_kv_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: bluestore_pricache_kv_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: bluestore_pricache_kv_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: bluestore_pricache_kv_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: bluestore_pricache_kv_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: bluestore_pricache_kv_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: bluestore_pricache_kv_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: bluestore_pricache_kv_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: bluestore_pricache_kv_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: bluestore_pricache_kv_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: bluestore_pricache_kv_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: bluestore_pricache_kv_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2620,59 +2620,59 @@ views:
       committed_bytes:
         signal: bluestore_pricache_kv_onode_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: bluestore_pricache_kv_onode_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: bluestore_pricache_kv_onode_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: bluestore_pricache_kv_onode_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: bluestore_pricache_kv_onode_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: bluestore_pricache_kv_onode_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: bluestore_pricache_kv_onode_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: bluestore_pricache_kv_onode_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: bluestore_pricache_kv_onode_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: bluestore_pricache_kv_onode_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: bluestore_pricache_kv_onode_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: bluestore_pricache_kv_onode_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: bluestore_pricache_kv_onode_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: bluestore_pricache_kv_onode_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2685,59 +2685,59 @@ views:
       committed_bytes:
         signal: bluestore_pricache_meta_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: bluestore_pricache_meta_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: bluestore_pricache_meta_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: bluestore_pricache_meta_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: bluestore_pricache_meta_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: bluestore_pricache_meta_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: bluestore_pricache_meta_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: bluestore_pricache_meta_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: bluestore_pricache_meta_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: bluestore_pricache_meta_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: bluestore_pricache_meta_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: bluestore_pricache_meta_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: bluestore_pricache_meta_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: bluestore_pricache_meta_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2750,23 +2750,23 @@ views:
       cache_bytes:
         signal: bluestore_pricache_cache_bytes
         components:
-        - value
+          - value
       heap_bytes:
         signal: bluestore_pricache_heap_bytes
         components:
-        - value
+          - value
       mapped_bytes:
         signal: bluestore_pricache_mapped_bytes
         components:
-        - value
+          - value
       target_bytes:
         signal: bluestore_pricache_target_bytes
         components:
-        - value
+          - value
       unmapped_bytes:
         signal: bluestore_pricache_unmapped_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2779,23 +2779,23 @@ views:
       clist_lat:
         signal: bluestore_clist_lat_sum
         components:
-        - value
+          - value
       kv_commit_lat:
         signal: bluestore_kv_commit_lat_sum
         components:
-        - value
+          - value
       kv_final_lat:
         signal: bluestore_kv_final_lat_sum
         components:
-        - value
+          - value
       kv_flush_lat:
         signal: bluestore_kv_flush_lat_sum
         components:
-        - value
+          - value
       kv_sync_lat:
         signal: bluestore_kv_sync_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2808,7 +2808,7 @@ views:
       blob_split:
         signal: bluestore_blob_split
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2821,7 +2821,7 @@ views:
       buffer_bytes:
         signal: bluestore_buffer_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2834,11 +2834,11 @@ views:
       hit_bytes:
         signal: bluestore_buffer_hit_bytes
         components:
-        - value
+          - value
       miss_bytes:
         signal: bluestore_buffer_miss_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2851,7 +2851,7 @@ views:
       value:
         signal: bluestore_buffers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2864,7 +2864,7 @@ views:
       value:
         signal: bluestore_slow_committed_kv_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2877,7 +2877,7 @@ views:
       value:
         signal: bluestore_fragmentation_micros
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2886,7 +2886,7 @@ views:
       convention: per_mille
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   bluestore.space_and_core_state.gc_merge_throughput:
     family: Ceph/BlueStore/Space and Core State
     question: What is the garbage-collection merge throughput for each ceph daemon?
@@ -2895,7 +2895,7 @@ views:
       gc_merged:
         signal: bluestore_gc_merged
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2908,23 +2908,23 @@ views:
       clist_lat:
         signal: bluestore_clist_lat_count
         components:
-        - value
+          - value
       kv_commit_lat:
         signal: bluestore_kv_commit_lat_count
         components:
-        - value
+          - value
       kv_final_lat:
         signal: bluestore_kv_final_lat_count
         components:
-        - value
+          - value
       kv_flush_lat:
         signal: bluestore_kv_flush_lat_count
         components:
-        - value
+          - value
       kv_sync_lat:
         signal: bluestore_kv_sync_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2937,7 +2937,7 @@ views:
       stored:
         signal: bluestore_stored
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -2950,59 +2950,59 @@ views:
       state_aio_wait_lat:
         signal: bluestore_state_aio_wait_lat_sum
         components:
-        - value
+          - value
       state_deferred_aio_wait_lat:
         signal: bluestore_state_deferred_aio_wait_lat_sum
         components:
-        - value
+          - value
       state_deferred_cleanup_lat:
         signal: bluestore_state_deferred_cleanup_lat_sum
         components:
-        - value
+          - value
       state_deferred_queued_lat:
         signal: bluestore_state_deferred_queued_lat_sum
         components:
-        - value
+          - value
       state_done_lat:
         signal: bluestore_state_done_lat_sum
         components:
-        - value
+          - value
       state_finishing_lat:
         signal: bluestore_state_finishing_lat_sum
         components:
-        - value
+          - value
       state_io_done_lat:
         signal: bluestore_state_io_done_lat_sum
         components:
-        - value
+          - value
       state_kv_commiting_lat:
         signal: bluestore_state_kv_commiting_lat_sum
         components:
-        - value
+          - value
       state_kv_done_lat:
         signal: bluestore_state_kv_done_lat_sum
         components:
-        - value
+          - value
       state_kv_queued_lat:
         signal: bluestore_state_kv_queued_lat_sum
         components:
-        - value
+          - value
       state_prepare_lat:
         signal: bluestore_state_prepare_lat_sum
         components:
-        - value
+          - value
       txc_commit_lat:
         signal: bluestore_txc_commit_lat_sum
         components:
-        - value
+          - value
       txc_submit_lat:
         signal: bluestore_txc_submit_lat_sum
         components:
-        - value
+          - value
       txc_throttle_lat:
         signal: bluestore_txc_throttle_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3015,59 +3015,59 @@ views:
       state_aio_wait_lat:
         signal: bluestore_state_aio_wait_lat_count
         components:
-        - value
+          - value
       state_deferred_aio_wait_lat:
         signal: bluestore_state_deferred_aio_wait_lat_count
         components:
-        - value
+          - value
       state_deferred_cleanup_lat:
         signal: bluestore_state_deferred_cleanup_lat_count
         components:
-        - value
+          - value
       state_deferred_queued_lat:
         signal: bluestore_state_deferred_queued_lat_count
         components:
-        - value
+          - value
       state_done_lat:
         signal: bluestore_state_done_lat_count
         components:
-        - value
+          - value
       state_finishing_lat:
         signal: bluestore_state_finishing_lat_count
         components:
-        - value
+          - value
       state_io_done_lat:
         signal: bluestore_state_io_done_lat_count
         components:
-        - value
+          - value
       state_kv_commiting_lat:
         signal: bluestore_state_kv_commiting_lat_count
         components:
-        - value
+          - value
       state_kv_done_lat:
         signal: bluestore_state_kv_done_lat_count
         components:
-        - value
+          - value
       state_kv_queued_lat:
         signal: bluestore_state_kv_queued_lat_count
         components:
-        - value
+          - value
       state_prepare_lat:
         signal: bluestore_state_prepare_lat_count
         components:
-        - value
+          - value
       txc_commit_lat:
         signal: bluestore_txc_commit_lat_count
         components:
-        - value
+          - value
       txc_submit_lat:
         signal: bluestore_txc_submit_lat_count
         components:
-        - value
+          - value
       txc_throttle_lat:
         signal: bluestore_txc_throttle_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3080,7 +3080,7 @@ views:
       value:
         signal: bluestore_txc_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3093,15 +3093,15 @@ views:
       degraded:
         signal: num_objects_degraded
         components:
-        - value
+          - value
       misplaced:
         signal: num_objects_misplaced
         components:
-        - value
+          - value
       unfound:
         signal: num_objects_unfound
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3114,15 +3114,15 @@ views:
       bytes:
         signal: cluster_total_bytes
         components:
-        - value
+          - value
       used_bytes:
         signal: cluster_total_used_bytes
         components:
-        - value
+          - value
       used_raw_bytes:
         signal: cluster_total_used_raw_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3135,15 +3135,15 @@ views:
       bytes:
         signal: cluster_by_class_total_bytes
         components:
-        - value
+          - value
       used_bytes:
         signal: cluster_by_class_total_used_bytes
         components:
-        - value
+          - value
       used_raw_bytes:
         signal: cluster_by_class_total_used_raw_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3156,15 +3156,15 @@ views:
       metadata:
         signal: client_mdops
         components:
-        - value
+          - value
       read:
         signal: client_rdops
         components:
-        - value
+          - value
       write:
         signal: client_wrops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3177,27 +3177,27 @@ views:
       rmxattr_latency:
         signal: mds_server_req_rmxattr_latency_sum
         components:
-        - value
+          - value
       setattr_latency:
         signal: mds_server_req_setattr_latency_sum
         components:
-        - value
+          - value
       setdirlayout_latency:
         signal: mds_server_req_setdirlayout_latency_sum
         components:
-        - value
+          - value
       setfilelock_latency:
         signal: mds_server_req_setfilelock_latency_sum
         components:
-        - value
+          - value
       setlayout_latency:
         signal: mds_server_req_setlayout_latency_sum
         components:
-        - value
+          - value
       setxattr_latency:
         signal: mds_server_req_setxattr_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3210,27 +3210,27 @@ views:
       rmxattr_latency:
         signal: mds_server_req_rmxattr_latency_count
         components:
-        - value
+          - value
       setattr_latency:
         signal: mds_server_req_setattr_latency_count
         components:
-        - value
+          - value
       setdirlayout_latency:
         signal: mds_server_req_setdirlayout_latency_count
         components:
-        - value
+          - value
       setfilelock_latency:
         signal: mds_server_req_setfilelock_latency_count
         components:
-        - value
+          - value
       setlayout_latency:
         signal: mds_server_req_setlayout_latency_count
         components:
-        - value
+          - value
       setxattr_latency:
         signal: mds_server_req_setxattr_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3243,15 +3243,15 @@ views:
       handle_client_cap_release:
         signal: mds_handle_client_cap_release
         components:
-        - value
+          - value
       handle_client_caps:
         signal: mds_handle_client_caps
         components:
-        - value
+          - value
       handle_client_caps_dirty:
         signal: mds_handle_client_caps_dirty
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3264,7 +3264,7 @@ views:
       value:
         signal: mds_caps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3277,7 +3277,7 @@ views:
       server_cap_revoke_eviction:
         signal: mds_server_cap_revoke_eviction
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3290,7 +3290,7 @@ views:
       value:
         signal: mds_inodes_with_caps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3303,7 +3303,7 @@ views:
       value:
         signal: mds_handle_inode_file_caps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3316,27 +3316,27 @@ views:
       ceph_cap_op_flush_ack:
         signal: mds_ceph_cap_op_flush_ack
         components:
-        - value
+          - value
       ceph_cap_op_flushsnap_ack:
         signal: mds_ceph_cap_op_flushsnap_ack
         components:
-        - value
+          - value
       ceph_cap_op_grant:
         signal: mds_ceph_cap_op_grant
         components:
-        - value
+          - value
       ceph_cap_op_revoke:
         signal: mds_ceph_cap_op_revoke
         components:
-        - value
+          - value
       ceph_cap_op_trunc:
         signal: mds_ceph_cap_op_trunc
         components:
-        - value
+          - value
       process_request_cap_release:
         signal: mds_process_request_cap_release
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3349,7 +3349,7 @@ views:
       server_cap_acquisition_throttle:
         signal: mds_server_cap_acquisition_throttle
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3362,7 +3362,7 @@ views:
       value:
         signal: mds_log_jlat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3375,15 +3375,15 @@ views:
       ev:
         signal: mds_log_ev
         components:
-        - value
+          - value
       evexd:
         signal: mds_log_evexd
         components:
-        - value
+          - value
       evexg:
         signal: mds_log_evexg
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3396,19 +3396,19 @@ views:
       evadd:
         signal: mds_log_evadd
         components:
-        - value
+          - value
       evex:
         signal: mds_log_evex
         components:
-        - value
+          - value
       evtrm:
         signal: mds_log_evtrm
         components:
-        - value
+          - value
       replayed:
         signal: mds_log_replayed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3421,15 +3421,15 @@ views:
       expos:
         signal: mds_log_expos
         components:
-        - value
+          - value
       rdpos:
         signal: mds_log_rdpos
         components:
-        - value
+          - value
       wrpos:
         signal: mds_log_wrpos
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3442,15 +3442,15 @@ views:
       segadd:
         signal: mds_log_segadd
         components:
-        - value
+          - value
       segex:
         signal: mds_log_segex
         components:
-        - value
+          - value
       segtrm:
         signal: mds_log_segtrm
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3463,7 +3463,7 @@ views:
       evlrg:
         signal: mds_log_evlrg
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3476,7 +3476,7 @@ views:
       value:
         signal: mds_log_jlat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3489,19 +3489,19 @@ views:
       seg:
         signal: mds_log_seg
         components:
-        - value
+          - value
       segexd:
         signal: mds_log_segexd
         components:
-        - value
+          - value
       segexg:
         signal: mds_log_segexg
         components:
-        - value
+          - value
       segmjr:
         signal: mds_log_segmjr
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3514,7 +3514,7 @@ views:
       try_discover:
         signal: mds_cache_dir_try_discover
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3527,11 +3527,11 @@ views:
       handle_discover:
         signal: mds_cache_dir_handle_discover
         components:
-        - value
+          - value
       send_discover:
         signal: mds_cache_dir_send_discover
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3544,11 +3544,11 @@ views:
       update:
         signal: mds_cache_dir_update
         components:
-        - value
+          - value
       update_receipt:
         signal: mds_cache_dir_update_receipt
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3561,11 +3561,11 @@ views:
       inodestats:
         signal: mds_cache_ireq_inodestats
         components:
-        - value
+          - value
       quiesce_inode:
         signal: mds_cache_ireq_quiesce_inode
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3578,23 +3578,23 @@ views:
       exportdir:
         signal: mds_cache_ireq_exportdir
         components:
-        - value
+          - value
       flush:
         signal: mds_cache_ireq_flush
         components:
-        - value
+          - value
       fragmentdir:
         signal: mds_cache_ireq_fragmentdir
         components:
-        - value
+          - value
       fragstats:
         signal: mds_cache_ireq_fragstats
         components:
-        - value
+          - value
       quiesce_path:
         signal: mds_cache_ireq_quiesce_path
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3607,7 +3607,7 @@ views:
       value:
         signal: mds_cache_ireq_enqueue_scrub
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3620,15 +3620,15 @@ views:
       strays:
         signal: mds_cache_num_strays
         components:
-        - value
+          - value
       delayed:
         signal: mds_cache_num_strays_delayed
         components:
-        - value
+          - value
       enqueuing:
         signal: mds_cache_num_strays_enqueuing
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3641,19 +3641,19 @@ views:
       created:
         signal: mds_cache_strays_created
         components:
-        - value
+          - value
       enqueued:
         signal: mds_cache_strays_enqueued
         components:
-        - value
+          - value
       migrated:
         signal: mds_cache_strays_migrated
         components:
-        - value
+          - value
       reintegrated:
         signal: mds_cache_strays_reintegrated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3666,15 +3666,15 @@ views:
       enqueued:
         signal: mds_cache_num_recovering_enqueued
         components:
-        - value
+          - value
       prioritized:
         signal: mds_cache_num_recovering_prioritized
         components:
-        - value
+          - value
       processing:
         signal: mds_cache_num_recovering_processing
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3687,11 +3687,11 @@ views:
       completed:
         signal: mds_cache_recovery_completed
         components:
-        - value
+          - value
       started:
         signal: mds_cache_recovery_started
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3704,11 +3704,11 @@ views:
       started:
         signal: mds_cache_uninline_started
         components:
-        - value
+          - value
       succeeded:
         signal: mds_cache_uninline_succeeded
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3721,7 +3721,7 @@ views:
       value:
         signal: mds_cache_uninline_write_failed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3734,35 +3734,35 @@ views:
       create_latency:
         signal: mds_server_req_create_latency_sum
         components:
-        - value
+          - value
       link_latency:
         signal: mds_server_req_link_latency_sum
         components:
-        - value
+          - value
       mkdir_latency:
         signal: mds_server_req_mkdir_latency_sum
         components:
-        - value
+          - value
       mknod_latency:
         signal: mds_server_req_mknod_latency_sum
         components:
-        - value
+          - value
       rename_latency:
         signal: mds_server_req_rename_latency_sum
         components:
-        - value
+          - value
       rmdir_latency:
         signal: mds_server_req_rmdir_latency_sum
         components:
-        - value
+          - value
       symlink_latency:
         signal: mds_server_req_symlink_latency_sum
         components:
-        - value
+          - value
       unlink_latency:
         signal: mds_server_req_unlink_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3775,35 +3775,35 @@ views:
       create_latency:
         signal: mds_server_req_create_latency_count
         components:
-        - value
+          - value
       link_latency:
         signal: mds_server_req_link_latency_count
         components:
-        - value
+          - value
       mkdir_latency:
         signal: mds_server_req_mkdir_latency_count
         components:
-        - value
+          - value
       mknod_latency:
         signal: mds_server_req_mknod_latency_count
         components:
-        - value
+          - value
       rename_latency:
         signal: mds_server_req_rename_latency_count
         components:
-        - value
+          - value
       rmdir_latency:
         signal: mds_server_req_rmdir_latency_count
         components:
-        - value
+          - value
       symlink_latency:
         signal: mds_server_req_symlink_latency_count
         components:
-        - value
+          - value
       unlink_latency:
         signal: mds_server_req_unlink_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3816,15 +3816,15 @@ views:
       dir_fetch_complete:
         signal: mds_dir_fetch_complete
         components:
-        - value
+          - value
       dir_merge:
         signal: mds_dir_merge
         components:
-        - value
+          - value
       dir_split:
         signal: mds_dir_split
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3837,7 +3837,7 @@ views:
       value:
         signal: mds_openino_peer_discover
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3850,7 +3850,7 @@ views:
       value:
         signal: mds_dir_fetch_keys
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3863,7 +3863,7 @@ views:
       value:
         signal: mds_traverse_hit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3876,15 +3876,15 @@ views:
       dir_commit:
         signal: mds_dir_commit
         components:
-        - value
+          - value
       openino_backtrace_fetch:
         signal: mds_openino_backtrace_fetch
         components:
-        - value
+          - value
       openino_dir_fetch:
         signal: mds_openino_dir_fetch
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3897,27 +3897,27 @@ views:
       traverse:
         signal: mds_traverse
         components:
-        - value
+          - value
       traverse_dir_fetch:
         signal: mds_traverse_dir_fetch
         components:
-        - value
+          - value
       traverse_discover:
         signal: mds_traverse_discover
         components:
-        - value
+          - value
       traverse_forward:
         signal: mds_traverse_forward
         components:
-        - value
+          - value
       traverse_lock:
         signal: mds_traverse_lock
         components:
-        - value
+          - value
       traverse_remote_ino:
         signal: mds_traverse_remote_ino
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3930,7 +3930,7 @@ views:
       value:
         signal: purge_queue_pq_item_in_journal
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3943,7 +3943,7 @@ views:
       value:
         signal: purge_queue_pq_executed_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3956,11 +3956,11 @@ views:
       ops:
         signal: purge_queue_pq_executing_ops
         components:
-        - value
+          - value
       high_water:
         signal: purge_queue_pq_executing_ops_high_water
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3973,7 +3973,7 @@ views:
       value:
         signal: purge_queue_pq_executed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -3986,11 +3986,11 @@ views:
       executing:
         signal: purge_queue_pq_executing
         components:
-        - value
+          - value
       high_water:
         signal: purge_queue_pq_executing_high_water
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4003,11 +4003,11 @@ views:
       exported:
         signal: mds_exported
         components:
-        - value
+          - value
       imported:
         signal: mds_imported
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4020,11 +4020,11 @@ views:
       exported_inodes:
         signal: mds_exported_inodes
         components:
-        - value
+          - value
       imported_inodes:
         signal: mds_imported_inodes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4037,51 +4037,51 @@ views:
       blockdiff_latency:
         signal: mds_server_req_blockdiff_latency_sum
         components:
-        - value
+          - value
       getattr_latency:
         signal: mds_server_req_getattr_latency_sum
         components:
-        - value
+          - value
       getfilelock_latency:
         signal: mds_server_req_getfilelock_latency_sum
         components:
-        - value
+          - value
       getvxattr_latency:
         signal: mds_server_req_getvxattr_latency_sum
         components:
-        - value
+          - value
       lookup_latency:
         signal: mds_server_req_lookup_latency_sum
         components:
-        - value
+          - value
       lookuphash_latency:
         signal: mds_server_req_lookuphash_latency_sum
         components:
-        - value
+          - value
       lookupino_latency:
         signal: mds_server_req_lookupino_latency_sum
         components:
-        - value
+          - value
       lookupname_latency:
         signal: mds_server_req_lookupname_latency_sum
         components:
-        - value
+          - value
       lookupparent_latency:
         signal: mds_server_req_lookupparent_latency_sum
         components:
-        - value
+          - value
       lookupsnap_latency:
         signal: mds_server_req_lookupsnap_latency_sum
         components:
-        - value
+          - value
       open_latency:
         signal: mds_server_req_open_latency_sum
         components:
-        - value
+          - value
       readdir_latency:
         signal: mds_server_req_readdir_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4094,51 +4094,51 @@ views:
       blockdiff_latency:
         signal: mds_server_req_blockdiff_latency_count
         components:
-        - value
+          - value
       getattr_latency:
         signal: mds_server_req_getattr_latency_count
         components:
-        - value
+          - value
       getfilelock_latency:
         signal: mds_server_req_getfilelock_latency_count
         components:
-        - value
+          - value
       getvxattr_latency:
         signal: mds_server_req_getvxattr_latency_count
         components:
-        - value
+          - value
       lookup_latency:
         signal: mds_server_req_lookup_latency_count
         components:
-        - value
+          - value
       lookuphash_latency:
         signal: mds_server_req_lookuphash_latency_count
         components:
-        - value
+          - value
       lookupino_latency:
         signal: mds_server_req_lookupino_latency_count
         components:
-        - value
+          - value
       lookupname_latency:
         signal: mds_server_req_lookupname_latency_count
         components:
-        - value
+          - value
       lookupparent_latency:
         signal: mds_server_req_lookupparent_latency_count
         components:
-        - value
+          - value
       lookupsnap_latency:
         signal: mds_server_req_lookupsnap_latency_count
         components:
-        - value
+          - value
       open_latency:
         signal: mds_server_req_open_latency_count
         components:
-        - value
+          - value
       readdir_latency:
         signal: mds_server_req_readdir_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4151,7 +4151,7 @@ views:
       value:
         signal: mds_reply_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4164,7 +4164,7 @@ views:
       client_metrics_num_clients:
         signal: mds_client_metrics_num_clients
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4177,11 +4177,11 @@ views:
       reply:
         signal: mds_reply
         components:
-        - value
+          - value
       server_handle_client_session:
         signal: mds_server_handle_client_session
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4194,7 +4194,7 @@ views:
       expired:
         signal: mds_inodes_expired
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4207,7 +4207,7 @@ views:
       value:
         signal: mds_slow_reply
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4220,7 +4220,7 @@ views:
       value:
         signal: mds_root_rfiles
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4233,23 +4233,23 @@ views:
       inodes:
         signal: mds_inodes
         components:
-        - value
+          - value
       bottom:
         signal: mds_inodes_bottom
         components:
-        - value
+          - value
       pin_tail:
         signal: mds_inodes_pin_tail
         components:
-        - value
+          - value
       pinned:
         signal: mds_inodes_pinned
         components:
-        - value
+          - value
       top:
         signal: mds_inodes_top
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4262,7 +4262,7 @@ views:
       value:
         signal: mds_reply_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4275,7 +4275,7 @@ views:
       value:
         signal: mds_load_cent
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4288,27 +4288,27 @@ views:
       forward:
         signal: mds_forward
         components:
-        - value
+          - value
       request:
         signal: mds_request
         components:
-        - value
+          - value
       server_dispatch_client_request:
         signal: mds_server_dispatch_client_request
         components:
-        - value
+          - value
       server_dispatch_server_request:
         signal: mds_server_dispatch_server_request
         components:
-        - value
+          - value
       server_handle_client_request:
         signal: mds_server_handle_client_request
         components:
-        - value
+          - value
       server_handle_peer_request:
         signal: mds_server_handle_peer_request
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4321,7 +4321,7 @@ views:
       q:
         signal: mds_q
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4334,7 +4334,7 @@ views:
       value:
         signal: mds_root_rsnaps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4347,7 +4347,7 @@ views:
       value:
         signal: mds_root_rbytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4360,7 +4360,7 @@ views:
       value:
         signal: mds_subtrees
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4373,7 +4373,7 @@ views:
       set_tag:
         signal: mds_scrub_set_tag
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4386,11 +4386,11 @@ views:
       backtrace_fetch:
         signal: mds_scrub_backtrace_fetch
         components:
-        - value
+          - value
       backtrace_repaired:
         signal: mds_scrub_backtrace_repaired
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4403,7 +4403,7 @@ views:
       value:
         signal: mds_scrub_dirfrag_rstats
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4416,7 +4416,7 @@ views:
       inotable_repaired:
         signal: mds_scrub_inotable_repaired
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4429,15 +4429,15 @@ views:
       dir_base_inodes:
         signal: mds_scrub_dir_base_inodes
         components:
-        - value
+          - value
       dir_inodes:
         signal: mds_scrub_dir_inodes
         components:
-        - value
+          - value
       file_inodes:
         signal: mds_scrub_file_inodes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4450,23 +4450,23 @@ views:
       lssnap_latency:
         signal: mds_server_req_lssnap_latency_sum
         components:
-        - value
+          - value
       mksnap_latency:
         signal: mds_server_req_mksnap_latency_sum
         components:
-        - value
+          - value
       renamesnap_latency:
         signal: mds_server_req_renamesnap_latency_sum
         components:
-        - value
+          - value
       rmsnap_latency:
         signal: mds_server_req_rmsnap_latency_sum
         components:
-        - value
+          - value
       snapdiff_latency:
         signal: mds_server_req_snapdiff_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4479,78 +4479,81 @@ views:
       lssnap_latency:
         signal: mds_server_req_lssnap_latency_count
         components:
-        - value
+          - value
       mksnap_latency:
         signal: mds_server_req_mksnap_latency_count
         components:
-        - value
+          - value
       renamesnap_latency:
         signal: mds_server_req_renamesnap_latency_count
         components:
-        - value
+          - value
       rmsnap_latency:
         signal: mds_server_req_rmsnap_latency_count
         components:
-        - value
+          - value
       snapdiff_latency:
         signal: mds_server_req_snapdiff_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mds_clients.average_operation_latency:
     family: Ceph/CephFS/MDS/Clients
-    question: What is the average operation latency for each ceph daemon and client and rank and mds filesystem key?
+    question: What is the average operation latency for each ceph daemon and client and rank and mds filesystem
+      key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
       read:
         signal: mds_per_client_avg_read_latency
         components:
-        - value
+          - value
       write:
         signal: mds_per_client_avg_write_latency
         components:
-        - value
+          - value
       metadata:
         signal: mds_per_client_avg_metadata_latency
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mds_clients.capability_outcomes:
     family: Ceph/CephFS/MDS/Clients
-    question: What is the capability access outcomes for each ceph daemon and client and rank and mds filesystem key?
+    question: What is the capability access outcomes for each ceph daemon and client and rank and mds filesystem
+      key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
       hits:
         signal: mds_per_client_cap_hits
         components:
-        - value
+          - value
       misses:
         signal: mds_per_client_cap_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mds_clients.dentry_lease_outcomes:
     family: Ceph/CephFS/MDS/Clients
-    question: What is the dentry lease lookup outcomes for each ceph daemon and client and rank and mds filesystem key?
+    question: What is the dentry lease lookup outcomes for each ceph daemon and client and rank and mds filesystem
+      key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
       hits:
         signal: mds_per_client_dentry_lease_hits
         components:
-        - value
+          - value
       misses:
         signal: mds_per_client_dentry_lease_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4563,11 +4566,11 @@ views:
       open:
         signal: mds_per_client_opened_inodes
         components:
-        - value
+          - value
       total:
         signal: mds_per_client_total_inodes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4580,20 +4583,21 @@ views:
       open:
         signal: mds_per_client_opened_files
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mds_clients.pinned_inode_capabilities:
     family: Ceph/CephFS/MDS/Clients
-    question: What is the pinned inode capabilities for each ceph daemon and client and rank and mds filesystem key?
+    question: What is the pinned inode capabilities for each ceph daemon and client and rank and mds filesystem
+      key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
       pinned:
         signal: mds_per_client_pinned_icaps
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4606,11 +4610,11 @@ views:
       read:
         signal: mds_per_client_total_read_ops
         components:
-        - value
+          - value
       write:
         signal: mds_per_client_total_write_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4623,11 +4627,11 @@ views:
       read:
         signal: mds_per_client_total_read_size
         components:
-        - value
+          - value
       write:
         signal: mds_per_client_total_write_size
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4640,7 +4644,7 @@ views:
       value:
         signal: mds_mem_cap
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4653,11 +4657,11 @@ views:
       minus:
         signal: mds_mem_cap_minus
         components:
-        - value
+          - value
       plus:
         signal: mds_mem_cap_plus
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4670,7 +4674,7 @@ views:
       value:
         signal: mds_mem_dn
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4683,11 +4687,11 @@ views:
       minus:
         signal: mds_mem_dn_minus
         components:
-        - value
+          - value
       plus:
         signal: mds_mem_dn_plus
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4700,7 +4704,7 @@ views:
       value:
         signal: mds_mem_dir
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4713,11 +4717,11 @@ views:
       minus:
         signal: mds_mem_dir_minus
         components:
-        - value
+          - value
       plus:
         signal: mds_mem_dir_plus
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4730,7 +4734,7 @@ views:
       value:
         signal: mds_mem_ino
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4743,11 +4747,11 @@ views:
       minus:
         signal: mds_mem_ino_minus
         components:
-        - value
+          - value
       plus:
         signal: mds_mem_ino_plus
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4760,11 +4764,11 @@ views:
       heap:
         signal: mds_mem_heap
         components:
-        - value
+          - value
       rss:
         signal: mds_mem_rss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4777,7 +4781,7 @@ views:
       average_load:
         signal: mds_sessions_average_load
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4790,7 +4794,7 @@ views:
       value:
         signal: mds_sessions_avg_session_uptime
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4803,11 +4807,11 @@ views:
       add:
         signal: mds_sessions_session_add
         components:
-        - value
+          - value
       remove:
         signal: mds_sessions_session_remove
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4820,7 +4824,7 @@ views:
       value:
         signal: mds_sessions_mdthresh_evicted
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4833,15 +4837,15 @@ views:
       session:
         signal: mds_sessions_session_count
         components:
-        - value
+          - value
       sessions_open:
         signal: mds_sessions_sessions_open
         components:
-        - value
+          - value
       sessions_stale:
         signal: mds_sessions_sessions_stale
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4854,7 +4858,7 @@ views:
       total_load:
         signal: mds_sessions_total_load
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4867,21 +4871,21 @@ views:
       value:
         signal: fs_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_metadata.mds_metadata.state:
     family: Ceph/CephFS/Metadata/MDS Metadata
-    question: What is the state and metadata for each ceph daemon and ceph version and fs id and hostname and public addr
-      and rank?
+    question: What is the state and metadata for each ceph daemon and ceph version and fs id and hostname and public
+      addr and rank?
     entity: by_ceph_daemon_and_ceph_version_and_fs_id_and_hostname_and_public_addr_and_rank
     inputs:
       value:
         signal: mds_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4894,7 +4898,7 @@ views:
       directories:
         signal: cephfs_mirror_mirrored_filesystems_directory_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -4907,121 +4911,121 @@ views:
       peers:
         signal: cephfs_mirror_mirrored_filesystems_mirroring_peers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mirror.peers.accumulated_sync_time:
     family: Ceph/CephFS/Mirror/Peers
-    question: What is the accumulated sync time for each ceph daemon and peer cluster filesystem and peer cluster name and
-      source filesystem and source fscid?
+    question: What is the accumulated sync time for each ceph daemon and peer cluster filesystem and peer cluster
+      name and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
     inputs:
       time:
         signal: cephfs_mirror_peers_avg_sync_time_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_duration:
     family: Ceph/CephFS/Mirror/Peers
-    question: What is the last sync duration for each ceph daemon and peer cluster filesystem and peer cluster name and source
-      filesystem and source fscid?
+    question: What is the last sync duration for each ceph daemon and peer cluster filesystem and peer cluster name
+      and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
     inputs:
       duration:
         signal: cephfs_mirror_peers_last_synced_duration
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_size:
     family: Ceph/CephFS/Mirror/Peers
-    question: What is the last sync size for each ceph daemon and peer cluster filesystem and peer cluster name and source
-      filesystem and source fscid?
+    question: What is the last sync size for each ceph daemon and peer cluster filesystem and peer cluster name
+      and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
     inputs:
       bytes:
         signal: cephfs_mirror_peers_last_synced_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_timestamps:
     family: Ceph/CephFS/Mirror/Peers
-    question: What is the last sync timestamps for each ceph daemon and peer cluster filesystem and peer cluster name and
-      source filesystem and source fscid?
+    question: What is the last sync timestamps for each ceph daemon and peer cluster filesystem and peer cluster
+      name and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
     inputs:
       started:
         signal: cephfs_mirror_peers_last_synced_start
         components:
-        - value
+          - value
       ended:
         signal: cephfs_mirror_peers_last_synced_end
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mirror.peers.snapshot_outcomes:
     family: Ceph/CephFS/Mirror/Peers
-    question: What is the snapshot outcomes for each ceph daemon and peer cluster filesystem and peer cluster name and source
-      filesystem and source fscid?
+    question: What is the snapshot outcomes for each ceph daemon and peer cluster filesystem and peer cluster name
+      and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
     inputs:
       synced:
         signal: cephfs_mirror_peers_snaps_synced
         components:
-        - value
+          - value
       deleted:
         signal: cephfs_mirror_peers_snaps_deleted
         components:
-        - value
+          - value
       renamed:
         signal: cephfs_mirror_peers_snaps_renamed
         components:
-        - value
+          - value
       failed:
         signal: cephfs_mirror_peers_sync_failures
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mirror.peers.sync_throughput:
     family: Ceph/CephFS/Mirror/Peers
-    question: What is the sync throughput for each ceph daemon and peer cluster filesystem and peer cluster name and source
-      filesystem and source fscid?
+    question: What is the sync throughput for each ceph daemon and peer cluster filesystem and peer cluster name
+      and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
     inputs:
       bytes:
         signal: cephfs_mirror_peers_sync_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cephfs_mirror.peers.sync_time_measurements:
     family: Ceph/CephFS/Mirror/Peers
-    question: What is the sync-time measurements for each ceph daemon and peer cluster filesystem and peer cluster name and
-      source filesystem and source fscid?
+    question: What is the sync-time measurements for each ceph daemon and peer cluster filesystem and peer cluster
+      name and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
     inputs:
       snapshots:
         signal: cephfs_mirror_peers_avg_sync_time_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5034,7 +5038,7 @@ views:
       failures:
         signal: cephfs_mirror_mirror_enable_failures
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5047,7 +5051,7 @@ views:
       mirrored:
         signal: cephfs_mirror_mirrored_filesystems
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5060,7 +5064,7 @@ views:
       value:
         signal: prometheus_collect_duration_seconds_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5073,7 +5077,7 @@ views:
       value:
         signal: cluster_osd_blocklist_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5086,7 +5090,7 @@ views:
       value:
         signal: prometheus_collect_duration_seconds_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5099,21 +5103,21 @@ views:
       human:
         signal: disk_occupation_human
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   cluster_overview.state_occupation:
     family: Ceph/Cluster Overview
-    question: What is the state and metadata — occupation for each ceph daemon and ceph instance and db device and device
-      and device ids and devices and wal device?
+    question: What is the state and metadata — occupation for each ceph daemon and ceph instance and db device and
+      device and device ids and devices and wal device?
     entity: by_ceph_daemon_and_ceph_instance_and_db_device_and_device_and_device_ids_and_devices_and_wal_device
     inputs:
       occupation:
         signal: disk_occupation
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5126,7 +5130,7 @@ views:
       value:
         signal: cephadm_daemon_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5139,7 +5143,7 @@ views:
       metadata:
         signal: mgr_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5152,7 +5156,7 @@ views:
       status:
         signal: mgr_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5165,25 +5169,25 @@ views:
       can_run:
         signal: mgr_module_can_run
         components:
-        - value
+          - value
       status:
         signal: mgr_module_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   control_plane.monitor.state_metadata:
     family: Ceph/Control Plane/Monitor
-    question: What is the state and metadata — metadata for each ceph daemon and ceph version and hostname and public addr
-      and rank?
+    question: What is the state and metadata — metadata for each ceph daemon and ceph version and hostname and public
+      addr and rank?
     entity: by_ceph_daemon_and_ceph_version_and_hostname_and_public_addr_and_rank
     inputs:
       metadata:
         signal: mon_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5212,7 +5216,8 @@ views:
         rank: Member metadata is not meaningful on the cluster population chart.
     reduction:
       reducer: sum
-      lost_comparison: Individual monitor rows remain available in the member charts; this view is the additive population for one MGR job.
+      lost_comparison: Individual monitor rows remain available in the member charts; this view is the additive
+        population for one MGR job.
   control_plane.monitor.state_quorum_status:
     family: Ceph/Control Plane/Monitor
     question: What is the state and metadata — quorum status for each ceph daemon?
@@ -5221,7 +5226,7 @@ views:
       quorum_status:
         signal: mon_quorum_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5234,23 +5239,23 @@ views:
       begin_bytes:
         signal: paxos_begin_bytes_sum
         components:
-        - value
+          - value
       collect_bytes:
         signal: paxos_collect_bytes_sum
         components:
-        - value
+          - value
       commit_bytes:
         signal: paxos_commit_bytes_sum
         components:
-        - value
+          - value
       share_state_bytes:
         signal: paxos_share_state_bytes_sum
         components:
-        - value
+          - value
       store_state_bytes:
         signal: paxos_store_state_bytes_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5263,23 +5268,23 @@ views:
       begin_keys:
         signal: paxos_begin_keys_sum
         components:
-        - value
+          - value
       collect_keys:
         signal: paxos_collect_keys_sum
         components:
-        - value
+          - value
       commit_keys:
         signal: paxos_commit_keys_sum
         components:
-        - value
+          - value
       share_state_keys:
         signal: paxos_share_state_keys_sum
         components:
-        - value
+          - value
       store_state_keys:
         signal: paxos_store_state_keys_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5292,27 +5297,27 @@ views:
       begin_latency:
         signal: paxos_begin_latency_sum
         components:
-        - value
+          - value
       collect_latency:
         signal: paxos_collect_latency_sum
         components:
-        - value
+          - value
       commit_latency:
         signal: paxos_commit_latency_sum
         components:
-        - value
+          - value
       new_pn_latency:
         signal: paxos_new_pn_latency_sum
         components:
-        - value
+          - value
       refresh_latency:
         signal: paxos_refresh_latency_sum
         components:
-        - value
+          - value
       store_state_latency:
         signal: paxos_store_state_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5325,23 +5330,23 @@ views:
       begin_bytes:
         signal: paxos_begin_bytes_count
         components:
-        - value
+          - value
       collect_bytes:
         signal: paxos_collect_bytes_count
         components:
-        - value
+          - value
       commit_bytes:
         signal: paxos_commit_bytes_count
         components:
-        - value
+          - value
       share_state_bytes:
         signal: paxos_share_state_bytes_count
         components:
-        - value
+          - value
       store_state_bytes:
         signal: paxos_store_state_bytes_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5354,7 +5359,7 @@ views:
       collect_uncommitted:
         signal: paxos_collect_uncommitted
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5367,31 +5372,31 @@ views:
       new_pn:
         signal: paxos_new_pn
         components:
-        - value
+          - value
       refresh:
         signal: paxos_refresh
         components:
-        - value
+          - value
       restart:
         signal: paxos_restart
         components:
-        - value
+          - value
       share_state:
         signal: paxos_share_state
         components:
-        - value
+          - value
       start_leader:
         signal: paxos_start_leader
         components:
-        - value
+          - value
       start_peon:
         signal: paxos_start_peon
         components:
-        - value
+          - value
       store_state:
         signal: paxos_store_state
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5404,19 +5409,19 @@ views:
       accept_timeout:
         signal: paxos_accept_timeout
         components:
-        - value
+          - value
       collect_timeout:
         signal: paxos_collect_timeout
         components:
-        - value
+          - value
       lease_ack_timeout:
         signal: paxos_lease_ack_timeout
         components:
-        - value
+          - value
       lease_timeout:
         signal: paxos_lease_timeout
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5429,23 +5434,23 @@ views:
       begin_keys:
         signal: paxos_begin_keys_count
         components:
-        - value
+          - value
       collect_keys:
         signal: paxos_collect_keys_count
         components:
-        - value
+          - value
       commit_keys:
         signal: paxos_commit_keys_count
         components:
-        - value
+          - value
       share_state_keys:
         signal: paxos_share_state_keys_count
         components:
-        - value
+          - value
       store_state_keys:
         signal: paxos_store_state_keys_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5458,27 +5463,27 @@ views:
       begin_latency:
         signal: paxos_begin_latency_count
         components:
-        - value
+          - value
       collect_latency:
         signal: paxos_collect_latency_count
         components:
-        - value
+          - value
       commit_latency:
         signal: paxos_commit_latency_count
         components:
-        - value
+          - value
       new_pn_latency:
         signal: paxos_new_pn_latency_count
         components:
-        - value
+          - value
       refresh_latency:
         signal: paxos_refresh_latency_count
         components:
-        - value
+          - value
       store_state_latency:
         signal: paxos_store_state_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5491,15 +5496,15 @@ views:
       begin:
         signal: paxos_begin
         components:
-        - value
+          - value
       collect:
         signal: paxos_collect
         components:
-        - value
+          - value
       commit:
         signal: paxos_commit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5512,7 +5517,7 @@ views:
       duration:
         signal: exporter_scrape_time
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5525,7 +5530,7 @@ views:
       reachable:
         signal: daemon_socket_up
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5538,7 +5543,7 @@ views:
       cpu_time:
         signal: exporter_cpu_total
         components:
-        - value
+          - value
     labels:
       dimensions:
         mode:
@@ -5553,7 +5558,7 @@ views:
       utilization:
         signal: exporter_cpu_usage
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5562,7 +5567,7 @@ views:
       convention: percentage
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   exporter_and_process_runtime.daemon_processes.memory:
     family: Ceph/Exporter and Process/Daemon Processes
     question: What is the memory for each ceph daemon?
@@ -5571,11 +5576,11 @@ views:
       virtual:
         signal: exporter_vm_size
         components:
-        - value
+          - value
       resident:
         signal: exporter_resident_size
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5588,11 +5593,11 @@ views:
       minor:
         signal: exporter_minflt_total
         components:
-        - value
+          - value
       major:
         signal: exporter_majflt_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5605,7 +5610,7 @@ views:
       threads:
         signal: exporter_num_threads
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5618,7 +5623,7 @@ views:
       value:
         signal: health_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5631,7 +5636,7 @@ views:
       value:
         signal: daemon_health_metrics
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5644,7 +5649,7 @@ views:
       value:
         signal: health_detail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote:
@@ -5658,7 +5663,7 @@ views:
       value:
         signal: healthcheck_slow_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5671,11 +5676,11 @@ views:
       hit:
         signal: mgr_cache_hit
         components:
-        - value
+          - value
       miss:
         signal: mgr_cache_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5688,7 +5693,7 @@ views:
       active_queue_pair:
         signal: asyncmessenger_rdmadispatcher_active_queue_pair
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5701,11 +5706,11 @@ views:
       async_last_wqe_events:
         signal: asyncmessenger_rdmadispatcher_async_last_wqe_events
         components:
-        - value
+          - value
       total_async_events:
         signal: asyncmessenger_rdmadispatcher_total_async_events
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5718,11 +5723,11 @@ views:
       worker_msgr_connection_idle_timeouts:
         signal: asyncmessenger_worker_msgr_connection_idle_timeouts
         components:
-        - value
+          - value
       worker_msgr_connection_ready_timeouts:
         signal: asyncmessenger_worker_msgr_connection_ready_timeouts
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5735,7 +5740,7 @@ views:
       created_queue_pair:
         signal: asyncmessenger_rdmadispatcher_created_queue_pair
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5748,7 +5753,7 @@ views:
       inflight_tx_chunks:
         signal: asyncmessenger_rdmadispatcher_inflight_tx_chunks
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5761,7 +5766,7 @@ views:
       polling:
         signal: asyncmessenger_rdmadispatcher_polling
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5774,23 +5779,23 @@ views:
       rdmadispatcher_handshake_errors:
         signal: asyncmessenger_rdmadispatcher_handshake_errors
         components:
-        - value
+          - value
       rdmadispatcher_rx_total_wc_errors:
         signal: asyncmessenger_rdmadispatcher_rx_total_wc_errors
         components:
-        - value
+          - value
       rdmadispatcher_tx_retry_errors:
         signal: asyncmessenger_rdmadispatcher_tx_retry_errors
         components:
-        - value
+          - value
       rdmadispatcher_tx_total_wc_errors:
         signal: asyncmessenger_rdmadispatcher_tx_total_wc_errors
         components:
-        - value
+          - value
       rdmadispatcher_tx_wr_flush_errors:
         signal: asyncmessenger_rdmadispatcher_tx_wr_flush_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5803,11 +5808,11 @@ views:
       rx_bufs_in_use:
         signal: asyncmessenger_rdmadispatcher_rx_bufs_in_use
         components:
-        - value
+          - value
       rx_bufs:
         signal: asyncmessenger_rdmadispatcher_rx_bufs_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5820,7 +5825,7 @@ views:
       rx_fin:
         signal: asyncmessenger_rdmadispatcher_rx_fin
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5833,11 +5838,11 @@ views:
       rx_total_wc:
         signal: asyncmessenger_rdmadispatcher_rx_total_wc
         components:
-        - value
+          - value
       tx_total_wc:
         signal: asyncmessenger_rdmadispatcher_tx_total_wc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5850,19 +5855,19 @@ views:
       election_call:
         signal: mon_election_call
         components:
-        - value
+          - value
       election_lose:
         signal: mon_election_lose
         components:
-        - value
+          - value
       election_win:
         signal: mon_election_win
         components:
-        - value
+          - value
       num_elections:
         signal: mon_num_elections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5875,7 +5880,7 @@ views:
       value:
         signal: mon_num_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5888,15 +5893,15 @@ views:
       add:
         signal: mon_session_add
         components:
-        - value
+          - value
       rm:
         signal: mon_session_rm
         components:
-        - value
+          - value
       trim:
         signal: mon_session_trim
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5909,7 +5914,7 @@ views:
       value:
         signal: hardware_health
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5930,7 +5935,8 @@ views:
   node_hardware.cooling.fan_speed:
     display:
       convention: fan_revolutions_per_minute
-      reason: Preserve the source's rotations-per-minute operator unit while normalizing the semantic axis to revolutions per second.
+      reason: Preserve the source's rotations-per-minute operator unit while normalizing the semantic axis to revolutions
+        per second.
       evidence:
         - ceph_display_conventions
     family: Ceph/Hardware/Cooling
@@ -5940,7 +5946,7 @@ views:
       value:
         signal: hardware_fan_rpm
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5953,7 +5959,7 @@ views:
       value:
         signal: hardware_memory_capacity_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5966,7 +5972,7 @@ views:
       value:
         signal: hardware_cpu_cores
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5979,7 +5985,7 @@ views:
       value:
         signal: hardware_storage_capacity_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5992,11 +5998,11 @@ views:
       read_bytes:
         signal: nvmeof_bdev_read_bytes_total
         components:
-        - value
+          - value
       written_bytes:
         signal: nvmeof_bdev_written_bytes_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6009,11 +6015,11 @@ views:
       reads_completed:
         signal: nvmeof_bdev_reads_completed_total
         components:
-        - value
+          - value
       writes_completed:
         signal: nvmeof_bdev_writes_completed_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6026,20 +6032,21 @@ views:
       value:
         signal: nvmeof_bdev_capacity_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   nvme_of.block_devices.state:
     family: Ceph/NVMe-oF/Block Devices
-    question: What is the state and metadata for each bdev name and block size and namespace and pool name and rbd name?
+    question: What is the state and metadata for each bdev name and block size and namespace and pool name and rbd
+      name?
     entity: by_bdev_name_and_block_size_and_namespace_and_pool_name_and_rbd_name
     inputs:
       value:
         signal: nvmeof_bdev_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6052,11 +6059,11 @@ views:
       read_seconds:
         signal: nvmeof_bdev_read_seconds_total
         components:
-        - value
+          - value
       write_seconds:
         signal: nvmeof_bdev_write_seconds_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6069,7 +6076,7 @@ views:
       value:
         signal: nvmeof_rpc_method_seconds
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6082,7 +6089,7 @@ views:
       value:
         signal: nvmeof_reactor_seconds_total
         components:
-        - value
+          - value
     labels:
       dimensions:
         mode: {render: label_value}
@@ -6096,7 +6103,7 @@ views:
       value:
         signal: nvmeof_host_connection_state
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6109,7 +6116,7 @@ views:
       value:
         signal: nvmeof_host_keepalive_timeout
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6122,7 +6129,7 @@ views:
       value:
         signal: nvmeof_subsystem_host_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6135,7 +6142,7 @@ views:
       value:
         signal: nvmeof_subsystem_listener_iface_speed_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6144,7 +6151,7 @@ views:
       convention: network_megabits_per_second
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - nvmeof_display_conventions
+        - nvmeof_display_conventions
   nvme_of.subsystems.listener_state:
     family: Ceph/NVMe-oF/Subsystems
     question: What is the listener addresses for each nqn?
@@ -6153,7 +6160,7 @@ views:
       value:
         signal: nvmeof_subsystem_listener_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6166,7 +6173,7 @@ views:
       nvmeof_subsystem_namespace_count:
         signal: nvmeof_subsystem_namespace_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6200,35 +6207,35 @@ views:
       limit:
         signal: nvmeof_subsystem_namespace_limit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   nvme_of.subsystems.state_metadata:
     family: Ceph/NVMe-oF/Subsystems
-    question: What is the state and metadata — metadata for each allow any host and group and ha enabled and model number and nqn
-      and serial number?
+    question: What is the state and metadata — metadata for each allow any host and group and ha enabled and model
+      number and nqn and serial number?
     entity: by_allow_any_host_and_group_and_ha_enabled_and_model_number_and_nqn_and_serial_number
     inputs:
       metadata:
         signal: nvmeof_subsystem_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   nvme_of.subsystems.state_namespace_metadata:
     family: Ceph/NVMe-oF/Subsystems
-    question: What is the state and metadata — namespace metadata for each anagrpid and bdev name and nqn and nsid and rados
-      namespace name?
+    question: What is the state and metadata — namespace metadata for each anagrpid and bdev name and nqn and nsid
+      and rados namespace name?
     entity: by_anagrpid_and_bdev_name_and_nqn_and_nsid_and_rados_namespace_name
     inputs:
       namespace_metadata:
         signal: nvmeof_subsystem_namespace_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6241,7 +6248,7 @@ views:
       value:
         signal: rgw_lc_abort_mpu
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6254,23 +6261,23 @@ views:
       expire_current:
         signal: rgw_lc_expire_current
         components:
-        - value
+          - value
       expire_dm:
         signal: rgw_lc_expire_dm
         components:
-        - value
+          - value
       expire_noncurrent:
         signal: rgw_lc_expire_noncurrent
         components:
-        - value
+          - value
       transition_current:
         signal: rgw_lc_transition_current
         components:
-        - value
+          - value
       transition_noncurrent:
         signal: rgw_lc_transition_noncurrent
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6283,7 +6290,7 @@ views:
       value:
         signal: rgw_lua_current_vms
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6292,7 +6299,7 @@ views:
       convention: virtual_machines
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   object_gateway.lua.script_executions:
     family: Ceph/Object Gateway/Lua
     question: What is the lua script executions for each instance id?
@@ -6301,11 +6308,11 @@ views:
       success:
         signal: rgw_lua_script_ok
         components:
-        - value
+          - value
       failure:
         signal: rgw_lua_script_fail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6318,7 +6325,7 @@ views:
       value:
         signal: rgw_pubsub_events
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6331,19 +6338,19 @@ views:
       event_lost:
         signal: rgw_pubsub_event_lost
         components:
-        - value
+          - value
       event_triggered:
         signal: rgw_pubsub_event_triggered
         components:
-        - value
+          - value
       push_ok:
         signal: rgw_pubsub_push_ok
         components:
-        - value
+          - value
       store_ok:
         signal: rgw_pubsub_store_ok
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6356,11 +6363,11 @@ views:
       push_failed:
         signal: rgw_pubsub_push_failed
         components:
-        - value
+          - value
       store_fail:
         signal: rgw_pubsub_store_fail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6373,7 +6380,7 @@ views:
       value:
         signal: rgw_pubsub_missing_conf
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6386,7 +6393,7 @@ views:
       value:
         signal: rgw_pubsub_push_pending
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6399,11 +6406,11 @@ views:
       get_initial_lat:
         signal: rgw_get_initial_lat_sum
         components:
-        - value
+          - value
       put_initial_lat:
         signal: rgw_put_initial_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6416,11 +6423,11 @@ views:
       get_b:
         signal: rgw_get_b
         components:
-        - value
+          - value
       put_b:
         signal: rgw_put_b
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6433,11 +6440,11 @@ views:
       qactive:
         signal: rgw_qactive
         components:
-        - value
+          - value
       qlen:
         signal: rgw_qlen
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6450,7 +6457,7 @@ views:
       value:
         signal: rgw_failed_req
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6463,11 +6470,11 @@ views:
       get_initial_lat:
         signal: rgw_get_initial_lat_count
         components:
-        - value
+          - value
       put_initial_lat:
         signal: rgw_put_initial_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6480,7 +6487,7 @@ views:
       value:
         signal: rgw_gc_retire_object
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6493,15 +6500,15 @@ views:
       get:
         signal: rgw_get
         components:
-        - value
+          - value
       put:
         signal: rgw_put
         components:
-        - value
+          - value
       req:
         signal: rgw_req
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6514,11 +6521,11 @@ views:
       hit:
         signal: rgw_keystone_token_cache_hit
         components:
-        - value
+          - value
       miss:
         signal: rgw_keystone_token_cache_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6531,11 +6538,11 @@ views:
       cache_hit:
         signal: rgw_cache_hit
         components:
-        - value
+          - value
       cache_miss:
         signal: rgw_cache_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6548,7 +6555,7 @@ views:
       value:
         signal: rgw_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6561,7 +6568,7 @@ views:
       value:
         signal: data_sync_from_zone_fetch_bytes_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6574,11 +6581,11 @@ views:
       lock_latency:
         signal: data_sync_from_zone_lock_latency_sum
         components:
-        - value
+          - value
       poll_latency:
         signal: data_sync_from_zone_poll_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6591,11 +6598,11 @@ views:
       lock_latency:
         signal: data_sync_from_zone_lock_latency_count
         components:
-        - value
+          - value
       poll_latency:
         signal: data_sync_from_zone_poll_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6608,11 +6615,11 @@ views:
       errors:
         signal: data_sync_from_zone_fetch_errors
         components:
-        - value
+          - value
       not_modified:
         signal: data_sync_from_zone_fetch_not_modified
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6625,7 +6632,7 @@ views:
       value:
         signal: data_sync_from_zone_fetch_bytes_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6638,7 +6645,7 @@ views:
       value:
         signal: data_sync_from_zone_poll_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6651,35 +6658,35 @@ views:
       admin_reservation:
         signal: dmclock_admin_res_latency_sum
         components:
-        - value
+          - value
       admin_priority:
         signal: dmclock_admin_prio_latency_sum
         components:
-        - value
+          - value
       auth_reservation:
         signal: dmclock_auth_res_latency_sum
         components:
-        - value
+          - value
       auth_priority:
         signal: dmclock_auth_prio_latency_sum
         components:
-        - value
+          - value
       data_reservation:
         signal: dmclock_data_res_latency_sum
         components:
-        - value
+          - value
       data_priority:
         signal: dmclock_data_prio_latency_sum
         components:
-        - value
+          - value
       metadata_reservation:
         signal: dmclock_metadata_res_latency_sum
         components:
-        - value
+          - value
       metadata_priority:
         signal: dmclock_metadata_prio_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6692,35 +6699,35 @@ views:
       admin_reservation:
         signal: dmclock_admin_res_latency_count
         components:
-        - value
+          - value
       admin_priority:
         signal: dmclock_admin_prio_latency_count
         components:
-        - value
+          - value
       auth_reservation:
         signal: dmclock_auth_res_latency_count
         components:
-        - value
+          - value
       auth_priority:
         signal: dmclock_auth_prio_latency_count
         components:
-        - value
+          - value
       data_reservation:
         signal: dmclock_data_res_latency_count
         components:
-        - value
+          - value
       data_priority:
         signal: dmclock_data_prio_latency_count
         components:
-        - value
+          - value
       metadata_reservation:
         signal: dmclock_metadata_res_latency_count
         components:
-        - value
+          - value
       metadata_priority:
         signal: dmclock_metadata_prio_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6733,7 +6740,7 @@ views:
       outstanding:
         signal: dmclock_scheduler_outstanding
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6746,19 +6753,19 @@ views:
       admin:
         signal: dmclock_admin_cost
         components:
-        - value
+          - value
       auth:
         signal: dmclock_auth_cost
         components:
-        - value
+          - value
       data:
         signal: dmclock_data_cost
         components:
-        - value
+          - value
       metadata:
         signal: dmclock_metadata_cost
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6771,19 +6778,19 @@ views:
       admin:
         signal: dmclock_admin_qlen
         components:
-        - value
+          - value
       auth:
         signal: dmclock_auth_qlen
         components:
-        - value
+          - value
       data:
         signal: dmclock_data_qlen
         components:
-        - value
+          - value
       metadata:
         signal: dmclock_metadata_qlen
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6796,35 +6803,35 @@ views:
       admin_limited:
         signal: dmclock_admin_limit
         components:
-        - value
+          - value
       admin_cancelled:
         signal: dmclock_admin_cancel
         components:
-        - value
+          - value
       auth_limited:
         signal: dmclock_auth_limit
         components:
-        - value
+          - value
       auth_cancelled:
         signal: dmclock_auth_cancel
         components:
-        - value
+          - value
       data_limited:
         signal: dmclock_data_limit
         components:
-        - value
+          - value
       data_cancelled:
         signal: dmclock_data_cancel
         components:
-        - value
+          - value
       metadata_limited:
         signal: dmclock_metadata_limit
         components:
-        - value
+          - value
       metadata_cancelled:
         signal: dmclock_metadata_cancel
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6837,67 +6844,67 @@ views:
       admin_reservation:
         signal: dmclock_admin_res_cost
         components:
-        - value
+          - value
       admin_priority:
         signal: dmclock_admin_prio_cost
         components:
-        - value
+          - value
       admin_limited:
         signal: dmclock_admin_limit_cost
         components:
-        - value
+          - value
       admin_cancelled:
         signal: dmclock_admin_cancel_cost
         components:
-        - value
+          - value
       auth_reservation:
         signal: dmclock_auth_res_cost
         components:
-        - value
+          - value
       auth_priority:
         signal: dmclock_auth_prio_cost
         components:
-        - value
+          - value
       auth_limited:
         signal: dmclock_auth_limit_cost
         components:
-        - value
+          - value
       auth_cancelled:
         signal: dmclock_auth_cancel_cost
         components:
-        - value
+          - value
       data_reservation:
         signal: dmclock_data_res_cost
         components:
-        - value
+          - value
       data_priority:
         signal: dmclock_data_prio_cost
         components:
-        - value
+          - value
       data_limited:
         signal: dmclock_data_limit_cost
         components:
-        - value
+          - value
       data_cancelled:
         signal: dmclock_data_cancel_cost
         components:
-        - value
+          - value
       metadata_reservation:
         signal: dmclock_metadata_res_cost
         components:
-        - value
+          - value
       metadata_priority:
         signal: dmclock_metadata_prio_cost
         components:
-        - value
+          - value
       metadata_limited:
         signal: dmclock_metadata_limit_cost
         components:
-        - value
+          - value
       metadata_cancelled:
         signal: dmclock_metadata_cancel_cost
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6910,35 +6917,35 @@ views:
       admin_reservation:
         signal: dmclock_admin_res
         components:
-        - value
+          - value
       admin_priority:
         signal: dmclock_admin_prio
         components:
-        - value
+          - value
       auth_reservation:
         signal: dmclock_auth_res
         components:
-        - value
+          - value
       auth_priority:
         signal: dmclock_auth_prio
         components:
-        - value
+          - value
       data_reservation:
         signal: dmclock_data_res
         components:
-        - value
+          - value
       data_priority:
         signal: dmclock_data_prio
         components:
-        - value
+          - value
       metadata_reservation:
         signal: dmclock_metadata_res
         components:
-        - value
+          - value
       metadata_priority:
         signal: dmclock_metadata_prio
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6951,7 +6958,7 @@ views:
       throttled:
         signal: dmclock_scheduler_throttle
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6964,31 +6971,31 @@ views:
       copy_obj:
         signal: rgw_op_copy_obj_ops
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_op_del_bucket_ops
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_op_del_obj_ops
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_op_get_obj_ops
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_op_list_buckets_ops
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_op_list_obj_ops
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_op_put_obj_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7001,19 +7008,19 @@ views:
       copy_obj:
         signal: rgw_op_copy_obj_bytes
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_op_del_obj_bytes
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_op_get_obj_bytes
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_op_put_obj_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7026,31 +7033,31 @@ views:
       copy_obj:
         signal: rgw_op_copy_obj_lat
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_op_del_bucket_lat
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_op_del_obj_lat
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_op_get_obj_lat
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_op_list_buckets_lat
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_op_list_obj_lat
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_op_put_obj_lat
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7063,31 +7070,31 @@ views:
       copy_obj:
         signal: rgw_op_copy_obj_lat_sum
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_op_del_bucket_lat_sum
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_op_del_obj_lat_sum
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_op_get_obj_lat_sum
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_op_list_buckets_lat_sum
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_op_list_obj_lat_sum
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_op_put_obj_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7100,31 +7107,31 @@ views:
       copy_obj:
         signal: rgw_user_op_copy_obj_ops
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_user_op_del_bucket_ops
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_user_op_del_obj_ops
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_user_op_get_obj_ops
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_user_op_list_buckets_ops
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_user_op_list_obj_ops
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_user_op_put_obj_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7137,19 +7144,19 @@ views:
       copy_obj:
         signal: rgw_user_op_copy_obj_bytes
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_user_op_del_obj_bytes
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_user_op_get_obj_bytes
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_user_op_put_obj_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7162,31 +7169,31 @@ views:
       copy_obj:
         signal: rgw_user_op_copy_obj_lat
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_user_op_del_bucket_lat
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_user_op_del_obj_lat
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_user_op_get_obj_lat
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_user_op_list_buckets_lat
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_user_op_list_obj_lat
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_user_op_put_obj_lat
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7199,31 +7206,31 @@ views:
       copy_obj:
         signal: rgw_user_op_copy_obj_lat_sum
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_user_op_del_bucket_lat_sum
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_user_op_del_obj_lat_sum
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_user_op_get_obj_lat_sum
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_user_op_list_buckets_lat_sum
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_user_op_list_obj_lat_sum
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_user_op_put_obj_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7236,31 +7243,31 @@ views:
       copy_obj:
         signal: rgw_bucket_op_copy_obj_ops
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_bucket_op_del_bucket_ops
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_bucket_op_del_obj_ops
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_bucket_op_get_obj_ops
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_bucket_op_list_buckets_ops
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_bucket_op_list_obj_ops
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_bucket_op_put_obj_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7273,19 +7280,19 @@ views:
       copy_obj:
         signal: rgw_bucket_op_copy_obj_bytes
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_bucket_op_del_obj_bytes
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_bucket_op_get_obj_bytes
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_bucket_op_put_obj_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7298,31 +7305,31 @@ views:
       copy_obj:
         signal: rgw_bucket_op_copy_obj_lat
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_bucket_op_del_bucket_lat
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_bucket_op_del_obj_lat
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_bucket_op_get_obj_lat
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_bucket_op_list_buckets_lat
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_bucket_op_list_obj_lat
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_bucket_op_put_obj_lat
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7335,31 +7342,31 @@ views:
       copy_obj:
         signal: rgw_bucket_op_copy_obj_lat_sum
         components:
-        - value
+          - value
       del_bucket:
         signal: rgw_bucket_op_del_bucket_lat_sum
         components:
-        - value
+          - value
       del_obj:
         signal: rgw_bucket_op_del_obj_lat_sum
         components:
-        - value
+          - value
       get_obj:
         signal: rgw_bucket_op_get_obj_lat_sum
         components:
-        - value
+          - value
       list_buckets:
         signal: rgw_bucket_op_list_buckets_lat_sum
         components:
-        - value
+          - value
       list_obj:
         signal: rgw_bucket_op_list_obj_lat_sum
         components:
-        - value
+          - value
       put_obj:
         signal: rgw_bucket_op_put_obj_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7372,7 +7379,7 @@ views:
       sync_delta:
         signal: rgw_sync_delta_sync_delta
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7386,7 +7393,7 @@ views:
       entries:
         signal: rgw_topic_persistent_topic_len
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7399,7 +7406,7 @@ views:
       bytes:
         signal: rgw_topic_persistent_topic_size
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7413,11 +7420,11 @@ views:
       hit:
         signal: rgw_d4n_cache_hits
         components:
-        - value
+          - value
       miss:
         signal: rgw_d4n_cache_misses
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7430,7 +7437,7 @@ views:
       eviction:
         signal: rgw_d4n_cache_evictions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7444,7 +7451,7 @@ views:
       outstanding:
         signal: simple_throttler_outstanding
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7457,7 +7464,7 @@ views:
       throttled:
         signal: simple_throttler_throttle
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7471,7 +7478,7 @@ views:
       value:
         signal: objecter_op_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7488,7 +7495,7 @@ views:
       command_active:
         signal: objecter_command_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7505,7 +7512,7 @@ views:
       linger_active:
         signal: objecter_linger_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7522,15 +7529,15 @@ views:
       op_active:
         signal: objecter_op_active
         components:
-        - value
+          - value
       op_inflight:
         signal: objecter_op_inflight
         components:
-        - value
+          - value
       op_laggy:
         signal: objecter_op_laggy
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7547,7 +7554,7 @@ views:
       poolop_active:
         signal: objecter_poolop_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7564,7 +7571,7 @@ views:
       poolstat_active:
         signal: objecter_poolstat_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7581,7 +7588,7 @@ views:
       statfs_active:
         signal: objecter_statfs_active
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7598,7 +7605,7 @@ views:
       value:
         signal: objecter_op_send_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7615,11 +7622,11 @@ views:
       command_resend:
         signal: objecter_command_resend
         components:
-        - value
+          - value
       command_send:
         signal: objecter_command_send
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7636,7 +7643,7 @@ views:
       value:
         signal: objecter_op_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7653,15 +7660,15 @@ views:
       linger_ping:
         signal: objecter_linger_ping
         components:
-        - value
+          - value
       linger_resend:
         signal: objecter_linger_resend
         components:
-        - value
+          - value
       linger_send:
         signal: objecter_linger_send
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7678,7 +7685,7 @@ views:
       map_epoch:
         signal: objecter_map_epoch
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7695,11 +7702,11 @@ views:
       map_full:
         signal: objecter_map_full
         components:
-        - value
+          - value
       map_inc:
         signal: objecter_map_inc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7716,7 +7723,7 @@ views:
       value:
         signal: objecter_oplen_avg_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7733,147 +7740,147 @@ views:
       omap_del:
         signal: objecter_omap_del
         components:
-        - value
+          - value
       omap_rd:
         signal: objecter_omap_rd
         components:
-        - value
+          - value
       omap_wr:
         signal: objecter_omap_wr
         components:
-        - value
+          - value
       op:
         signal: objecter_op
         components:
-        - value
+          - value
       op_pg:
         signal: objecter_op_pg
         components:
-        - value
+          - value
       op_r:
         signal: objecter_op_r
         components:
-        - value
+          - value
       op_reply:
         signal: objecter_op_reply
         components:
-        - value
+          - value
       op_resend:
         signal: objecter_op_resend
         components:
-        - value
+          - value
       op_rmw:
         signal: objecter_op_rmw
         components:
-        - value
+          - value
       op_send:
         signal: objecter_op_send
         components:
-        - value
+          - value
       op_w:
         signal: objecter_op_w
         components:
-        - value
+          - value
       osdop_append:
         signal: objecter_osdop_append
         components:
-        - value
+          - value
       osdop_call:
         signal: objecter_osdop_call
         components:
-        - value
+          - value
       osdop_clonerange:
         signal: objecter_osdop_clonerange
         components:
-        - value
+          - value
       osdop_cmpxattr:
         signal: objecter_osdop_cmpxattr
         components:
-        - value
+          - value
       osdop_create:
         signal: objecter_osdop_create
         components:
-        - value
+          - value
       osdop_delete:
         signal: objecter_osdop_delete
         components:
-        - value
+          - value
       osdop_getxattr:
         signal: objecter_osdop_getxattr
         components:
-        - value
+          - value
       osdop_mapext:
         signal: objecter_osdop_mapext
         components:
-        - value
+          - value
       osdop_notify:
         signal: objecter_osdop_notify
         components:
-        - value
+          - value
       osdop_other:
         signal: objecter_osdop_other
         components:
-        - value
+          - value
       osdop_pgls:
         signal: objecter_osdop_pgls
         components:
-        - value
+          - value
       osdop_pgls_filter:
         signal: objecter_osdop_pgls_filter
         components:
-        - value
+          - value
       osdop_read:
         signal: objecter_osdop_read
         components:
-        - value
+          - value
       osdop_resetxattrs:
         signal: objecter_osdop_resetxattrs
         components:
-        - value
+          - value
       osdop_rmxattr:
         signal: objecter_osdop_rmxattr
         components:
-        - value
+          - value
       osdop_setxattr:
         signal: objecter_osdop_setxattr
         components:
-        - value
+          - value
       osdop_sparse_read:
         signal: objecter_osdop_sparse_read
         components:
-        - value
+          - value
       osdop_src_cmpxattr:
         signal: objecter_osdop_src_cmpxattr
         components:
-        - value
+          - value
       osdop_stat:
         signal: objecter_osdop_stat
         components:
-        - value
+          - value
       osdop_truncate:
         signal: objecter_osdop_truncate
         components:
-        - value
+          - value
       osdop_watch:
         signal: objecter_osdop_watch
         components:
-        - value
+          - value
       osdop_write:
         signal: objecter_osdop_write
         components:
-        - value
+          - value
       osdop_writefull:
         signal: objecter_osdop_writefull
         components:
-        - value
+          - value
       osdop_writesame:
         signal: objecter_osdop_writesame
         components:
-        - value
+          - value
       osdop_zero:
         signal: objecter_osdop_zero
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7890,11 +7897,11 @@ views:
       osd_session_close:
         signal: objecter_osd_session_close
         components:
-        - value
+          - value
       osd_session_open:
         signal: objecter_osd_session_open
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7911,11 +7918,11 @@ views:
       poolop_resend:
         signal: objecter_poolop_resend
         components:
-        - value
+          - value
       poolop_send:
         signal: objecter_poolop_send
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7932,15 +7939,15 @@ views:
       replica_read_sent:
         signal: objecter_replica_read_sent
         components:
-        - value
+          - value
       replica_read_bounced:
         signal: objecter_replica_read_bounced
         components:
-        - value
+          - value
       replica_read_completed:
         signal: objecter_replica_read_completed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7957,11 +7964,11 @@ views:
       laggy:
         signal: objecter_osd_laggy
         components:
-        - value
+          - value
       sessions:
         signal: objecter_osd_sessions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -7978,19 +7985,19 @@ views:
       poolstat_resend:
         signal: objecter_poolstat_resend
         components:
-        - value
+          - value
       poolstat_send:
         signal: objecter_poolstat_send
         components:
-        - value
+          - value
       statfs_resend:
         signal: objecter_statfs_resend
         components:
-        - value
+          - value
       statfs_send:
         signal: objecter_statfs_send
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8007,7 +8014,7 @@ views:
       value:
         signal: objecter_oplen_avg_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8024,31 +8031,31 @@ views:
       nodeep_scrub:
         signal: osd_flag_nodeep_scrub
         components:
-        - value
+          - value
       nodown:
         signal: osd_flag_nodown
         components:
-        - value
+          - value
       noin:
         signal: osd_flag_noin
         components:
-        - value
+          - value
       noout:
         signal: osd_flag_noout
         components:
-        - value
+          - value
       norebalance:
         signal: osd_flag_norebalance
         components:
-        - value
+          - value
       noscrub:
         signal: osd_flag_noscrub
         components:
-        - value
+          - value
       noup:
         signal: osd_flag_noup
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8061,11 +8068,11 @@ views:
       full_ratio:
         signal: osd_full_ratio
         components:
-        - value
+          - value
       nearfull_ratio:
         signal: osd_nearfull_ratio
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8077,14 +8084,14 @@ views:
       evidence:
         - ceph_display_conventions
     family: Ceph/OSDs/Capacity and State/Metadata
-    question: What is the state and metadata for each back iface and ceph daemon and ceph version and cluster addr and device
-      class and front iface and hostname and objectstore and public addr?
+    question: What is the state and metadata for each back iface and ceph daemon and ceph version and cluster addr
+      and device class and front iface and hostname and objectstore and public addr?
     entity: by_back_iface_and_ceph_daemon_and_ceph_version_and_cluster_addr_and_device_class_and_front_iface_and_hostname_and_objectstore_and_public_addr
     inputs:
       value:
         signal: osd_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8102,11 +8109,11 @@ views:
       in:
         signal: osd_in
         components:
-        - value
+          - value
       up:
         signal: osd_up
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8144,7 +8151,8 @@ views:
         public_addr: Member metadata is not meaningful on the cluster population chart.
     reduction:
       reducer: sum
-      lost_comparison: Individual OSD rows remain available in the member charts; this view is the additive population for one MGR job.
+      lost_comparison: Individual OSD rows remain available in the member charts; this view is the additive population
+        for one MGR job.
   osd_capacity_and_state.osd_state.weight:
     family: Ceph/OSDs/Capacity and State/OSD State
     question: What is the osd weight for each ceph daemon?
@@ -8153,7 +8161,7 @@ views:
       weight:
         signal: osd_weight
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8166,75 +8174,75 @@ views:
       op_before_dequeue_op_lat:
         signal: osd_op_before_dequeue_op_lat_sum
         components:
-        - value
+          - value
       op_before_queue_op_lat:
         signal: osd_op_before_queue_op_lat_sum
         components:
-        - value
+          - value
       op_latency:
         signal: osd_op_latency_sum
         components:
-        - value
+          - value
       op_prepare_latency:
         signal: osd_op_prepare_latency_sum
         components:
-        - value
+          - value
       op_process_latency:
         signal: osd_op_process_latency_sum
         components:
-        - value
+          - value
       op_r_latency:
         signal: osd_op_r_latency_sum
         components:
-        - value
+          - value
       op_r_prepare_latency:
         signal: osd_op_r_prepare_latency_sum
         components:
-        - value
+          - value
       op_r_process_latency:
         signal: osd_op_r_process_latency_sum
         components:
-        - value
+          - value
       op_rw_latency:
         signal: osd_op_rw_latency_sum
         components:
-        - value
+          - value
       op_rw_prepare_latency:
         signal: osd_op_rw_prepare_latency_sum
         components:
-        - value
+          - value
       op_rw_process_latency:
         signal: osd_op_rw_process_latency_sum
         components:
-        - value
+          - value
       op_w_latency:
         signal: osd_op_w_latency_sum
         components:
-        - value
+          - value
       op_w_prepare_latency:
         signal: osd_op_w_prepare_latency_sum
         components:
-        - value
+          - value
       op_w_process_latency:
         signal: osd_op_w_process_latency_sum
         components:
-        - value
+          - value
       subop_latency:
         signal: osd_subop_latency_sum
         components:
-        - value
+          - value
       subop_pull_latency:
         signal: osd_subop_pull_latency_sum
         components:
-        - value
+          - value
       subop_push_latency:
         signal: osd_subop_push_latency_sum
         components:
-        - value
+          - value
       subop_w_latency:
         signal: osd_subop_w_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8247,39 +8255,39 @@ views:
       op_in_bytes:
         signal: osd_op_in_bytes
         components:
-        - value
+          - value
       op_out_bytes:
         signal: osd_op_out_bytes
         components:
-        - value
+          - value
       op_r_out_bytes:
         signal: osd_op_r_out_bytes
         components:
-        - value
+          - value
       op_rw_in_bytes:
         signal: osd_op_rw_in_bytes
         components:
-        - value
+          - value
       op_rw_out_bytes:
         signal: osd_op_rw_out_bytes
         components:
-        - value
+          - value
       op_w_in_bytes:
         signal: osd_op_w_in_bytes
         components:
-        - value
+          - value
       subop_in_bytes:
         signal: osd_subop_in_bytes
         components:
-        - value
+          - value
       subop_push_in_bytes:
         signal: osd_subop_push_in_bytes
         components:
-        - value
+          - value
       subop_w_in_bytes:
         signal: osd_subop_w_in_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8292,7 +8300,7 @@ views:
       value:
         signal: osd_op_wip
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8305,7 +8313,7 @@ views:
       value:
         signal: osd_subop_push
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8318,7 +8326,7 @@ views:
       value:
         signal: osd_slow_ops_slow_ops_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8331,75 +8339,75 @@ views:
       op_before_dequeue_op_lat:
         signal: osd_op_before_dequeue_op_lat_count
         components:
-        - value
+          - value
       op_before_queue_op_lat:
         signal: osd_op_before_queue_op_lat_count
         components:
-        - value
+          - value
       op_latency:
         signal: osd_op_latency_count
         components:
-        - value
+          - value
       op_prepare_latency:
         signal: osd_op_prepare_latency_count
         components:
-        - value
+          - value
       op_process_latency:
         signal: osd_op_process_latency_count
         components:
-        - value
+          - value
       op_r_latency:
         signal: osd_op_r_latency_count
         components:
-        - value
+          - value
       op_r_prepare_latency:
         signal: osd_op_r_prepare_latency_count
         components:
-        - value
+          - value
       op_r_process_latency:
         signal: osd_op_r_process_latency_count
         components:
-        - value
+          - value
       op_rw_latency:
         signal: osd_op_rw_latency_count
         components:
-        - value
+          - value
       op_rw_prepare_latency:
         signal: osd_op_rw_prepare_latency_count
         components:
-        - value
+          - value
       op_rw_process_latency:
         signal: osd_op_rw_process_latency_count
         components:
-        - value
+          - value
       op_w_latency:
         signal: osd_op_w_latency_count
         components:
-        - value
+          - value
       op_w_prepare_latency:
         signal: osd_op_w_prepare_latency_count
         components:
-        - value
+          - value
       op_w_process_latency:
         signal: osd_op_w_process_latency_count
         components:
-        - value
+          - value
       subop_latency:
         signal: osd_subop_latency_count
         components:
-        - value
+          - value
       subop_pull_latency:
         signal: osd_subop_pull_latency_count
         components:
-        - value
+          - value
       subop_push_latency:
         signal: osd_subop_push_latency_count
         components:
-        - value
+          - value
       subop_w_latency:
         signal: osd_subop_w_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8412,7 +8420,7 @@ views:
       value:
         signal: osd_op_cache_hit
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8425,15 +8433,15 @@ views:
       op_delayed_degraded:
         signal: osd_op_delayed_degraded
         components:
-        - value
+          - value
       op_delayed_unreadable:
         signal: osd_op_delayed_unreadable
         components:
-        - value
+          - value
       replica_read_redirect_missing:
         signal: osd_replica_read_redirect_missing
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8446,47 +8454,47 @@ views:
       op:
         signal: osd_op
         components:
-        - value
+          - value
       op_r:
         signal: osd_op_r
         components:
-        - value
+          - value
       op_rw:
         signal: osd_op_rw
         components:
-        - value
+          - value
       op_w:
         signal: osd_op_w
         components:
-        - value
+          - value
       replica_read:
         signal: osd_replica_read
         components:
-        - value
+          - value
       replica_read_redirect_conflict:
         signal: osd_replica_read_redirect_conflict
         components:
-        - value
+          - value
       replica_read_served:
         signal: osd_replica_read_served
         components:
-        - value
+          - value
       subop_pull:
         signal: osd_subop_pull
         components:
-        - value
+          - value
       subop_w:
         signal: osd_subop_w
         components:
-        - value
+          - value
       tier_proxy_read:
         signal: osd_tier_proxy_read
         components:
-        - value
+          - value
       tier_proxy_write:
         signal: osd_tier_proxy_write
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8499,11 +8507,11 @@ views:
       apply_latency_ms:
         signal: osd_apply_latency_ms
         components:
-        - value
+          - value
       commit_latency_ms:
         signal: osd_commit_latency_ms
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8512,7 +8520,7 @@ views:
       convention: duration_milliseconds
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   osd_recovery.accumulated_latency:
     family: Ceph/OSDs/Recovery
     question: What is the accumulated latency for each ceph daemon?
@@ -8521,35 +8529,35 @@ views:
       backfill_queue_latency:
         signal: osd_l_osd_recovery_backfill_queue_latency_sum
         components:
-        - value
+          - value
       backfill_remove_queue_latency:
         signal: osd_l_osd_recovery_backfill_remove_queue_latency_sum
         components:
-        - value
+          - value
       context_queue_latency:
         signal: osd_l_osd_recovery_context_queue_latency_sum
         components:
-        - value
+          - value
       pull_queue_latency:
         signal: osd_l_osd_recovery_pull_queue_latency_sum
         components:
-        - value
+          - value
       push_queue_latency:
         signal: osd_l_osd_recovery_push_queue_latency_sum
         components:
-        - value
+          - value
       push_reply_queue_latency:
         signal: osd_l_osd_recovery_push_reply_queue_latency_sum
         components:
-        - value
+          - value
       queue_latency:
         signal: osd_l_osd_recovery_queue_latency_sum
         components:
-        - value
+          - value
       scan_queue_latency:
         signal: osd_l_osd_recovery_scan_queue_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8562,7 +8570,7 @@ views:
       value:
         signal: osd_recovery_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8575,35 +8583,35 @@ views:
       backfill_queue_latency:
         signal: osd_l_osd_recovery_backfill_queue_latency_count
         components:
-        - value
+          - value
       backfill_remove_queue_latency:
         signal: osd_l_osd_recovery_backfill_remove_queue_latency_count
         components:
-        - value
+          - value
       context_queue_latency:
         signal: osd_l_osd_recovery_context_queue_latency_count
         components:
-        - value
+          - value
       pull_queue_latency:
         signal: osd_l_osd_recovery_pull_queue_latency_count
         components:
-        - value
+          - value
       push_queue_latency:
         signal: osd_l_osd_recovery_push_queue_latency_count
         components:
-        - value
+          - value
       push_reply_queue_latency:
         signal: osd_l_osd_recovery_push_reply_queue_latency_count
         components:
-        - value
+          - value
       queue_latency:
         signal: osd_l_osd_recovery_queue_latency_count
         components:
-        - value
+          - value
       scan_queue_latency:
         signal: osd_l_osd_recovery_scan_queue_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8616,7 +8624,7 @@ views:
       value:
         signal: osd_recovery_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8629,7 +8637,7 @@ views:
       value:
         signal: recoverystate_perf_pg_rebuild_duration_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8642,7 +8650,7 @@ views:
       value:
         signal: recoverystate_perf_pg_rebuild_duration_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8655,11 +8663,11 @@ views:
       maximum:
         signal: recoverystate_perf_pg_rebuild_max_secs
         components:
-        - value
+          - value
       minimum:
         signal: recoverystate_perf_pg_rebuild_min_secs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8672,15 +8680,15 @@ views:
       flush_lat:
         signal: osd_osd_tier_flush_lat_sum
         components:
-        - value
+          - value
       promote_lat:
         signal: osd_osd_tier_promote_lat_sum
         components:
-        - value
+          - value
       r_lat:
         signal: osd_osd_tier_r_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8693,7 +8701,7 @@ views:
       value:
         signal: osd_osd_map_cache_miss_low_avg_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8706,7 +8714,7 @@ views:
       value:
         signal: osd_push_out_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8719,7 +8727,7 @@ views:
       copyfrom:
         signal: osd_copyfrom
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8732,15 +8740,15 @@ views:
       cached_crc:
         signal: osd_cached_crc
         components:
-        - value
+          - value
       cached_crc_adjusted:
         signal: osd_cached_crc_adjusted
         components:
-        - value
+          - value
       missed_crc:
         signal: osd_missed_crc
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8753,11 +8761,11 @@ views:
       tier_flush_fail:
         signal: osd_tier_flush_fail
         components:
-        - value
+          - value
       tier_try_flush_fail:
         signal: osd_tier_try_flush_fail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8770,7 +8778,7 @@ views:
       heartbeat_to_peers:
         signal: osd_heartbeat_to_peers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8783,15 +8791,15 @@ views:
       flush_lat:
         signal: osd_osd_tier_flush_lat_count
         components:
-        - value
+          - value
       promote_lat:
         signal: osd_osd_tier_promote_lat_count
         components:
-        - value
+          - value
       r_lat:
         signal: osd_osd_tier_r_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8804,7 +8812,7 @@ views:
       loadavg:
         signal: osd_loadavg
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8817,11 +8825,11 @@ views:
       osd_map_bl_cache_hit:
         signal: osd_osd_map_bl_cache_hit
         components:
-        - value
+          - value
       osd_map_bl_cache_miss:
         signal: osd_osd_map_bl_cache_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8834,15 +8842,15 @@ views:
       osd_map_cache_hit:
         signal: osd_osd_map_cache_hit
         components:
-        - value
+          - value
       osd_map_cache_miss:
         signal: osd_osd_map_cache_miss
         components:
-        - value
+          - value
       osd_map_cache_miss_low:
         signal: osd_osd_map_cache_miss_low
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8855,11 +8863,11 @@ views:
       map_message_epochs:
         signal: osd_map_message_epochs
         components:
-        - value
+          - value
       map_message_epoch_dups:
         signal: osd_map_message_epoch_dups
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8872,11 +8880,11 @@ views:
       map_messages:
         signal: osd_map_messages
         components:
-        - value
+          - value
       messages_delayed_for_map:
         signal: osd_messages_delayed_for_map
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8889,11 +8897,11 @@ views:
       object_ctx_cache_hit:
         signal: osd_object_ctx_cache_hit
         components:
-        - value
+          - value
       object_ctx_cache:
         signal: osd_object_ctx_cache_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8906,23 +8914,23 @@ views:
       numpg:
         signal: osd_numpg
         components:
-        - value
+          - value
       primary:
         signal: osd_numpg_primary
         components:
-        - value
+          - value
       removing:
         signal: osd_numpg_removing
         components:
-        - value
+          - value
       replica:
         signal: osd_numpg_replica
         components:
-        - value
+          - value
       stray:
         signal: osd_numpg_stray
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8931,7 +8939,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   osd_runtime.pg_updates:
     family: Ceph/OSDs/Runtime
     question: What is the placement-group updates for each ceph daemon?
@@ -8940,11 +8948,11 @@ views:
       osd_pg_biginfo:
         signal: osd_osd_pg_biginfo
         components:
-        - value
+          - value
       osd_pg_fastinfo:
         signal: osd_osd_pg_fastinfo
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8957,7 +8965,7 @@ views:
       total:
         signal: osd_osd_pg_info
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8970,7 +8978,7 @@ views:
       pull:
         signal: osd_pull
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8983,7 +8991,7 @@ views:
       push:
         signal: osd_push
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -8996,7 +9004,7 @@ views:
       agent_skip:
         signal: osd_agent_skip
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9009,15 +9017,15 @@ views:
       bytes:
         signal: osd_stat_bytes
         components:
-        - value
+          - value
       avail:
         signal: osd_stat_bytes_avail
         components:
-        - value
+          - value
       used:
         signal: osd_stat_bytes_used
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9030,7 +9038,7 @@ views:
       subop:
         signal: osd_subop
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9043,31 +9051,31 @@ views:
       agent_evict:
         signal: osd_agent_evict
         components:
-        - value
+          - value
       agent_wake:
         signal: osd_agent_wake
         components:
-        - value
+          - value
       tier_clean:
         signal: osd_tier_clean
         components:
-        - value
+          - value
       tier_delay:
         signal: osd_tier_delay
         components:
-        - value
+          - value
       tier_dirty:
         signal: osd_tier_dirty
         components:
-        - value
+          - value
       tier_evict:
         signal: osd_tier_evict
         components:
-        - value
+          - value
       tier_promote:
         signal: osd_tier_promote
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9080,15 +9088,15 @@ views:
       agent_flush:
         signal: osd_agent_flush
         components:
-        - value
+          - value
       tier_flush:
         signal: osd_tier_flush
         components:
-        - value
+          - value
       tier_try_flush:
         signal: osd_tier_try_flush
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9101,7 +9109,7 @@ views:
       tier_whiteout:
         signal: osd_tier_whiteout
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9114,7 +9122,7 @@ views:
       value:
         signal: osd_osd_map_cache_miss_low_avg_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9127,7 +9135,7 @@ views:
       watch_timeouts:
         signal: osd_watch_timeouts
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9140,35 +9148,35 @@ views:
       dp_ec_failed_reservations_elapsed:
         signal: osd_scrub_dp_ec_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       dp_ec_successful_reservations_elapsed:
         signal: osd_scrub_dp_ec_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
       dp_repl_failed_reservations_elapsed:
         signal: osd_scrub_dp_repl_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       dp_repl_successful_reservations_elapsed:
         signal: osd_scrub_dp_repl_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
       sh_ec_failed_reservations_elapsed:
         signal: osd_scrub_sh_ec_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       sh_ec_successful_reservations_elapsed:
         signal: osd_scrub_sh_ec_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
       sh_repl_failed_reservations_elapsed:
         signal: osd_scrub_sh_repl_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       sh_repl_successful_reservations_elapsed:
         signal: osd_scrub_sh_repl_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9181,35 +9189,35 @@ views:
       dp_ec_failed_scrubs_elapsed:
         signal: osd_scrub_dp_ec_failed_scrubs_elapsed_sum
         components:
-        - value
+          - value
       dp_ec_successful_scrubs_elapsed:
         signal: osd_scrub_dp_ec_successful_scrubs_elapsed_sum
         components:
-        - value
+          - value
       dp_repl_failed_scrubs_elapsed:
         signal: osd_scrub_dp_repl_failed_scrubs_elapsed_sum
         components:
-        - value
+          - value
       dp_repl_successful_scrubs_elapsed:
         signal: osd_scrub_dp_repl_successful_scrubs_elapsed_sum
         components:
-        - value
+          - value
       sh_ec_failed_scrubs_elapsed:
         signal: osd_scrub_sh_ec_failed_scrubs_elapsed_sum
         components:
-        - value
+          - value
       sh_ec_successful_scrubs_elapsed:
         signal: osd_scrub_sh_ec_successful_scrubs_elapsed_sum
         components:
-        - value
+          - value
       sh_repl_failed_scrubs_elapsed:
         signal: osd_scrub_sh_repl_failed_scrubs_elapsed_sum
         components:
-        - value
+          - value
       sh_repl_successful_scrubs_elapsed:
         signal: osd_scrub_sh_repl_successful_scrubs_elapsed_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9222,35 +9230,35 @@ views:
       dp_ec_failed_reservations_elapsed:
         signal: osd_scrub_dp_ec_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       dp_ec_successful_reservations_elapsed:
         signal: osd_scrub_dp_ec_successful_reservations_elapsed_count
         components:
-        - value
+          - value
       dp_repl_failed_reservations_elapsed:
         signal: osd_scrub_dp_repl_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       dp_repl_successful_reservations_elapsed:
         signal: osd_scrub_dp_repl_successful_reservations_elapsed_count
         components:
-        - value
+          - value
       sh_ec_failed_reservations_elapsed:
         signal: osd_scrub_sh_ec_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       sh_ec_successful_reservations_elapsed:
         signal: osd_scrub_sh_ec_successful_reservations_elapsed_count
         components:
-        - value
+          - value
       sh_repl_failed_reservations_elapsed:
         signal: osd_scrub_sh_repl_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       sh_repl_successful_reservations_elapsed:
         signal: osd_scrub_sh_repl_successful_reservations_elapsed_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9263,35 +9271,35 @@ views:
       dp_ec_failed_scrubs_elapsed:
         signal: osd_scrub_dp_ec_failed_scrubs_elapsed_count
         components:
-        - value
+          - value
       dp_ec_successful_scrubs_elapsed:
         signal: osd_scrub_dp_ec_successful_scrubs_elapsed_count
         components:
-        - value
+          - value
       dp_repl_failed_scrubs_elapsed:
         signal: osd_scrub_dp_repl_failed_scrubs_elapsed_count
         components:
-        - value
+          - value
       dp_repl_successful_scrubs_elapsed:
         signal: osd_scrub_dp_repl_successful_scrubs_elapsed_count
         components:
-        - value
+          - value
       sh_ec_failed_scrubs_elapsed:
         signal: osd_scrub_sh_ec_failed_scrubs_elapsed_count
         components:
-        - value
+          - value
       sh_ec_successful_scrubs_elapsed:
         signal: osd_scrub_sh_ec_successful_scrubs_elapsed_count
         components:
-        - value
+          - value
       sh_repl_failed_scrubs_elapsed:
         signal: osd_scrub_sh_repl_failed_scrubs_elapsed_count
         components:
-        - value
+          - value
       sh_repl_successful_scrubs_elapsed:
         signal: osd_scrub_sh_repl_successful_scrubs_elapsed_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9304,51 +9312,51 @@ views:
       dp_ec_failed_scrubs:
         signal: osd_scrub_dp_ec_failed_scrubs
         components:
-        - value
+          - value
       dp_ec_num_scrubs_started:
         signal: osd_scrub_dp_ec_num_scrubs_started
         components:
-        - value
+          - value
       dp_ec_successful_scrubs:
         signal: osd_scrub_dp_ec_successful_scrubs
         components:
-        - value
+          - value
       dp_repl_failed_scrubs:
         signal: osd_scrub_dp_repl_failed_scrubs
         components:
-        - value
+          - value
       dp_repl_num_scrubs_started:
         signal: osd_scrub_dp_repl_num_scrubs_started
         components:
-        - value
+          - value
       dp_repl_successful_scrubs:
         signal: osd_scrub_dp_repl_successful_scrubs
         components:
-        - value
+          - value
       sh_ec_failed_scrubs:
         signal: osd_scrub_sh_ec_failed_scrubs
         components:
-        - value
+          - value
       sh_ec_num_scrubs_started:
         signal: osd_scrub_sh_ec_num_scrubs_started
         components:
-        - value
+          - value
       sh_ec_successful_scrubs:
         signal: osd_scrub_sh_ec_successful_scrubs
         components:
-        - value
+          - value
       sh_repl_failed_scrubs:
         signal: osd_scrub_sh_repl_failed_scrubs
         components:
-        - value
+          - value
       sh_repl_num_scrubs_started:
         signal: osd_scrub_sh_repl_num_scrubs_started
         components:
-        - value
+          - value
       sh_repl_successful_scrubs:
         signal: osd_scrub_sh_repl_successful_scrubs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9361,19 +9369,19 @@ views:
       dp_ec_replicas_in_reservation:
         signal: osd_scrub_dp_ec_replicas_in_reservation
         components:
-        - value
+          - value
       dp_repl_replicas_in_reservation:
         signal: osd_scrub_dp_repl_replicas_in_reservation
         components:
-        - value
+          - value
       sh_ec_replicas_in_reservation:
         signal: osd_scrub_sh_ec_replicas_in_reservation
         components:
-        - value
+          - value
       sh_repl_replicas_in_reservation:
         signal: osd_scrub_sh_repl_replicas_in_reservation
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9386,51 +9394,51 @@ views:
       dp_ec_reservation_process_aborted:
         signal: osd_scrub_dp_ec_reservation_process_aborted
         components:
-        - value
+          - value
       dp_ec_reservation_process_failure:
         signal: osd_scrub_dp_ec_reservation_process_failure
         components:
-        - value
+          - value
       dp_ec_reservation_process_skipped:
         signal: osd_scrub_dp_ec_reservation_process_skipped
         components:
-        - value
+          - value
       dp_repl_reservation_process_aborted:
         signal: osd_scrub_dp_repl_reservation_process_aborted
         components:
-        - value
+          - value
       dp_repl_reservation_process_failure:
         signal: osd_scrub_dp_repl_reservation_process_failure
         components:
-        - value
+          - value
       dp_repl_reservation_process_skipped:
         signal: osd_scrub_dp_repl_reservation_process_skipped
         components:
-        - value
+          - value
       sh_ec_reservation_process_aborted:
         signal: osd_scrub_sh_ec_reservation_process_aborted
         components:
-        - value
+          - value
       sh_ec_reservation_process_failure:
         signal: osd_scrub_sh_ec_reservation_process_failure
         components:
-        - value
+          - value
       sh_ec_reservation_process_skipped:
         signal: osd_scrub_sh_ec_reservation_process_skipped
         components:
-        - value
+          - value
       sh_repl_reservation_process_aborted:
         signal: osd_scrub_sh_repl_reservation_process_aborted
         components:
-        - value
+          - value
       sh_repl_reservation_process_failure:
         signal: osd_scrub_sh_repl_reservation_process_failure
         components:
-        - value
+          - value
       sh_repl_reservation_process_skipped:
         signal: osd_scrub_sh_repl_reservation_process_skipped
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9443,19 +9451,19 @@ views:
       dp_ec_num_scrubs_past_reservation:
         signal: osd_scrub_dp_ec_num_scrubs_past_reservation
         components:
-        - value
+          - value
       dp_repl_num_scrubs_past_reservation:
         signal: osd_scrub_dp_repl_num_scrubs_past_reservation
         components:
-        - value
+          - value
       sh_ec_num_scrubs_past_reservation:
         signal: osd_scrub_sh_ec_num_scrubs_past_reservation
         components:
-        - value
+          - value
       sh_repl_num_scrubs_past_reservation:
         signal: osd_scrub_sh_repl_num_scrubs_past_reservation
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9468,19 +9476,19 @@ views:
       scrub_ec_failed_reservations_elapsed:
         signal: osd_scrub_ec_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       scrub_ec_successful_reservations_elapsed:
         signal: osd_scrub_ec_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
       scrub_replicated_failed_reservations_elapsed:
         signal: osd_scrub_replicated_failed_reservations_elapsed_sum
         components:
-        - value
+          - value
       scrub_replicated_successful_reservations_elapsed:
         signal: osd_scrub_replicated_successful_reservations_elapsed_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9493,19 +9501,19 @@ views:
       failed_scrubs_ec_elapsed:
         signal: osd_failed_scrubs_ec_elapsed_sum
         components:
-        - value
+          - value
       failed_scrubs_replicated_elapsed:
         signal: osd_failed_scrubs_replicated_elapsed_sum
         components:
-        - value
+          - value
       successful_scrubs_ec_elapsed:
         signal: osd_successful_scrubs_ec_elapsed_sum
         components:
-        - value
+          - value
       successful_scrubs_replicated_elapsed:
         signal: osd_successful_scrubs_replicated_elapsed_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9518,19 +9526,19 @@ views:
       scrub_ec_failed_reservations_elapsed:
         signal: osd_scrub_ec_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       scrub_ec_successful_reservations_elapsed:
         signal: osd_scrub_ec_successful_reservations_elapsed_count
         components:
-        - value
+          - value
       scrub_replicated_failed_reservations_elapsed:
         signal: osd_scrub_replicated_failed_reservations_elapsed_count
         components:
-        - value
+          - value
       scrub_replicated_successful_reservations_elapsed:
         signal: osd_scrub_replicated_successful_reservations_elapsed_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9543,19 +9551,19 @@ views:
       failed_scrubs_ec_elapsed:
         signal: osd_failed_scrubs_ec_elapsed_count
         components:
-        - value
+          - value
       failed_scrubs_replicated_elapsed:
         signal: osd_failed_scrubs_replicated_elapsed_count
         components:
-        - value
+          - value
       successful_scrubs_ec_elapsed:
         signal: osd_successful_scrubs_ec_elapsed_count
         components:
-        - value
+          - value
       successful_scrubs_replicated_elapsed:
         signal: osd_successful_scrubs_replicated_elapsed_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9568,19 +9576,19 @@ views:
       ec_io_blocked:
         signal: osd_scrub_ec_io_blocked
         components:
-        - value
+          - value
       ec_io_intersects:
         signal: osd_scrub_ec_io_intersects
         components:
-        - value
+          - value
       replicated_io_blocked:
         signal: osd_scrub_replicated_io_blocked
         components:
-        - value
+          - value
       replicated_io_intersects:
         signal: osd_scrub_replicated_io_intersects
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9593,27 +9601,27 @@ views:
       failed_scrubs_ec:
         signal: osd_failed_scrubs_ec
         components:
-        - value
+          - value
       failed_scrubs_replicated:
         signal: osd_failed_scrubs_replicated
         components:
-        - value
+          - value
       num_scrubs_started_ec:
         signal: osd_num_scrubs_started_ec
         components:
-        - value
+          - value
       num_scrubs_started_replicated:
         signal: osd_num_scrubs_started_replicated
         components:
-        - value
+          - value
       successful_scrubs_ec:
         signal: osd_successful_scrubs_ec
         components:
-        - value
+          - value
       successful_scrubs_replicated:
         signal: osd_successful_scrubs_replicated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9626,11 +9634,11 @@ views:
       ec_replicas_in_reservation:
         signal: osd_scrub_ec_replicas_in_reservation
         components:
-        - value
+          - value
       replicated_replicas_in_reservation:
         signal: osd_scrub_replicated_replicas_in_reservation
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9643,35 +9651,35 @@ views:
       scrub_ec_reservation_process_aborted:
         signal: osd_scrub_ec_reservation_process_aborted
         components:
-        - value
+          - value
       scrub_ec_reservation_process_failure:
         signal: osd_scrub_ec_reservation_process_failure
         components:
-        - value
+          - value
       scrub_ec_reservation_process_skipped:
         signal: osd_scrub_ec_reservation_process_skipped
         components:
-        - value
+          - value
       scrub_ec_reservations_completed:
         signal: osd_scrub_ec_reservations_completed
         components:
-        - value
+          - value
       scrub_replicated_reservation_process_aborted:
         signal: osd_scrub_replicated_reservation_process_aborted
         components:
-        - value
+          - value
       scrub_replicated_reservation_process_failure:
         signal: osd_scrub_replicated_reservation_process_failure
         components:
-        - value
+          - value
       scrub_replicated_reservation_process_skipped:
         signal: osd_scrub_replicated_reservation_process_skipped
         components:
-        - value
+          - value
       scrub_replicated_scrub_reservations_completed:
         signal: osd_scrub_replicated_scrub_reservations_completed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9684,11 +9692,11 @@ views:
       num_scrubs_past_reservation_ec:
         signal: osd_num_scrubs_past_reservation_ec
         components:
-        - value
+          - value
       num_scrubs_past_reservation_replicated:
         signal: osd_num_scrubs_past_reservation_replicated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9701,11 +9709,11 @@ views:
       ec_read_bytes:
         signal: osd_scrub_ec_read_bytes
         components:
-        - value
+          - value
       replicated_read_bytes:
         signal: osd_scrub_replicated_read_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9718,27 +9726,27 @@ views:
       ec_getattr_cnt:
         signal: osd_scrub_ec_getattr_cnt
         components:
-        - value
+          - value
       ec_read_cnt:
         signal: osd_scrub_ec_read_cnt
         components:
-        - value
+          - value
       ec_stats_cnt:
         signal: osd_scrub_ec_stats_cnt
         components:
-        - value
+          - value
       replicated_getattr_cnt:
         signal: osd_scrub_replicated_getattr_cnt
         components:
-        - value
+          - value
       replicated_read_cnt:
         signal: osd_scrub_replicated_read_cnt
         components:
-        - value
+          - value
       replicated_stats_cnt:
         signal: osd_scrub_replicated_stats_cnt
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9751,19 +9759,19 @@ views:
       dp_ec_write_blocked_by_scrub:
         signal: osd_scrub_dp_ec_write_blocked_by_scrub
         components:
-        - value
+          - value
       dp_repl_write_blocked_by_scrub:
         signal: osd_scrub_dp_repl_write_blocked_by_scrub
         components:
-        - value
+          - value
       sh_ec_write_blocked_by_scrub:
         signal: osd_scrub_sh_ec_write_blocked_by_scrub
         components:
-        - value
+          - value
       sh_repl_write_blocked_by_scrub:
         signal: osd_scrub_sh_repl_write_blocked_by_scrub
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9776,35 +9784,35 @@ views:
       dp_ec_chunk_busy:
         signal: osd_scrub_dp_ec_chunk_busy
         components:
-        - value
+          - value
       dp_ec_chunk_selected:
         signal: osd_scrub_dp_ec_chunk_selected
         components:
-        - value
+          - value
       dp_repl_chunk_busy:
         signal: osd_scrub_dp_repl_chunk_busy
         components:
-        - value
+          - value
       dp_repl_chunk_selected:
         signal: osd_scrub_dp_repl_chunk_selected
         components:
-        - value
+          - value
       sh_ec_chunk_busy:
         signal: osd_scrub_sh_ec_chunk_busy
         components:
-        - value
+          - value
       sh_ec_chunk_selected:
         signal: osd_scrub_sh_ec_chunk_selected
         components:
-        - value
+          - value
       sh_repl_chunk_busy:
         signal: osd_scrub_sh_repl_chunk_busy
         components:
-        - value
+          - value
       sh_repl_chunk_selected:
         signal: osd_scrub_sh_repl_chunk_selected
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9817,19 +9825,19 @@ views:
       dp_ec_locked_object:
         signal: osd_scrub_dp_ec_locked_object
         components:
-        - value
+          - value
       dp_repl_locked_object:
         signal: osd_scrub_dp_repl_locked_object
         components:
-        - value
+          - value
       sh_ec_locked_object:
         signal: osd_scrub_sh_ec_locked_object
         components:
-        - value
+          - value
       sh_repl_locked_object:
         signal: osd_scrub_sh_repl_locked_object
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9842,19 +9850,19 @@ views:
       dp_ec_preemptions:
         signal: osd_scrub_dp_ec_preemptions
         components:
-        - value
+          - value
       dp_repl_preemptions:
         signal: osd_scrub_dp_repl_preemptions
         components:
-        - value
+          - value
       sh_ec_preemptions:
         signal: osd_scrub_sh_ec_preemptions
         components:
-        - value
+          - value
       sh_repl_preemptions:
         signal: osd_scrub_sh_repl_preemptions
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9867,19 +9875,19 @@ views:
       dp_ec_scrub_reservations_completed:
         signal: osd_scrub_dp_ec_scrub_reservations_completed
         components:
-        - value
+          - value
       dp_repl_scrub_reservations_completed:
         signal: osd_scrub_dp_repl_scrub_reservations_completed
         components:
-        - value
+          - value
       sh_ec_scrub_reservations_completed:
         signal: osd_scrub_sh_ec_scrub_reservations_completed
         components:
-        - value
+          - value
       sh_repl_scrub_reservations_completed:
         signal: osd_scrub_sh_repl_scrub_reservations_completed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9892,11 +9900,11 @@ views:
       omapget_bytes:
         signal: osd_scrub_omapget_bytes
         components:
-        - value
+          - value
       omapgetheader_bytes:
         signal: osd_scrub_omapgetheader_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9909,11 +9917,11 @@ views:
       omapget_cnt:
         signal: osd_scrub_omapget_cnt
         components:
-        - value
+          - value
       omapgetheader_cnt:
         signal: osd_scrub_omapgetheader_cnt
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9926,27 +9934,27 @@ views:
       backfill_toofull:
         signal: pg_backfill_toofull
         components:
-        - value
+          - value
       backfill_unfound:
         signal: pg_backfill_unfound
         components:
-        - value
+          - value
       backfill_wait:
         signal: pg_backfill_wait
         components:
-        - value
+          - value
       backfilling:
         signal: pg_backfilling
         components:
-        - value
+          - value
       forced_backfill:
         signal: pg_forced_backfill
         components:
-        - value
+          - value
       remapped:
         signal: pg_remapped
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9955,7 +9963,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   placement_groups_and_recovery.healthy_state.pg_state:
     family: Ceph/Placement Groups/Healthy State
     question: What is the placement groups for each pool id?
@@ -9964,19 +9972,19 @@ views:
       active:
         signal: pg_active
         components:
-        - value
+          - value
       clean:
         signal: pg_clean
         components:
-        - value
+          - value
       deep:
         signal: pg_deep
         components:
-        - value
+          - value
       pg_total:
         signal: pg_total
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -9985,7 +9993,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   placement_groups_and_recovery.peering_and_availability.pg_state:
     family: Ceph/Placement Groups/Peering and Availability
     question: What is the placement groups for each pool id?
@@ -9994,47 +10002,47 @@ views:
       activating:
         signal: pg_activating
         components:
-        - value
+          - value
       creating:
         signal: pg_creating
         components:
-        - value
+          - value
       down:
         signal: pg_down
         components:
-        - value
+          - value
       incomplete:
         signal: pg_incomplete
         components:
-        - value
+          - value
       laggy:
         signal: pg_laggy
         components:
-        - value
+          - value
       peered:
         signal: pg_peered
         components:
-        - value
+          - value
       peering:
         signal: pg_peering
         components:
-        - value
+          - value
       premerge:
         signal: pg_premerge
         components:
-        - value
+          - value
       stale:
         signal: pg_stale
         components:
-        - value
+          - value
       unknown:
         signal: pg_unknown
         components:
-        - value
+          - value
       wait:
         signal: pg_wait
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10043,7 +10051,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   placement_groups_and_recovery.recovery_and_degradation.pg_state:
     family: Ceph/Placement Groups/Recovery and Degradation
     question: What is the placement groups for each pool id?
@@ -10052,31 +10060,31 @@ views:
       degraded:
         signal: pg_degraded
         components:
-        - value
+          - value
       forced_recovery:
         signal: pg_forced_recovery
         components:
-        - value
+          - value
       recovering:
         signal: pg_recovering
         components:
-        - value
+          - value
       recovery_toofull:
         signal: pg_recovery_toofull
         components:
-        - value
+          - value
       recovery_unfound:
         signal: pg_recovery_unfound
         components:
-        - value
+          - value
       recovery_wait:
         signal: pg_recovery_wait
         components:
-        - value
+          - value
       undersized:
         signal: pg_undersized
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10085,7 +10093,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   placement_groups_and_recovery.recovery_flags.state:
     family: Ceph/Placement Groups/Recovery Flags
     question: What is the state and metadata?
@@ -10094,11 +10102,11 @@ views:
       nobackfill:
         signal: osd_flag_nobackfill
         components:
-        - value
+          - value
       norecover:
         signal: osd_flag_norecover
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10111,31 +10119,31 @@ views:
       failed_repair:
         signal: pg_failed_repair
         components:
-        - value
+          - value
       inconsistent:
         signal: pg_inconsistent
         components:
-        - value
+          - value
       repair:
         signal: pg_repair
         components:
-        - value
+          - value
       scrubbing:
         signal: pg_scrubbing
         components:
-        - value
+          - value
       snaptrim:
         signal: pg_snaptrim
         components:
-        - value
+          - value
       snaptrim_error:
         signal: pg_snaptrim_error
         components:
-        - value
+          - value
       snaptrim_wait:
         signal: pg_snaptrim_wait
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10144,7 +10152,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   pools.capacity_and_quotas.compression_space:
     family: Ceph/Pools/Capacity and Quotas
     question: What is the compression space for each pool id?
@@ -10153,11 +10161,11 @@ views:
       compress_bytes_used:
         signal: pool_compress_bytes_used
         components:
-        - value
+          - value
       compress_under_bytes:
         signal: pool_compress_under_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10170,15 +10178,15 @@ views:
       max_avail:
         signal: pool_max_avail
         components:
-        - value
+          - value
       quota_bytes:
         signal: pool_quota_bytes
         components:
-        - value
+          - value
       stored:
         signal: pool_stored
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10191,7 +10199,7 @@ views:
       value:
         signal: pool_quota_objects
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10204,15 +10212,15 @@ views:
       avail_raw:
         signal: pool_avail_raw
         components:
-        - value
+          - value
       bytes_used:
         signal: pool_bytes_used
         components:
-        - value
+          - value
       stored_raw:
         signal: pool_stored_raw
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10225,7 +10233,7 @@ views:
       value:
         signal: pool_percent_used
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10234,7 +10242,7 @@ views:
       convention: percentage
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   pools.client_i_o.byte_throughput:
     family: Ceph/Pools/Client IO
     question: What is the byte throughput for each pool id?
@@ -10243,11 +10251,11 @@ views:
       rd_bytes:
         signal: pool_rd_bytes
         components:
-        - value
+          - value
       wr_bytes:
         signal: pool_wr_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10260,25 +10268,25 @@ views:
       rd:
         signal: pool_rd
         components:
-        - value
+          - value
       wr:
         signal: pool_wr
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   pools.metadata.state:
     family: Ceph/Pools/Metadata
-    question: What is the state and metadata for each application and compression mode and description and name and pool id
-      and type?
+    question: What is the state and metadata for each application and compression mode and description and name
+      and pool id and type?
     entity: by_application_and_compression_mode_and_description_and_name_and_pool_id_and_type
     inputs:
       value:
         signal: pool_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10291,11 +10299,11 @@ views:
       dirty:
         signal: pool_dirty
         components:
-        - value
+          - value
       objects:
         signal: pool_objects
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10308,7 +10316,7 @@ views:
       value:
         signal: pool_recovering_bytes_per_sec
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10321,7 +10329,7 @@ views:
       value:
         signal: pool_recovering_keys_per_sec
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10334,7 +10342,7 @@ views:
       value:
         signal: pool_recovering_objects_per_sec
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10347,7 +10355,7 @@ views:
       value:
         signal: pool_num_objects_recovered
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10360,7 +10368,7 @@ views:
       value:
         signal: pool_objects_repaired
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10373,7 +10381,7 @@ views:
       value:
         signal: pool_num_bytes_recovered
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10386,15 +10394,15 @@ views:
       discard:
         signal: rbd_librbd_image_discard_latency_sum
         components:
-        - value
+          - value
       write_same:
         signal: rbd_librbd_image_ws_latency_sum
         components:
-        - value
+          - value
       compare_and_write:
         signal: rbd_librbd_image_cmp_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10407,7 +10415,7 @@ views:
       flush:
         signal: rbd_librbd_image_flush_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10420,11 +10428,11 @@ views:
       read:
         signal: rbd_librbd_image_rd_latency_sum
         components:
-        - value
+          - value
       write:
         signal: rbd_librbd_image_wr_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10437,15 +10445,15 @@ views:
       discard:
         signal: rbd_librbd_image_discard_bytes
         components:
-        - value
+          - value
       write_same:
         signal: rbd_librbd_image_ws_bytes
         components:
-        - value
+          - value
       compare_and_write:
         signal: rbd_librbd_image_cmp_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10458,15 +10466,15 @@ views:
       discard:
         signal: rbd_librbd_image_discard_latency_count
         components:
-        - value
+          - value
       write_same:
         signal: rbd_librbd_image_ws_latency_count
         components:
-        - value
+          - value
       compare_and_write:
         signal: rbd_librbd_image_cmp_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10479,15 +10487,15 @@ views:
       discard:
         signal: rbd_librbd_image_discard
         components:
-        - value
+          - value
       write_same:
         signal: rbd_librbd_image_ws
         components:
-        - value
+          - value
       compare_and_write:
         signal: rbd_librbd_image_cmp
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10500,7 +10508,7 @@ views:
       flush:
         signal: rbd_librbd_image_flush_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10513,7 +10521,7 @@ views:
       flush:
         signal: rbd_librbd_image_flush
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10526,11 +10534,11 @@ views:
       read:
         signal: rbd_librbd_image_rd_bytes
         components:
-        - value
+          - value
       write:
         signal: rbd_librbd_image_wr_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10543,11 +10551,11 @@ views:
       read:
         signal: rbd_librbd_image_rd_latency_count
         components:
-        - value
+          - value
       write:
         signal: rbd_librbd_image_wr_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10560,11 +10568,11 @@ views:
       read:
         signal: rbd_librbd_image_rd
         components:
-        - value
+          - value
       write:
         signal: rbd_librbd_image_wr
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10577,11 +10585,11 @@ views:
       opened:
         signal: rbd_librbd_image_opened_time
         components:
-        - value
+          - value
       lock_acquired:
         signal: rbd_librbd_image_lock_acquired_time
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10594,19 +10602,19 @@ views:
       notify:
         signal: rbd_librbd_image_notify
         components:
-        - value
+          - value
       resize:
         signal: rbd_librbd_image_resize
         components:
-        - value
+          - value
       readahead:
         signal: rbd_librbd_image_readahead
         components:
-        - value
+          - value
       invalidate_cache:
         signal: rbd_librbd_image_invalidate_cache
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10619,7 +10627,7 @@ views:
       readahead:
         signal: rbd_librbd_image_readahead_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10632,19 +10640,19 @@ views:
       create:
         signal: rbd_librbd_image_snap_create
         components:
-        - value
+          - value
       remove:
         signal: rbd_librbd_image_snap_remove
         components:
-        - value
+          - value
       rollback:
         signal: rbd_librbd_image_snap_rollback
         components:
-        - value
+          - value
       rename:
         signal: rbd_librbd_image_snap_rename
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10657,11 +10665,11 @@ views:
       read_bytes:
         signal: rbd_read_bytes
         components:
-        - value
+          - value
       write_bytes:
         signal: rbd_write_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10674,11 +10682,11 @@ views:
       read_ops:
         signal: rbd_read_ops
         components:
-        - value
+          - value
       write_ops:
         signal: rbd_write_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10691,7 +10699,7 @@ views:
       value:
         signal: rbd_image_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10704,11 +10712,11 @@ views:
       read_latency:
         signal: rbd_read_latency_sum
         components:
-        - value
+          - value
       write_latency:
         signal: rbd_write_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10721,24 +10729,25 @@ views:
       read_latency:
         signal: rbd_read_latency_count
         components:
-        - value
+          - value
       write_latency:
         signal: rbd_write_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   rbd_images.mirror_metadata.state:
     family: Ceph/RBD Images/Mirror Metadata
-    question: What is the state and metadata for each ceph daemon and ceph version and hostname and id and instance id?
+    question: What is the state and metadata for each ceph daemon and ceph version and hostname and id and instance
+      id?
     entity: by_ceph_daemon_and_ceph_version_and_hostname_and_id_and_instance_id
     inputs:
       value:
         signal: rbd_mirror_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10751,7 +10760,7 @@ views:
       value:
         signal: rbd_mirror_journal_replay_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10764,33 +10773,35 @@ views:
       value:
         signal: rbd_mirror_journal_replay_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   rbd_mirror.journal.image_accumulated_latency:
     family: Ceph/RBD Images/Mirror/Journal
-    question: What is the accumulated image journal replay latency for each ceph daemon and image and namespace and pool?
+    question: What is the accumulated image journal replay latency for each ceph daemon and image and namespace
+      and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
       value:
         signal: rbd_mirror_journal_image_replay_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   rbd_mirror.journal.image_byte_throughput:
     family: Ceph/RBD Images/Mirror/Journal
-    question: What is the image journal replay byte throughput for each ceph daemon and image and namespace and pool?
+    question: What is the image journal replay byte throughput for each ceph daemon and image and namespace and
+      pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
       value:
         signal: rbd_mirror_journal_image_replay_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10803,20 +10814,21 @@ views:
       value:
         signal: rbd_mirror_journal_image_entries
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   rbd_mirror.journal.image_latency_measurements:
     family: Ceph/RBD Images/Mirror/Journal
-    question: What is the image journal replay latency measurements for each ceph daemon and image and namespace and pool?
+    question: What is the image journal replay latency measurements for each ceph daemon and image and namespace
+      and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
       value:
         signal: rbd_mirror_journal_image_replay_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10829,7 +10841,7 @@ views:
       value:
         signal: rbd_mirror_journal_entries
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10842,20 +10854,21 @@ views:
       value:
         signal: rbd_mirror_journal_replay_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.accumulated_latency_image_sync_time:
     family: Ceph/RBD Images/Mirror/Snapshot Replication
-    question: What is the accumulated latency — image sync time for each ceph daemon and image and namespace and pool?
+    question: What is the accumulated latency — image sync time for each ceph daemon and image and namespace and
+      pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
       image_sync_time:
         signal: rbd_mirror_snapshot_image_sync_time_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10868,7 +10881,7 @@ views:
       sync_time:
         signal: rbd_mirror_snapshot_sync_time_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10881,7 +10894,7 @@ views:
       image_sync_bytes:
         signal: rbd_mirror_snapshot_image_sync_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10894,7 +10907,7 @@ views:
       sync_bytes:
         signal: rbd_mirror_snapshot_sync_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10907,7 +10920,7 @@ views:
       value:
         signal: rbd_mirror_snapshot_image_last_sync_time
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10920,21 +10933,21 @@ views:
       value:
         signal: rbd_mirror_snapshot_image_last_sync_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.latency_measurements_image_sync_time:
     family: Ceph/RBD Images/Mirror/Snapshot Replication
-    question: What is the snapshot sync latency measurements — image sync time for each ceph daemon and image and namespace
-      and pool?
+    question: What is the snapshot sync latency measurements — image sync time for each ceph daemon and image and
+      namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
       image_sync_time:
         signal: rbd_mirror_snapshot_image_sync_time_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10947,7 +10960,7 @@ views:
       sync_time:
         signal: rbd_mirror_snapshot_sync_time_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10960,7 +10973,7 @@ views:
       image_snapshots:
         signal: rbd_mirror_snapshot_image_snapshots
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10973,7 +10986,7 @@ views:
       snapshots:
         signal: rbd_mirror_snapshot_snapshots
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -10986,11 +10999,11 @@ views:
       local_timestamp:
         signal: rbd_mirror_snapshot_image_local_timestamp
         components:
-        - value
+          - value
       remote_timestamp:
         signal: rbd_mirror_snapshot_image_remote_timestamp
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11003,7 +11016,7 @@ views:
       client_lat:
         signal: client_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11016,19 +11029,19 @@ views:
       client_fsync:
         signal: client_fsync_sum
         components:
-        - value
+          - value
       client_rdlat:
         signal: client_rdlat_sum
         components:
-        - value
+          - value
       client_reply:
         signal: client_reply_sum
         components:
-        - value
+          - value
       client_wrlat:
         signal: client_wrlat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11041,23 +11054,23 @@ views:
       kstore_state_done_lat:
         signal: kstore_state_done_lat_sum
         components:
-        - value
+          - value
       kstore_state_finishing_lat:
         signal: kstore_state_finishing_lat_sum
         components:
-        - value
+          - value
       kstore_state_kv_done_lat:
         signal: kstore_state_kv_done_lat_sum
         components:
-        - value
+          - value
       kstore_state_kv_queued_lat:
         signal: kstore_state_kv_queued_lat_sum
         components:
-        - value
+          - value
       kstore_state_prepare_lat:
         signal: kstore_state_prepare_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11070,127 +11083,127 @@ views:
       recoverystate_perf_activating_latency:
         signal: recoverystate_perf_activating_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_active_latency:
         signal: recoverystate_perf_active_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_backfilling_latency:
         signal: recoverystate_perf_backfilling_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_clean_latency:
         signal: recoverystate_perf_clean_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_down_latency:
         signal: recoverystate_perf_down_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_getinfo_latency:
         signal: recoverystate_perf_getinfo_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_getlog_latency:
         signal: recoverystate_perf_getlog_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_getmissing_latency:
         signal: recoverystate_perf_getmissing_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_incomplete_latency:
         signal: recoverystate_perf_incomplete_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_initial_latency:
         signal: recoverystate_perf_initial_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_notbackfilling_latency:
         signal: recoverystate_perf_notbackfilling_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_notrecovering_latency:
         signal: recoverystate_perf_notrecovering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_peering_latency:
         signal: recoverystate_perf_peering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_primary_latency:
         signal: recoverystate_perf_primary_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_recovered_latency:
         signal: recoverystate_perf_recovered_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_recovering_latency:
         signal: recoverystate_perf_recovering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_replicaactive_latency:
         signal: recoverystate_perf_replicaactive_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_repnotrecovering_latency:
         signal: recoverystate_perf_repnotrecovering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_reprecovering_latency:
         signal: recoverystate_perf_reprecovering_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_repwaitbackfillreserved_latency:
         signal: recoverystate_perf_repwaitbackfillreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_repwaitrecoveryreserved_latency:
         signal: recoverystate_perf_repwaitrecoveryreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_reset_latency:
         signal: recoverystate_perf_reset_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_start_latency:
         signal: recoverystate_perf_start_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_started_latency:
         signal: recoverystate_perf_started_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_stray_latency:
         signal: recoverystate_perf_stray_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitactingchange_latency:
         signal: recoverystate_perf_waitactingchange_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitlocalbackfillreserved_latency:
         signal: recoverystate_perf_waitlocalbackfillreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitlocalrecoveryreserved_latency:
         signal: recoverystate_perf_waitlocalrecoveryreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitremotebackfillreserved_latency:
         signal: recoverystate_perf_waitremotebackfillreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitremoterecoveryreserved_latency:
         signal: recoverystate_perf_waitremoterecoveryreserved_latency_sum
         components:
-        - value
+          - value
       recoverystate_perf_waitupthru_latency:
         signal: recoverystate_perf_waitupthru_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11203,71 +11216,71 @@ views:
       libcephsqlite_vfs_op_access:
         signal: libcephsqlite_vfs_op_access_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_currenttime:
         signal: libcephsqlite_vfs_op_currenttime_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_delete:
         signal: libcephsqlite_vfs_op_delete_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_fullpathname:
         signal: libcephsqlite_vfs_op_fullpathname_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_open:
         signal: libcephsqlite_vfs_op_open_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_checkreservedlock:
         signal: libcephsqlite_vfs_opf_checkreservedlock_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_close:
         signal: libcephsqlite_vfs_opf_close_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_devicecharacteristics:
         signal: libcephsqlite_vfs_opf_devicecharacteristics_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_filecontrol:
         signal: libcephsqlite_vfs_opf_filecontrol_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_filesize:
         signal: libcephsqlite_vfs_opf_filesize_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_lock:
         signal: libcephsqlite_vfs_opf_lock_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_read:
         signal: libcephsqlite_vfs_opf_read_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_sectorsize:
         signal: libcephsqlite_vfs_opf_sectorsize_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_sync:
         signal: libcephsqlite_vfs_opf_sync_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_truncate:
         signal: libcephsqlite_vfs_opf_truncate_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_unlock:
         signal: libcephsqlite_vfs_opf_unlock_sum
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_write:
         signal: libcephsqlite_vfs_opf_write_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11280,7 +11293,7 @@ views:
       client_lat:
         signal: client_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11293,15 +11306,15 @@ views:
       client_mdsqsum:
         signal: client_mdsqsum
         components:
-        - value
+          - value
       client_readsqsum:
         signal: client_readsqsum
         components:
-        - value
+          - value
       client_writesqsum:
         signal: client_writesqsum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11310,7 +11323,7 @@ views:
       convention: duration_squared_microseconds_per_second
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   runtime.shared_daemon.client_operation_latency_measurements:
     family: Ceph/Runtime/Shared Daemon
     question: What is the client operation latency measurements for each ceph daemon?
@@ -11319,19 +11332,19 @@ views:
       client_fsync:
         signal: client_fsync_count
         components:
-        - value
+          - value
       client_rdlat:
         signal: client_rdlat_count
         components:
-        - value
+          - value
       client_reply:
         signal: client_reply_count
         components:
-        - value
+          - value
       client_wrlat:
         signal: client_wrlat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11344,15 +11357,15 @@ views:
       mdavg:
         signal: client_mdavg
         components:
-        - value
+          - value
       readavg:
         signal: client_readavg
         components:
-        - value
+          - value
       writeavg:
         signal: client_writeavg
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11365,7 +11378,7 @@ views:
       value:
         signal: recoverystate_perf_stats_invalidated
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11378,23 +11391,23 @@ views:
       kstore_state_done_lat:
         signal: kstore_state_done_lat_count
         components:
-        - value
+          - value
       kstore_state_finishing_lat:
         signal: kstore_state_finishing_lat_count
         components:
-        - value
+          - value
       kstore_state_kv_done_lat:
         signal: kstore_state_kv_done_lat_count
         components:
-        - value
+          - value
       kstore_state_kv_queued_lat:
         signal: kstore_state_kv_queued_lat_count
         components:
-        - value
+          - value
       kstore_state_prepare_lat:
         signal: kstore_state_prepare_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11407,11 +11420,11 @@ views:
       num_mon:
         signal: cluster_num_mon
         components:
-        - value
+          - value
       cluster_num_mon_quorum:
         signal: cluster_num_mon_quorum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11424,19 +11437,19 @@ views:
       object:
         signal: cluster_num_object
         components:
-        - value
+          - value
       degraded:
         signal: cluster_num_object_degraded
         components:
-        - value
+          - value
       misplaced:
         signal: cluster_num_object_misplaced
         components:
-        - value
+          - value
       unfound:
         signal: cluster_num_object_unfound
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11449,7 +11462,7 @@ views:
       oft_omap_total_kv_pairs:
         signal: oft_omap_total_kv_pairs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11462,7 +11475,7 @@ views:
       oft_omap_total_objs:
         signal: oft_omap_total_objs
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11475,11 +11488,11 @@ views:
       oft_omap_total_updates:
         signal: oft_omap_total_updates
         components:
-        - value
+          - value
       oft_omap_total_removes:
         signal: oft_omap_total_removes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11492,7 +11505,7 @@ views:
       value:
         signal: ipv4_dpdk_ip_linearize_operations
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11505,7 +11518,7 @@ views:
       osd_epoch:
         signal: cluster_osd_epoch
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11518,15 +11531,15 @@ views:
       num_osd:
         signal: cluster_num_osd
         components:
-        - value
+          - value
       cluster_num_osd_in:
         signal: cluster_num_osd_in
         components:
-        - value
+          - value
       cluster_num_osd_up:
         signal: cluster_num_osd_up
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11535,7 +11548,7 @@ views:
       convention: osds
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   runtime.shared_daemon.pg_state:
     family: Ceph/Runtime/Shared Daemon
     question: What is the placement groups for each ceph daemon?
@@ -11544,19 +11557,19 @@ views:
       cluster_num_pg:
         signal: cluster_num_pg
         components:
-        - value
+          - value
       cluster_num_pg_active:
         signal: cluster_num_pg_active
         components:
-        - value
+          - value
       cluster_num_pg_active_clean:
         signal: cluster_num_pg_active_clean
         components:
-        - value
+          - value
       cluster_num_pg_peering:
         signal: cluster_num_pg_peering
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11565,7 +11578,7 @@ views:
       convention: placement_groups
       reason: Retain the established operator-facing Ceph unit using the registered exact conversion.
       evidence:
-      - ceph_display_conventions
+        - ceph_display_conventions
   runtime.shared_daemon.pool_state:
     family: Ceph/Runtime/Shared Daemon
     question: What is the pools for each ceph daemon?
@@ -11574,7 +11587,7 @@ views:
       num_pool:
         signal: cluster_num_pool
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11587,127 +11600,127 @@ views:
       recoverystate_perf_activating_latency:
         signal: recoverystate_perf_activating_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_active_latency:
         signal: recoverystate_perf_active_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_backfilling_latency:
         signal: recoverystate_perf_backfilling_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_clean_latency:
         signal: recoverystate_perf_clean_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_down_latency:
         signal: recoverystate_perf_down_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_getinfo_latency:
         signal: recoverystate_perf_getinfo_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_getlog_latency:
         signal: recoverystate_perf_getlog_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_getmissing_latency:
         signal: recoverystate_perf_getmissing_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_incomplete_latency:
         signal: recoverystate_perf_incomplete_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_initial_latency:
         signal: recoverystate_perf_initial_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_notbackfilling_latency:
         signal: recoverystate_perf_notbackfilling_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_notrecovering_latency:
         signal: recoverystate_perf_notrecovering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_peering_latency:
         signal: recoverystate_perf_peering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_primary_latency:
         signal: recoverystate_perf_primary_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_recovered_latency:
         signal: recoverystate_perf_recovered_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_recovering_latency:
         signal: recoverystate_perf_recovering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_replicaactive_latency:
         signal: recoverystate_perf_replicaactive_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_repnotrecovering_latency:
         signal: recoverystate_perf_repnotrecovering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_reprecovering_latency:
         signal: recoverystate_perf_reprecovering_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_repwaitbackfillreserved_latency:
         signal: recoverystate_perf_repwaitbackfillreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_repwaitrecoveryreserved_latency:
         signal: recoverystate_perf_repwaitrecoveryreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_reset_latency:
         signal: recoverystate_perf_reset_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_start_latency:
         signal: recoverystate_perf_start_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_started_latency:
         signal: recoverystate_perf_started_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_stray_latency:
         signal: recoverystate_perf_stray_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitactingchange_latency:
         signal: recoverystate_perf_waitactingchange_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitlocalbackfillreserved_latency:
         signal: recoverystate_perf_waitlocalbackfillreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitlocalrecoveryreserved_latency:
         signal: recoverystate_perf_waitlocalrecoveryreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitremotebackfillreserved_latency:
         signal: recoverystate_perf_waitremotebackfillreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitremoterecoveryreserved_latency:
         signal: recoverystate_perf_waitremoterecoveryreserved_latency_count
         components:
-        - value
+          - value
       recoverystate_perf_waitupthru_latency:
         signal: recoverystate_perf_waitupthru_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11720,19 +11733,19 @@ views:
       num_bytes:
         signal: cluster_num_bytes
         components:
-        - value
+          - value
       osd_bytes:
         signal: cluster_osd_bytes
         components:
-        - value
+          - value
       osd_bytes_avail:
         signal: cluster_osd_bytes_avail
         components:
-        - value
+          - value
       osd_bytes_used:
         signal: cluster_osd_bytes_used
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11745,71 +11758,71 @@ views:
       libcephsqlite_vfs_op_access:
         signal: libcephsqlite_vfs_op_access_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_currenttime:
         signal: libcephsqlite_vfs_op_currenttime_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_delete:
         signal: libcephsqlite_vfs_op_delete_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_fullpathname:
         signal: libcephsqlite_vfs_op_fullpathname_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_op_open:
         signal: libcephsqlite_vfs_op_open_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_checkreservedlock:
         signal: libcephsqlite_vfs_opf_checkreservedlock_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_close:
         signal: libcephsqlite_vfs_opf_close_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_devicecharacteristics:
         signal: libcephsqlite_vfs_opf_devicecharacteristics_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_filecontrol:
         signal: libcephsqlite_vfs_opf_filecontrol_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_filesize:
         signal: libcephsqlite_vfs_opf_filesize_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_lock:
         signal: libcephsqlite_vfs_opf_lock_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_read:
         signal: libcephsqlite_vfs_opf_read_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_sectorsize:
         signal: libcephsqlite_vfs_opf_sectorsize_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_sync:
         signal: libcephsqlite_vfs_opf_sync_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_truncate:
         signal: libcephsqlite_vfs_opf_truncate_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_unlock:
         signal: libcephsqlite_vfs_opf_unlock_count
         components:
-        - value
+          - value
       libcephsqlite_vfs_opf_write:
         signal: libcephsqlite_vfs_opf_write_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11822,11 +11835,11 @@ views:
       cct_total_workers:
         signal: cct_total_workers
         components:
-        - value
+          - value
       cct_unhealthy_workers:
         signal: cct_unhealthy_workers
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11839,7 +11852,7 @@ views:
       value:
         signal: trackedop_slow_ops_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11852,7 +11865,7 @@ views:
       received:
         signal: dpdk_port_dpdk_device_receive_multicast_packets
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11865,19 +11878,19 @@ views:
       badcrc:
         signal: dpdk_port_dpdk_device_receive_badcrc_errors
         components:
-        - value
+          - value
       total:
         signal: dpdk_port_dpdk_device_receive_total_errors
         components:
-        - value
+          - value
       dropped:
         signal: dpdk_port_dpdk_device_receive_dropped_errors
         components:
-        - value
+          - value
       nombuf:
         signal: dpdk_port_dpdk_device_receive_nombuf_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11890,7 +11903,7 @@ views:
       total:
         signal: dpdk_port_dpdk_device_send_total_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11903,19 +11916,19 @@ views:
       receive:
         signal: dpdk_queue_dpdk_receive_bytes
         components:
-        - value
+          - value
       send:
         signal: dpdk_queue_dpdk_send_bytes
         components:
-        - value
+          - value
       receive_copy:
         signal: dpdk_queue_dpdk_receive_copy_bytes
         components:
-        - value
+          - value
       send_copy:
         signal: dpdk_queue_dpdk_send_copy_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11928,19 +11941,19 @@ views:
       receive_copy_ops:
         signal: dpdk_queue_dpdk_receive_copy_ops
         components:
-        - value
+          - value
       send_copy_ops:
         signal: dpdk_queue_dpdk_send_copy_ops
         components:
-        - value
+          - value
       receive_linearize_ops:
         signal: dpdk_queue_dpdk_receive_linearize_ops
         components:
-        - value
+          - value
       send_linearize_ops:
         signal: dpdk_queue_dpdk_send_linearize_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11953,11 +11966,11 @@ views:
       receive:
         signal: dpdk_queue_dpdk_receive_last_bunch
         components:
-        - value
+          - value
       send:
         signal: dpdk_queue_dpdk_send_last_bunch
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11970,11 +11983,11 @@ views:
       receive_fragments:
         signal: dpdk_queue_dpdk_receive_fragments
         components:
-        - value
+          - value
       send_fragments:
         signal: dpdk_queue_dpdk_send_fragments
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -11987,11 +12000,11 @@ views:
       receive:
         signal: dpdk_queue_dpdk_receive_packets
         components:
-        - value
+          - value
       send:
         signal: dpdk_queue_dpdk_send_packets
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12004,11 +12017,11 @@ views:
       bad_checksum:
         signal: dpdk_queue_dpdk_receive_bad_checksum_errors
         components:
-        - value
+          - value
       no_memory:
         signal: dpdk_queue_dpdk_receive_no_memory_errors
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12021,7 +12034,7 @@ views:
       queued:
         signal: dpdk_queue_dpdk_send_queue_length
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12034,7 +12047,7 @@ views:
       latency:
         signal: finisher_complete_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12047,7 +12060,7 @@ views:
       completed:
         signal: finisher_complete_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12060,7 +12073,7 @@ views:
       queued:
         signal: finisher_queue_len
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12073,7 +12086,7 @@ views:
       discard:
         signal: kernel_device_discard_op
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12086,7 +12099,7 @@ views:
       threads:
         signal: kernel_device_discard_threads
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12099,23 +12112,23 @@ views:
       immediate:
         signal: mclock_shard_mclock_immediate_queue_len
         components:
-        - value
+          - value
       client:
         signal: mclock_shard_mclock_client_queue_len
         components:
-        - value
+          - value
       recovery:
         signal: mclock_shard_mclock_recovery_queue_len
         components:
-        - value
+          - value
       best_effort:
         signal: mclock_shard_mclock_best_effort_queue_len
         components:
-        - value
+          - value
       all_type:
         signal: mclock_shard_mclock_all_type_queue_len
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12128,123 +12141,123 @@ views:
       bloom_filter:
         signal: mempool_bloom_filter_items
         components:
-        - value
+          - value
       bluestore_alloc:
         signal: mempool_bluestore_alloc_items
         components:
-        - value
+          - value
       bluestore_cache_data:
         signal: mempool_bluestore_cache_data_items
         components:
-        - value
+          - value
       bluestore_cache_onode:
         signal: mempool_bluestore_cache_onode_items
         components:
-        - value
+          - value
       bluestore_cache_meta:
         signal: mempool_bluestore_cache_meta_items
         components:
-        - value
+          - value
       bluestore_cache_other:
         signal: mempool_bluestore_cache_other_items
         components:
-        - value
+          - value
       bluestore_cache_buffer:
         signal: mempool_bluestore_cache_buffer_items
         components:
-        - value
+          - value
       bluestore_extent:
         signal: mempool_bluestore_extent_items
         components:
-        - value
+          - value
       bluestore_blob:
         signal: mempool_bluestore_blob_items
         components:
-        - value
+          - value
       bluestore_shared_blob:
         signal: mempool_bluestore_shared_blob_items
         components:
-        - value
+          - value
       bluestore_inline_bl:
         signal: mempool_bluestore_inline_bl_items
         components:
-        - value
+          - value
       bluestore_fsck:
         signal: mempool_bluestore_fsck_items
         components:
-        - value
+          - value
       bluestore_txc:
         signal: mempool_bluestore_txc_items
         components:
-        - value
+          - value
       bluestore_writing_deferred:
         signal: mempool_bluestore_writing_deferred_items
         components:
-        - value
+          - value
       bluestore_writing:
         signal: mempool_bluestore_writing_items
         components:
-        - value
+          - value
       bluefs:
         signal: mempool_bluefs_items
         components:
-        - value
+          - value
       bluefs_file_reader:
         signal: mempool_bluefs_file_reader_items
         components:
-        - value
+          - value
       bluefs_file_writer:
         signal: mempool_bluefs_file_writer_items
         components:
-        - value
+          - value
       buffer_anon:
         signal: mempool_buffer_anon_items
         components:
-        - value
+          - value
       buffer_meta:
         signal: mempool_buffer_meta_items
         components:
-        - value
+          - value
       osd:
         signal: mempool_osd_items
         components:
-        - value
+          - value
       osd_mapbl:
         signal: mempool_osd_mapbl_items
         components:
-        - value
+          - value
       osd_pglog:
         signal: mempool_osd_pglog_items
         components:
-        - value
+          - value
       osdmap:
         signal: mempool_osdmap_items
         components:
-        - value
+          - value
       osdmap_mapping:
         signal: mempool_osdmap_mapping_items
         components:
-        - value
+          - value
       pgmap:
         signal: mempool_pgmap_items
         components:
-        - value
+          - value
       mds_co:
         signal: mempool_mds_co_items
         components:
-        - value
+          - value
       unittest_1:
         signal: mempool_unittest_1_items
         components:
-        - value
+          - value
       unittest_2:
         signal: mempool_unittest_2_items
         components:
-        - value
+          - value
       ec_extent_cache:
         signal: mempool_ec_extent_cache_items
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12257,123 +12270,123 @@ views:
       bloom_filter:
         signal: mempool_bloom_filter_bytes
         components:
-        - value
+          - value
       bluestore_alloc:
         signal: mempool_bluestore_alloc_bytes
         components:
-        - value
+          - value
       bluestore_cache_data:
         signal: mempool_bluestore_cache_data_bytes
         components:
-        - value
+          - value
       bluestore_cache_onode:
         signal: mempool_bluestore_cache_onode_bytes
         components:
-        - value
+          - value
       bluestore_cache_meta:
         signal: mempool_bluestore_cache_meta_bytes
         components:
-        - value
+          - value
       bluestore_cache_other:
         signal: mempool_bluestore_cache_other_bytes
         components:
-        - value
+          - value
       bluestore_cache_buffer:
         signal: mempool_bluestore_cache_buffer_bytes
         components:
-        - value
+          - value
       bluestore_extent:
         signal: mempool_bluestore_extent_bytes
         components:
-        - value
+          - value
       bluestore_blob:
         signal: mempool_bluestore_blob_bytes
         components:
-        - value
+          - value
       bluestore_shared_blob:
         signal: mempool_bluestore_shared_blob_bytes
         components:
-        - value
+          - value
       bluestore_inline_bl:
         signal: mempool_bluestore_inline_bl_bytes
         components:
-        - value
+          - value
       bluestore_fsck:
         signal: mempool_bluestore_fsck_bytes
         components:
-        - value
+          - value
       bluestore_txc:
         signal: mempool_bluestore_txc_bytes
         components:
-        - value
+          - value
       bluestore_writing_deferred:
         signal: mempool_bluestore_writing_deferred_bytes
         components:
-        - value
+          - value
       bluestore_writing:
         signal: mempool_bluestore_writing_bytes
         components:
-        - value
+          - value
       bluefs:
         signal: mempool_bluefs_bytes
         components:
-        - value
+          - value
       bluefs_file_reader:
         signal: mempool_bluefs_file_reader_bytes
         components:
-        - value
+          - value
       bluefs_file_writer:
         signal: mempool_bluefs_file_writer_bytes
         components:
-        - value
+          - value
       buffer_anon:
         signal: mempool_buffer_anon_bytes
         components:
-        - value
+          - value
       buffer_meta:
         signal: mempool_buffer_meta_bytes
         components:
-        - value
+          - value
       osd:
         signal: mempool_osd_bytes
         components:
-        - value
+          - value
       osd_mapbl:
         signal: mempool_osd_mapbl_bytes
         components:
-        - value
+          - value
       osd_pglog:
         signal: mempool_osd_pglog_bytes
         components:
-        - value
+          - value
       osdmap:
         signal: mempool_osdmap_bytes
         components:
-        - value
+          - value
       osdmap_mapping:
         signal: mempool_osdmap_mapping_bytes
         components:
-        - value
+          - value
       pgmap:
         signal: mempool_pgmap_bytes
         components:
-        - value
+          - value
       mds_co:
         signal: mempool_mds_co_bytes
         components:
-        - value
+          - value
       unittest_1:
         signal: mempool_unittest_1_bytes
         components:
-        - value
+          - value
       unittest_2:
         signal: mempool_unittest_2_bytes
         components:
-        - value
+          - value
       ec_extent_cache:
         signal: mempool_ec_extent_cache_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12386,7 +12399,7 @@ views:
       handle_ack:
         signal: async_messenger_worker_msgr_handle_ack_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12399,7 +12412,7 @@ views:
       send_messages_queue:
         signal: async_messenger_worker_msgr_send_messages_queue_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12412,19 +12425,19 @@ views:
       total:
         signal: async_messenger_worker_msgr_running_total_time
         components:
-        - value
+          - value
       send:
         signal: async_messenger_worker_msgr_running_send_time
         components:
-        - value
+          - value
       recv:
         signal: async_messenger_worker_msgr_running_recv_time
         components:
-        - value
+          - value
       fast_dispatch:
         signal: async_messenger_worker_msgr_running_fast_dispatch_time
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12437,7 +12450,7 @@ views:
       handle_ack:
         signal: async_messenger_worker_msgr_handle_ack_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12450,19 +12463,19 @@ views:
       recv:
         signal: async_messenger_worker_msgr_recv_bytes
         components:
-        - value
+          - value
       send:
         signal: async_messenger_worker_msgr_send_bytes
         components:
-        - value
+          - value
       recv_encrypted:
         signal: async_messenger_worker_msgr_recv_encrypted_bytes
         components:
-        - value
+          - value
       send_encrypted:
         signal: async_messenger_worker_msgr_send_encrypted_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12475,7 +12488,7 @@ views:
       active:
         signal: async_messenger_worker_msgr_active_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12488,7 +12501,7 @@ views:
       created:
         signal: async_messenger_worker_msgr_created_connections
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12501,11 +12514,11 @@ views:
       recv:
         signal: async_messenger_worker_msgr_recv_messages
         components:
-        - value
+          - value
       send:
         signal: async_messenger_worker_msgr_send_messages
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12518,7 +12531,7 @@ views:
       send_messages_queue:
         signal: async_messenger_worker_msgr_send_messages_queue_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12531,7 +12544,7 @@ views:
       bytes:
         signal: objectcacher_write_bytes_blocked
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12544,7 +12557,7 @@ views:
       time:
         signal: objectcacher_write_time_blocked
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12557,7 +12570,7 @@ views:
       operations:
         signal: objectcacher_write_ops_blocked
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12570,11 +12583,11 @@ views:
       hit:
         signal: objectcacher_cache_bytes_hit
         components:
-        - value
+          - value
       miss:
         signal: objectcacher_cache_bytes_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12587,11 +12600,11 @@ views:
       hit:
         signal: objectcacher_cache_ops_hit
         components:
-        - value
+          - value
       miss:
         signal: objectcacher_cache_ops_miss
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12604,19 +12617,19 @@ views:
       read:
         signal: objectcacher_data_read
         components:
-        - value
+          - value
       written:
         signal: objectcacher_data_written
         components:
-        - value
+          - value
       flushed:
         signal: objectcacher_data_flushed
         components:
-        - value
+          - value
       overwritten_while_flushing:
         signal: objectcacher_data_overwritten_while_flushing
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12629,31 +12642,31 @@ views:
       update_metadata:
         signal: libcephsqlite_striper_update_metadata
         components:
-        - value
+          - value
       update_allocated:
         signal: libcephsqlite_striper_update_allocated
         components:
-        - value
+          - value
       update_size:
         signal: libcephsqlite_striper_update_size
         components:
-        - value
+          - value
       update_version:
         signal: libcephsqlite_striper_update_version
         components:
-        - value
+          - value
       shrink:
         signal: libcephsqlite_striper_shrink
         components:
-        - value
+          - value
       lock:
         signal: libcephsqlite_striper_lock
         components:
-        - value
+          - value
       unlock:
         signal: libcephsqlite_striper_unlock
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12666,7 +12679,7 @@ views:
       bytes:
         signal: libcephsqlite_striper_shrink_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12679,23 +12692,23 @@ views:
       discard_lat_sum:
         signal: rbd_librbd_pwl_discard_lat_sum
         components:
-        - value
+          - value
       aio_flush_lat_sum:
         signal: rbd_librbd_pwl_aio_flush_lat_sum
         components:
-        - value
+          - value
       ws_lat_sum:
         signal: rbd_librbd_pwl_ws_lat_sum
         components:
-        - value
+          - value
       cmp_lat_sum:
         signal: rbd_librbd_pwl_cmp_lat_sum
         components:
-        - value
+          - value
       writeback_lat_sum:
         signal: rbd_librbd_pwl_writeback_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12708,35 +12721,35 @@ views:
       op_alloc_t_sum:
         signal: rbd_librbd_pwl_op_alloc_t_sum
         components:
-        - value
+          - value
       op_dis_to_buf_t_sum:
         signal: rbd_librbd_pwl_op_dis_to_buf_t_sum
         components:
-        - value
+          - value
       op_dis_to_app_t_sum:
         signal: rbd_librbd_pwl_op_dis_to_app_t_sum
         components:
-        - value
+          - value
       op_dis_to_cmp_t_sum:
         signal: rbd_librbd_pwl_op_dis_to_cmp_t_sum
         components:
-        - value
+          - value
       op_buf_to_app_t_sum:
         signal: rbd_librbd_pwl_op_buf_to_app_t_sum
         components:
-        - value
+          - value
       op_buf_to_bufc_t_sum:
         signal: rbd_librbd_pwl_op_buf_to_bufc_t_sum
         components:
-        - value
+          - value
       op_app_to_cmp_t_sum:
         signal: rbd_librbd_pwl_op_app_to_cmp_t_sum
         components:
-        - value
+          - value
       op_app_to_appc_t_sum:
         signal: rbd_librbd_pwl_op_app_to_appc_t_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12749,11 +12762,11 @@ views:
       rd_latency_sum:
         signal: rbd_librbd_pwl_rd_latency_sum
         components:
-        - value
+          - value
       hit_rd_latency_sum:
         signal: rbd_librbd_pwl_hit_rd_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12766,11 +12779,11 @@ views:
       append_tx_lat_sum:
         signal: rbd_librbd_pwl_append_tx_lat_sum
         components:
-        - value
+          - value
       retire_tx_lat_sum:
         signal: rbd_librbd_pwl_retire_tx_lat_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12783,43 +12796,43 @@ views:
       req_arr_to_all_t_sum:
         signal: rbd_librbd_pwl_req_arr_to_all_t_sum
         components:
-        - value
+          - value
       req_arr_to_dis_t_sum:
         signal: rbd_librbd_pwl_req_arr_to_dis_t_sum
         components:
-        - value
+          - value
       req_all_to_dis_t_sum:
         signal: rbd_librbd_pwl_req_all_to_dis_t_sum
         components:
-        - value
+          - value
       wr_latency_sum:
         signal: rbd_librbd_pwl_wr_latency_sum
         components:
-        - value
+          - value
       caller_wr_latency_sum:
         signal: rbd_librbd_pwl_caller_wr_latency_sum
         components:
-        - value
+          - value
       req_arr_to_all_nw_t_sum:
         signal: rbd_librbd_pwl_req_arr_to_all_nw_t_sum
         components:
-        - value
+          - value
       req_arr_to_dis_nw_t_sum:
         signal: rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
         components:
-        - value
+          - value
       req_all_to_dis_nw_t_sum:
         signal: rbd_librbd_pwl_req_all_to_dis_nw_t_sum
         components:
-        - value
+          - value
       wr_latency_nw_sum:
         signal: rbd_librbd_pwl_wr_latency_nw_sum
         components:
-        - value
+          - value
       caller_wr_latency_nw_sum:
         signal: rbd_librbd_pwl_caller_wr_latency_nw_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12832,35 +12845,35 @@ views:
       discard:
         signal: rbd_librbd_pwl_discard
         components:
-        - value
+          - value
       aio_flush:
         signal: rbd_librbd_pwl_aio_flush
         components:
-        - value
+          - value
       aio_flush_def:
         signal: rbd_librbd_pwl_aio_flush_def
         components:
-        - value
+          - value
       ws:
         signal: rbd_librbd_pwl_ws
         components:
-        - value
+          - value
       cmp:
         signal: rbd_librbd_pwl_cmp
         components:
-        - value
+          - value
       cmp_fails:
         signal: rbd_librbd_pwl_cmp_fails
         components:
-        - value
+          - value
       internal_flush:
         signal: rbd_librbd_pwl_internal_flush
         components:
-        - value
+          - value
       invalidate:
         signal: rbd_librbd_pwl_invalidate
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12873,23 +12886,23 @@ views:
       discard_lat_count:
         signal: rbd_librbd_pwl_discard_lat_count
         components:
-        - value
+          - value
       aio_flush_lat_count:
         signal: rbd_librbd_pwl_aio_flush_lat_count
         components:
-        - value
+          - value
       ws_lat_count:
         signal: rbd_librbd_pwl_ws_lat_count
         components:
-        - value
+          - value
       cmp_lat_count:
         signal: rbd_librbd_pwl_cmp_lat_count
         components:
-        - value
+          - value
       writeback_lat_count:
         signal: rbd_librbd_pwl_writeback_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12902,15 +12915,15 @@ views:
       discard_bytes:
         signal: rbd_librbd_pwl_discard_bytes
         components:
-        - value
+          - value
       ws_bytes:
         signal: rbd_librbd_pwl_ws_bytes
         components:
-        - value
+          - value
       cmp_bytes:
         signal: rbd_librbd_pwl_cmp_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12923,7 +12936,7 @@ views:
       log_op_bytes_count:
         signal: rbd_librbd_pwl_log_op_bytes_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12936,7 +12949,7 @@ views:
       log_op_bytes_sum:
         signal: rbd_librbd_pwl_log_op_bytes_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12949,7 +12962,7 @@ views:
       log_ops:
         signal: rbd_librbd_pwl_log_ops
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -12962,35 +12975,35 @@ views:
       op_alloc_t_count:
         signal: rbd_librbd_pwl_op_alloc_t_count
         components:
-        - value
+          - value
       op_dis_to_buf_t_count:
         signal: rbd_librbd_pwl_op_dis_to_buf_t_count
         components:
-        - value
+          - value
       op_dis_to_app_t_count:
         signal: rbd_librbd_pwl_op_dis_to_app_t_count
         components:
-        - value
+          - value
       op_dis_to_cmp_t_count:
         signal: rbd_librbd_pwl_op_dis_to_cmp_t_count
         components:
-        - value
+          - value
       op_buf_to_app_t_count:
         signal: rbd_librbd_pwl_op_buf_to_app_t_count
         components:
-        - value
+          - value
       op_buf_to_bufc_t_count:
         signal: rbd_librbd_pwl_op_buf_to_bufc_t_count
         components:
-        - value
+          - value
       op_app_to_cmp_t_count:
         signal: rbd_librbd_pwl_op_app_to_cmp_t_count
         components:
-        - value
+          - value
       op_app_to_appc_t_count:
         signal: rbd_librbd_pwl_op_app_to_appc_t_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13003,11 +13016,11 @@ views:
       rd_latency_count:
         signal: rbd_librbd_pwl_rd_latency_count
         components:
-        - value
+          - value
       hit_rd_latency_count:
         signal: rbd_librbd_pwl_hit_rd_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13020,11 +13033,11 @@ views:
       rd_bytes:
         signal: rbd_librbd_pwl_rd_bytes
         components:
-        - value
+          - value
       rd_hit_bytes:
         signal: rbd_librbd_pwl_rd_hit_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13037,15 +13050,15 @@ views:
       rd:
         signal: rbd_librbd_pwl_rd
         components:
-        - value
+          - value
       hit_rd:
         signal: rbd_librbd_pwl_hit_rd
         components:
-        - value
+          - value
       part_hit_rd:
         signal: rbd_librbd_pwl_part_hit_rd
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13058,11 +13071,11 @@ views:
       append_tx_lat_count:
         signal: rbd_librbd_pwl_append_tx_lat_count
         components:
-        - value
+          - value
       retire_tx_lat_count:
         signal: rbd_librbd_pwl_retire_tx_lat_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13075,43 +13088,43 @@ views:
       req_arr_to_all_t_count:
         signal: rbd_librbd_pwl_req_arr_to_all_t_count
         components:
-        - value
+          - value
       req_arr_to_dis_t_count:
         signal: rbd_librbd_pwl_req_arr_to_dis_t_count
         components:
-        - value
+          - value
       req_all_to_dis_t_count:
         signal: rbd_librbd_pwl_req_all_to_dis_t_count
         components:
-        - value
+          - value
       wr_latency_count:
         signal: rbd_librbd_pwl_wr_latency_count
         components:
-        - value
+          - value
       caller_wr_latency_count:
         signal: rbd_librbd_pwl_caller_wr_latency_count
         components:
-        - value
+          - value
       req_arr_to_all_nw_t_count:
         signal: rbd_librbd_pwl_req_arr_to_all_nw_t_count
         components:
-        - value
+          - value
       req_arr_to_dis_nw_t_count:
         signal: rbd_librbd_pwl_req_arr_to_dis_nw_t_count
         components:
-        - value
+          - value
       req_all_to_dis_nw_t_count:
         signal: rbd_librbd_pwl_req_all_to_dis_nw_t_count
         components:
-        - value
+          - value
       wr_latency_nw_count:
         signal: rbd_librbd_pwl_wr_latency_nw_count
         components:
-        - value
+          - value
       caller_wr_latency_nw_count:
         signal: rbd_librbd_pwl_caller_wr_latency_nw_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13124,7 +13137,7 @@ views:
       wr_bytes:
         signal: rbd_librbd_pwl_wr_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13137,31 +13150,31 @@ views:
       wr:
         signal: rbd_librbd_pwl_wr
         components:
-        - value
+          - value
       wr_def:
         signal: rbd_librbd_pwl_wr_def
         components:
-        - value
+          - value
       wr_def_lanes:
         signal: rbd_librbd_pwl_wr_def_lanes
         components:
-        - value
+          - value
       wr_def_log:
         signal: rbd_librbd_pwl_wr_def_log
         components:
-        - value
+          - value
       wr_def_buf:
         signal: rbd_librbd_pwl_wr_def_buf
         components:
-        - value
+          - value
       wr_overlap:
         signal: rbd_librbd_pwl_wr_overlap
         components:
-        - value
+          - value
       wr_q_barrier:
         signal: rbd_librbd_pwl_wr_q_barrier
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13174,11 +13187,11 @@ views:
       tx:
         signal: async_messenger_rdma_worker_tx_bytes
         components:
-        - value
+          - value
       rx:
         signal: async_messenger_rdma_worker_rx_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13191,11 +13204,11 @@ views:
       tx:
         signal: async_messenger_rdma_worker_tx_chunks
         components:
-        - value
+          - value
       rx:
         signal: async_messenger_rdma_worker_rx_chunks
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13208,7 +13221,7 @@ views:
       pending:
         signal: async_messenger_rdma_worker_pending_sent_conns
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13221,15 +13234,15 @@ views:
       tx_no_mem:
         signal: async_messenger_rdma_worker_tx_no_mem
         components:
-        - value
+          - value
       tx_parital_mem:
         signal: async_messenger_rdma_worker_tx_parital_mem
         components:
-        - value
+          - value
       tx_failed_post:
         signal: async_messenger_rdma_worker_tx_failed_post
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13242,7 +13255,7 @@ views:
       present:
         signal: service_unique_id
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13255,7 +13268,7 @@ views:
       wait:
         signal: throttle_wait_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13268,27 +13281,27 @@ views:
       get_started:
         signal: throttle_get_started
         components:
-        - value
+          - value
       get:
         signal: throttle_get
         components:
-        - value
+          - value
       get_or_fail_fail:
         signal: throttle_get_or_fail_fail
         components:
-        - value
+          - value
       get_or_fail_success:
         signal: throttle_get_or_fail_success
         components:
-        - value
+          - value
       take:
         signal: throttle_take
         components:
-        - value
+          - value
       put:
         signal: throttle_put
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13301,15 +13314,15 @@ views:
       get_sum:
         signal: throttle_get_sum
         components:
-        - value
+          - value
       take_sum:
         signal: throttle_take_sum
         components:
-        - value
+          - value
       put_sum:
         signal: throttle_put_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13322,11 +13335,11 @@ views:
       val:
         signal: throttle_val
         components:
-        - value
+          - value
       max:
         signal: throttle_max
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13339,21 +13352,21 @@ views:
       waits:
         signal: throttle_wait_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
       omit: {}
   smb_metadata.state:
     family: Ceph/CephFS/SMB/Metadata
-    question: What is the state and metadata for each netbiosname and share and smb version and subvolume and subvolume group
-      and volume?
+    question: What is the state and metadata for each netbiosname and share and smb version and subvolume and subvolume
+      group and volume?
     entity: by_netbiosname_and_share_and_smb_version_and_subvolume_and_subvolume_group_and_volume
     inputs:
       value:
         signal: smb_metadata
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13366,59 +13379,59 @@ views:
       committed_bytes:
         signal: prioritycache_full_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: prioritycache_full_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: prioritycache_full_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: prioritycache_full_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: prioritycache_full_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: prioritycache_full_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: prioritycache_full_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: prioritycache_full_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: prioritycache_full_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: prioritycache_full_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: prioritycache_full_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: prioritycache_full_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: prioritycache_full_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: prioritycache_full_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13431,59 +13444,59 @@ views:
       committed_bytes:
         signal: prioritycache_inc_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: prioritycache_inc_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: prioritycache_inc_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: prioritycache_inc_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: prioritycache_inc_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: prioritycache_inc_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: prioritycache_inc_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: prioritycache_inc_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: prioritycache_inc_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: prioritycache_inc_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: prioritycache_inc_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: prioritycache_inc_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: prioritycache_inc_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: prioritycache_inc_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13496,59 +13509,59 @@ views:
       committed_bytes:
         signal: prioritycache_kv_committed_bytes
         components:
-        - value
+          - value
       pri0_bytes:
         signal: prioritycache_kv_pri0_bytes
         components:
-        - value
+          - value
       pri10_bytes:
         signal: prioritycache_kv_pri10_bytes
         components:
-        - value
+          - value
       pri11_bytes:
         signal: prioritycache_kv_pri11_bytes
         components:
-        - value
+          - value
       pri1_bytes:
         signal: prioritycache_kv_pri1_bytes
         components:
-        - value
+          - value
       pri2_bytes:
         signal: prioritycache_kv_pri2_bytes
         components:
-        - value
+          - value
       pri3_bytes:
         signal: prioritycache_kv_pri3_bytes
         components:
-        - value
+          - value
       pri4_bytes:
         signal: prioritycache_kv_pri4_bytes
         components:
-        - value
+          - value
       pri5_bytes:
         signal: prioritycache_kv_pri5_bytes
         components:
-        - value
+          - value
       pri6_bytes:
         signal: prioritycache_kv_pri6_bytes
         components:
-        - value
+          - value
       pri7_bytes:
         signal: prioritycache_kv_pri7_bytes
         components:
-        - value
+          - value
       pri8_bytes:
         signal: prioritycache_kv_pri8_bytes
         components:
-        - value
+          - value
       pri9_bytes:
         signal: prioritycache_kv_pri9_bytes
         components:
-        - value
+          - value
       reserved_bytes:
         signal: prioritycache_kv_reserved_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13561,23 +13574,23 @@ views:
       cache_bytes:
         signal: prioritycache_cache_bytes
         components:
-        - value
+          - value
       heap_bytes:
         signal: prioritycache_heap_bytes
         components:
-        - value
+          - value
       mapped_bytes:
         signal: prioritycache_mapped_bytes
         components:
-        - value
+          - value
       target_bytes:
         signal: prioritycache_target_bytes
         components:
-        - value
+          - value
       unmapped_bytes:
         signal: prioritycache_unmapped_bytes
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13590,11 +13603,11 @@ views:
       queue_len:
         signal: rocksdb_compact_queue_len
         components:
-        - value
+          - value
       running:
         signal: rocksdb_compact_running
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13607,11 +13620,11 @@ views:
       compact:
         signal: rocksdb_compact
         components:
-        - value
+          - value
       completed:
         signal: rocksdb_compact_completed
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13624,7 +13637,7 @@ views:
       value:
         signal: rocksdb_compact_lasted
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13637,7 +13650,7 @@ views:
       queue_merge:
         signal: rocksdb_compact_queue_merge
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13650,15 +13663,15 @@ views:
       get_latency:
         signal: rocksdb_get_latency_sum
         components:
-        - value
+          - value
       submit_latency:
         signal: rocksdb_submit_latency_sum
         components:
-        - value
+          - value
       submit_sync_latency:
         signal: rocksdb_submit_sync_latency_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13671,15 +13684,15 @@ views:
       get_latency:
         signal: rocksdb_get_latency_count
         components:
-        - value
+          - value
       submit_latency:
         signal: rocksdb_submit_latency_count
         components:
-        - value
+          - value
       submit_sync_latency:
         signal: rocksdb_submit_sync_latency_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13692,19 +13705,19 @@ views:
       delay_time:
         signal: rocksdb_rocksdb_write_delay_time_sum
         components:
-        - value
+          - value
       memtable_time:
         signal: rocksdb_rocksdb_write_memtable_time_sum
         components:
-        - value
+          - value
       pre_and_post_time:
         signal: rocksdb_rocksdb_write_pre_and_post_time_sum
         components:
-        - value
+          - value
       wal_time:
         signal: rocksdb_rocksdb_write_wal_time_sum
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13717,19 +13730,19 @@ views:
       delay_time:
         signal: rocksdb_rocksdb_write_delay_time_count
         components:
-        - value
+          - value
       memtable_time:
         signal: rocksdb_rocksdb_write_memtable_time_count
         components:
-        - value
+          - value
       pre_and_post_time:
         signal: rocksdb_rocksdb_write_pre_and_post_time_count
         components:
-        - value
+          - value
       wal_time:
         signal: rocksdb_rocksdb_write_wal_time_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13742,11 +13755,11 @@ views:
       physical:
         signal: extblkdev_dev_phy_size
         components:
-        - value
+          - value
       logical:
         signal: extblkdev_dev_log_size
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13759,11 +13772,11 @@ views:
       physical:
         signal: extblkdev_dev_phy_util
         components:
-        - value
+          - value
       logical:
         signal: extblkdev_dev_log_util
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13776,19 +13789,19 @@ views:
       physical_size:
         signal: extblkdev_part_phy_size
         components:
-        - value
+          - value
       logical_size:
         signal: extblkdev_part_log_size
         components:
-        - value
+          - value
       physical_available:
         signal: extblkdev_part_phy_avail
         components:
-        - value
+          - value
       logical_available:
         signal: extblkdev_part_log_avail
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13801,7 +13814,7 @@ views:
       fcm:
         signal: extblkdev_fcm
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13814,7 +13827,7 @@ views:
       items:
         signal: rocksdb_binned_cache_elems
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13827,7 +13840,7 @@ views:
       insertions:
         signal: rocksdb_binned_cache_inserts
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13840,11 +13853,11 @@ views:
       hits:
         signal: rocksdb_binned_cache_hits
         components:
-        - value
+          - value
       misses:
         signal: rocksdb_binned_cache_misses
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13857,7 +13870,7 @@ views:
       lookups:
         signal: rocksdb_binned_cache_lookups
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -13870,15 +13883,15 @@ views:
       capacity:
         signal: rocksdb_binned_cache_capacity
         components:
-        - value
+          - value
       used:
         signal: rocksdb_binned_cache_usage
         components:
-        - value
+          - value
       pinned:
         signal: rocksdb_binned_cache_pinned
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -596,16 +596,6 @@ entities:
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
-  by_name_and_severity:
-    grain: Ceph name and severity
-    identity:
-      required:
-      - name
-      - severity
-      optional: []
-    high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
   by_netbiosname_and_share_and_smb_version_and_subvolume_and_subvolume_group_and_volume:
     grain: Ceph netbiosname and share and smb version and subvolume and subvolume group and volume
     identity:
@@ -992,7 +982,70 @@ normalizations:
       - label_throttle_key
     evidence:
     - normalization_throttle_identity
-exclusions: {}
+# `hardware_firmware_info` is a source-declared info family. The writer rejects it as
+# `writer_ineligible/info_family` before authored or autogen output, so it has no
+# exclusion. P1-M03 owns any future presentation after a deliberate writer-policy decision.
+exclusions:
+  hardware_cpu_cores_deferred_to_p1_m03:
+    source: {signal: hardware_cpu_cores, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
+    evidence: [delegation_hardware_metrics]
+    outcome: retain_writable_unrendered
+  hardware_fan_rpm_deferred_to_p1_m03:
+    source: {signal: hardware_fan_rpm, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
+    evidence: [delegation_hardware_metrics]
+    outcome: retain_writable_unrendered
+  hardware_health_deferred_to_p1_m03:
+    source: {signal: hardware_health, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
+    evidence: [delegation_hardware_metrics]
+    outcome: retain_writable_unrendered
+  hardware_memory_capacity_bytes_deferred_to_p1_m03:
+    source: {signal: hardware_memory_capacity_bytes, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
+    evidence: [delegation_hardware_metrics]
+    outcome: retain_writable_unrendered
+  hardware_storage_capacity_bytes_deferred_to_p1_m03:
+    source: {signal: hardware_storage_capacity_bytes, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
+    evidence: [delegation_hardware_metrics]
+    outcome: retain_writable_unrendered
+  hardware_temperature_celsius_deferred_to_p1_m03:
+    source: {signal: hardware_temperature_celsius, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
+    evidence: [delegation_hardware_metrics]
+    outcome: retain_writable_unrendered
+  recoverystate_perf_pg_rebuild_duration_count_deferred_to_p1_m04:
+    source: {signal: recoverystate_perf_pg_rebuild_duration_count, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M04 PG recovery and capacity signal and output disposition
+    evidence: [delegation_pg_rebuild]
+    outcome: retain_writable_unrendered
+  recoverystate_perf_pg_rebuild_duration_sum_deferred_to_p1_m04:
+    source: {signal: recoverystate_perf_pg_rebuild_duration_sum, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M04 PG recovery and capacity signal and output disposition
+    evidence: [delegation_pg_rebuild]
+    outcome: retain_writable_unrendered
+  recoverystate_perf_pg_rebuild_max_secs_deferred_to_p1_m04:
+    source: {signal: recoverystate_perf_pg_rebuild_max_secs, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M04 PG recovery and capacity signal and output disposition
+    evidence: [delegation_pg_rebuild]
+    outcome: retain_writable_unrendered
+  recoverystate_perf_pg_rebuild_min_secs_deferred_to_p1_m04:
+    source: {signal: recoverystate_perf_pg_rebuild_min_secs, components: [value]}
+    reason: scope_delegation
+    delegated_domain: P1-M04 PG recovery and capacity signal and output disposition
+    evidence: [delegation_pg_rebuild]
+    outcome: retain_writable_unrendered
 limitations:
   objecter.accumulated_latency#value:
     contributor_variant: objecter_handles
@@ -5556,9 +5609,9 @@ views:
       dimensions: {}
       promote: []
       omit: {}
-  health.daemon_health.state:
+  health.daemon_health.item_count:
     family: Ceph/Health/Daemon Health
-    question: What is the state and metadata for each ceph daemon and type?
+    question: How many items does each Ceph daemon health metric currently report?
     entity: by_ceph_daemon_and_type
     inputs:
       value:
@@ -5571,8 +5624,8 @@ views:
       omit: {}
   health.health_checks.state:
     family: Ceph/Health/Health Checks
-    question: What is the state and metadata for each name and severity?
-    entity: by_name_and_severity
+    question: What are the state and source-recorded severity of each health check?
+    entity: by_name
     inputs:
       value:
         signal: health_detail
@@ -5580,11 +5633,12 @@ views:
         - value
     labels:
       dimensions: {}
-      promote: []
+      promote:
+      - severity
       omit: {}
-  health.slow_operations.state:
+  health.slow_operations.current_operations:
     family: Ceph/Health/Slow Operations
-    question: What is the state and metadata?
+    question: How many slow operations does the cluster currently report?
     entity: cluster
     inputs:
       value:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -5118,11 +5118,11 @@ views:
       total:
         signal: mon_metadata
         components:
-        - value
+          - value
       in_quorum:
         signal: mon_quorum_status
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -5570,7 +5570,7 @@ views:
     labels:
       dimensions: {}
       promote:
-      - severity
+        - severity
       omit: {}
   health.slow_operations.current_operations:
     family: Ceph/Health/Slow Operations
@@ -5844,7 +5844,7 @@ views:
       value:
         signal: hardware_temperature_celsius
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6096,7 +6096,7 @@ views:
       namespace_count:
         signal: nvmeof_subsystem_namespace_count
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []
@@ -6113,7 +6113,7 @@ views:
       count:
         signal: nvmeof_subsystem_namespace_count
         components:
-        - value
+          - value
       limit:
         signal: nvmeof_subsystem_namespace_limit
         components:
@@ -7519,11 +7519,11 @@ views:
       total:
         signal: osd_metadata
         components:
-        - value
+          - value
       up:
         signal: osd_up
         components:
-        - value
+          - value
     labels:
       dimensions: {}
       promote: []

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -8,12 +8,11 @@ namespace: ceph
 composition:
   supports: {}
 entities:
-  by_allow_any_host_and_ceph_instance_and_group_and_ha_enabled_and_model_number_and_nqn_and_serial_number:
-    grain: Ceph allow any host and ceph instance and group and ha enabled and model number and nqn and serial number
+  by_allow_any_host_and_group_and_ha_enabled_and_model_number_and_nqn_and_serial_number:
+    grain: Ceph NVMe-oF subsystem security/group/HA/model/NQN/serial metadata
     identity:
       required:
       - allow_any_host
-      - ceph_instance
       - group
       - ha_enabled
       - model_number
@@ -23,13 +22,12 @@ entities:
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
-  by_anagrpid_and_bdev_name_and_ceph_instance_and_nqn_and_nsid_and_rados_namespace_name:
-    grain: Ceph anagrpid and bdev name and ceph instance and nqn and nsid and rados namespace name
+  by_anagrpid_and_bdev_name_and_nqn_and_nsid_and_rados_namespace_name:
+    grain: Ceph NVMe-oF namespace metadata identity
     identity:
       required:
       - anagrpid
       - bdev_name
-      - ceph_instance
       - nqn
       - nsid
       - rados_namespace_name
@@ -78,26 +76,15 @@ entities:
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
-  by_bdev_name_and_block_size_and_ceph_instance_and_namespace_and_pool_name_and_rbd_name:
-    grain: Ceph bdev name and block size and ceph instance and namespace and pool name and rbd name
+  by_bdev_name_and_block_size_and_namespace_and_pool_name_and_rbd_name:
+    grain: Ceph NVMe-oF bdev name, block size, namespace, pool name, and RBD name
     identity:
       required:
       - bdev_name
       - block_size
-      - ceph_instance
       - namespace
       - pool_name
       - rbd_name
-      optional: []
-    high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
-  by_bdev_name_and_ceph_instance:
-    grain: Ceph bdev name and ceph instance
-    identity:
-      required:
-      - bdev_name
-      - ceph_instance
       optional: []
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
@@ -441,11 +428,10 @@ entities:
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
-  by_ceph_instance_and_gw_name_and_host_nqn_and_nqn:
-    grain: Ceph ceph instance and gw name and host nqn and nqn
+  by_gw_name_and_host_nqn_and_nqn:
+    grain: Ceph NVMe-oF gateway name, host NQN, and subsystem NQN
     identity:
       required:
-      - ceph_instance
       - gw_name
       - host_nqn
       - nqn
@@ -453,27 +439,11 @@ entities:
     high_cardinality_acceptance:
       operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
         Netdata aggregation.
-  by_ceph_instance_and_mode_and_name:
-    grain: Ceph ceph instance and mode and name
+  local_gateway_endpoint:
+    grain: One direct NVMe-oF exporter endpoint selected by the collector job
     identity:
-      required:
-      - ceph_instance
-      - mode
-      - name
+      required: []
       optional: []
-    high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
-  by_ceph_instance_and_nqn:
-    grain: Ceph ceph instance and nqn
-    identity:
-      required:
-      - ceph_instance
-      - nqn
-      optional: []
-    high_cardinality_acceptance:
-      operator_value: This draft preserves the source's finest existing chart grain for explicit operator review and broader
-        Netdata aggregation.
   by_daemon_name_and_hostname_and_service_name_and_service_type:
     grain: Ceph daemon name and hostname and service name and service type
     identity:
@@ -5950,8 +5920,8 @@ views:
       omit: {}
   nvme_of.block_devices.operations:
     family: Ceph/NVMe-oF/Block Devices
-    question: What is the operations for each bdev name and ceph instance?
-    entity: by_bdev_name_and_ceph_instance
+    question: What is the operations for each bdev name?
+    entity: by_bdev_name
     inputs:
       reads_completed:
         signal: nvmeof_bdev_reads_completed_total
@@ -5980,9 +5950,8 @@ views:
       omit: {}
   nvme_of.block_devices.state:
     family: Ceph/NVMe-oF/Block Devices
-    question: What is the state and metadata for each bdev name and block size and ceph instance and namespace and pool name
-      and rbd name?
-    entity: by_bdev_name_and_block_size_and_ceph_instance_and_namespace_and_pool_name_and_rbd_name
+    question: What is the state and metadata for each bdev name and block size and namespace and pool name and rbd name?
+    entity: by_bdev_name_and_block_size_and_namespace_and_pool_name_and_rbd_name
     inputs:
       value:
         signal: nvmeof_bdev_metadata
@@ -5994,8 +5963,8 @@ views:
       omit: {}
   nvme_of.block_devices.time_accumulation:
     family: Ceph/NVMe-oF/Block Devices
-    question: What is the accumulated time for each bdev name and ceph instance?
-    entity: by_bdev_name_and_ceph_instance
+    question: What is the accumulated time for each bdev name?
+    entity: by_bdev_name
     inputs:
       read_seconds:
         signal: nvmeof_bdev_read_seconds_total
@@ -6024,15 +5993,16 @@ views:
       omit: {}
   nvme_of.gateways.time_accumulation:
     family: Ceph/NVMe-oF/Gateways
-    question: What is the accumulated time for each ceph instance and mode and name?
-    entity: by_ceph_instance_and_mode_and_name
+    question: What is the accumulated busy and idle reactor time for each local gateway reactor thread?
+    entity: by_name
     inputs:
       value:
         signal: nvmeof_reactor_seconds_total
         components:
         - value
     labels:
-      dimensions: {}
+      dimensions:
+        mode: {render: label_value}
       promote: []
       omit: {}
   nvme_of.hosts.connection_state:
@@ -6050,8 +6020,8 @@ views:
       omit: {}
   nvme_of.hosts.keepalive_timeout_state:
     family: Ceph/NVMe-oF/Hosts
-    question: What is the keepalive timeout state for each ceph instance and gw name and host nqn and nqn?
-    entity: by_ceph_instance_and_gw_name_and_host_nqn_and_nqn
+    question: What is the keepalive timeout state for each gw name and host nqn and nqn?
+    entity: by_gw_name_and_host_nqn_and_nqn
     inputs:
       value:
         signal: nvmeof_host_keepalive_timeout
@@ -6094,8 +6064,8 @@ views:
       - nvmeof_display_conventions
   nvme_of.subsystems.listener_state:
     family: Ceph/NVMe-oF/Subsystems
-    question: What is the listener addresses for each ceph instance and nqn?
-    entity: by_ceph_instance_and_nqn
+    question: What is the listener addresses for each nqn?
+    entity: by_nqn
     inputs:
       value:
         signal: nvmeof_subsystem_listener_count
@@ -6107,8 +6077,8 @@ views:
       omit: {}
   nvme_of.subsystems.namespace_count:
     family: Ceph/NVMe-oF/Subsystems
-    question: What is the namespaces for each ceph instance and nqn?
-    entity: by_ceph_instance_and_nqn
+    question: What is the namespaces for each nqn?
+    entity: by_nqn
     inputs:
       nvmeof_subsystem_namespace_count:
         signal: nvmeof_subsystem_namespace_count
@@ -6118,11 +6088,32 @@ views:
       dimensions: {}
       promote: []
       omit: {}
-  nvme_of.subsystems.namespace_limit:
+  nvme_of.gateways.namespace_count:
+    family: Ceph/NVMe-oF/Gateways
+    question: How many namespaces does this local exporter endpoint serve?
+    entity: local_gateway_endpoint
+    inputs:
+      namespace_count:
+        signal: nvmeof_subsystem_namespace_count
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit:
+        nqn: Subsystem identity is intentionally summed to the local gateway endpoint.
+    reduction:
+      reducer: sum
+      lost_comparison: Individual subsystem namespace counts remain available in the Subsystems/Namespaces chart.
+  nvme_of.subsystems.namespace_capacity:
     family: Ceph/NVMe-oF/Subsystems
-    question: What is the namespace limit for each nqn?
+    question: How does each subsystem namespace population compare with its configured limit?
     entity: by_nqn
     inputs:
+      count:
+        signal: nvmeof_subsystem_namespace_count
+        components:
+        - value
       limit:
         signal: nvmeof_subsystem_namespace_limit
         components:
@@ -6133,9 +6124,9 @@ views:
       omit: {}
   nvme_of.subsystems.state_metadata:
     family: Ceph/NVMe-oF/Subsystems
-    question: What is the state and metadata — metadata for each allow any host and ceph instance and group and ha enabled
-      and model number and nqn and serial number?
-    entity: by_allow_any_host_and_ceph_instance_and_group_and_ha_enabled_and_model_number_and_nqn_and_serial_number
+    question: What is the state and metadata — metadata for each allow any host and group and ha enabled and model number and nqn
+      and serial number?
+    entity: by_allow_any_host_and_group_and_ha_enabled_and_model_number_and_nqn_and_serial_number
     inputs:
       metadata:
         signal: nvmeof_subsystem_metadata
@@ -6147,9 +6138,9 @@ views:
       omit: {}
   nvme_of.subsystems.state_namespace_metadata:
     family: Ceph/NVMe-oF/Subsystems
-    question: What is the state and metadata — namespace metadata for each anagrpid and bdev name and ceph instance and nqn
-      and nsid and rados namespace name?
-    entity: by_anagrpid_and_bdev_name_and_ceph_instance_and_nqn_and_nsid_and_rados_namespace_name
+    question: What is the state and metadata — namespace metadata for each anagrpid and bdev name and nqn and nsid and rados
+      namespace name?
+    entity: by_anagrpid_and_bdev_name_and_nqn_and_nsid_and_rados_namespace_name
     inputs:
       namespace_metadata:
         signal: nvmeof_subsystem_namespace_metadata

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -984,68 +984,9 @@ normalizations:
     - normalization_throttle_identity
 # `hardware_firmware_info` is a source-declared info family. The writer rejects it as
 # `writer_ineligible/info_family` before authored or autogen output, so it has no
-# exclusion. P1-M03 owns any future presentation after a deliberate writer-policy decision.
-exclusions:
-  hardware_cpu_cores_deferred_to_p1_m03:
-    source: {signal: hardware_cpu_cores, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
-    evidence: [delegation_hardware_metrics]
-    outcome: retain_writable_unrendered
-  hardware_fan_rpm_deferred_to_p1_m03:
-    source: {signal: hardware_fan_rpm, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
-    evidence: [delegation_hardware_metrics]
-    outcome: retain_writable_unrendered
-  hardware_health_deferred_to_p1_m03:
-    source: {signal: hardware_health, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
-    evidence: [delegation_hardware_metrics]
-    outcome: retain_writable_unrendered
-  hardware_memory_capacity_bytes_deferred_to_p1_m03:
-    source: {signal: hardware_memory_capacity_bytes, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
-    evidence: [delegation_hardware_metrics]
-    outcome: retain_writable_unrendered
-  hardware_storage_capacity_bytes_deferred_to_p1_m03:
-    source: {signal: hardware_storage_capacity_bytes, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
-    evidence: [delegation_hardware_metrics]
-    outcome: retain_writable_unrendered
-  hardware_temperature_celsius_deferred_to_p1_m03:
-    source: {signal: hardware_temperature_celsius, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M03 Tentacle hardware signal and output disposition
-    evidence: [delegation_hardware_metrics]
-    outcome: retain_writable_unrendered
-  recoverystate_perf_pg_rebuild_duration_count_deferred_to_p1_m04:
-    source: {signal: recoverystate_perf_pg_rebuild_duration_count, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M04 PG recovery and capacity signal and output disposition
-    evidence: [delegation_pg_rebuild]
-    outcome: retain_writable_unrendered
-  recoverystate_perf_pg_rebuild_duration_sum_deferred_to_p1_m04:
-    source: {signal: recoverystate_perf_pg_rebuild_duration_sum, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M04 PG recovery and capacity signal and output disposition
-    evidence: [delegation_pg_rebuild]
-    outcome: retain_writable_unrendered
-  recoverystate_perf_pg_rebuild_max_secs_deferred_to_p1_m04:
-    source: {signal: recoverystate_perf_pg_rebuild_max_secs, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M04 PG recovery and capacity signal and output disposition
-    evidence: [delegation_pg_rebuild]
-    outcome: retain_writable_unrendered
-  recoverystate_perf_pg_rebuild_min_secs_deferred_to_p1_m04:
-    source: {signal: recoverystate_perf_pg_rebuild_min_secs, components: [value]}
-    reason: scope_delegation
-    delegated_domain: P1-M04 PG recovery and capacity signal and output disposition
-    evidence: [delegation_pg_rebuild]
-    outcome: retain_writable_unrendered
+# exclusion. A future inventory presentation requires a deliberate writer-policy decision.
+exclusions: {}
+
 limitations:
   objecter.accumulated_latency#value:
     contributor_variant: objecter_handles
@@ -5912,19 +5853,6 @@ views:
       dimensions: {}
       promote: []
       omit: {}
-  node_hardware.cooling.fan_speed:
-    family: Ceph/Node Hardware/Cooling
-    question: What is the current speed of each reported fan?
-    entity: node_hardware_fan
-    inputs:
-      value:
-        signal: hardware_fan_rpm
-        components:
-        - value
-    labels:
-      dimensions: {}
-      promote: []
-      omit: {}
   node_hardware.health.state:
     family: Ceph/Node Hardware/Health
     question: What is the current health state of each reported hardware component?
@@ -5932,6 +5860,32 @@ views:
     inputs:
       value:
         signal: hardware_health
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  node_hardware.temperature.temperature:
+    family: Ceph/Node Hardware/Temperature
+    question: What temperature does each reported hardware sensor observe?
+    entity: node_hardware_temperature_sensor
+    inputs:
+      value:
+        signal: hardware_temperature_celsius
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit: {}
+  node_hardware.cooling.fan_speed:
+    family: Ceph/Node Hardware/Cooling
+    question: What is the current speed of each reported fan?
+    entity: node_hardware_fan
+    inputs:
+      value:
+        signal: hardware_fan_rpm
         components:
         - value
     labels:
@@ -5971,19 +5925,6 @@ views:
     inputs:
       value:
         signal: hardware_storage_capacity_bytes
-        components:
-        - value
-    labels:
-      dimensions: {}
-      promote: []
-      omit: {}
-  node_hardware.temperature.temperature:
-    family: Ceph/Node Hardware/Temperature
-    question: What temperature does each reported hardware sensor observe?
-    entity: node_hardware_temperature_sensor
-    inputs:
-      value:
-        signal: hardware_temperature_celsius
         components:
         - value
     labels:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -5199,6 +5199,31 @@ views:
       dimensions: {}
       promote: []
       omit: {}
+  control_plane.monitor.cluster_summary:
+    family: Ceph/Control Plane/Monitor
+    question: How many monitors exist and are currently in quorum for this cluster endpoint?
+    entity: cluster
+    inputs:
+      total:
+        signal: mon_metadata
+        components:
+        - value
+      in_quorum:
+        signal: mon_quorum_status
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit:
+        ceph_daemon: Member identity is reduced into the cluster population.
+        ceph_version: Member metadata is not meaningful on the cluster population chart.
+        hostname: Member metadata is not meaningful on the cluster population chart.
+        public_addr: Member metadata is not meaningful on the cluster population chart.
+        rank: Member metadata is not meaningful on the cluster population chart.
+    reduction:
+      reducer: sum
+      lost_comparison: Individual monitor rows remain available in the member charts; this view is the additive population for one MGR job.
   control_plane.monitor.state_quorum_status:
     family: Ceph/Control Plane/Monitor
     question: What is the state and metadata — quorum status for each ceph daemon?
@@ -7554,6 +7579,35 @@ views:
       dimensions: {}
       promote: []
       omit: {}
+  osd_capacity_and_state.osd_state.cluster_summary:
+    family: Ceph/OSD Capacity and State/OSD State
+    question: How many OSDs exist and are currently up for this cluster endpoint?
+    entity: cluster
+    inputs:
+      total:
+        signal: osd_metadata
+        components:
+        - value
+      up:
+        signal: osd_up
+        components:
+        - value
+    labels:
+      dimensions: {}
+      promote: []
+      omit:
+        back_iface: Member metadata is not meaningful on the cluster population chart.
+        ceph_daemon: Member identity is reduced into the cluster population.
+        ceph_version: Member metadata is not meaningful on the cluster population chart.
+        cluster_addr: Member metadata is not meaningful on the cluster population chart.
+        device_class: Member metadata is not meaningful on the cluster population chart.
+        front_iface: Member metadata is not meaningful on the cluster population chart.
+        hostname: Member metadata is not meaningful on the cluster population chart.
+        objectstore: Member metadata is not meaningful on the cluster population chart.
+        public_addr: Member metadata is not meaningful on the cluster population chart.
+    reduction:
+      reducer: sum
+      lost_comparison: Individual OSD rows remain available in the member charts; this view is the additive population for one MGR job.
   osd_capacity_and_state.osd_state.weight:
     family: Ceph/OSD Capacity and State/OSD State
     question: What is the osd weight for each ceph daemon?

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -3071,7 +3071,7 @@ views:
       promote: []
       omit: {}
   ceph_clients.io_operations:
-    family: Ceph/Ceph Clients
+    family: Ceph/Clients
     question: What is the client i/o operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3092,7 +3092,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.attribute_and_layout_mutation_latency.accumulated_latency:
-    family: Ceph/CephFS MDS/Attribute and Layout Mutation Latency
+    family: Ceph/CephFS/MDS/Attribute and Layout Mutation Latency
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3125,7 +3125,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.attribute_and_layout_mutation_latency.latency_measurements:
-    family: Ceph/CephFS MDS/Attribute and Layout Mutation Latency
+    family: Ceph/CephFS/MDS/Attribute and Layout Mutation Latency
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3158,7 +3158,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.capability_messages:
-    family: Ceph/CephFS MDS/Capabilities
+    family: Ceph/CephFS/MDS/Capabilities
     question: What is the capability messages for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3179,7 +3179,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.capability_state:
-    family: Ceph/CephFS MDS/Capabilities
+    family: Ceph/CephFS/MDS/Capabilities
     question: What is the capabilities for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3192,7 +3192,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.evicted_clients:
-    family: Ceph/CephFS MDS/Capabilities
+    family: Ceph/CephFS/MDS/Capabilities
     question: What is the capability-revoke evictions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3205,7 +3205,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.inode_state:
-    family: Ceph/CephFS MDS/Capabilities
+    family: Ceph/CephFS/MDS/Capabilities
     question: What is the inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3218,7 +3218,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.inode_work:
-    family: Ceph/CephFS MDS/Capabilities
+    family: Ceph/CephFS/MDS/Capabilities
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3231,7 +3231,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.operations:
-    family: Ceph/CephFS MDS/Capabilities
+    family: Ceph/CephFS/MDS/Capabilities
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3264,7 +3264,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.throttled_requests:
-    family: Ceph/CephFS MDS/Capabilities
+    family: Ceph/CephFS/MDS/Capabilities
     question: What is the capability-throttled requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3277,7 +3277,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.accumulated_latency:
-    family: Ceph/CephFS MDS/Journal
+    family: Ceph/CephFS/MDS/Journal
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3290,7 +3290,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.events_current:
-    family: Ceph/CephFS MDS/Journal
+    family: Ceph/CephFS/MDS/Journal
     question: What is the current journal events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3311,7 +3311,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.journal_events:
-    family: Ceph/CephFS MDS/Journal
+    family: Ceph/CephFS/MDS/Journal
     question: What is the journal events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3336,7 +3336,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.journal_positions:
-    family: Ceph/CephFS MDS/Journal
+    family: Ceph/CephFS/MDS/Journal
     question: What is the journal positions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3357,7 +3357,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.journal_segments:
-    family: Ceph/CephFS MDS/Journal
+    family: Ceph/CephFS/MDS/Journal
     question: What is the journal segments for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3378,7 +3378,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.large_events:
-    family: Ceph/CephFS MDS/Journal
+    family: Ceph/CephFS/MDS/Journal
     question: What is the large journal events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3391,7 +3391,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.latency_measurements:
-    family: Ceph/CephFS MDS/Journal
+    family: Ceph/CephFS/MDS/Journal
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3404,7 +3404,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.segments_current:
-    family: Ceph/CephFS MDS/Journal
+    family: Ceph/CephFS/MDS/Journal
     question: What is the journal segments for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3429,7 +3429,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_directory.discovery_attempts:
-    family: Ceph/CephFS MDS/Metadata Cache Directory
+    family: Ceph/CephFS/MDS/Metadata Cache Directory
     question: What is the discovery attempts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3442,7 +3442,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_directory.discovery_messages:
-    family: Ceph/CephFS MDS/Metadata Cache Directory
+    family: Ceph/CephFS/MDS/Metadata Cache Directory
     question: What is the discovery messages for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3459,7 +3459,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_directory.replication_directives:
-    family: Ceph/CephFS MDS/Metadata Cache Directory
+    family: Ceph/CephFS/MDS/Metadata Cache Directory
     question: What is the replication directives for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3476,7 +3476,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_internal_requests.inode_work:
-    family: Ceph/CephFS MDS/Metadata Cache Internal Requests
+    family: Ceph/CephFS/MDS/Metadata Cache Internal Requests
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3493,7 +3493,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_internal_requests.operations:
-    family: Ceph/CephFS MDS/Metadata Cache Internal Requests
+    family: Ceph/CephFS/MDS/Metadata Cache Internal Requests
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3522,7 +3522,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_internal_requests.scrub_work:
-    family: Ceph/CephFS MDS/Metadata Cache Internal Requests
+    family: Ceph/CephFS/MDS/Metadata Cache Internal Requests
     question: What is the scrub work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3535,7 +3535,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_recovery.current_work:
-    family: Ceph/CephFS MDS/Metadata Cache Recovery
+    family: Ceph/CephFS/MDS/Metadata Cache Recovery
     question: What is the current work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3556,7 +3556,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_recovery.events:
-    family: Ceph/CephFS MDS/Metadata Cache Recovery
+    family: Ceph/CephFS/MDS/Metadata Cache Recovery
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3581,7 +3581,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_recovery.file_state:
-    family: Ceph/CephFS MDS/Metadata Cache Recovery
+    family: Ceph/CephFS/MDS/Metadata Cache Recovery
     question: What is the files for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3602,7 +3602,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_recovery.file_work:
-    family: Ceph/CephFS MDS/Metadata Cache Recovery
+    family: Ceph/CephFS/MDS/Metadata Cache Recovery
     question: What is the file work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3619,7 +3619,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_uninline.events:
-    family: Ceph/CephFS MDS/Metadata Cache Uninline
+    family: Ceph/CephFS/MDS/Metadata Cache Uninline
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3636,7 +3636,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_uninline.failure_outcomes:
-    family: Ceph/CephFS MDS/Metadata Cache Uninline
+    family: Ceph/CephFS/MDS/Metadata Cache Uninline
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3649,7 +3649,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_mutation_latency.accumulated_latency:
-    family: Ceph/CephFS MDS/Namespace Mutation Latency
+    family: Ceph/CephFS/MDS/Namespace Mutation Latency
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3690,7 +3690,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_mutation_latency.latency_measurements:
-    family: Ceph/CephFS MDS/Namespace Mutation Latency
+    family: Ceph/CephFS/MDS/Namespace Mutation Latency
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3731,7 +3731,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.dirfrag_lifecycle:
-    family: Ceph/CephFS MDS/Namespace Traversal
+    family: Ceph/CephFS/MDS/Namespace Traversal
     question: What is the directory-fragment lifecycle for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3752,7 +3752,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.inode_work:
-    family: Ceph/CephFS MDS/Namespace Traversal
+    family: Ceph/CephFS/MDS/Namespace Traversal
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3765,7 +3765,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.key_work:
-    family: Ceph/CephFS MDS/Namespace Traversal
+    family: Ceph/CephFS/MDS/Namespace Traversal
     question: What is the key work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3778,7 +3778,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.lookup_outcomes:
-    family: Ceph/CephFS MDS/Namespace Traversal
+    family: Ceph/CephFS/MDS/Namespace Traversal
     question: What is the lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3791,7 +3791,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.operations:
-    family: Ceph/CephFS MDS/Namespace Traversal
+    family: Ceph/CephFS/MDS/Namespace Traversal
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3812,7 +3812,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.traversals:
-    family: Ceph/CephFS MDS/Namespace Traversal
+    family: Ceph/CephFS/MDS/Namespace Traversal
     question: What is the namespace traversals for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3845,7 +3845,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.current_work:
-    family: Ceph/CephFS MDS/Purge Queue
+    family: Ceph/CephFS/MDS/Purge Queue
     question: What is the current work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3858,7 +3858,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.purge_operations:
-    family: Ceph/CephFS MDS/Purge Queue
+    family: Ceph/CephFS/MDS/Purge Queue
     question: What is the executed purge operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3871,7 +3871,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.purge_operations_state:
-    family: Ceph/CephFS MDS/Purge Queue
+    family: Ceph/CephFS/MDS/Purge Queue
     question: What is the purge operations in flight for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3888,7 +3888,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.purge_tasks:
-    family: Ceph/CephFS MDS/Purge Queue
+    family: Ceph/CephFS/MDS/Purge Queue
     question: What is the executed purge tasks for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3901,7 +3901,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.purge_tasks_state:
-    family: Ceph/CephFS MDS/Purge Queue
+    family: Ceph/CephFS/MDS/Purge Queue
     question: What is the purge tasks in flight for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3918,7 +3918,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.rank_migration.events:
-    family: Ceph/CephFS MDS/Rank Migration
+    family: Ceph/CephFS/MDS/Rank Migration
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3935,7 +3935,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.rank_migration.inode_work:
-    family: Ceph/CephFS MDS/Rank Migration
+    family: Ceph/CephFS/MDS/Rank Migration
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3952,7 +3952,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.read_request_latency.accumulated_latency:
-    family: Ceph/CephFS MDS/Read Request Latency
+    family: Ceph/CephFS/MDS/Read Request Latency
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4009,7 +4009,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.read_request_latency.latency_measurements:
-    family: Ceph/CephFS MDS/Read Request Latency
+    family: Ceph/CephFS/MDS/Read Request Latency
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4066,7 +4066,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.accumulated_latency:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4079,7 +4079,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.connected_clients:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the connected clients for each ceph daemon and fs name and id?
     entity: by_ceph_daemon_and_fs_name_and_id
     inputs:
@@ -4092,7 +4092,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.events:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4109,7 +4109,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.expired_inodes:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the expired inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4122,7 +4122,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.failure_outcomes:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4135,7 +4135,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.file_state:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the files for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4148,7 +4148,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.inode_state:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4177,7 +4177,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.latency_measurements:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4190,7 +4190,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.load:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the load for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4203,7 +4203,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.operations:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4236,7 +4236,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.queued_requests:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the queued requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4249,7 +4249,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.snapshot_state:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the snapshots for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4262,7 +4262,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.space:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4275,7 +4275,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.subtrees:
-    family: Ceph/CephFS MDS/Request Handling and State
+    family: Ceph/CephFS/MDS/Request Handling and State
     question: What is the subtrees for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4288,7 +4288,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.applied_tags:
-    family: Ceph/CephFS MDS/Scrubbing
+    family: Ceph/CephFS/MDS/Scrubbing
     question: What is the applied scrub tags for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4301,7 +4301,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.backtrace_work:
-    family: Ceph/CephFS MDS/Scrubbing
+    family: Ceph/CephFS/MDS/Scrubbing
     question: What is the backtrace work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4318,7 +4318,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.dirfrag_rstat_updates:
-    family: Ceph/CephFS MDS/Scrubbing
+    family: Ceph/CephFS/MDS/Scrubbing
     question: What is the directory-fragment recursive-stat updates for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4331,7 +4331,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.repaired_inotables:
-    family: Ceph/CephFS MDS/Scrubbing
+    family: Ceph/CephFS/MDS/Scrubbing
     question: What is the repaired inotables for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4344,7 +4344,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.scrubbed_inodes:
-    family: Ceph/CephFS MDS/Scrubbing
+    family: Ceph/CephFS/MDS/Scrubbing
     question: What is the scrubbed inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4365,7 +4365,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.snapshot_mutation_latency.accumulated_latency:
-    family: Ceph/CephFS MDS/Snapshot Mutation Latency
+    family: Ceph/CephFS/MDS/Snapshot Mutation Latency
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4394,7 +4394,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.snapshot_mutation_latency.latency_measurements:
-    family: Ceph/CephFS MDS/Snapshot Mutation Latency
+    family: Ceph/CephFS/MDS/Snapshot Mutation Latency
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4423,7 +4423,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.average_operation_latency:
-    family: Ceph/CephFS MDS Clients
+    family: Ceph/CephFS/MDS/Clients
     question: What is the average operation latency for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4444,7 +4444,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.capability_outcomes:
-    family: Ceph/CephFS MDS Clients
+    family: Ceph/CephFS/MDS/Clients
     question: What is the capability access outcomes for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4461,7 +4461,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.dentry_lease_outcomes:
-    family: Ceph/CephFS MDS Clients
+    family: Ceph/CephFS/MDS/Clients
     question: What is the dentry lease lookup outcomes for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4478,7 +4478,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.inode_state:
-    family: Ceph/CephFS MDS Clients
+    family: Ceph/CephFS/MDS/Clients
     question: What is the inode state for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4495,7 +4495,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.open_files:
-    family: Ceph/CephFS MDS Clients
+    family: Ceph/CephFS/MDS/Clients
     question: What is the open files for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4508,7 +4508,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.pinned_inode_capabilities:
-    family: Ceph/CephFS MDS Clients
+    family: Ceph/CephFS/MDS/Clients
     question: What is the pinned inode capabilities for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4521,7 +4521,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.reported_io_operations:
-    family: Ceph/CephFS MDS Clients
+    family: Ceph/CephFS/MDS/Clients
     question: What is the reported i/o operations for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4538,7 +4538,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.reported_io_volume:
-    family: Ceph/CephFS MDS Clients
+    family: Ceph/CephFS/MDS/Clients
     question: What is the reported i/o volume for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4555,7 +4555,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.capability_state:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the capabilities for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4568,7 +4568,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.capability_work:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the capability work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4585,7 +4585,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.dentry_state:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the dentries for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4598,7 +4598,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.dentry_work:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the dentry cache churn for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4615,7 +4615,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.directory_state:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the directories for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4628,7 +4628,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.directory_work:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the directory cache churn for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4645,7 +4645,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.inode_state:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4658,7 +4658,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.inode_work:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4675,7 +4675,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.space:
-    family: Ceph/CephFS MDS Memory
+    family: Ceph/CephFS/MDS/Memory
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4692,7 +4692,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.average_load:
-    family: Ceph/CephFS MDS Sessions
+    family: Ceph/CephFS/MDS/Sessions
     question: What is the average session load for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4705,7 +4705,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.duration:
-    family: Ceph/CephFS MDS Sessions
+    family: Ceph/CephFS/MDS/Sessions
     question: What is the duration and time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4718,7 +4718,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.events:
-    family: Ceph/CephFS MDS Sessions
+    family: Ceph/CephFS/MDS/Sessions
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4735,7 +4735,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.metadata_threshold_evictions:
-    family: Ceph/CephFS MDS Sessions
+    family: Ceph/CephFS/MDS/Sessions
     question: What is the metadata-threshold evictions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4748,7 +4748,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.session_state:
-    family: Ceph/CephFS MDS Sessions
+    family: Ceph/CephFS/MDS/Sessions
     question: What is the sessions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4769,7 +4769,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.total_load:
-    family: Ceph/CephFS MDS Sessions
+    family: Ceph/CephFS/MDS/Sessions
     question: What is the total session load for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4782,7 +4782,7 @@ views:
       promote: []
       omit: {}
   cephfs_metadata.filesystem_metadata.state:
-    family: Ceph/CephFS Metadata/Filesystem Metadata
+    family: Ceph/CephFS/Metadata/Filesystem Metadata
     question: What is the state and metadata for each data pools and fs id and metadata pool and name?
     entity: by_data_pools_and_fs_id_and_metadata_pool_and_name
     inputs:
@@ -4795,7 +4795,7 @@ views:
       promote: []
       omit: {}
   cephfs_metadata.mds_metadata.state:
-    family: Ceph/CephFS Metadata/MDS Metadata
+    family: Ceph/CephFS/Metadata/MDS Metadata
     question: What is the state and metadata for each ceph daemon and ceph version and fs id and hostname and public addr
       and rank?
     entity: by_ceph_daemon_and_ceph_version_and_fs_id_and_hostname_and_public_addr_and_rank
@@ -4809,7 +4809,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.filesystems.directories:
-    family: Ceph/CephFS Mirror/Filesystems
+    family: Ceph/CephFS/Mirror/Filesystems
     question: What is the mirrored directories for each ceph daemon and filesystem?
     entity: by_ceph_daemon_and_filesystem
     inputs:
@@ -4822,7 +4822,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.filesystems.peers:
-    family: Ceph/CephFS Mirror/Filesystems
+    family: Ceph/CephFS/Mirror/Filesystems
     question: What is the mirroring peers for each ceph daemon and filesystem?
     entity: by_ceph_daemon_and_filesystem
     inputs:
@@ -4835,7 +4835,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.accumulated_sync_time:
-    family: Ceph/CephFS Mirror/Peers
+    family: Ceph/CephFS/Mirror/Peers
     question: What is the accumulated sync time for each ceph daemon and peer cluster filesystem and peer cluster name and
       source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4849,7 +4849,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_duration:
-    family: Ceph/CephFS Mirror/Peers
+    family: Ceph/CephFS/Mirror/Peers
     question: What is the last sync duration for each ceph daemon and peer cluster filesystem and peer cluster name and source
       filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4863,7 +4863,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_size:
-    family: Ceph/CephFS Mirror/Peers
+    family: Ceph/CephFS/Mirror/Peers
     question: What is the last sync size for each ceph daemon and peer cluster filesystem and peer cluster name and source
       filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4877,7 +4877,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_timestamps:
-    family: Ceph/CephFS Mirror/Peers
+    family: Ceph/CephFS/Mirror/Peers
     question: What is the last sync timestamps for each ceph daemon and peer cluster filesystem and peer cluster name and
       source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4895,7 +4895,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.snapshot_outcomes:
-    family: Ceph/CephFS Mirror/Peers
+    family: Ceph/CephFS/Mirror/Peers
     question: What is the snapshot outcomes for each ceph daemon and peer cluster filesystem and peer cluster name and source
       filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4921,7 +4921,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.sync_throughput:
-    family: Ceph/CephFS Mirror/Peers
+    family: Ceph/CephFS/Mirror/Peers
     question: What is the sync throughput for each ceph daemon and peer cluster filesystem and peer cluster name and source
       filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4935,7 +4935,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.sync_time_measurements:
-    family: Ceph/CephFS Mirror/Peers
+    family: Ceph/CephFS/Mirror/Peers
     question: What is the sync-time measurements for each ceph daemon and peer cluster filesystem and peer cluster name and
       source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4949,7 +4949,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.service.enable_failures:
-    family: Ceph/CephFS Mirror/Service
+    family: Ceph/CephFS/Mirror/Service
     question: What is the mirroring enable failures for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4962,7 +4962,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.service.filesystems:
-    family: Ceph/CephFS Mirror/Service
+    family: Ceph/CephFS/Mirror/Service
     question: What is the mirrored filesystems for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5427,7 +5427,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.collection.duration:
-    family: Ceph/Exporter and Process Runtime/Collection
+    family: Ceph/Exporter and Process/Collection
     question: What is the collection duration for each function and host?
     entity: by_function_and_host
     inputs:
@@ -5440,7 +5440,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_availability.state:
-    family: Ceph/Exporter and Process Runtime/Daemon Availability
+    family: Ceph/Exporter and Process/Daemon Availability
     question: What is the daemon socket state for each ceph daemon and hostname?
     entity: by_ceph_daemon_and_hostname
     inputs:
@@ -5453,7 +5453,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_processes.cpu_time:
-    family: Ceph/Exporter and Process Runtime/Daemon Processes
+    family: Ceph/Exporter and Process/Daemon Processes
     question: What is the cpu time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5468,7 +5468,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_processes.cpu_utilization:
-    family: Ceph/Exporter and Process Runtime/Daemon Processes
+    family: Ceph/Exporter and Process/Daemon Processes
     question: What is the cpu utilization for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5486,7 +5486,7 @@ views:
       evidence:
       - ceph_display_conventions
   exporter_and_process_runtime.daemon_processes.memory:
-    family: Ceph/Exporter and Process Runtime/Daemon Processes
+    family: Ceph/Exporter and Process/Daemon Processes
     question: What is the memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5503,7 +5503,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_processes.page_faults:
-    family: Ceph/Exporter and Process Runtime/Daemon Processes
+    family: Ceph/Exporter and Process/Daemon Processes
     question: What is the page faults for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5520,7 +5520,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_processes.threads:
-    family: Ceph/Exporter and Process Runtime/Daemon Processes
+    family: Ceph/Exporter and Process/Daemon Processes
     question: What is the threads for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5586,7 +5586,7 @@ views:
       promote: []
       omit: {}
   manager_daemons.lookup_outcomes:
-    family: Ceph/Manager Daemons
+    family: Ceph/Managers/Daemons
     question: What is the lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5765,7 +5765,7 @@ views:
       promote: []
       omit: {}
   monitor_daemons.elections:
-    family: Ceph/Monitor Daemons
+    family: Ceph/Monitors/Daemons
     question: What is the elections for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5790,7 +5790,7 @@ views:
       promote: []
       omit: {}
   monitor_daemons.session_state:
-    family: Ceph/Monitor Daemons
+    family: Ceph/Monitors/Daemons
     question: What is the sessions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5803,7 +5803,7 @@ views:
       promote: []
       omit: {}
   monitor_daemons.session_work:
-    family: Ceph/Monitor Daemons
+    family: Ceph/Monitors/Daemons
     question: What is the session churn for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5824,7 +5824,7 @@ views:
       promote: []
       omit: {}
   node_hardware.health.state:
-    family: Ceph/Node Hardware/Health
+    family: Ceph/Hardware/Health
     question: What is the current health state of each reported hardware component?
     entity: node_hardware_component
     inputs:
@@ -5837,7 +5837,7 @@ views:
       promote: []
       omit: {}
   node_hardware.temperature.temperature:
-    family: Ceph/Node Hardware/Temperature
+    family: Ceph/Hardware/Temperature
     question: What temperature does each reported hardware sensor observe?
     entity: node_hardware_temperature_sensor
     inputs:
@@ -5855,7 +5855,7 @@ views:
       reason: Preserve the source's rotations-per-minute operator unit while normalizing the semantic axis to revolutions per second.
       evidence:
         - ceph_display_conventions
-    family: Ceph/Node Hardware/Cooling
+    family: Ceph/Hardware/Cooling
     question: What is the current speed of each reported fan?
     entity: node_hardware_fan
     inputs:
@@ -5868,7 +5868,7 @@ views:
       promote: []
       omit: {}
   node_hardware.memory.capacity:
-    family: Ceph/Node Hardware/Memory
+    family: Ceph/Hardware/Memory
     question: What capacity does each reported memory module provide?
     entity: node_hardware_memory_module
     inputs:
@@ -5881,7 +5881,7 @@ views:
       promote: []
       omit: {}
   node_hardware.processors.cpu_cores:
-    family: Ceph/Node Hardware/Processors
+    family: Ceph/Hardware/Processors
     question: How many cores does each reported CPU provide?
     entity: node_hardware_cpu
     inputs:
@@ -5894,7 +5894,7 @@ views:
       promote: []
       omit: {}
   node_hardware.storage.capacity:
-    family: Ceph/Node Hardware/Storage
+    family: Ceph/Hardware/Storage
     question: What capacity does each reported storage device provide?
     entity: node_hardware_storage_device
     inputs:
@@ -6429,7 +6429,7 @@ views:
       promote: []
       omit: {}
   object_gateway_cache.keystone_lookup_outcomes:
-    family: Ceph/Object Gateway Cache
+    family: Ceph/Object Gateway/Cache
     question: What is the keystone token cache lookup outcomes for each instance id?
     entity: by_instance_id
     inputs:
@@ -6446,7 +6446,7 @@ views:
       promote: []
       omit: {}
   object_gateway_cache.lookup_outcomes:
-    family: Ceph/Object Gateway Cache
+    family: Ceph/Object Gateway/Cache
     question: What is the lookup outcomes for each instance id?
     entity: by_instance_id
     inputs:
@@ -6463,7 +6463,7 @@ views:
       promote: []
       omit: {}
   object_gateway_metadata.state:
-    family: Ceph/Object Gateway Metadata
+    family: Ceph/Object Gateway/Metadata
     question: What is the state and metadata for each ceph daemon and ceph version and hostname and instance id?
     entity: by_ceph_daemon_and_ceph_version_and_hostname_and_instance_id
     inputs:
@@ -6476,7 +6476,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.accumulated_bytes:
-    family: Ceph/Object Gateway Multisite
+    family: Ceph/Object Gateway/Multisite
     question: What is the accumulated byte measurement for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6489,7 +6489,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.accumulated_latency:
-    family: Ceph/Object Gateway Multisite
+    family: Ceph/Object Gateway/Multisite
     question: What is the accumulated latency for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6506,7 +6506,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.latency_measurements:
-    family: Ceph/Object Gateway Multisite
+    family: Ceph/Object Gateway/Multisite
     question: What is the latency measurements for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6523,7 +6523,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.object_work:
-    family: Ceph/Object Gateway Multisite
+    family: Ceph/Object Gateway/Multisite
     question: What is the object work for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6540,7 +6540,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.replicated_objects:
-    family: Ceph/Object Gateway Multisite
+    family: Ceph/Object Gateway/Multisite
     question: What is the replicated objects for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6553,7 +6553,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.replication_log_request_errors:
-    family: Ceph/Object Gateway Multisite
+    family: Ceph/Object Gateway/Multisite
     question: What is the replication-log request errors for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6566,7 +6566,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.accumulated_latency:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the accumulated scheduling latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6607,7 +6607,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.latency_measurements:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the scheduling-latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6648,7 +6648,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.outstanding_requests:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the outstanding requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6661,7 +6661,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.queue_cost:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the queued request cost for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6686,7 +6686,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.queue_depth:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the queue depth for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6711,7 +6711,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.rejected_and_cancelled_requests:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the rejected and cancelled requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6752,7 +6752,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.scheduled_and_rejected_cost:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the scheduled and rejected cost for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6825,7 +6825,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.scheduled_requests:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the scheduled requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6866,7 +6866,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.throttled_requests:
-    family: Ceph/Object Gateway Scheduling
+    family: Ceph/Object Gateway/Scheduling
     question: What is the throttled requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6879,7 +6879,7 @@ views:
       promote: []
       omit: {}
   objecter.accumulated_latency:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the accumulated latency for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -6896,7 +6896,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_commands:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the active commands for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -6913,7 +6913,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_lingering_operations:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the active lingering operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -6930,7 +6930,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_operations:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the objecter operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -6955,7 +6955,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_pool_operations:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the active pool operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -6972,7 +6972,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_poolstat_requests:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the active pool-stat requests for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -6989,7 +6989,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_statfs_requests:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the active statfs requests for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7006,7 +7006,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.byte_throughput:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the byte throughput for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7023,7 +7023,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.commands:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the commands for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7044,7 +7044,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.latency_measurements:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the latency measurements for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7061,7 +7061,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.lingering_operations:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the lingering operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7086,7 +7086,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.map_epoch:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the osd-map epoch for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7103,7 +7103,7 @@ views:
       reducer: min
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.maps:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the osd maps for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7124,7 +7124,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.operation_vector_entries:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the operation-vector entries for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7141,7 +7141,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.operations:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the object operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7298,7 +7298,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.osd_sessions:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the osd sessions for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7319,7 +7319,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.pool_operations:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the pool operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7340,7 +7340,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.replica_reads:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the replica reads for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7365,7 +7365,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.session_state:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the sessions for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7386,7 +7386,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.stat_requests:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the pool-stat and statfs requests for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7415,7 +7415,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.submitted_operations:
-    family: Ceph/Objecter
+    family: Ceph/Runtime and Clients/Objecter
     question: What is the submitted top-level operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7432,7 +7432,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   osd_capacity_and_state.cluster_flags.state:
-    family: Ceph/OSD Capacity and State/Cluster Flags
+    family: Ceph/OSDs/Capacity and State/Cluster Flags
     question: What is the state and metadata?
     entity: cluster
     inputs:
@@ -7469,7 +7469,7 @@ views:
       promote: []
       omit: {}
   osd_capacity_and_state.fullness_thresholds.ratio:
-    family: Ceph/OSD Capacity and State/Fullness Thresholds
+    family: Ceph/OSDs/Capacity and State/Fullness Thresholds
     question: What is the ratios?
     entity: cluster
     inputs:
@@ -7491,7 +7491,7 @@ views:
       reason: Render the additive OSD population with the established operator-facing unit.
       evidence:
         - ceph_display_conventions
-    family: Ceph/OSD Capacity and State/Metadata
+    family: Ceph/OSDs/Capacity and State/Metadata
     question: What is the state and metadata for each back iface and ceph daemon and ceph version and cluster addr and device
       class and front iface and hostname and objectstore and public addr?
     entity: by_back_iface_and_ceph_daemon_and_ceph_version_and_cluster_addr_and_device_class_and_front_iface_and_hostname_and_objectstore_and_public_addr
@@ -7510,7 +7510,7 @@ views:
       reason: Render the additive OSD population with the established operator-facing unit.
       evidence:
         - ceph_display_conventions
-    family: Ceph/OSD Capacity and State/OSD State
+    family: Ceph/OSDs/Capacity and State/OSD State
     question: What is the osd state for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7532,7 +7532,7 @@ views:
       reason: Render the additive OSD population with the established operator-facing unit.
       evidence:
         - ceph_display_conventions
-    family: Ceph/OSD Capacity and State/OSD State
+    family: Ceph/OSDs/Capacity and State/OSD State
     question: How many OSDs exist and are currently up for this cluster endpoint?
     entity: cluster
     inputs:
@@ -7561,7 +7561,7 @@ views:
       reducer: sum
       lost_comparison: Individual OSD rows remain available in the member charts; this view is the additive population for one MGR job.
   osd_capacity_and_state.osd_state.weight:
-    family: Ceph/OSD Capacity and State/OSD State
+    family: Ceph/OSDs/Capacity and State/OSD State
     question: What is the osd weight for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7574,7 +7574,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.accumulated_latency:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7655,7 +7655,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.byte_throughput:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7700,7 +7700,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.current_operations:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the operations in progress for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7713,7 +7713,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.events:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7726,7 +7726,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.failure_outcomes:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7739,7 +7739,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.latency_measurements:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7820,7 +7820,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.lookup_outcomes:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7833,7 +7833,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.object_work:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the object work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7854,7 +7854,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.operations:
-    family: Ceph/OSD Client IO
+    family: Ceph/OSDs/Client IO
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7907,7 +7907,7 @@ views:
       promote: []
       omit: {}
   osd_overview.latency:
-    family: Ceph/OSD Overview
+    family: Ceph/OSDs/Overview
     question: What is the latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7929,7 +7929,7 @@ views:
       evidence:
       - ceph_display_conventions
   osd_recovery.accumulated_latency:
-    family: Ceph/OSD Recovery
+    family: Ceph/OSDs/Recovery
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7970,7 +7970,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.byte_throughput:
-    family: Ceph/OSD Recovery
+    family: Ceph/OSDs/Recovery
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -7983,7 +7983,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.latency_measurements:
-    family: Ceph/OSD Recovery
+    family: Ceph/OSDs/Recovery
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8024,7 +8024,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.operations:
-    family: Ceph/OSD Recovery
+    family: Ceph/OSDs/Recovery
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8037,7 +8037,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.pg_rebuild_accumulated_duration:
-    family: Ceph/OSD Recovery
+    family: Ceph/OSDs/Recovery
     question: At what rate is primary-OSD PG-rebuild duration accumulating for each Ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8050,7 +8050,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.pg_rebuild_duration_measurements:
-    family: Ceph/OSD Recovery
+    family: Ceph/OSDs/Recovery
     question: At what rate are primary-OSD PG-rebuild duration measurements recorded for each Ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8063,7 +8063,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.pg_rebuild_duration_range:
-    family: Ceph/OSD Recovery
+    family: Ceph/OSDs/Recovery
     question: What minimum and maximum PG-rebuild durations does each primary OSD currently report?
     entity: by_ceph_daemon
     inputs:
@@ -8080,7 +8080,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.accumulated_latency:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8101,7 +8101,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.accumulated_value:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the accumulated value measurement for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8114,7 +8114,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.byte_throughput:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8127,7 +8127,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.copyfrom_operations:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the copy-from operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8140,7 +8140,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.crc_lookup_outcomes:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the crc cache lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8161,7 +8161,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.failed_tier_flush_attempts:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the failed tier flush attempts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8178,7 +8178,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.heartbeat_peers:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the heartbeat peers for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8191,7 +8191,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.latency_measurements:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8212,7 +8212,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.load_average:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the osd load average for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8225,7 +8225,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.map_buffer_cache_lookup_outcomes:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the osd-map buffer-cache lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8242,7 +8242,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.map_cache_lookup_outcomes:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the decoded osd-map cache lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8263,7 +8263,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.map_epochs:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the osd-map epochs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8280,7 +8280,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.map_messages:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the osd-map messages for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8297,7 +8297,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.object_context_cache_lookup_outcomes:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the object-context cache lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8314,7 +8314,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.pg_state:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the placement groups for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8348,7 +8348,7 @@ views:
       evidence:
       - ceph_display_conventions
   osd_runtime.pg_updates:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the placement-group updates for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8365,7 +8365,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.pg_updates_total:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the total placement-group updates for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8378,7 +8378,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.pulls:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the pulls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8391,7 +8391,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.pushes:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the pushes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8404,7 +8404,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.skipped_objects:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the skipped objects for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8417,7 +8417,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.space:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8438,7 +8438,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.suboperations:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the suboperations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8451,7 +8451,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.tier_agent_actions:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the tier-agent actions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8488,7 +8488,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.tier_flush_attempts:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the tier flush attempts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8509,7 +8509,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.tier_whiteouts:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the tier whiteouts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8522,7 +8522,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.value_measurements:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the value measurement measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8535,7 +8535,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.watch_timeouts:
-    family: Ceph/OSD Runtime
+    family: Ceph/OSDs/Runtime
     question: What is the watch timeouts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8548,7 +8548,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.accumulated_reservation_latency:
-    family: Ceph/OSD Scrubbing - Ceph 19/Elapsed Time
+    family: Ceph/OSDs/Scrubbing/Ceph 19/Elapsed Time
     question: What is the accumulated reservation elapsed time for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -8589,7 +8589,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.accumulated_scrub_latency:
-    family: Ceph/OSD Scrubbing - Ceph 19/Elapsed Time
+    family: Ceph/OSDs/Scrubbing/Ceph 19/Elapsed Time
     question: What is the accumulated scrub elapsed time for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -8630,7 +8630,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.reservation_latency_measurements:
-    family: Ceph/OSD Scrubbing - Ceph 19/Elapsed Time
+    family: Ceph/OSDs/Scrubbing/Ceph 19/Elapsed Time
     question: What is the reservation elapsed-time measurements for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -8671,7 +8671,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.scrub_latency_measurements:
-    family: Ceph/OSD Scrubbing - Ceph 19/Elapsed Time
+    family: Ceph/OSDs/Scrubbing/Ceph 19/Elapsed Time
     question: What is the scrub elapsed-time measurements for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -8712,7 +8712,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.outcomes.scrub_work:
-    family: Ceph/OSD Scrubbing - Ceph 19/Outcomes
+    family: Ceph/OSDs/Scrubbing/Ceph 19/Outcomes
     question: What is the scrub work for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -8769,7 +8769,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.replicas_in_reservation:
-    family: Ceph/OSD Scrubbing - Ceph 19/Reservations
+    family: Ceph/OSDs/Scrubbing/Ceph 19/Reservations
     question: What is the replicas in reservation for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -8794,7 +8794,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.reservation_process_outcomes:
-    family: Ceph/OSD Scrubbing - Ceph 19/Reservations
+    family: Ceph/OSDs/Scrubbing/Ceph 19/Reservations
     question: What is the reservation process outcomes for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -8851,7 +8851,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.scrubs_past_reservation:
-    family: Ceph/OSD Scrubbing - Ceph 19/Reservations
+    family: Ceph/OSDs/Scrubbing/Ceph 19/Reservations
     question: What is the scrubs past reservation for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -8876,7 +8876,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.accumulated_reservation_latency:
-    family: Ceph/OSD Scrubbing - Ceph 20/Elapsed Time
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Elapsed Time
     question: What is the accumulated reservation elapsed time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8901,7 +8901,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.accumulated_scrub_latency:
-    family: Ceph/OSD Scrubbing - Ceph 20/Elapsed Time
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Elapsed Time
     question: What is the accumulated scrub elapsed time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8926,7 +8926,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.reservation_latency_measurements:
-    family: Ceph/OSD Scrubbing - Ceph 20/Elapsed Time
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Elapsed Time
     question: What is the reservation elapsed-time measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8951,7 +8951,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.scrub_latency_measurements:
-    family: Ceph/OSD Scrubbing - Ceph 20/Elapsed Time
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Elapsed Time
     question: What is the scrub elapsed-time measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8976,7 +8976,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.interference_and_scheduling.client_write_interference:
-    family: Ceph/OSD Scrubbing - Ceph 20/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Interference and Scheduling
     question: What is the client write interference for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9001,7 +9001,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.outcomes.scrub_work:
-    family: Ceph/OSD Scrubbing - Ceph 20/Outcomes
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Outcomes
     question: What is the scrub work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9034,7 +9034,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.replicas_in_reservation:
-    family: Ceph/OSD Scrubbing - Ceph 20/Reservations
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Reservations
     question: What is the replicas in reservation for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9051,7 +9051,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.reservation_process_outcomes:
-    family: Ceph/OSD Scrubbing - Ceph 20/Reservations
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Reservations
     question: What is the reservation process outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9092,7 +9092,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.scrubs_past_reservation:
-    family: Ceph/OSD Scrubbing - Ceph 20/Reservations
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Reservations
     question: What is the scrubs past reservation for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9109,7 +9109,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.scrub_work.byte_throughput:
-    family: Ceph/OSD Scrubbing - Ceph 20/Scrub Work
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Scrub Work
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9126,7 +9126,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.scrub_work.scrub_calls:
-    family: Ceph/OSD Scrubbing - Ceph 20/Scrub Work
+    family: Ceph/OSDs/Scrubbing/Ceph 20/Scrub Work
     question: What is the scrub calls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9159,7 +9159,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.blocked_client_writes:
-    family: Ceph/OSD Scrubbing - Common Work/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing/Common Work/Interference and Scheduling
     question: What is the client writes blocked by scrub for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9184,7 +9184,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.chunk_selection_outcomes:
-    family: Ceph/OSD Scrubbing - Common Work/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing/Common Work/Interference and Scheduling
     question: What is the chunk selection outcomes for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9225,7 +9225,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.object_lock_waits:
-    family: Ceph/OSD Scrubbing - Common Work/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing/Common Work/Interference and Scheduling
     question: What is the object-lock waits for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9250,7 +9250,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.preemptions:
-    family: Ceph/OSD Scrubbing - Common Work/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing/Common Work/Interference and Scheduling
     question: What is the scrub preemptions for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9275,7 +9275,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.reservations.completed_reservations:
-    family: Ceph/OSD Scrubbing - Common Work/Reservations
+    family: Ceph/OSDs/Scrubbing/Common Work/Reservations
     question: What is the completed scrub reservations for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9300,7 +9300,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.scrub_work.byte_throughput:
-    family: Ceph/OSD Scrubbing - Common Work/Scrub Work
+    family: Ceph/OSDs/Scrubbing/Common Work/Scrub Work
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9317,7 +9317,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.scrub_work.omap_calls:
-    family: Ceph/OSD Scrubbing - Common Work/Scrub Work
+    family: Ceph/OSDs/Scrubbing/Common Work/Scrub Work
     question: What is the omap scrub calls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9334,7 +9334,7 @@ views:
       promote: []
       omit: {}
   placement_groups_and_recovery.backfill.pg_state:
-    family: Ceph/Placement Groups and Recovery/Backfill
+    family: Ceph/Placement Groups/Backfill
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -9372,7 +9372,7 @@ views:
       evidence:
       - ceph_display_conventions
   placement_groups_and_recovery.healthy_state.pg_state:
-    family: Ceph/Placement Groups and Recovery/Healthy State
+    family: Ceph/Placement Groups/Healthy State
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -9402,7 +9402,7 @@ views:
       evidence:
       - ceph_display_conventions
   placement_groups_and_recovery.peering_and_availability.pg_state:
-    family: Ceph/Placement Groups and Recovery/Peering and Availability
+    family: Ceph/Placement Groups/Peering and Availability
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -9460,7 +9460,7 @@ views:
       evidence:
       - ceph_display_conventions
   placement_groups_and_recovery.recovery_and_degradation.pg_state:
-    family: Ceph/Placement Groups and Recovery/Recovery and Degradation
+    family: Ceph/Placement Groups/Recovery and Degradation
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -9502,7 +9502,7 @@ views:
       evidence:
       - ceph_display_conventions
   placement_groups_and_recovery.recovery_flags.state:
-    family: Ceph/Placement Groups and Recovery/Recovery Flags
+    family: Ceph/Placement Groups/Recovery Flags
     question: What is the state and metadata?
     entity: cluster
     inputs:
@@ -9519,7 +9519,7 @@ views:
       promote: []
       omit: {}
   placement_groups_and_recovery.scrub_and_repair_state.pg_state:
-    family: Ceph/Placement Groups and Recovery/Scrub and Repair State
+    family: Ceph/Placement Groups/Scrub and Repair State
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -9794,7 +9794,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.accumulated_data_operation_latency:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the accumulated data operation latency for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9815,7 +9815,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.accumulated_flush_latency:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the accumulated flush latency for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9828,7 +9828,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.accumulated_io_latency:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the accumulated i/o latency for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9845,7 +9845,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.data_operation_byte_throughput:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the data operation byte throughput for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9866,7 +9866,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.data_operation_latency_measurements:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the data operation latency measurements for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9887,7 +9887,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.data_operations:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the data operations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9908,7 +9908,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.flush_latency_measurements:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the flush latency measurements for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9921,7 +9921,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.flush_operations:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the flush operations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9934,7 +9934,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.io_byte_throughput:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the i/o byte throughput for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9951,7 +9951,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.io_latency_measurements:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the i/o latency measurements for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9968,7 +9968,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.io_operations:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the i/o operations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -9985,7 +9985,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.lifecycle_timestamps:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the lifecycle timestamps for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10002,7 +10002,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.maintenance_operations:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the maintenance operations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10027,7 +10027,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.readahead_byte_throughput:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the readahead byte throughput for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10040,7 +10040,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.snapshot_mutations:
-    family: Ceph/RBD Client Images
+    family: Ceph/RBD Images/Client Images
     question: What is the snapshot mutations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10159,7 +10159,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.accumulated_latency:
-    family: Ceph/RBD Mirror/Journal
+    family: Ceph/RBD Images/Mirror/Journal
     question: What is the accumulated latency for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10172,7 +10172,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.byte_throughput:
-    family: Ceph/RBD Mirror/Journal
+    family: Ceph/RBD Images/Mirror/Journal
     question: What is the byte throughput for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10185,7 +10185,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.image_accumulated_latency:
-    family: Ceph/RBD Mirror/Journal
+    family: Ceph/RBD Images/Mirror/Journal
     question: What is the accumulated image journal replay latency for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10198,7 +10198,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.image_byte_throughput:
-    family: Ceph/RBD Mirror/Journal
+    family: Ceph/RBD Images/Mirror/Journal
     question: What is the image journal replay byte throughput for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10211,7 +10211,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.image_journal_entries:
-    family: Ceph/RBD Mirror/Journal
+    family: Ceph/RBD Images/Mirror/Journal
     question: What is the journal entries queued for replay for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10224,7 +10224,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.image_latency_measurements:
-    family: Ceph/RBD Mirror/Journal
+    family: Ceph/RBD Images/Mirror/Journal
     question: What is the image journal replay latency measurements for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10237,7 +10237,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.journal_entries:
-    family: Ceph/RBD Mirror/Journal
+    family: Ceph/RBD Images/Mirror/Journal
     question: What is the journal entries for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10250,7 +10250,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.latency_measurements:
-    family: Ceph/RBD Mirror/Journal
+    family: Ceph/RBD Images/Mirror/Journal
     question: What is the journal replay latency measurements for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10263,7 +10263,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.accumulated_latency_image_sync_time:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the accumulated latency — image sync time for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10276,7 +10276,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.accumulated_latency_sync_time:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the accumulated latency — sync time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -10289,7 +10289,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.byte_throughput_image_sync_bytes:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the byte throughput — image sync bytes for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10302,7 +10302,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.byte_throughput_sync_bytes:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the byte throughput — sync bytes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -10315,7 +10315,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.last_sync_duration:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the last snapshot sync duration for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10328,7 +10328,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.last_sync_size:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the last snapshot sync size for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10341,7 +10341,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.latency_measurements_image_sync_time:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the snapshot sync latency measurements — image sync time for each ceph daemon and image and namespace
       and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
@@ -10355,7 +10355,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.latency_measurements_sync_time:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the snapshot sync latency measurements — sync time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -10368,7 +10368,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.snapshot_work_image_snapshots:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the snapshot work — image snapshots for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10381,7 +10381,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.snapshot_work_snapshots:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the snapshot work — snapshots for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -10394,7 +10394,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.timestamp:
-    family: Ceph/RBD Mirror/Snapshot Replication
+    family: Ceph/RBD Images/Mirror/Snapshot Replication
     question: What is the timestamps for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -11260,7 +11260,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_ports.multicast_packets:
-    family: Ceph/Runtime and Client Components/DPDK Ports
+    family: Ceph/Runtime and Clients/DPDK Ports
     question: What is the multicast packets for each ceph daemon and dpdk port?
     entity: by_ceph_daemon_and_dpdk_port
     inputs:
@@ -11273,7 +11273,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_ports.receive_errors:
-    family: Ceph/Runtime and Client Components/DPDK Ports
+    family: Ceph/Runtime and Clients/DPDK Ports
     question: What is the receive errors for each ceph daemon and dpdk port?
     entity: by_ceph_daemon_and_dpdk_port
     inputs:
@@ -11298,7 +11298,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_ports.send_errors:
-    family: Ceph/Runtime and Client Components/DPDK Ports
+    family: Ceph/Runtime and Clients/DPDK Ports
     question: What is the send errors for each ceph daemon and dpdk port?
     entity: by_ceph_daemon_and_dpdk_port
     inputs:
@@ -11311,7 +11311,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.byte_throughput:
-    family: Ceph/Runtime and Client Components/DPDK Queues
+    family: Ceph/Runtime and Clients/DPDK Queues
     question: What is the byte throughput for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11336,7 +11336,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.copy_linearize_operations:
-    family: Ceph/Runtime and Client Components/DPDK Queues
+    family: Ceph/Runtime and Clients/DPDK Queues
     question: What is the copy and linearize operations for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11361,7 +11361,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.last_batch_size:
-    family: Ceph/Runtime and Client Components/DPDK Queues
+    family: Ceph/Runtime and Clients/DPDK Queues
     question: What is the last batch size for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11378,7 +11378,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.packet_fragments:
-    family: Ceph/Runtime and Client Components/DPDK Queues
+    family: Ceph/Runtime and Clients/DPDK Queues
     question: What is the packet fragments for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11395,7 +11395,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.packets:
-    family: Ceph/Runtime and Client Components/DPDK Queues
+    family: Ceph/Runtime and Clients/DPDK Queues
     question: What is the packets for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11412,7 +11412,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.receive_errors:
-    family: Ceph/Runtime and Client Components/DPDK Queues
+    family: Ceph/Runtime and Clients/DPDK Queues
     question: What is the receive errors for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11429,7 +11429,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.send_queue_depth:
-    family: Ceph/Runtime and Client Components/DPDK Queues
+    family: Ceph/Runtime and Clients/DPDK Queues
     question: What is the send queue depth for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11442,7 +11442,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.finishers.accumulated_completion_latency:
-    family: Ceph/Runtime and Client Components/Finishers
+    family: Ceph/Runtime and Clients/Finishers
     question: What is the accumulated completion latency for each ceph daemon and finisher key?
     entity: by_ceph_daemon_and_finisher_key
     inputs:
@@ -11455,7 +11455,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.finishers.completions:
-    family: Ceph/Runtime and Client Components/Finishers
+    family: Ceph/Runtime and Clients/Finishers
     question: What is the drained completion batches for each ceph daemon and finisher key?
     entity: by_ceph_daemon_and_finisher_key
     inputs:
@@ -11468,7 +11468,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.finishers.queue_depth:
-    family: Ceph/Runtime and Client Components/Finishers
+    family: Ceph/Runtime and Clients/Finishers
     question: What is the queued callbacks for each ceph daemon and finisher key?
     entity: by_ceph_daemon_and_finisher_key
     inputs:
@@ -11481,7 +11481,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.kernel_devices.discard_operations:
-    family: Ceph/Runtime and Client Components/Kernel Devices
+    family: Ceph/Runtime and Clients/Kernel Devices
     question: What is the discard operations for each ceph daemon and kernel device key?
     entity: by_ceph_daemon_and_kernel_device_key
     inputs:
@@ -11494,7 +11494,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.kernel_devices.discard_threads:
-    family: Ceph/Runtime and Client Components/Kernel Devices
+    family: Ceph/Runtime and Clients/Kernel Devices
     question: What is the discard threads for each ceph daemon and kernel device key?
     entity: by_ceph_daemon_and_kernel_device_key
     inputs:
@@ -11507,7 +11507,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.mclock_shards.queue_depth:
-    family: Ceph/Runtime and Client Components/mClock Shards
+    family: Ceph/Runtime and Clients/mClock Shards
     question: What is the queue depth for each ceph daemon and mclock shard?
     entity: by_ceph_daemon_and_mclock_shard
     inputs:
@@ -11536,7 +11536,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.memory_pools.item_count:
-    family: Ceph/Runtime and Client Components/Memory Pools
+    family: Ceph/Runtime and Clients/Memory Pools
     question: What is the item count for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11665,7 +11665,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.memory_pools.memory_use:
-    family: Ceph/Runtime and Client Components/Memory Pools
+    family: Ceph/Runtime and Clients/Memory Pools
     question: What is the memory use for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11794,7 +11794,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.accumulated_ack_latency:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the accumulated acknowledgement latency for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11807,7 +11807,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.accumulated_send_queue_latency:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the accumulated send-queue latency for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11820,7 +11820,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.accumulated_worker_time:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the accumulated worker time for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11845,7 +11845,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.ack_latency_measurements:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the acknowledgement latency measurements for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11858,7 +11858,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.byte_throughput:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the byte throughput for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11883,7 +11883,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.connections:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the connections for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11896,7 +11896,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.created_connections:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the created connections for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11909,7 +11909,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.messages:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the messages for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11926,7 +11926,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.send_queue_latency_measurements:
-    family: Ceph/Runtime and Client Components/Messenger Workers
+    family: Ceph/Runtime and Clients/Messenger Workers
     question: What is the send-queue latency measurements for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -11939,7 +11939,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.blocked_write_throughput:
-    family: Ceph/Runtime and Client Components/Object Caches
+    family: Ceph/Runtime and Clients/Object Caches
     question: What is the blocked write throughput for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -11952,7 +11952,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.blocked_write_time:
-    family: Ceph/Runtime and Client Components/Object Caches
+    family: Ceph/Runtime and Clients/Object Caches
     question: What is the blocked write time for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -11965,7 +11965,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.blocked_writes:
-    family: Ceph/Runtime and Client Components/Object Caches
+    family: Ceph/Runtime and Clients/Object Caches
     question: What is the blocked writes for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -11978,7 +11978,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.cache_byte_outcomes:
-    family: Ceph/Runtime and Client Components/Object Caches
+    family: Ceph/Runtime and Clients/Object Caches
     question: What is the cache byte outcomes for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -11995,7 +11995,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.cache_outcomes:
-    family: Ceph/Runtime and Client Components/Object Caches
+    family: Ceph/Runtime and Clients/Object Caches
     question: What is the cache outcomes for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -12012,7 +12012,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.data_throughput:
-    family: Ceph/Runtime and Client Components/Object Caches
+    family: Ceph/Runtime and Clients/Object Caches
     question: What is the data throughput for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -12037,7 +12037,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rados_striper.metadata_and_lock_work:
-    family: Ceph/Runtime and Client Components/RADOS Striper
+    family: Ceph/Runtime and Clients/RADOS Striper
     question: What is the metadata and lock work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -12074,7 +12074,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rados_striper.shrink_throughput:
-    family: Ceph/Runtime and Client Components/RADOS Striper
+    family: Ceph/Runtime and Clients/RADOS Striper
     question: What is the shrink throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -12087,7 +12087,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_data_operation_latency:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated data operation latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12116,7 +12116,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_log_operation_latency:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated log operation latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12157,7 +12157,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_read_latency:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated read request latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12174,7 +12174,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_transaction_latency:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated transaction latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12191,7 +12191,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_write_latency:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated write request latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12240,7 +12240,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.cache_image_operations:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the cache and image operations for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12281,7 +12281,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.data_operation_latency_measurements:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the data operation latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12310,7 +12310,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.data_operation_throughput:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the data-operation throughput for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12331,7 +12331,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.log_append_size_measurements:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the log-append size measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12344,7 +12344,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.log_append_throughput:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the log-append throughput for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12357,7 +12357,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.log_appends:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the log appends for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12370,7 +12370,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.log_operation_latency_measurements:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the log operation latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12411,7 +12411,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.read_latency_measurements:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the read request latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12428,7 +12428,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.read_throughput:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the read throughput for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12445,7 +12445,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.reads:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the reads for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12466,7 +12466,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.transaction_latency_measurements:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the transaction latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12483,7 +12483,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.write_latency_measurements:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the write request latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12532,7 +12532,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.write_throughput:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the write throughput for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12545,7 +12545,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.writes:
-    family: Ceph/Runtime and Client Components/RBD Persistent Write Log
+    family: Ceph/Runtime and Clients/RBD Persistent Write Log
     question: What is the writes for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12582,7 +12582,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rdma_workers.byte_throughput:
-    family: Ceph/Runtime and Client Components/RDMA Workers
+    family: Ceph/Runtime and Clients/RDMA Workers
     question: What is the byte throughput for each ceph daemon and rdma worker?
     entity: by_ceph_daemon_and_rdma_worker
     inputs:
@@ -12599,7 +12599,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rdma_workers.chunk_throughput:
-    family: Ceph/Runtime and Client Components/RDMA Workers
+    family: Ceph/Runtime and Clients/RDMA Workers
     question: What is the chunk throughput for each ceph daemon and rdma worker?
     entity: by_ceph_daemon_and_rdma_worker
     inputs:
@@ -12616,7 +12616,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rdma_workers.pending_connections:
-    family: Ceph/Runtime and Client Components/RDMA Workers
+    family: Ceph/Runtime and Clients/RDMA Workers
     question: What is the pending connections for each ceph daemon and rdma worker?
     entity: by_ceph_daemon_and_rdma_worker
     inputs:
@@ -12629,7 +12629,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rdma_workers.transfer_errors:
-    family: Ceph/Runtime and Client Components/RDMA Workers
+    family: Ceph/Runtime and Clients/RDMA Workers
     question: What is the rdma transfer errors for each ceph daemon and rdma worker?
     entity: by_ceph_daemon_and_rdma_worker
     inputs:
@@ -12650,7 +12650,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.service_identity.identity_metadata:
-    family: Ceph/Runtime and Client Components/Service Identity
+    family: Ceph/Runtime and Clients/Service Identity
     question: What is the service identity metadata sentinel for each ceph daemon and service unique id?
     entity: by_ceph_daemon_and_service_unique_id
     inputs:
@@ -12663,7 +12663,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.accumulated_wait_time:
-    family: Ceph/Runtime and Client Components/Throttles
+    family: Ceph/Runtime and Clients/Throttles
     question: What is the accumulated wait time for each ceph daemon and throttle key?
     entity: by_ceph_daemon_and_throttle_key
     inputs:
@@ -12676,7 +12676,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.operations:
-    family: Ceph/Runtime and Client Components/Throttles
+    family: Ceph/Runtime and Clients/Throttles
     question: What is the operations for each ceph daemon and throttle key?
     entity: by_ceph_daemon_and_throttle_key
     inputs:
@@ -12709,7 +12709,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.slot_throughput:
-    family: Ceph/Runtime and Client Components/Throttles
+    family: Ceph/Runtime and Clients/Throttles
     question: What is the slot throughput for each throttle key?
     entity: by_throttle_key
     inputs:
@@ -12730,7 +12730,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.utilization:
-    family: Ceph/Runtime and Client Components/Throttles
+    family: Ceph/Runtime and Clients/Throttles
     question: What is the utilization for each ceph daemon and throttle key?
     entity: by_ceph_daemon_and_throttle_key
     inputs:
@@ -12747,7 +12747,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.wait_measurements:
-    family: Ceph/Runtime and Client Components/Throttles
+    family: Ceph/Runtime and Clients/Throttles
     question: What is the waits for each ceph daemon and throttle key?
     entity: by_ceph_daemon_and_throttle_key
     inputs:
@@ -12760,7 +12760,7 @@ views:
       promote: []
       omit: {}
   smb_metadata.state:
-    family: Ceph/SMB Metadata
+    family: Ceph/CephFS/SMB/Metadata
     question: What is the state and metadata for each netbiosname and share and smb version and subvolume and subvolume group
       and volume?
     entity: by_netbiosname_and_share_and_smb_version_and_subvolume_and_subvolume_group_and_volume
@@ -13150,7 +13150,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.external_block_devices.device_size:
-    family: Ceph/Storage Engine Extensions/External Block Devices
+    family: Ceph/Storage Engine/Extensions/External Block Devices
     question: What is the device size for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13167,7 +13167,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.external_block_devices.device_utilization:
-    family: Ceph/Storage Engine Extensions/External Block Devices
+    family: Ceph/Storage Engine/Extensions/External Block Devices
     question: What is the device utilization for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13184,7 +13184,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.external_block_devices.partition_space:
-    family: Ceph/Storage Engine Extensions/External Block Devices
+    family: Ceph/Storage Engine/Extensions/External Block Devices
     question: What is the partition space for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13209,7 +13209,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.external_block_devices.plugin_state:
-    family: Ceph/Storage Engine Extensions/External Block Devices
+    family: Ceph/Storage Engine/Extensions/External Block Devices
     question: What is the fcm plugin state for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13222,7 +13222,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.entries:
-    family: Ceph/Storage Engine Extensions/RocksDB Binned Cache
+    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache entries for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:
@@ -13235,7 +13235,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.insertions:
-    family: Ceph/Storage Engine Extensions/RocksDB Binned Cache
+    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache insertions for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:
@@ -13248,7 +13248,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.lookup_outcomes:
-    family: Ceph/Storage Engine Extensions/RocksDB Binned Cache
+    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache lookup outcomes for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:
@@ -13265,7 +13265,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.lookups:
-    family: Ceph/Storage Engine Extensions/RocksDB Binned Cache
+    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache lookups for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:
@@ -13278,7 +13278,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.memory:
-    family: Ceph/Storage Engine Extensions/RocksDB Binned Cache
+    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache memory for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -5850,6 +5850,11 @@ views:
       promote: []
       omit: {}
   node_hardware.cooling.fan_speed:
+    display:
+      convention: fan_revolutions_per_minute
+      reason: Preserve the source's rotations-per-minute operator unit while normalizing the semantic axis to revolutions per second.
+      evidence:
+        - ceph_display_conventions
     family: Ceph/Node Hardware/Cooling
     question: What is the current speed of each reported fan?
     entity: node_hardware_fan
@@ -7481,6 +7486,11 @@ views:
       promote: []
       omit: {}
   osd_capacity_and_state.metadata.state:
+    display:
+      convention: osds
+      reason: Render the additive OSD population with the established operator-facing unit.
+      evidence:
+        - ceph_display_conventions
     family: Ceph/OSD Capacity and State/Metadata
     question: What is the state and metadata for each back iface and ceph daemon and ceph version and cluster addr and device
       class and front iface and hostname and objectstore and public addr?
@@ -7495,6 +7505,11 @@ views:
       promote: []
       omit: {}
   osd_capacity_and_state.osd_state.state:
+    display:
+      convention: osds
+      reason: Render the additive OSD population with the established operator-facing unit.
+      evidence:
+        - ceph_display_conventions
     family: Ceph/OSD Capacity and State/OSD State
     question: What is the osd state for each ceph daemon?
     entity: by_ceph_daemon
@@ -7512,6 +7527,11 @@ views:
       promote: []
       omit: {}
   osd_capacity_and_state.osd_state.cluster_summary:
+    display:
+      convention: osds
+      reason: Render the additive OSD population with the established operator-facing unit.
+      evidence:
+        - ceph_display_conventions
     family: Ceph/OSD Capacity and State/OSD State
     question: How many OSDs exist and are currently up for this cluster endpoint?
     entity: cluster

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
@@ -231,10 +231,15 @@ cases:
         perf_priority_limit: 0
         mgr_perf_counters: disabled
         mgr_rbd_stats: disabled
-    fixture: fixtures/ceph_nvmeof.prom
     coverage: true
-    expected:
-      verdict: PASS
+    steps:
+    - fixture: fixtures/ceph_nvmeof.prom
+      expected:
+        verdict: PASS
+      observations:
+        nvme_of.gateways.time_accumulation#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   reef_ceph_exporter_limit0:
     environment:
       ceph:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
@@ -78,10 +78,24 @@ cases:
         perf_priority_limit: 11
         mgr_perf_counters: enabled
         mgr_rbd_stats: enabled
-    fixture: fixtures/ceph_reef_mgr_limit11.prom
     coverage: true
-    expected:
-      verdict: PASS
+    steps:
+    - fixture: fixtures/ceph_reef_mgr_limit11.prom
+      expected:
+        verdict: PASS
+      observations:
+        health.cluster_status.state#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.daemon_health.item_count#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.health_checks.state#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.slow_operations.current_operations#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   squid_ceph_exporter_limit11:
     environment:
       ceph:
@@ -102,10 +116,24 @@ cases:
         perf_priority_limit: 11
         mgr_perf_counters: enabled
         mgr_rbd_stats: enabled
-    fixture: fixtures/ceph_squid_mgr_limit11.prom
     coverage: true
-    expected:
-      verdict: PASS
+    steps:
+    - fixture: fixtures/ceph_squid_mgr_limit11.prom
+      expected:
+        verdict: PASS
+      observations:
+        health.cluster_status.state#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.daemon_health.item_count#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.health_checks.state#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.slow_operations.current_operations#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   tentacle_ceph_exporter_limit11:
     environment:
       ceph:
@@ -126,10 +154,24 @@ cases:
         perf_priority_limit: 11
         mgr_perf_counters: enabled
         mgr_rbd_stats: enabled
-    fixture: fixtures/ceph_tentacle_mgr_limit11.prom
     coverage: true
-    expected:
-      verdict: PASS
+    steps:
+    - fixture: fixtures/ceph_tentacle_mgr_limit11.prom
+      expected:
+        verdict: PASS
+      observations:
+        health.cluster_status.state#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.daemon_health.item_count#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.health_checks.state#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        health.slow_operations.current_operations#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   nvmeof:
     environment:
       ceph:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
@@ -80,34 +80,34 @@ cases:
         mgr_rbd_stats: enabled
     coverage: true
     steps:
-    - fixture: fixtures/ceph_reef_mgr_limit11.prom
-      expected:
-        verdict: PASS
-      observations:
-        control_plane.monitor.cluster_summary#total:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        control_plane.monitor.cluster_summary#in_quorum:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.cluster_status.state#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.daemon_health.item_count#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.health_checks.state#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.slow_operations.current_operations#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        osd_capacity_and_state.osd_state.cluster_summary#total:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        osd_capacity_and_state.osd_state.cluster_summary#up:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+      - fixture: fixtures/ceph_reef_mgr_limit11.prom
+        expected:
+          verdict: PASS
+        observations:
+          control_plane.monitor.cluster_summary#total:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          control_plane.monitor.cluster_summary#in_quorum:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.cluster_status.state#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.daemon_health.item_count#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.health_checks.state#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.slow_operations.current_operations#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          osd_capacity_and_state.osd_state.cluster_summary#total:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          osd_capacity_and_state.osd_state.cluster_summary#up:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   squid_ceph_exporter_limit11:
     environment:
       ceph:
@@ -130,34 +130,34 @@ cases:
         mgr_rbd_stats: enabled
     coverage: true
     steps:
-    - fixture: fixtures/ceph_squid_mgr_limit11.prom
-      expected:
-        verdict: PASS
-      observations:
-        control_plane.monitor.cluster_summary#total:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        control_plane.monitor.cluster_summary#in_quorum:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.cluster_status.state#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.daemon_health.item_count#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.health_checks.state#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.slow_operations.current_operations#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        osd_capacity_and_state.osd_state.cluster_summary#total:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        osd_capacity_and_state.osd_state.cluster_summary#up:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+      - fixture: fixtures/ceph_squid_mgr_limit11.prom
+        expected:
+          verdict: PASS
+        observations:
+          control_plane.monitor.cluster_summary#total:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          control_plane.monitor.cluster_summary#in_quorum:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.cluster_status.state#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.daemon_health.item_count#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.health_checks.state#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.slow_operations.current_operations#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          osd_capacity_and_state.osd_state.cluster_summary#total:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          osd_capacity_and_state.osd_state.cluster_summary#up:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   tentacle_ceph_exporter_limit11:
     environment:
       ceph:
@@ -180,49 +180,49 @@ cases:
         mgr_rbd_stats: enabled
     coverage: true
     steps:
-    - fixture: fixtures/ceph_tentacle_mgr_limit11.prom
-      expected:
-        verdict: PASS
-      observations:
-        node_hardware.health.state#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        placement_groups_and_recovery.healthy_state.pg_state#active:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        placement_groups_and_recovery.healthy_state.pg_state#clean:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        placement_groups_and_recovery.healthy_state.pg_state#pg_total:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        node_hardware.temperature.temperature#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        control_plane.monitor.cluster_summary#total:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        control_plane.monitor.cluster_summary#in_quorum:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.cluster_status.state#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.daemon_health.item_count#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.health_checks.state#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        health.slow_operations.current_operations#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        osd_capacity_and_state.osd_state.cluster_summary#total:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-        osd_capacity_and_state.osd_state.cluster_summary#up:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+      - fixture: fixtures/ceph_tentacle_mgr_limit11.prom
+        expected:
+          verdict: PASS
+        observations:
+          node_hardware.health.state#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          placement_groups_and_recovery.healthy_state.pg_state#active:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          placement_groups_and_recovery.healthy_state.pg_state#clean:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          placement_groups_and_recovery.healthy_state.pg_state#pg_total:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          node_hardware.temperature.temperature#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          control_plane.monitor.cluster_summary#total:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          control_plane.monitor.cluster_summary#in_quorum:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.cluster_status.state#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.daemon_health.item_count#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.health_checks.state#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          health.slow_operations.current_operations#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          osd_capacity_and_state.osd_state.cluster_summary#total:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+          osd_capacity_and_state.osd_state.cluster_summary#up:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   nvmeof:
     environment:
       ceph:
@@ -233,13 +233,13 @@ cases:
         mgr_rbd_stats: disabled
     coverage: true
     steps:
-    - fixture: fixtures/ceph_nvmeof.prom
-      expected:
-        verdict: PASS
-      observations:
-        nvme_of.gateways.time_accumulation#value:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+      - fixture: fixtures/ceph_nvmeof.prom
+        expected:
+          verdict: PASS
+        observations:
+          nvme_of.gateways.time_accumulation#value:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   reef_ceph_exporter_limit0:
     environment:
       ceph:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
@@ -184,6 +184,21 @@ cases:
       expected:
         verdict: PASS
       observations:
+        node_hardware.health.state#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        placement_groups_and_recovery.healthy_state.pg_state#active:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        placement_groups_and_recovery.healthy_state.pg_state#clean:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        placement_groups_and_recovery.healthy_state.pg_state#pg_total:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        node_hardware.temperature.temperature#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
         control_plane.monitor.cluster_summary#total:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
@@ -57,6 +57,23 @@ future_inputs:
   service_identity:
     name: ceph_service_unique_id_future_service
     type: gauge
+  rgw_topic_identity:
+    name: ceph_rgw_topic_futuretopic_persistent_topic_len
+    type: gauge
+    labels:
+      topic: futuretopic
+  rgw_topic_size_identity:
+    name: ceph_rgw_topic_futuretopic_persistent_topic_size
+    type: gauge
+    labels:
+      topic: futuretopic
+  rgw_sync_delta_identity:
+    name: ceph_rgw_sync_delta_future_local_future_source_99_sync_delta
+    type: gauge
+    labels:
+      local_zone_id: future_local
+      source_zone_id: future_source
+      shard_id: "99"
 cases:
   reef_ceph_exporter_limit11:
     environment:
@@ -262,6 +279,54 @@ cases:
         mgr_rbd_stats: disabled
     fixture: fixtures/ceph_reef_ceph_exporter_limit1.prom
     coverage: true
+    expected:
+      verdict: PASS
+  squid_mgr_simple_throttle_gauge_reset:
+    environment:
+      ceph:
+        source: mgr
+        release: squid
+        perf_priority_limit: 11
+        mgr_perf_counters: enabled
+        mgr_rbd_stats: enabled
+    coverage: false
+    steps:
+    - fixture: fixtures/ceph_squid_mgr_limit11.prom
+      expected:
+        verdict: PASS
+      observations:
+        object_gateway_scheduling.simple_throttler_rejections#throttled:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+    - fixture: fixtures/ceph_squid_mgr_simple_throttle_reset.prom
+      expected:
+        verdict: PASS
+      observations:
+        object_gateway_scheduling.simple_throttler_rejections#throttled:
+          state: current
+          predicates: {membership: unchanged, aggregate: decreased, identity: unchanged}
+  squid_ceph_exporter_connection_no_instance:
+    environment:
+      ceph:
+        source: ceph_exporter
+        release: squid
+        perf_priority_limit: 11
+        mgr_perf_counters: enabled
+        mgr_rbd_stats: enabled
+    coverage: true
+    fixture: fixtures/ceph_squid_ceph_exporter_connection_no_instance.prom
+    expected:
+      verdict: PASS
+  tentacle_ceph_exporter_connection_no_instance:
+    environment:
+      ceph:
+        source: ceph_exporter
+        release: tentacle
+        perf_priority_limit: 11
+        mgr_perf_counters: enabled
+        mgr_rbd_stats: enabled
+    coverage: false
+    fixture: fixtures/ceph_tentacle_ceph_exporter_connection_no_instance.prom
     expected:
       verdict: PASS
   reef_mgr_features_disabled:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
@@ -291,20 +291,20 @@ cases:
         mgr_rbd_stats: enabled
     coverage: false
     steps:
-    - fixture: fixtures/ceph_squid_mgr_limit11.prom
-      expected:
-        verdict: PASS
-      observations:
-        object_gateway_scheduling.simple_throttler_rejections#throttled:
-          state: current
-          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
-    - fixture: fixtures/ceph_squid_mgr_simple_throttle_reset.prom
-      expected:
-        verdict: PASS
-      observations:
-        object_gateway_scheduling.simple_throttler_rejections#throttled:
-          state: current
-          predicates: {membership: unchanged, aggregate: decreased, identity: unchanged}
+      - fixture: fixtures/ceph_squid_mgr_limit11.prom
+        expected:
+          verdict: PASS
+        observations:
+          object_gateway_scheduling.simple_throttler_rejections#throttled:
+            state: current
+            predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+      - fixture: fixtures/ceph_squid_mgr_simple_throttle_reset.prom
+        expected:
+          verdict: PASS
+        observations:
+          object_gateway_scheduling.simple_throttler_rejections#throttled:
+            state: current
+            predicates: {membership: unchanged, aggregate: decreased, identity: unchanged}
   squid_ceph_exporter_connection_no_instance:
     environment:
       ceph:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/proof.yaml
@@ -84,6 +84,12 @@ cases:
       expected:
         verdict: PASS
       observations:
+        control_plane.monitor.cluster_summary#total:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        control_plane.monitor.cluster_summary#in_quorum:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
         health.cluster_status.state#value:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
@@ -94,6 +100,12 @@ cases:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
         health.slow_operations.current_operations#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        osd_capacity_and_state.osd_state.cluster_summary#total:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        osd_capacity_and_state.osd_state.cluster_summary#up:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   squid_ceph_exporter_limit11:
@@ -122,6 +134,12 @@ cases:
       expected:
         verdict: PASS
       observations:
+        control_plane.monitor.cluster_summary#total:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        control_plane.monitor.cluster_summary#in_quorum:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
         health.cluster_status.state#value:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
@@ -132,6 +150,12 @@ cases:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
         health.slow_operations.current_operations#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        osd_capacity_and_state.osd_state.cluster_summary#total:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        osd_capacity_and_state.osd_state.cluster_summary#up:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   tentacle_ceph_exporter_limit11:
@@ -160,6 +184,12 @@ cases:
       expected:
         verdict: PASS
       observations:
+        control_plane.monitor.cluster_summary#total:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        control_plane.monitor.cluster_summary#in_quorum:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
         health.cluster_status.state#value:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
@@ -170,6 +200,12 @@ cases:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
         health.slow_operations.current_operations#value:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        osd_capacity_and_state.osd_state.cluster_summary#total:
+          state: current
+          predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
+        osd_capacity_and_state.osd_state.cluster_summary#up:
           state: current
           predicates: {membership: establish, aggregate: matches_reducer, identity: establish}
   nvmeof:

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+version: v1
+kind: source-alert-map
+profile: ceph
+netdata_alert_cadence: 10s
+definition_sha256_contract: >-
+  SHA-256 of the UTF-8 canonical JSON for the complete parsed source alert rule, with object keys sorted
+  lexicographically, no insignificant whitespace, and non-ASCII characters preserved
+
+sources:
+  reef:
+    tag: v18.2.8
+    commit: efac5a54607c13fa50d4822e50242b86e6e446df
+    path: monitoring/ceph-mixin/prometheus_alerts.yml
+    sha256: 0325e5c481d00c674f7faf759e00f6c5c22028dbcc8bb95491404d600c6f3efd
+  squid:
+    tag: v19.2.5
+    commit: abc7aa7f2701e5d46878fd5e6bb7e2955f1a395a
+    path: monitoring/ceph-mixin/prometheus_alerts.yml
+    sha256: 259ee363694d174f46427a443ba0a8952b28df0c17af2bb65a2378511bc321ba
+  tentacle:
+    tag: v20.2.3
+    commit: 06c2f9c35b67055a8a6fb99d1be236b3c4832ace
+    path: monitoring/ceph-mixin/prometheus_alerts.yml
+    sha256: 09308346d3d143ff128813f1142f1499142799174da4e0505ddad7144b8d8716
+
+adaptation_contracts:
+  observed_binary_window:
+    preserved:
+      - source incident and predicate
+      - source severity and Netdata notification policy
+      - source persistence duration as the Netdata lookup-window length
+      - ordinary numeric recovery
+    differences:
+      - the lookup requires every observed numeric sample, not every scheduled evaluation, to remain active
+      - partial collection gaps do not reset the window
+      - a new chart may be evaluated with up to one chart update interval less history
+      - a sufficiently stale lookup stops evaluating until collection resumes
+      - chart obsoletion removes the instance alert
+  observed_enumerated_window:
+    preserved:
+      - source incident and exact enumerated predicate
+      - source severity and Netdata notification policy
+      - source persistence duration as the Netdata lookup-window length
+      - ordinary numeric recovery and transitions to other states
+    differences:
+      - the lookup requires every observed numeric sample, not every scheduled evaluation, to match the target state
+      - partial collection gaps do not reset the window
+      - a new chart may be evaluated with up to one chart update interval less history
+      - a sufficiently stale lookup stops evaluating until collection resumes
+      - chart obsoletion removes the instance alert
+  generic_collection_reuse:
+    preserved:
+      - configured Prometheus job collection failure remains visible
+    differences:
+      - Netdata uses its generic per-job collection-failure owner instead of a Ceph-named duplicate
+      - the stock generic alert is warning-level and silent rather than the source rule's critical routing
+
+alerts:
+  ceph_health_error:
+    sow_id: CEPH-013
+    source_alert: CephHealthError
+    source:
+      expression: ceph_health_status == 2
+      persistence: 5m
+      severity: critical
+      lines: {reef: 4, squid: 4, tentacle: 4}
+      definition_sha256:
+        reef: ae390eeeca1b5b10d85ae2492cc3f2ba2adea54815c616c490b3fd1698c695d3
+        squid: ae390eeeca1b5b10d85ae2492cc3f2ba2adea54815c616c490b3fd1698c695d3
+        tentacle: 9257578f534e068764d19aab1262aafee949586a6c307b3d22269634c3403895
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.cluster_status.state
+      labels: ''
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)'
+      recipient: sysadmin
+      adaptation: observed_enumerated_window
+  ceph_health_warning:
+    sow_id: CEPH-014
+    source_alert: CephHealthWarning
+    source:
+      expression: ceph_health_status == 1
+      persistence: 15m
+      severity: warning
+      lines: {reef: 14, squid: 14, tentacle: 14}
+      definition_sha256:
+        reef: a01aa6d1a5f8a2447dacda41cc52915afc8cc54d99d69ed7ecd83eea5a6f4bd0
+        squid: a01aa6d1a5f8a2447dacda41cc52915afc8cc54d99d69ed7ecd83eea5a6f4bd0
+        tentacle: 1c114f8acb1d6e00b267e0285560b44eade5583e242cbf63256b4ec3679699d0
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.cluster_status.state
+      labels: ''
+      lookup: countif(!=1) -15m unaligned of value
+      units: '%'
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 0)'
+      recipient: silent
+      adaptation: observed_enumerated_window
+  ceph_daemon_crash:
+    sow_id: CEPH-001
+    source_alert: CephDaemonCrash
+    source:
+      expression: 'ceph_health_detail{name="RECENT_CRASH"} == 1'
+      persistence: 1m
+      severity: critical
+      lines: {reef: 730, squid: 742, tentacle: 830}
+      definition_sha256:
+        reef: 7c3ac6a0ed76c16b526e310ae132387e26ce3614670b05da1422eb2ce75ca8c7
+        squid: 7c3ac6a0ed76c16b526e310ae132387e26ce3614670b05da1422eb2ce75ca8c7
+        tentacle: 7babe1141b56b27744e65eb7b66d772410c1d19888e9165b2df6d267b9f19514
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=RECENT_CRASH
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_mgr_module_crash:
+    sow_id: CEPH-015
+    source_alert: CephMgrModuleCrash
+    source:
+      expression: 'ceph_health_detail{name="RECENT_MGR_MODULE_CRASH"} == 1'
+      persistence: 5m
+      severity: critical
+      lines: {reef: 331, squid: 343, tentacle: 341}
+      definition_sha256:
+        reef: 8142cbb18ce8e6d13bb64eee2bf081f84f4e87fe6673cf4175bfb064ba3c36f6
+        squid: 8142cbb18ce8e6d13bb64eee2bf081f84f4e87fe6673cf4175bfb064ba3c36f6
+        tentacle: 7415113121e04fc74a4faf660762f6ef110fc6025d6ae8e4ab1e001c13b11461
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=RECENT_MGR_MODULE_CRASH
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_daemon_slow_ops:
+    sow_id: CEPH-002
+    source_alert: CephDaemonSlowOps
+    source:
+      expression: 'ceph_daemon_health_metrics{type="SLOW_OPS"} > 0'
+      persistence: 30s
+      severity: warning
+      lines: {reef: 599, squid: 611, tentacle: 609}
+      definition_sha256:
+        reef: 37b301daeab704a018729c61d1a14be8fb38ad25acbd5aaf2be5a418fdccb062
+        squid: 37b301daeab704a018729c61d1a14be8fb38ad25acbd5aaf2be5a418fdccb062
+        tentacle: 441f7e00682791eaa49d3b0f51d6a14ad156bbb4b36eb20d787925f798f55bbc
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.daemon_health.item_count
+      labels: type=SLOW_OPS
+      lookup: min -30s unaligned of value
+      units: operations
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_slow_ops:
+    sow_id: CEPH-059
+    source_alert: CephSlowOps
+    source:
+      expression: ceph_healthcheck_slow_ops > 0
+      persistence: 30s
+      severity: warning
+      lines: {reef: 589, squid: 601, tentacle: 599}
+      definition_sha256:
+        reef: ef6e804fd44b4f4d872b80c26563d847e7536afcd6e00844ca07da2de79efe91
+        squid: ef6e804fd44b4f4d872b80c26563d847e7536afcd6e00844ca07da2de79efe91
+        tentacle: 653e7582f85edea931f24cea11b80b673ae2f44b99335ddbbdc4d66d0ce6f47b
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.slow_operations.current_operations
+      labels: ''
+      lookup: min -30s unaligned of value
+      units: operations
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  cephadm_daemon_failed:
+    sow_id: CEPH-060
+    source_alert: CephadmDaemonFailed
+    source:
+      expression: 'ceph_health_detail{name="CEPHADM_FAILED_DAEMON"} > 0'
+      persistence: 30s
+      severity: critical
+      lines: {reef: 621, squid: 633, tentacle: 631}
+      definition_sha256:
+        reef: a0ee1de7560b1b6ef8ce0f94c56bea910826544b017bb2d890e3b7203a8428da
+        squid: 6d871d38ccec822a7f3f34fcf9892c8900f418525a98f0d80f29b1dc02c47b59
+        tentacle: ba91fc7eb3a2b8564288683532056a2c23287f004d33e62a2d92cdfd61353484
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=CEPHADM_FAILED_DAEMON
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  cephadm_paused:
+    sow_id: CEPH-061
+    source_alert: CephadmPaused
+    source:
+      expression: 'ceph_health_detail{name="CEPHADM_PAUSED"} > 0'
+      persistence: 1m
+      severity: warning
+      lines: {reef: 631, squid: 643, tentacle: 641}
+      definition_sha256:
+        reef: aec4f34a24695b538f1f69ce7f8aba74ecc77185283ca56f5cca31826e6e8156
+        squid: aec4f34a24695b538f1f69ce7f8aba74ecc77185283ca56f5cca31826e6e8156
+        tentacle: 396b18624fba7df528640527667b766d8f38431b870fc9e7297f4f81920ed11d
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=CEPHADM_PAUSED
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  cephadm_upgrade_failed:
+    sow_id: CEPH-062
+    source_alert: CephadmUpgradeFailed
+    source:
+      expression: 'ceph_health_detail{name="UPGRADE_EXCEPTION"} > 0'
+      persistence: 30s
+      severity: critical
+      lines: {reef: 611, squid: 623, tentacle: 621}
+      definition_sha256:
+        reef: 5fcdb2df81632b4655b73d9b3e306afd711a85f1a7695c9520a93ce06a186880
+        squid: 5fcdb2df81632b4655b73d9b3e306afd711a85f1a7695c9520a93ce06a186880
+        tentacle: 4d65f6b0f5d9d2f1cc7a79094b5cf86b04a9bc2901cd72b69cfc61abcb9a71b3
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=UPGRADE_EXCEPTION
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  plugin_data_collection_status:
+    sow_id: CEPH-016
+    source_alert: CephMgrPrometheusModuleInactive
+    source:
+      expression: 'up{job="ceph"} == 0'
+      persistence: 1m
+      severity: critical
+      lines: {reef: 342, squid: 354, tentacle: 352}
+      definition_sha256:
+        reef: 6b8e4f6dd58e74045f0ad4cb3e0f45a92329d09519362b6d1458239bb32d6710
+        squid: 6b8e4f6dd58e74045f0ad4cb3e0f45a92329d09519362b6d1458239bb32d6710
+        tentacle: 6b8e4f6dd58e74045f0ad4cb3e0f45a92329d09519362b6d1458239bb32d6710
+    netdata:
+      disposition: reuse
+      fidelity: CORRECTED-INTENT
+      owner: generic_go_d_collection
+      context: netdata.plugin_data_collection_status
+      labels: ''
+      lookup: average -30s unaligned of failed
+      units: status
+      condition: 'warn: $this == 1'
+      recipient: silent
+      adaptation: generic_collection_reuse
+
+netdata_extensions:
+  ceph_unknown_health_check:
+    sow_id: CEPH-ND-001
+    reason: forward-compatible warning for ordinary Ceph health-detail names without a dedicated rule
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.health.health_checks.state
+    labels_policy: exclude every supported named health code and main-only certificate code, then match all remaining names
+    lookup: min -1m unaligned of value
+    units: status
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+    recipient: silent
+    adaptation: observed_binary_window
+  ceph_component_collection_failed:
+    sow_id: CEPH-ND-002
+    reason: native Dashboard API component-integrity owner retained without an MGR duplicate
+    fidelity: NETDATA-ADAPTED
+    owner: native_ceph_dashboard
+    context: ceph.component_collection_status
+  rgw_daemon_failed:
+    sow_id: RGW-M-01
+    reason: existing Cephadm and recent-crash health checks already identify failed RGW daemons
+    fidelity: CORRECTED-INTENT
+    owner: mgr_prometheus
+  rgw_telemetry_missing:
+    sow_id: RGW-M-02
+    reason: generic configured-job collection health owns missing metric telemetry
+    fidelity: CORRECTED-INTENT
+    owner: generic_go_d_collection

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -26,6 +26,53 @@ sources:
     sha256: 09308346d3d143ff128813f1142f1499142799174da4e0505ddad7144b8d8716
 
 adaptation_contracts:
+  local_nvmeof_window_helper:
+    preserved:
+      - the local one-minute database window used by the source expression
+      - the local exporter identity
+    differences:
+      - the helper is instrumentation and does not notify
+      - no cross-exporter cluster aggregation is performed
+  local_nvmeof_inventory_helper:
+    preserved:
+      - the exporter's namespace inventory population
+      - local subsystem or gateway identity
+    differences:
+      - the helper is instrumentation and does not notify
+      - no cross-exporter cluster aggregation is performed
+  local_nvmeof_percent_persistence:
+    preserved:
+      - reactor busy seconds-per-second source signal
+      - strictly greater than 80 percent threshold
+      - ten-minute observation window
+    differences:
+      - busy seconds-per-second is scaled to a percentage before comparison
+      - Netdata applies the threshold to every available local reactor-rate sample in the window rather than first averaging
+        each one-minute source range, making brief sub-threshold dips stricter
+      - scope is each reactor thread rather than the exporter-wide average
+  local_nvmeof_latency_persistence:
+    preserved:
+      - one-minute service-time rate divided by completed-operation rate
+      - read 10 ms and write 20 ms thresholds
+    differences:
+      - scope is each local block device rather than the exporter-wide average
+      - the current ratio does not nest the source five-minute persistence window; a nested lookup-of-lookup would require shared health framework work
+  current_exporter_acknowledgement_state:
+    preserved:
+      - affected host, subsystem, and local gateway identity
+      - warning severity
+    differences:
+      - Netdata observes the exporter's read-on-collect one-shot 0/1 state rather than synthesizing a 24-hour change count
+      - exporter refresh clears the source latch, so the incident may be visible for only one collection cycle
+  local_nvmeof_inventory_limit:
+    preserved:
+      - subsystem or local gateway namespace population
+      - configured namespace limit or supported maximum
+      - inclusive at-limit comparison
+    differences:
+      - aggregation remains inside one exporter endpoint instead of combining gateways across a cluster
+      - the compound count-versus-limit condition is evaluated from current stored dimensions; the source one-minute
+        persistence window is not represented because a health lookup cannot persist this cross-dimension comparison
   observed_binary_window:
     preserved:
       - source incident and predicate
@@ -2099,6 +2146,332 @@ alerts:
       condition: 'warn: $this == 1'
       recipient: silent
       adaptation: generic_collection_reuse
+
+
+  ceph_nvmeof_read_latency_1m:
+    sow_id: CEPH-082-HELPER-READ-TIME
+    source_alert: NVMeoFHighReadLatency
+    source:
+      expression: 'label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m]) / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),"gateway","$1","instance","(.*):.*") > 0.01'
+      persistence: ''
+      severity: warning
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: internal-helper
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.block_devices.time_accumulation
+      labels: ''
+      lookup: average -1m unaligned of read_seconds
+      units: seconds
+      condition: 'warn: $this == 999999999'
+      recipient: silent
+      adaptation: local_nvmeof_window_helper
+  ceph_nvmeof_read_operations_1m:
+    sow_id: CEPH-082-HELPER-READ-OPS
+    source_alert: NVMeoFHighReadLatency
+    source:
+      expression: 'label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m]) / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),"gateway","$1","instance","(.*):.*") > 0.01'
+      persistence: ''
+      severity: warning
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: internal-helper
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.block_devices.operations
+      labels: ''
+      lookup: average -1m unaligned of reads_completed
+      units: operations
+      condition: 'warn: $this == 999999999'
+      recipient: silent
+      adaptation: local_nvmeof_window_helper
+  ceph_nvmeof_write_latency_1m:
+    sow_id: CEPH-083-HELPER-WRITE-TIME
+    source_alert: NVMeoFHighWriteLatency
+    source:
+      expression: 'label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),"gateway","$1","instance","(.*):.*") > 0.02'
+      persistence: ''
+      severity: warning
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: internal-helper
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.block_devices.time_accumulation
+      labels: ''
+      lookup: average -1m unaligned of write_seconds
+      units: seconds
+      condition: 'warn: $this == 999999999'
+      recipient: silent
+      adaptation: local_nvmeof_window_helper
+  ceph_nvmeof_write_operations_1m:
+    sow_id: CEPH-083-HELPER-WRITE-OPS
+    source_alert: NVMeoFHighWriteLatency
+    source:
+      expression: 'label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),"gateway","$1","instance","(.*):.*") > 0.02'
+      persistence: ''
+      severity: warning
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: internal-helper
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.block_devices.operations
+      labels: ''
+      lookup: average -1m unaligned of writes_completed
+      units: operations
+      condition: 'warn: $this == 999999999'
+      recipient: silent
+      adaptation: local_nvmeof_window_helper
+
+  ceph_nvmeof_gateway_namespaces:
+    sow_id: CEPH-094-HELPER-GATEWAY
+    source_alert: NVMeoFTooManyNamespaces
+    source:
+      expression: 'sum by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_namespace_count,"gateway_host","$1","instance","(.*?)(?::.*)?")) >= 4096.00'
+      persistence: ''
+      severity: warning
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: internal-helper
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.gateways.namespace_count
+      labels: ''
+      lookup: average -1m unaligned of namespace_count
+      units: namespaces
+      condition: 'warn: $this == 999999999'
+      recipient: silent
+      adaptation: local_nvmeof_inventory_helper
+  ceph_nvmeof_subsystem_open_security:
+    sow_id: CEPH-078
+    source_alert: NVMeoFGatewayOpenSecurity
+    source:
+      expression: 'ceph_nvmeof_subsystem_metadata{allow_any_host="yes"}'
+      persistence: 5m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 830, squid: 842, tentacle: 948}
+      definition_sha256:
+        reef: 80177d1f73976b80b2e85b4c709ebeb0b940c0967a39dc0fd4bae5de10c548c3
+        squid: 80177d1f73976b80b2e85b4c709ebeb0b940c0967a39dc0fd4bae5de10c548c3
+        tentacle: eeea254679ec25eb206b92b91d0ba43d801033aada2e282d96acbb8e3f1358e0
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.subsystems.state_metadata
+      labels: allow_any_host=yes
+      lookup: min -5m unaligned of metadata
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_nvmeof_gateway_cpu_10m:
+    sow_id: CEPH-080-HELPER-PERSIST
+    source_alert: NVMeoFHighGatewayCPU
+    source:
+      expression: 'label_replace(avg by(instance) (rate(ceph_nvmeof_reactor_seconds_total{mode="busy"}[1m])),"instance","$1","instance","(.*):.*")'
+      persistence: ''
+      severity: warning
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: internal-helper
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.gateways.time_accumulation
+      labels: ''
+      lookup: min -10m unaligned of busy
+      units: status
+      condition: 'warn: $this == 999999999'
+      recipient: silent
+      adaptation: local_nvmeof_window_helper
+  ceph_nvmeof_gateway_cpu:
+    sow_id: CEPH-080
+    source_alert: NVMeoFHighGatewayCPU
+    source:
+      expressions:
+        reef: 'label_replace(avg by(instance) (rate(ceph_nvmeof_reactor_seconds_total{mode="busy"}[1m])),"instance","$1","instance","(.*):.*") > 80.00'
+        squid: 'label_replace(avg by(instance) (rate(ceph_nvmeof_reactor_seconds_total{mode="busy"}[1m])),"instance","$1","instance","(.*):.*") > 80.00'
+        tentacle: 'label_replace(avg by(instance, cluster) (rate(ceph_nvmeof_reactor_seconds_total{mode="busy"}[1m])),"instance","$1","instance","(.*):.*") > 80.00'
+      persistence: 10m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 821, squid: 833, tentacle: 939}
+      definition_sha256:
+        reef: 40fd408fb03395a7185d95a512e68b8464ef91ddee00ecf63b87fc8d5528c48c
+        squid: 40fd408fb03395a7185d95a512e68b8464ef91ddee00ecf63b87fc8d5528c48c
+        tentacle: c677ced0cc130893242aba81a6269ff7ede96bf9015bdac6f5a31dd99733237c
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.gateways.time_accumulation
+      labels: ''
+      lookup: ''
+      calc: '($ceph_nvmeof_gateway_cpu_10m == nan or $ceph_nvmeof_gateway_cpu_10m == inf) ? (nan) : ($ceph_nvmeof_gateway_cpu_10m * 100)'
+      units: '%'
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 80)'
+      recipient: silent
+      adaptation: local_nvmeof_percent_persistence
+  ceph_nvmeof_high_read_latency:
+    sow_id: CEPH-082
+    source_alert: NVMeoFHighReadLatency
+    source:
+      expression: 'label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m]) / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),"gateway","$1","instance","(.*):.*") > 0.01'
+      persistence: 5m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 894, squid: 906, tentacle: 1039}
+      definition_sha256:
+        reef: 0158b445aedd463ec76ed17d514ec4d046cf3fa6c646b352b3c6b70647256f63
+        squid: 0158b445aedd463ec76ed17d514ec4d046cf3fa6c646b352b3c6b70647256f63
+        tentacle: 0158b445aedd463ec76ed17d514ec4d046cf3fa6c646b352b3c6b70647256f63
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.block_devices.time_accumulation
+      labels: ''
+      lookup: ''
+      calc: '($ceph_nvmeof_read_latency_1m == nan or $ceph_nvmeof_read_latency_1m == inf or $ceph_nvmeof_read_operations_1m == nan or $ceph_nvmeof_read_operations_1m == inf or $ceph_nvmeof_read_operations_1m <= 0) ? (nan) : ($ceph_nvmeof_read_latency_1m / $ceph_nvmeof_read_operations_1m)'
+      units: seconds
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0.01)'
+      recipient: silent
+      adaptation: local_nvmeof_latency_persistence
+  ceph_nvmeof_high_write_latency:
+    sow_id: CEPH-083
+    source_alert: NVMeoFHighWriteLatency
+    source:
+      expression: 'label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),"gateway","$1","instance","(.*):.*") > 0.02'
+      persistence: 5m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 903, squid: 915, tentacle: 1048}
+      definition_sha256:
+        reef: 753e7942b97773739a79a8384353025e506ffca88c4c08e7e3a701c75fe34666
+        squid: 753e7942b97773739a79a8384353025e506ffca88c4c08e7e3a701c75fe34666
+        tentacle: 753e7942b97773739a79a8384353025e506ffca88c4c08e7e3a701c75fe34666
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.block_devices.time_accumulation
+      labels: ''
+      lookup: ''
+      calc: '($ceph_nvmeof_write_latency_1m == nan or $ceph_nvmeof_write_latency_1m == inf or $ceph_nvmeof_write_operations_1m == nan or $ceph_nvmeof_write_operations_1m == inf or $ceph_nvmeof_write_operations_1m <= 0) ? (nan) : ($ceph_nvmeof_write_latency_1m / $ceph_nvmeof_write_operations_1m)'
+      units: seconds
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0.02)'
+      recipient: silent
+      adaptation: local_nvmeof_latency_persistence
+  ceph_nvmeof_host_keepalive_timeout:
+    sow_id: CEPH-084
+    source_alert: NVMeoFHostKeepAliveTimeout
+    source:
+      expression: 'ceil(changes(ceph_nvmeof_host_keepalive_timeout[24h:]) / 2) > 0'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 1057}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ba085dfb924f3a7307d287840f898dfe88c73c61e947f965be907d6e698e78ae
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.hosts.keepalive_timeout_state
+      labels: ''
+      calc: $value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: current_exporter_acknowledgement_state
+  ceph_nvmeof_subsystem_namespace_limit:
+    sow_id: CEPH-092
+    source_alert: NVMeoFSubsystemNamespaceLimit
+    source:
+      expressions:
+        reef: '(count by(nqn) (ceph_nvmeof_subsystem_namespace_metadata)) >= ceph_nvmeof_subsystem_namespace_limit'
+        squid: '(count by(nqn) (ceph_nvmeof_subsystem_namespace_metadata)) >= ceph_nvmeof_subsystem_namespace_limit'
+        tentacle: '(count by(nqn, cluster, instance) (ceph_nvmeof_subsystem_namespace_metadata)) >= on(nqn, instance) group_right(cluster) ceph_nvmeof_subsystem_namespace_limit'
+      persistence: 1m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 785, squid: 797, tentacle: 885}
+      definition_sha256:
+        reef: 8bf254c3be042ccadff0c0747d5b6c80a041739c19629719845932dfece83198
+        squid: 8bf254c3be042ccadff0c0747d5b6c80a041739c19629719845932dfece83198
+        tentacle: b4f1f27cb1df316f19e01b5b01fe1d8f25278822e825af0c737b27fbe4c35e3e
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.subsystems.namespace_capacity
+      labels: ''
+      lookup: ''
+      calc: '($count == nan or $count == inf or $limit == nan or $limit == inf or $limit < 0) ? (nan) : ($count >= $limit)'
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: silent
+      adaptation: local_nvmeof_inventory_limit
+  ceph_nvmeof_too_many_namespaces:
+    sow_id: CEPH-094
+    source_alert: NVMeoFTooManyNamespaces
+    source:
+      expression: 'sum by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_namespace_count,"gateway_host","$1","instance","(.*?)(?::.*)?")) >= 4096.00'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 966}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 6bd6d0e65cd08d8c27e13668418487a80aa700584658950ef29d96068eaac1fc
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.nvme_of.gateways.namespace_count
+      labels: ''
+      lookup: ''
+      calc: '($ceph_nvmeof_gateway_namespaces == nan or $ceph_nvmeof_gateway_namespaces == inf) ? (nan) : ($ceph_nvmeof_gateway_namespaces)'
+      units: namespaces
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this >= 4096)'
+      recipient: silent
+      adaptation: local_nvmeof_inventory_limit
 
 netdata_extensions:
   ceph_unknown_health_check:

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -56,6 +56,25 @@ adaptation_contracts:
     differences:
       - Netdata uses its generic per-job collection-failure owner instead of a Ceph-named duplicate
       - the stock generic alert is warning-level and silent rather than the source rule's critical routing
+  current_cluster_compound_state:
+    preserved:
+      - source incident and current cluster-population predicate
+      - source severity and Netdata notification policy
+      - one logical cluster scope per configured MGR job or vnode
+      - ordinary numeric recovery and chart obsoletion
+    differences:
+      - Netdata evaluates a current source-owned summary chart instead of a Prometheus vector aggregation
+      - the source 30-second pending state is not preserved for compound monitor conditions
+      - each health beat evaluates the latest stored dimensions and a failed scrape does not fabricate a new state
+      - generic configured-job collection health owns scrape failure
+  generic_host_policy_reuse:
+    preserved:
+      - source host resource and operator policy category
+      - per-interface or per-filesystem instance ownership
+    differences:
+      - the stock Netdata owner uses its own threshold, observation window, hysteresis, and routing policy
+      - local host collectors own the incident instead of a Ceph MGR job
+      - no Ceph-named duplicate is created
 
 alerts:
   ceph_health_error:
@@ -265,6 +284,525 @@ alerts:
       condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
       recipient: sysadmin
       adaptation: observed_binary_window
+  ceph_device_failure_predicted:
+    sow_id: CEPH-003
+    source_alert: CephDeviceFailurePredicted
+    source:
+      expression: 'ceph_health_detail{name="DEVICE_HEALTH"} == 1'
+      persistence: 1m
+      severity: warning
+      lines: {reef: 187, squid: 187, tentacle: 185}
+      definition_sha256:
+        reef: a0e7a0173902f00e50b5af70fe408e26c15348647916e2f692e44b9a2b9ca7f1
+        squid: a0e7a0173902f00e50b5af70fe408e26c15348647916e2f692e44b9a2b9ca7f1
+        tentacle: 1000bdc47ce29702e1ae940d060d5553a3056193a56daaa18254e71e0cc48f00
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=DEVICE_HEALTH
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_device_failure_prediction_too_high:
+    sow_id: CEPH-004
+    source_alert: CephDeviceFailurePredictionTooHigh
+    source:
+      expression: 'ceph_health_detail{name="DEVICE_HEALTH_TOOMANY"} == 1'
+      persistence: 1m
+      severity: critical
+      lines: {reef: 197, squid: 197, tentacle: 195}
+      definition_sha256:
+        reef: fdb33a93781a7148eb8ba627e14bf0073b099919f4264ae594b9c3d6407e6371
+        squid: 93d548271e3ede508d68938897739f71de243294c817ee78459951a32a0c6a91
+        tentacle: b8e7bde9691b29176e21efe63376ab66836d469e4e18c46cd8c5dc65549b5323
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=DEVICE_HEALTH_TOOMANY
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_device_failure_relocation_incomplete:
+    sow_id: CEPH-005
+    source_alert: CephDeviceFailureRelocationIncomplete
+    source:
+      expression: 'ceph_health_detail{name="DEVICE_HEALTH_IN_USE"} == 1'
+      persistence: 1m
+      severity: warning
+      lines: {reef: 208, squid: 208, tentacle: 206}
+      definition_sha256:
+        reef: 2e9f1504a2029a0994f03b46879ad1837ced45d38be8ebca9c171784d559aeb0
+        squid: 2e9f1504a2029a0994f03b46879ad1837ced45d38be8ebca9c171784d559aeb0
+        tentacle: ee5266e4634e305efad2e656b88d6c7f2cd285768e84273c193986240479e955
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=DEVICE_HEALTH_IN_USE
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_mon_clock_skew:
+    sow_id: CEPH-017
+    source_alert: CephMonClockSkew
+    source:
+      expression: 'ceph_health_detail{name="MON_CLOCK_SKEW"} == 1'
+      persistence: 1m
+      severity: warning
+      lines: {reef: 74, squid: 74, tentacle: 73}
+      definition_sha256:
+        reef: ec7718df89db747132126f5a04c2b0d6b2f44affe82fa8104fc3f11e3cf6b6a5
+        squid: ec7718df89db747132126f5a04c2b0d6b2f44affe82fa8104fc3f11e3cf6b6a5
+        tentacle: 1f63bf68a8749f2f77b304d2578e7155ea74069ff9572fd523525f899394fd1c
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=MON_CLOCK_SKEW
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_mon_diskspace_critical:
+    sow_id: CEPH-018
+    source_alert: CephMonDiskspaceCritical
+    source:
+      expression: 'ceph_health_detail{name="MON_DISK_CRIT"} == 1'
+      persistence: 1m
+      severity: critical
+      lines: {reef: 53, squid: 53, tentacle: 52}
+      definition_sha256:
+        reef: f758b921ed4a142c7a9cbfe2c8064ec41c29d96c6b127a612859ec63e0691458
+        squid: f758b921ed4a142c7a9cbfe2c8064ec41c29d96c6b127a612859ec63e0691458
+        tentacle: 001e5a09d73b88ca0a4f972181eb5725b07364ed7cf464ae9219c9f167cc00e5
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=MON_DISK_CRIT
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_mon_diskspace_low:
+    sow_id: CEPH-019
+    source_alert: CephMonDiskspaceLow
+    source:
+      expression: 'ceph_health_detail{name="MON_DISK_LOW"} == 1'
+      persistence: 5m
+      severity: warning
+      lines: {reef: 64, squid: 64, tentacle: 63}
+      definition_sha256:
+        reef: 1d3c288676304f6602ef34889a8c7c9fe6b821131f0109c78ed4fe0ab5be48e7
+        squid: 1d3c288676304f6602ef34889a8c7c9fe6b821131f0109c78ed4fe0ab5be48e7
+        tentacle: a724c6284c13b884aa983eb232a5d57778d16c8779198762afb5e65501cce2e3
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=MON_DISK_LOW
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_mon_down:
+    sow_id: CEPH-020
+    source_alert: CephMonDown
+    source:
+      expressions:
+        reef: |
+          count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1)
+        squid: |
+          count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1)
+        tentacle: |
+          (count by (cluster) (ceph_mon_quorum_status == 0)) <= (count by (cluster) (ceph_mon_metadata) - floor((count by (cluster) (ceph_mon_metadata) / 2 + 1)))
+      persistence: 30s
+      severity: warning
+      lines: {reef: 41, squid: 41, tentacle: 41}
+      definition_sha256:
+        reef: 5b50c1592e474d03a4ce349d9435a0ac1485b44631321d696b9ddd6ca9f7a848
+        squid: 5b50c1592e474d03a4ce349d9435a0ac1485b44631321d696b9ddd6ca9f7a848
+        tentacle: f16d0207c80cc21d6ed5c441ed31c89502dd780e2dffadd7553dacd1ce2aa19b
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.control_plane.monitor.cluster_summary
+      labels: ''
+      calc: '($total == nan or $total == inf or $in_quorum == nan or $in_quorum == inf or $total <= 0 or $in_quorum < 0 or $in_quorum > $total) ? (nan) : ($in_quorum < $total and $in_quorum * 2 > $total)'
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: current_cluster_compound_state
+  ceph_mon_quorum_at_risk:
+    sow_id: CEPH-021
+    source_alert: CephMonDownQuorumAtRisk
+    source:
+      expressions:
+        reef: |
+          (
+            (ceph_health_detail{name="MON_DOWN"} == 1) * on() (
+              count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1)
+            )
+          ) == 1
+        squid: |
+          (
+            (ceph_health_detail{name="MON_DOWN"} == 1) * on() (
+              count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1)
+            )
+          ) == 1
+        tentacle: |
+          (
+            (ceph_health_detail{name="MON_DOWN"} == 1) * on() group_right(cluster) (
+              count(ceph_mon_quorum_status == 1) by(cluster)== bool (floor(count(ceph_mon_metadata) by(cluster) / 2) + 1)
+            )
+          ) == 1
+      persistence: 30s
+      severity: critical
+      lines: {reef: 25, squid: 25, tentacle: 25}
+      definition_sha256:
+        reef: baad73e6b0d2ad63e0aa2dc4cb4c7cf985bfe5ff2e6d90f68e45439331bb1d71
+        squid: baad73e6b0d2ad63e0aa2dc4cb4c7cf985bfe5ff2e6d90f68e45439331bb1d71
+        tentacle: 5b1c99f9c94d44386f9b60e851d9b6585d04f8601a8b5643431cde14990f5e03
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.control_plane.monitor.cluster_summary
+      labels: ''
+      calc: '($total == nan or $total == inf or $in_quorum == nan or $in_quorum == inf or $total <= 0 or $in_quorum < 0 or $in_quorum > $total) ? (nan) : ($in_quorum < $total and $in_quorum * 2 > $total and ($in_quorum - 1) * 2 <= $total)'
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: current_cluster_compound_state
+  ceph_node_network_packet_drops:
+    sow_id: CEPH-025
+    source_alert: CephNodeNetworkPacketDrops
+    source:
+      expression: |
+        (
+          rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+          rate(node_network_transmit_drop_total{device!="lo"}[1m])
+        ) / (
+          rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+          rate(node_network_transmit_packets_total{device!="lo"}[1m])
+        ) >= 0.0050000000000000001 and (
+          rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+          rate(node_network_transmit_drop_total{device!="lo"}[1m])
+        ) >= 10
+      persistence: ''
+      severity: warning
+      lines: {reef: 460, squid: 472, tentacle: 470}
+      definition_sha256:
+        reef: b38d4361876c2b5a6f494b86e914f5d1f10ecc815baca276c6d789ffa0e12004
+        squid: b38d4361876c2b5a6f494b86e914f5d1f10ecc815baca276c6d789ffa0e12004
+        tentacle: b38d4361876c2b5a6f494b86e914f5d1f10ecc815baca276c6d789ffa0e12004
+    netdata:
+      disposition: reuse
+      fidelity: CORRECTED-INTENT
+      owner: generic_host_network
+      context: net.drops
+      owner_file: src/health/health.d/net.conf
+      owner_alerts:
+        - inbound_packets_dropped_ratio
+        - outbound_packets_dropped_ratio
+        - wifi_inbound_packets_dropped_ratio
+        - wifi_outbound_packets_dropped_ratio
+      adaptation: generic_host_policy_reuse
+  ceph_node_root_filesystem_full:
+    sow_id: CEPH-027
+    source_alert: CephNodeRootFilesystemFull
+    source:
+      expression: 'node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} * 100 < 5'
+      persistence: 5m
+      severity: critical
+      lines: {reef: 450, squid: 462, tentacle: 460}
+      definition_sha256:
+        reef: 851c365408c91a21531fbdab8fff8e77d1ab747e24a6a17fca30297dd238a32a
+        squid: 851c365408c91a21531fbdab8fff8e77d1ab747e24a6a17fca30297dd238a32a
+        tentacle: 851c365408c91a21531fbdab8fff8e77d1ab747e24a6a17fca30297dd238a32a
+    netdata:
+      disposition: reuse
+      fidelity: CORRECTED-INTENT
+      owner: generic_host_disk
+      context: disk.space
+      owner_file: src/health/health.d/disks.conf
+      owner_alerts:
+        - disk_space_usage
+      adaptation: generic_host_policy_reuse
+  ceph_osd_backfill_full:
+    sow_id: CEPH-028
+    source_alert: CephOSDBackfillFull
+    source:
+      expression: 'ceph_health_detail{name="OSD_BACKFILLFULL"} > 0'
+      persistence: 1m
+      severity: warning
+      lines: {reef: 139, squid: 139, tentacle: 137}
+      definition_sha256:
+        reef: 390b75a7f034ee0517309871c74b2492c3efffd59cf490184ad608e9c8b6c8e2
+        squid: 390b75a7f034ee0517309871c74b2492c3efffd59cf490184ad608e9c8b6c8e2
+        tentacle: 540c1093d513f10b4fe7140049e3955abefa848b7e9ba527e215bc4001eef11f
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_BACKFILLFULL
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_osd_down:
+    sow_id: CEPH-029
+    source_alert: CephOSDDown
+    source:
+      expression: 'ceph_health_detail{name="OSD_DOWN"} == 1'
+      persistence: 5m
+      severity: warning
+      lines: {reef: 105, squid: 105, tentacle: 104}
+      definition_sha256:
+        reef: 3957cd5cfc4b511e35cf253d12a11b1a3a9bd57c591eacfc6aef00cc000b2b08
+        squid: 3957cd5cfc4b511e35cf253d12a11b1a3a9bd57c591eacfc6aef00cc000b2b08
+        tentacle: 64cdcb2bec8b3fc0a2ddefd6123b08def64db42bda5429e02a7e817087c5b049
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_DOWN
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_osd_down_high:
+    sow_id: CEPH-030
+    source_alert: CephOSDDownHigh
+    source:
+      expressions:
+        reef: count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10
+        squid: count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10
+        tentacle: count by (cluster) (ceph_osd_up == 0) / count by (cluster) (ceph_osd_up) * 100 >= 10
+      persistence: ''
+      severity: critical
+      lines: {reef: 86, squid: 86, tentacle: 85}
+      definition_sha256:
+        reef: 88f727f1e22972fc2c23db5d1f9a43b5b8949c40fa757ad859d355e7d4c515bd
+        squid: 88f727f1e22972fc2c23db5d1f9a43b5b8949c40fa757ad859d355e7d4c515bd
+        tentacle: 842161b09a79229c678d5231e5d0f5547607c769be29e0ff3654d419420b8e69
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
+      labels: ''
+      calc: '($total == nan or $total == inf or $up == nan or $up == inf or $total <= 0 or $up < 0 or $up > $total) ? (nan) : (($total - $up) * 100 / $total)'
+      units: '%'
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this >= 10)'
+      recipient: silent
+      adaptation: current_cluster_compound_state
+  ceph_osd_full:
+    sow_id: CEPH-032
+    source_alert: CephOSDFull
+    source:
+      expression: 'ceph_health_detail{name="OSD_FULL"} > 0'
+      persistence: 1m
+      severity: critical
+      lines: {reef: 128, squid: 128, tentacle: 126}
+      definition_sha256:
+        reef: 93f91a875ce3d9559b25294fa35dda7002ebe9c37b02bf5643a35edb7465fdb5
+        squid: 93f91a875ce3d9559b25294fa35dda7002ebe9c37b02bf5643a35edb7465fdb5
+        tentacle: c7a5d04cd38f6fab4e131c208722a40602e34f3ff201ff318faaba093a8b4f92
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_FULL
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_osd_host_down:
+    sow_id: CEPH-033
+    source_alert: CephOSDHostDown
+    source:
+      expression: 'ceph_health_detail{name="OSD_HOST_DOWN"} == 1'
+      persistence: 5m
+      severity: warning
+      lines: {reef: 95, squid: 95, tentacle: 94}
+      definition_sha256:
+        reef: b5fef504434d810f3a53ecb46491ffd8fab99b09f72774a9b17d8c0dd173e652
+        squid: b5fef504434d810f3a53ecb46491ffd8fab99b09f72774a9b17d8c0dd173e652
+        tentacle: d6e2832cfba9c3b19cd4f55893c36f899f94aee76dbc08473c88ceeb053c30bb
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_HOST_DOWN
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_osd_internal_disk_size_mismatch:
+    sow_id: CEPH-034
+    source_alert: CephOSDInternalDiskSizeMismatch
+    source:
+      expression: 'ceph_health_detail{name="BLUESTORE_DISK_SIZE_MISMATCH"} == 1'
+      persistence: 1m
+      severity: warning
+      lines: {reef: 177, squid: 177, tentacle: 175}
+      definition_sha256:
+        reef: 862a4c8c61b001be8f4c598688cd5caa5dac479abd873562706b5e3353e22c46
+        squid: 862a4c8c61b001be8f4c598688cd5caa5dac479abd873562706b5e3353e22c46
+        tentacle: 3fec3b57360299ef75ce05ca04a561f675454728a93bc523a759ec358980ed97
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=BLUESTORE_DISK_SIZE_MISMATCH
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_osd_near_full:
+    sow_id: CEPH-035
+    source_alert: CephOSDNearFull
+    source:
+      expression: 'ceph_health_detail{name="OSD_NEARFULL"} == 1'
+      persistence: 5m
+      severity: warning
+      lines: {reef: 117, squid: 117, tentacle: 115}
+      definition_sha256:
+        reef: 290ddd2d4df7a20637b6d05028a3752bb6b976c66f33af1e8b6abe013d3a1c05
+        squid: 290ddd2d4df7a20637b6d05028a3752bb6b976c66f33af1e8b6abe013d3a1c05
+        tentacle: 21517a22e0f930e5b86140b8cb550d40ba1376640de177ea7fbc6d330c76c795
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_NEARFULL
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_osd_read_errors:
+    sow_id: CEPH-036
+    source_alert: CephOSDReadErrors
+    source:
+      expression: 'ceph_health_detail{name="BLUESTORE_SPURIOUS_READ_ERRORS"} == 1'
+      persistence: 30s
+      severity: warning
+      lines: {reef: 228, squid: 228, tentacle: 226}
+      definition_sha256:
+        reef: 5d95cceb135ac37034b1bf6512307bf53ca011338858de959136be39930e9db2
+        squid: 5d95cceb135ac37034b1bf6512307bf53ca011338858de959136be39930e9db2
+        tentacle: 78b9698e6081701a7602299e9438d899b6a8b71a64f976a92c226d29db0ff339
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=BLUESTORE_SPURIOUS_READ_ERRORS
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_osd_timeouts_cluster_network:
+    sow_id: CEPH-037
+    source_alert: CephOSDTimeoutsClusterNetwork
+    source:
+      expression: 'ceph_health_detail{name="OSD_SLOW_PING_TIME_BACK"} == 1'
+      persistence: 1m
+      severity: warning
+      lines: {reef: 168, squid: 168, tentacle: 166}
+      definition_sha256:
+        reef: b171b1604f028303af15b2f3a3f6b7f6d6eca1bcf0dd2d83662ff12684a0154e
+        squid: b171b1604f028303af15b2f3a3f6b7f6d6eca1bcf0dd2d83662ff12684a0154e
+        tentacle: 2dac309c4a87b39d657b489dcae82e1aa8c2ce17a88939a28340de3ec3dd89ec
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_SLOW_PING_TIME_BACK
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_osd_timeouts_public_network:
+    sow_id: CEPH-038
+    source_alert: CephOSDTimeoutsPublicNetwork
+    source:
+      expression: 'ceph_health_detail{name="OSD_SLOW_PING_TIME_FRONT"} == 1'
+      persistence: 1m
+      severity: warning
+      lines: {reef: 159, squid: 159, tentacle: 157}
+      definition_sha256:
+        reef: 6d5d349f3162e6f143250245b23782b45086c3c0fd5f3d6b2fb62038e95af222
+        squid: 6d5d349f3162e6f143250245b23782b45086c3c0fd5f3d6b2fb62038e95af222
+        tentacle: 56b3789ff346de47b1c3230886f5a41e7a10528b1be91dc0a235acc9398c3232
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_SLOW_PING_TIME_FRONT
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_osd_too_many_repairs:
+    sow_id: CEPH-039
+    source_alert: CephOSDTooManyRepairs
+    source:
+      expression: 'ceph_health_detail{name="OSD_TOO_MANY_REPAIRS"} == 1'
+      persistence: 30s
+      severity: warning
+      lines: {reef: 149, squid: 149, tentacle: 147}
+      definition_sha256:
+        reef: 04be9998b215f9804cb1a14c1bbf059ddc928681c27d974a0033403d28f1b270
+        squid: 04be9998b215f9804cb1a14c1bbf059ddc928681c27d974a0033403d28f1b270
+        tentacle: ec92c6232bea5e685e912fe1d012525643664ad16f899070f4ceb98239ac25b7
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_TOO_MANY_REPAIRS
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
   plugin_data_collection_status:
     sow_id: CEPH-016
     source_alert: CephMgrPrometheusModuleInactive
@@ -281,6 +819,9 @@ alerts:
       disposition: reuse
       fidelity: CORRECTED-INTENT
       owner: generic_go_d_collection
+      owner_file: src/health/health.d/go.d.plugin.conf
+      owner_alerts:
+        - plugin_data_collection_status
       context: netdata.plugin_data_collection_status
       labels: ''
       lookup: average -30s unaligned of failed

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -1504,7 +1504,7 @@ alerts:
       fidelity: CORRECTED-INTENT
       owner: ceph_pgs_damaged
       context: prometheus.ceph.health.health_checks.state
-      labels: name=OSD_SCRUB_ERRORS !PG_DAMAGED *
+      labels: name=OSD_SCRUB_ERRORS
       lookup: min -5m unaligned of value
       units: status
       condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)'

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -87,6 +87,24 @@ adaptation_contracts:
       - partial collection gaps do not reset the window
       - a new chart may be evaluated with up to one chart update interval less history
       - a sufficiently stale lookup stops evaluating until collection resumes
+  same_chart_current_difference:
+    preserved:
+      - source current difference between dimensions on one chart instance
+      - source identity of that chart instance
+      - source severity and notification policy
+    differences:
+      - Netdata subtracts latest stored dimension values; it does not persist each operand over the source duration
+      - the source joins metadata to derive pool identity, while Netdata already owns per-pool chart identity
+      - non-finite or impossible counts become NaN rather than a false active or clear state
+  different_chart_current_composite:
+    preserved:
+      - source incident across related signals in one configured MGR job
+      - source severity and notification policy
+      - generic configured-job collection failure remains the scrape owner
+    differences:
+      - Netdata selects the latest matching chart/alert instance by equal label overlap instead of PromQL vector matching
+      - the source pending state is not reproduced for current composite signals
+      - missing or ambiguous operands become NaN rather than a fabricated clear or active state
   corrected_sensor_policy:
     preserved:
       - source sensor-family intent and severity
@@ -914,6 +932,404 @@ alerts:
       condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 80)'
       recipient: silent
       adaptation: corrected_sensor_policy
+  ceph_osd_all_up:
+    sow_id: CEPH-040-HELPER
+    source_alert: CephObjectMissing
+    source:
+      expression: 'count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)'
+      persistence: ''
+      severity: warning
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: internal-helper
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
+      calc: '($total == nan or $total == inf or $up == nan or $up == inf or $total <= 0 or $up < 0 or $up > $total) ? (nan) : ($up == $total)'
+      units: status
+      condition: 'warn: $this == 999999999'
+      recipient: silent
+      adaptation: different_chart_current_composite
+
+  ceph_object_missing:
+    sow_id: CEPH-040
+    source_alert: CephObjectMissing
+    source:
+      expressions:
+        reef: '(ceph_health_detail{name="OBJECT_UNFOUND"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1'
+        squid: '(ceph_health_detail{name="OBJECT_UNFOUND"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1'
+        tentacle: '(ceph_health_detail{name="OBJECT_UNFOUND"} == 1) * on() group_right(cluster) (count(ceph_osd_up == 1) by (cluster) == bool count(ceph_osd_metadata) by(cluster)) == 1'
+      persistence: 30s
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 717, squid: 729, tentacle: 817}
+      definition_sha256:
+        reef: 826d395caff801e17bed4ca839e0fe50d9dcfee2f2f25b8e679cf2fc334d0833
+        squid: 826d395caff801e17bed4ca839e0fe50d9dcfee2f2f25b8e679cf2fc334d0833
+        tentacle: c78a6a51640fc3a04715aafa8356ab6ed612fbd7319be6a90818eb2e34e2c3f0
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OBJECT_UNFOUND
+      calc: '($value == nan or $value == inf or $value == 0 or $ceph_osd_all_up == nan or $ceph_osd_all_up == inf) ? (nan) : ($ceph_osd_all_up == 1)'
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: different_chart_current_composite
+  ceph_pg_backfill_at_risk:
+    sow_id: CEPH-041
+    source_alert: CephPGBackfillAtRisk
+    source:
+      expression: 'ceph_health_detail{name="PG_BACKFILL_FULL"} == 1'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 407, squid: 419, tentacle: 417}
+      definition_sha256:
+        reef: b52630866db8087e37b218f1ec5f8f447559e390938fc0ea8787cf404de016ae
+        squid: b52630866db8087e37b218f1ec5f8f447559e390938fc0ea8787cf404de016ae
+        tentacle: 85e997ee6274e7f582a6da7b892ba3b933d421f0315f90d38e5dc7f633003064
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=PG_BACKFILL_FULL
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_pg_not_deep_scrubbed:
+    sow_id: CEPH-043
+    source_alert: CephPGNotDeepScrubbed
+    source:
+      expression: 'ceph_health_detail{name="PG_NOT_DEEP_SCRUBBED"} == 1'
+      persistence: 5m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 438, squid: 450, tentacle: 448}
+      definition_sha256:
+        reef: ed05ed6bf6b4471f9aba1484b7b6ae3abc1aa475c148d799684b8e9feeb37345
+        squid: ed05ed6bf6b4471f9aba1484b7b6ae3abc1aa475c148d799684b8e9feeb37345
+        tentacle: a954f3f3b8e8508fef32f78ef2b0248d6ac9f174cf86b841cdcc4f3dafb5648d
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=PG_NOT_DEEP_SCRUBBED
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_pg_not_scrubbed:
+    sow_id: CEPH-044
+    source_alert: CephPGNotScrubbed
+    source:
+      expression: 'ceph_health_detail{name="PG_NOT_SCRUBBED"} == 1'
+      persistence: 5m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 418, squid: 430, tentacle: 428}
+      definition_sha256:
+        reef: 04eac2c237a04114030d917bcd58708173dc2d0cc60ed8883632ecd598e8e042
+        squid: 04eac2c237a04114030d917bcd58708173dc2d0cc60ed8883632ecd598e8e042
+        tentacle: 8f2184ba8fc1a9ea06ca903619a7c8906f4ec9eaad755515022adad39800b8e2
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=PG_NOT_SCRUBBED
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_pg_recovery_at_risk:
+    sow_id: CEPH-045
+    source_alert: CephPGRecoveryAtRisk
+    source:
+      expression: 'ceph_health_detail{name="PG_RECOVERY_FULL"} == 1'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 385, squid: 397, tentacle: 395}
+      definition_sha256:
+        reef: 38a10375657dafab8027461e1615d6264c17713193f56a1b51227f9bf826191d
+        squid: 38a10375657dafab8027461e1615d6264c17713193f56a1b51227f9bf826191d
+        tentacle: 552d0eda278b405211ab59c0394f10246a4c5c025a1d174732e5afac523d45a6
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=PG_RECOVERY_FULL
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_osd_down_current:
+    sow_id: CEPH-046-HELPER
+    source_alert: CephPGUnavailableBlockingIO
+    source:
+      expression: 'ceph_health_detail{name="OSD_DOWN"}'
+      persistence: ''
+      severity: warning
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: internal-helper
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_DOWN
+      calc: $value
+      units: status
+      condition: 'warn: $this == 999999999'
+      recipient: silent
+      adaptation: different_chart_current_composite
+
+  ceph_pg_unavailable_blocking_io:
+    sow_id: CEPH-046
+    source_alerts: {reef: CephPGUnavilableBlockingIO, squid: CephPGUnavailableBlockingIO, tentacle: CephPGUnavailableBlockingIO}
+    source:
+      expressions:
+        reef: '((ceph_health_detail{name="PG_AVAILABILITY"} == 1) - scalar(ceph_health_detail{name="OSD_DOWN"})) == 1'
+        squid: '((ceph_health_detail{name="PG_AVAILABILITY"} == 1) - scalar(ceph_health_detail{name="OSD_DOWN"})) == 1'
+        tentacle: '((ceph_health_detail{name="PG_AVAILABILITY"} == 1) - scalar(ceph_health_detail{name="OSD_DOWN"})) == 1'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 396, squid: 408, tentacle: 406}
+      definition_sha256:
+        reef: 65efad4c535b268c90b6ceea31882af9a5dd457b4706cbbee5f8fb2ff8495041
+        squid: bc6128d320ccd55cc2980bc14e9fc460db86810053505a97946ede8bd8e67066
+        tentacle: 1d02f70b254220351139f98455dd1f5aa563cd7558750005b6bcdd1c973e5cfa
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=PG_AVAILABILITY
+      calc: '($value == nan or $value == inf or $ceph_osd_down_current == nan or $ceph_osd_down_current == inf) ? (nan) : ($value == 1 and $ceph_osd_down_current != 1)'
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: different_chart_current_composite
+  ceph_osd_scrub_errors:
+    sow_id: CEPH-047-HELPER
+    source_alert: CephPGsDamaged
+    source:
+      expression: 'ceph_health_detail{name=~"PG_DAMAGED|OSD_SCRUB_ERRORS"} == 1'
+      persistence: 5m
+      severity: critical
+      releases: []
+      lines: {reef: 0, squid: 0, tentacle: 0}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: ""
+    netdata:
+      disposition: subsumed-helper
+      fidelity: CORRECTED-INTENT
+      owner: ceph_pgs_damaged
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=OSD_SCRUB_ERRORS !PG_DAMAGED *
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: silent
+      adaptation: observed_binary_window
+
+  ceph_pgs_damaged:
+    sow_id: CEPH-047
+    source_alert: CephPGsDamaged
+    source:
+      expression: 'ceph_health_detail{name=~"PG_DAMAGED|OSD_SCRUB_ERRORS"} == 1'
+      persistence: 5m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 374, squid: 386, tentacle: 384}
+      definition_sha256:
+        reef: f5983c7564d5d01cacb557a427a67f6c0b7e0a0019f6af517da558f9a75d6147
+        squid: f5983c7564d5d01cacb557a427a67f6c0b7e0a0019f6af517da558f9a75d6147
+        tentacle: acc24dda7d0ec78cb1ef0c346919f75941b114d3ce2fb59ee839e13e1222d100
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=PG_DAMAGED
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_enumerated_window
+  ceph_pgs_high_per_osd:
+    sow_id: CEPH-048
+    source_alert: CephPGsHighPerOSD
+    source:
+      expression: 'ceph_health_detail{name="TOO_MANY_PGS"} == 1'
+      persistence: 1m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 428, squid: 440, tentacle: 438}
+      definition_sha256:
+        reef: aa65787dec1f6aa6f6130dbbe9db6567e44240acd6d3d6eb55df3bab86ec7e94
+        squid: aa65787dec1f6aa6f6130dbbe9db6567e44240acd6d3d6eb55df3bab86ec7e94
+        tentacle: 98ba75442e8a2af30f8985178d10440ae31c7f65183090203e427a6c7580fc01
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=TOO_MANY_PGS
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_pgs_inactive:
+    sow_id: CEPH-049
+    source_alert: CephPGsInactive
+    source:
+      expressions:
+        reef: 'ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0'
+        squid: 'ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0'
+        tentacle: 'ceph_pool_metadata * on(cluster,pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0'
+      persistence: 5m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 354, squid: 366, tentacle: 364}
+      definition_sha256:
+        reef: e03b49df7df58b41f1ff5718ff7ba6327330c639050e1995b56051ed91594e46
+        squid: e03b49df7df58b41f1ff5718ff7ba6327330c639050e1995b56051ed91594e46
+        tentacle: 1659e8fb4587751e452393879b299f02174cdb101c39b7cfcb331a27b6d63e34
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.placement_groups_and_recovery.healthy_state.pg_state
+      lookup: ''
+      calc: '($pg_total == nan or $pg_total == inf or $active == nan or $active == inf or $pg_total < 0 or $active < 0 or $active > $pg_total) ? (nan) : ($pg_total - $active)'
+      units: PGs
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: same_chart_current_difference
+  ceph_pgs_unclean:
+    sow_id: CEPH-050
+    source_alert: CephPGsUnclean
+    source:
+      expressions:
+        reef: 'ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0'
+        squid: 'ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0'
+        tentacle: 'ceph_pool_metadata * on(cluster,pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0'
+      persistence: 15m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 364, squid: 376, tentacle: 374}
+      definition_sha256:
+        reef: e294271fd383cc035f1d0bf3265b375905060d74cbc95c7fb4293b0a8d3c516a
+        squid: e294271fd383cc035f1d0bf3265b375905060d74cbc95c7fb4293b0a8d3c516a
+        tentacle: fa4ea2a8a53db172a1431fcbe95efa904287249951805ac685041e1e7c1c80b0
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.placement_groups_and_recovery.healthy_state.pg_state
+      lookup: ''
+      calc: '($pg_total == nan or $pg_total == inf or $clean == nan or $clean == inf or $pg_total < 0 or $clean < 0 or $clean > $pg_total) ? (nan) : ($pg_total - $clean)'
+      units: PGs
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: same_chart_current_difference
+  ceph_pool_backfill_full:
+    sow_id: CEPH-051
+    source_alert: CephPoolBackfillFull
+    source:
+      expression: 'ceph_health_detail{name="POOL_BACKFILLFULL"} > 0'
+      persistence: ''
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 559, squid: 571, tentacle: 569}
+      definition_sha256:
+        reef: 79579b93902826a6c4828d6878f19815c2b2fd044101170f34e86dabdbb38537
+        squid: 79579b93902826a6c4828d6878f19815c2b2fd044101170f34e86dabdbb38537
+        tentacle: a1f14e5bcbb36f9e33b20be3b80995718f28fb5491064d8c199f0f542a76e528
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=POOL_BACKFILLFULL
+      lookup: min -10s unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_pool_full:
+    sow_id: CEPH-052
+    source_alert: CephPoolFull
+    source:
+      expression: 'ceph_health_detail{name="POOL_FULL"} > 0'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 567, squid: 579, tentacle: 577}
+      definition_sha256:
+        reef: f76686ab452b125c78e2d4ed4d95caa337725a77411d5cd6e68e780ebc802e5c
+        squid: f76686ab452b125c78e2d4ed4d95caa337725a77411d5cd6e68e780ebc802e5c
+        tentacle: 1c20dc103119c3d0695de58fabecec199f40f5e7cf2ee54fbcfb3ee36ed02b93
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=POOL_FULL
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_pool_near_full:
+    sow_id: CEPH-054
+    source_alert: CephPoolNearFull
+    source:
+      expression: 'ceph_health_detail{name="POOL_NEAR_FULL"} > 0'
+      persistence: 5m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 578, squid: 590, tentacle: 588}
+      definition_sha256:
+        reef: 3038cf243067ca2ebf497ee99e74dcc917f2f2d2776e76794206f15737fc7686
+        squid: 3038cf243067ca2ebf497ee99e74dcc917f2f2d2776e76794206f15737fc7686
+        tentacle: 7c140b077eba3e0c4b41e4fb7a96806a3752c8f75a35c7e0cfb0a02d773d5018
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=POOL_NEAR_FULL
+      lookup: min -5m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
   ceph_mon_clock_skew:
     sow_id: CEPH-017
     source_alert: CephMonClockSkew

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -76,6 +76,27 @@ adaptation_contracts:
       - local host collectors own the incident instead of a Ceph MGR job
       - no Ceph-named duplicate is created
 
+  observed_hardware_ordinal_window:
+    preserved:
+      - source incident and exact degraded-or-failed ordinal predicate
+      - source severity and Netdata notification policy
+      - hostname, component, and category identity on one chart instance
+      - ordinary numeric recovery and chart obsoletion
+    differences:
+      - the lookup requires every observed numeric sample, not every scheduled evaluation, to match the target state
+      - partial collection gaps do not reset the window
+      - a new chart may be evaluated with up to one chart update interval less history
+      - a sufficiently stale lookup stops evaluating until collection resumes
+  corrected_sensor_policy:
+    preserved:
+      - source sensor-family intent and severity
+      - per-host, per-sensor identity and ordinary numeric recovery
+    differences:
+      - source regex matching is corrected to exact recognized sensor-family suffixes, avoiding accidental matching of
+        unrelated sensor names that merely contain the source substring
+      - each alert is installed as silent SHOULD policy because fixed temperature limits are workload- and vendor-dependent
+      - unknown sensor families are intentionally not alerted by these rules
+
 alerts:
   ceph_health_error:
     sow_id: CEPH-013
@@ -84,6 +105,7 @@ alerts:
       expression: ceph_health_status == 2
       persistence: 5m
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 4, squid: 4, tentacle: 4}
       definition_sha256:
         reef: ae390eeeca1b5b10d85ae2492cc3f2ba2adea54815c616c490b3fd1698c695d3
@@ -107,6 +129,7 @@ alerts:
       expression: ceph_health_status == 1
       persistence: 15m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 14, squid: 14, tentacle: 14}
       definition_sha256:
         reef: a01aa6d1a5f8a2447dacda41cc52915afc8cc54d99d69ed7ecd83eea5a6f4bd0
@@ -130,6 +153,7 @@ alerts:
       expression: 'ceph_health_detail{name="RECENT_CRASH"} == 1'
       persistence: 1m
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 730, squid: 742, tentacle: 830}
       definition_sha256:
         reef: 7c3ac6a0ed76c16b526e310ae132387e26ce3614670b05da1422eb2ce75ca8c7
@@ -153,6 +177,7 @@ alerts:
       expression: 'ceph_health_detail{name="RECENT_MGR_MODULE_CRASH"} == 1'
       persistence: 5m
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 331, squid: 343, tentacle: 341}
       definition_sha256:
         reef: 8142cbb18ce8e6d13bb64eee2bf081f84f4e87fe6673cf4175bfb064ba3c36f6
@@ -176,6 +201,7 @@ alerts:
       expression: 'ceph_daemon_health_metrics{type="SLOW_OPS"} > 0'
       persistence: 30s
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 599, squid: 611, tentacle: 609}
       definition_sha256:
         reef: 37b301daeab704a018729c61d1a14be8fb38ad25acbd5aaf2be5a418fdccb062
@@ -199,6 +225,7 @@ alerts:
       expression: ceph_healthcheck_slow_ops > 0
       persistence: 30s
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 589, squid: 601, tentacle: 599}
       definition_sha256:
         reef: ef6e804fd44b4f4d872b80c26563d847e7536afcd6e00844ca07da2de79efe91
@@ -222,6 +249,7 @@ alerts:
       expression: 'ceph_health_detail{name="CEPHADM_FAILED_DAEMON"} > 0'
       persistence: 30s
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 621, squid: 633, tentacle: 631}
       definition_sha256:
         reef: a0ee1de7560b1b6ef8ce0f94c56bea910826544b017bb2d890e3b7203a8428da
@@ -245,6 +273,7 @@ alerts:
       expression: 'ceph_health_detail{name="CEPHADM_PAUSED"} > 0'
       persistence: 1m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 631, squid: 643, tentacle: 641}
       definition_sha256:
         reef: aec4f34a24695b538f1f69ce7f8aba74ecc77185283ca56f5cca31826e6e8156
@@ -268,6 +297,7 @@ alerts:
       expression: 'ceph_health_detail{name="UPGRADE_EXCEPTION"} > 0'
       persistence: 30s
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 611, squid: 623, tentacle: 621}
       definition_sha256:
         reef: 5fcdb2df81632b4655b73d9b3e306afd711a85f1a7695c9520a93ce06a186880
@@ -291,6 +321,7 @@ alerts:
       expression: 'ceph_health_detail{name="DEVICE_HEALTH"} == 1'
       persistence: 1m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 187, squid: 187, tentacle: 185}
       definition_sha256:
         reef: a0e7a0173902f00e50b5af70fe408e26c15348647916e2f692e44b9a2b9ca7f1
@@ -314,6 +345,7 @@ alerts:
       expression: 'ceph_health_detail{name="DEVICE_HEALTH_TOOMANY"} == 1'
       persistence: 1m
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 197, squid: 197, tentacle: 195}
       definition_sha256:
         reef: fdb33a93781a7148eb8ba627e14bf0073b099919f4264ae594b9c3d6407e6371
@@ -337,6 +369,7 @@ alerts:
       expression: 'ceph_health_detail{name="DEVICE_HEALTH_IN_USE"} == 1'
       persistence: 1m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 208, squid: 208, tentacle: 206}
       definition_sha256:
         reef: 2e9f1504a2029a0994f03b46879ad1837ced45d38be8ebca9c171784d559aeb0
@@ -353,6 +386,534 @@ alerts:
       condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
       recipient: sysadmin
       adaptation: observed_binary_window
+  ceph_cooling_degraded:
+    sow_id: CEPH-063
+    source_alert: CoolingDegraded
+    source:
+      expression: 'ceph_hardware_health{category="fans"} == 1'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 672}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: b7813f0989d6f3cc1b2dbf82029f9441eb13eec552886d1aa3f36b2ddae9f604
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=fans
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_cooling_failed:
+    sow_id: CEPH-064
+    source_alert: CoolingFailed
+    source:
+      expression: 'ceph_hardware_health{category="fans"} == 2'
+      persistence: 1m
+      severity: critical
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 681}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: d8410890a111c6dca0f3e62885e85c87a36bb4eaa86cc3af18d5548abd3dce65
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=fans
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_dimm_temperature_high:
+    sow_id: CEPH-065
+    source_alert: DIMMTemperatureHigh
+    source:
+      expression: 'ceph_hardware_temperature_celsius{sensor_name=~".*DIMM.*_TEMP"} > 80'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 776}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 5eba1a2e745d07520825f926cbd2c8463b0837461f043fed3327d07c12764d8b
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.temperature.temperature
+      labels: sensor_name=*DIMM*_TEMP
+      lookup: min -1m unaligned of value
+      units: celsius
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 80)'
+      recipient: silent
+      adaptation: corrected_sensor_policy
+  ceph_hardware_fan_error:
+    sow_id: CEPH-066
+    source_alert: HardwareFanError
+    source:
+      expression: 'ceph_health_detail{name="HARDWARE_FANS"} > 0'
+      persistence: 30s
+      severity: critical
+      releases: [reef, squid]
+      lines: {reef: 693, squid: 705, tentacle: 0}
+      definition_sha256:
+        reef: c07217d03f7f6cce2b4b0ed62be9e4935961f684cf7588a67475cbeff7726f74
+        squid: c07217d03f7f6cce2b4b0ed62be9e4935961f684cf7588a67475cbeff7726f74
+        tentacle: ""
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=HARDWARE_FANS
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_hardware_memory_error:
+    sow_id: CEPH-067
+    source_alert: HardwareMemoryError
+    source:
+      expression: 'ceph_health_detail{name="HARDWARE_MEMORY"} > 0'
+      persistence: 30s
+      severity: critical
+      releases: [reef, squid]
+      lines: {reef: 653, squid: 665, tentacle: 0}
+      definition_sha256:
+        reef: 23c27eeba0fcb16a11356282621a161a60c494bb428f0354591d6f15fc2b390b
+        squid: 23c27eeba0fcb16a11356282621a161a60c494bb428f0354591d6f15fc2b390b
+        tentacle: ""
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=HARDWARE_MEMORY
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_hardware_network_error:
+    sow_id: CEPH-068
+    source_alert: HardwareNetworkError
+    source:
+      expression: 'ceph_health_detail{name="HARDWARE_NETWORK"} > 0'
+      persistence: 30s
+      severity: critical
+      releases: [reef, squid]
+      lines: {reef: 673, squid: 685, tentacle: 0}
+      definition_sha256:
+        reef: e5fae57b059b253d0ee077c75fc5f29f0a3ec4fa9a4636c8a0c5561a0558d569
+        squid: e5fae57b059b253d0ee077c75fc5f29f0a3ec4fa9a4636c8a0c5561a0558d569
+        tentacle: ""
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=HARDWARE_NETWORK
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_hardware_power_error:
+    sow_id: CEPH-069
+    source_alert: HardwarePowerError
+    source:
+      expression: 'ceph_health_detail{name="HARDWARE_POWER"} > 0'
+      persistence: 30s
+      severity: critical
+      releases: [reef, squid]
+      lines: {reef: 683, squid: 695, tentacle: 0}
+      definition_sha256:
+        reef: 8474296ca13af3b5de1343a3c8a77f2d8a9702a75b57ba4f51dfd95858f82b68
+        squid: 8474296ca13af3b5de1343a3c8a77f2d8a9702a75b57ba4f51dfd95858f82b68
+        tentacle: ""
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=HARDWARE_POWER
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_hardware_processor_error:
+    sow_id: CEPH-070
+    source_alert: HardwareProcessorError
+    source:
+      expression: 'ceph_health_detail{name="HARDWARE_PROCESSOR"} > 0'
+      persistence: 30s
+      severity: critical
+      releases: [reef, squid]
+      lines: {reef: 663, squid: 675, tentacle: 0}
+      definition_sha256:
+        reef: 9290719d1825576f637f25ee59833574397fa37645339a4374342ef4a4d55d37
+        squid: 9290719d1825576f637f25ee59833574397fa37645339a4374342ef4a4d55d37
+        tentacle: ""
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=HARDWARE_PROCESSOR
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_hardware_storage_error:
+    sow_id: CEPH-071
+    source_alert: HardwareStorageError
+    source:
+      expression: 'ceph_health_detail{name="HARDWARE_STORAGE"} > 0'
+      persistence: 30s
+      severity: critical
+      releases: [reef, squid]
+      lines: {reef: 643, squid: 655, tentacle: 0}
+      definition_sha256:
+        reef: f3222e3e30848242a1b708d1906f2bc2e7d26f0354c92bd5d1e8a01ea1961ad1
+        squid: f3222e3e30848242a1b708d1906f2bc2e7d26f0354c92bd5d1e8a01ea1961ad1
+        tentacle: ""
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=HARDWARE_STORAGE
+      lookup: min -30s unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_memory_degraded:
+    sow_id: CEPH-072
+    source_alert: MemoryDegraded
+    source:
+      expression: 'ceph_hardware_health{category="memory"} == 1'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 710}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 16cb8a62dd230abb1de7dd4624074565fe2d8131adad93e455d692f4cc9fa0d3
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=memory
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_memory_failed:
+    sow_id: CEPH-073
+    source_alert: MemoryFailed
+    source:
+      expression: 'ceph_hardware_health{category="memory"} == 2'
+      persistence: 1m
+      severity: critical
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 719}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 59f7184d352a1bc154012cc9b26573edc6697f61cddfadc659062363ee86a103
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=memory
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_motherboard_temperature_high:
+    sow_id: CEPH-074
+    source_alert: MotherboardTemperatureHigh
+    source:
+      expression: 'ceph_hardware_temperature_celsius{sensor_name=~".*MB_TEMP.*"} > 60'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 767}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 38b9589be5a2db91f3d4d3dad3866600c12716a418735066509652d78f0cb09c
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.temperature.temperature
+      labels: sensor_name=*MB_TEMP*
+      lookup: min -1m unaligned of value
+      units: celsius
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 60)'
+      recipient: silent
+      adaptation: corrected_sensor_policy
+  ceph_nvme_drive_degraded:
+    sow_id: CEPH-075
+    source_alert: NVMeDriveDegraded
+    source:
+      expression: 'ceph_hardware_health{category="storage"} == 1'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 691}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 5b16b54695a35e9b50758f90f3f9433a2295fd25d035ee1c8e324356a878b6ce
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=storage
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_nvme_drive_failed:
+    sow_id: CEPH-076
+    source_alert: NVMeDriveFailed
+    source:
+      expression: 'ceph_hardware_health{category="storage"} == 2'
+      persistence: 1m
+      severity: critical
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 700}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 7519f4a2a37c1af20b0efa461f59c8588dfd6ec4473496938ccb2b1a6435b875
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=storage
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_nvme_temperature_high:
+    sow_id: CEPH-077
+    source_alert: NVMeTemperatureHigh
+    source:
+      expression: 'ceph_hardware_temperature_celsius{sensor_name=~"NVME.*_TEMP"} > 70'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 794}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 57d05196852314d8d9e5fe86f1e08074843ddd8ac90afc3cdd26cc6c44d6ba93
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.temperature.temperature
+      labels: sensor_name=NVME*_TEMP
+      lookup: min -1m unaligned of value
+      units: celsius
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 70)'
+      recipient: silent
+      adaptation: corrected_sensor_policy
+  ceph_network_degraded:
+    sow_id: CEPH-098
+    source_alert: NetworkDegraded
+    source:
+      expression: 'ceph_hardware_health{category="network"} == 1'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 748}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 4308291b36fe4f716367c7ad9c99aaa7ef7ca6efcdab730cf3c046b95d8a4b2d
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=network
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_network_failed:
+    sow_id: CEPH-099
+    source_alert: NetworkFailed
+    source:
+      expression: 'ceph_hardware_health{category="network"} == 2'
+      persistence: 1m
+      severity: critical
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 757}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 7150d3c8e2f6b65c38039693322f7f35639c3f14d15d6e0a1f3c3bd494b94c3d
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=network
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_power_supply_degraded:
+    sow_id: CEPH-100
+    source_alert: PowerSupplyDegraded
+    source:
+      expression: 'ceph_hardware_health{category="power"} == 1'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 653}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 7173038dda2f70067abbe407ddfc6654bee15b393091dc1c9b482d3033b6c28c
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=power
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_power_supply_failed:
+    sow_id: CEPH-101
+    source_alert: PowerSupplyFailed
+    source:
+      expression: 'ceph_hardware_health{category="power"} == 2'
+      persistence: 1m
+      severity: critical
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 662}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 9935d770708251abb2dcbeeece4a1529514fe803bdf70b3ccf2e76da8dd70921
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=power
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_processor_degraded:
+    sow_id: CEPH-102
+    source_alert: ProcessorDegraded
+    source:
+      expression: 'ceph_hardware_health{category="processors"} == 1'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 729}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: 78d8ac7804d4e77d9ae3e3e89abd1c760eec3319a6c8408a951041eb102894e4
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=processors
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_processor_failed:
+    sow_id: CEPH-103
+    source_alert: ProcessorFailed
+    source:
+      expression: 'ceph_hardware_health{category="processors"} == 2'
+      persistence: 1m
+      severity: critical
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 738}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: b097c9c48a5babbd9c62ae0220defcaf33fe02622345d46279942fa6a8accbd9
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.health.state
+      labels: category=processors
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)'
+      recipient: sysadmin
+      adaptation: observed_hardware_ordinal_window
+  ceph_processor_temperature_high:
+    sow_id: CEPH-104
+    source_alert: ProcessorTemperatureHigh
+    source:
+      expression: 'ceph_hardware_temperature_celsius{sensor_name=~".*CPU_TEMP"} > 80'
+      persistence: 1m
+      severity: warning
+      releases: [tentacle]
+      lines: {reef: 0, squid: 0, tentacle: 785}
+      definition_sha256:
+        reef: ""
+        squid: ""
+        tentacle: d3e74a534606a9b74bf8832c1ebb260d4f0b68d025e8f764a17cd44f1c80ca74
+    netdata:
+      disposition: correct
+      fidelity: CORRECTED-INTENT
+      owner: mgr_prometheus
+      context: prometheus.ceph.node_hardware.temperature.temperature
+      labels: sensor_name=*CPU_TEMP
+      lookup: min -1m unaligned of value
+      units: celsius
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 80)'
+      recipient: silent
+      adaptation: corrected_sensor_policy
   ceph_mon_clock_skew:
     sow_id: CEPH-017
     source_alert: CephMonClockSkew
@@ -360,6 +921,7 @@ alerts:
       expression: 'ceph_health_detail{name="MON_CLOCK_SKEW"} == 1'
       persistence: 1m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 74, squid: 74, tentacle: 73}
       definition_sha256:
         reef: ec7718df89db747132126f5a04c2b0d6b2f44affe82fa8104fc3f11e3cf6b6a5
@@ -383,6 +945,7 @@ alerts:
       expression: 'ceph_health_detail{name="MON_DISK_CRIT"} == 1'
       persistence: 1m
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 53, squid: 53, tentacle: 52}
       definition_sha256:
         reef: f758b921ed4a142c7a9cbfe2c8064ec41c29d96c6b127a612859ec63e0691458
@@ -406,6 +969,7 @@ alerts:
       expression: 'ceph_health_detail{name="MON_DISK_LOW"} == 1'
       persistence: 5m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 64, squid: 64, tentacle: 63}
       definition_sha256:
         reef: 1d3c288676304f6602ef34889a8c7c9fe6b821131f0109c78ed4fe0ab5be48e7
@@ -435,6 +999,7 @@ alerts:
           (count by (cluster) (ceph_mon_quorum_status == 0)) <= (count by (cluster) (ceph_mon_metadata) - floor((count by (cluster) (ceph_mon_metadata) / 2 + 1)))
       persistence: 30s
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 41, squid: 41, tentacle: 41}
       definition_sha256:
         reef: 5b50c1592e474d03a4ce349d9435a0ac1485b44631321d696b9ddd6ca9f7a848
@@ -476,6 +1041,7 @@ alerts:
           ) == 1
       persistence: 30s
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 25, squid: 25, tentacle: 25}
       definition_sha256:
         reef: baad73e6b0d2ad63e0aa2dc4cb4c7cf985bfe5ff2e6d90f68e45439331bb1d71
@@ -509,6 +1075,7 @@ alerts:
         ) >= 10
       persistence: ''
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 460, squid: 472, tentacle: 470}
       definition_sha256:
         reef: b38d4361876c2b5a6f494b86e914f5d1f10ecc815baca276c6d789ffa0e12004
@@ -533,6 +1100,7 @@ alerts:
       expression: 'node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} * 100 < 5'
       persistence: 5m
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 450, squid: 462, tentacle: 460}
       definition_sha256:
         reef: 851c365408c91a21531fbdab8fff8e77d1ab747e24a6a17fca30297dd238a32a
@@ -554,6 +1122,7 @@ alerts:
       expression: 'ceph_health_detail{name="OSD_BACKFILLFULL"} > 0'
       persistence: 1m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 139, squid: 139, tentacle: 137}
       definition_sha256:
         reef: 390b75a7f034ee0517309871c74b2492c3efffd59cf490184ad608e9c8b6c8e2
@@ -577,6 +1146,7 @@ alerts:
       expression: 'ceph_health_detail{name="OSD_DOWN"} == 1'
       persistence: 5m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 105, squid: 105, tentacle: 104}
       definition_sha256:
         reef: 3957cd5cfc4b511e35cf253d12a11b1a3a9bd57c591eacfc6aef00cc000b2b08
@@ -603,6 +1173,7 @@ alerts:
         tentacle: count by (cluster) (ceph_osd_up == 0) / count by (cluster) (ceph_osd_up) * 100 >= 10
       persistence: ''
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 86, squid: 86, tentacle: 85}
       definition_sha256:
         reef: 88f727f1e22972fc2c23db5d1f9a43b5b8949c40fa757ad859d355e7d4c515bd
@@ -626,6 +1197,7 @@ alerts:
       expression: 'ceph_health_detail{name="OSD_FULL"} > 0'
       persistence: 1m
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 128, squid: 128, tentacle: 126}
       definition_sha256:
         reef: 93f91a875ce3d9559b25294fa35dda7002ebe9c37b02bf5643a35edb7465fdb5
@@ -649,6 +1221,7 @@ alerts:
       expression: 'ceph_health_detail{name="OSD_HOST_DOWN"} == 1'
       persistence: 5m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 95, squid: 95, tentacle: 94}
       definition_sha256:
         reef: b5fef504434d810f3a53ecb46491ffd8fab99b09f72774a9b17d8c0dd173e652
@@ -672,6 +1245,7 @@ alerts:
       expression: 'ceph_health_detail{name="BLUESTORE_DISK_SIZE_MISMATCH"} == 1'
       persistence: 1m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 177, squid: 177, tentacle: 175}
       definition_sha256:
         reef: 862a4c8c61b001be8f4c598688cd5caa5dac479abd873562706b5e3353e22c46
@@ -695,6 +1269,7 @@ alerts:
       expression: 'ceph_health_detail{name="OSD_NEARFULL"} == 1'
       persistence: 5m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 117, squid: 117, tentacle: 115}
       definition_sha256:
         reef: 290ddd2d4df7a20637b6d05028a3752bb6b976c66f33af1e8b6abe013d3a1c05
@@ -718,6 +1293,7 @@ alerts:
       expression: 'ceph_health_detail{name="BLUESTORE_SPURIOUS_READ_ERRORS"} == 1'
       persistence: 30s
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 228, squid: 228, tentacle: 226}
       definition_sha256:
         reef: 5d95cceb135ac37034b1bf6512307bf53ca011338858de959136be39930e9db2
@@ -741,6 +1317,7 @@ alerts:
       expression: 'ceph_health_detail{name="OSD_SLOW_PING_TIME_BACK"} == 1'
       persistence: 1m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 168, squid: 168, tentacle: 166}
       definition_sha256:
         reef: b171b1604f028303af15b2f3a3f6b7f6d6eca1bcf0dd2d83662ff12684a0154e
@@ -764,6 +1341,7 @@ alerts:
       expression: 'ceph_health_detail{name="OSD_SLOW_PING_TIME_FRONT"} == 1'
       persistence: 1m
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 159, squid: 159, tentacle: 157}
       definition_sha256:
         reef: 6d5d349f3162e6f143250245b23782b45086c3c0fd5f3d6b2fb62038e95af222
@@ -787,6 +1365,7 @@ alerts:
       expression: 'ceph_health_detail{name="OSD_TOO_MANY_REPAIRS"} == 1'
       persistence: 30s
       severity: warning
+      releases: [reef, squid, tentacle]
       lines: {reef: 149, squid: 149, tentacle: 147}
       definition_sha256:
         reef: 04be9998b215f9804cb1a14c1bbf059ddc928681c27d974a0033403d28f1b270
@@ -810,6 +1389,7 @@ alerts:
       expression: 'up{job="ceph"} == 0'
       persistence: 1m
       severity: critical
+      releases: [reef, squid, tentacle]
       lines: {reef: 342, squid: 354, tentacle: 352}
       definition_sha256:
         reef: 6b8e4f6dd58e74045f0ad4cb3e0f45a92329d09519362b6d1458239bb32d6710

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -105,6 +105,20 @@ adaptation_contracts:
       - Netdata selects the latest matching chart/alert instance by equal label overlap instead of PromQL vector matching
       - the source pending state is not reproduced for current composite signals
       - missing or ambiguous operands become NaN rather than a fabricated clear or active state
+  per_image_current_timestamp_difference:
+    preserved:
+      - per-image local-versus-remote snapshot timestamp inequality
+      - ceph-exporter per daemon/image/namespace/pool identity
+      - source severity and notification policy
+    differences:
+      - Netdata compares the latest stored timestamp dimensions on the existing per-image chart
+      - the source 1-minute pending state is not reproduced for the current timestamp inequality
+      - non-finite timestamps become NaN rather than a false synchronized or unsynchronized state
+  rejected_rule:
+    preserved:
+      - source rule identity and exact source expression
+    differences:
+      - no Netdata alert or derived chart is implemented because the source semantic is invalid or redundant
   corrected_sensor_policy:
     preserved:
       - source sensor-family intent and severity
@@ -932,6 +946,266 @@ alerts:
       condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 80)'
       recipient: silent
       adaptation: corrected_sensor_policy
+  ceph_filesystem_damaged:
+    sow_id: CEPH-006
+    source_alert: CephFilesystemDamaged
+    source:
+      expression: 'ceph_health_detail{name="MDS_DAMAGE"} > 0'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 254, squid: 266, tentacle: 264}
+      definition_sha256:
+        reef: 72f0f958515b66ab624f7d9c8418f6ba80839be530107b647116bdfef95237f3
+        squid: 72f0f958515b66ab624f7d9c8418f6ba80839be530107b647116bdfef95237f3
+        tentacle: de5eb9c55bfdfff6dfb4df1b6bf38298d648d80c90e20e23bbea137974223cac
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=MDS_DAMAGE
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_filesystem_degraded:
+    sow_id: CEPH-007
+    source_alert: CephFilesystemDegraded
+    source:
+      expression: 'ceph_health_detail{name="FS_DEGRADED"} > 0'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 276, squid: 288, tentacle: 286}
+      definition_sha256:
+        reef: 79e20a41eba3f59560365126ea00dae0722772394c5611da120bb893f1b6ac59
+        squid: 79e20a41eba3f59560365126ea00dae0722772394c5611da120bb893f1b6ac59
+        tentacle: 62a25086e294d0d5813cfde820b259f4df0e1dda564abe0f725a08a2460dab32
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=FS_DEGRADED
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_filesystem_failure_no_standby:
+    sow_id: CEPH-008
+    source_alert: CephFilesystemFailureNoStandby
+    source:
+      expression: 'ceph_health_detail{name="FS_WITH_FAILED_MDS"} > 0'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 307, squid: 319, tentacle: 317}
+      definition_sha256:
+        reef: 2c8605a9dec384e3a7a3e8c3e0fb9dd446e8a222dcd228f8451fe370a9be08c2
+        squid: 2c8605a9dec384e3a7a3e8c3e0fb9dd446e8a222dcd228f8451fe370a9be08c2
+        tentacle: 63229778a5d8886a888214f64f95eb7f5a9360351588b91a5a52e061d28db720
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=FS_WITH_FAILED_MDS
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_filesystem_insufficient_standby:
+    sow_id: CEPH-009
+    source_alert: CephFilesystemInsufficientStandby
+    source:
+      expression: 'ceph_health_detail{name="MDS_INSUFFICIENT_STANDBY"} > 0'
+      persistence: 1m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 297, squid: 309, tentacle: 307}
+      definition_sha256:
+        reef: 9212f1408c37b22b48bf21c5b3e75803b5b3e71e129bc4d5104b3f170181e207
+        squid: 9212f1408c37b22b48bf21c5b3e75803b5b3e71e129bc4d5104b3f170181e207
+        tentacle: b9d45525808dfe6f6eea4eb0cf88c36e314ae420b7ec2f6517edf4740ad98696
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=MDS_INSUFFICIENT_STANDBY
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_filesystem_mds_ranks_low:
+    sow_id: CEPH-010
+    source_alert: CephFilesystemMDSRanksLow
+    source:
+      expression: 'ceph_health_detail{name="MDS_UP_LESS_THAN_MAX"} > 0'
+      persistence: 1m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 287, squid: 299, tentacle: 297}
+      definition_sha256:
+        reef: ef973b812ca36d7a81f8e4ffa9bc1519f763c259d333a6b6ec02c7dce4840057
+        squid: ef973b812ca36d7a81f8e4ffa9bc1519f763c259d333a6b6ec02c7dce4840057
+        tentacle: 3f04c6cfe9fe27d21d21b48b9618558b31a7d7b4d4e62024c13e0e796d47fd27
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=MDS_UP_LESS_THAN_MAX
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: silent
+      adaptation: observed_binary_window
+  ceph_filesystem_offline:
+    sow_id: CEPH-011
+    source_alert: CephFilesystemOffline
+    source:
+      expression: 'ceph_health_detail{name="MDS_ALL_DOWN"} > 0'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 265, squid: 277, tentacle: 275}
+      definition_sha256:
+        reef: 6e26074baff4517d532657495f258ffed3dccbb7d4a0f1b6853771fa59e4bb27
+        squid: 6e26074baff4517d532657495f258ffed3dccbb7d4a0f1b6853771fa59e4bb27
+        tentacle: 5fc6b7ff315496d9dac72ecb8540f9812fabe288c10a0659e403b58e2590180c
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=MDS_ALL_DOWN
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_filesystem_read_only:
+    sow_id: CEPH-012
+    source_alert: CephFilesystemReadOnly
+    source:
+      expression: 'ceph_health_detail{name="MDS_HEALTH_READ_ONLY"} > 0'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 318, squid: 330, tentacle: 328}
+      definition_sha256:
+        reef: 1748e2ac9fe8670090c677e24beb5e83e032b8ca3bbdd373740a7e1ecdf51c4b
+        squid: 1748e2ac9fe8670090c677e24beb5e83e032b8ca3bbdd373740a7e1ecdf51c4b
+        tentacle: 87ba15677f3f2b942d284a4071c8e71e2b648d17248dd0d0ddc5f5fc29496aea
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: mgr_prometheus
+      context: prometheus.ceph.health.health_checks.state
+      labels: name=MDS_HEALTH_READ_ONLY
+      lookup: min -1m unaligned of value
+      units: status
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+      recipient: sysadmin
+      adaptation: observed_binary_window
+  ceph_rbd_mirror_images_not_in_sync:
+    sow_id: CEPH-056
+    source_alert: CephRBDMirrorImagesNotInSync
+    source:
+      expressions:
+        reef: 'sum by (ceph_daemon, image, namespace, pool) (topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0'
+        squid: 'sum by (ceph_daemon, image, namespace, pool) (topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0'
+        tentacle: 'sum by (cluster, ceph_daemon, image, namespace, pool) (topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 753, squid: 765, tentacle: 853}
+      definition_sha256:
+        reef: 8970913636aa3c0e7cc30424ebe7add2f84edb4788f824135f3885b1759bb8c3
+        squid: 8970913636aa3c0e7cc30424ebe7add2f84edb4788f824135f3885b1759bb8c3
+        tentacle: e58c14fb0337cfb50ab51ec0210a6a2bf559a50c456ac493b349d3f894898f7f
+    netdata:
+      disposition: ship
+      fidelity: NETDATA-ADAPTED
+      owner: ceph_exporter
+      context: prometheus.ceph.rbd_mirror.snapshot_replication.timestamp
+      calc: '($local_timestamp == nan or $local_timestamp == inf or $remote_timestamp == nan or $remote_timestamp == inf or $local_timestamp < 0 or $remote_timestamp < 0) ? (nan) : ($local_timestamp - $remote_timestamp)'
+      units: seconds
+      condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this != 0)'
+      recipient: sysadmin
+      adaptation: per_image_current_timestamp_difference
+  ceph_rbd_mirror_image_transfer_bandwidth_high:
+    sow_id: CEPH-055
+    source_alert: CephRBDMirrorImageTransferBandwidthHigh
+    source:
+      expressions:
+        reef: 'rate(ceph_rbd_mirror_journal_replay_bytes[30m]) > 0.80'
+        squid: 'rate(ceph_rbd_mirror_journal_replay_bytes[30m]) > 0.80'
+        tentacle: 'rate(ceph_rbd_mirror_journal_replay_bytes[30m]) > 0.80'
+      persistence: 1m
+      severity: warning
+      releases: [reef, squid, tentacle]
+      lines: {reef: 773, squid: 785, tentacle: 873}
+      definition_sha256:
+        reef: 3a7ca6fcbfd8a9648b43d129310b25f6fdc7f52e759b9ffa675e594a1a7fddb1
+        squid: 3a7ca6fcbfd8a9648b43d129310b25f6fdc7f52e759b9ffa675e594a1a7fddb1
+        tentacle: 9cb36cb3a43ace0cbb87ea6caa067b864e1fa826d2e960f11beb498b4812c4a8
+    netdata:
+      disposition: reject
+      fidelity: UNSUPPORTED
+      owner: none
+      reason: 'Byte rate is compared with dimensionless 0.80 and no capacity denominator exists.'
+      adaptation: rejected_rule
+  ceph_rbd_mirror_images_not_in_sync_very_high:
+    sow_id: CEPH-057
+    source_alert: CephRBDMirrorImagesNotInSyncVeryHigh
+    source:
+      expressions:
+        reef: 'count by (ceph_daemon) ((topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon) (ceph_rbd_mirror_snapshot_snapshots)*.1)'
+        squid: 'count by (ceph_daemon) ((topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon) (ceph_rbd_mirror_snapshot_snapshots)*.1)'
+        tentacle: 'count by (ceph_daemon, cluster) ((topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon, cluster) (ceph_rbd_mirror_snapshot_snapshots)*.1)'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 763, squid: 775, tentacle: 863}
+      definition_sha256:
+        reef: 3132c55422fade0e024ec542dd55893b465d3b3cb95700c8991ea0f24bcc1a46
+        squid: 3132c55422fade0e024ec542dd55893b465d3b3cb95700c8991ea0f24bcc1a46
+        tentacle: 3a5769edfc0a643ade62008c9b7b44fbb1a3c570732faf2cf3b1f4180c09d349
+    netdata:
+      disposition: reject
+      fidelity: UNSUPPORTED
+      owner: none
+      reason: Aggregate escalation is redundant with the per-image hard alert and expensive Dashboard enumeration is not a valid threshold denominator.
+      adaptation: rejected_rule
+  ceph_rbd_mirror_images_per_daemon_high:
+    sow_id: CEPH-058
+    source_alert: CephRBDMirrorImagesPerDaemonHigh
+    source:
+      expressions:
+        reef: 'sum by (ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100'
+        squid: 'sum by (ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100'
+        tentacle: 'sum by (cluster, ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100'
+      persistence: 1m
+      severity: critical
+      releases: [reef, squid, tentacle]
+      lines: {reef: 743, squid: 755, tentacle: 843}
+      definition_sha256:
+        reef: fdd26da31520059866e0f3a977bb15a2b76ad1e9ae801af87fd59eefc379e14b
+        squid: fdd26da31520059866e0f3a977bb15a2b76ad1e9ae801af87fd59eefc379e14b
+        tentacle: 00df93373a4f8394a30ec1d4270d6d7a75225416a2f47e5f9ceb0dc0daa9b515
+    netdata:
+      disposition: reject
+      fidelity: UNSUPPORTED
+      owner: none
+      reason: Summed cumulative per-image snapshot counters are not active-image inventory and can remain above the threshold after historical activity.
+      adaptation: rejected_rule
   ceph_osd_all_up:
     sow_id: CEPH-040-HELPER
     source_alert: CephObjectMissing

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -73,6 +73,28 @@ adaptation_contracts:
       - aggregation remains inside one exporter endpoint instead of combining gateways across a cluster
       - the compound count-versus-limit condition is evaluated from current stored dimensions; the source one-minute
         persistence window is not represented because a health lookup cannot persist this cross-dimension comparison
+  rgw_counter_rate_window:
+    preserved:
+      - source counter population and threshold direction
+      - recovery when no new source failures occur
+    differences:
+      - the health lookup evaluates the rendered counter rate over an observation window rather than treating the lifetime
+        cumulative total as currently active
+      - partial collection gaps do not reset the observation window
+  rgw_policy_pressure_window:
+    preserved:
+      - current source population and affected RGW instance identity
+      - silent-by-default policy
+    differences:
+      - the numeric threshold is a local operator policy rather than a source-provided limit
+      - the observation window uses every available sample and must be tuned with the endpoint or workload
+  rgw_multisite_retry_window:
+    preserved:
+      - affected source-zone-optional identity and error population
+      - retryable error classification
+    differences:
+      - a sustained non-zero rendered rate is required so isolated retries do not page
+      - source persistence timing is approximated with the observation window
   observed_binary_window:
     preserved:
       - source incident and predicate
@@ -2474,29 +2496,262 @@ alerts:
       adaptation: local_nvmeof_inventory_limit
 
 netdata_extensions:
+  rgw_tls_certificate_revoked:
+    sow_id: RGW-M-03
+    reason: revoked TLS certificates are owned by x509check when the RGW certificate endpoint
+      is explicitly configured and revocation checking is enabled
+    fidelity: CORRECTED-INTENT
+    owner: x509check
+    context: x509check.revocation_status
+
+  rgw_basic_endpoint_unavailable:
+    sow_id: RGW-M-04
+    reason: basic HTTP liveness is owned by httpcheck; this does not verify authenticated
+      S3 correctness
+    fidelity: CORRECTED-INTENT
+    owner: httpcheck
+    context: httpcheck.status
+
+  rgw_tls_certificate_expiring:
+    sow_id: RGW-S-01
+    reason: TLS lead-time policy is owned by x509check
+    fidelity: CORRECTED-INTENT
+    owner: x509check
+    context: x509check.time_until_expiration
+
+  rgw_http_5xx_rate:
+    sow_id: RGW-S-02
+    reason: server-error rate and error-budget policy are owned by web_log when complete
+      RGW access logs are configured
+    fidelity: CORRECTED-INTENT
+    owner: weblog
+    context: web_log.type_requests
+
+  rgw_http_4xx_rate:
+    sow_id: RGW-S-03
+    reason: client-error rate and policy are owned by web_log when complete RGW access
+      logs are configured
+    fidelity: CORRECTED-INTENT
+    owner: weblog
+    context: web_log.type_requests
+
+  rgw_overall_request_latency:
+    sow_id: RGW-S-09
+    reason: overall request latency is measured from the configured RGW access log total_time
+      numeric field
+    fidelity: CORRECTED-INTENT
+    owner: weblog
+    context: web_log.custom_numeric_field_total_time_summary
+
+  rgw_request_volume_change:
+    sow_id: RGW-S-13
+    reason: request volume anomalies are owned by web_log anomaly policies when complete
+      access logs are configured
+    fidelity: CORRECTED-INTENT
+    owner: weblog
+    context: web_log.type_requests
+
+  rgw_operation_throughput_anomaly:
+    sow_id: RGW-S-14
+    reason: aggregate GET/PUT request charts support Netdata anomaly detection without
+      a fixed throughput threshold
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.requests_and_queue.requests
+
+  rgw_selected_user_or_bucket_anomaly:
+    sow_id: RGW-S-15
+    reason: selected tenant/user/bucket detail requires an operator-enabled source-backed
+      companion; no active high-cardinality stock profile is enabled
+    fidelity: UNSUPPORTED
+    owner: none
+
+  rgw_notification_event_lost:
+    sow_id: RGW-M-08
+    reason: final notification event loss detected by aggregate counter rate
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.notifications.events
+    labels_policy: none
+    lookup: min -1m unaligned of event_lost
+    calc: ''
+    units: events/s
+    condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+    recipient: silent
+    adaptation: rgw_counter_rate_window
+
+  rgw_notification_missing_configuration:
+    sow_id: RGW-M-09
+    reason: notification missing-configuration failure detected by aggregate counter rate
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.notifications.missing_configurations
+    labels_policy: none
+    lookup: min -1m unaligned of value
+    calc: ''
+    units: events/s
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+    recipient: silent
+    adaptation: rgw_counter_rate_window
+
+  rgw_lua_script_failed:
+    sow_id: RGW-M-10
+    reason: Lua request script failure detected by aggregate counter rate
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.lua.script_executions
+    labels_policy: none
+    lookup: min -1m unaligned of failure
+    calc: ''
+    units: executions/s
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+    recipient: silent
+    adaptation: rgw_counter_rate_window
+
+  rgw_failed_request_rate_fallback:
+    sow_id: RGW-S-04
+    reason: aborted-request fallback counter detects request failures when complete access
+      logs are absent
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.requests_and_queue.failed_requests
+    labels_policy: none
+    lookup: min -5m unaligned of value
+    calc: ''
+    units: requests/s
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+    recipient: silent
+    adaptation: rgw_counter_rate_window
+
+  rgw_notification_push_or_store_failures:
+    sow_id: RGW-S-16
+    reason: retryable notification push/store failure rate detected separately from final
+      event loss
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.notifications.failure_outcomes
+    labels_policy: none
+    lookup: min -5m unaligned of push_failed,store_fail
+    calc: ''
+    units: events/s
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+    recipient: silent
+    adaptation: rgw_counter_rate_window
+
+  rgw_notification_inflight_pressure:
+    sow_id: RGW-S-17
+    reason: operator policy for sustained notification in-flight pressure
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.notifications.pending_events
+    labels_policy: none
+    lookup: min -5m unaligned of value
+    calc: ''
+    units: events
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)'
+    recipient: silent
+    adaptation: rgw_policy_pressure_window
+
+  rgw_notification_store_backlog:
+    sow_id: RGW-S-18
+    reason: operator policy for sustained persistent notification store backlog
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.notifications.event_state
+    labels_policy: none
+    lookup: min -5m unaligned of value
+    calc: ''
+    units: events
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)'
+    recipient: silent
+    adaptation: rgw_policy_pressure_window
+
+  rgw_request_queue_pressure:
+    sow_id: RGW-S-12
+    reason: operator policy for sustained RGW request queue pressure
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway.requests_and_queue.current_requests
+    labels_policy: none
+    lookup: min -5m unaligned of qlen
+    calc: ''
+    units: requests
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)'
+    recipient: silent
+    adaptation: rgw_policy_pressure_window
+
+  rgw_multisite_fetch_errors:
+    sow_id: RGW-S-20
+    reason: sustained multisite fetch error rate
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway_multisite.object_work
+    labels_policy: none
+    lookup: min -5m unaligned of errors
+    calc: ''
+    units: objects/s
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+    recipient: silent
+    adaptation: rgw_multisite_retry_window
+
+  rgw_multisite_poll_errors:
+    sow_id: RGW-S-20
+    reason: sustained replication-log poll error rate
+    fidelity: NETDATA-ADAPTED
+    owner: mgr_prometheus
+    context: prometheus.ceph.object_gateway_multisite.replication_log_request_errors
+    labels_policy: none
+    lookup: min -5m unaligned of value
+    calc: ''
+    units: requests/s
+    condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
+    recipient: silent
+    adaptation: rgw_multisite_retry_window
+
+  rgw_persistent_topic_backlog:
+    sow_id: RGW-S-19
+    reason: No source-complete per-topic Prometheus numeric family exists; topic APIs
+      and persistent-topic dumps are not numeric exporter telemetry.
+    fidelity: UNSUPPORTED
+    owner: none
+    context: ''
+    labels_policy: none
+    lookup: ''
+    calc: ''
+    units: ''
+    condition: ''
+    recipient: ''
+    adaptation: rejected_rule
+
   ceph_unknown_health_check:
     sow_id: CEPH-ND-001
-    reason: forward-compatible warning for ordinary Ceph health-detail names without a dedicated rule
+    reason: forward-compatible warning for ordinary Ceph health-detail names without a
+      dedicated rule
     fidelity: NETDATA-ADAPTED
     owner: mgr_prometheus
     context: prometheus.ceph.health.health_checks.state
-    labels_policy: exclude every supported named health code and main-only certificate code, then match all remaining names
+    labels_policy: exclude every supported named health code and main-only certificate
+      code, then match all remaining names
     lookup: min -1m unaligned of value
     units: status
     condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
     recipient: silent
     adaptation: observed_binary_window
+
   ceph_component_collection_failed:
     sow_id: CEPH-ND-002
     reason: native Dashboard API component-integrity owner retained without an MGR duplicate
     fidelity: NETDATA-ADAPTED
     owner: native_ceph_dashboard
     context: ceph.component_collection_status
+
   rgw_daemon_failed:
     sow_id: RGW-M-01
-    reason: existing Cephadm and recent-crash health checks already identify failed RGW daemons
+    reason: existing Cephadm and recent-crash health checks already identify failed RGW
+      daemons
     fidelity: CORRECTED-INTENT
     owner: mgr_prometheus
+
   rgw_telemetry_missing:
     sow_id: RGW-M-02
     reason: generic configured-job collection health owns missing metric telemetry

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -73,14 +73,25 @@ adaptation_contracts:
       - aggregation remains inside one exporter endpoint instead of combining gateways across a cluster
       - the compound count-versus-limit condition is evaluated from current stored dimensions; the source one-minute
         persistence window is not represented because a health lookup cannot persist this cross-dimension comparison
+  rgw_categorical_counter_occurrence:
+    preserved:
+      - each rendered counter-rate occurrence within the observation window
+      - source counter population and threshold direction
+      - recovery when the occurrence leaves the observation window
+    differences:
+      - the health lookup evaluates the rendered counter rate over an occurrence window rather than treating the lifetime
+        cumulative total as currently active
+      - a partial collection gap does not reset the observation window
+      - categorical failure occurrences notify by default
   rgw_counter_rate_window:
     preserved:
-      - source counter population and threshold direction
+      - sustained source counter population and threshold direction
+      - silent workload-policy routing
       - recovery when no new source failures occur
     differences:
-      - the health lookup evaluates the rendered counter rate over an observation window rather than treating the lifetime
-        cumulative total as currently active
-      - partial collection gaps do not reset the observation window
+      - the health lookup evaluates the rendered counter rate over a sustained observation window rather than treating the
+        lifetime cumulative total as currently active
+      - a partial collection gap does not reset the observation window
   rgw_policy_pressure_window:
     preserved:
       - current source population and affected RGW instance identity
@@ -2187,7 +2198,7 @@ alerts:
     netdata:
       disposition: internal-helper
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.block_devices.time_accumulation
       labels: ''
       lookup: average -1m unaligned of read_seconds
@@ -2211,7 +2222,7 @@ alerts:
     netdata:
       disposition: internal-helper
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.block_devices.operations
       labels: ''
       lookup: average -1m unaligned of reads_completed
@@ -2235,7 +2246,7 @@ alerts:
     netdata:
       disposition: internal-helper
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.block_devices.time_accumulation
       labels: ''
       lookup: average -1m unaligned of write_seconds
@@ -2259,7 +2270,7 @@ alerts:
     netdata:
       disposition: internal-helper
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.block_devices.operations
       labels: ''
       lookup: average -1m unaligned of writes_completed
@@ -2284,7 +2295,7 @@ alerts:
     netdata:
       disposition: internal-helper
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.gateways.namespace_count
       labels: ''
       lookup: average -1m unaligned of namespace_count
@@ -2308,7 +2319,7 @@ alerts:
     netdata:
       disposition: ship
       fidelity: NETDATA-ADAPTED
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.subsystems.state_metadata
       labels: allow_any_host=yes
       lookup: min -5m unaligned of metadata
@@ -2332,7 +2343,7 @@ alerts:
     netdata:
       disposition: internal-helper
       fidelity: NETDATA-ADAPTED
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.gateways.time_accumulation
       labels: ''
       lookup: min -10m unaligned of busy
@@ -2359,7 +2370,7 @@ alerts:
     netdata:
       disposition: correct
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.gateways.time_accumulation
       labels: ''
       lookup: ''
@@ -2384,7 +2395,7 @@ alerts:
     netdata:
       disposition: correct
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.block_devices.time_accumulation
       labels: ''
       lookup: ''
@@ -2409,7 +2420,7 @@ alerts:
     netdata:
       disposition: correct
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.block_devices.time_accumulation
       labels: ''
       lookup: ''
@@ -2434,7 +2445,7 @@ alerts:
     netdata:
       disposition: correct
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.hosts.keepalive_timeout_state
       labels: ''
       calc: $value
@@ -2461,7 +2472,7 @@ alerts:
     netdata:
       disposition: correct
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.subsystems.namespace_capacity
       labels: ''
       lookup: ''
@@ -2486,7 +2497,7 @@ alerts:
     netdata:
       disposition: correct
       fidelity: CORRECTED-INTENT
-      owner: mgr_prometheus
+      owner: nvmeof_exporter
       context: prometheus.ceph.nvme_of.gateways.namespace_count
       labels: ''
       lookup: ''
@@ -2574,12 +2585,12 @@ netdata_extensions:
     owner: mgr_prometheus
     context: prometheus.ceph.object_gateway.notifications.events
     labels_policy: none
-    lookup: min -1m unaligned of event_lost
+    lookup: max -1m unaligned of event_lost
     calc: ''
     units: events/s
     condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
-    recipient: silent
-    adaptation: rgw_counter_rate_window
+    recipient: sysadmin
+    adaptation: rgw_categorical_counter_occurrence
 
   rgw_notification_missing_configuration:
     sow_id: RGW-M-09
@@ -2588,12 +2599,12 @@ netdata_extensions:
     owner: mgr_prometheus
     context: prometheus.ceph.object_gateway.notifications.missing_configurations
     labels_policy: none
-    lookup: min -1m unaligned of value
+    lookup: max -1m unaligned of value
     calc: ''
     units: events/s
     condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
-    recipient: silent
-    adaptation: rgw_counter_rate_window
+    recipient: sysadmin
+    adaptation: rgw_categorical_counter_occurrence
 
   rgw_lua_script_failed:
     sow_id: RGW-M-10
@@ -2602,12 +2613,12 @@ netdata_extensions:
     owner: mgr_prometheus
     context: prometheus.ceph.object_gateway.lua.script_executions
     labels_policy: none
-    lookup: min -1m unaligned of failure
+    lookup: max -1m unaligned of failure
     calc: ''
     units: executions/s
     condition: 'warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)'
-    recipient: silent
-    adaptation: rgw_counter_rate_window
+    recipient: sysadmin
+    adaptation: rgw_categorical_counter_occurrence
 
   rgw_failed_request_rate_fallback:
     sow_id: RGW-S-04

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_alerts.yaml
@@ -172,8 +172,9 @@ adaptation_contracts:
       - generic configured-job collection failure remains the scrape owner
     differences:
       - Netdata selects the latest matching chart/alert instance by equal label overlap instead of PromQL vector matching
-      - the source pending state is not reproduced for current composite signals
-      - missing or ambiguous operands become NaN rather than a fabricated clear or active state
+      - the source 30-second pending state is not reproduced for current compound monitor conditions
+      - a missing or ambiguous operand is NaN rather than a fabricated active state; when the primary condition is
+        numerically inactive, the rule clears without resolving an optional secondary helper that Ceph has withdrawn
   per_image_current_timestamp_difference:
     preserved:
       - per-image local-versus-remote snapshot timestamp inequality
@@ -1469,7 +1470,7 @@ alerts:
       owner: mgr_prometheus
       context: prometheus.ceph.health.health_checks.state
       labels: name=PG_AVAILABILITY
-      calc: '($value == nan or $value == inf or $ceph_osd_down_current == nan or $ceph_osd_down_current == inf) ? (nan) : ($value == 1 and $ceph_osd_down_current != 1)'
+      calc: '($value == nan or $value == inf) ? (nan) : (($value == 1) ? (($ceph_osd_down_current == nan or $ceph_osd_down_current == inf) ? (nan) : (($ceph_osd_down_current == 1) ? (0) : (1))) : (0))'
       units: status
       condition: 'crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)'
       recipient: sysadmin

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_source_alerts/README.md
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_source_alerts/README.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+# Ceph Alert Source Snapshots
+
+These files are exact, unmodified snapshots of `monitoring/ceph-mixin/prometheus_alerts.yml` from `ceph/ceph`:
+
+- `reef.yaml`: `efac5a54607c13fa50d4822e50242b86e6e446df` (`v18.2.8`), SHA-256
+  `0325e5c481d00c674f7faf759e00f6c5c22028dbcc8bb95491404d600c6f3efd`.
+- `squid.yaml`: `abc7aa7f2701e5d46878fd5e6bb7e2955f1a395a` (`v19.2.5`), SHA-256
+  `259ee363694d174f46427a443ba0a8952b28df0c17af2bb65a2378511bc321ba`.
+- `tentacle.yaml`: `06c2f9c35b67055a8a6fb99d1be236b3c4832ace` (`v20.2.3`), SHA-256
+  `09308346d3d143ff128813f1142f1499142799174da4e0505ddad7144b8d8716`.
+
+They provide hermetic source inputs for the adjacent Ceph alert-mapping tests. Do not edit a snapshot in place. Refresh
+it from a new approved upstream commit and update every coupled source pin and mapping together.

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_source_alerts/reef.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_source_alerts/reef.yaml
@@ -1,0 +1,911 @@
+groups:
+  - name: "cluster health"
+    rules:
+      - alert: "CephHealthError"
+        annotations:
+          description: "The cluster state has been HEALTH_ERROR for more than 5 minutes. Please check 'ceph health detail' for more information."
+          summary: "Ceph is in the ERROR state"
+        expr: "ceph_health_status == 2"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.2.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephHealthWarning"
+        annotations:
+          description: "The cluster state has been HEALTH_WARN for more than 15 minutes. Please check 'ceph health detail' for more information."
+          summary: "Ceph is in the WARNING state"
+        expr: "ceph_health_status == 1"
+        for: "15m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "mon"
+    rules:
+      - alert: "CephMonDownQuorumAtRisk"
+        annotations:
+          description: "{{ $min := query \"floor(count(ceph_mon_metadata) / 2) + 1\" | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active. Without quorum the cluster will become inoperable, affecting all services and connected clients. The following monitors are down: {{- range query \"(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
+          summary: "Monitor quorum is at risk"
+        expr: |
+          (
+            (ceph_health_detail{name="MON_DOWN"} == 1) * on() (
+              count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1)
+            )
+          ) == 1
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.3.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMonDown"
+        annotations:
+          description: |
+            {{ $down := query "count(ceph_mon_quorum_status == 0)" | first | value }}{{ $s := "" }}{{ if gt $down 1.0 }}{{ $s = "s" }}{{ end }}You have {{ $down }} monitor{{ $s }} down. Quorum is still intact, but the loss of an additional monitor will make your cluster inoperable.  The following monitors are down: {{- range query "(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)" }}   - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
+          summary: "One or more monitors down"
+        expr: |
+          count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1)
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephMonDiskspaceCritical"
+        annotations:
+          description: "The free space available to a monitor's store is critically low. You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*. Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit"
+          summary: "Filesystem space on at least one monitor is critically low"
+        expr: "ceph_health_detail{name=\"MON_DISK_CRIT\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.3.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMonDiskspaceLow"
+        annotations:
+          description: "The space available to a monitor's store is approaching full (>70% is the default). You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*.  Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low"
+          summary: "Drive space on at least one monitor is approaching full"
+        expr: "ceph_health_detail{name=\"MON_DISK_LOW\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephMonClockSkew"
+        annotations:
+          description: "Ceph monitors rely on closely synchronized time to maintain quorum and cluster consistency. This event indicates that the time on at least one mon has drifted too far from the lead mon. Review cluster status with ceph -s. This will show which monitors are affected. Check the time sync status on each monitor host with 'ceph time-sync-status' and the state and peers of your ntpd or chrony daemon."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew"
+          summary: "Clock skew detected among monitors"
+        expr: "ceph_health_detail{name=\"MON_CLOCK_SKEW\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "osd"
+    rules:
+      - alert: "CephOSDDownHigh"
+        annotations:
+          description: "{{ $value | humanize }}% or {{ with query \"count(ceph_osd_up == 0)\" }}{{ . | first | value }}{{ end }} of {{ with query \"count(ceph_osd_up)\" }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%). The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          summary: "More than 10% of OSDs are down"
+        expr: "count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephOSDHostDown"
+        annotations:
+          description: "The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }} {{- end }}"
+          summary: "An OSD host is offline"
+        expr: "ceph_health_detail{name=\"OSD_HOST_DOWN\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.8"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDDown"
+        annotations:
+          description: |
+            {{ $num := query "count(ceph_osd_up == 0)" | first | value }}{{ $s := "" }}{{ if gt $num 1.0 }}{{ $s = "s" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins. The following OSD{{ $s }} {{ if eq $s "" }}is{{ else }}are{{ end }} down: {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0"}} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down"
+          summary: "An OSD has been marked down"
+        expr: "ceph_health_detail{name=\"OSD_DOWN\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDNearFull"
+        annotations:
+          description: "One or more OSDs have reached the NEARFULL threshold. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull"
+          summary: "OSD(s) running low on free space (NEARFULL)"
+        expr: "ceph_health_detail{name=\"OSD_NEARFULL\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.3"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDFull"
+        annotations:
+          description: "An OSD has reached the FULL threshold. Writes to pools that share the affected OSD will be blocked. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full"
+          summary: "OSD full, writes blocked"
+        expr: "ceph_health_detail{name=\"OSD_FULL\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.6"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephOSDBackfillFull"
+        annotations:
+          description: "An OSD has reached the BACKFILL FULL threshold. This will prevent rebalance operations from completing. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull"
+          summary: "OSD(s) too full for backfill operations"
+        expr: "ceph_health_detail{name=\"OSD_BACKFILLFULL\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTooManyRepairs"
+        annotations:
+          description: "Reads from an OSD have used a secondary PG to return data to the client, indicating a potential failing drive."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs"
+          summary: "OSD reports a high number of read errors"
+        expr: "ceph_health_detail{name=\"OSD_TOO_MANY_REPAIRS\"} == 1"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTimeoutsPublicNetwork"
+        annotations:
+          description: "OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network for latency or loss issues. Use 'ceph health detail' to show the affected OSDs."
+          summary: "Network issues delaying OSD heartbeats (public network)"
+        expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_FRONT\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTimeoutsClusterNetwork"
+        annotations:
+          description: "OSD heartbeats on the cluster's 'cluster' network (backend) are slow. Investigate the network for latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs."
+          summary: "Network issues delaying OSD heartbeats (cluster network)"
+        expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_BACK\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDInternalDiskSizeMismatch"
+        annotations:
+          description: "One or more OSDs have an internal inconsistency between metadata and the size of the device. This could lead to the OSD(s) crashing in future. You should redeploy the affected OSDs."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch"
+          summary: "OSD size inconsistency error"
+        expr: "ceph_health_detail{name=\"BLUESTORE_DISK_SIZE_MISMATCH\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDeviceFailurePredicted"
+        annotations:
+          description: "The device health module has determined that one or more devices will fail soon. To review device status use 'ceph device ls'. To show a specific device use 'ceph device info <dev id>'. Mark the OSD out so that data may migrate to other OSDs. Once the OSD has drained, destroy the OSD, replace the device, and redeploy the OSD."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#id2"
+          summary: "Device(s) predicted to fail soon"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDeviceFailurePredictionTooHigh"
+        annotations:
+          description: "The device health module has determined that devices predicted to fail can not be remediated automatically, since too many OSDs would be removed from the cluster to ensure performance and availabililty. Prevent data integrity issues by adding new OSDs so that data may be relocated."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany"
+          summary: "Too many devices are predicted to fail, unable to resolve"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH_TOOMANY\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.7"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephDeviceFailureRelocationIncomplete"
+        annotations:
+          description: "The device health module has determined that one or more devices will fail soon, but the normal process of relocating the data on the device to other OSDs in the cluster is blocked. \nEnsure that the cluster has available free space. It may be necessary to add capacity to the cluster to allow data from the failing device to successfully migrate, or to enable the balancer."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use"
+          summary: "Device failure is predicted, but unable to relocate data"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH_IN_USE\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDFlapping"
+        annotations:
+          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} was marked down and back up {{ $value | humanize }} times once a minute for 5 minutes. This may indicate a network issue (latency, packet loss, MTU mismatch) on the cluster network, or the public network if no cluster network is deployed. Check the network stats on the listed host(s)."
+          documentation: "https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds"
+          summary: "Network issues are causing OSDs to flap (mark each other down)"
+        expr: "(rate(ceph_osd_up[5m]) * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) * 60 > 1"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.4"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDReadErrors"
+        annotations:
+          description: "An OSD has encountered read errors, but the OSD has recovered by retrying the reads. This may indicate an issue with hardware or the kernel."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors"
+          summary: "Device read errors detected"
+        expr: "ceph_health_detail{name=\"BLUESTORE_SPURIOUS_READ_ERRORS\"} == 1"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGImbalance"
+        annotations:
+          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count."
+          summary: "PGs are not balanced across OSDs"
+        expr: |
+          abs(
+            ((ceph_osd_numpg > 0) - on (job) group_left avg(ceph_osd_numpg > 0) by (job)) /
+            on (job) group_left avg(ceph_osd_numpg > 0) by (job)
+          ) * on (ceph_daemon) group_left(hostname) ceph_osd_metadata > 0.30
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.5"
+          severity: "warning"
+          type: "ceph_default"
+  - name: "mds"
+    rules:
+      - alert: "CephFilesystemDamaged"
+        annotations:
+          description: "Filesystem metadata has been corrupted. Data may be inaccessible. Analyze metrics from the MDS daemon admin socket, or escalate to support."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
+          summary: "CephFS filesystem is damaged."
+        expr: "ceph_health_detail{name=\"MDS_DAMAGE\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemOffline"
+        annotations:
+          description: "All MDS ranks are unavailable. The MDS daemons managing metadata are down, rendering the filesystem offline."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-all-down"
+          summary: "CephFS filesystem is offline"
+        expr: "ceph_health_detail{name=\"MDS_ALL_DOWN\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemDegraded"
+        annotations:
+          description: "One or more metadata daemons (MDS ranks) are failed or in a damaged state. At best the filesystem is partially available, at worst the filesystem is completely unusable."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded"
+          summary: "CephFS filesystem is degraded"
+        expr: "ceph_health_detail{name=\"FS_DEGRADED\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemMDSRanksLow"
+        annotations:
+          description: "The filesystem's 'max_mds' setting defines the number of MDS ranks in the filesystem. The current number of active MDS daemons is less than this value."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-up-less-than-max"
+          summary: "Ceph MDS daemon count is lower than configured"
+        expr: "ceph_health_detail{name=\"MDS_UP_LESS_THAN_MAX\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephFilesystemInsufficientStandby"
+        annotations:
+          description: "The minimum number of standby daemons required by standby_count_wanted is less than the current number of standby daemons. Adjust the standby count or increase the number of MDS daemons."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-insufficient-standby"
+          summary: "Ceph filesystem standby daemons too few"
+        expr: "ceph_health_detail{name=\"MDS_INSUFFICIENT_STANDBY\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephFilesystemFailureNoStandby"
+        annotations:
+          description: "An MDS daemon has failed, leaving only one active rank and no available standby. Investigate the cause of the failure or add a standby MDS."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-with-failed-mds"
+          summary: "MDS daemon failed, no further standby available"
+        expr: "ceph_health_detail{name=\"FS_WITH_FAILED_MDS\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemReadOnly"
+        annotations:
+          description: "The filesystem has switched to READ ONLY due to an unexpected error when writing to the metadata pool. Either analyze the output from the MDS daemon admin socket, or escalate to support."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
+          summary: "CephFS filesystem in read only mode due to write error(s)"
+        expr: "ceph_health_detail{name=\"MDS_HEALTH_READ_ONLY\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "mgr"
+    rules:
+      - alert: "CephMgrModuleCrash"
+        annotations:
+          description: "One or more mgr modules have crashed and have yet to be acknowledged by an administrator. A crashed module may impact functionality within the cluster. Use the 'ceph crash' command to determine which module has failed, and archive it to acknowledge the failure."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash"
+          summary: "A manager module has recently crashed"
+        expr: "ceph_health_detail{name=\"RECENT_MGR_MODULE_CRASH\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.6.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMgrPrometheusModuleInactive"
+        annotations:
+          description: "The mgr/prometheus module at {{ $labels.instance }} is unreachable. This could mean that the module has been disabled or the mgr daemon itself is down. Without the mgr/prometheus module metrics and alerts will no longer function. Open a shell to an admin node or toolbox pod and use 'ceph -s' to to determine whether the mgr is active. If the mgr is not active, restart it, otherwise you can determine module status with 'ceph mgr module ls'. If it is not listed as enabled, enable it with 'ceph mgr module enable prometheus'."
+          summary: "The mgr/prometheus module is not available"
+        expr: "up{job=\"ceph\"} == 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.6.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "pgs"
+    rules:
+      - alert: "CephPGsInactive"
+        annotations:
+          description: "{{ $value }} PGs have been inactive for more than 5 minutes in pool {{ $labels.name }}. Inactive placement groups are not able to serve read/write requests."
+          summary: "One or more placement groups are inactive"
+        expr: "ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGsUnclean"
+        annotations:
+          description: "{{ $value }} PGs have been unclean for more than 15 minutes in pool {{ $labels.name }}. Unclean PGs have not recovered from a previous failure."
+          summary: "One or more placement groups are marked unclean"
+        expr: "ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0"
+        for: "15m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGsDamaged"
+        annotations:
+          description: "During data consistency checks (scrub), at least one PG has been flagged as being damaged or inconsistent. Check to see which PG is affected, and attempt a manual repair if necessary. To list problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use the 'ceph pg repair <pg_num>' command."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged"
+          summary: "Placement group damaged, manual intervention needed"
+        expr: "ceph_health_detail{name=~\"PG_DAMAGED|OSD_SCRUB_ERRORS\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGRecoveryAtRisk"
+        annotations:
+          description: "Data redundancy is at risk since one or more OSDs are at or above the 'full' threshold. Add more capacity to the cluster, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full"
+          summary: "OSDs are too full for recovery"
+        expr: "ceph_health_detail{name=\"PG_RECOVERY_FULL\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGUnavilableBlockingIO"
+        annotations:
+          description: "Data availability is reduced, impacting the cluster's ability to service I/O. One or more placement groups (PGs) are in a state that blocks I/O."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability"
+          summary: "PG is unavailable, blocking I/O"
+        expr: "((ceph_health_detail{name=\"PG_AVAILABILITY\"} == 1) - scalar(ceph_health_detail{name=\"OSD_DOWN\"})) == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGBackfillAtRisk"
+        annotations:
+          description: "Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs have reached the 'backfillfull' threshold. Add more capacity, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full"
+          summary: "Backfill operations are blocked due to lack of free space"
+        expr: "ceph_health_detail{name=\"PG_BACKFILL_FULL\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.6"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGNotScrubbed"
+        annotations:
+          description: "One or more PGs have not been scrubbed recently. Scrubs check metadata integrity, protecting against bit-rot. They check that metadata is consistent across data replicas. When PGs miss their scrub interval, it may indicate that the scrub window is too small, or PGs were not in a 'clean' state during the scrub window. You can manually initiate a scrub with: ceph pg scrub <pgid>"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed"
+          summary: "Placement group(s) have not been scrubbed"
+        expr: "ceph_health_detail{name=\"PG_NOT_SCRUBBED\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGsHighPerOSD"
+        annotations:
+          description: "The number of placement groups per OSD is too high (exceeds the mon_max_pg_per_osd setting).\n Check that the pg_autoscaler has not been disabled for any pools with 'ceph osd pool autoscale-status', and that the profile selected is appropriate. You may also adjust the target_size_ratio of a pool to guide the autoscaler based on the expected relative size of the pool ('ceph osd pool set cephfs.cephfs.meta target_size_ratio .1') or set the pg_autoscaler mode to 'warn' and adjust pg_num appropriately for one or more pools."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#too-many-pgs"
+          summary: "Placement groups per OSD is too high"
+        expr: "ceph_health_detail{name=\"TOO_MANY_PGS\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGNotDeepScrubbed"
+        annotations:
+          description: "One or more PGs have not been deep scrubbed recently. Deep scrubs protect against bit-rot. They compare data replicas to ensure consistency. When PGs miss their deep scrub interval, it may indicate that the window is too small or PGs were not in a 'clean' state during the deep-scrub window."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed"
+          summary: "Placement group(s) have not been deep scrubbed"
+        expr: "ceph_health_detail{name=\"PG_NOT_DEEP_SCRUBBED\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "nodes"
+    rules:
+      - alert: "CephNodeRootFilesystemFull"
+        annotations:
+          description: "Root volume is dangerously full: {{ $value | humanize }}% free."
+          summary: "Root filesystem is dangerously full"
+        expr: "node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"} * 100 < 5"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkPacketDrops"
+        annotations:
+          description: "Node {{ $labels.instance }} experiences packet drop > 0.5% or > 10 packets/s on interface {{ $labels.device }}."
+          summary: "One or more NICs reports packet drops"
+        expr: |
+          (
+            rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_drop_total{device!="lo"}[1m])
+          ) / (
+            rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_packets_total{device!="lo"}[1m])
+          ) >= 0.0050000000000000001 and (
+            rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_drop_total{device!="lo"}[1m])
+          ) >= 10
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkPacketErrors"
+        annotations:
+          description: "Node {{ $labels.instance }} experiences packet errors > 0.01% or > 10 packets/s on interface {{ $labels.device }}."
+          summary: "One or more NICs reports packet errors"
+        expr: |
+          (
+            rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_errs_total{device!="lo"}[1m])
+          ) / (
+            rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_packets_total{device!="lo"}[1m])
+          ) >= 0.0001 or (
+            rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_errs_total{device!="lo"}[1m])
+          ) >= 10
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.3"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkBondDegraded"
+        annotations:
+          description: "Bond {{ $labels.master }} is degraded on Node {{ $labels.instance }}."
+          summary: "Degraded Bond on Node {{ $labels.instance }}"
+        expr: |
+          node_bonding_slaves - node_bonding_active != 0
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeDiskspaceWarning"
+        annotations:
+          description: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.nodename }} will be full in less than 5 days based on the 48 hour trailing fill rate."
+          summary: "Host filesystem free space is getting low"
+        expr: "predict_linear(node_filesystem_free_bytes{device=~\"/.*\"}[2d], 3600 * 24 * 5) *on(instance) group_left(nodename) node_uname_info < 0"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.4"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: CephNodeInconsistentMTU
+        expr: |
+          node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+          != on (cluster, device) group_left
+            quantile by (cluster, device) (
+              0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+            )
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          summary: "Node {{ $labels.instance }} has inconsistent MTU settings in cluster {{ $labels.cluster }}"
+          description: "Network interface {{ $labels.device }} on node {{ $labels.instance }} has MTU {{ $value }} which differs from the cluster median."
+          impact: |
+            - May cause packet fragmentation or packet drops
+            - Risk of degraded cluster communication and performance
+            - Potential instability in services relying on consistent networking (e.g., Ceph, Kubernetes)
+          fix: |
+            - Check the MTU of interface `{{ $labels.device }}` on node `{{ $labels.instance }}`:
+              ip link show {{ $labels.device }}
+
+            - Find the median MTU value across the cluster by running this PromQL query in Prometheus:
+              quantile by (cluster, device) (0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0))
+
+            - Standardize MTU across all nodes to match the median (commonly 1500 or 9000):
+              ip link set dev {{ $labels.device }} mtu <median-value>
+
+            - Make MTU setting persistent:
+              - RHEL/CentOS: edit `/etc/sysconfig/network-scripts/ifcfg-<device>`
+              - Debian/Ubuntu: edit `/etc/netplan/*.yaml` and apply with `netplan apply`
+
+            - Restart the affected interface or node if required.
+  - name: "pools"
+    rules:
+      - alert: "CephPoolGrowthWarning"
+        annotations:
+          description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
+          summary: "Pool growth rate may soon exceed capacity"
+        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance) group_right() ceph_pool_metadata) >= 95"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPoolBackfillFull"
+        annotations:
+          description: "A pool is approaching the near full threshold, which will prevent recovery/backfill operations from completing. Consider adding more capacity."
+          summary: "Free space in a pool is too low for recovery/backfill"
+        expr: "ceph_health_detail{name=\"POOL_BACKFILLFULL\"} > 0"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPoolFull"
+        annotations:
+          description: "A pool has reached its MAX quota, or OSDs supporting the pool have reached the FULL threshold. Until this is resolved, writes to the pool will be blocked. Pool Breakdown (top 5) {{- range query \"topk(5, sort_desc(ceph_pool_percent_used * on(pool_id) group_right ceph_pool_metadata))\" }} - {{ .Labels.name }} at {{ .Value }}% {{- end }} Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full"
+          summary: "Pool is full - writes are blocked"
+        expr: "ceph_health_detail{name=\"POOL_FULL\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.9.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPoolNearFull"
+        annotations:
+          description: "A pool has exceeded the warning (percent full) threshold, or OSDs supporting the pool have reached the NEARFULL threshold. Writes may continue, but you are at risk of the pool going read-only if more capacity isn't made available. Determine the affected pool with 'ceph df detail', looking at QUOTA BYTES and STORED. Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>). Also ensure that the balancer is active."
+          summary: "One or more Ceph pools are nearly full"
+        expr: "ceph_health_detail{name=\"POOL_NEAR_FULL\"} > 0"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "healthchecks"
+    rules:
+      - alert: "CephSlowOps"
+        annotations:
+          description: "{{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
+          summary: "OSD operations are slow to complete"
+        expr: "ceph_healthcheck_slow_ops > 0"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDaemonSlowOps"
+        annotations:
+          description: "{{ $labels.ceph_daemon }} operations are taking too long to process (complaint time exceeded)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
+          summary: "{{ $labels.ceph_daemon }} operations are slow to complete"
+        expr: "ceph_daemon_health_metrics{type=\"SLOW_OPS\"} > 0"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "cephadm"
+    rules:
+      - alert: "CephadmUpgradeFailed"
+        annotations:
+          description: "The cephadm cluster upgrade process has failed. The cluster remains in an undetermined state. Please review the cephadm logs, to understand the nature of the issue"
+          summary: "Ceph version upgrade has failed"
+        expr: "ceph_health_detail{name=\"UPGRADE_EXCEPTION\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.11.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephadmDaemonFailed"
+        annotations:
+          description: "A daemon managed by cephadm is no longer active. Determine, which daemon is down with 'ceph health detail'. you may start daemons with the 'ceph orch daemon start <daemon_id>'"
+          summary: "A ceph daemon manged by cephadm is down"
+        expr: "ceph_health_detail{name=\"CEPHADM_FAILED_DAEMON\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.11.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephadmPaused"
+        annotations:
+          description: "Cluster management has been paused manually. This will prevent the orchestrator from service management and reconciliation. If this is not intentional, resume cephadm operations with 'ceph orch resume'"
+          documentation: "https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused"
+          summary: "Orchestration tasks via cephadm are PAUSED"
+        expr: "ceph_health_detail{name=\"CEPHADM_PAUSED\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "hardware"
+    rules:
+      - alert: "HardwareStorageError"
+        annotations:
+          description: "Some storage devices are in error. Check `ceph health detail`."
+          summary: "Storage devices error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_STORAGE\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwareMemoryError"
+        annotations:
+          description: "DIMM error(s) detected. Check `ceph health detail`."
+          summary: "DIMM error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_MEMORY\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwareProcessorError"
+        annotations:
+          description: "Processor error(s) detected. Check `ceph health detail`."
+          summary: "Processor error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_PROCESSOR\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwareNetworkError"
+        annotations:
+          description: "Network error(s) detected. Check `ceph health detail`."
+          summary: "Network error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_NETWORK\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwarePowerError"
+        annotations:
+          description: "Power supply error(s) detected. Check `ceph health detail`."
+          summary: "Power supply error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_POWER\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwareFanError"
+        annotations:
+          description: "Fan error(s) detected. Check `ceph health detail`."
+          summary: "Fan error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_FANS\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.6"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "PrometheusServer"
+    rules:
+      - alert: "PrometheusJobMissing"
+        annotations:
+          description: "The prometheus job that scrapes from Ceph is no longer defined, this will effectively mean you'll have no metrics or alerts for the cluster.  Please review the job definitions in the prometheus.yml file of the prometheus instance."
+          summary: "The scrape job for Ceph is missing from Prometheus"
+        expr: "absent(up{job=\"ceph\"})"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.12.1"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "rados"
+    rules:
+      - alert: "CephObjectMissing"
+        annotations:
+          description: "The latest version of a RADOS object can not be found, even though all OSDs are up. I/O requests for this object from clients will block (hang). Resolving this issue may require the object to be rolled back to a prior version manually, and manually verified."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound"
+          summary: "Object(s) marked UNFOUND"
+        expr: "(ceph_health_detail{name=\"OBJECT_UNFOUND\"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.1"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "generic"
+    rules:
+      - alert: "CephDaemonCrash"
+        annotations:
+          description: "One or more daemons have crashed recently, and need to be acknowledged. This notification ensures that software crashes do not go unseen. To acknowledge a crash, use the 'ceph crash archive <id>' command."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-crash"
+          summary: "One or more Ceph daemons have crashed, and are pending acknowledgement"
+        expr: "ceph_health_detail{name=\"RECENT_CRASH\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.1.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "rbdmirror"
+    rules:
+      - alert: "CephRBDMirrorImagesPerDaemonHigh"
+        annotations:
+          description: "Number of image replications per daemon is not suppossed to go beyond threshold 100"
+          summary: "Number of image replications are now above 100"
+        expr: "sum by (ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImagesNotInSync"
+        annotations:
+          description: "Both local and remote RBD mirror images should be in sync."
+          summary: "Some of the RBD mirror images are not in sync with the remote counter parts."
+        expr: "sum by (ceph_daemon, image, namespace, pool) (topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImagesNotInSyncVeryHigh"
+        annotations:
+          description: "More than 10% of the images have synchronization problems"
+          summary: "Number of unsynchronized images are very high."
+        expr: "count by (ceph_daemon) ((topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon) (ceph_rbd_mirror_snapshot_snapshots)*.1)"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImageTransferBandwidthHigh"
+        annotations:
+          description: "Detected a heavy increase in bandwidth for rbd replications (over 80%) in the last 30 min. This might not be a problem, but it is good to review the number of images being replicated simultaneously"
+          summary: "The replication network usage has been increased over 80% in the last 30 minutes. Review the number of images being replicated. This alert will be cleaned automatically after 30 minutes"
+        expr: "rate(ceph_rbd_mirror_journal_replay_bytes[30m]) > 0.80"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.5"
+          severity: "warning"
+          type: "ceph_default"
+  - name: "nvmeof"
+    rules:
+      - alert: "NVMeoFSubsystemNamespaceLimit"
+        annotations:
+          description: "Subsystems have a max namespace limit defined at creation time. This alert means that no more namespaces can be added to {{ $labels.nqn }}"
+          summary: "{{ $labels.nqn }} subsystem has reached its maximum number of namespaces "
+        expr: "(count by(nqn) (ceph_nvmeof_subsystem_namespace_metadata)) >= ceph_nvmeof_subsystem_namespace_limit"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFTooManyGateways"
+        annotations:
+          description: "You may create many gateways, but 4 is the tested limit"
+          summary: "Max supported gateways exceeded "
+        expr: "count(ceph_nvmeof_gateway_info) > 4.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFMaxGatewayGroupSize"
+        annotations:
+          description: "You may create many gateways in a gateway group, but 2 is the tested limit"
+          summary: "Max gateways within a gateway group ({{ $labels.group }}) exceeded "
+        expr: "count by(group) (ceph_nvmeof_gateway_info) > 2.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFSingleGatewayGroup"
+        annotations:
+          description: "Although a single member gateway group is valid, it should only be used for test purposes"
+          summary: "The gateway group {{ $labels.group }} consists of a single gateway - HA is not possible "
+        expr: "count by(group) (ceph_nvmeof_gateway_info) == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighGatewayCPU"
+        annotations:
+          description: "Typically, high CPU may indicate degraded performance. Consider increasing the number of reactor cores"
+          summary: "CPU used by {{ $labels.instance }} NVMe-oF Gateway is high "
+        expr: "label_replace(avg by(instance) (rate(ceph_nvmeof_reactor_seconds_total{mode=\"busy\"}[1m])),\"instance\",\"$1\",\"instance\",\"(.*):.*\") > 80.00"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFGatewayOpenSecurity"
+        annotations:
+          description: "It is good practice to ensure subsystems use host security to reduce the risk of unexpected data loss"
+          summary: "Subsystem {{ $labels.nqn }} has been defined without host level security "
+        expr: "ceph_nvmeof_subsystem_metadata{allow_any_host=\"yes\"}"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFTooManySubsystems"
+        annotations:
+          description: "Although you may continue to create subsystems in {{ $labels.gateway_host }}, the configuration may not be supported"
+          summary: "The number of subsystems defined to the gateway exceeds supported values "
+        expr: "count by(gateway_host) (label_replace(ceph_nvmeof_subsystem_metadata,\"gateway_host\",\"$1\",\"instance\",\"(.*):.*\")) > 16.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFVersionMismatch"
+        annotations:
+          description: "This may indicate an issue with deployment. Check cephadm logs"
+          summary: "The cluster has different NVMe-oF gateway releases active "
+        expr: "count(count by(version) (ceph_nvmeof_gateway_info)) > 1"
+        for: "1h"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighClientCount"
+        annotations:
+          description: "The supported limit for clients connecting to a subsystem is 32"
+          summary: "The number of clients connected to {{ $labels.nqn }} is too high "
+        expr: "ceph_nvmeof_subsystem_host_count > 32.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighHostCPU"
+        annotations:
+          description: "High CPU on a gateway host can lead to CPU contention and performance degradation"
+          summary: "The CPU is high ({{ $value }}%) on NVMeoF Gateway host ({{ $labels.host }}) "
+        expr: "100-((100*(avg by(host) (label_replace(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]),\"host\",\"$1\",\"instance\",\"(.*):.*\")) * on(host) group_right label_replace(ceph_nvmeof_gateway_info,\"host\",\"$1\",\"instance\",\"(.*):.*\")))) >= 80.00"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFInterfaceDown"
+        annotations:
+          description: "A NIC used by one or more subsystems is in a down state"
+          summary: "Network interface {{ $labels.device }} is down "
+        expr: "ceph_nvmeof_subsystem_listener_iface_info{operstate=\"down\"}"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.14.1"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFInterfaceDuplex"
+        annotations:
+          description: "Until this is resolved, performance from the gateway will be degraded"
+          summary: "Network interface {{ $labels.device }} is not running in full duplex mode "
+        expr: "ceph_nvmeof_subsystem_listener_iface_info{duplex!=\"full\"}"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighReadLatency"
+        annotations:
+          description: "High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate"
+          summary: "The average read latency over the last 5 mins has reached 10 ms or more on {{ $labels.gateway }}"
+        expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m]) / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.01"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighWriteLatency"
+        annotations:
+          description: "High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate"
+          summary: "The average write latency over the last 5 mins has reached 20 ms or more on {{ $labels.gateway }}"
+        expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.02"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_source_alerts/squid.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_source_alerts/squid.yaml
@@ -1,0 +1,923 @@
+groups:
+  - name: "cluster health"
+    rules:
+      - alert: "CephHealthError"
+        annotations:
+          description: "The cluster state has been HEALTH_ERROR for more than 5 minutes. Please check 'ceph health detail' for more information."
+          summary: "Ceph is in the ERROR state"
+        expr: "ceph_health_status == 2"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.2.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephHealthWarning"
+        annotations:
+          description: "The cluster state has been HEALTH_WARN for more than 15 minutes. Please check 'ceph health detail' for more information."
+          summary: "Ceph is in the WARNING state"
+        expr: "ceph_health_status == 1"
+        for: "15m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "mon"
+    rules:
+      - alert: "CephMonDownQuorumAtRisk"
+        annotations:
+          description: "{{ $min := query \"floor(count(ceph_mon_metadata) / 2) + 1\" | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active. Without quorum the cluster will become inoperable, affecting all services and connected clients. The following monitors are down: {{- range query \"(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
+          summary: "Monitor quorum is at risk"
+        expr: |
+          (
+            (ceph_health_detail{name="MON_DOWN"} == 1) * on() (
+              count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1)
+            )
+          ) == 1
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.3.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMonDown"
+        annotations:
+          description: |
+            {{ $down := query "count(ceph_mon_quorum_status == 0)" | first | value }}{{ $s := "" }}{{ if gt $down 1.0 }}{{ $s = "s" }}{{ end }}You have {{ $down }} monitor{{ $s }} down. Quorum is still intact, but the loss of an additional monitor will make your cluster inoperable.  The following monitors are down: {{- range query "(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)" }}   - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
+          summary: "One or more monitors down"
+        expr: |
+          count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1)
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephMonDiskspaceCritical"
+        annotations:
+          description: "The free space available to a monitor's store is critically low. You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*. Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit"
+          summary: "Filesystem space on at least one monitor is critically low"
+        expr: "ceph_health_detail{name=\"MON_DISK_CRIT\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.3.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMonDiskspaceLow"
+        annotations:
+          description: "The space available to a monitor's store is approaching full (>70% is the default). You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*.  Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low"
+          summary: "Drive space on at least one monitor is approaching full"
+        expr: "ceph_health_detail{name=\"MON_DISK_LOW\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephMonClockSkew"
+        annotations:
+          description: "Ceph monitors rely on closely synchronized time to maintain quorum and cluster consistency. This event indicates that the time on at least one mon has drifted too far from the lead mon. Review cluster status with ceph -s. This will show which monitors are affected. Check the time sync status on each monitor host with 'ceph time-sync-status' and the state and peers of your ntpd or chrony daemon."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew"
+          summary: "Clock skew detected among monitors"
+        expr: "ceph_health_detail{name=\"MON_CLOCK_SKEW\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "osd"
+    rules:
+      - alert: "CephOSDDownHigh"
+        annotations:
+          description: "{{ $value | humanize }}% or {{ with query \"count(ceph_osd_up == 0)\" }}{{ . | first | value }}{{ end }} of {{ with query \"count(ceph_osd_up)\" }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%). The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          summary: "More than 10% of OSDs are down"
+        expr: "count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephOSDHostDown"
+        annotations:
+          description: "The following OSDs are down: {{- range query \"(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" }} - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }} {{- end }}"
+          summary: "An OSD host is offline"
+        expr: "ceph_health_detail{name=\"OSD_HOST_DOWN\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.8"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDDown"
+        annotations:
+          description: |
+            {{ $num := query "count(ceph_osd_up == 0)" | first | value }}{{ $s := "" }}{{ if gt $num 1.0 }}{{ $s = "s" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins. The following OSD{{ $s }} {{ if eq $s "" }}is{{ else }}are{{ end }} down: {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0"}} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down"
+          summary: "An OSD has been marked down"
+        expr: "ceph_health_detail{name=\"OSD_DOWN\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDNearFull"
+        annotations:
+          description: "One or more OSDs have reached the NEARFULL threshold. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull"
+          summary: "OSD(s) running low on free space (NEARFULL)"
+        expr: "ceph_health_detail{name=\"OSD_NEARFULL\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.3"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDFull"
+        annotations:
+          description: "An OSD has reached the FULL threshold. Writes to pools that share the affected OSD will be blocked. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full"
+          summary: "OSD full, writes blocked"
+        expr: "ceph_health_detail{name=\"OSD_FULL\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.6"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephOSDBackfillFull"
+        annotations:
+          description: "An OSD has reached the BACKFILL FULL threshold. This will prevent rebalance operations from completing. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull"
+          summary: "OSD(s) too full for backfill operations"
+        expr: "ceph_health_detail{name=\"OSD_BACKFILLFULL\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTooManyRepairs"
+        annotations:
+          description: "Reads from an OSD have used a secondary PG to return data to the client, indicating a potential failing drive."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs"
+          summary: "OSD reports a high number of read errors"
+        expr: "ceph_health_detail{name=\"OSD_TOO_MANY_REPAIRS\"} == 1"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTimeoutsPublicNetwork"
+        annotations:
+          description: "OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network for latency or loss issues. Use 'ceph health detail' to show the affected OSDs."
+          summary: "Network issues delaying OSD heartbeats (public network)"
+        expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_FRONT\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTimeoutsClusterNetwork"
+        annotations:
+          description: "OSD heartbeats on the cluster's 'cluster' network (backend) are slow. Investigate the network for latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs."
+          summary: "Network issues delaying OSD heartbeats (cluster network)"
+        expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_BACK\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDInternalDiskSizeMismatch"
+        annotations:
+          description: "One or more OSDs have an internal inconsistency between metadata and the size of the device. This could lead to the OSD(s) crashing in future. You should redeploy the affected OSDs."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch"
+          summary: "OSD size inconsistency error"
+        expr: "ceph_health_detail{name=\"BLUESTORE_DISK_SIZE_MISMATCH\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDeviceFailurePredicted"
+        annotations:
+          description: "The device health module has determined that one or more devices will fail soon. To review device status use 'ceph device ls'. To show a specific device use 'ceph device info <dev id>'. Mark the OSD out so that data may migrate to other OSDs. Once the OSD has drained, destroy the OSD, replace the device, and redeploy the OSD."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#id2"
+          summary: "Device(s) predicted to fail soon"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDeviceFailurePredictionTooHigh"
+        annotations:
+          description: "The device health module has determined that devices predicted to fail can not be remediated automatically, since too many OSDs would be removed from the cluster to ensure performance and availability. Prevent data integrity issues by adding new OSDs so that data may be relocated."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany"
+          summary: "Too many devices are predicted to fail, unable to resolve"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH_TOOMANY\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.7"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephDeviceFailureRelocationIncomplete"
+        annotations:
+          description: "The device health module has determined that one or more devices will fail soon, but the normal process of relocating the data on the device to other OSDs in the cluster is blocked. \nEnsure that the cluster has available free space. It may be necessary to add capacity to the cluster to allow data from the failing device to successfully migrate, or to enable the balancer."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use"
+          summary: "Device failure is predicted, but unable to relocate data"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH_IN_USE\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDFlapping"
+        annotations:
+          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} was marked down and back up {{ $value | humanize }} times once a minute for 5 minutes. This may indicate a network issue (latency, packet loss, MTU mismatch) on the cluster network, or the public network if no cluster network is deployed. Check the network stats on the listed host(s)."
+          documentation: "https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds"
+          summary: "Network issues are causing OSDs to flap (mark each other down)"
+        expr: "(rate(ceph_osd_up[5m]) * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) * 60 > 1"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.4"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDReadErrors"
+        annotations:
+          description: "An OSD has encountered read errors, but the OSD has recovered by retrying the reads. This may indicate an issue with hardware or the kernel."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors"
+          summary: "Device read errors detected"
+        expr: "ceph_health_detail{name=\"BLUESTORE_SPURIOUS_READ_ERRORS\"} == 1"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGImbalance"
+        annotations:
+          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count in the device class {{ $labels.device_class }}."
+          summary: "PGs are not balanced across OSDs"
+        expr: |
+          abs(
+            (
+              (
+                (ceph_osd_numpg > 0)
+                * on (job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+              )
+              - on (job, device_class) group_left avg(
+                  (ceph_osd_numpg > 0)
+                  * on (job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+                ) by (job, device_class)
+            )
+            / on (job, device_class) group_left avg(
+                (ceph_osd_numpg > 0)
+                * on (job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+              ) by (job, device_class)
+          ) > 0.30
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.5"
+          severity: "warning"
+          type: "ceph_default"
+  - name: "mds"
+    rules:
+      - alert: "CephFilesystemDamaged"
+        annotations:
+          description: "Filesystem metadata has been corrupted. Data may be inaccessible. Analyze metrics from the MDS daemon admin socket, or escalate to support."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
+          summary: "CephFS filesystem is damaged."
+        expr: "ceph_health_detail{name=\"MDS_DAMAGE\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemOffline"
+        annotations:
+          description: "All MDS ranks are unavailable. The MDS daemons managing metadata are down, rendering the filesystem offline."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-all-down"
+          summary: "CephFS filesystem is offline"
+        expr: "ceph_health_detail{name=\"MDS_ALL_DOWN\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemDegraded"
+        annotations:
+          description: "One or more metadata daemons (MDS ranks) are failed or in a damaged state. At best the filesystem is partially available, at worst the filesystem is completely unusable."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded"
+          summary: "CephFS filesystem is degraded"
+        expr: "ceph_health_detail{name=\"FS_DEGRADED\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemMDSRanksLow"
+        annotations:
+          description: "The filesystem's 'max_mds' setting defines the number of MDS ranks in the filesystem. The current number of active MDS daemons is less than this value."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-up-less-than-max"
+          summary: "Ceph MDS daemon count is lower than configured"
+        expr: "ceph_health_detail{name=\"MDS_UP_LESS_THAN_MAX\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephFilesystemInsufficientStandby"
+        annotations:
+          description: "The minimum number of standby daemons required by standby_count_wanted is less than the current number of standby daemons. Adjust the standby count or increase the number of MDS daemons."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-insufficient-standby"
+          summary: "Ceph filesystem standby daemons too few"
+        expr: "ceph_health_detail{name=\"MDS_INSUFFICIENT_STANDBY\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephFilesystemFailureNoStandby"
+        annotations:
+          description: "An MDS daemon has failed, leaving only one active rank and no available standby. Investigate the cause of the failure or add a standby MDS."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-with-failed-mds"
+          summary: "MDS daemon failed, no further standby available"
+        expr: "ceph_health_detail{name=\"FS_WITH_FAILED_MDS\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemReadOnly"
+        annotations:
+          description: "The filesystem has switched to READ ONLY due to an unexpected error when writing to the metadata pool. Either analyze the output from the MDS daemon admin socket, or escalate to support."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
+          summary: "CephFS filesystem in read only mode due to write error(s)"
+        expr: "ceph_health_detail{name=\"MDS_HEALTH_READ_ONLY\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "mgr"
+    rules:
+      - alert: "CephMgrModuleCrash"
+        annotations:
+          description: "One or more mgr modules have crashed and have yet to be acknowledged by an administrator. A crashed module may impact functionality within the cluster. Use the 'ceph crash' command to determine which module has failed, and archive it to acknowledge the failure."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash"
+          summary: "A manager module has recently crashed"
+        expr: "ceph_health_detail{name=\"RECENT_MGR_MODULE_CRASH\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.6.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMgrPrometheusModuleInactive"
+        annotations:
+          description: "The mgr/prometheus module at {{ $labels.instance }} is unreachable. This could mean that the module has been disabled or the mgr daemon itself is down. Without the mgr/prometheus module metrics and alerts will no longer function. Open a shell to an admin node or toolbox pod and use 'ceph -s' to to determine whether the mgr is active. If the mgr is not active, restart it, otherwise you can determine module status with 'ceph mgr module ls'. If it is not listed as enabled, enable it with 'ceph mgr module enable prometheus'."
+          summary: "The mgr/prometheus module is not available"
+        expr: "up{job=\"ceph\"} == 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.6.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "pgs"
+    rules:
+      - alert: "CephPGsInactive"
+        annotations:
+          description: "{{ $value }} PGs have been inactive for more than 5 minutes in pool {{ $labels.name }}. Inactive placement groups are not able to serve read/write requests."
+          summary: "One or more placement groups are inactive"
+        expr: "ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGsUnclean"
+        annotations:
+          description: "{{ $value }} PGs have been unclean for more than 15 minutes in pool {{ $labels.name }}. Unclean PGs have not recovered from a previous failure."
+          summary: "One or more placement groups are marked unclean"
+        expr: "ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0"
+        for: "15m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGsDamaged"
+        annotations:
+          description: "During data consistency checks (scrub), at least one PG has been flagged as being damaged or inconsistent. Check to see which PG is affected, and attempt a manual repair if necessary. To list problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use the 'ceph pg repair <pg_num>' command."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged"
+          summary: "Placement group damaged, manual intervention needed"
+        expr: "ceph_health_detail{name=~\"PG_DAMAGED|OSD_SCRUB_ERRORS\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGRecoveryAtRisk"
+        annotations:
+          description: "Data redundancy is at risk since one or more OSDs are at or above the 'full' threshold. Add more capacity to the cluster, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full"
+          summary: "OSDs are too full for recovery"
+        expr: "ceph_health_detail{name=\"PG_RECOVERY_FULL\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGUnavailableBlockingIO"
+        annotations:
+          description: "Data availability is reduced, impacting the cluster's ability to service I/O. One or more placement groups (PGs) are in a state that blocks I/O."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability"
+          summary: "PG is unavailable, blocking I/O"
+        expr: "((ceph_health_detail{name=\"PG_AVAILABILITY\"} == 1) - scalar(ceph_health_detail{name=\"OSD_DOWN\"})) == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGBackfillAtRisk"
+        annotations:
+          description: "Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs have reached the 'backfillfull' threshold. Add more capacity, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full"
+          summary: "Backfill operations are blocked due to lack of free space"
+        expr: "ceph_health_detail{name=\"PG_BACKFILL_FULL\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.6"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGNotScrubbed"
+        annotations:
+          description: "One or more PGs have not been scrubbed recently. Scrubs check metadata integrity, protecting against bit-rot. They check that metadata is consistent across data replicas. When PGs miss their scrub interval, it may indicate that the scrub window is too small, or PGs were not in a 'clean' state during the scrub window. You can manually initiate a scrub with: ceph pg scrub <pgid>"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed"
+          summary: "Placement group(s) have not been scrubbed"
+        expr: "ceph_health_detail{name=\"PG_NOT_SCRUBBED\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGsHighPerOSD"
+        annotations:
+          description: "The number of placement groups per OSD is too high (exceeds the mon_max_pg_per_osd setting).\n Check that the pg_autoscaler has not been disabled for any pools with 'ceph osd pool autoscale-status', and that the profile selected is appropriate. You may also adjust the target_size_ratio of a pool to guide the autoscaler based on the expected relative size of the pool ('ceph osd pool set cephfs.cephfs.meta target_size_ratio .1') or set the pg_autoscaler mode to 'warn' and adjust pg_num appropriately for one or more pools."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#too-many-pgs"
+          summary: "Placement groups per OSD is too high"
+        expr: "ceph_health_detail{name=\"TOO_MANY_PGS\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGNotDeepScrubbed"
+        annotations:
+          description: "One or more PGs have not been deep scrubbed recently. Deep scrubs protect against bit-rot. They compare data replicas to ensure consistency. When PGs miss their deep scrub interval, it may indicate that the window is too small or PGs were not in a 'clean' state during the deep-scrub window."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed"
+          summary: "Placement group(s) have not been deep scrubbed"
+        expr: "ceph_health_detail{name=\"PG_NOT_DEEP_SCRUBBED\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "nodes"
+    rules:
+      - alert: "CephNodeRootFilesystemFull"
+        annotations:
+          description: "Root volume is dangerously full: {{ $value | humanize }}% free."
+          summary: "Root filesystem is dangerously full"
+        expr: "node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"} * 100 < 5"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkPacketDrops"
+        annotations:
+          description: "Node {{ $labels.instance }} experiences packet drop > 0.5% or > 10 packets/s on interface {{ $labels.device }}."
+          summary: "One or more NICs reports packet drops"
+        expr: |
+          (
+            rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_drop_total{device!="lo"}[1m])
+          ) / (
+            rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_packets_total{device!="lo"}[1m])
+          ) >= 0.0050000000000000001 and (
+            rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_drop_total{device!="lo"}[1m])
+          ) >= 10
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkPacketErrors"
+        annotations:
+          description: "Node {{ $labels.instance }} experiences packet errors > 0.01% or > 10 packets/s on interface {{ $labels.device }}."
+          summary: "One or more NICs reports packet errors"
+        expr: |
+          (
+            rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_errs_total{device!="lo"}[1m])
+          ) / (
+            rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_packets_total{device!="lo"}[1m])
+          ) >= 0.0001 or (
+            rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_errs_total{device!="lo"}[1m])
+          ) >= 10
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.3"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkBondDegraded"
+        annotations:
+          description: "Bond {{ $labels.master }} is degraded on Node {{ $labels.instance }}."
+          summary: "Degraded Bond on Node {{ $labels.instance }}"
+        expr: |
+          node_bonding_slaves - node_bonding_active != 0
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeDiskspaceWarning"
+        annotations:
+          description: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.nodename }} will be full in less than 5 days based on the 48 hour trailing fill rate."
+          summary: "Host filesystem free space is getting low"
+        expr: "predict_linear(node_filesystem_free_bytes{device=~\"/.*\"}[2d], 3600 * 24 * 5) *on(instance) group_left(nodename) node_uname_info < 0"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.4"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: CephNodeInconsistentMTU
+        expr: |
+          node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+          != on (cluster, device) group_left
+            quantile by (cluster, device) (
+              0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+            )
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          summary: "Node {{ $labels.instance }} has inconsistent MTU settings in cluster {{ $labels.cluster }}"
+          description: "Network interface {{ $labels.device }} on node {{ $labels.instance }} has MTU {{ $value }} which differs from the cluster median."
+          impact: |
+            - May cause packet fragmentation or packet drops
+            - Risk of degraded cluster communication and performance
+            - Potential instability in services relying on consistent networking (e.g., Ceph, Kubernetes)
+          fix: |
+            - Check the MTU of interface `{{ $labels.device }}` on node `{{ $labels.instance }}`:
+              ip link show {{ $labels.device }}
+
+            - Find the median MTU value across the cluster by running this PromQL query in Prometheus:
+              quantile by (cluster, device) (0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0))
+
+            - Standardize MTU across all nodes to match the median (commonly 1500 or 9000):
+              ip link set dev {{ $labels.device }} mtu <median-value>
+
+            - Make MTU setting persistent:
+              - RHEL/CentOS: edit `/etc/sysconfig/network-scripts/ifcfg-<device>`
+              - Debian/Ubuntu: edit `/etc/netplan/*.yaml` and apply with `netplan apply`
+
+            - Restart the affected interface or node if required.
+  - name: "pools"
+    rules:
+      - alert: "CephPoolGrowthWarning"
+        annotations:
+          description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
+          summary: "Pool growth rate may soon exceed capacity"
+        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id, instance) group_right() ceph_pool_metadata) >= 95"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPoolBackfillFull"
+        annotations:
+          description: "A pool is approaching the near full threshold, which will prevent recovery/backfill operations from completing. Consider adding more capacity."
+          summary: "Free space in a pool is too low for recovery/backfill"
+        expr: "ceph_health_detail{name=\"POOL_BACKFILLFULL\"} > 0"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPoolFull"
+        annotations:
+          description: "A pool has reached its MAX quota, or OSDs supporting the pool have reached the FULL threshold. Until this is resolved, writes to the pool will be blocked. Pool Breakdown (top 5) {{- range query \"topk(5, sort_desc(ceph_pool_percent_used * on(pool_id) group_right ceph_pool_metadata))\" }} - {{ .Labels.name }} at {{ .Value }}% {{- end }} Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full"
+          summary: "Pool is full - writes are blocked"
+        expr: "ceph_health_detail{name=\"POOL_FULL\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.9.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPoolNearFull"
+        annotations:
+          description: "A pool has exceeded the warning (percent full) threshold, or OSDs supporting the pool have reached the NEARFULL threshold. Writes may continue, but you are at risk of the pool going read-only if more capacity isn't made available. Determine the affected pool with 'ceph df detail', looking at QUOTA BYTES and STORED. Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>). Also ensure that the balancer is active."
+          summary: "One or more Ceph pools are nearly full"
+        expr: "ceph_health_detail{name=\"POOL_NEAR_FULL\"} > 0"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "healthchecks"
+    rules:
+      - alert: "CephSlowOps"
+        annotations:
+          description: "{{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
+          summary: "OSD operations are slow to complete"
+        expr: "ceph_healthcheck_slow_ops > 0"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDaemonSlowOps"
+        annotations:
+          description: "{{ $labels.ceph_daemon }} operations are taking too long to process (complaint time exceeded)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
+          summary: "{{ $labels.ceph_daemon }} operations are slow to complete"
+        expr: "ceph_daemon_health_metrics{type=\"SLOW_OPS\"} > 0"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "cephadm"
+    rules:
+      - alert: "CephadmUpgradeFailed"
+        annotations:
+          description: "The cephadm cluster upgrade process has failed. The cluster remains in an undetermined state. Please review the cephadm logs, to understand the nature of the issue"
+          summary: "Ceph version upgrade has failed"
+        expr: "ceph_health_detail{name=\"UPGRADE_EXCEPTION\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.11.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephadmDaemonFailed"
+        annotations:
+          description: "A daemon managed by cephadm is no longer active. Determine, which daemon is down with 'ceph health detail'. you may start daemons with the 'ceph orch daemon start <daemon_id>'"
+          summary: "A ceph daemon managed by cephadm is down"
+        expr: "ceph_health_detail{name=\"CEPHADM_FAILED_DAEMON\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.11.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephadmPaused"
+        annotations:
+          description: "Cluster management has been paused manually. This will prevent the orchestrator from service management and reconciliation. If this is not intentional, resume cephadm operations with 'ceph orch resume'"
+          documentation: "https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused"
+          summary: "Orchestration tasks via cephadm are PAUSED"
+        expr: "ceph_health_detail{name=\"CEPHADM_PAUSED\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "hardware"
+    rules:
+      - alert: "HardwareStorageError"
+        annotations:
+          description: "Some storage devices are in error. Check `ceph health detail`."
+          summary: "Storage devices error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_STORAGE\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwareMemoryError"
+        annotations:
+          description: "DIMM error(s) detected. Check `ceph health detail`."
+          summary: "DIMM error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_MEMORY\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwareProcessorError"
+        annotations:
+          description: "Processor error(s) detected. Check `ceph health detail`."
+          summary: "Processor error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_PROCESSOR\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwareNetworkError"
+        annotations:
+          description: "Network error(s) detected. Check `ceph health detail`."
+          summary: "Network error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_NETWORK\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwarePowerError"
+        annotations:
+          description: "Power supply error(s) detected. Check `ceph health detail`."
+          summary: "Power supply error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_POWER\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "HardwareFanError"
+        annotations:
+          description: "Fan error(s) detected. Check `ceph health detail`."
+          summary: "Fan error(s) detected"
+        expr: "ceph_health_detail{name=\"HARDWARE_FANS\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.6"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "PrometheusServer"
+    rules:
+      - alert: "PrometheusJobMissing"
+        annotations:
+          description: "The prometheus job that scrapes from Ceph is no longer defined, this will effectively mean you'll have no metrics or alerts for the cluster.  Please review the job definitions in the prometheus.yml file of the prometheus instance."
+          summary: "The scrape job for Ceph is missing from Prometheus"
+        expr: "absent(up{job=\"ceph\"})"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.12.1"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "rados"
+    rules:
+      - alert: "CephObjectMissing"
+        annotations:
+          description: "The latest version of a RADOS object can not be found, even though all OSDs are up. I/O requests for this object from clients will block (hang). Resolving this issue may require the object to be rolled back to a prior version manually, and manually verified."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound"
+          summary: "Object(s) marked UNFOUND"
+        expr: "(ceph_health_detail{name=\"OBJECT_UNFOUND\"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.1"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "generic"
+    rules:
+      - alert: "CephDaemonCrash"
+        annotations:
+          description: "One or more daemons have crashed recently, and need to be acknowledged. This notification ensures that software crashes do not go unseen. To acknowledge a crash, use the 'ceph crash archive <id>' command."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-crash"
+          summary: "One or more Ceph daemons have crashed, and are pending acknowledgement"
+        expr: "ceph_health_detail{name=\"RECENT_CRASH\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.1.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "rbdmirror"
+    rules:
+      - alert: "CephRBDMirrorImagesPerDaemonHigh"
+        annotations:
+          description: "Number of image replications per daemon is not suppossed to go beyond threshold 100"
+          summary: "Number of image replications are now above 100"
+        expr: "sum by (ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImagesNotInSync"
+        annotations:
+          description: "Both local and remote RBD mirror images should be in sync."
+          summary: "Some of the RBD mirror images are not in sync with the remote counter parts."
+        expr: "sum by (ceph_daemon, image, namespace, pool) (topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImagesNotInSyncVeryHigh"
+        annotations:
+          description: "More than 10% of the images have synchronization problems"
+          summary: "Number of unsynchronized images are very high."
+        expr: "count by (ceph_daemon) ((topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon) (ceph_rbd_mirror_snapshot_snapshots)*.1)"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImageTransferBandwidthHigh"
+        annotations:
+          description: "Detected a heavy increase in bandwidth for rbd replications (over 80%) in the last 30 min. This might not be a problem, but it is good to review the number of images being replicated simultaneously"
+          summary: "The replication network usage has been increased over 80% in the last 30 minutes. Review the number of images being replicated. This alert will be cleaned automatically after 30 minutes"
+        expr: "rate(ceph_rbd_mirror_journal_replay_bytes[30m]) > 0.80"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.5"
+          severity: "warning"
+          type: "ceph_default"
+  - name: "nvmeof"
+    rules:
+      - alert: "NVMeoFSubsystemNamespaceLimit"
+        annotations:
+          description: "Subsystems have a max namespace limit defined at creation time. This alert means that no more namespaces can be added to {{ $labels.nqn }}"
+          summary: "{{ $labels.nqn }} subsystem has reached its maximum number of namespaces "
+        expr: "(count by(nqn) (ceph_nvmeof_subsystem_namespace_metadata)) >= ceph_nvmeof_subsystem_namespace_limit"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFTooManyGateways"
+        annotations:
+          description: "You may create many gateways, but 4 is the tested limit"
+          summary: "Max supported gateways exceeded "
+        expr: "count(ceph_nvmeof_gateway_info) > 4.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFMaxGatewayGroupSize"
+        annotations:
+          description: "You may create many gateways in a gateway group, but 2 is the tested limit"
+          summary: "Max gateways within a gateway group ({{ $labels.group }}) exceeded "
+        expr: "count by(group) (ceph_nvmeof_gateway_info) > 2.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFSingleGatewayGroup"
+        annotations:
+          description: "Although a single member gateway group is valid, it should only be used for test purposes"
+          summary: "The gateway group {{ $labels.group }} consists of a single gateway - HA is not possible "
+        expr: "count by(group) (ceph_nvmeof_gateway_info) == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighGatewayCPU"
+        annotations:
+          description: "Typically, high CPU may indicate degraded performance. Consider increasing the number of reactor cores"
+          summary: "CPU used by {{ $labels.instance }} NVMe-oF Gateway is high "
+        expr: "label_replace(avg by(instance) (rate(ceph_nvmeof_reactor_seconds_total{mode=\"busy\"}[1m])),\"instance\",\"$1\",\"instance\",\"(.*):.*\") > 80.00"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFGatewayOpenSecurity"
+        annotations:
+          description: "It is good practice to ensure subsystems use host security to reduce the risk of unexpected data loss"
+          summary: "Subsystem {{ $labels.nqn }} has been defined without host level security "
+        expr: "ceph_nvmeof_subsystem_metadata{allow_any_host=\"yes\"}"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFTooManySubsystems"
+        annotations:
+          description: "Although you may continue to create subsystems in {{ $labels.gateway_host }}, the configuration may not be supported"
+          summary: "The number of subsystems defined to the gateway exceeds supported values "
+        expr: "count by(gateway_host) (label_replace(ceph_nvmeof_subsystem_metadata,\"gateway_host\",\"$1\",\"instance\",\"(.*):.*\")) > 16.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFVersionMismatch"
+        annotations:
+          description: "This may indicate an issue with deployment. Check cephadm logs"
+          summary: "The cluster has different NVMe-oF gateway releases active "
+        expr: "count(count by(version) (ceph_nvmeof_gateway_info)) > 1"
+        for: "1h"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighClientCount"
+        annotations:
+          description: "The supported limit for clients connecting to a subsystem is 32"
+          summary: "The number of clients connected to {{ $labels.nqn }} is too high "
+        expr: "ceph_nvmeof_subsystem_host_count > 32.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighHostCPU"
+        annotations:
+          description: "High CPU on a gateway host can lead to CPU contention and performance degradation"
+          summary: "The CPU is high ({{ $value }}%) on NVMeoF Gateway host ({{ $labels.host }}) "
+        expr: "100-((100*(avg by(host) (label_replace(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]),\"host\",\"$1\",\"instance\",\"(.*):.*\")) * on(host) group_right label_replace(ceph_nvmeof_gateway_info,\"host\",\"$1\",\"instance\",\"(.*):.*\")))) >= 80.00"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFInterfaceDown"
+        annotations:
+          description: "A NIC used by one or more subsystems is in a down state"
+          summary: "Network interface {{ $labels.device }} is down "
+        expr: "ceph_nvmeof_subsystem_listener_iface_info{operstate=\"down\"}"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.14.1"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFInterfaceDuplex"
+        annotations:
+          description: "Until this is resolved, performance from the gateway will be degraded"
+          summary: "Network interface {{ $labels.device }} is not running in full duplex mode "
+        expr: "ceph_nvmeof_subsystem_listener_iface_info{duplex!=\"full\"}"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighReadLatency"
+        annotations:
+          description: "High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate"
+          summary: "The average read latency over the last 5 mins has reached 10 ms or more on {{ $labels.gateway }}"
+        expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m]) / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.01"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighWriteLatency"
+        annotations:
+          description: "High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate"
+          summary: "The average write latency over the last 5 mins has reached 20 ms or more on {{ $labels.gateway }}"
+        expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.02"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"

--- a/src/go/plugin/go.d/collector/prometheus/testdata/ceph_source_alerts/tentacle.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/testdata/ceph_source_alerts/tentacle.yaml
@@ -1,0 +1,1065 @@
+groups:
+  - name: "cluster health"
+    rules:
+      - alert: "CephHealthError"
+        annotations:
+          description: "The cluster state has been HEALTH_ERROR for more than 5 minutes on cluster {{ $labels.cluster }}. Please check 'ceph health detail' for more information."
+          summary: "Ceph is in the ERROR state on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_status == 2"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.2.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephHealthWarning"
+        annotations:
+          description: "The cluster state has been HEALTH_WARN for more than 15 minutes on cluster {{ $labels.cluster }}. Please check 'ceph health detail' for more information."
+          summary: "Ceph is in the WARNING state on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_status == 1"
+        for: "15m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "mon"
+    rules:
+      - alert: "CephMonDownQuorumAtRisk"
+        annotations:
+          description: "{{ $min := printf \"floor(count(ceph_mon_metadata{cluster='%s'}) / 2) + 1\" .Labels.cluster | query | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active. Without quorum the cluster will become inoperable, affecting all services and connected clients. The following monitors are down: {{- range printf \"(ceph_mon_quorum_status{cluster='%s'} == 0) + on(cluster,ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
+          summary: "Monitor quorum is at risk on cluster {{ $labels.cluster }}"
+        expr: |
+          (
+            (ceph_health_detail{name="MON_DOWN"} == 1) * on() group_right(cluster) (
+              count(ceph_mon_quorum_status == 1) by(cluster)== bool (floor(count(ceph_mon_metadata) by(cluster) / 2) + 1)
+            )
+          ) == 1
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.3.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMonDown"
+        annotations:
+          description: "{{ $down := printf \"count(ceph_mon_quorum_status{cluster='%s'} == 0)\" .Labels.cluster | query | first | value }}{{ $s := \"\" }}{{ if gt $down 1.0 }}{{ $s = \"s\" }}{{ end }}You have {{ $down }} monitor{{ $s }} down. Quorum is still intact, but the loss of an additional monitor will make your cluster inoperable. The following monitors are down: {{- range printf \"(ceph_mon_quorum_status{cluster='%s'} == 0) + on(cluster,ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down"
+          summary: "One or more monitors down on cluster {{ $labels.cluster }}"
+        expr: |
+          (count by (cluster) (ceph_mon_quorum_status == 0)) <= (count by (cluster) (ceph_mon_metadata) - floor((count by (cluster) (ceph_mon_metadata) / 2 + 1)))
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephMonDiskspaceCritical"
+        annotations:
+          description: "The free space available to a monitor's store is critically low. You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*. Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit"
+          summary: "Filesystem space on at least one monitor is critically low on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"MON_DISK_CRIT\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.3.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMonDiskspaceLow"
+        annotations:
+          description: "The space available to a monitor's store is approaching full (>70% is the default). You should increase the space available to the monitor(s). The default directory is /var/lib/ceph/mon-*/data/store.db on traditional deployments, and /var/lib/rook/mon-*/data/store.db on the mon pod's worker node for Rook. Look for old, rotated versions of *.log and MANIFEST*.  Do NOT touch any *.sst files. Also check any other directories under /var/lib/rook and other directories on the same filesystem, often /var/log and /var/tmp are culprits. Your monitor hosts are; {{- range query \"ceph_mon_metadata\"}} - {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low"
+          summary: "Drive space on at least one monitor is approaching full on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"MON_DISK_LOW\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephMonClockSkew"
+        annotations:
+          description: "Ceph monitors rely on closely synchronized time to maintain quorum and cluster consistency. This event indicates that the time on at least one mon has drifted too far from the lead mon. Review cluster status with ceph -s. This will show which monitors are affected. Check the time sync status on each monitor host with 'ceph time-sync-status' and the state and peers of your ntpd or chrony daemon."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew"
+          summary: "Clock skew detected among monitors on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"MON_CLOCK_SKEW\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "osd"
+    rules:
+      - alert: "CephOSDDownHigh"
+        annotations:
+          description: "{{ $value | humanize }}% or {{ with printf \"count (ceph_osd_up{cluster='%s'} == 0)\" .Labels.cluster | query }}{{ . | first | value }}{{ end }} of {{ with printf \"count (ceph_osd_up{cluster='%s'})\" .Labels.cluster | query }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%). The following OSDs are down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster, ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          summary: "More than 10% of OSDs are down on cluster {{ $labels.cluster }}"
+        expr: "count by (cluster) (ceph_osd_up == 0) / count by (cluster) (ceph_osd_up) * 100 >= 10"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephOSDHostDown"
+        annotations:
+          description: "The following OSDs are down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }} {{- end }}"
+          summary: "An OSD host is offline on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"OSD_HOST_DOWN\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.8"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDDown"
+        annotations:
+          description: "{{ $num := printf \"count(ceph_osd_up{cluster='%s'} == 0) \" .Labels.cluster | query | first | value }}{{ $s := \"\" }}{{ if gt $num 1.0 }}{{ $s = \"s\" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins. The following OSD{{ $s }} {{ if eq $s \"\" }}is{{ else }}are{{ end }} down: {{- range printf \"(ceph_osd_up{cluster='%s'} * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0\" .Labels.cluster | query }} - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }} {{- end }}"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down"
+          summary: "An OSD has been marked down on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"OSD_DOWN\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDNearFull"
+        annotations:
+          description: "One or more OSDs have reached the NEARFULL threshold. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull"
+          summary: "OSD(s) running low on free space (NEARFULL) on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"OSD_NEARFULL\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.3"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDFull"
+        annotations:
+          description: "An OSD has reached the FULL threshold. Writes to pools that share the affected OSD will be blocked. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full"
+          summary: "OSD full, writes blocked on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"OSD_FULL\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.6"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephOSDBackfillFull"
+        annotations:
+          description: "An OSD has reached the BACKFILL FULL threshold. This will prevent rebalance operations from completing. Use 'ceph health detail' and 'ceph osd df' to identify the problem. To resolve, add capacity to the affected OSD's failure domain, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull"
+          summary: "OSD(s) too full for backfill operations on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"OSD_BACKFILLFULL\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTooManyRepairs"
+        annotations:
+          description: "Reads from an OSD have used a secondary PG to return data to the client, indicating a potential failing drive."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs"
+          summary: "OSD reports a high number of read errors on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"OSD_TOO_MANY_REPAIRS\"} == 1"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTimeoutsPublicNetwork"
+        annotations:
+          description: "OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network for latency or loss issues. Use 'ceph health detail' to show the affected OSDs."
+          summary: "Network issues delaying OSD heartbeats (public network) on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_FRONT\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDTimeoutsClusterNetwork"
+        annotations:
+          description: "OSD heartbeats on the cluster's 'cluster' network (backend) are slow. Investigate the network for latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs."
+          summary: "Network issues delaying OSD heartbeats (cluster network) on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"OSD_SLOW_PING_TIME_BACK\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDInternalDiskSizeMismatch"
+        annotations:
+          description: "One or more OSDs have an internal inconsistency between metadata and the size of the device. This could lead to the OSD(s) crashing in future. You should redeploy the affected OSDs."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch"
+          summary: "OSD size inconsistency error on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"BLUESTORE_DISK_SIZE_MISMATCH\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDeviceFailurePredicted"
+        annotations:
+          description: "The device health module has determined that one or more devices will fail soon. To review device status use 'ceph device ls'. To show a specific device use 'ceph device info <dev id>'. Mark the OSD out so that data may migrate to other OSDs. Once the OSD has drained, destroy the OSD, replace the device, and redeploy the OSD."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#id2"
+          summary: "Device(s) predicted to fail soon on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDeviceFailurePredictionTooHigh"
+        annotations:
+          description: "The device health module has determined that devices predicted to fail can not be remediated automatically, since too many OSDs would be removed from the cluster to ensure performance and availability. Prevent data integrity issues by adding new OSDs so that data may be relocated."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany"
+          summary: "Too many devices are predicted to fail on cluster {{ $labels.cluster }}, unable to resolve"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH_TOOMANY\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.7"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephDeviceFailureRelocationIncomplete"
+        annotations:
+          description: "The device health module has determined that one or more devices will fail soon, but the normal process of relocating the data on the device to other OSDs in the cluster is blocked. \nEnsure that the cluster has available free space. It may be necessary to add capacity to the cluster to allow data from the failing device to successfully migrate, or to enable the balancer."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use"
+          summary: "Device failure is predicted, but unable to relocate data on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"DEVICE_HEALTH_IN_USE\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDFlapping"
+        annotations:
+          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} was marked down and back up {{ $value | humanize }} times once a minute for 5 minutes. This may indicate a network issue (latency, packet loss, MTU mismatch) on the cluster network, or the public network if no cluster network is deployed. Check the network stats on the listed host(s)."
+          documentation: "https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds"
+          summary: "Network issues are causing OSDs to flap (mark each other down) on cluster {{ $labels.cluster }}"
+        expr: "(rate(ceph_osd_up[5m]) * on(cluster,ceph_daemon) group_left(hostname) ceph_osd_metadata) * 60 > 1"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.4"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephOSDReadErrors"
+        annotations:
+          description: "An OSD has encountered read errors, but the OSD has recovered by retrying the reads. This may indicate an issue with hardware or the kernel."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors"
+          summary: "Device read errors detected on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"BLUESTORE_SPURIOUS_READ_ERRORS\"} == 1"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGImbalance"
+        annotations:
+          description: "OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates by more than 30% from average PG count in the device class {{ $labels.device_class }}."
+          summary: "PGs are not balanced across OSDs on cluster {{ $labels.cluster }}"
+        expr: |
+          abs(
+            (
+              (
+                (ceph_osd_numpg > 0)
+                * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+              )
+              - on (cluster, job, device_class) group_left avg(
+                  (ceph_osd_numpg > 0)
+                  * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+                ) by (cluster, job, device_class)
+            )
+            / on (cluster, job, device_class) group_left avg(
+                (ceph_osd_numpg > 0)
+                * on (cluster, job, ceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+              ) by (cluster, job, device_class)
+          ) > 0.30
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.4.5"
+          severity: "warning"
+          type: "ceph_default"
+  - name: "mds"
+    rules:
+      - alert: "CephFilesystemDamaged"
+        annotations:
+          description: "Filesystem metadata has been corrupted. Data may be inaccessible. Analyze metrics from the MDS daemon admin socket, or escalate to support."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
+          summary: "CephFS filesystem is damaged on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"MDS_DAMAGE\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemOffline"
+        annotations:
+          description: "All MDS ranks are unavailable. The MDS daemons managing metadata are down, rendering the filesystem offline."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-all-down"
+          summary: "CephFS filesystem is offline on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"MDS_ALL_DOWN\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemDegraded"
+        annotations:
+          description: "One or more metadata daemons (MDS ranks) are failed or in a damaged state. At best the filesystem is partially available, at worst the filesystem is completely unusable."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded"
+          summary: "CephFS filesystem is degraded on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"FS_DEGRADED\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemMDSRanksLow"
+        annotations:
+          description: "The filesystem's 'max_mds' setting defines the number of MDS ranks in the filesystem. The current number of active MDS daemons is less than this value."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-up-less-than-max"
+          summary: "Ceph MDS daemon count is lower than configured on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"MDS_UP_LESS_THAN_MAX\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephFilesystemInsufficientStandby"
+        annotations:
+          description: "The minimum number of standby daemons required by standby_count_wanted is less than the current number of standby daemons. Adjust the standby count or increase the number of MDS daemons."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-insufficient-standby"
+          summary: "Ceph filesystem standby daemons too few on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"MDS_INSUFFICIENT_STANDBY\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephFilesystemFailureNoStandby"
+        annotations:
+          description: "An MDS daemon has failed, leaving only one active rank and no available standby. Investigate the cause of the failure or add a standby MDS."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-with-failed-mds"
+          summary: "MDS daemon failed, no further standby available on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"FS_WITH_FAILED_MDS\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephFilesystemReadOnly"
+        annotations:
+          description: "The filesystem has switched to READ ONLY due to an unexpected error when writing to the metadata pool. Either analyze the output from the MDS daemon admin socket, or escalate to support."
+          documentation: "https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages"
+          summary: "CephFS filesystem in read only mode due to write error(s) on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"MDS_HEALTH_READ_ONLY\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.5.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "mgr"
+    rules:
+      - alert: "CephMgrModuleCrash"
+        annotations:
+          description: "One or more mgr modules have crashed and have yet to be acknowledged by an administrator. A crashed module may impact functionality within the cluster. Use the 'ceph crash' command to determine which module has failed, and archive it to acknowledge the failure."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash"
+          summary: "A manager module has recently crashed on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"RECENT_MGR_MODULE_CRASH\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.6.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephMgrPrometheusModuleInactive"
+        annotations:
+          description: "The mgr/prometheus module at {{ $labels.instance }} is unreachable. This could mean that the module has been disabled or the mgr daemon itself is down. Without the mgr/prometheus module metrics and alerts will no longer function. Open a shell to an admin node or toolbox pod and use 'ceph -s' to to determine whether the mgr is active. If the mgr is not active, restart it, otherwise you can determine module status with 'ceph mgr module ls'. If it is not listed as enabled, enable it with 'ceph mgr module enable prometheus'."
+          summary: "The mgr/prometheus module is not available"
+        expr: "up{job=\"ceph\"} == 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.6.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "pgs"
+    rules:
+      - alert: "CephPGsInactive"
+        annotations:
+          description: "{{ $value }} PGs have been inactive for more than 5 minutes in pool {{ $labels.name }}. Inactive placement groups are not able to serve read/write requests."
+          summary: "One or more placement groups are inactive on cluster {{ $labels.cluster }}"
+        expr: "ceph_pool_metadata * on(cluster,pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGsUnclean"
+        annotations:
+          description: "{{ $value }} PGs have been unclean for more than 15 minutes in pool {{ $labels.name }}. Unclean PGs have not recovered from a previous failure."
+          summary: "One or more placement groups are marked unclean on cluster {{ $labels.cluster }}"
+        expr: "ceph_pool_metadata * on(cluster,pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0"
+        for: "15m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGsDamaged"
+        annotations:
+          description: "During data consistency checks (scrub), at least one PG has been flagged as being damaged or inconsistent. Check to see which PG is affected, and attempt a manual repair if necessary. To list problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use the 'ceph pg repair <pg_num>' command."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged"
+          summary: "Placement group damaged, manual intervention needed on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=~\"PG_DAMAGED|OSD_SCRUB_ERRORS\"} == 1"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGRecoveryAtRisk"
+        annotations:
+          description: "Data redundancy is at risk since one or more OSDs are at or above the 'full' threshold. Add more capacity to the cluster, restore down/out OSDs, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full"
+          summary: "OSDs are too full for recovery on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"PG_RECOVERY_FULL\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGUnavailableBlockingIO"
+        annotations:
+          description: "Data availability is reduced, impacting the cluster's ability to service I/O. One or more placement groups (PGs) are in a state that blocks I/O."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability"
+          summary: "PG is unavailable on cluster {{ $labels.cluster }}, blocking I/O"
+        expr: "((ceph_health_detail{name=\"PG_AVAILABILITY\"} == 1) - scalar(ceph_health_detail{name=\"OSD_DOWN\"})) == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGBackfillAtRisk"
+        annotations:
+          description: "Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs have reached the 'backfillfull' threshold. Add more capacity, or delete unwanted data."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full"
+          summary: "Backfill operations are blocked due to lack of free space on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"PG_BACKFILL_FULL\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.7.6"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPGNotScrubbed"
+        annotations:
+          description: "One or more PGs have not been scrubbed recently. Scrubs check metadata integrity, protecting against bit-rot. They check that metadata is consistent across data replicas. When PGs miss their scrub interval, it may indicate that the scrub window is too small, or PGs were not in a 'clean' state during the scrub window. You can manually initiate a scrub with: ceph pg scrub <pgid>"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed"
+          summary: "Placement group(s) have not been scrubbed on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"PG_NOT_SCRUBBED\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGsHighPerOSD"
+        annotations:
+          description: "The number of placement groups per OSD is too high (exceeds the mon_max_pg_per_osd setting).\n Check that the pg_autoscaler has not been disabled for any pools with 'ceph osd pool autoscale-status', and that the profile selected is appropriate. You may also adjust the target_size_ratio of a pool to guide the autoscaler based on the expected relative size of the pool ('ceph osd pool set cephfs.cephfs.meta target_size_ratio .1') or set the pg_autoscaler mode to 'warn' and adjust pg_num appropriately for one or more pools."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#too-many-pgs"
+          summary: "Placement groups per OSD is too high on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"TOO_MANY_PGS\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPGNotDeepScrubbed"
+        annotations:
+          description: "One or more PGs have not been deep scrubbed recently. Deep scrubs protect against bit-rot. They compare data replicas to ensure consistency. When PGs miss their deep scrub interval, it may indicate that the window is too small or PGs were not in a 'clean' state during the deep-scrub window."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed"
+          summary: "Placement group(s) have not been deep scrubbed on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"PG_NOT_DEEP_SCRUBBED\"} == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "nodes"
+    rules:
+      - alert: "CephNodeRootFilesystemFull"
+        annotations:
+          description: "Root volume is dangerously full: {{ $value | humanize }}% free."
+          summary: "Root filesystem is dangerously full"
+        expr: "node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"} * 100 < 5"
+        for: "5m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkPacketDrops"
+        annotations:
+          description: "Node {{ $labels.instance }} experiences packet drop > 0.5% or > 10 packets/s on interface {{ $labels.device }}."
+          summary: "One or more NICs reports packet drops"
+        expr: |
+          (
+            rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_drop_total{device!="lo"}[1m])
+          ) / (
+            rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_packets_total{device!="lo"}[1m])
+          ) >= 0.0050000000000000001 and (
+            rate(node_network_receive_drop_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_drop_total{device!="lo"}[1m])
+          ) >= 10
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkPacketErrors"
+        annotations:
+          description: "Node {{ $labels.instance }} experiences packet errors > 0.01% or > 10 packets/s on interface {{ $labels.device }}."
+          summary: "One or more NICs reports packet errors on cluster {{ $labels.cluster }}"
+        expr: |
+          (
+            rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_errs_total{device!="lo"}[1m])
+          ) / (
+            rate(node_network_receive_packets_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_packets_total{device!="lo"}[1m])
+          ) >= 0.0001 or (
+            rate(node_network_receive_errs_total{device!="lo"}[1m]) +
+            rate(node_network_transmit_errs_total{device!="lo"}[1m])
+          ) >= 10
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.3"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeNetworkBondDegraded"
+        annotations:
+          description: "Bond {{ $labels.master }} is degraded on Node {{ $labels.instance }}."
+          summary: "Degraded Bond on Node {{ $labels.instance }} on cluster {{ $labels.cluster }}"
+        expr: |
+          node_bonding_slaves - node_bonding_active != 0
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephNodeDiskspaceWarning"
+        annotations:
+          description: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.nodename }} will be full in less than 5 days based on the 48 hour trailing fill rate."
+          summary: "Host filesystem free space is getting low on cluster {{ $labels.cluster }}"
+        expr: "predict_linear(node_filesystem_free_bytes{device=~\"/.*\"}[2d], 3600 * 24 * 5) * on(cluster, instance) group_left(nodename) node_uname_info < 0"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.8.4"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: CephNodeInconsistentMTU
+        expr: |
+          node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+          != on (cluster, device) group_left
+            quantile by (cluster, device) (
+              0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)
+            )
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          summary: "Node {{ $labels.instance }} has inconsistent MTU settings in cluster {{ $labels.cluster }}"
+          description: "Network interface {{ $labels.device }} on node {{ $labels.instance }} has MTU {{ $value }} which differs from the cluster median."
+          impact: |
+            - May cause packet fragmentation or packet drops
+            - Risk of degraded cluster communication and performance
+            - Potential instability in services relying on consistent networking (e.g., Ceph, Kubernetes)
+          fix: |
+            - Check the MTU of interface `{{ $labels.device }}` on node `{{ $labels.instance }}`:
+              ip link show {{ $labels.device }}
+
+            - Find the median MTU value across the cluster by running this PromQL query in Prometheus:
+              quantile by (cluster, device) (0.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0))
+
+            - Standardize MTU across all nodes to match the median (commonly 1500 or 9000):
+              ip link set dev {{ $labels.device }} mtu <median-value>
+
+            - Make MTU setting persistent:
+              - RHEL/CentOS: edit `/etc/sysconfig/network-scripts/ifcfg-<device>`
+              - Debian/Ubuntu: edit `/etc/netplan/*.yaml` and apply with `netplan apply`
+
+            - Restart the affected interface or node if required.
+  - name: "pools"
+    rules:
+      - alert: "CephPoolGrowthWarning"
+        annotations:
+          description: "Pool '{{ $labels.name }}' will be full in less than 5 days assuming the average fill-up rate of the past 48 hours."
+          summary: "Pool growth rate may soon exceed capacity on cluster {{ $labels.cluster }}"
+        expr: "(predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.9.2"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPoolBackfillFull"
+        annotations:
+          description: "A pool is approaching the near full threshold, which will prevent recovery/backfill operations from completing. Consider adding more capacity."
+          summary: "Free space in a pool is too low for recovery/backfill on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"POOL_BACKFILLFULL\"} > 0"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephPoolFull"
+        annotations:
+          description: "A pool has reached its MAX quota, or OSDs supporting the pool have reached the FULL threshold. Until this is resolved, writes to the pool will be blocked. Pool Breakdown (top 5) {{- range printf \"topk(5, sort_desc(ceph_pool_percent_used{cluster='%s'} * on(cluster,pool_id) group_right ceph_pool_metadata))\" .Labels.cluster | query }} - {{ .Labels.name }} at {{ .Value }}% {{- end }} Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full"
+          summary: "Pool is full - writes are blocked on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"POOL_FULL\"} > 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.9.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephPoolNearFull"
+        annotations:
+          description: "A pool has exceeded the warning (percent full) threshold, or OSDs supporting the pool have reached the NEARFULL threshold. Writes may continue, but you are at risk of the pool going read-only if more capacity isn't made available. Determine the affected pool with 'ceph df detail', looking at QUOTA BYTES and STORED. Increase the pool's quota, or add capacity to the cluster first then increase the pool's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>). Also ensure that the balancer is active."
+          summary: "One or more Ceph pools are nearly full on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"POOL_NEAR_FULL\"} > 0"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "healthchecks"
+    rules:
+      - alert: "CephSlowOps"
+        annotations:
+          description: "{{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
+          summary: "OSD operations are slow to complete on cluster {{ $labels.cluster }}"
+        expr: "ceph_healthcheck_slow_ops > 0"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CephDaemonSlowOps"
+        annotations:
+          description: "{{ $labels.ceph_daemon }} operations are taking too long to process (complaint time exceeded)"
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops"
+          summary: "{{ $labels.ceph_daemon }} operations are slow to complete on cluster {{ $labels.cluster }}"
+        expr: "ceph_daemon_health_metrics{type=\"SLOW_OPS\"} > 0"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "cephadm"
+    rules:
+      - alert: "CephadmUpgradeFailed"
+        annotations:
+          description: "The cephadm cluster upgrade process has failed. The cluster remains in an undetermined state. Please review the cephadm logs, to understand the nature of the issue"
+          summary: "Ceph version upgrade has failed on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"UPGRADE_EXCEPTION\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.11.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephadmDaemonFailed"
+        annotations:
+          description: "A daemon managed by cephadm is no longer active. Determine, which daemon is down with 'ceph health detail'. you may start daemons with the 'ceph orch daemon start <daemon_id>'"
+          summary: "A ceph daemon managed by cephadm is down on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"CEPHADM_FAILED_DAEMON\"} > 0"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.11.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephadmPaused"
+        annotations:
+          description: "Cluster management has been paused manually. This will prevent the orchestrator from service management and reconciliation. If this is not intentional, resume cephadm operations with 'ceph orch resume'"
+          documentation: "https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused"
+          summary: "Orchestration tasks via cephadm are PAUSED on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"CEPHADM_PAUSED\"} > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "hardware"
+    rules:
+      - alert: "PowerSupplyDegraded"
+        annotations:
+          description: "PSU {{ $labels.component }} is in a degraded state on {{ $labels.hostname }}."
+          summary: "Power supply {{ $labels.component }} degraded on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"power\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "PowerSupplyFailed"
+        annotations:
+          description: "PSU fault detected on {{ $labels.hostname }}. PSU {{ $labels.component }} has failed."
+          summary: "Power supply {{ $labels.component }} failed on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"power\"} == 2"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.5"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CoolingDegraded"
+        annotations:
+          description: "Fan module {{ $labels.component }} is in a degraded state on {{ $labels.hostname }}."
+          summary: "Fan {{ $labels.component }} degraded on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"fans\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "CoolingFailed"
+        annotations:
+          description: "A cooling fault has been detected on {{ $labels.hostname }}. A cooling FAN within the enclosure has failed."
+          summary: "Fan {{ $labels.component }} failed on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"fans\"} == 2"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.6"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "NVMeDriveDegraded"
+        annotations:
+          description: "Storage device {{ $labels.component }} is in a degraded state on {{ $labels.hostname }}."
+          summary: "Storage device {{ $labels.component }} degraded on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"storage\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeDriveFailed"
+        annotations:
+          description: "A drive fault has been detected on {{ $labels.hostname }}. Storage device {{ $labels.component }} has failed."
+          summary: "Storage device {{ $labels.component }} failed on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"storage\"} == 2"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.1"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "MemoryDegraded"
+        annotations:
+          description: "Memory module {{ $labels.component }} is in a degraded state on {{ $labels.hostname }}."
+          summary: "Memory module {{ $labels.component }} degraded on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"memory\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "MemoryFailed"
+        annotations:
+          description: "A memory fault has been detected on {{ $labels.hostname }}. Memory module {{ $labels.component }} has failed."
+          summary: "Memory module {{ $labels.component }} failed on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"memory\"} == 2"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "ProcessorDegraded"
+        annotations:
+          description: "Processor {{ $labels.component }} is in a degraded state on {{ $labels.hostname }}."
+          summary: "Processor {{ $labels.component }} degraded on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"processors\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "ProcessorFailed"
+        annotations:
+          description: "A processor fault has been detected on {{ $labels.hostname }}. Processor {{ $labels.component }} has failed."
+          summary: "Processor {{ $labels.component }} failed on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"processors\"} == 2"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "NetworkDegraded"
+        annotations:
+          description: "Network interface {{ $labels.component }} is in a degraded state on {{ $labels.hostname }}."
+          summary: "Network interface {{ $labels.component }} degraded on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"network\"} == 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NetworkFailed"
+        annotations:
+          description: "A network fault has been detected on {{ $labels.hostname }}. Network interface {{ $labels.component }} has failed."
+          summary: "Network interface {{ $labels.component }} failed on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_health{category=\"network\"} == 2"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.13.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "MotherboardTemperatureHigh"
+        annotations:
+          description: "Prolonged high temperatures could lead to platform instability. Investigate cooling issues and hot-spots in the server room/hall."
+          summary: "Motherboard sensor {{ $labels.sensor_name }} above 60°C on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_temperature_celsius{sensor_name=~\".*MB_TEMP.*\"} > 60"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "DIMMTemperatureHigh"
+        annotations:
+          description: "Prolonged high temperatures could lead to platform instability. Investigate cooling issues and hot-spots in the server room/hall."
+          summary: "DIMM sensor {{ $labels.sensor_name }} above 80°C on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_temperature_celsius{sensor_name=~\".*DIMM.*_TEMP\"} > 80"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "ProcessorTemperatureHigh"
+        annotations:
+          description: "Prolonged high temperatures could lead to platform instability. Investigate cooling issues and hot-spots in the server room/hall."
+          summary: "CPU sensor {{ $labels.sensor_name }} above 80°C on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_temperature_celsius{sensor_name=~\".*CPU_TEMP\"} > 80"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeTemperatureHigh"
+        annotations:
+          description: "An NVMe temperature sensor is indicating a potential cooling problem. NVMe may power down if the temperature continues to rise."
+          summary: "NVMe sensor {{ $labels.sensor_name }} above 70°C on {{ $labels.hostname }} on cluster {{ $labels.cluster }}"
+        expr: "ceph_hardware_temperature_celsius{sensor_name=~\"NVME.*_TEMP\"} > 70"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+  - name: "PrometheusServer"
+    rules:
+      - alert: "PrometheusJobMissing"
+        annotations:
+          description: "The prometheus job that scrapes from Ceph is no longer defined, this will effectively mean you'll have no metrics or alerts for the cluster.  Please review the job definitions in the prometheus.yml file of the prometheus instance."
+          summary: "The scrape job for Ceph is missing from Prometheus"
+        expr: "absent(up{job=\"ceph\"})"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.12.1"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "rados"
+    rules:
+      - alert: "CephObjectMissing"
+        annotations:
+          description: "The latest version of a RADOS object can not be found, even though all OSDs are up. I/O requests for this object from clients will block (hang). Resolving this issue may require the object to be rolled back to a prior version manually, and manually verified."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound"
+          summary: "Object(s) marked UNFOUND on cluster {{ $labels.cluster }}"
+        expr: "(ceph_health_detail{name=\"OBJECT_UNFOUND\"} == 1) * on() group_right(cluster) (count(ceph_osd_up == 1) by (cluster) == bool count(ceph_osd_metadata) by(cluster)) == 1"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.1"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "generic"
+    rules:
+      - alert: "CephDaemonCrash"
+        annotations:
+          description: "One or more daemons have crashed recently, and need to be acknowledged. This notification ensures that software crashes do not go unseen. To acknowledge a crash, use the 'ceph crash archive <id>' command."
+          documentation: "https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-crash"
+          summary: "One or more Ceph daemons have crashed, and are pending acknowledgement on cluster {{ $labels.cluster }}"
+        expr: "ceph_health_detail{name=\"RECENT_CRASH\"} == 1"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.1.2"
+          severity: "critical"
+          type: "ceph_default"
+  - name: "rbdmirror"
+    rules:
+      - alert: "CephRBDMirrorImagesPerDaemonHigh"
+        annotations:
+          description: "Number of image replications per daemon is not supposed to go beyond threshold 100"
+          summary: "Number of image replications are now above 100 on cluster {{ $labels.cluster }}"
+        expr: "sum by (cluster, ceph_daemon, namespace) (ceph_rbd_mirror_snapshot_image_snapshots) > 100"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.2"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImagesNotInSync"
+        annotations:
+          description: "Both local and remote RBD mirror images should be in sync."
+          summary: "Some of the RBD mirror images are not in sync with the remote counter parts on cluster {{ $labels.cluster }}"
+        expr: "sum by (cluster, ceph_daemon, image, namespace, pool) (topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.3"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImagesNotInSyncVeryHigh"
+        annotations:
+          description: "More than 10% of the images have synchronization problems."
+          summary: "Number of unsynchronized images are very high on cluster {{ $labels.cluster }}"
+        expr: "count by (ceph_daemon, cluster) ((topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_local_timestamp) - topk by (cluster, ceph_daemon, image, namespace, pool) (1, ceph_rbd_mirror_snapshot_image_remote_timestamp)) != 0) > (sum by (ceph_daemon, cluster) (ceph_rbd_mirror_snapshot_snapshots)*.1)"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.4"
+          severity: "critical"
+          type: "ceph_default"
+      - alert: "CephRBDMirrorImageTransferBandwidthHigh"
+        annotations:
+          description: "Detected a heavy increase in bandwidth for rbd replications (over 80%) in the last 30 min. This might not be a problem, but it is good to review the number of images being replicated simultaneously"
+          summary: "The replication network usage on cluster {{ $labels.cluster }} has been increased over 80% in the last 30 minutes. Review the number of images being replicated. This alert will be cleaned automatically after 30 minutes"
+        expr: "rate(ceph_rbd_mirror_journal_replay_bytes[30m]) > 0.80"
+        for: "1m"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.10.5"
+          severity: "warning"
+          type: "ceph_default"
+  - name: "nvmeof"
+    rules:
+      - alert: "NVMeoFSubsystemNamespaceLimit"
+        annotations:
+          description: "Subsystems have a max namespace limit defined at creation time. This alert means that no more namespaces can be added to {{ $labels.nqn }}"
+          summary: "{{ $labels.nqn }} subsystem has reached its maximum number of namespaces on cluster {{ $labels.cluster }}"
+        expr: "(count by(nqn, cluster, instance) (ceph_nvmeof_subsystem_namespace_metadata)) >= on(nqn, instance) group_right(cluster) ceph_nvmeof_subsystem_namespace_limit"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFMultipleNamespacesOfRBDImage"
+        annotations:
+          description: "Each NVMeoF namespace must have a unique RBD pool and image, across all different gateway groups."
+          summary: "RBD image {{ $labels.pool_name }}/{{ $labels.rbd_name }} cannot be reused for multiple NVMeoF namespace "
+        expr: "count by(pool_name, rbd_name) (count by(bdev_name, pool_name, rbd_name) (ceph_nvmeof_bdev_metadata and on (bdev_name) ceph_nvmeof_subsystem_namespace_metadata)) > 1"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFTooManyGateways"
+        annotations:
+          description: "You may create many gateways, but 32 is the tested limit"
+          summary: "Max supported gateways exceeded on cluster {{ $labels.cluster }}"
+        expr: "count(ceph_nvmeof_gateway_info) by (cluster) > 32.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFMaxGatewayGroupSize"
+        annotations:
+          description: "You may create many gateways in a gateway group, but 8 is the tested limit"
+          summary: "Max gateways within a gateway group ({{ $labels.group }}) exceeded on cluster {{ $labels.cluster }}"
+        expr: "count(ceph_nvmeof_gateway_info) by (cluster,group) > 8.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFMaxGatewayGroups"
+        annotations:
+          description: "You may create many gateway groups, but 4 is the tested limit"
+          summary: "Max gateway groups exceeded on cluster {{ $labels.cluster }}"
+        expr: "count(count by (group, cluster) (ceph_nvmeof_gateway_info)) by (cluster) > 4.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFSingleGateway"
+        annotations:
+          description: "Although a single member gateway group is valid, it should only be used for test purposes"
+          summary: "The gateway group {{ $labels.group }} consists of a single gateway - HA is not possible on cluster {{ $labels.cluster }}"
+        expr: "count(ceph_nvmeof_gateway_info) by(cluster,group) == 1"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighGatewayCPU"
+        annotations:
+          description: "Typically, high CPU may indicate degraded performance. Consider increasing the number of reactor cores"
+          summary: "CPU used by {{ $labels.instance }} NVMe-oF Gateway is high on cluster {{ $labels.cluster }}"
+        expr: "label_replace(avg by(instance, cluster) (rate(ceph_nvmeof_reactor_seconds_total{mode=\"busy\"}[1m])),\"instance\",\"$1\",\"instance\",\"(.*):.*\") > 80.00"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFGatewayOpenSecurity"
+        annotations:
+          description: "It is good practice to ensure subsystems use host security to reduce the risk of unexpected data loss"
+          summary: "Subsystem {{ $labels.nqn }} has been defined without host level security on cluster {{ $labels.cluster }}"
+        expr: "ceph_nvmeof_subsystem_metadata{allow_any_host=\"yes\"}"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFTooManySubsystems"
+        annotations:
+          description: "NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded the supported maximum of 128 subsystems. Current count: {{ $value }}."
+          summary: "The number of subsystems defined to the NVMeoF gateway reached or exceeded the supported values on cluster {{ $labels.cluster }}"
+        expr: "count by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_metadata,\"gateway_host\",\"$1\",\"instance\",\"(.*?)(?::.*)?\")) >= 128.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFTooManyNamespaces"
+        annotations:
+          description: "NVMeoF gateway {{ $labels.gateway_host }} has reached or exceeded the supported maximum of 4096 namespaces. Current count: {{ $value }}."
+          summary: "The number of namespaces defined to the NVMeoF gateway reached or exceeded supported values on cluster {{ $labels.cluster }}"
+        expr: "sum by(gateway_host, cluster) (label_replace(ceph_nvmeof_subsystem_namespace_count,\"gateway_host\",\"$1\",\"instance\",\"(.*?)(?::.*)?\")) >= 4096.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFVersionMismatch"
+        annotations:
+          description: "This may indicate an issue with deployment. Check cephadm logs"
+          summary: "Too many different NVMe-oF gateway releases active on cluster {{ $labels.cluster }}"
+        expr: "count(count(ceph_nvmeof_gateway_info) by (cluster, version)) by (cluster) > 1"
+        for: "1h"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighClientCount"
+        annotations:
+          description: "The supported limit for clients connecting to a subsystem is 128"
+          summary: "The number of clients connected to {{ $labels.nqn }} is too high on cluster {{ $labels.cluster }}"
+        expr: "ceph_nvmeof_subsystem_host_count > 128.00"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFMissingListener"
+        annotations:
+          description: "For every subsystem, each gateway should have a listener to balance traffic between gateways."
+          summary: "No listener added for {{ $labels.instance }} NVMe-oF Gateway to {{ $labels.nqn }} subsystem"
+        expr: "ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count) by (nqn) > 0"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFZeroListenerSubsystem"
+        annotations:
+          description: "NVMeoF gateway configuration incomplete; one of the subsystems have zero listeners."
+          summary: "No listeners added to {{ $labels.nqn }} subsystem"
+        expr: "sum(ceph_nvmeof_subsystem_listener_count) by (nqn) == 0"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighHostCPU"
+        annotations:
+          description: "High CPU on a gateway host can lead to CPU contention and performance degradation"
+          summary: "The CPU is high ({{ $value }}%) on NVMeoF Gateway host ({{ $labels.host }}) on cluster {{ $labels.cluster }}"
+        expr: "100-((100*(avg by(cluster,host) (label_replace(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]),\"host\",\"$1\",\"instance\",\"(.*):.*\")) * on(cluster, host) group_right label_replace(ceph_nvmeof_gateway_info,\"host\",\"$1\",\"instance\",\"(.*):.*\")))) >= 80.00"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFInterfaceDown"
+        annotations:
+          description: "A NIC used by one or more subsystems is in a down state"
+          summary: "Network interface {{ $labels.device }} is down on cluster {{ $labels.cluster }}"
+        expr: "ceph_nvmeof_subsystem_listener_iface_info{operstate=\"down\"}"
+        for: "30s"
+        labels:
+          oid: "1.3.6.1.4.1.50495.1.2.1.14.1"
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFInterfaceDuplex"
+        annotations:
+          description: "Until this is resolved, performance from the gateway will be degraded"
+          summary: "Network interface {{ $labels.device }} is not running in full duplex mode on cluster {{ $labels.cluster }}"
+        expr: "ceph_nvmeof_subsystem_listener_iface_info{duplex!=\"full\"}"
+        for: "30s"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighReadLatency"
+        annotations:
+          description: "High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate"
+          summary: "The average read latency over the last 5 mins has reached 10 ms or more on {{ $labels.gateway }}"
+        expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_read_seconds_total[1m]) / rate(ceph_nvmeof_bdev_reads_completed_total[1m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.01"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHighWriteLatency"
+        annotations:
+          description: "High latencies may indicate a constraint within the cluster e.g. CPU, network. Please investigate"
+          summary: "The average write latency over the last 5 mins has reached 20 ms or more on {{ $labels.gateway }}"
+        expr: "label_replace((avg by(instance) ((rate(ceph_nvmeof_bdev_write_seconds_total[5m]) / rate(ceph_nvmeof_bdev_writes_completed_total[5m])))),\"gateway\",\"$1\",\"instance\",\"(.*):.*\") > 0.02"
+        for: "5m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFHostKeepAliveTimeout"
+        annotations:
+          description: "Host was disconnected due to host keep alive timeout"
+          summary: "Host ({{ $labels.host_nqn }}) was disconnected {{ $value }} times from subsystem ({{ $labels.nqn }}) in last 24 hours"
+        expr: "ceil(changes(ceph_nvmeof_host_keepalive_timeout[24h:]) / 2) > 0"
+        for: "1m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"

--- a/src/go/plugin/go.d/collector/weblog/ceph_rgw_test.go
+++ b/src/go/plugin/go.d/collector/weblog/ceph_rgw_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package weblog
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/logs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollector_CephRGWAccessLogParsesTotalTimeMilliseconds(t *testing.T) {
+	record := []byte(`{"remote_addr":"192.0.2.10","uri":"GET /bucket/object HTTP/1.1","http_status":"200",` +
+		`"bytes_sent":"1024","total_time":"17"}` + "\n")
+
+	cfg := Config{
+		ParserConfig: logs.ParserConfig{
+			LogType: logs.TypeJSON,
+			JSON: logs.JSONConfig{
+				Mapping: map[string]string{
+					"remote_addr": "remote_addr",
+					"uri":         "request",
+					"http_status": "status",
+					"bytes_sent":  "bytes_sent",
+					"total_time":  "total_time",
+				},
+			},
+		},
+		CustomNumericFields: []customNumericField{{Name: "total_time", Units: "milliseconds"}},
+		Path:                "testdata/ceph_rgw_access.json",
+		ExcludePath:         "*.gz",
+	}
+	collr := New()
+	collr.Config = cfg
+	require.NoError(t, collr.Init(context.Background()))
+	defer collr.Cleanup(context.Background())
+
+	parser, err := logs.NewJSONParser(collr.ParserConfig.JSON, bytes.NewReader(record))
+	require.NoError(t, err)
+
+	collr.line.reset()
+	require.NoError(t, parser.Parse(record, collr.line))
+
+	var total string
+	for _, custom := range collr.line.custom.values {
+		if custom.name == "total_time" {
+			total = custom.value
+		}
+	}
+	require.Equal(t, "17", total)
+	require.Contains(t, collr.customNumericFields, "total_time")
+}

--- a/src/go/plugin/go.d/collector/weblog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/weblog/metadata.yaml
@@ -297,7 +297,23 @@ modules:
           folding:
             title: Config
             enabled: true
-          list: []
+          list:
+            - name: Ceph RGW access log
+              description: Parse a Ceph RGW access log and expose its numeric total_time field explicitly as milliseconds.
+              config: |
+                jobs:
+                  - name: ceph_rgw_access_log
+                    path: /var/log/ceph/rgw/access.log
+                    log_type: json
+                    json_config:
+                      mapping:
+                        remote_addr: remote_addr
+                        uri: request
+                        http_status: status
+                        bytes_sent: bytes_sent
+                    custom_numeric_fields:
+                      - name: total_time
+                        units: milliseconds
     troubleshooting:
       problems:
         list:

--- a/src/go/plugin/go.d/collector/weblog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/weblog/metadata.yaml
@@ -271,6 +271,66 @@ modules:
                     label1: field1
                     label2: field2
                 ```
+            - name: custom_fields
+              description: List of custom text fields to collect per request.
+              default_value: '[]'
+              required: false
+              group: Custom fields
+            - name: custom_fields.name
+              description: Field name used for lookup in the parsed log and chart dimensions.
+              default_value: ''
+              required: true
+              group: Custom fields
+            - name: custom_fields.pattern
+              description: Pattern used to match the custom field.
+              default_value: ''
+              required: true
+              group: Custom fields
+            - name: custom_time_fields
+              description: List of custom duration fields to collect per request.
+              default_value: '[]'
+              required: false
+              group: Custom fields
+            - name: custom_time_fields.name
+              description: Field name used for lookup in the parsed log.
+              default_value: ''
+              required: true
+              group: Custom fields
+            - name: custom_time_fields.pattern
+              description: Pattern used to match the custom duration field.
+              default_value: ''
+              required: true
+              group: Custom fields
+            - name: custom_time_fields.units
+              description: Duration units rendered on the custom time-field charts.
+              default_value: ''
+              required: true
+              group: Custom fields
+            - name: custom_numeric_fields
+              description: List of custom numeric fields to collect per request.
+              default_value: '[]'
+              required: false
+              group: Custom fields
+            - name: custom_numeric_fields.name
+              description: Field name used for lookup in the parsed log.
+              default_value: ''
+              required: true
+              group: Custom fields
+            - name: custom_numeric_fields.units
+              description: Units rendered on the custom numeric-field charts.
+              default_value: ''
+              required: true
+              group: Custom fields
+            - name: custom_numeric_fields.multiplier
+              description: Multiplier applied to the custom numeric field.
+              default_value: 1
+              required: false
+              group: Custom fields
+            - name: custom_numeric_fields.divisor
+              description: Divisor applied to the custom numeric field.
+              default_value: 1
+              required: false
+              group: Custom fields
             - name: regexp_config
               description: RegExp log parser config.
               default_value: ""

--- a/src/go/plugin/go.d/collector/weblog/metadata.yaml
+++ b/src/go/plugin/go.d/collector/weblog/metadata.yaml
@@ -281,8 +281,13 @@ modules:
               default_value: ''
               required: true
               group: Custom fields
-            - name: custom_fields.pattern
-              description: Pattern used to match the custom field.
+            - name: custom_fields.patterns.name
+              description: Dimension name for a custom-field pattern.
+              default_value: ''
+              required: true
+              group: Custom fields
+            - name: custom_fields.patterns.match
+              description: Pattern matched against the custom-field value. Match syntax in [matcher](/src/go/pkg/matcher/README.md#supported-format).
               default_value: ''
               required: true
               group: Custom fields
@@ -296,15 +301,10 @@ modules:
               default_value: ''
               required: true
               group: Custom fields
-            - name: custom_time_fields.pattern
-              description: Pattern used to match the custom duration field.
-              default_value: ''
-              required: true
-              group: Custom fields
-            - name: custom_time_fields.units
-              description: Duration units rendered on the custom time-field charts.
-              default_value: ''
-              required: true
+            - name: custom_time_fields.histogram
+              description: Histogram buckets, in seconds. Summary charts always render milliseconds.
+              default_value: '[]'
+              required: false
               group: Custom fields
             - name: custom_numeric_fields
               description: List of custom numeric fields to collect per request.

--- a/src/go/plugin/go.d/collector/weblog/testdata/ceph_rgw_access.json
+++ b/src/go/plugin/go.d/collector/weblog/testdata/ceph_rgw_access.json
@@ -1,0 +1,1 @@
+{"remote_addr":"192.0.2.10","uri":"GET /bucket/object HTTP/1.1","http_status":"200","bytes_sent":"1024","total_time":"17"}

--- a/src/go/plugin/go.d/collector/x509check/metadata.yaml
+++ b/src/go/plugin/go.d/collector/x509check/metadata.yaml
@@ -113,6 +113,13 @@ modules:
             title: Config
             enabled: true
           list:
+            - name: Ceph RGW certificate
+              description: Check the certificate presented by a Ceph RGW HTTPS endpoint.
+              config: |
+                jobs:
+                  - name: ceph_rgw_cert
+                    source: https://rgw.example.org:443
+                    check_revocation_status: yes
             - name: Website certificate
               description: Website certificate.
               config: |

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -28,19 +28,6 @@ fallback_type:
     - ceph_rbd_mirror_metadata
     - ceph_rgw_metadata
     - ceph_smb_metadata
-autogen:
-  selector:
-    deny:
-      - ceph_hardware_cpu_cores
-      - ceph_hardware_fan_rpm
-      - ceph_hardware_health
-      - ceph_hardware_memory_capacity_bytes
-      - ceph_hardware_storage_capacity_bytes
-      - ceph_hardware_temperature_celsius
-      - ceph_recoverystate_perf_pg_rebuild_duration_count
-      - ceph_recoverystate_perf_pg_rebuild_duration_sum
-      - ceph_recoverystate_perf_pg_rebuild_max_secs
-      - ceph_recoverystate_perf_pg_rebuild_min_secs
 relabeling:
   - match: ceph_*
     metric_relabel_configs:
@@ -519,7 +506,7 @@ template:
               aggregation: sum
             - title: State and Metadata — Metadata
               context: state_metadata
-              units: '{status}'
+              units: monitors
               label_promotion: []
               dimensions:
                 - selector: ceph_mon_metadata
@@ -534,7 +521,7 @@ template:
                 optional_by_labels: []
             - title: State and Metadata — Quorum Status
               context: state_quorum_status
-              units: '{status}'
+              units: monitors
               label_promotion: []
               dimensions:
                 - selector: ceph_mon_quorum_status
@@ -897,7 +884,7 @@ template:
           charts:
             - title: State and Metadata
               context: state
-              units: '{status}'
+              units: OSDs
               label_promotion: []
               dimensions:
                 - selector: ceph_osd_metadata
@@ -934,7 +921,7 @@ template:
               aggregation: sum
             - title: OSD State
               context: state
-              units: '{status}'
+              units: OSDs
               label_promotion: []
               dimensions:
                 - selector: ceph_osd_in

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -4,11352 +4,11352 @@ match: ceph_*
 app: ceph
 fallback_type:
   gauge:
-  - ceph_disk_occupation
-  - ceph_disk_occupation_human
-  - ceph_fs_metadata
-  - ceph_health_status
-  - ceph_mds_metadata
-  - ceph_mon_metadata
-  - ceph_osd_flag_nobackfill
-  - ceph_osd_flag_nodeep_scrub
-  - ceph_osd_flag_nodown
-  - ceph_osd_flag_noin
-  - ceph_osd_flag_noout
-  - ceph_osd_flag_norebalance
-  - ceph_osd_flag_norecover
-  - ceph_osd_flag_noscrub
-  - ceph_osd_flag_noup
-  - ceph_osd_in
-  - ceph_osd_metadata
-  - ceph_osd_up
-  - ceph_osd_weight
-  - ceph_pool_metadata
-  - ceph_rbd_image_metadata
-  - ceph_rbd_mirror_metadata
-  - ceph_rgw_metadata
-  - ceph_smb_metadata
+    - ceph_disk_occupation
+    - ceph_disk_occupation_human
+    - ceph_fs_metadata
+    - ceph_health_status
+    - ceph_mds_metadata
+    - ceph_mon_metadata
+    - ceph_osd_flag_nobackfill
+    - ceph_osd_flag_nodeep_scrub
+    - ceph_osd_flag_nodown
+    - ceph_osd_flag_noin
+    - ceph_osd_flag_noout
+    - ceph_osd_flag_norebalance
+    - ceph_osd_flag_norecover
+    - ceph_osd_flag_noscrub
+    - ceph_osd_flag_noup
+    - ceph_osd_in
+    - ceph_osd_metadata
+    - ceph_osd_up
+    - ceph_osd_weight
+    - ceph_pool_metadata
+    - ceph_rbd_image_metadata
+    - ceph_rbd_mirror_metadata
+    - ceph_rgw_metadata
+    - ceph_smb_metadata
 autogen:
   selector:
     deny:
-    - ceph_hardware_cpu_cores
-    - ceph_hardware_fan_rpm
-    - ceph_hardware_health
-    - ceph_hardware_memory_capacity_bytes
-    - ceph_hardware_storage_capacity_bytes
-    - ceph_hardware_temperature_celsius
-    - ceph_recoverystate_perf_pg_rebuild_duration_count
-    - ceph_recoverystate_perf_pg_rebuild_duration_sum
-    - ceph_recoverystate_perf_pg_rebuild_max_secs
-    - ceph_recoverystate_perf_pg_rebuild_min_secs
+      - ceph_hardware_cpu_cores
+      - ceph_hardware_fan_rpm
+      - ceph_hardware_health
+      - ceph_hardware_memory_capacity_bytes
+      - ceph_hardware_storage_capacity_bytes
+      - ceph_hardware_temperature_celsius
+      - ceph_recoverystate_perf_pg_rebuild_duration_count
+      - ceph_recoverystate_perf_pg_rebuild_duration_sum
+      - ceph_recoverystate_perf_pg_rebuild_max_secs
+      - ceph_recoverystate_perf_pg_rebuild_min_secs
 relabeling:
-- match: ceph_*
-  metric_relabel_configs:
-  - regex: instance
-    action: labelmap
-    replacement: ceph_instance
-  - regex: instance
-    action: labeldrop
-- match: '!ceph_data_sync_from_zone_* ceph_data_sync_from_*'
-  metric_relabel_configs:
-  - source_labels:
-    - source_zone
-    - __name__
-    regex: ;ceph_data_sync_from_.+_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
-    action: drop
-  - source_labels:
-    - __name__
-    regex: ceph_data_sync_from_(.+?)_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
-    target_label: source_zone_fragment
-    replacement: ${1}
-  - source_labels:
-    - source_zone_fragment
-    - source_zone
-    regex: (.+);(.+)
-    target_label: source_zone
-    replacement: ${1}_${2}
-  - source_labels:
-    - __name__
-    regex: ceph_data_sync_from_(.+?)_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
-    target_label: __name__
-    replacement: ceph_data_sync_from_zone_${2}
-  - regex: source_zone_fragment
-    action: labeldrop
-- match: ceph_port*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_port(.+?)_(dpdk_device_receive_multicast_packets|dpdk_device_receive_dropped_errors|dpdk_device_receive_badcrc_errors|dpdk_device_receive_nombuf_errors|dpdk_device_receive_total_errors|dpdk_device_send_total_errors)
-    target_label: dpdk_port
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_port(.+?)_(dpdk_device_receive_multicast_packets|dpdk_device_receive_dropped_errors|dpdk_device_receive_badcrc_errors|dpdk_device_receive_nombuf_errors|dpdk_device_receive_total_errors|dpdk_device_send_total_errors)
-    target_label: __name__
-    replacement: ceph_dpdk_port_${2}
-- match: ceph_queue*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_queue(.+?)_(dpdk_receive_bad_checksum_errors|dpdk_receive_no_memory_errors|dpdk_receive_linearize_ops|dpdk_receive_copy_bytes|dpdk_receive_last_bunch|dpdk_send_linearize_ops|dpdk_receive_fragments|dpdk_send_queue_length|dpdk_receive_copy_ops|dpdk_receive_packets|dpdk_send_copy_bytes|dpdk_send_last_bunch|dpdk_send_fragments|dpdk_receive_bytes|dpdk_send_copy_ops|dpdk_send_packets|dpdk_send_bytes)
-    target_label: dpdk_queue
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_queue(.+?)_(dpdk_receive_bad_checksum_errors|dpdk_receive_no_memory_errors|dpdk_receive_linearize_ops|dpdk_receive_copy_bytes|dpdk_receive_last_bunch|dpdk_send_linearize_ops|dpdk_receive_fragments|dpdk_send_queue_length|dpdk_receive_copy_ops|dpdk_receive_packets|dpdk_send_copy_bytes|dpdk_send_last_bunch|dpdk_send_fragments|dpdk_receive_bytes|dpdk_send_copy_ops|dpdk_send_packets|dpdk_send_bytes)
-    target_label: __name__
-    replacement: ceph_dpdk_queue_${2}
-- match: ceph_finisher_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_finisher_(.+?)_(complete_latency_count|complete_latency_sum|queue_len)
-    target_label: finisher_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_finisher_(.+?)_(complete_latency_count|complete_latency_sum|queue_len)
-    target_label: __name__
-    replacement: ceph_finisher_${2}
-- match: ceph_blk_kernel_device_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_blk_kernel_device_(.+?)_(discard_threads|discard_op)
-    target_label: kernel_device_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_blk_kernel_device_(.+?)_(discard_threads|discard_op)
-    target_label: __name__
-    replacement: ceph_kernel_device_${2}
-- match: '!ceph_librbd_pwl_* ceph_librbd_*'
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_librbd_(.+?)_(discard_latency_count|discard_latency_sum|flush_latency_count|lock_acquired_time|cmp_latency_count|flush_latency_sum|invalidate_cache|rd_latency_count|wr_latency_count|ws_latency_count|cmp_latency_sum|readahead_bytes|rd_latency_sum|wr_latency_sum|ws_latency_sum|discard_bytes|snap_rollback|opened_time|snap_create|snap_remove|snap_rename|cmp_bytes|readahead|rd_bytes|wr_bytes|ws_bytes|discard|notify|resize|flush|cmp|rd|wr|ws)
-    target_label: librbd_image_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_librbd_(.+?)_(discard_latency_count|discard_latency_sum|flush_latency_count|lock_acquired_time|cmp_latency_count|flush_latency_sum|invalidate_cache|rd_latency_count|wr_latency_count|ws_latency_count|cmp_latency_sum|readahead_bytes|rd_latency_sum|wr_latency_sum|ws_latency_sum|discard_bytes|snap_rollback|opened_time|snap_create|snap_remove|snap_rename|cmp_bytes|readahead|rd_bytes|wr_bytes|ws_bytes|discard|notify|resize|flush|cmp|rd|wr|ws)
-    target_label: __name__
-    replacement: ceph_rbd_librbd_image_${2}
-- match: ceph_librbd_pwl_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_librbd_pwl_(.+?)_(caller_wr_latency_nw_count|req_all_to_dis_nw_t_count|req_arr_to_all_nw_t_count|req_arr_to_dis_nw_t_count|caller_wr_latency_nw_sum|caller_wr_latency_count|req_all_to_dis_nw_t_sum|req_arr_to_all_nw_t_sum|req_arr_to_dis_nw_t_sum|op_app_to_appc_t_count|op_buf_to_bufc_t_count|req_all_to_dis_t_count|req_arr_to_all_t_count|req_arr_to_dis_t_count|caller_wr_latency_sum|op_app_to_cmp_t_count|op_buf_to_app_t_count|op_dis_to_app_t_count|op_dis_to_buf_t_count|op_dis_to_cmp_t_count|hit_rd_latency_count|op_app_to_appc_t_sum|op_buf_to_bufc_t_sum|req_all_to_dis_t_sum|req_arr_to_all_t_sum|req_arr_to_dis_t_sum|aio_flush_lat_count|append_tx_lat_count|op_app_to_cmp_t_sum|op_buf_to_app_t_sum|op_dis_to_app_t_sum|op_dis_to_buf_t_sum|op_dis_to_cmp_t_sum|retire_tx_lat_count|wr_latency_nw_count|writeback_lat_count|hit_rd_latency_sum|log_op_bytes_count|aio_flush_lat_sum|append_tx_lat_sum|discard_lat_count|retire_tx_lat_sum|wr_latency_nw_sum|writeback_lat_sum|log_op_bytes_sum|op_alloc_t_count|rd_latency_count|wr_latency_count|discard_lat_sum|internal_flush|op_alloc_t_sum|rd_latency_sum|wr_latency_sum|aio_flush_def|cmp_lat_count|discard_bytes|rd_hit_bytes|wr_def_lanes|wr_q_barrier|ws_lat_count|cmp_lat_sum|part_hit_rd|invalidate|wr_def_buf|wr_def_log|wr_overlap|ws_lat_sum|aio_flush|cmp_bytes|cmp_fails|rd_bytes|wr_bytes|ws_bytes|discard|log_ops|hit_rd|wr_def|cmp|rd|wr|ws)
-    target_label: librbd_pwl_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_librbd_pwl_(.+?)_(caller_wr_latency_nw_count|req_all_to_dis_nw_t_count|req_arr_to_all_nw_t_count|req_arr_to_dis_nw_t_count|caller_wr_latency_nw_sum|caller_wr_latency_count|req_all_to_dis_nw_t_sum|req_arr_to_all_nw_t_sum|req_arr_to_dis_nw_t_sum|op_app_to_appc_t_count|op_buf_to_bufc_t_count|req_all_to_dis_t_count|req_arr_to_all_t_count|req_arr_to_dis_t_count|caller_wr_latency_sum|op_app_to_cmp_t_count|op_buf_to_app_t_count|op_dis_to_app_t_count|op_dis_to_buf_t_count|op_dis_to_cmp_t_count|hit_rd_latency_count|op_app_to_appc_t_sum|op_buf_to_bufc_t_sum|req_all_to_dis_t_sum|req_arr_to_all_t_sum|req_arr_to_dis_t_sum|aio_flush_lat_count|append_tx_lat_count|op_app_to_cmp_t_sum|op_buf_to_app_t_sum|op_dis_to_app_t_sum|op_dis_to_buf_t_sum|op_dis_to_cmp_t_sum|retire_tx_lat_count|wr_latency_nw_count|writeback_lat_count|hit_rd_latency_sum|log_op_bytes_count|aio_flush_lat_sum|append_tx_lat_sum|discard_lat_count|retire_tx_lat_sum|wr_latency_nw_sum|writeback_lat_sum|log_op_bytes_sum|op_alloc_t_count|rd_latency_count|wr_latency_count|discard_lat_sum|internal_flush|op_alloc_t_sum|rd_latency_sum|wr_latency_sum|aio_flush_def|cmp_lat_count|discard_bytes|rd_hit_bytes|wr_def_lanes|wr_q_barrier|ws_lat_count|cmp_lat_sum|part_hit_rd|invalidate|wr_def_buf|wr_def_log|wr_overlap|ws_lat_sum|aio_flush|cmp_bytes|cmp_fails|rd_bytes|wr_bytes|ws_bytes|discard|log_ops|hit_rd|wr_def|cmp|rd|wr|ws)
-    target_label: __name__
-    replacement: ceph_rbd_librbd_pwl_${2}
-- match: ceph_mclock_shard_queue_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_mclock_shard_queue_(.+?)_(mclock_best_effort_queue_len|mclock_immediate_queue_len|mclock_all_type_queue_len|mclock_recovery_queue_len|mclock_client_queue_len)
-    target_label: mclock_shard
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_mclock_shard_queue_(.+?)_(mclock_best_effort_queue_len|mclock_immediate_queue_len|mclock_all_type_queue_len|mclock_recovery_queue_len|mclock_client_queue_len)
-    target_label: __name__
-    replacement: ceph_mclock_shard_${2}
-- match: ceph_mds_client_metrics_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_mds_client_metrics_(.+?)_(avg_metadata_latency|avg_write_latency|dentry_lease_hits|dentry_lease_miss|avg_read_latency|total_write_size|total_read_size|total_write_ops|total_read_ops|opened_inodes|opened_files|pinned_icaps|total_inodes|cap_hits|cap_miss)
-    target_label: mds_filesystem_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_mds_client_metrics_(.+?)_(avg_metadata_latency|avg_write_latency|dentry_lease_hits|dentry_lease_miss|avg_read_latency|total_write_size|total_read_size|total_write_ops|total_read_ops|opened_inodes|opened_files|pinned_icaps|total_inodes|cap_hits|cap_miss)
-    target_label: __name__
-    replacement: ceph_mds_per_client_${2}
-- match: ceph_AsyncMessenger_Worker_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_AsyncMessenger_Worker_(.+?)_(msgr_send_messages_queue_lat_count|msgr_send_messages_queue_lat_sum|msgr_running_fast_dispatch_time|msgr_handle_ack_lat_count|msgr_recv_encrypted_bytes|msgr_send_encrypted_bytes|msgr_created_connections|msgr_active_connections|msgr_handle_ack_lat_sum|msgr_running_total_time|msgr_running_recv_time|msgr_running_send_time|msgr_recv_messages|msgr_send_messages|msgr_recv_bytes|msgr_send_bytes)
-    target_label: messenger_worker
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_AsyncMessenger_Worker_(.+?)_(msgr_send_messages_queue_lat_count|msgr_send_messages_queue_lat_sum|msgr_running_fast_dispatch_time|msgr_handle_ack_lat_count|msgr_recv_encrypted_bytes|msgr_send_encrypted_bytes|msgr_created_connections|msgr_active_connections|msgr_handle_ack_lat_sum|msgr_running_total_time|msgr_running_recv_time|msgr_running_send_time|msgr_recv_messages|msgr_send_messages|msgr_recv_bytes|msgr_send_bytes)
-    target_label: __name__
-    replacement: ceph_async_messenger_worker_${2}
-- match: ceph_objectcacher_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_objectcacher_(.+?)_(data_overwritten_while_flushing|write_bytes_blocked|write_time_blocked|write_ops_blocked|cache_bytes_miss|cache_bytes_hit|cache_ops_miss|cache_ops_hit|data_flushed|data_written|data_read)
-    target_label: objectcacher_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_objectcacher_(.+?)_(data_overwritten_while_flushing|write_bytes_blocked|write_time_blocked|write_ops_blocked|cache_bytes_miss|cache_bytes_hit|cache_ops_miss|cache_ops_hit|data_flushed|data_written|data_read)
-    target_label: __name__
-    replacement: ceph_objectcacher_${2}
-- match: ceph_objecter_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_objecter_(.+?)_(replica_read_completed|replica_read_bounced|osdop_src_cmpxattr|osd_session_close|osdop_pgls_filter|osdop_resetxattrs|osdop_sparse_read|replica_read_sent|op_latency_count|osd_session_open|osdop_clonerange|oplen_avg_count|osdop_writefull|osdop_writesame|poolstat_active|poolstat_resend|command_active|command_resend|op_latency_sum|osdop_cmpxattr|osdop_getxattr|osdop_setxattr|osdop_truncate|linger_active|linger_resend|op_send_bytes|oplen_avg_sum|osdop_rmxattr|poolop_active|poolop_resend|poolstat_send|statfs_active|statfs_resend|command_send|osd_sessions|osdop_append|osdop_create|osdop_delete|osdop_mapext|osdop_notify|linger_ping|linger_send|op_inflight|osdop_other|osdop_watch|osdop_write|poolop_send|statfs_send|osdop_call|osdop_pgls|osdop_read|osdop_stat|osdop_zero|map_epoch|op_active|op_resend|osd_laggy|map_full|omap_del|op_laggy|op_reply|map_inc|omap_rd|omap_wr|op_send|op_rmw|op_pg|op_r|op_w|op)
-    target_label: objecter_handle
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_objecter_(.+?)_(replica_read_completed|replica_read_bounced|osdop_src_cmpxattr|osd_session_close|osdop_pgls_filter|osdop_resetxattrs|osdop_sparse_read|replica_read_sent|op_latency_count|osd_session_open|osdop_clonerange|oplen_avg_count|osdop_writefull|osdop_writesame|poolstat_active|poolstat_resend|command_active|command_resend|op_latency_sum|osdop_cmpxattr|osdop_getxattr|osdop_setxattr|osdop_truncate|linger_active|linger_resend|op_send_bytes|oplen_avg_sum|osdop_rmxattr|poolop_active|poolop_resend|poolstat_send|statfs_active|statfs_resend|command_send|osd_sessions|osdop_append|osdop_create|osdop_delete|osdop_mapext|osdop_notify|linger_ping|linger_send|op_inflight|osdop_other|osdop_watch|osdop_write|poolop_send|statfs_send|osdop_call|osdop_pgls|osdop_read|osdop_stat|osdop_zero|map_epoch|op_active|op_resend|osd_laggy|map_full|omap_del|op_laggy|op_reply|map_inc|omap_rd|omap_wr|op_send|op_rmw|op_pg|op_r|op_w|op)
-    target_label: __name__
-    replacement: ceph_objecter_${2}
-- match: ceph_AsyncMessenger_RDMAWorker_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_AsyncMessenger_RDMAWorker_(.+?)_(pending_sent_conns|tx_failed_post|tx_parital_mem|rx_chunks|tx_chunks|tx_no_mem|rx_bytes|tx_bytes)
-    target_label: rdma_worker
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_AsyncMessenger_RDMAWorker_(.+?)_(pending_sent_conns|tx_failed_post|tx_parital_mem|rx_chunks|tx_chunks|tx_no_mem|rx_bytes|tx_bytes)
-    target_label: __name__
-    replacement: ceph_async_messenger_rdma_worker_${2}
-- match: ceph_rocksdb_cache_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_rocksdb_cache_(.+?)_(capacity|inserts|lookups|misses|pinned|elems|usage|hits)
-    target_label: rocksdb_cache_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_rocksdb_cache_(.+?)_(capacity|inserts|lookups|misses|pinned|elems|usage|hits)
-    target_label: __name__
-    replacement: ceph_rocksdb_binned_cache_${2}
-- match: ceph_service_unique_id_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_service_unique_id_(.+)
-    target_label: service_unique_id
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_service_unique_id_(.+)
-    target_label: __name__
-    replacement: ceph_service_unique_id
-- match: ceph_throttle_*
-  metric_relabel_configs:
-  - source_labels:
-    - __name__
-    regex: ceph_throttle_(.+?)_(get_or_fail_success|get_or_fail_fail|get_started|wait_count|take_sum|wait_sum|get_sum|put_sum|take|get|max|put|val)
-    target_label: throttle_key
-    replacement: ${1}
-  - source_labels:
-    - __name__
-    regex: ceph_throttle_(.+?)_(get_or_fail_success|get_or_fail_fail|get_started|wait_count|take_sum|wait_sum|get_sum|put_sum|take|get|max|put|val)
-    target_label: __name__
-    replacement: ceph_throttle_${2}
+  - match: ceph_*
+    metric_relabel_configs:
+      - regex: instance
+        action: labelmap
+        replacement: ceph_instance
+      - regex: instance
+        action: labeldrop
+  - match: '!ceph_data_sync_from_zone_* ceph_data_sync_from_*'
+    metric_relabel_configs:
+      - source_labels:
+          - source_zone
+          - __name__
+        regex: ;ceph_data_sync_from_.+_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
+        action: drop
+      - source_labels:
+          - __name__
+        regex: ceph_data_sync_from_(.+?)_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
+        target_label: source_zone_fragment
+        replacement: ${1}
+      - source_labels:
+          - source_zone_fragment
+          - source_zone
+        regex: (.+);(.+)
+        target_label: source_zone
+        replacement: ${1}_${2}
+      - source_labels:
+          - __name__
+        regex: ceph_data_sync_from_(.+?)_(fetch_not_modified|lock_latency_count|poll_latency_count|fetch_bytes_count|lock_latency_sum|poll_latency_sum|fetch_bytes_sum|fetch_errors|poll_errors)
+        target_label: __name__
+        replacement: ceph_data_sync_from_zone_${2}
+      - regex: source_zone_fragment
+        action: labeldrop
+  - match: ceph_port*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_port(.+?)_(dpdk_device_receive_multicast_packets|dpdk_device_receive_dropped_errors|dpdk_device_receive_badcrc_errors|dpdk_device_receive_nombuf_errors|dpdk_device_receive_total_errors|dpdk_device_send_total_errors)
+        target_label: dpdk_port
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_port(.+?)_(dpdk_device_receive_multicast_packets|dpdk_device_receive_dropped_errors|dpdk_device_receive_badcrc_errors|dpdk_device_receive_nombuf_errors|dpdk_device_receive_total_errors|dpdk_device_send_total_errors)
+        target_label: __name__
+        replacement: ceph_dpdk_port_${2}
+  - match: ceph_queue*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_queue(.+?)_(dpdk_receive_bad_checksum_errors|dpdk_receive_no_memory_errors|dpdk_receive_linearize_ops|dpdk_receive_copy_bytes|dpdk_receive_last_bunch|dpdk_send_linearize_ops|dpdk_receive_fragments|dpdk_send_queue_length|dpdk_receive_copy_ops|dpdk_receive_packets|dpdk_send_copy_bytes|dpdk_send_last_bunch|dpdk_send_fragments|dpdk_receive_bytes|dpdk_send_copy_ops|dpdk_send_packets|dpdk_send_bytes)
+        target_label: dpdk_queue
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_queue(.+?)_(dpdk_receive_bad_checksum_errors|dpdk_receive_no_memory_errors|dpdk_receive_linearize_ops|dpdk_receive_copy_bytes|dpdk_receive_last_bunch|dpdk_send_linearize_ops|dpdk_receive_fragments|dpdk_send_queue_length|dpdk_receive_copy_ops|dpdk_receive_packets|dpdk_send_copy_bytes|dpdk_send_last_bunch|dpdk_send_fragments|dpdk_receive_bytes|dpdk_send_copy_ops|dpdk_send_packets|dpdk_send_bytes)
+        target_label: __name__
+        replacement: ceph_dpdk_queue_${2}
+  - match: ceph_finisher_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_finisher_(.+?)_(complete_latency_count|complete_latency_sum|queue_len)
+        target_label: finisher_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_finisher_(.+?)_(complete_latency_count|complete_latency_sum|queue_len)
+        target_label: __name__
+        replacement: ceph_finisher_${2}
+  - match: ceph_blk_kernel_device_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_blk_kernel_device_(.+?)_(discard_threads|discard_op)
+        target_label: kernel_device_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_blk_kernel_device_(.+?)_(discard_threads|discard_op)
+        target_label: __name__
+        replacement: ceph_kernel_device_${2}
+  - match: '!ceph_librbd_pwl_* ceph_librbd_*'
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_librbd_(.+?)_(discard_latency_count|discard_latency_sum|flush_latency_count|lock_acquired_time|cmp_latency_count|flush_latency_sum|invalidate_cache|rd_latency_count|wr_latency_count|ws_latency_count|cmp_latency_sum|readahead_bytes|rd_latency_sum|wr_latency_sum|ws_latency_sum|discard_bytes|snap_rollback|opened_time|snap_create|snap_remove|snap_rename|cmp_bytes|readahead|rd_bytes|wr_bytes|ws_bytes|discard|notify|resize|flush|cmp|rd|wr|ws)
+        target_label: librbd_image_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_librbd_(.+?)_(discard_latency_count|discard_latency_sum|flush_latency_count|lock_acquired_time|cmp_latency_count|flush_latency_sum|invalidate_cache|rd_latency_count|wr_latency_count|ws_latency_count|cmp_latency_sum|readahead_bytes|rd_latency_sum|wr_latency_sum|ws_latency_sum|discard_bytes|snap_rollback|opened_time|snap_create|snap_remove|snap_rename|cmp_bytes|readahead|rd_bytes|wr_bytes|ws_bytes|discard|notify|resize|flush|cmp|rd|wr|ws)
+        target_label: __name__
+        replacement: ceph_rbd_librbd_image_${2}
+  - match: ceph_librbd_pwl_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_librbd_pwl_(.+?)_(caller_wr_latency_nw_count|req_all_to_dis_nw_t_count|req_arr_to_all_nw_t_count|req_arr_to_dis_nw_t_count|caller_wr_latency_nw_sum|caller_wr_latency_count|req_all_to_dis_nw_t_sum|req_arr_to_all_nw_t_sum|req_arr_to_dis_nw_t_sum|op_app_to_appc_t_count|op_buf_to_bufc_t_count|req_all_to_dis_t_count|req_arr_to_all_t_count|req_arr_to_dis_t_count|caller_wr_latency_sum|op_app_to_cmp_t_count|op_buf_to_app_t_count|op_dis_to_app_t_count|op_dis_to_buf_t_count|op_dis_to_cmp_t_count|hit_rd_latency_count|op_app_to_appc_t_sum|op_buf_to_bufc_t_sum|req_all_to_dis_t_sum|req_arr_to_all_t_sum|req_arr_to_dis_t_sum|aio_flush_lat_count|append_tx_lat_count|op_app_to_cmp_t_sum|op_buf_to_app_t_sum|op_dis_to_app_t_sum|op_dis_to_buf_t_sum|op_dis_to_cmp_t_sum|retire_tx_lat_count|wr_latency_nw_count|writeback_lat_count|hit_rd_latency_sum|log_op_bytes_count|aio_flush_lat_sum|append_tx_lat_sum|discard_lat_count|retire_tx_lat_sum|wr_latency_nw_sum|writeback_lat_sum|log_op_bytes_sum|op_alloc_t_count|rd_latency_count|wr_latency_count|discard_lat_sum|internal_flush|op_alloc_t_sum|rd_latency_sum|wr_latency_sum|aio_flush_def|cmp_lat_count|discard_bytes|rd_hit_bytes|wr_def_lanes|wr_q_barrier|ws_lat_count|cmp_lat_sum|part_hit_rd|invalidate|wr_def_buf|wr_def_log|wr_overlap|ws_lat_sum|aio_flush|cmp_bytes|cmp_fails|rd_bytes|wr_bytes|ws_bytes|discard|log_ops|hit_rd|wr_def|cmp|rd|wr|ws)
+        target_label: librbd_pwl_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_librbd_pwl_(.+?)_(caller_wr_latency_nw_count|req_all_to_dis_nw_t_count|req_arr_to_all_nw_t_count|req_arr_to_dis_nw_t_count|caller_wr_latency_nw_sum|caller_wr_latency_count|req_all_to_dis_nw_t_sum|req_arr_to_all_nw_t_sum|req_arr_to_dis_nw_t_sum|op_app_to_appc_t_count|op_buf_to_bufc_t_count|req_all_to_dis_t_count|req_arr_to_all_t_count|req_arr_to_dis_t_count|caller_wr_latency_sum|op_app_to_cmp_t_count|op_buf_to_app_t_count|op_dis_to_app_t_count|op_dis_to_buf_t_count|op_dis_to_cmp_t_count|hit_rd_latency_count|op_app_to_appc_t_sum|op_buf_to_bufc_t_sum|req_all_to_dis_t_sum|req_arr_to_all_t_sum|req_arr_to_dis_t_sum|aio_flush_lat_count|append_tx_lat_count|op_app_to_cmp_t_sum|op_buf_to_app_t_sum|op_dis_to_app_t_sum|op_dis_to_buf_t_sum|op_dis_to_cmp_t_sum|retire_tx_lat_count|wr_latency_nw_count|writeback_lat_count|hit_rd_latency_sum|log_op_bytes_count|aio_flush_lat_sum|append_tx_lat_sum|discard_lat_count|retire_tx_lat_sum|wr_latency_nw_sum|writeback_lat_sum|log_op_bytes_sum|op_alloc_t_count|rd_latency_count|wr_latency_count|discard_lat_sum|internal_flush|op_alloc_t_sum|rd_latency_sum|wr_latency_sum|aio_flush_def|cmp_lat_count|discard_bytes|rd_hit_bytes|wr_def_lanes|wr_q_barrier|ws_lat_count|cmp_lat_sum|part_hit_rd|invalidate|wr_def_buf|wr_def_log|wr_overlap|ws_lat_sum|aio_flush|cmp_bytes|cmp_fails|rd_bytes|wr_bytes|ws_bytes|discard|log_ops|hit_rd|wr_def|cmp|rd|wr|ws)
+        target_label: __name__
+        replacement: ceph_rbd_librbd_pwl_${2}
+  - match: ceph_mclock_shard_queue_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_mclock_shard_queue_(.+?)_(mclock_best_effort_queue_len|mclock_immediate_queue_len|mclock_all_type_queue_len|mclock_recovery_queue_len|mclock_client_queue_len)
+        target_label: mclock_shard
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_mclock_shard_queue_(.+?)_(mclock_best_effort_queue_len|mclock_immediate_queue_len|mclock_all_type_queue_len|mclock_recovery_queue_len|mclock_client_queue_len)
+        target_label: __name__
+        replacement: ceph_mclock_shard_${2}
+  - match: ceph_mds_client_metrics_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_mds_client_metrics_(.+?)_(avg_metadata_latency|avg_write_latency|dentry_lease_hits|dentry_lease_miss|avg_read_latency|total_write_size|total_read_size|total_write_ops|total_read_ops|opened_inodes|opened_files|pinned_icaps|total_inodes|cap_hits|cap_miss)
+        target_label: mds_filesystem_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_mds_client_metrics_(.+?)_(avg_metadata_latency|avg_write_latency|dentry_lease_hits|dentry_lease_miss|avg_read_latency|total_write_size|total_read_size|total_write_ops|total_read_ops|opened_inodes|opened_files|pinned_icaps|total_inodes|cap_hits|cap_miss)
+        target_label: __name__
+        replacement: ceph_mds_per_client_${2}
+  - match: ceph_AsyncMessenger_Worker_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_AsyncMessenger_Worker_(.+?)_(msgr_send_messages_queue_lat_count|msgr_send_messages_queue_lat_sum|msgr_running_fast_dispatch_time|msgr_handle_ack_lat_count|msgr_recv_encrypted_bytes|msgr_send_encrypted_bytes|msgr_created_connections|msgr_active_connections|msgr_handle_ack_lat_sum|msgr_running_total_time|msgr_running_recv_time|msgr_running_send_time|msgr_recv_messages|msgr_send_messages|msgr_recv_bytes|msgr_send_bytes)
+        target_label: messenger_worker
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_AsyncMessenger_Worker_(.+?)_(msgr_send_messages_queue_lat_count|msgr_send_messages_queue_lat_sum|msgr_running_fast_dispatch_time|msgr_handle_ack_lat_count|msgr_recv_encrypted_bytes|msgr_send_encrypted_bytes|msgr_created_connections|msgr_active_connections|msgr_handle_ack_lat_sum|msgr_running_total_time|msgr_running_recv_time|msgr_running_send_time|msgr_recv_messages|msgr_send_messages|msgr_recv_bytes|msgr_send_bytes)
+        target_label: __name__
+        replacement: ceph_async_messenger_worker_${2}
+  - match: ceph_objectcacher_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_objectcacher_(.+?)_(data_overwritten_while_flushing|write_bytes_blocked|write_time_blocked|write_ops_blocked|cache_bytes_miss|cache_bytes_hit|cache_ops_miss|cache_ops_hit|data_flushed|data_written|data_read)
+        target_label: objectcacher_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_objectcacher_(.+?)_(data_overwritten_while_flushing|write_bytes_blocked|write_time_blocked|write_ops_blocked|cache_bytes_miss|cache_bytes_hit|cache_ops_miss|cache_ops_hit|data_flushed|data_written|data_read)
+        target_label: __name__
+        replacement: ceph_objectcacher_${2}
+  - match: ceph_objecter_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_objecter_(.+?)_(replica_read_completed|replica_read_bounced|osdop_src_cmpxattr|osd_session_close|osdop_pgls_filter|osdop_resetxattrs|osdop_sparse_read|replica_read_sent|op_latency_count|osd_session_open|osdop_clonerange|oplen_avg_count|osdop_writefull|osdop_writesame|poolstat_active|poolstat_resend|command_active|command_resend|op_latency_sum|osdop_cmpxattr|osdop_getxattr|osdop_setxattr|osdop_truncate|linger_active|linger_resend|op_send_bytes|oplen_avg_sum|osdop_rmxattr|poolop_active|poolop_resend|poolstat_send|statfs_active|statfs_resend|command_send|osd_sessions|osdop_append|osdop_create|osdop_delete|osdop_mapext|osdop_notify|linger_ping|linger_send|op_inflight|osdop_other|osdop_watch|osdop_write|poolop_send|statfs_send|osdop_call|osdop_pgls|osdop_read|osdop_stat|osdop_zero|map_epoch|op_active|op_resend|osd_laggy|map_full|omap_del|op_laggy|op_reply|map_inc|omap_rd|omap_wr|op_send|op_rmw|op_pg|op_r|op_w|op)
+        target_label: objecter_handle
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_objecter_(.+?)_(replica_read_completed|replica_read_bounced|osdop_src_cmpxattr|osd_session_close|osdop_pgls_filter|osdop_resetxattrs|osdop_sparse_read|replica_read_sent|op_latency_count|osd_session_open|osdop_clonerange|oplen_avg_count|osdop_writefull|osdop_writesame|poolstat_active|poolstat_resend|command_active|command_resend|op_latency_sum|osdop_cmpxattr|osdop_getxattr|osdop_setxattr|osdop_truncate|linger_active|linger_resend|op_send_bytes|oplen_avg_sum|osdop_rmxattr|poolop_active|poolop_resend|poolstat_send|statfs_active|statfs_resend|command_send|osd_sessions|osdop_append|osdop_create|osdop_delete|osdop_mapext|osdop_notify|linger_ping|linger_send|op_inflight|osdop_other|osdop_watch|osdop_write|poolop_send|statfs_send|osdop_call|osdop_pgls|osdop_read|osdop_stat|osdop_zero|map_epoch|op_active|op_resend|osd_laggy|map_full|omap_del|op_laggy|op_reply|map_inc|omap_rd|omap_wr|op_send|op_rmw|op_pg|op_r|op_w|op)
+        target_label: __name__
+        replacement: ceph_objecter_${2}
+  - match: ceph_AsyncMessenger_RDMAWorker_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_AsyncMessenger_RDMAWorker_(.+?)_(pending_sent_conns|tx_failed_post|tx_parital_mem|rx_chunks|tx_chunks|tx_no_mem|rx_bytes|tx_bytes)
+        target_label: rdma_worker
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_AsyncMessenger_RDMAWorker_(.+?)_(pending_sent_conns|tx_failed_post|tx_parital_mem|rx_chunks|tx_chunks|tx_no_mem|rx_bytes|tx_bytes)
+        target_label: __name__
+        replacement: ceph_async_messenger_rdma_worker_${2}
+  - match: ceph_rocksdb_cache_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_rocksdb_cache_(.+?)_(capacity|inserts|lookups|misses|pinned|elems|usage|hits)
+        target_label: rocksdb_cache_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_rocksdb_cache_(.+?)_(capacity|inserts|lookups|misses|pinned|elems|usage|hits)
+        target_label: __name__
+        replacement: ceph_rocksdb_binned_cache_${2}
+  - match: ceph_service_unique_id_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_service_unique_id_(.+)
+        target_label: service_unique_id
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_service_unique_id_(.+)
+        target_label: __name__
+        replacement: ceph_service_unique_id
+  - match: ceph_throttle_*
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_throttle_(.+?)_(get_or_fail_success|get_or_fail_fail|get_started|wait_count|take_sum|wait_sum|get_sum|put_sum|take|get|max|put|val)
+        target_label: throttle_key
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_throttle_(.+?)_(get_or_fail_success|get_or_fail_fail|get_started|wait_count|take_sum|wait_sum|get_sum|put_sum|take|get|max|put|val)
+        target_label: __name__
+        replacement: ceph_throttle_${2}
 template:
   family: Ceph
   context_namespace: ceph
   groups:
-  - family: Capacity
-    context_namespace: capacity
-    groups:
-    - family: Object Health
-      context_namespace: object_health
+    - family: Capacity
+      context_namespace: capacity
+      groups:
+        - family: Object Health
+          context_namespace: object_health
+          metrics:
+            - ceph_num_objects_degraded
+            - ceph_num_objects_misplaced
+            - ceph_num_objects_unfound
+          charts:
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_num_objects_degraded
+                  name: degraded
+                - selector: ceph_num_objects_misplaced
+                  name: misplaced
+                - selector: ceph_num_objects_unfound
+                  name: unfound
+        - family: Overall Cluster Space
+          context_namespace: overall_cluster_space
+          metrics:
+            - ceph_cluster_total_bytes
+            - ceph_cluster_total_used_bytes
+            - ceph_cluster_total_used_raw_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_total_bytes
+                  name: bytes
+                - selector: ceph_cluster_total_used_bytes
+                  name: used_bytes
+                - selector: ceph_cluster_total_used_raw_bytes
+                  name: used_raw_bytes
+        - family: Space by Device Class
+          context_namespace: space_by_device_class
+          metrics:
+            - ceph_cluster_by_class_total_bytes
+            - ceph_cluster_by_class_total_used_bytes
+            - ceph_cluster_by_class_total_used_raw_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_by_class_total_bytes
+                  name: bytes
+                - selector: ceph_cluster_by_class_total_used_bytes
+                  name: used_bytes
+                - selector: ceph_cluster_by_class_total_used_raw_bytes
+                  name: used_raw_bytes
+              instances:
+                by_labels:
+                  - device_class
+                optional_by_labels: []
+    - family: CephFS Metadata
+      context_namespace: cephfs_metadata
+      groups:
+        - family: Filesystem Metadata
+          context_namespace: filesystem_metadata
+          metrics:
+            - ceph_fs_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_fs_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - data_pools
+                  - fs_id
+                  - metadata_pool
+                  - name
+                optional_by_labels: []
+        - family: MDS Metadata
+          context_namespace: mds_metadata
+          metrics:
+            - ceph_mds_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - ceph_version
+                  - fs_id
+                  - hostname
+                  - public_addr
+                  - rank
+                optional_by_labels: []
+    - family: Cluster Overview
+      context_namespace: cluster_overview
       metrics:
-      - ceph_num_objects_degraded
-      - ceph_num_objects_misplaced
-      - ceph_num_objects_unfound
+        - ceph_cluster_osd_blocklist_count
+        - ceph_disk_occupation
+        - ceph_disk_occupation_human
+        - ceph_prometheus_collect_duration_seconds_count
+        - ceph_prometheus_collect_duration_seconds_sum
       charts:
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_num_objects_degraded
-          name: degraded
-        - selector: ceph_num_objects_misplaced
-          name: misplaced
-        - selector: ceph_num_objects_unfound
-          name: unfound
-    - family: Overall Cluster Space
-      context_namespace: overall_cluster_space
-      metrics:
-      - ceph_cluster_total_bytes
-      - ceph_cluster_total_used_bytes
-      - ceph_cluster_total_used_raw_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_total_bytes
-          name: bytes
-        - selector: ceph_cluster_total_used_bytes
-          name: used_bytes
-        - selector: ceph_cluster_total_used_raw_bytes
-          name: used_raw_bytes
-    - family: Space by Device Class
-      context_namespace: space_by_device_class
-      metrics:
-      - ceph_cluster_by_class_total_bytes
-      - ceph_cluster_by_class_total_used_bytes
-      - ceph_cluster_by_class_total_used_raw_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_by_class_total_bytes
-          name: bytes
-        - selector: ceph_cluster_by_class_total_used_bytes
-          name: used_bytes
-        - selector: ceph_cluster_by_class_total_used_raw_bytes
-          name: used_raw_bytes
-        instances:
-          by_labels:
-          - device_class
-          optional_by_labels: []
-  - family: CephFS Metadata
-    context_namespace: cephfs_metadata
-    groups:
-    - family: Filesystem Metadata
-      context_namespace: filesystem_metadata
-      metrics:
-      - ceph_fs_metadata
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_fs_metadata
-          name: value
-        instances:
-          by_labels:
-          - data_pools
-          - fs_id
-          - metadata_pool
-          - name
-          optional_by_labels: []
-    - family: MDS Metadata
-      context_namespace: mds_metadata
-      metrics:
-      - ceph_mds_metadata
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_metadata
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - ceph_version
-          - fs_id
-          - hostname
-          - public_addr
-          - rank
-          optional_by_labels: []
-  - family: Cluster Overview
-    context_namespace: cluster_overview
-    metrics:
-    - ceph_cluster_osd_blocklist_count
-    - ceph_disk_occupation
-    - ceph_disk_occupation_human
-    - ceph_prometheus_collect_duration_seconds_count
-    - ceph_prometheus_collect_duration_seconds_sum
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_prometheus_collect_duration_seconds_count
-        name: value
-      instances:
-        by_labels:
-        - method
-        optional_by_labels: []
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_prometheus_collect_duration_seconds_sum
-        name: value
-      instances:
-        by_labels:
-        - method
-        optional_by_labels: []
-    - title: Current Work
-      context: current_work
-      units: items
-      label_promotion: []
-      dimensions:
-      - selector: ceph_cluster_osd_blocklist_count
-        name: value
-    - title: State and Metadata — Occupation
-      context: state_occupation
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_disk_occupation
-        name: occupation
-      instances:
-        by_labels:
-        - ceph_daemon
-        - ceph_instance
-        - db_device
-        - device
-        - device_ids
-        - devices
-        - wal_device
-        optional_by_labels: []
-    - title: State and Metadata — Human
-      context: state_human
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_disk_occupation_human
-        name: human
-      instances:
-        by_labels:
-        - ceph_daemon
-        - ceph_instance
-        - device
-        optional_by_labels: []
-  - family: Control Plane
-    context_namespace: control_plane
-    groups:
-    - family: Cephadm
-      context_namespace: cephadm
-      metrics:
-      - ceph_cephadm_daemon_status
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephadm_daemon_status
-          name: value
-        instances:
-          by_labels:
-          - daemon_name
-          - hostname
-          - service_name
-          - service_type
-          optional_by_labels: []
-    - family: Manager
-      context_namespace: manager
-      metrics:
-      - ceph_mgr_metadata
-      - ceph_mgr_status
-      charts:
-      - title: State and Metadata — Metadata
-        context: state_metadata
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mgr_metadata
-          name: metadata
-        instances:
-          by_labels:
-          - ceph_daemon
-          - ceph_version
-          - hostname
-          optional_by_labels: []
-      - title: State and Metadata — Status
-        context: state_status
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mgr_status
-          name: status
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Manager Modules
-      context_namespace: manager_modules
-      metrics:
-      - ceph_mgr_module_can_run
-      - ceph_mgr_module_status
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mgr_module_can_run
-          name: can_run
-        - selector: ceph_mgr_module_status
-          name: status
-        instances:
-          by_labels:
-          - name
-          optional_by_labels: []
-    - family: Monitor
-      context_namespace: monitor
-      metrics:
-      - ceph_mon_metadata
-      - ceph_mon_quorum_status
-      charts:
-      - title: Cluster Summary
-        context: cluster_summary
-        units: monitors
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mon_metadata
-          name: total
-        - selector: ceph_mon_quorum_status
-          name: in_quorum
-        aggregation: sum
-      - title: State and Metadata — Metadata
-        context: state_metadata
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mon_metadata
-          name: metadata
-        instances:
-          by_labels:
-          - ceph_daemon
-          - ceph_version
-          - hostname
-          - public_addr
-          - rank
-          optional_by_labels: []
-      - title: State and Metadata — Quorum Status
-        context: state_quorum_status
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mon_quorum_status
-          name: quorum_status
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Paxos
-      context_namespace: paxos
-      metrics:
-      - ceph_paxos_accept_timeout
-      - ceph_paxos_begin
-      - ceph_paxos_begin_bytes_count
-      - ceph_paxos_begin_bytes_sum
-      - ceph_paxos_begin_keys_count
-      - ceph_paxos_begin_keys_sum
-      - ceph_paxos_begin_latency_count
-      - ceph_paxos_begin_latency_sum
-      - ceph_paxos_collect
-      - ceph_paxos_collect_bytes_count
-      - ceph_paxos_collect_bytes_sum
-      - ceph_paxos_collect_keys_count
-      - ceph_paxos_collect_keys_sum
-      - ceph_paxos_collect_latency_count
-      - ceph_paxos_collect_latency_sum
-      - ceph_paxos_collect_timeout
-      - ceph_paxos_collect_uncommitted
-      - ceph_paxos_commit
-      - ceph_paxos_commit_bytes_count
-      - ceph_paxos_commit_bytes_sum
-      - ceph_paxos_commit_keys_count
-      - ceph_paxos_commit_keys_sum
-      - ceph_paxos_commit_latency_count
-      - ceph_paxos_commit_latency_sum
-      - ceph_paxos_lease_ack_timeout
-      - ceph_paxos_lease_timeout
-      - ceph_paxos_new_pn
-      - ceph_paxos_new_pn_latency_count
-      - ceph_paxos_new_pn_latency_sum
-      - ceph_paxos_refresh
-      - ceph_paxos_refresh_latency_count
-      - ceph_paxos_refresh_latency_sum
-      - ceph_paxos_restart
-      - ceph_paxos_share_state
-      - ceph_paxos_share_state_bytes_count
-      - ceph_paxos_share_state_bytes_sum
-      - ceph_paxos_share_state_keys_count
-      - ceph_paxos_share_state_keys_sum
-      - ceph_paxos_start_leader
-      - ceph_paxos_start_peon
-      - ceph_paxos_store_state
-      - ceph_paxos_store_state_bytes_count
-      - ceph_paxos_store_state_bytes_sum
-      - ceph_paxos_store_state_keys_count
-      - ceph_paxos_store_state_keys_sum
-      - ceph_paxos_store_state_latency_count
-      - ceph_paxos_store_state_latency_sum
-      charts:
-      - title: Byte Measurement Measurements
-        context: bytes_measurements
-        units: measurements/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_bytes_count
-          name: begin_bytes
-        - selector: ceph_paxos_collect_bytes_count
-          name: collect_bytes
-        - selector: ceph_paxos_commit_bytes_count
-          name: commit_bytes
-        - selector: ceph_paxos_share_state_bytes_count
-          name: share_state_bytes
-        - selector: ceph_paxos_store_state_bytes_count
-          name: store_state_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Byte Measurement
-        context: accumulated_bytes
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_bytes_sum
-          name: begin_bytes
-        - selector: ceph_paxos_collect_bytes_sum
-          name: collect_bytes
-        - selector: ceph_paxos_commit_bytes_sum
-          name: commit_bytes
-        - selector: ceph_paxos_share_state_bytes_sum
-          name: share_state_bytes
-        - selector: ceph_paxos_store_state_bytes_sum
-          name: store_state_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Key Measurement Measurements
-        context: keys_measurements
-        units: measurements/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_keys_count
-          name: begin_keys
-        - selector: ceph_paxos_collect_keys_count
-          name: collect_keys
-        - selector: ceph_paxos_commit_keys_count
-          name: commit_keys
-        - selector: ceph_paxos_share_state_keys_count
-          name: share_state_keys
-        - selector: ceph_paxos_store_state_keys_count
-          name: store_state_keys
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Key Measurement
-        context: accumulated_keys
-        units: keys/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_keys_sum
-          name: begin_keys
-        - selector: ceph_paxos_collect_keys_sum
-          name: collect_keys
-        - selector: ceph_paxos_commit_keys_sum
-          name: commit_keys
-        - selector: ceph_paxos_share_state_keys_sum
-          name: share_state_keys
-        - selector: ceph_paxos_store_state_keys_sum
-          name: store_state_keys
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_latency_count
-          name: begin_latency
-        - selector: ceph_paxos_collect_latency_count
-          name: collect_latency
-        - selector: ceph_paxos_commit_latency_count
-          name: commit_latency
-        - selector: ceph_paxos_new_pn_latency_count
-          name: new_pn_latency
-        - selector: ceph_paxos_refresh_latency_count
-          name: refresh_latency
-        - selector: ceph_paxos_store_state_latency_count
-          name: store_state_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin_latency_sum
-          name: begin_latency
-        - selector: ceph_paxos_collect_latency_sum
-          name: collect_latency
-        - selector: ceph_paxos_commit_latency_sum
-          name: commit_latency
-        - selector: ceph_paxos_new_pn_latency_sum
-          name: new_pn_latency
-        - selector: ceph_paxos_refresh_latency_sum
-          name: refresh_latency
-        - selector: ceph_paxos_store_state_latency_sum
-          name: store_state_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_new_pn
-          name: new_pn
-        - selector: ceph_paxos_refresh
-          name: refresh
-        - selector: ceph_paxos_restart
-          name: restart
-        - selector: ceph_paxos_share_state
-          name: share_state
-        - selector: ceph_paxos_start_leader
-          name: start_leader
-        - selector: ceph_paxos_start_peon
-          name: start_peon
-        - selector: ceph_paxos_store_state
-          name: store_state
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_accept_timeout
-          name: accept_timeout
-        - selector: ceph_paxos_collect_timeout
-          name: collect_timeout
-        - selector: ceph_paxos_lease_ack_timeout
-          name: lease_ack_timeout
-        - selector: ceph_paxos_lease_timeout
-          name: lease_timeout
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Paxos Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_begin
-          name: begin
-        - selector: ceph_paxos_collect
-          name: collect
-        - selector: ceph_paxos_commit
-          name: commit
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Collected Uncommitted Values
-        context: collected_uncommitted_values
-        units: values/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_paxos_collect_uncommitted
-          name: collect_uncommitted
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Health
-    context_namespace: health
-    groups:
-    - family: Cluster Status
-      context_namespace: cluster_status
-      metrics:
-      - ceph_health_status
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_health_status
-          name: value
-    - family: Daemon Health
-      context_namespace: daemon_health
-      metrics:
-      - ceph_daemon_health_metrics
-      charts:
-      - title: Health Metric Count
-        context: item_count
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_daemon_health_metrics
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - type
-          optional_by_labels: []
-    - family: Health Checks
-      context_namespace: health_checks
-      metrics:
-      - ceph_health_detail
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion:
-        - severity
-        dimensions:
-        - selector: ceph_health_detail
-          name: value
-        instances:
-          by_labels:
-          - name
-          optional_by_labels: []
-    - family: Slow Operations
-      context_namespace: slow_operations
-      metrics:
-      - ceph_healthcheck_slow_ops
-      charts:
-      - title: Slow Operations
-        context: current_operations
-        units: operations
-        label_promotion: []
-        dimensions:
-        - selector: ceph_healthcheck_slow_ops
-          name: value
-  - family: OSD Capacity and State
-    context_namespace: osd_capacity_and_state
-    groups:
-    - family: Cluster Flags
-      context_namespace: cluster_flags
-      metrics:
-      - ceph_osd_flag_nodeep_scrub
-      - ceph_osd_flag_nodown
-      - ceph_osd_flag_noin
-      - ceph_osd_flag_noout
-      - ceph_osd_flag_norebalance
-      - ceph_osd_flag_noscrub
-      - ceph_osd_flag_noup
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_flag_nodeep_scrub
-          name: nodeep_scrub
-        - selector: ceph_osd_flag_nodown
-          name: nodown
-        - selector: ceph_osd_flag_noin
-          name: noin
-        - selector: ceph_osd_flag_noout
-          name: noout
-        - selector: ceph_osd_flag_norebalance
-          name: norebalance
-        - selector: ceph_osd_flag_noscrub
-          name: noscrub
-        - selector: ceph_osd_flag_noup
-          name: noup
-    - family: Fullness Thresholds
-      context_namespace: fullness_thresholds
-      metrics:
-      - ceph_osd_full_ratio
-      - ceph_osd_nearfull_ratio
-      charts:
-      - title: Ratios
-        context: ratio
-        units: ratio
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_full_ratio
-          name: full_ratio
-        - selector: ceph_osd_nearfull_ratio
-          name: nearfull_ratio
-    - family: Metadata
-      context_namespace: metadata
-      metrics:
-      - ceph_osd_metadata
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_metadata
-          name: value
-        instances:
-          by_labels:
-          - back_iface
-          - ceph_daemon
-          - ceph_version
-          - cluster_addr
-          - device_class
-          - front_iface
-          - hostname
-          - objectstore
-          - public_addr
-          optional_by_labels: []
-    - family: OSD State
-      context_namespace: osd_state
-      metrics:
-      - ceph_osd_metadata
-      - ceph_osd_in
-      - ceph_osd_up
-      - ceph_osd_weight
-      charts:
-      - title: Cluster Summary
-        context: cluster_summary
-        units: OSDs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_metadata
-          name: total
-        - selector: ceph_osd_up
-          name: up
-        aggregation: sum
-      - title: OSD State
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_in
-          name: in
-        - selector: ceph_osd_up
-          name: up
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OSD Weight
-        context: weight
-        units: ratio
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_weight
-          name: weight
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Node Hardware
-    context_namespace: node_hardware
-    groups:
-    - family: Processors
-      context_namespace: processors
-      metrics:
-      - ceph_hardware_cpu_cores
-      charts:
-      - title: CPU Cores
-        context: cpu_cores
-        units: cpu cores
-        label_promotion: []
-        dimensions:
-        - selector: ceph_hardware_cpu_cores
-          name: value
-        instances:
-          by_labels:
-          - hostname
-          - cpu
-          - manufacturer
-          - model
-          - total_threads
-          optional_by_labels: []
-    - family: Cooling
-      context_namespace: cooling
-      metrics:
-      - ceph_hardware_fan_rpm
-      charts:
-      - title: Fan Speed
-        context: fan_speed
-        units: fan revolutions per minute
-        label_promotion: []
-        dimensions:
-        - selector: ceph_hardware_fan_rpm
-          name: value
-        instances:
-          by_labels:
-          - hostname
-          - fan_name
-          optional_by_labels: []
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_prometheus_collect_duration_seconds_count
+              name: value
+          instances:
+            by_labels:
+              - method
+            optional_by_labels: []
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_prometheus_collect_duration_seconds_sum
+              name: value
+          instances:
+            by_labels:
+              - method
+            optional_by_labels: []
+        - title: Current Work
+          context: current_work
+          units: items
+          label_promotion: []
+          dimensions:
+            - selector: ceph_cluster_osd_blocklist_count
+              name: value
+        - title: State and Metadata — Occupation
+          context: state_occupation
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_disk_occupation
+              name: occupation
+          instances:
+            by_labels:
+              - ceph_daemon
+              - ceph_instance
+              - db_device
+              - device
+              - device_ids
+              - devices
+              - wal_device
+            optional_by_labels: []
+        - title: State and Metadata — Human
+          context: state_human
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_disk_occupation_human
+              name: human
+          instances:
+            by_labels:
+              - ceph_daemon
+              - ceph_instance
+              - device
+            optional_by_labels: []
+    - family: Control Plane
+      context_namespace: control_plane
+      groups:
+        - family: Cephadm
+          context_namespace: cephadm
+          metrics:
+            - ceph_cephadm_daemon_status
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephadm_daemon_status
+                  name: value
+              instances:
+                by_labels:
+                  - daemon_name
+                  - hostname
+                  - service_name
+                  - service_type
+                optional_by_labels: []
+        - family: Manager
+          context_namespace: manager
+          metrics:
+            - ceph_mgr_metadata
+            - ceph_mgr_status
+          charts:
+            - title: State and Metadata — Metadata
+              context: state_metadata
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mgr_metadata
+                  name: metadata
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - ceph_version
+                  - hostname
+                optional_by_labels: []
+            - title: State and Metadata — Status
+              context: state_status
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mgr_status
+                  name: status
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Manager Modules
+          context_namespace: manager_modules
+          metrics:
+            - ceph_mgr_module_can_run
+            - ceph_mgr_module_status
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mgr_module_can_run
+                  name: can_run
+                - selector: ceph_mgr_module_status
+                  name: status
+              instances:
+                by_labels:
+                  - name
+                optional_by_labels: []
+        - family: Monitor
+          context_namespace: monitor
+          metrics:
+            - ceph_mon_metadata
+            - ceph_mon_quorum_status
+          charts:
+            - title: Cluster Summary
+              context: cluster_summary
+              units: monitors
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mon_metadata
+                  name: total
+                - selector: ceph_mon_quorum_status
+                  name: in_quorum
+              aggregation: sum
+            - title: State and Metadata — Metadata
+              context: state_metadata
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mon_metadata
+                  name: metadata
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - ceph_version
+                  - hostname
+                  - public_addr
+                  - rank
+                optional_by_labels: []
+            - title: State and Metadata — Quorum Status
+              context: state_quorum_status
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mon_quorum_status
+                  name: quorum_status
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Paxos
+          context_namespace: paxos
+          metrics:
+            - ceph_paxos_accept_timeout
+            - ceph_paxos_begin
+            - ceph_paxos_begin_bytes_count
+            - ceph_paxos_begin_bytes_sum
+            - ceph_paxos_begin_keys_count
+            - ceph_paxos_begin_keys_sum
+            - ceph_paxos_begin_latency_count
+            - ceph_paxos_begin_latency_sum
+            - ceph_paxos_collect
+            - ceph_paxos_collect_bytes_count
+            - ceph_paxos_collect_bytes_sum
+            - ceph_paxos_collect_keys_count
+            - ceph_paxos_collect_keys_sum
+            - ceph_paxos_collect_latency_count
+            - ceph_paxos_collect_latency_sum
+            - ceph_paxos_collect_timeout
+            - ceph_paxos_collect_uncommitted
+            - ceph_paxos_commit
+            - ceph_paxos_commit_bytes_count
+            - ceph_paxos_commit_bytes_sum
+            - ceph_paxos_commit_keys_count
+            - ceph_paxos_commit_keys_sum
+            - ceph_paxos_commit_latency_count
+            - ceph_paxos_commit_latency_sum
+            - ceph_paxos_lease_ack_timeout
+            - ceph_paxos_lease_timeout
+            - ceph_paxos_new_pn
+            - ceph_paxos_new_pn_latency_count
+            - ceph_paxos_new_pn_latency_sum
+            - ceph_paxos_refresh
+            - ceph_paxos_refresh_latency_count
+            - ceph_paxos_refresh_latency_sum
+            - ceph_paxos_restart
+            - ceph_paxos_share_state
+            - ceph_paxos_share_state_bytes_count
+            - ceph_paxos_share_state_bytes_sum
+            - ceph_paxos_share_state_keys_count
+            - ceph_paxos_share_state_keys_sum
+            - ceph_paxos_start_leader
+            - ceph_paxos_start_peon
+            - ceph_paxos_store_state
+            - ceph_paxos_store_state_bytes_count
+            - ceph_paxos_store_state_bytes_sum
+            - ceph_paxos_store_state_keys_count
+            - ceph_paxos_store_state_keys_sum
+            - ceph_paxos_store_state_latency_count
+            - ceph_paxos_store_state_latency_sum
+          charts:
+            - title: Byte Measurement Measurements
+              context: bytes_measurements
+              units: measurements/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_bytes_count
+                  name: begin_bytes
+                - selector: ceph_paxos_collect_bytes_count
+                  name: collect_bytes
+                - selector: ceph_paxos_commit_bytes_count
+                  name: commit_bytes
+                - selector: ceph_paxos_share_state_bytes_count
+                  name: share_state_bytes
+                - selector: ceph_paxos_store_state_bytes_count
+                  name: store_state_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Byte Measurement
+              context: accumulated_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_bytes_sum
+                  name: begin_bytes
+                - selector: ceph_paxos_collect_bytes_sum
+                  name: collect_bytes
+                - selector: ceph_paxos_commit_bytes_sum
+                  name: commit_bytes
+                - selector: ceph_paxos_share_state_bytes_sum
+                  name: share_state_bytes
+                - selector: ceph_paxos_store_state_bytes_sum
+                  name: store_state_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Key Measurement Measurements
+              context: keys_measurements
+              units: measurements/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_keys_count
+                  name: begin_keys
+                - selector: ceph_paxos_collect_keys_count
+                  name: collect_keys
+                - selector: ceph_paxos_commit_keys_count
+                  name: commit_keys
+                - selector: ceph_paxos_share_state_keys_count
+                  name: share_state_keys
+                - selector: ceph_paxos_store_state_keys_count
+                  name: store_state_keys
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Key Measurement
+              context: accumulated_keys
+              units: keys/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_keys_sum
+                  name: begin_keys
+                - selector: ceph_paxos_collect_keys_sum
+                  name: collect_keys
+                - selector: ceph_paxos_commit_keys_sum
+                  name: commit_keys
+                - selector: ceph_paxos_share_state_keys_sum
+                  name: share_state_keys
+                - selector: ceph_paxos_store_state_keys_sum
+                  name: store_state_keys
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_latency_count
+                  name: begin_latency
+                - selector: ceph_paxos_collect_latency_count
+                  name: collect_latency
+                - selector: ceph_paxos_commit_latency_count
+                  name: commit_latency
+                - selector: ceph_paxos_new_pn_latency_count
+                  name: new_pn_latency
+                - selector: ceph_paxos_refresh_latency_count
+                  name: refresh_latency
+                - selector: ceph_paxos_store_state_latency_count
+                  name: store_state_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin_latency_sum
+                  name: begin_latency
+                - selector: ceph_paxos_collect_latency_sum
+                  name: collect_latency
+                - selector: ceph_paxos_commit_latency_sum
+                  name: commit_latency
+                - selector: ceph_paxos_new_pn_latency_sum
+                  name: new_pn_latency
+                - selector: ceph_paxos_refresh_latency_sum
+                  name: refresh_latency
+                - selector: ceph_paxos_store_state_latency_sum
+                  name: store_state_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_new_pn
+                  name: new_pn
+                - selector: ceph_paxos_refresh
+                  name: refresh
+                - selector: ceph_paxos_restart
+                  name: restart
+                - selector: ceph_paxos_share_state
+                  name: share_state
+                - selector: ceph_paxos_start_leader
+                  name: start_leader
+                - selector: ceph_paxos_start_peon
+                  name: start_peon
+                - selector: ceph_paxos_store_state
+                  name: store_state
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_accept_timeout
+                  name: accept_timeout
+                - selector: ceph_paxos_collect_timeout
+                  name: collect_timeout
+                - selector: ceph_paxos_lease_ack_timeout
+                  name: lease_ack_timeout
+                - selector: ceph_paxos_lease_timeout
+                  name: lease_timeout
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Paxos Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_begin
+                  name: begin
+                - selector: ceph_paxos_collect
+                  name: collect
+                - selector: ceph_paxos_commit
+                  name: commit
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Collected Uncommitted Values
+              context: collected_uncommitted_values
+              units: values/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_paxos_collect_uncommitted
+                  name: collect_uncommitted
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
     - family: Health
       context_namespace: health
+      groups:
+        - family: Cluster Status
+          context_namespace: cluster_status
+          metrics:
+            - ceph_health_status
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_health_status
+                  name: value
+        - family: Daemon Health
+          context_namespace: daemon_health
+          metrics:
+            - ceph_daemon_health_metrics
+          charts:
+            - title: Health Metric Count
+              context: item_count
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_daemon_health_metrics
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - type
+                optional_by_labels: []
+        - family: Health Checks
+          context_namespace: health_checks
+          metrics:
+            - ceph_health_detail
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion:
+                - severity
+              dimensions:
+                - selector: ceph_health_detail
+                  name: value
+              instances:
+                by_labels:
+                  - name
+                optional_by_labels: []
+        - family: Slow Operations
+          context_namespace: slow_operations
+          metrics:
+            - ceph_healthcheck_slow_ops
+          charts:
+            - title: Slow Operations
+              context: current_operations
+              units: operations
+              label_promotion: []
+              dimensions:
+                - selector: ceph_healthcheck_slow_ops
+                  name: value
+    - family: OSD Capacity and State
+      context_namespace: osd_capacity_and_state
+      groups:
+        - family: Cluster Flags
+          context_namespace: cluster_flags
+          metrics:
+            - ceph_osd_flag_nodeep_scrub
+            - ceph_osd_flag_nodown
+            - ceph_osd_flag_noin
+            - ceph_osd_flag_noout
+            - ceph_osd_flag_norebalance
+            - ceph_osd_flag_noscrub
+            - ceph_osd_flag_noup
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_flag_nodeep_scrub
+                  name: nodeep_scrub
+                - selector: ceph_osd_flag_nodown
+                  name: nodown
+                - selector: ceph_osd_flag_noin
+                  name: noin
+                - selector: ceph_osd_flag_noout
+                  name: noout
+                - selector: ceph_osd_flag_norebalance
+                  name: norebalance
+                - selector: ceph_osd_flag_noscrub
+                  name: noscrub
+                - selector: ceph_osd_flag_noup
+                  name: noup
+        - family: Fullness Thresholds
+          context_namespace: fullness_thresholds
+          metrics:
+            - ceph_osd_full_ratio
+            - ceph_osd_nearfull_ratio
+          charts:
+            - title: Ratios
+              context: ratio
+              units: ratio
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_full_ratio
+                  name: full_ratio
+                - selector: ceph_osd_nearfull_ratio
+                  name: nearfull_ratio
+        - family: Metadata
+          context_namespace: metadata
+          metrics:
+            - ceph_osd_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - back_iface
+                  - ceph_daemon
+                  - ceph_version
+                  - cluster_addr
+                  - device_class
+                  - front_iface
+                  - hostname
+                  - objectstore
+                  - public_addr
+                optional_by_labels: []
+        - family: OSD State
+          context_namespace: osd_state
+          metrics:
+            - ceph_osd_metadata
+            - ceph_osd_in
+            - ceph_osd_up
+            - ceph_osd_weight
+          charts:
+            - title: Cluster Summary
+              context: cluster_summary
+              units: OSDs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_metadata
+                  name: total
+                - selector: ceph_osd_up
+                  name: up
+              aggregation: sum
+            - title: OSD State
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_in
+                  name: in
+                - selector: ceph_osd_up
+                  name: up
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OSD Weight
+              context: weight
+              units: ratio
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_weight
+                  name: weight
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Node Hardware
+      context_namespace: node_hardware
+      groups:
+        - family: Processors
+          context_namespace: processors
+          metrics:
+            - ceph_hardware_cpu_cores
+          charts:
+            - title: CPU Cores
+              context: cpu_cores
+              units: cpu cores
+              label_promotion: []
+              dimensions:
+                - selector: ceph_hardware_cpu_cores
+                  name: value
+              instances:
+                by_labels:
+                  - hostname
+                  - cpu
+                  - manufacturer
+                  - model
+                  - total_threads
+                optional_by_labels: []
+        - family: Cooling
+          context_namespace: cooling
+          metrics:
+            - ceph_hardware_fan_rpm
+          charts:
+            - title: Fan Speed
+              context: fan_speed
+              units: fan revolutions per minute
+              label_promotion: []
+              dimensions:
+                - selector: ceph_hardware_fan_rpm
+                  name: value
+              instances:
+                by_labels:
+                  - hostname
+                  - fan_name
+                optional_by_labels: []
+        - family: Health
+          context_namespace: health
+          metrics:
+            - ceph_hardware_health
+          charts:
+            - title: Hardware Health
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_hardware_health
+                  name: value
+              instances:
+                by_labels:
+                  - hostname
+                  - category
+                  - component
+                optional_by_labels: []
+        - family: Memory
+          context_namespace: memory
+          metrics:
+            - ceph_hardware_memory_capacity_bytes
+          charts:
+            - title: Memory Module Capacity
+              context: capacity
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_hardware_memory_capacity_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - hostname
+                  - dimm
+                  - type
+                optional_by_labels: []
+        - family: Storage
+          context_namespace: storage
+          metrics:
+            - ceph_hardware_storage_capacity_bytes
+          charts:
+            - title: Storage Device Capacity
+              context: capacity
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_hardware_storage_capacity_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - hostname
+                  - device
+                  - model
+                  - protocol
+                  - firmware_version
+                  - slot
+                  - serial_number
+                optional_by_labels: []
+        - family: Temperature
+          context_namespace: temperature
+          metrics:
+            - ceph_hardware_temperature_celsius
+          charts:
+            - title: Sensor Temperature
+              context: temperature
+              units: Celsius
+              label_promotion: []
+              dimensions:
+                - selector: ceph_hardware_temperature_celsius
+                  name: value
+              instances:
+                by_labels:
+                  - hostname
+                  - sensor_name
+                optional_by_labels: []
+    - family: OSD Overview
+      context_namespace: osd_overview
       metrics:
-      - ceph_hardware_health
+        - ceph_osd_apply_latency_ms
+        - ceph_osd_commit_latency_ms
       charts:
-      - title: Hardware Health
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_hardware_health
-          name: value
-        instances:
-          by_labels:
-          - hostname
-          - category
-          - component
-          optional_by_labels: []
-    - family: Memory
-      context_namespace: memory
+        - title: Latency
+          context: latency
+          units: milliseconds
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_apply_latency_ms
+              name: apply_latency_ms
+            - selector: ceph_osd_commit_latency_ms
+              name: commit_latency_ms
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: Object Gateway Metadata
+      context_namespace: object_gateway_metadata
       metrics:
-      - ceph_hardware_memory_capacity_bytes
+        - ceph_rgw_metadata
       charts:
-      - title: Memory Module Capacity
-        context: capacity
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_hardware_memory_capacity_bytes
-          name: value
-        instances:
-          by_labels:
-          - hostname
-          - dimm
-          - type
-          optional_by_labels: []
-    - family: Storage
-      context_namespace: storage
+        - title: State and Metadata
+          context: state
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_metadata
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+              - ceph_version
+              - hostname
+              - instance_id
+            optional_by_labels: []
+    - family: Placement Groups and Recovery
+      context_namespace: placement_groups_and_recovery
+      groups:
+        - family: Backfill
+          context_namespace: backfill
+          metrics:
+            - ceph_pg_backfill_toofull
+            - ceph_pg_backfill_unfound
+            - ceph_pg_backfill_wait
+            - ceph_pg_backfilling
+            - ceph_pg_forced_backfill
+            - ceph_pg_remapped
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_backfill_toofull
+                  name: backfill_toofull
+                - selector: ceph_pg_backfill_unfound
+                  name: backfill_unfound
+                - selector: ceph_pg_backfill_wait
+                  name: backfill_wait
+                - selector: ceph_pg_backfilling
+                  name: backfilling
+                - selector: ceph_pg_forced_backfill
+                  name: forced_backfill
+                - selector: ceph_pg_remapped
+                  name: remapped
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Healthy State
+          context_namespace: healthy_state
+          metrics:
+            - ceph_pg_active
+            - ceph_pg_clean
+            - ceph_pg_deep
+            - ceph_pg_total
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_active
+                  name: active
+                - selector: ceph_pg_clean
+                  name: clean
+                - selector: ceph_pg_deep
+                  name: deep
+                - selector: ceph_pg_total
+                  name: pg_total
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Peering and Availability
+          context_namespace: peering_and_availability
+          metrics:
+            - ceph_pg_activating
+            - ceph_pg_creating
+            - ceph_pg_down
+            - ceph_pg_incomplete
+            - ceph_pg_laggy
+            - ceph_pg_peered
+            - ceph_pg_peering
+            - ceph_pg_premerge
+            - ceph_pg_stale
+            - ceph_pg_unknown
+            - ceph_pg_wait
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_activating
+                  name: activating
+                - selector: ceph_pg_creating
+                  name: creating
+                - selector: ceph_pg_down
+                  name: down
+                - selector: ceph_pg_incomplete
+                  name: incomplete
+                - selector: ceph_pg_laggy
+                  name: laggy
+                - selector: ceph_pg_peered
+                  name: peered
+                - selector: ceph_pg_peering
+                  name: peering
+                - selector: ceph_pg_premerge
+                  name: premerge
+                - selector: ceph_pg_stale
+                  name: stale
+                - selector: ceph_pg_unknown
+                  name: unknown
+                - selector: ceph_pg_wait
+                  name: wait
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Recovery Flags
+          context_namespace: recovery_flags
+          metrics:
+            - ceph_osd_flag_nobackfill
+            - ceph_osd_flag_norecover
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_flag_nobackfill
+                  name: nobackfill
+                - selector: ceph_osd_flag_norecover
+                  name: norecover
+        - family: Recovery and Degradation
+          context_namespace: recovery_and_degradation
+          metrics:
+            - ceph_pg_degraded
+            - ceph_pg_forced_recovery
+            - ceph_pg_recovering
+            - ceph_pg_recovery_toofull
+            - ceph_pg_recovery_unfound
+            - ceph_pg_recovery_wait
+            - ceph_pg_undersized
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_degraded
+                  name: degraded
+                - selector: ceph_pg_forced_recovery
+                  name: forced_recovery
+                - selector: ceph_pg_recovering
+                  name: recovering
+                - selector: ceph_pg_recovery_toofull
+                  name: recovery_toofull
+                - selector: ceph_pg_recovery_unfound
+                  name: recovery_unfound
+                - selector: ceph_pg_recovery_wait
+                  name: recovery_wait
+                - selector: ceph_pg_undersized
+                  name: undersized
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Scrub and Repair State
+          context_namespace: scrub_and_repair_state
+          metrics:
+            - ceph_pg_failed_repair
+            - ceph_pg_inconsistent
+            - ceph_pg_repair
+            - ceph_pg_scrubbing
+            - ceph_pg_snaptrim
+            - ceph_pg_snaptrim_error
+            - ceph_pg_snaptrim_wait
+          charts:
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pg_failed_repair
+                  name: failed_repair
+                - selector: ceph_pg_inconsistent
+                  name: inconsistent
+                - selector: ceph_pg_repair
+                  name: repair
+                - selector: ceph_pg_scrubbing
+                  name: scrubbing
+                - selector: ceph_pg_snaptrim
+                  name: snaptrim
+                - selector: ceph_pg_snaptrim_error
+                  name: snaptrim_error
+                - selector: ceph_pg_snaptrim_wait
+                  name: snaptrim_wait
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+    - family: Pools
+      context_namespace: pools
+      groups:
+        - family: Capacity and Quotas
+          context_namespace: capacity_and_quotas
+          metrics:
+            - ceph_pool_avail_raw
+            - ceph_pool_bytes_used
+            - ceph_pool_compress_bytes_used
+            - ceph_pool_compress_under_bytes
+            - ceph_pool_max_avail
+            - ceph_pool_percent_used
+            - ceph_pool_quota_bytes
+            - ceph_pool_quota_objects
+            - ceph_pool_stored
+            - ceph_pool_stored_raw
+          charts:
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_quota_objects
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Logical Pool Capacity
+              context: logical_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_max_avail
+                  name: max_avail
+                - selector: ceph_pool_quota_bytes
+                  name: quota_bytes
+                - selector: ceph_pool_stored
+                  name: stored
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Raw Pool Capacity
+              context: raw_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_avail_raw
+                  name: avail_raw
+                - selector: ceph_pool_bytes_used
+                  name: bytes_used
+                - selector: ceph_pool_stored_raw
+                  name: stored_raw
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Compression Space
+              context: compression_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_compress_bytes_used
+                  name: compress_bytes_used
+                - selector: ceph_pool_compress_under_bytes
+                  name: compress_under_bytes
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Utilization
+              context: utilization
+              units: percentage
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_percent_used
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Client I/O
+          context_namespace: client_i_o
+          metrics:
+            - ceph_pool_rd
+            - ceph_pool_rd_bytes
+            - ceph_pool_wr
+            - ceph_pool_wr_bytes
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_rd_bytes
+                  name: rd_bytes
+                - selector: ceph_pool_wr_bytes
+                  name: wr_bytes
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_rd
+                  name: rd
+                - selector: ceph_pool_wr
+                  name: wr
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Metadata
+          context_namespace: metadata
+          metrics:
+            - ceph_pool_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - application
+                  - compression_mode
+                  - description
+                  - name
+                  - pool_id
+                  - type
+                optional_by_labels: []
+        - family: Objects
+          context_namespace: objects
+          metrics:
+            - ceph_pool_dirty
+            - ceph_pool_objects
+          charts:
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_dirty
+                  name: dirty
+                - selector: ceph_pool_objects
+                  name: objects
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+        - family: Recovery
+          context_namespace: recovery
+          metrics:
+            - ceph_pool_num_bytes_recovered
+            - ceph_pool_num_objects_recovered
+            - ceph_pool_objects_repaired
+            - ceph_pool_recovering_bytes_per_sec
+            - ceph_pool_recovering_keys_per_sec
+            - ceph_pool_recovering_objects_per_sec
+          charts:
+            - title: Current Throughput
+              context: current_throughput_bytes_s
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_recovering_bytes_per_sec
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Current Throughput
+              context: current_throughput_keys_s
+              units: keys/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_recovering_keys_per_sec
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Current Throughput
+              context: current_throughput_objects_s
+              units: objects/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_recovering_objects_per_sec
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_num_objects_recovered
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Object Work
+              context: object_work
+              units: objects/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_objects_repaired
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+            - title: Pool Capacity and Data Volume
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_pool_num_bytes_recovered
+                  name: value
+              instances:
+                by_labels:
+                  - pool_id
+                optional_by_labels: []
+    - family: RBD Images
+      context_namespace: rbd_images
+      groups:
+        - family: I/O
+          context_namespace: i_o
+          metrics:
+            - ceph_rbd_read_bytes
+            - ceph_rbd_read_ops
+            - ceph_rbd_write_bytes
+            - ceph_rbd_write_ops
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_read_bytes
+                  name: read_bytes
+                - selector: ceph_rbd_write_bytes
+                  name: write_bytes
+              instances:
+                by_labels:
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_read_ops
+                  name: read_ops
+                - selector: ceph_rbd_write_ops
+                  name: write_ops
+              instances:
+                by_labels:
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+        - family: Image Metadata
+          context_namespace: image_metadata
+          metrics:
+            - ceph_rbd_image_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_image_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - image_name
+                  - pool_id
+                optional_by_labels: []
+        - family: Latency
+          context_namespace: latency
+          metrics:
+            - ceph_rbd_read_latency_count
+            - ceph_rbd_read_latency_sum
+            - ceph_rbd_write_latency_count
+            - ceph_rbd_write_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_read_latency_count
+                  name: read_latency
+                - selector: ceph_rbd_write_latency_count
+                  name: write_latency
+              instances:
+                by_labels:
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_read_latency_sum
+                  name: read_latency
+                - selector: ceph_rbd_write_latency_sum
+                  name: write_latency
+              instances:
+                by_labels:
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+        - family: Mirror Metadata
+          context_namespace: mirror_metadata
+          metrics:
+            - ceph_rbd_mirror_metadata
+          charts:
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - ceph_version
+                  - hostname
+                  - id
+                  - instance_id
+                optional_by_labels: []
+    - family: SMB Metadata
+      context_namespace: smb_metadata
       metrics:
-      - ceph_hardware_storage_capacity_bytes
+        - ceph_smb_metadata
       charts:
-      - title: Storage Device Capacity
-        context: capacity
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_hardware_storage_capacity_bytes
-          name: value
-        instances:
-          by_labels:
-          - hostname
-          - device
-          - model
-          - protocol
-          - firmware_version
-          - slot
-          - serial_number
-          optional_by_labels: []
-    - family: Temperature
-      context_namespace: temperature
+        - title: State and Metadata
+          context: state
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_smb_metadata
+              name: value
+          instances:
+            by_labels:
+              - netbiosname
+              - share
+              - smb_version
+              - subvolume
+              - subvolume_group
+              - volume
+            optional_by_labels: []
+    - family: BlueFS
+      context_namespace: bluefs
+      groups:
+        - family: Allocation
+          context_namespace: allocation
+          metrics:
+            - ceph_bluefs_alloc_db_max_lat
+            - ceph_bluefs_alloc_slow_fallback
+            - ceph_bluefs_alloc_slow_max_lat
+            - ceph_bluefs_alloc_slow_size_fallback
+            - ceph_bluefs_alloc_unit_db
+            - ceph_bluefs_alloc_unit_slow
+            - ceph_bluefs_alloc_unit_wal
+            - ceph_bluefs_alloc_wal_max_lat
+            - ceph_bluefs_db_alloc_lat_count
+            - ceph_bluefs_db_alloc_lat_sum
+            - ceph_bluefs_slow_alloc_lat_count
+            - ceph_bluefs_slow_alloc_lat_sum
+            - ceph_bluefs_wal_alloc_lat_count
+            - ceph_bluefs_wal_alloc_lat_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_db_alloc_lat_count
+                  name: db_alloc_lat
+                - selector: ceph_bluefs_slow_alloc_lat_count
+                  name: slow_alloc_lat
+                - selector: ceph_bluefs_wal_alloc_lat_count
+                  name: wal_alloc_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_db_alloc_lat_sum
+                  name: db_alloc_lat
+                - selector: ceph_bluefs_slow_alloc_lat_sum
+                  name: slow_alloc_lat
+                - selector: ceph_bluefs_wal_alloc_lat_sum
+                  name: wal_alloc_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Allocation Sizes and High-Water Marks
+              context: allocation_high_water
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_alloc_unit_db
+                  name: db
+                - selector: ceph_bluefs_alloc_unit_slow
+                  name: slow
+                - selector: ceph_bluefs_alloc_unit_wal
+                  name: wal
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: absolute
+            - title: Duration and Time
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_alloc_db_max_lat
+                  name: db_max_lat
+                - selector: ceph_bluefs_alloc_slow_max_lat
+                  name: slow_max_lat
+                - selector: ceph_bluefs_alloc_wal_max_lat
+                  name: wal_max_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_alloc_slow_fallback
+                  name: fallback
+                - selector: ceph_bluefs_alloc_slow_size_fallback
+                  name: size_fallback
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Compaction
+          context_namespace: compaction
+          metrics:
+            - ceph_bluefs_compact_lat_count
+            - ceph_bluefs_compact_lat_sum
+            - ceph_bluefs_compact_lock_lat_count
+            - ceph_bluefs_compact_lock_lat_sum
+            - ceph_bluefs_log_compactions
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_compact_lat_count
+                  name: lat
+                - selector: ceph_bluefs_compact_lock_lat_count
+                  name: lock_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_compact_lat_sum
+                  name: lat
+                - selector: ceph_bluefs_compact_lock_lat_sum
+                  name: lock_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_log_compactions
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: I/O and Files
+          context_namespace: i_o_and_files
+          metrics:
+            - ceph_bluefs_flush_lat_count
+            - ceph_bluefs_flush_lat_sum
+            - ceph_bluefs_fsync_lat_count
+            - ceph_bluefs_fsync_lat_sum
+            - ceph_bluefs_log_write_count
+            - ceph_bluefs_read_bytes
+            - ceph_bluefs_read_count
+            - ceph_bluefs_read_disk_bytes
+            - ceph_bluefs_read_disk_bytes_db
+            - ceph_bluefs_read_disk_bytes_slow
+            - ceph_bluefs_read_disk_bytes_wal
+            - ceph_bluefs_read_disk_count
+            - ceph_bluefs_read_lat_count
+            - ceph_bluefs_read_lat_sum
+            - ceph_bluefs_read_prefetch_bytes
+            - ceph_bluefs_read_prefetch_count
+            - ceph_bluefs_read_random_buffer_bytes
+            - ceph_bluefs_read_random_buffer_count
+            - ceph_bluefs_read_random_bytes
+            - ceph_bluefs_read_random_count
+            - ceph_bluefs_read_random_disk_bytes
+            - ceph_bluefs_read_random_disk_bytes_db
+            - ceph_bluefs_read_random_disk_bytes_slow
+            - ceph_bluefs_read_random_disk_bytes_wal
+            - ceph_bluefs_read_random_disk_count
+            - ceph_bluefs_read_random_lat_count
+            - ceph_bluefs_read_random_lat_sum
+            - ceph_bluefs_read_zeros_candidate
+            - ceph_bluefs_read_zeros_errors
+            - ceph_bluefs_truncate_lat_count
+            - ceph_bluefs_truncate_lat_sum
+            - ceph_bluefs_unlink_lat_count
+            - ceph_bluefs_unlink_lat_sum
+            - ceph_bluefs_write_bytes
+            - ceph_bluefs_write_count
+            - ceph_bluefs_write_count_sst
+            - ceph_bluefs_write_count_wal
+            - ceph_bluefs_write_disk_count
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_flush_lat_count
+                  name: flush_lat
+                - selector: ceph_bluefs_fsync_lat_count
+                  name: fsync_lat
+                - selector: ceph_bluefs_read_lat_count
+                  name: read_lat
+                - selector: ceph_bluefs_read_random_lat_count
+                  name: read_random_lat
+                - selector: ceph_bluefs_truncate_lat_count
+                  name: truncate_lat
+                - selector: ceph_bluefs_unlink_lat_count
+                  name: unlink_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_flush_lat_sum
+                  name: flush_lat
+                - selector: ceph_bluefs_fsync_lat_sum
+                  name: fsync_lat
+                - selector: ceph_bluefs_read_lat_sum
+                  name: read_lat
+                - selector: ceph_bluefs_read_random_lat_sum
+                  name: read_random_lat
+                - selector: ceph_bluefs_truncate_lat_sum
+                  name: truncate_lat
+                - selector: ceph_bluefs_unlink_lat_sum
+                  name: unlink_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_read_bytes
+                  name: read_bytes
+                - selector: ceph_bluefs_read_disk_bytes
+                  name: read_disk_bytes
+                - selector: ceph_bluefs_read_disk_bytes_db
+                  name: read_disk_bytes_db
+                - selector: ceph_bluefs_read_disk_bytes_slow
+                  name: read_disk_bytes_slow
+                - selector: ceph_bluefs_read_disk_bytes_wal
+                  name: read_disk_bytes_wal
+                - selector: ceph_bluefs_read_prefetch_bytes
+                  name: read_prefetch_bytes
+                - selector: ceph_bluefs_read_random_buffer_bytes
+                  name: read_random_buffer_bytes
+                - selector: ceph_bluefs_read_random_bytes
+                  name: read_random_bytes
+                - selector: ceph_bluefs_read_random_disk_bytes
+                  name: read_random_disk_bytes
+                - selector: ceph_bluefs_read_random_disk_bytes_db
+                  name: read_random_disk_bytes_db
+                - selector: ceph_bluefs_read_random_disk_bytes_slow
+                  name: read_random_disk_bytes_slow
+                - selector: ceph_bluefs_read_random_disk_bytes_wal
+                  name: read_random_disk_bytes_wal
+                - selector: ceph_bluefs_write_bytes
+                  name: write_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_log_write_count
+                  name: log_write
+                - selector: ceph_bluefs_read_count
+                  name: read
+                - selector: ceph_bluefs_read_disk_count
+                  name: read_disk
+                - selector: ceph_bluefs_read_prefetch_count
+                  name: read_prefetch
+                - selector: ceph_bluefs_read_random_buffer_count
+                  name: read_random_buffer
+                - selector: ceph_bluefs_read_random_count
+                  name: read_random
+                - selector: ceph_bluefs_read_random_disk_count
+                  name: read_random_disk
+                - selector: ceph_bluefs_write_count
+                  name: write
+                - selector: ceph_bluefs_write_count_sst
+                  name: write_count_sst
+                - selector: ceph_bluefs_write_count_wal
+                  name: write_count_wal
+                - selector: ceph_bluefs_write_disk_count
+                  name: write_disk
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Zero-Read Outcomes
+              context: zero_read_outcomes
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_read_zeros_candidate
+                  name: candidate
+                - selector: ceph_bluefs_read_zeros_errors
+                  name: errors
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Space and Files
+          context_namespace: space_and_files
+          metrics:
+            - ceph_bluefs_bytes_written_slow
+            - ceph_bluefs_bytes_written_sst
+            - ceph_bluefs_bytes_written_wal
+            - ceph_bluefs_db_total_bytes
+            - ceph_bluefs_db_used_bytes
+            - ceph_bluefs_files_written_sst
+            - ceph_bluefs_files_written_wal
+            - ceph_bluefs_log_bytes
+            - ceph_bluefs_logged_bytes
+            - ceph_bluefs_max_bytes_db
+            - ceph_bluefs_max_bytes_slow
+            - ceph_bluefs_max_bytes_wal
+            - ceph_bluefs_num_files
+            - ceph_bluefs_slow_total_bytes
+            - ceph_bluefs_slow_used_bytes
+            - ceph_bluefs_wal_total_bytes
+            - ceph_bluefs_wal_used_bytes
+          charts:
+            - title: Allocation Sizes and High-Water Marks
+              context: allocation_high_water
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_max_bytes_db
+                  name: db
+                - selector: ceph_bluefs_max_bytes_slow
+                  name: slow
+                - selector: ceph_bluefs_max_bytes_wal
+                  name: wal
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: absolute
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_bytes_written_slow
+                  name: bytes_written_slow
+                - selector: ceph_bluefs_bytes_written_sst
+                  name: bytes_written_sst
+                - selector: ceph_bluefs_bytes_written_wal
+                  name: bytes_written_wal
+                - selector: ceph_bluefs_logged_bytes
+                  name: logged_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Files
+              context: file_state
+              units: files
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_num_files
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: File Work
+              context: file_work
+              units: files/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_files_written_sst
+                  name: sst
+                - selector: ceph_bluefs_files_written_wal
+                  name: wal
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluefs_db_total_bytes
+                  name: db_total_bytes
+                - selector: ceph_bluefs_db_used_bytes
+                  name: db_used_bytes
+                - selector: ceph_bluefs_log_bytes
+                  name: log_bytes
+                - selector: ceph_bluefs_slow_total_bytes
+                  name: slow_total_bytes
+                - selector: ceph_bluefs_slow_used_bytes
+                  name: slow_used_bytes
+                - selector: ceph_bluefs_wal_total_bytes
+                  name: wal_total_bytes
+                - selector: ceph_bluefs_wal_used_bytes
+                  name: wal_used_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: BlueStore
+      context_namespace: bluestore
+      groups:
+        - family: Allocation
+          context_namespace: allocation
+          metrics:
+            - ceph_bluestore_alloc_unit
+            - ceph_bluestore_allocated
+            - ceph_bluestore_allocator_lat_count
+            - ceph_bluestore_allocator_lat_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_allocator_lat_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_allocator_lat_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Allocation Unit
+              context: allocation_unit
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_alloc_unit
+                  name: alloc_unit
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Allocated Space
+              context: allocated_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_allocated
+                  name: allocated
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Compression and Checksums
+          context_namespace: compression_and_checksums
+          metrics:
+            - ceph_bluestore_compress_lat_count
+            - ceph_bluestore_compress_lat_sum
+            - ceph_bluestore_compress_rejected_count
+            - ceph_bluestore_compress_success_count
+            - ceph_bluestore_compressed
+            - ceph_bluestore_compressed_allocated
+            - ceph_bluestore_compressed_original
+            - ceph_bluestore_csum_lat_count
+            - ceph_bluestore_csum_lat_sum
+            - ceph_bluestore_decompress_lat_count
+            - ceph_bluestore_decompress_lat_sum
+            - ceph_bluestore_extent_compress
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_compress_lat_count
+                  name: compress_lat
+                - selector: ceph_bluestore_csum_lat_count
+                  name: csum_lat
+                - selector: ceph_bluestore_decompress_lat_count
+                  name: decompress_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_compress_lat_sum
+                  name: compress_lat
+                - selector: ceph_bluestore_csum_lat_sum
+                  name: csum_lat
+                - selector: ceph_bluestore_decompress_lat_sum
+                  name: decompress_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Compression Operations
+              context: compression_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_compress_rejected_count
+                  name: compress_rejected
+                - selector: ceph_bluestore_compress_success_count
+                  name: compress_success
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Compressed Extents
+              context: compressed_extents
+              units: extents/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_extent_compress
+                  name: extent_compress
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_compressed
+                  name: compressed
+                - selector: ceph_bluestore_compressed_allocated
+                  name: allocated
+                - selector: ceph_bluestore_compressed_original
+                  name: original
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: I/O
+          context_namespace: i_o
+          metrics:
+            - ceph_bluestore_issued_deferred_write_bytes
+            - ceph_bluestore_issued_deferred_writes
+            - ceph_bluestore_read_eio
+            - ceph_bluestore_read_lat_count
+            - ceph_bluestore_read_lat_sum
+            - ceph_bluestore_read_onode_meta_lat_count
+            - ceph_bluestore_read_onode_meta_lat_sum
+            - ceph_bluestore_read_wait_aio_lat_count
+            - ceph_bluestore_read_wait_aio_lat_sum
+            - ceph_bluestore_reads_with_retries
+            - ceph_bluestore_remove_lat_count
+            - ceph_bluestore_remove_lat_sum
+            - ceph_bluestore_slow_aio_wait_count
+            - ceph_bluestore_slow_read_onode_meta_count
+            - ceph_bluestore_slow_read_wait_aio_count
+            - ceph_bluestore_submitted_deferred_write_bytes
+            - ceph_bluestore_submitted_deferred_writes
+            - ceph_bluestore_truncate_lat_count
+            - ceph_bluestore_truncate_lat_sum
+            - ceph_bluestore_write_big
+            - ceph_bluestore_write_big_blobs
+            - ceph_bluestore_write_big_bytes
+            - ceph_bluestore_write_big_deferred
+            - ceph_bluestore_write_big_skipped_blobs
+            - ceph_bluestore_write_big_skipped_bytes
+            - ceph_bluestore_write_lat_count
+            - ceph_bluestore_write_lat_sum
+            - ceph_bluestore_write_new
+            - ceph_bluestore_write_pad_bytes
+            - ceph_bluestore_write_penalty_read_ops
+            - ceph_bluestore_write_small
+            - ceph_bluestore_write_small_bytes
+            - ceph_bluestore_write_small_pre_read
+            - ceph_bluestore_write_small_skipped
+            - ceph_bluestore_write_small_skipped_bytes
+            - ceph_bluestore_write_small_unused
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_read_lat_count
+                  name: read_lat
+                - selector: ceph_bluestore_read_onode_meta_lat_count
+                  name: read_onode_meta_lat
+                - selector: ceph_bluestore_read_wait_aio_lat_count
+                  name: read_wait_aio_lat
+                - selector: ceph_bluestore_remove_lat_count
+                  name: remove_lat
+                - selector: ceph_bluestore_truncate_lat_count
+                  name: truncate_lat
+                - selector: ceph_bluestore_write_lat_count
+                  name: write_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_read_lat_sum
+                  name: read_lat
+                - selector: ceph_bluestore_read_onode_meta_lat_sum
+                  name: read_onode_meta_lat
+                - selector: ceph_bluestore_read_wait_aio_lat_sum
+                  name: read_wait_aio_lat
+                - selector: ceph_bluestore_remove_lat_sum
+                  name: remove_lat
+                - selector: ceph_bluestore_truncate_lat_sum
+                  name: truncate_lat
+                - selector: ceph_bluestore_write_lat_sum
+                  name: write_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_issued_deferred_write_bytes
+                  name: issued_deferred_write_bytes
+                - selector: ceph_bluestore_submitted_deferred_write_bytes
+                  name: submitted_deferred_write_bytes
+                - selector: ceph_bluestore_write_big_bytes
+                  name: write_big_bytes
+                - selector: ceph_bluestore_write_big_skipped_bytes
+                  name: write_big_skipped_bytes
+                - selector: ceph_bluestore_write_pad_bytes
+                  name: write_pad_bytes
+                - selector: ceph_bluestore_write_small_bytes
+                  name: write_small_bytes
+                - selector: ceph_bluestore_write_small_skipped_bytes
+                  name: write_small_skipped_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Read Outcomes
+              context: read_outcomes
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_read_eio
+                  name: read_eio
+                - selector: ceph_bluestore_reads_with_retries
+                  name: reads_with_retries
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Slow Reads
+              context: slow_reads
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_slow_read_onode_meta_count
+                  name: slow_read_onode_meta
+                - selector: ceph_bluestore_slow_read_wait_aio_count
+                  name: slow_read_wait_aio
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Slow AIO Waits
+              context: slow_aio_waits
+              units: waits/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_slow_aio_wait_count
+                  name: slow_aio_wait
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Skipped Blobs
+              context: skipped_blobs
+              units: blobs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_write_big_skipped_blobs
+                  name: write_big_skipped_blobs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Skipped Writes
+              context: skipped_writes
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_write_small_skipped
+                  name: write_small_skipped
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Write Operations
+              context: write_operations
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_issued_deferred_writes
+                  name: issued_deferred_writes
+                - selector: ceph_bluestore_submitted_deferred_writes
+                  name: submitted_deferred_writes
+                - selector: ceph_bluestore_write_big
+                  name: write_big
+                - selector: ceph_bluestore_write_big_deferred
+                  name: write_big_deferred
+                - selector: ceph_bluestore_write_new
+                  name: write_new
+                - selector: ceph_bluestore_write_small
+                  name: write_small
+                - selector: ceph_bluestore_write_small_pre_read
+                  name: write_small_pre_read
+                - selector: ceph_bluestore_write_small_unused
+                  name: write_small_unused
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Written Blobs
+              context: written_blobs
+              units: blobs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_write_big_blobs
+                  name: write_big_blobs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Penalty Reads
+              context: penalty_reads
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_write_penalty_read_ops
+                  name: write_penalty_read_ops
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: OMAP
+          context_namespace: omap
+          metrics:
+            - ceph_bluestore_omap_clear_lat_count
+            - ceph_bluestore_omap_clear_lat_sum
+            - ceph_bluestore_omap_get_keys_lat_count
+            - ceph_bluestore_omap_get_keys_lat_sum
+            - ceph_bluestore_omap_get_values_lat_count
+            - ceph_bluestore_omap_get_values_lat_sum
+            - ceph_bluestore_omap_iterator_count
+            - ceph_bluestore_omap_lower_bound_lat_count
+            - ceph_bluestore_omap_lower_bound_lat_sum
+            - ceph_bluestore_omap_next_lat_count
+            - ceph_bluestore_omap_next_lat_sum
+            - ceph_bluestore_omap_rmkey_range_count
+            - ceph_bluestore_omap_rmkeys_count
+            - ceph_bluestore_omap_seek_to_first_lat_count
+            - ceph_bluestore_omap_seek_to_first_lat_sum
+            - ceph_bluestore_omap_setheader_bytes
+            - ceph_bluestore_omap_setheader_count
+            - ceph_bluestore_omap_setkeys_bytes
+            - ceph_bluestore_omap_setkeys_count
+            - ceph_bluestore_omap_setkeys_records
+            - ceph_bluestore_omap_upper_bound_lat_count
+            - ceph_bluestore_omap_upper_bound_lat_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_clear_lat_count
+                  name: clear_lat
+                - selector: ceph_bluestore_omap_get_keys_lat_count
+                  name: get_keys_lat
+                - selector: ceph_bluestore_omap_get_values_lat_count
+                  name: get_values_lat
+                - selector: ceph_bluestore_omap_lower_bound_lat_count
+                  name: lower_bound_lat
+                - selector: ceph_bluestore_omap_next_lat_count
+                  name: next_lat
+                - selector: ceph_bluestore_omap_seek_to_first_lat_count
+                  name: seek_to_first_lat
+                - selector: ceph_bluestore_omap_upper_bound_lat_count
+                  name: upper_bound_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_clear_lat_sum
+                  name: clear_lat
+                - selector: ceph_bluestore_omap_get_keys_lat_sum
+                  name: get_keys_lat
+                - selector: ceph_bluestore_omap_get_values_lat_sum
+                  name: get_values_lat
+                - selector: ceph_bluestore_omap_lower_bound_lat_sum
+                  name: lower_bound_lat
+                - selector: ceph_bluestore_omap_next_lat_sum
+                  name: next_lat
+                - selector: ceph_bluestore_omap_seek_to_first_lat_sum
+                  name: seek_to_first_lat
+                - selector: ceph_bluestore_omap_upper_bound_lat_sum
+                  name: upper_bound_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_setheader_bytes
+                  name: setheader_bytes
+                - selector: ceph_bluestore_omap_setkeys_bytes
+                  name: setkeys_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Open Iterators
+              context: open_iterators
+              units: iterators
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_iterator_count
+                  name: iterator
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: absolute
+            - title: Mutation Calls
+              context: mutation_calls
+              units: calls/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_setheader_count
+                  name: setheader
+                - selector: ceph_bluestore_omap_setkeys_count
+                  name: setkeys
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Removed Key Ranges
+              context: removed_key_ranges
+              units: ranges/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_rmkey_range_count
+                  name: rmkey_range
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Key Mutations
+              context: key_mutations
+              units: keys/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_omap_rmkeys_count
+                  name: rmkeys
+                - selector: ceph_bluestore_omap_setkeys_records
+                  name: setkeys_records
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Onode Cache
+          context_namespace: onode_cache
+          metrics:
+            - ceph_bluestore_onode_blobs
+            - ceph_bluestore_onode_extents
+            - ceph_bluestore_onode_hits
+            - ceph_bluestore_onode_misses
+            - ceph_bluestore_onode_reshard
+            - ceph_bluestore_onode_shard_hits
+            - ceph_bluestore_onode_shard_misses
+            - ceph_bluestore_onode_spanning_blobs
+            - ceph_bluestore_onodes
+            - ceph_bluestore_onodes_pinned
+          charts:
+            - title: Onode Blobs
+              context: blob_state
+              units: blobs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_blobs
+                  name: onode_blobs
+                - selector: ceph_bluestore_onode_spanning_blobs
+                  name: onode_spanning_blobs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Onode Extents
+              context: extent_state
+              units: extents
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_extents
+                  name: onode_extents
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Onodes
+              context: onode_state
+              units: onodes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onodes
+                  name: onodes
+                - selector: ceph_bluestore_onodes_pinned
+                  name: onodes_pinned
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_reshard
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Onode Lookup Outcomes
+              context: onode_lookup_outcomes
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_hits
+                  name: hits
+                - selector: ceph_bluestore_onode_misses
+                  name: misses
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Onode Shard Lookup Outcomes
+              context: shard_lookup_outcomes
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_onode_shard_hits
+                  name: shard_hits
+                - selector: ceph_bluestore_onode_shard_misses
+                  name: shard_misses
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Data
+          context_namespace: priority_cache_data
+          metrics:
+            - ceph_bluestore_pricache:data_committed_bytes
+            - ceph_bluestore_pricache:data_pri0_bytes
+            - ceph_bluestore_pricache:data_pri10_bytes
+            - ceph_bluestore_pricache:data_pri11_bytes
+            - ceph_bluestore_pricache:data_pri1_bytes
+            - ceph_bluestore_pricache:data_pri2_bytes
+            - ceph_bluestore_pricache:data_pri3_bytes
+            - ceph_bluestore_pricache:data_pri4_bytes
+            - ceph_bluestore_pricache:data_pri5_bytes
+            - ceph_bluestore_pricache:data_pri6_bytes
+            - ceph_bluestore_pricache:data_pri7_bytes
+            - ceph_bluestore_pricache:data_pri8_bytes
+            - ceph_bluestore_pricache:data_pri9_bytes
+            - ceph_bluestore_pricache:data_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache:data_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_bluestore_pricache:data_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_bluestore_pricache:data_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_bluestore_pricache:data_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_bluestore_pricache:data_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_bluestore_pricache:data_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_bluestore_pricache:data_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_bluestore_pricache:data_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_bluestore_pricache:data_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_bluestore_pricache:data_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_bluestore_pricache:data_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_bluestore_pricache:data_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_bluestore_pricache:data_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_bluestore_pricache:data_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache KV
+          context_namespace: priority_cache_kv
+          metrics:
+            - ceph_bluestore_pricache:kv_committed_bytes
+            - ceph_bluestore_pricache:kv_pri0_bytes
+            - ceph_bluestore_pricache:kv_pri10_bytes
+            - ceph_bluestore_pricache:kv_pri11_bytes
+            - ceph_bluestore_pricache:kv_pri1_bytes
+            - ceph_bluestore_pricache:kv_pri2_bytes
+            - ceph_bluestore_pricache:kv_pri3_bytes
+            - ceph_bluestore_pricache:kv_pri4_bytes
+            - ceph_bluestore_pricache:kv_pri5_bytes
+            - ceph_bluestore_pricache:kv_pri6_bytes
+            - ceph_bluestore_pricache:kv_pri7_bytes
+            - ceph_bluestore_pricache:kv_pri8_bytes
+            - ceph_bluestore_pricache:kv_pri9_bytes
+            - ceph_bluestore_pricache:kv_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache:kv_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_bluestore_pricache:kv_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_bluestore_pricache:kv_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_bluestore_pricache:kv_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_bluestore_pricache:kv_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_bluestore_pricache:kv_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_bluestore_pricache:kv_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_bluestore_pricache:kv_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_bluestore_pricache:kv_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_bluestore_pricache:kv_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_bluestore_pricache:kv_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_bluestore_pricache:kv_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_bluestore_pricache:kv_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_bluestore_pricache:kv_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache KV Onode
+          context_namespace: priority_cache_kv_onode
+          metrics:
+            - ceph_bluestore_pricache:kv_onode_committed_bytes
+            - ceph_bluestore_pricache:kv_onode_pri0_bytes
+            - ceph_bluestore_pricache:kv_onode_pri10_bytes
+            - ceph_bluestore_pricache:kv_onode_pri11_bytes
+            - ceph_bluestore_pricache:kv_onode_pri1_bytes
+            - ceph_bluestore_pricache:kv_onode_pri2_bytes
+            - ceph_bluestore_pricache:kv_onode_pri3_bytes
+            - ceph_bluestore_pricache:kv_onode_pri4_bytes
+            - ceph_bluestore_pricache:kv_onode_pri5_bytes
+            - ceph_bluestore_pricache:kv_onode_pri6_bytes
+            - ceph_bluestore_pricache:kv_onode_pri7_bytes
+            - ceph_bluestore_pricache:kv_onode_pri8_bytes
+            - ceph_bluestore_pricache:kv_onode_pri9_bytes
+            - ceph_bluestore_pricache:kv_onode_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache:kv_onode_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_bluestore_pricache:kv_onode_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Metadata
+          context_namespace: priority_cache_metadata
+          metrics:
+            - ceph_bluestore_pricache:meta_committed_bytes
+            - ceph_bluestore_pricache:meta_pri0_bytes
+            - ceph_bluestore_pricache:meta_pri10_bytes
+            - ceph_bluestore_pricache:meta_pri11_bytes
+            - ceph_bluestore_pricache:meta_pri1_bytes
+            - ceph_bluestore_pricache:meta_pri2_bytes
+            - ceph_bluestore_pricache:meta_pri3_bytes
+            - ceph_bluestore_pricache:meta_pri4_bytes
+            - ceph_bluestore_pricache:meta_pri5_bytes
+            - ceph_bluestore_pricache:meta_pri6_bytes
+            - ceph_bluestore_pricache:meta_pri7_bytes
+            - ceph_bluestore_pricache:meta_pri8_bytes
+            - ceph_bluestore_pricache:meta_pri9_bytes
+            - ceph_bluestore_pricache:meta_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache:meta_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_bluestore_pricache:meta_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_bluestore_pricache:meta_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_bluestore_pricache:meta_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_bluestore_pricache:meta_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_bluestore_pricache:meta_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_bluestore_pricache:meta_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_bluestore_pricache:meta_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_bluestore_pricache:meta_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_bluestore_pricache:meta_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_bluestore_pricache:meta_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_bluestore_pricache:meta_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_bluestore_pricache:meta_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_bluestore_pricache:meta_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Runtime
+          context_namespace: priority_cache_runtime
+          metrics:
+            - ceph_bluestore_pricache_cache_bytes
+            - ceph_bluestore_pricache_heap_bytes
+            - ceph_bluestore_pricache_mapped_bytes
+            - ceph_bluestore_pricache_target_bytes
+            - ceph_bluestore_pricache_unmapped_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_pricache_cache_bytes
+                  name: cache_bytes
+                - selector: ceph_bluestore_pricache_heap_bytes
+                  name: heap_bytes
+                - selector: ceph_bluestore_pricache_mapped_bytes
+                  name: mapped_bytes
+                - selector: ceph_bluestore_pricache_target_bytes
+                  name: target_bytes
+                - selector: ceph_bluestore_pricache_unmapped_bytes
+                  name: unmapped_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Space and Core State
+          context_namespace: space_and_core_state
+          metrics:
+            - ceph_bluestore_blob_split
+            - ceph_bluestore_buffer_bytes
+            - ceph_bluestore_buffer_hit_bytes
+            - ceph_bluestore_buffer_miss_bytes
+            - ceph_bluestore_buffers
+            - ceph_bluestore_clist_lat_count
+            - ceph_bluestore_clist_lat_sum
+            - ceph_bluestore_fragmentation_micros
+            - ceph_bluestore_gc_merged
+            - ceph_bluestore_kv_commit_lat_count
+            - ceph_bluestore_kv_commit_lat_sum
+            - ceph_bluestore_kv_final_lat_count
+            - ceph_bluestore_kv_final_lat_sum
+            - ceph_bluestore_kv_flush_lat_count
+            - ceph_bluestore_kv_flush_lat_sum
+            - ceph_bluestore_kv_sync_lat_count
+            - ceph_bluestore_kv_sync_lat_sum
+            - ceph_bluestore_slow_committed_kv_count
+            - ceph_bluestore_stored
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_clist_lat_count
+                  name: clist_lat
+                - selector: ceph_bluestore_kv_commit_lat_count
+                  name: kv_commit_lat
+                - selector: ceph_bluestore_kv_final_lat_count
+                  name: kv_final_lat
+                - selector: ceph_bluestore_kv_flush_lat_count
+                  name: kv_flush_lat
+                - selector: ceph_bluestore_kv_sync_lat_count
+                  name: kv_sync_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_clist_lat_sum
+                  name: clist_lat
+                - selector: ceph_bluestore_kv_commit_lat_sum
+                  name: kv_commit_lat
+                - selector: ceph_bluestore_kv_final_lat_sum
+                  name: kv_final_lat
+                - selector: ceph_bluestore_kv_flush_lat_sum
+                  name: kv_flush_lat
+                - selector: ceph_bluestore_kv_sync_lat_sum
+                  name: kv_sync_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_buffer_hit_bytes
+                  name: hit_bytes
+                - selector: ceph_bluestore_buffer_miss_bytes
+                  name: miss_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Current Work
+              context: current_work
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_buffers
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Blob Splits
+              context: blob_splits
+              units: blobs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_blob_split
+                  name: blob_split
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Garbage-Collection Merge Throughput
+              context: gc_merge_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_gc_merged
+                  name: gc_merged
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_slow_committed_kv_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Fragmentation
+              context: fragmentation
+              units: per mille
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_fragmentation_micros
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Buffer Cache Residency
+              context: buffer_cache_residency
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_buffer_bytes
+                  name: buffer_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Logical Stored Data
+              context: logical_stored_data
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_stored
+                  name: stored
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Transaction Pipeline
+          context_namespace: transaction_pipeline
+          metrics:
+            - ceph_bluestore_state_aio_wait_lat_count
+            - ceph_bluestore_state_aio_wait_lat_sum
+            - ceph_bluestore_state_deferred_aio_wait_lat_count
+            - ceph_bluestore_state_deferred_aio_wait_lat_sum
+            - ceph_bluestore_state_deferred_cleanup_lat_count
+            - ceph_bluestore_state_deferred_cleanup_lat_sum
+            - ceph_bluestore_state_deferred_queued_lat_count
+            - ceph_bluestore_state_deferred_queued_lat_sum
+            - ceph_bluestore_state_done_lat_count
+            - ceph_bluestore_state_done_lat_sum
+            - ceph_bluestore_state_finishing_lat_count
+            - ceph_bluestore_state_finishing_lat_sum
+            - ceph_bluestore_state_io_done_lat_count
+            - ceph_bluestore_state_io_done_lat_sum
+            - ceph_bluestore_state_kv_commiting_lat_count
+            - ceph_bluestore_state_kv_commiting_lat_sum
+            - ceph_bluestore_state_kv_done_lat_count
+            - ceph_bluestore_state_kv_done_lat_sum
+            - ceph_bluestore_state_kv_queued_lat_count
+            - ceph_bluestore_state_kv_queued_lat_sum
+            - ceph_bluestore_state_prepare_lat_count
+            - ceph_bluestore_state_prepare_lat_sum
+            - ceph_bluestore_txc_commit_lat_count
+            - ceph_bluestore_txc_commit_lat_sum
+            - ceph_bluestore_txc_count
+            - ceph_bluestore_txc_submit_lat_count
+            - ceph_bluestore_txc_submit_lat_sum
+            - ceph_bluestore_txc_throttle_lat_count
+            - ceph_bluestore_txc_throttle_lat_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_state_aio_wait_lat_count
+                  name: state_aio_wait_lat
+                - selector: ceph_bluestore_state_deferred_aio_wait_lat_count
+                  name: state_deferred_aio_wait_lat
+                - selector: ceph_bluestore_state_deferred_cleanup_lat_count
+                  name: state_deferred_cleanup_lat
+                - selector: ceph_bluestore_state_deferred_queued_lat_count
+                  name: state_deferred_queued_lat
+                - selector: ceph_bluestore_state_done_lat_count
+                  name: state_done_lat
+                - selector: ceph_bluestore_state_finishing_lat_count
+                  name: state_finishing_lat
+                - selector: ceph_bluestore_state_io_done_lat_count
+                  name: state_io_done_lat
+                - selector: ceph_bluestore_state_kv_commiting_lat_count
+                  name: state_kv_commiting_lat
+                - selector: ceph_bluestore_state_kv_done_lat_count
+                  name: state_kv_done_lat
+                - selector: ceph_bluestore_state_kv_queued_lat_count
+                  name: state_kv_queued_lat
+                - selector: ceph_bluestore_state_prepare_lat_count
+                  name: state_prepare_lat
+                - selector: ceph_bluestore_txc_commit_lat_count
+                  name: txc_commit_lat
+                - selector: ceph_bluestore_txc_submit_lat_count
+                  name: txc_submit_lat
+                - selector: ceph_bluestore_txc_throttle_lat_count
+                  name: txc_throttle_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_state_aio_wait_lat_sum
+                  name: state_aio_wait_lat
+                - selector: ceph_bluestore_state_deferred_aio_wait_lat_sum
+                  name: state_deferred_aio_wait_lat
+                - selector: ceph_bluestore_state_deferred_cleanup_lat_sum
+                  name: state_deferred_cleanup_lat
+                - selector: ceph_bluestore_state_deferred_queued_lat_sum
+                  name: state_deferred_queued_lat
+                - selector: ceph_bluestore_state_done_lat_sum
+                  name: state_done_lat
+                - selector: ceph_bluestore_state_finishing_lat_sum
+                  name: state_finishing_lat
+                - selector: ceph_bluestore_state_io_done_lat_sum
+                  name: state_io_done_lat
+                - selector: ceph_bluestore_state_kv_commiting_lat_sum
+                  name: state_kv_commiting_lat
+                - selector: ceph_bluestore_state_kv_done_lat_sum
+                  name: state_kv_done_lat
+                - selector: ceph_bluestore_state_kv_queued_lat_sum
+                  name: state_kv_queued_lat
+                - selector: ceph_bluestore_state_prepare_lat_sum
+                  name: state_prepare_lat
+                - selector: ceph_bluestore_txc_commit_lat_sum
+                  name: txc_commit_lat
+                - selector: ceph_bluestore_txc_submit_lat_sum
+                  name: txc_submit_lat
+                - selector: ceph_bluestore_txc_throttle_lat_sum
+                  name: txc_throttle_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_bluestore_txc_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: CephFS MDS
+      context_namespace: cephfs_mds
+      groups:
+        - family: Attribute and Layout Mutation Latency
+          context_namespace: attribute_and_layout_mutation_latency
+          metrics:
+            - ceph_mds_server_req_rmxattr_latency_count
+            - ceph_mds_server_req_rmxattr_latency_sum
+            - ceph_mds_server_req_setattr_latency_count
+            - ceph_mds_server_req_setattr_latency_sum
+            - ceph_mds_server_req_setdirlayout_latency_count
+            - ceph_mds_server_req_setdirlayout_latency_sum
+            - ceph_mds_server_req_setfilelock_latency_count
+            - ceph_mds_server_req_setfilelock_latency_sum
+            - ceph_mds_server_req_setlayout_latency_count
+            - ceph_mds_server_req_setlayout_latency_sum
+            - ceph_mds_server_req_setxattr_latency_count
+            - ceph_mds_server_req_setxattr_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_rmxattr_latency_count
+                  name: rmxattr_latency
+                - selector: ceph_mds_server_req_setattr_latency_count
+                  name: setattr_latency
+                - selector: ceph_mds_server_req_setdirlayout_latency_count
+                  name: setdirlayout_latency
+                - selector: ceph_mds_server_req_setfilelock_latency_count
+                  name: setfilelock_latency
+                - selector: ceph_mds_server_req_setlayout_latency_count
+                  name: setlayout_latency
+                - selector: ceph_mds_server_req_setxattr_latency_count
+                  name: setxattr_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_rmxattr_latency_sum
+                  name: rmxattr_latency
+                - selector: ceph_mds_server_req_setattr_latency_sum
+                  name: setattr_latency
+                - selector: ceph_mds_server_req_setdirlayout_latency_sum
+                  name: setdirlayout_latency
+                - selector: ceph_mds_server_req_setfilelock_latency_sum
+                  name: setfilelock_latency
+                - selector: ceph_mds_server_req_setlayout_latency_sum
+                  name: setlayout_latency
+                - selector: ceph_mds_server_req_setxattr_latency_sum
+                  name: setxattr_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Capabilities
+          context_namespace: capabilities
+          metrics:
+            - ceph_mds_caps
+            - ceph_mds_ceph_cap_op_flush_ack
+            - ceph_mds_ceph_cap_op_flushsnap_ack
+            - ceph_mds_ceph_cap_op_grant
+            - ceph_mds_ceph_cap_op_revoke
+            - ceph_mds_ceph_cap_op_trunc
+            - ceph_mds_handle_client_cap_release
+            - ceph_mds_handle_client_caps
+            - ceph_mds_handle_client_caps_dirty
+            - ceph_mds_handle_inode_file_caps
+            - ceph_mds_inodes_with_caps
+            - ceph_mds_process_request_cap_release
+            - ceph_mds_server_cap_acquisition_throttle
+            - ceph_mds_server_cap_revoke_eviction
+          charts:
+            - title: Capabilities
+              context: capability_state
+              units: capabilities
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_caps
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Capability Messages
+              context: capability_messages
+              units: messages/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_handle_client_cap_release
+                  name: handle_client_cap_release
+                - selector: ceph_mds_handle_client_caps
+                  name: handle_client_caps
+                - selector: ceph_mds_handle_client_caps_dirty
+                  name: handle_client_caps_dirty
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Capability-Throttled Requests
+              context: throttled_requests
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_cap_acquisition_throttle
+                  name: server_cap_acquisition_throttle
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Capability-Revoke Evictions
+              context: evicted_clients
+              units: clients/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_cap_revoke_eviction
+                  name: server_cap_revoke_eviction
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inodes
+              context: inode_state
+              units: inodes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_inodes_with_caps
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inode Work
+              context: inode_work
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_handle_inode_file_caps
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_ceph_cap_op_flush_ack
+                  name: ceph_cap_op_flush_ack
+                - selector: ceph_mds_ceph_cap_op_flushsnap_ack
+                  name: ceph_cap_op_flushsnap_ack
+                - selector: ceph_mds_ceph_cap_op_grant
+                  name: ceph_cap_op_grant
+                - selector: ceph_mds_ceph_cap_op_revoke
+                  name: ceph_cap_op_revoke
+                - selector: ceph_mds_ceph_cap_op_trunc
+                  name: ceph_cap_op_trunc
+                - selector: ceph_mds_process_request_cap_release
+                  name: process_request_cap_release
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Journal
+          context_namespace: journal
+          metrics:
+            - ceph_mds_log_ev
+            - ceph_mds_log_evadd
+            - ceph_mds_log_evex
+            - ceph_mds_log_evexd
+            - ceph_mds_log_evexg
+            - ceph_mds_log_evlrg
+            - ceph_mds_log_evtrm
+            - ceph_mds_log_expos
+            - ceph_mds_log_jlat_count
+            - ceph_mds_log_jlat_sum
+            - ceph_mds_log_rdpos
+            - ceph_mds_log_replayed
+            - ceph_mds_log_seg
+            - ceph_mds_log_segadd
+            - ceph_mds_log_segex
+            - ceph_mds_log_segexd
+            - ceph_mds_log_segexg
+            - ceph_mds_log_segmjr
+            - ceph_mds_log_segtrm
+            - ceph_mds_log_wrpos
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_jlat_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_jlat_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Current Journal Events
+              context: events_current
+              units: events
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_ev
+                  name: ev
+                - selector: ceph_mds_log_evexd
+                  name: evexd
+                - selector: ceph_mds_log_evexg
+                  name: evexg
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Large Journal Events
+              context: large_events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_evlrg
+                  name: evlrg
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Journal Events
+              context: journal_events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_evadd
+                  name: evadd
+                - selector: ceph_mds_log_evex
+                  name: evex
+                - selector: ceph_mds_log_evtrm
+                  name: evtrm
+                - selector: ceph_mds_log_replayed
+                  name: replayed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Journal Positions
+              context: journal_positions
+              units: position
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_expos
+                  name: expos
+                - selector: ceph_mds_log_rdpos
+                  name: rdpos
+                - selector: ceph_mds_log_wrpos
+                  name: wrpos
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Journal Segments
+              context: journal_segments
+              units: segments/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_segadd
+                  name: segadd
+                - selector: ceph_mds_log_segex
+                  name: segex
+                - selector: ceph_mds_log_segtrm
+                  name: segtrm
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Journal Segments
+              context: segments_current
+              units: segments
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_log_seg
+                  name: seg
+                - selector: ceph_mds_log_segexd
+                  name: segexd
+                - selector: ceph_mds_log_segexg
+                  name: segexg
+                - selector: ceph_mds_log_segmjr
+                  name: segmjr
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Metadata Cache Directory
+          context_namespace: metadata_cache_directory
+          metrics:
+            - ceph_mds_cache_dir_handle_discover
+            - ceph_mds_cache_dir_send_discover
+            - ceph_mds_cache_dir_try_discover
+            - ceph_mds_cache_dir_update
+            - ceph_mds_cache_dir_update_receipt
+          charts:
+            - title: Discovery Messages
+              context: discovery_messages
+              units: messages/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_dir_handle_discover
+                  name: handle_discover
+                - selector: ceph_mds_cache_dir_send_discover
+                  name: send_discover
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Discovery Attempts
+              context: discovery_attempts
+              units: attempts/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_dir_try_discover
+                  name: try_discover
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Replication Directives
+              context: replication_directives
+              units: directives/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_dir_update
+                  name: update
+                - selector: ceph_mds_cache_dir_update_receipt
+                  name: update_receipt
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Metadata Cache Internal Requests
+          context_namespace: metadata_cache_internal_requests
+          metrics:
+            - ceph_mds_cache_ireq_enqueue_scrub
+            - ceph_mds_cache_ireq_exportdir
+            - ceph_mds_cache_ireq_flush
+            - ceph_mds_cache_ireq_fragmentdir
+            - ceph_mds_cache_ireq_fragstats
+            - ceph_mds_cache_ireq_inodestats
+            - ceph_mds_cache_ireq_quiesce_inode
+            - ceph_mds_cache_ireq_quiesce_path
+          charts:
+            - title: Inode Work
+              context: inode_work
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_ireq_inodestats
+                  name: inodestats
+                - selector: ceph_mds_cache_ireq_quiesce_inode
+                  name: quiesce_inode
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_ireq_exportdir
+                  name: exportdir
+                - selector: ceph_mds_cache_ireq_flush
+                  name: flush
+                - selector: ceph_mds_cache_ireq_fragmentdir
+                  name: fragmentdir
+                - selector: ceph_mds_cache_ireq_fragstats
+                  name: fragstats
+                - selector: ceph_mds_cache_ireq_quiesce_path
+                  name: quiesce_path
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Scrub Work
+              context: scrub_work
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_ireq_enqueue_scrub
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Metadata Cache Recovery
+          context_namespace: metadata_cache_recovery
+          metrics:
+            - ceph_mds_cache_num_recovering_enqueued
+            - ceph_mds_cache_num_recovering_prioritized
+            - ceph_mds_cache_num_recovering_processing
+            - ceph_mds_cache_num_strays
+            - ceph_mds_cache_num_strays_delayed
+            - ceph_mds_cache_num_strays_enqueuing
+            - ceph_mds_cache_recovery_completed
+            - ceph_mds_cache_recovery_started
+            - ceph_mds_cache_strays_created
+            - ceph_mds_cache_strays_enqueued
+            - ceph_mds_cache_strays_migrated
+            - ceph_mds_cache_strays_reintegrated
+          charts:
+            - title: Current Work
+              context: current_work
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_num_strays
+                  name: strays
+                - selector: ceph_mds_cache_num_strays_delayed
+                  name: delayed
+                - selector: ceph_mds_cache_num_strays_enqueuing
+                  name: enqueuing
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_strays_created
+                  name: created
+                - selector: ceph_mds_cache_strays_enqueued
+                  name: enqueued
+                - selector: ceph_mds_cache_strays_migrated
+                  name: migrated
+                - selector: ceph_mds_cache_strays_reintegrated
+                  name: reintegrated
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Files
+              context: file_state
+              units: files
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_num_recovering_enqueued
+                  name: enqueued
+                - selector: ceph_mds_cache_num_recovering_prioritized
+                  name: prioritized
+                - selector: ceph_mds_cache_num_recovering_processing
+                  name: processing
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: File Work
+              context: file_work
+              units: files/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_recovery_completed
+                  name: completed
+                - selector: ceph_mds_cache_recovery_started
+                  name: started
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Metadata Cache Uninline
+          context_namespace: metadata_cache_uninline
+          metrics:
+            - ceph_mds_cache_uninline_started
+            - ceph_mds_cache_uninline_succeeded
+            - ceph_mds_cache_uninline_write_failed
+          charts:
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_uninline_started
+                  name: started
+                - selector: ceph_mds_cache_uninline_succeeded
+                  name: succeeded
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_cache_uninline_write_failed
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Namespace Mutation Latency
+          context_namespace: namespace_mutation_latency
+          metrics:
+            - ceph_mds_server_req_create_latency_count
+            - ceph_mds_server_req_create_latency_sum
+            - ceph_mds_server_req_link_latency_count
+            - ceph_mds_server_req_link_latency_sum
+            - ceph_mds_server_req_mkdir_latency_count
+            - ceph_mds_server_req_mkdir_latency_sum
+            - ceph_mds_server_req_mknod_latency_count
+            - ceph_mds_server_req_mknod_latency_sum
+            - ceph_mds_server_req_rename_latency_count
+            - ceph_mds_server_req_rename_latency_sum
+            - ceph_mds_server_req_rmdir_latency_count
+            - ceph_mds_server_req_rmdir_latency_sum
+            - ceph_mds_server_req_symlink_latency_count
+            - ceph_mds_server_req_symlink_latency_sum
+            - ceph_mds_server_req_unlink_latency_count
+            - ceph_mds_server_req_unlink_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_create_latency_count
+                  name: create_latency
+                - selector: ceph_mds_server_req_link_latency_count
+                  name: link_latency
+                - selector: ceph_mds_server_req_mkdir_latency_count
+                  name: mkdir_latency
+                - selector: ceph_mds_server_req_mknod_latency_count
+                  name: mknod_latency
+                - selector: ceph_mds_server_req_rename_latency_count
+                  name: rename_latency
+                - selector: ceph_mds_server_req_rmdir_latency_count
+                  name: rmdir_latency
+                - selector: ceph_mds_server_req_symlink_latency_count
+                  name: symlink_latency
+                - selector: ceph_mds_server_req_unlink_latency_count
+                  name: unlink_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_create_latency_sum
+                  name: create_latency
+                - selector: ceph_mds_server_req_link_latency_sum
+                  name: link_latency
+                - selector: ceph_mds_server_req_mkdir_latency_sum
+                  name: mkdir_latency
+                - selector: ceph_mds_server_req_mknod_latency_sum
+                  name: mknod_latency
+                - selector: ceph_mds_server_req_rename_latency_sum
+                  name: rename_latency
+                - selector: ceph_mds_server_req_rmdir_latency_sum
+                  name: rmdir_latency
+                - selector: ceph_mds_server_req_symlink_latency_sum
+                  name: symlink_latency
+                - selector: ceph_mds_server_req_unlink_latency_sum
+                  name: unlink_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Namespace Traversal
+          context_namespace: namespace_traversal
+          metrics:
+            - ceph_mds_dir_commit
+            - ceph_mds_dir_fetch_complete
+            - ceph_mds_dir_fetch_keys
+            - ceph_mds_dir_merge
+            - ceph_mds_dir_split
+            - ceph_mds_openino_backtrace_fetch
+            - ceph_mds_openino_dir_fetch
+            - ceph_mds_openino_peer_discover
+            - ceph_mds_traverse
+            - ceph_mds_traverse_dir_fetch
+            - ceph_mds_traverse_discover
+            - ceph_mds_traverse_forward
+            - ceph_mds_traverse_hit
+            - ceph_mds_traverse_lock
+            - ceph_mds_traverse_remote_ino
+          charts:
+            - title: Directory-Fragment Lifecycle
+              context: dirfrag_lifecycle
+              units: dirfrags/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_dir_fetch_complete
+                  name: dir_fetch_complete
+                - selector: ceph_mds_dir_merge
+                  name: dir_merge
+                - selector: ceph_mds_dir_split
+                  name: dir_split
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Namespace Traversals
+              context: traversals
+              units: traversals/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_traverse
+                  name: traverse
+                - selector: ceph_mds_traverse_dir_fetch
+                  name: traverse_dir_fetch
+                - selector: ceph_mds_traverse_discover
+                  name: traverse_discover
+                - selector: ceph_mds_traverse_forward
+                  name: traverse_forward
+                - selector: ceph_mds_traverse_lock
+                  name: traverse_lock
+                - selector: ceph_mds_traverse_remote_ino
+                  name: traverse_remote_ino
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inode Work
+              context: inode_work
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_openino_peer_discover
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Key Work
+              context: key_work
+              units: keys/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_dir_fetch_keys
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Lookup Outcomes
+              context: lookup_outcomes
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_traverse_hit
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_dir_commit
+                  name: dir_commit
+                - selector: ceph_mds_openino_backtrace_fetch
+                  name: openino_backtrace_fetch
+                - selector: ceph_mds_openino_dir_fetch
+                  name: openino_dir_fetch
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Purge Queue
+          context_namespace: purge_queue
+          metrics:
+            - ceph_purge_queue_pq_executed
+            - ceph_purge_queue_pq_executed_ops
+            - ceph_purge_queue_pq_executing
+            - ceph_purge_queue_pq_executing_high_water
+            - ceph_purge_queue_pq_executing_ops
+            - ceph_purge_queue_pq_executing_ops_high_water
+            - ceph_purge_queue_pq_item_in_journal
+          charts:
+            - title: Current Work
+              context: current_work
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_item_in_journal
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Executed Purge Operations
+              context: purge_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_executed_ops
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Purge Operations in Flight
+              context: purge_operations_state
+              units: operations
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_executing_ops
+                  name: ops
+                - selector: ceph_purge_queue_pq_executing_ops_high_water
+                  name: high_water
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Executed Purge Tasks
+              context: purge_tasks
+              units: tasks/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_executed
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Purge Tasks in Flight
+              context: purge_tasks_state
+              units: tasks
+              label_promotion: []
+              dimensions:
+                - selector: ceph_purge_queue_pq_executing
+                  name: executing
+                - selector: ceph_purge_queue_pq_executing_high_water
+                  name: high_water
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Rank Migration
+          context_namespace: rank_migration
+          metrics:
+            - ceph_mds_exported
+            - ceph_mds_exported_inodes
+            - ceph_mds_imported
+            - ceph_mds_imported_inodes
+          charts:
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_exported
+                  name: exported
+                - selector: ceph_mds_imported
+                  name: imported
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inode Work
+              context: inode_work
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_exported_inodes
+                  name: exported_inodes
+                - selector: ceph_mds_imported_inodes
+                  name: imported_inodes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Read Request Latency
+          context_namespace: read_request_latency
+          metrics:
+            - ceph_mds_server_req_blockdiff_latency_count
+            - ceph_mds_server_req_blockdiff_latency_sum
+            - ceph_mds_server_req_getattr_latency_count
+            - ceph_mds_server_req_getattr_latency_sum
+            - ceph_mds_server_req_getfilelock_latency_count
+            - ceph_mds_server_req_getfilelock_latency_sum
+            - ceph_mds_server_req_getvxattr_latency_count
+            - ceph_mds_server_req_getvxattr_latency_sum
+            - ceph_mds_server_req_lookup_latency_count
+            - ceph_mds_server_req_lookup_latency_sum
+            - ceph_mds_server_req_lookuphash_latency_count
+            - ceph_mds_server_req_lookuphash_latency_sum
+            - ceph_mds_server_req_lookupino_latency_count
+            - ceph_mds_server_req_lookupino_latency_sum
+            - ceph_mds_server_req_lookupname_latency_count
+            - ceph_mds_server_req_lookupname_latency_sum
+            - ceph_mds_server_req_lookupparent_latency_count
+            - ceph_mds_server_req_lookupparent_latency_sum
+            - ceph_mds_server_req_lookupsnap_latency_count
+            - ceph_mds_server_req_lookupsnap_latency_sum
+            - ceph_mds_server_req_open_latency_count
+            - ceph_mds_server_req_open_latency_sum
+            - ceph_mds_server_req_readdir_latency_count
+            - ceph_mds_server_req_readdir_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_blockdiff_latency_count
+                  name: blockdiff_latency
+                - selector: ceph_mds_server_req_getattr_latency_count
+                  name: getattr_latency
+                - selector: ceph_mds_server_req_getfilelock_latency_count
+                  name: getfilelock_latency
+                - selector: ceph_mds_server_req_getvxattr_latency_count
+                  name: getvxattr_latency
+                - selector: ceph_mds_server_req_lookup_latency_count
+                  name: lookup_latency
+                - selector: ceph_mds_server_req_lookuphash_latency_count
+                  name: lookuphash_latency
+                - selector: ceph_mds_server_req_lookupino_latency_count
+                  name: lookupino_latency
+                - selector: ceph_mds_server_req_lookupname_latency_count
+                  name: lookupname_latency
+                - selector: ceph_mds_server_req_lookupparent_latency_count
+                  name: lookupparent_latency
+                - selector: ceph_mds_server_req_lookupsnap_latency_count
+                  name: lookupsnap_latency
+                - selector: ceph_mds_server_req_open_latency_count
+                  name: open_latency
+                - selector: ceph_mds_server_req_readdir_latency_count
+                  name: readdir_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_blockdiff_latency_sum
+                  name: blockdiff_latency
+                - selector: ceph_mds_server_req_getattr_latency_sum
+                  name: getattr_latency
+                - selector: ceph_mds_server_req_getfilelock_latency_sum
+                  name: getfilelock_latency
+                - selector: ceph_mds_server_req_getvxattr_latency_sum
+                  name: getvxattr_latency
+                - selector: ceph_mds_server_req_lookup_latency_sum
+                  name: lookup_latency
+                - selector: ceph_mds_server_req_lookuphash_latency_sum
+                  name: lookuphash_latency
+                - selector: ceph_mds_server_req_lookupino_latency_sum
+                  name: lookupino_latency
+                - selector: ceph_mds_server_req_lookupname_latency_sum
+                  name: lookupname_latency
+                - selector: ceph_mds_server_req_lookupparent_latency_sum
+                  name: lookupparent_latency
+                - selector: ceph_mds_server_req_lookupsnap_latency_sum
+                  name: lookupsnap_latency
+                - selector: ceph_mds_server_req_open_latency_sum
+                  name: open_latency
+                - selector: ceph_mds_server_req_readdir_latency_sum
+                  name: readdir_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Request Handling and State
+          context_namespace: request_handling_and_state
+          metrics:
+            - ceph_mds_client_metrics_num_clients
+            - ceph_mds_forward
+            - ceph_mds_inodes
+            - ceph_mds_inodes_bottom
+            - ceph_mds_inodes_expired
+            - ceph_mds_inodes_pin_tail
+            - ceph_mds_inodes_pinned
+            - ceph_mds_inodes_top
+            - ceph_mds_load_cent
+            - ceph_mds_q
+            - ceph_mds_reply
+            - ceph_mds_reply_latency_count
+            - ceph_mds_reply_latency_sum
+            - ceph_mds_request
+            - ceph_mds_root_rbytes
+            - ceph_mds_root_rfiles
+            - ceph_mds_root_rsnaps
+            - ceph_mds_server_dispatch_client_request
+            - ceph_mds_server_dispatch_server_request
+            - ceph_mds_server_handle_client_request
+            - ceph_mds_server_handle_client_session
+            - ceph_mds_server_handle_peer_request
+            - ceph_mds_slow_reply
+            - ceph_mds_subtrees
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_reply_latency_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_reply_latency_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Connected Clients
+              context: connected_clients
+              units: clients
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_client_metrics_num_clients
+                  name: client_metrics_num_clients
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - fs_name
+                  - id
+                optional_by_labels: []
+            - title: Queued Requests
+              context: queued_requests
+              units: requests
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_q
+                  name: q
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_reply
+                  name: reply
+                - selector: ceph_mds_server_handle_client_session
+                  name: server_handle_client_session
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_slow_reply
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Files
+              context: file_state
+              units: files
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_root_rfiles
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Inodes
+              context: inode_state
+              units: inodes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_inodes
+                  name: inodes
+                - selector: ceph_mds_inodes_bottom
+                  name: bottom
+                - selector: ceph_mds_inodes_pin_tail
+                  name: pin_tail
+                - selector: ceph_mds_inodes_pinned
+                  name: pinned
+                - selector: ceph_mds_inodes_top
+                  name: top
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Expired Inodes
+              context: expired_inodes
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_inodes_expired
+                  name: expired
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Load
+              context: load
+              units: load
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_load_cent
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_forward
+                  name: forward
+                - selector: ceph_mds_request
+                  name: request
+                - selector: ceph_mds_server_dispatch_client_request
+                  name: server_dispatch_client_request
+                - selector: ceph_mds_server_dispatch_server_request
+                  name: server_dispatch_server_request
+                - selector: ceph_mds_server_handle_client_request
+                  name: server_handle_client_request
+                - selector: ceph_mds_server_handle_peer_request
+                  name: server_handle_peer_request
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Snapshots
+              context: snapshot_state
+              units: snapshots
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_root_rsnaps
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_root_rbytes
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Subtrees
+              context: subtrees
+              units: subtrees
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_subtrees
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Scrubbing
+          context_namespace: scrubbing
+          metrics:
+            - ceph_mds_scrub_backtrace_fetch
+            - ceph_mds_scrub_backtrace_repaired
+            - ceph_mds_scrub_dir_base_inodes
+            - ceph_mds_scrub_dir_inodes
+            - ceph_mds_scrub_dirfrag_rstats
+            - ceph_mds_scrub_file_inodes
+            - ceph_mds_scrub_inotable_repaired
+            - ceph_mds_scrub_set_tag
+          charts:
+            - title: Scrubbed Inodes
+              context: scrubbed_inodes
+              units: inodes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_dir_base_inodes
+                  name: dir_base_inodes
+                - selector: ceph_mds_scrub_dir_inodes
+                  name: dir_inodes
+                - selector: ceph_mds_scrub_file_inodes
+                  name: file_inodes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Backtrace Work
+              context: backtrace_work
+              units: backtraces/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_backtrace_fetch
+                  name: backtrace_fetch
+                - selector: ceph_mds_scrub_backtrace_repaired
+                  name: backtrace_repaired
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Repaired Inotables
+              context: repaired_inotables
+              units: inotables/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_inotable_repaired
+                  name: inotable_repaired
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Applied Scrub Tags
+              context: applied_tags
+              units: tags/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_set_tag
+                  name: set_tag
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Directory-Fragment Recursive-Stat Updates
+              context: dirfrag_rstat_updates
+              units: dirfrags/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_scrub_dirfrag_rstats
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Snapshot Mutation Latency
+          context_namespace: snapshot_mutation_latency
+          metrics:
+            - ceph_mds_server_req_lssnap_latency_count
+            - ceph_mds_server_req_lssnap_latency_sum
+            - ceph_mds_server_req_mksnap_latency_count
+            - ceph_mds_server_req_mksnap_latency_sum
+            - ceph_mds_server_req_renamesnap_latency_count
+            - ceph_mds_server_req_renamesnap_latency_sum
+            - ceph_mds_server_req_rmsnap_latency_count
+            - ceph_mds_server_req_rmsnap_latency_sum
+            - ceph_mds_server_req_snapdiff_latency_count
+            - ceph_mds_server_req_snapdiff_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_lssnap_latency_count
+                  name: lssnap_latency
+                - selector: ceph_mds_server_req_mksnap_latency_count
+                  name: mksnap_latency
+                - selector: ceph_mds_server_req_renamesnap_latency_count
+                  name: renamesnap_latency
+                - selector: ceph_mds_server_req_rmsnap_latency_count
+                  name: rmsnap_latency
+                - selector: ceph_mds_server_req_snapdiff_latency_count
+                  name: snapdiff_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mds_server_req_lssnap_latency_sum
+                  name: lssnap_latency
+                - selector: ceph_mds_server_req_mksnap_latency_sum
+                  name: mksnap_latency
+                - selector: ceph_mds_server_req_renamesnap_latency_sum
+                  name: renamesnap_latency
+                - selector: ceph_mds_server_req_rmsnap_latency_sum
+                  name: rmsnap_latency
+                - selector: ceph_mds_server_req_snapdiff_latency_sum
+                  name: snapdiff_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+    - family: CephFS MDS Memory
+      context_namespace: cephfs_mds_memory
       metrics:
-      - ceph_hardware_temperature_celsius
+        - ceph_mds_mem_cap
+        - ceph_mds_mem_cap_minus
+        - ceph_mds_mem_cap_plus
+        - ceph_mds_mem_dir
+        - ceph_mds_mem_dir_minus
+        - ceph_mds_mem_dir_plus
+        - ceph_mds_mem_dn
+        - ceph_mds_mem_dn_minus
+        - ceph_mds_mem_dn_plus
+        - ceph_mds_mem_heap
+        - ceph_mds_mem_ino
+        - ceph_mds_mem_ino_minus
+        - ceph_mds_mem_ino_plus
+        - ceph_mds_mem_rss
       charts:
-      - title: Sensor Temperature
-        context: temperature
-        units: Celsius
-        label_promotion: []
-        dimensions:
-        - selector: ceph_hardware_temperature_celsius
-          name: value
-        instances:
-          by_labels:
-          - hostname
-          - sensor_name
-          optional_by_labels: []
-  - family: OSD Overview
-    context_namespace: osd_overview
-    metrics:
-    - ceph_osd_apply_latency_ms
-    - ceph_osd_commit_latency_ms
-    charts:
-    - title: Latency
-      context: latency
-      units: milliseconds
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_apply_latency_ms
-        name: apply_latency_ms
-      - selector: ceph_osd_commit_latency_ms
-        name: commit_latency_ms
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: Object Gateway Metadata
-    context_namespace: object_gateway_metadata
-    metrics:
-    - ceph_rgw_metadata
-    charts:
-    - title: State and Metadata
-      context: state
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rgw_metadata
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        - ceph_version
-        - hostname
-        - instance_id
-        optional_by_labels: []
-  - family: Placement Groups and Recovery
-    context_namespace: placement_groups_and_recovery
-    groups:
-    - family: Backfill
-      context_namespace: backfill
+        - title: Capabilities
+          context: capability_state
+          units: capabilities
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_cap
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Capability Work
+          context: capability_work
+          units: capabilities/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_cap_minus
+              name: minus
+            - selector: ceph_mds_mem_cap_plus
+              name: plus
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Dentries
+          context: dentry_state
+          units: dentries
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_dn
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Dentry Cache Churn
+          context: dentry_work
+          units: dentries/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_dn_minus
+              name: minus
+            - selector: ceph_mds_mem_dn_plus
+              name: plus
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Directories
+          context: directory_state
+          units: directories
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_dir
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Directory Cache Churn
+          context: directory_work
+          units: directories/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_dir_minus
+              name: minus
+            - selector: ceph_mds_mem_dir_plus
+              name: plus
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Inodes
+          context: inode_state
+          units: inodes
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_ino
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Inode Work
+          context: inode_work
+          units: inodes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_ino_minus
+              name: minus
+            - selector: ceph_mds_mem_ino_plus
+              name: plus
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Space and Memory
+          context: space
+          units: bytes
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_mem_heap
+              name: heap
+            - selector: ceph_mds_mem_rss
+              name: rss
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: CephFS MDS Sessions
+      context_namespace: cephfs_mds_sessions
       metrics:
-      - ceph_pg_backfill_toofull
-      - ceph_pg_backfill_unfound
-      - ceph_pg_backfill_wait
-      - ceph_pg_backfilling
-      - ceph_pg_forced_backfill
-      - ceph_pg_remapped
+        - ceph_mds_sessions_average_load
+        - ceph_mds_sessions_avg_session_uptime
+        - ceph_mds_sessions_mdthresh_evicted
+        - ceph_mds_sessions_session_add
+        - ceph_mds_sessions_session_count
+        - ceph_mds_sessions_session_remove
+        - ceph_mds_sessions_sessions_open
+        - ceph_mds_sessions_sessions_stale
+        - ceph_mds_sessions_total_load
       charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_backfill_toofull
-          name: backfill_toofull
-        - selector: ceph_pg_backfill_unfound
-          name: backfill_unfound
-        - selector: ceph_pg_backfill_wait
-          name: backfill_wait
-        - selector: ceph_pg_backfilling
-          name: backfilling
-        - selector: ceph_pg_forced_backfill
-          name: forced_backfill
-        - selector: ceph_pg_remapped
-          name: remapped
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Healthy State
-      context_namespace: healthy_state
+        - title: Duration and Time
+          context: duration
+          units: seconds
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_avg_session_uptime
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Events
+          context: events
+          units: events/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_session_add
+              name: add
+            - selector: ceph_mds_sessions_session_remove
+              name: remove
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Average Session Load
+          context: average_load
+          units: load
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_average_load
+              name: average_load
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Total Session Load
+          context: total_load
+          units: load
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_total_load
+              name: total_load
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Metadata-Threshold Evictions
+          context: metadata_threshold_evictions
+          units: sessions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_mdthresh_evicted
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Sessions
+          context: session_state
+          units: sessions
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_sessions_session_count
+              name: session
+            - selector: ceph_mds_sessions_sessions_open
+              name: sessions_open
+            - selector: ceph_mds_sessions_sessions_stale
+              name: sessions_stale
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: CephFS MDS Clients
+      context_namespace: cephfs_mds_clients
       metrics:
-      - ceph_pg_active
-      - ceph_pg_clean
-      - ceph_pg_deep
-      - ceph_pg_total
+        - ceph_mds_per_client_avg_metadata_latency
+        - ceph_mds_per_client_avg_read_latency
+        - ceph_mds_per_client_avg_write_latency
+        - ceph_mds_per_client_cap_hits
+        - ceph_mds_per_client_cap_miss
+        - ceph_mds_per_client_dentry_lease_hits
+        - ceph_mds_per_client_dentry_lease_miss
+        - ceph_mds_per_client_opened_files
+        - ceph_mds_per_client_opened_inodes
+        - ceph_mds_per_client_pinned_icaps
+        - ceph_mds_per_client_total_inodes
+        - ceph_mds_per_client_total_read_ops
+        - ceph_mds_per_client_total_read_size
+        - ceph_mds_per_client_total_write_ops
+        - ceph_mds_per_client_total_write_size
       charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_active
-          name: active
-        - selector: ceph_pg_clean
-          name: clean
-        - selector: ceph_pg_deep
-          name: deep
-        - selector: ceph_pg_total
-          name: pg_total
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Peering and Availability
-      context_namespace: peering_and_availability
+        - title: Capability Access Outcomes
+          context: capability_outcomes
+          units: accesses/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_cap_hits
+              name: hits
+            - selector: ceph_mds_per_client_cap_miss
+              name: misses
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+          algorithm: incremental
+        - title: Dentry Lease Lookup Outcomes
+          context: dentry_lease_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_dentry_lease_hits
+              name: hits
+            - selector: ceph_mds_per_client_dentry_lease_miss
+              name: misses
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+          algorithm: incremental
+        - title: Average Operation Latency
+          context: average_operation_latency
+          units: seconds
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_avg_read_latency
+              name: read
+            - selector: ceph_mds_per_client_avg_write_latency
+              name: write
+            - selector: ceph_mds_per_client_avg_metadata_latency
+              name: metadata
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+        - title: Open Files
+          context: open_files
+          units: files
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_opened_files
+              name: open
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+        - title: Inode State
+          context: inode_state
+          units: inodes
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_opened_inodes
+              name: open
+            - selector: ceph_mds_per_client_total_inodes
+              name: total
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+        - title: Pinned Inode Capabilities
+          context: pinned_inode_capabilities
+          units: capabilities
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_pinned_icaps
+              name: pinned
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+        - title: Reported I/O Operations
+          context: reported_io_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_total_read_ops
+              name: read
+            - selector: ceph_mds_per_client_total_write_ops
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+          algorithm: incremental
+        - title: Reported I/O Volume
+          context: reported_io_volume
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mds_per_client_total_read_size
+              name: read
+            - selector: ceph_mds_per_client_total_write_size
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+              - client
+              - rank
+            optional_by_labels:
+              - mds_filesystem_key
+          algorithm: incremental
+    - family: Exporter and Process Runtime
+      context_namespace: exporter_and_process_runtime
+      groups:
+        - family: Collection
+          context_namespace: collection
+          metrics:
+            - ceph_exporter_scrape_time
+          charts:
+            - title: Collection Duration
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_scrape_time
+                  name: duration
+              instances:
+                by_labels:
+                  - function
+                  - host
+                optional_by_labels: []
+        - family: Daemon Availability
+          context_namespace: daemon_availability
+          metrics:
+            - ceph_daemon_socket_up
+          charts:
+            - title: Daemon Socket State
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_daemon_socket_up
+                  name: reachable
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - hostname
+                optional_by_labels: []
+        - family: Daemon Processes
+          context_namespace: daemon_processes
+          metrics:
+            - ceph_exporter_cpu_total
+            - ceph_exporter_cpu_usage
+            - ceph_exporter_majflt_total
+            - ceph_exporter_minflt_total
+            - ceph_exporter_num_threads
+            - ceph_exporter_resident_size
+            - ceph_exporter_vm_size
+          charts:
+            - title: Page Faults
+              context: page_faults
+              units: faults/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_minflt_total
+                  name: minor
+                - selector: ceph_exporter_majflt_total
+                  name: major
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Threads
+              context: threads
+              units: threads
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_num_threads
+                  name: threads
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: CPU Utilization
+              context: cpu_utilization
+              units: percentage
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_cpu_usage
+                  name: utilization
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: CPU Time
+              context: cpu_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_cpu_total
+                  name_from_label: mode
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Memory
+              context: memory
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_exporter_vm_size
+                  name: virtual
+                - selector: ceph_exporter_resident_size
+                  name: resident
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Manager Daemons
+      context_namespace: manager_daemons
       metrics:
-      - ceph_pg_activating
-      - ceph_pg_creating
-      - ceph_pg_down
-      - ceph_pg_incomplete
-      - ceph_pg_laggy
-      - ceph_pg_peered
-      - ceph_pg_peering
-      - ceph_pg_premerge
-      - ceph_pg_stale
-      - ceph_pg_unknown
-      - ceph_pg_wait
+        - ceph_mgr_cache_hit
+        - ceph_mgr_cache_miss
       charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_activating
-          name: activating
-        - selector: ceph_pg_creating
-          name: creating
-        - selector: ceph_pg_down
-          name: down
-        - selector: ceph_pg_incomplete
-          name: incomplete
-        - selector: ceph_pg_laggy
-          name: laggy
-        - selector: ceph_pg_peered
-          name: peered
-        - selector: ceph_pg_peering
-          name: peering
-        - selector: ceph_pg_premerge
-          name: premerge
-        - selector: ceph_pg_stale
-          name: stale
-        - selector: ceph_pg_unknown
-          name: unknown
-        - selector: ceph_pg_wait
-          name: wait
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Recovery Flags
-      context_namespace: recovery_flags
+        - title: Lookup Outcomes
+          context: lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mgr_cache_hit
+              name: hit
+            - selector: ceph_mgr_cache_miss
+              name: miss
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: Messenger
+      context_namespace: messenger
       metrics:
-      - ceph_osd_flag_nobackfill
-      - ceph_osd_flag_norecover
+        - ceph_AsyncMessenger_RDMADispatcher_active_queue_pair
+        - ceph_AsyncMessenger_RDMADispatcher_async_last_wqe_events
+        - ceph_AsyncMessenger_RDMADispatcher_created_queue_pair
+        - ceph_AsyncMessenger_RDMADispatcher_handshake_errors
+        - ceph_AsyncMessenger_RDMADispatcher_inflight_tx_chunks
+        - ceph_AsyncMessenger_RDMADispatcher_polling
+        - ceph_AsyncMessenger_RDMADispatcher_rx_bufs_in_use
+        - ceph_AsyncMessenger_RDMADispatcher_rx_bufs_total
+        - ceph_AsyncMessenger_RDMADispatcher_rx_fin
+        - ceph_AsyncMessenger_RDMADispatcher_rx_total_wc
+        - ceph_AsyncMessenger_RDMADispatcher_rx_total_wc_errors
+        - ceph_AsyncMessenger_RDMADispatcher_total_async_events
+        - ceph_AsyncMessenger_RDMADispatcher_tx_retry_errors
+        - ceph_AsyncMessenger_RDMADispatcher_tx_total_wc
+        - ceph_AsyncMessenger_RDMADispatcher_tx_total_wc_errors
+        - ceph_AsyncMessenger_RDMADispatcher_tx_wr_flush_errors
+        - ceph_AsyncMessenger_Worker_msgr_connection_idle_timeouts
+        - ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_flag_nobackfill
-          name: nobackfill
-        - selector: ceph_osd_flag_norecover
-          name: norecover
-    - family: Recovery and Degradation
-      context_namespace: recovery_and_degradation
+        - title: RDMA Errors
+          context: rdma_errors
+          units: errors/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_handshake_errors
+              name: rdmadispatcher_handshake_errors
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_total_wc_errors
+              name: rdmadispatcher_rx_total_wc_errors
+            - selector: ceph_AsyncMessenger_RDMADispatcher_tx_retry_errors
+              name: rdmadispatcher_tx_retry_errors
+            - selector: ceph_AsyncMessenger_RDMADispatcher_tx_total_wc_errors
+              name: rdmadispatcher_tx_total_wc_errors
+            - selector: ceph_AsyncMessenger_RDMADispatcher_tx_wr_flush_errors
+              name: rdmadispatcher_tx_wr_flush_errors
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Connection Timeouts
+          context: connection_timeouts
+          units: connections/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_Worker_msgr_connection_idle_timeouts
+              name: worker_msgr_connection_idle_timeouts
+            - selector: ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
+              name: worker_msgr_connection_ready_timeouts
+          instances:
+            by_labels:
+              - ceph_daemon
+              - id
+              - instance_id
+            optional_by_labels: []
+        - title: Active Queue Pairs
+          context: active_queue_pairs
+          units: queue pairs
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_active_queue_pair
+              name: active_queue_pair
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: absolute
+        - title: Created Queue Pairs
+          context: created_queue_pairs
+          units: queue pairs/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_created_queue_pair
+              name: created_queue_pair
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: In-Flight Transmit Chunks
+          context: inflight_tx_chunks
+          units: chunks
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_inflight_tx_chunks
+              name: inflight_tx_chunks
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: absolute
+        - title: Polling State
+          context: polling_state
+          units: '{status}'
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_polling
+              name: polling
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: absolute
+        - title: Receive Buffers
+          context: receive_buffers
+          units: buffers
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_bufs_in_use
+              name: rx_bufs_in_use
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_bufs_total
+              name: rx_bufs
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: absolute
+        - title: Asynchronous Events
+          context: async_events
+          units: events/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_async_last_wqe_events
+              name: async_last_wqe_events
+            - selector: ceph_AsyncMessenger_RDMADispatcher_total_async_events
+              name: total_async_events
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Work Completions
+          context: work_completions
+          units: completions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_total_wc
+              name: rx_total_wc
+            - selector: ceph_AsyncMessenger_RDMADispatcher_tx_total_wc
+              name: tx_total_wc
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Received FIN Messages
+          context: received_fin_messages
+          units: messages/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_AsyncMessenger_RDMADispatcher_rx_fin
+              name: rx_fin
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: Monitor Daemons
+      context_namespace: monitor_daemons
       metrics:
-      - ceph_pg_degraded
-      - ceph_pg_forced_recovery
-      - ceph_pg_recovering
-      - ceph_pg_recovery_toofull
-      - ceph_pg_recovery_unfound
-      - ceph_pg_recovery_wait
-      - ceph_pg_undersized
+        - ceph_mon_election_call
+        - ceph_mon_election_lose
+        - ceph_mon_election_win
+        - ceph_mon_num_elections
+        - ceph_mon_num_sessions
+        - ceph_mon_session_add
+        - ceph_mon_session_rm
+        - ceph_mon_session_trim
       charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_degraded
-          name: degraded
-        - selector: ceph_pg_forced_recovery
-          name: forced_recovery
-        - selector: ceph_pg_recovering
-          name: recovering
-        - selector: ceph_pg_recovery_toofull
-          name: recovery_toofull
-        - selector: ceph_pg_recovery_unfound
-          name: recovery_unfound
-        - selector: ceph_pg_recovery_wait
-          name: recovery_wait
-        - selector: ceph_pg_undersized
-          name: undersized
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Scrub and Repair State
-      context_namespace: scrub_and_repair_state
+        - title: Elections
+          context: elections
+          units: elections/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mon_election_call
+              name: election_call
+            - selector: ceph_mon_election_lose
+              name: election_lose
+            - selector: ceph_mon_election_win
+              name: election_win
+            - selector: ceph_mon_num_elections
+              name: num_elections
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Sessions
+          context: session_state
+          units: sessions
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mon_num_sessions
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Session Churn
+          context: session_work
+          units: sessions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_mon_session_add
+              name: add
+            - selector: ceph_mon_session_rm
+              name: rm
+            - selector: ceph_mon_session_trim
+              name: trim
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: OSD Client I/O
+      context_namespace: osd_client_i_o
       metrics:
-      - ceph_pg_failed_repair
-      - ceph_pg_inconsistent
-      - ceph_pg_repair
-      - ceph_pg_scrubbing
-      - ceph_pg_snaptrim
-      - ceph_pg_snaptrim_error
-      - ceph_pg_snaptrim_wait
+        - ceph_osd_op
+        - ceph_osd_op_before_dequeue_op_lat_count
+        - ceph_osd_op_before_dequeue_op_lat_sum
+        - ceph_osd_op_before_queue_op_lat_count
+        - ceph_osd_op_before_queue_op_lat_sum
+        - ceph_osd_op_cache_hit
+        - ceph_osd_op_delayed_degraded
+        - ceph_osd_op_delayed_unreadable
+        - ceph_osd_op_in_bytes
+        - ceph_osd_op_latency_count
+        - ceph_osd_op_latency_sum
+        - ceph_osd_op_out_bytes
+        - ceph_osd_op_prepare_latency_count
+        - ceph_osd_op_prepare_latency_sum
+        - ceph_osd_op_process_latency_count
+        - ceph_osd_op_process_latency_sum
+        - ceph_osd_op_r
+        - ceph_osd_op_r_latency_count
+        - ceph_osd_op_r_latency_sum
+        - ceph_osd_op_r_out_bytes
+        - ceph_osd_op_r_prepare_latency_count
+        - ceph_osd_op_r_prepare_latency_sum
+        - ceph_osd_op_r_process_latency_count
+        - ceph_osd_op_r_process_latency_sum
+        - ceph_osd_op_rw
+        - ceph_osd_op_rw_in_bytes
+        - ceph_osd_op_rw_latency_count
+        - ceph_osd_op_rw_latency_sum
+        - ceph_osd_op_rw_out_bytes
+        - ceph_osd_op_rw_prepare_latency_count
+        - ceph_osd_op_rw_prepare_latency_sum
+        - ceph_osd_op_rw_process_latency_count
+        - ceph_osd_op_rw_process_latency_sum
+        - ceph_osd_op_w
+        - ceph_osd_op_w_in_bytes
+        - ceph_osd_op_w_latency_count
+        - ceph_osd_op_w_latency_sum
+        - ceph_osd_op_w_prepare_latency_count
+        - ceph_osd_op_w_prepare_latency_sum
+        - ceph_osd_op_w_process_latency_count
+        - ceph_osd_op_w_process_latency_sum
+        - ceph_osd_op_wip
+        - ceph_osd_replica_read
+        - ceph_osd_replica_read_redirect_conflict
+        - ceph_osd_replica_read_redirect_missing
+        - ceph_osd_replica_read_served
+        - ceph_osd_slow_ops_slow_ops_count
+        - ceph_osd_subop_in_bytes
+        - ceph_osd_subop_latency_count
+        - ceph_osd_subop_latency_sum
+        - ceph_osd_subop_pull
+        - ceph_osd_subop_pull_latency_count
+        - ceph_osd_subop_pull_latency_sum
+        - ceph_osd_subop_push
+        - ceph_osd_subop_push_in_bytes
+        - ceph_osd_subop_push_latency_count
+        - ceph_osd_subop_push_latency_sum
+        - ceph_osd_subop_w
+        - ceph_osd_subop_w_in_bytes
+        - ceph_osd_subop_w_latency_count
+        - ceph_osd_subop_w_latency_sum
+        - ceph_osd_tier_proxy_read
+        - ceph_osd_tier_proxy_write
       charts:
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pg_failed_repair
-          name: failed_repair
-        - selector: ceph_pg_inconsistent
-          name: inconsistent
-        - selector: ceph_pg_repair
-          name: repair
-        - selector: ceph_pg_scrubbing
-          name: scrubbing
-        - selector: ceph_pg_snaptrim
-          name: snaptrim
-        - selector: ceph_pg_snaptrim_error
-          name: snaptrim_error
-        - selector: ceph_pg_snaptrim_wait
-          name: snaptrim_wait
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-  - family: Pools
-    context_namespace: pools
-    groups:
-    - family: Capacity and Quotas
-      context_namespace: capacity_and_quotas
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_before_dequeue_op_lat_count
+              name: op_before_dequeue_op_lat
+            - selector: ceph_osd_op_before_queue_op_lat_count
+              name: op_before_queue_op_lat
+            - selector: ceph_osd_op_latency_count
+              name: op_latency
+            - selector: ceph_osd_op_prepare_latency_count
+              name: op_prepare_latency
+            - selector: ceph_osd_op_process_latency_count
+              name: op_process_latency
+            - selector: ceph_osd_op_r_latency_count
+              name: op_r_latency
+            - selector: ceph_osd_op_r_prepare_latency_count
+              name: op_r_prepare_latency
+            - selector: ceph_osd_op_r_process_latency_count
+              name: op_r_process_latency
+            - selector: ceph_osd_op_rw_latency_count
+              name: op_rw_latency
+            - selector: ceph_osd_op_rw_prepare_latency_count
+              name: op_rw_prepare_latency
+            - selector: ceph_osd_op_rw_process_latency_count
+              name: op_rw_process_latency
+            - selector: ceph_osd_op_w_latency_count
+              name: op_w_latency
+            - selector: ceph_osd_op_w_prepare_latency_count
+              name: op_w_prepare_latency
+            - selector: ceph_osd_op_w_process_latency_count
+              name: op_w_process_latency
+            - selector: ceph_osd_subop_latency_count
+              name: subop_latency
+            - selector: ceph_osd_subop_pull_latency_count
+              name: subop_pull_latency
+            - selector: ceph_osd_subop_push_latency_count
+              name: subop_push_latency
+            - selector: ceph_osd_subop_w_latency_count
+              name: subop_w_latency
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_before_dequeue_op_lat_sum
+              name: op_before_dequeue_op_lat
+            - selector: ceph_osd_op_before_queue_op_lat_sum
+              name: op_before_queue_op_lat
+            - selector: ceph_osd_op_latency_sum
+              name: op_latency
+            - selector: ceph_osd_op_prepare_latency_sum
+              name: op_prepare_latency
+            - selector: ceph_osd_op_process_latency_sum
+              name: op_process_latency
+            - selector: ceph_osd_op_r_latency_sum
+              name: op_r_latency
+            - selector: ceph_osd_op_r_prepare_latency_sum
+              name: op_r_prepare_latency
+            - selector: ceph_osd_op_r_process_latency_sum
+              name: op_r_process_latency
+            - selector: ceph_osd_op_rw_latency_sum
+              name: op_rw_latency
+            - selector: ceph_osd_op_rw_prepare_latency_sum
+              name: op_rw_prepare_latency
+            - selector: ceph_osd_op_rw_process_latency_sum
+              name: op_rw_process_latency
+            - selector: ceph_osd_op_w_latency_sum
+              name: op_w_latency
+            - selector: ceph_osd_op_w_prepare_latency_sum
+              name: op_w_prepare_latency
+            - selector: ceph_osd_op_w_process_latency_sum
+              name: op_w_process_latency
+            - selector: ceph_osd_subop_latency_sum
+              name: subop_latency
+            - selector: ceph_osd_subop_pull_latency_sum
+              name: subop_pull_latency
+            - selector: ceph_osd_subop_push_latency_sum
+              name: subop_push_latency
+            - selector: ceph_osd_subop_w_latency_sum
+              name: subop_w_latency
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Byte Throughput
+          context: byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_in_bytes
+              name: op_in_bytes
+            - selector: ceph_osd_op_out_bytes
+              name: op_out_bytes
+            - selector: ceph_osd_op_r_out_bytes
+              name: op_r_out_bytes
+            - selector: ceph_osd_op_rw_in_bytes
+              name: op_rw_in_bytes
+            - selector: ceph_osd_op_rw_out_bytes
+              name: op_rw_out_bytes
+            - selector: ceph_osd_op_w_in_bytes
+              name: op_w_in_bytes
+            - selector: ceph_osd_subop_in_bytes
+              name: subop_in_bytes
+            - selector: ceph_osd_subop_push_in_bytes
+              name: subop_push_in_bytes
+            - selector: ceph_osd_subop_w_in_bytes
+              name: subop_w_in_bytes
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Operations in Progress
+          context: current_operations
+          units: operations
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_wip
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Events
+          context: events
+          units: events/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_subop_push
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Failure and Delay Outcomes
+          context: failure_outcomes
+          units: events/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_slow_ops_slow_ops_count
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Lookup Outcomes
+          context: lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_cache_hit
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Object Work
+          context: object_work
+          units: objects/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op_delayed_degraded
+              name: op_delayed_degraded
+            - selector: ceph_osd_op_delayed_unreadable
+              name: op_delayed_unreadable
+            - selector: ceph_osd_replica_read_redirect_missing
+              name: replica_read_redirect_missing
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Operations
+          context: operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_op
+              name: op
+            - selector: ceph_osd_op_r
+              name: op_r
+            - selector: ceph_osd_op_rw
+              name: op_rw
+            - selector: ceph_osd_op_w
+              name: op_w
+            - selector: ceph_osd_replica_read
+              name: replica_read
+            - selector: ceph_osd_replica_read_redirect_conflict
+              name: replica_read_redirect_conflict
+            - selector: ceph_osd_replica_read_served
+              name: replica_read_served
+            - selector: ceph_osd_subop_pull
+              name: subop_pull
+            - selector: ceph_osd_subop_w
+              name: subop_w
+            - selector: ceph_osd_tier_proxy_read
+              name: tier_proxy_read
+            - selector: ceph_osd_tier_proxy_write
+              name: tier_proxy_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: OSD Recovery
+      context_namespace: osd_recovery
       metrics:
-      - ceph_pool_avail_raw
-      - ceph_pool_bytes_used
-      - ceph_pool_compress_bytes_used
-      - ceph_pool_compress_under_bytes
-      - ceph_pool_max_avail
-      - ceph_pool_percent_used
-      - ceph_pool_quota_bytes
-      - ceph_pool_quota_objects
-      - ceph_pool_stored
-      - ceph_pool_stored_raw
+        - ceph_osd_l_osd_recovery_backfill_queue_latency_count
+        - ceph_osd_l_osd_recovery_backfill_queue_latency_sum
+        - ceph_osd_l_osd_recovery_backfill_remove_queue_latency_count
+        - ceph_osd_l_osd_recovery_backfill_remove_queue_latency_sum
+        - ceph_osd_l_osd_recovery_context_queue_latency_count
+        - ceph_osd_l_osd_recovery_context_queue_latency_sum
+        - ceph_osd_l_osd_recovery_pull_queue_latency_count
+        - ceph_osd_l_osd_recovery_pull_queue_latency_sum
+        - ceph_osd_l_osd_recovery_push_queue_latency_count
+        - ceph_osd_l_osd_recovery_push_queue_latency_sum
+        - ceph_osd_l_osd_recovery_push_reply_queue_latency_count
+        - ceph_osd_l_osd_recovery_push_reply_queue_latency_sum
+        - ceph_osd_l_osd_recovery_queue_latency_count
+        - ceph_osd_l_osd_recovery_queue_latency_sum
+        - ceph_osd_l_osd_recovery_scan_queue_latency_count
+        - ceph_osd_l_osd_recovery_scan_queue_latency_sum
+        - ceph_osd_recovery_bytes
+        - ceph_osd_recovery_ops
+        - ceph_recoverystate_perf_pg_rebuild_duration_count
+        - ceph_recoverystate_perf_pg_rebuild_duration_sum
+        - ceph_recoverystate_perf_pg_rebuild_max_secs
+        - ceph_recoverystate_perf_pg_rebuild_min_secs
       charts:
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_quota_objects
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Logical Pool Capacity
-        context: logical_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_max_avail
-          name: max_avail
-        - selector: ceph_pool_quota_bytes
-          name: quota_bytes
-        - selector: ceph_pool_stored
-          name: stored
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Raw Pool Capacity
-        context: raw_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_avail_raw
-          name: avail_raw
-        - selector: ceph_pool_bytes_used
-          name: bytes_used
-        - selector: ceph_pool_stored_raw
-          name: stored_raw
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Compression Space
-        context: compression_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_compress_bytes_used
-          name: compress_bytes_used
-        - selector: ceph_pool_compress_under_bytes
-          name: compress_under_bytes
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Utilization
-        context: utilization
-        units: percentage
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_percent_used
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Client I/O
-      context_namespace: client_i_o
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_l_osd_recovery_backfill_queue_latency_count
+              name: backfill_queue_latency
+            - selector: ceph_osd_l_osd_recovery_backfill_remove_queue_latency_count
+              name: backfill_remove_queue_latency
+            - selector: ceph_osd_l_osd_recovery_context_queue_latency_count
+              name: context_queue_latency
+            - selector: ceph_osd_l_osd_recovery_pull_queue_latency_count
+              name: pull_queue_latency
+            - selector: ceph_osd_l_osd_recovery_push_queue_latency_count
+              name: push_queue_latency
+            - selector: ceph_osd_l_osd_recovery_push_reply_queue_latency_count
+              name: push_reply_queue_latency
+            - selector: ceph_osd_l_osd_recovery_queue_latency_count
+              name: queue_latency
+            - selector: ceph_osd_l_osd_recovery_scan_queue_latency_count
+              name: scan_queue_latency
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_l_osd_recovery_backfill_queue_latency_sum
+              name: backfill_queue_latency
+            - selector: ceph_osd_l_osd_recovery_backfill_remove_queue_latency_sum
+              name: backfill_remove_queue_latency
+            - selector: ceph_osd_l_osd_recovery_context_queue_latency_sum
+              name: context_queue_latency
+            - selector: ceph_osd_l_osd_recovery_pull_queue_latency_sum
+              name: pull_queue_latency
+            - selector: ceph_osd_l_osd_recovery_push_queue_latency_sum
+              name: push_queue_latency
+            - selector: ceph_osd_l_osd_recovery_push_reply_queue_latency_sum
+              name: push_reply_queue_latency
+            - selector: ceph_osd_l_osd_recovery_queue_latency_sum
+              name: queue_latency
+            - selector: ceph_osd_l_osd_recovery_scan_queue_latency_sum
+              name: scan_queue_latency
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Byte Throughput
+          context: byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_recovery_bytes
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Operations
+          context: operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_recovery_ops
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: PG Rebuild Duration Measurements
+          context: pg_rebuild_duration_measurements
+          units: duration measurements/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_recoverystate_perf_pg_rebuild_duration_count
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: PG Rebuild Accumulated Duration
+          context: pg_rebuild_accumulated_duration
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_recoverystate_perf_pg_rebuild_duration_sum
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: PG Rebuild Duration Range
+          context: pg_rebuild_duration_range
+          units: seconds
+          label_promotion: []
+          dimensions:
+            - selector: ceph_recoverystate_perf_pg_rebuild_max_secs
+              name: maximum
+            - selector: ceph_recoverystate_perf_pg_rebuild_min_secs
+              name: minimum
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: OSD Runtime
+      context_namespace: osd_runtime
       metrics:
-      - ceph_pool_rd
-      - ceph_pool_rd_bytes
-      - ceph_pool_wr
-      - ceph_pool_wr_bytes
+        - ceph_osd_agent_evict
+        - ceph_osd_agent_flush
+        - ceph_osd_agent_skip
+        - ceph_osd_agent_wake
+        - ceph_osd_cached_crc
+        - ceph_osd_cached_crc_adjusted
+        - ceph_osd_copyfrom
+        - ceph_osd_heartbeat_to_peers
+        - ceph_osd_loadavg
+        - ceph_osd_map_message_epoch_dups
+        - ceph_osd_map_message_epochs
+        - ceph_osd_map_messages
+        - ceph_osd_messages_delayed_for_map
+        - ceph_osd_missed_crc
+        - ceph_osd_numpg
+        - ceph_osd_numpg_primary
+        - ceph_osd_numpg_removing
+        - ceph_osd_numpg_replica
+        - ceph_osd_numpg_stray
+        - ceph_osd_object_ctx_cache_hit
+        - ceph_osd_object_ctx_cache_total
+        - ceph_osd_osd_map_bl_cache_hit
+        - ceph_osd_osd_map_bl_cache_miss
+        - ceph_osd_osd_map_cache_hit
+        - ceph_osd_osd_map_cache_miss
+        - ceph_osd_osd_map_cache_miss_low
+        - ceph_osd_osd_map_cache_miss_low_avg_count
+        - ceph_osd_osd_map_cache_miss_low_avg_sum
+        - ceph_osd_osd_pg_biginfo
+        - ceph_osd_osd_pg_fastinfo
+        - ceph_osd_osd_pg_info
+        - ceph_osd_osd_tier_flush_lat_count
+        - ceph_osd_osd_tier_flush_lat_sum
+        - ceph_osd_osd_tier_promote_lat_count
+        - ceph_osd_osd_tier_promote_lat_sum
+        - ceph_osd_osd_tier_r_lat_count
+        - ceph_osd_osd_tier_r_lat_sum
+        - ceph_osd_pull
+        - ceph_osd_push
+        - ceph_osd_push_out_bytes
+        - ceph_osd_stat_bytes
+        - ceph_osd_stat_bytes_avail
+        - ceph_osd_stat_bytes_used
+        - ceph_osd_subop
+        - ceph_osd_tier_clean
+        - ceph_osd_tier_delay
+        - ceph_osd_tier_dirty
+        - ceph_osd_tier_evict
+        - ceph_osd_tier_flush
+        - ceph_osd_tier_flush_fail
+        - ceph_osd_tier_promote
+        - ceph_osd_tier_try_flush
+        - ceph_osd_tier_try_flush_fail
+        - ceph_osd_tier_whiteout
+        - ceph_osd_watch_timeouts
       charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_rd_bytes
-          name: rd_bytes
-        - selector: ceph_pool_wr_bytes
-          name: wr_bytes
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_rd
-          name: rd
-        - selector: ceph_pool_wr
-          name: wr
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Metadata
-      context_namespace: metadata
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_tier_flush_lat_count
+              name: flush_lat
+            - selector: ceph_osd_osd_tier_promote_lat_count
+              name: promote_lat
+            - selector: ceph_osd_osd_tier_r_lat_count
+              name: r_lat
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_tier_flush_lat_sum
+              name: flush_lat
+            - selector: ceph_osd_osd_tier_promote_lat_sum
+              name: promote_lat
+            - selector: ceph_osd_osd_tier_r_lat_sum
+              name: r_lat
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Value Measurement Measurements
+          context: value_measurements
+          units: measurements/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_map_cache_miss_low_avg_count
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Value Measurement
+          context: accumulated_value
+          units: value/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_map_cache_miss_low_avg_sum
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Byte Throughput
+          context: byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_push_out_bytes
+              name: value
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: CRC Cache Lookup Outcomes
+          context: crc_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_cached_crc
+              name: cached_crc
+            - selector: ceph_osd_cached_crc_adjusted
+              name: cached_crc_adjusted
+            - selector: ceph_osd_missed_crc
+              name: missed_crc
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Tier-Agent Actions
+          context: tier_agent_actions
+          units: actions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_agent_evict
+              name: agent_evict
+            - selector: ceph_osd_agent_wake
+              name: agent_wake
+            - selector: ceph_osd_tier_clean
+              name: tier_clean
+            - selector: ceph_osd_tier_delay
+              name: tier_delay
+            - selector: ceph_osd_tier_dirty
+              name: tier_dirty
+            - selector: ceph_osd_tier_evict
+              name: tier_evict
+            - selector: ceph_osd_tier_promote
+              name: tier_promote
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Copy-From Operations
+          context: copyfrom_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_copyfrom
+              name: copyfrom
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: OSD-Map Messages
+          context: map_messages
+          units: messages/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_map_messages
+              name: map_messages
+            - selector: ceph_osd_messages_delayed_for_map
+              name: messages_delayed_for_map
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: OSD-Map Epochs
+          context: map_epochs
+          units: epochs/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_map_message_epochs
+              name: map_message_epochs
+            - selector: ceph_osd_map_message_epoch_dups
+              name: map_message_epoch_dups
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Placement-Group Updates
+          context: pg_updates
+          units: updates/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_pg_biginfo
+              name: osd_pg_biginfo
+            - selector: ceph_osd_osd_pg_fastinfo
+              name: osd_pg_fastinfo
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Total Placement-Group Updates
+          context: pg_updates_total
+          units: placement group updates/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_pg_info
+              name: total
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Pushes
+          context: pushes
+          units: pushes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_push
+              name: push
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Suboperations
+          context: suboperations
+          units: suboperations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_subop
+              name: subop
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Failed Tier Flush Attempts
+          context: failed_tier_flush_attempts
+          units: attempts/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_tier_flush_fail
+              name: tier_flush_fail
+            - selector: ceph_osd_tier_try_flush_fail
+              name: tier_try_flush_fail
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Watch Timeouts
+          context: watch_timeouts
+          units: watches/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_watch_timeouts
+              name: watch_timeouts
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: OSD-Map Buffer-Cache Lookup Outcomes
+          context: map_buffer_cache_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_map_bl_cache_hit
+              name: osd_map_bl_cache_hit
+            - selector: ceph_osd_osd_map_bl_cache_miss
+              name: osd_map_bl_cache_miss
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Decoded OSD-Map Cache Lookup Outcomes
+          context: map_cache_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_osd_map_cache_hit
+              name: osd_map_cache_hit
+            - selector: ceph_osd_osd_map_cache_miss
+              name: osd_map_cache_miss
+            - selector: ceph_osd_osd_map_cache_miss_low
+              name: osd_map_cache_miss_low
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Tier Whiteouts
+          context: tier_whiteouts
+          units: whiteouts/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_tier_whiteout
+              name: tier_whiteout
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Skipped Objects
+          context: skipped_objects
+          units: objects/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_agent_skip
+              name: agent_skip
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Object-Context Cache Lookup Outcomes
+          context: object_context_cache_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_object_ctx_cache_hit
+              name: object_ctx_cache_hit
+            - selector: ceph_osd_object_ctx_cache_total
+              name: object_ctx_cache
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Tier Flush Attempts
+          context: tier_flush_attempts
+          units: attempts/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_agent_flush
+              name: agent_flush
+            - selector: ceph_osd_tier_flush
+              name: tier_flush
+            - selector: ceph_osd_tier_try_flush
+              name: tier_try_flush
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Pulls
+          context: pulls
+          units: pulls/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_pull
+              name: pull
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Placement Groups
+          context: pg_state
+          units: PGs
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_numpg
+              name: numpg
+            - selector: ceph_osd_numpg_primary
+              name: primary
+            - selector: ceph_osd_numpg_removing
+              name: removing
+            - selector: ceph_osd_numpg_replica
+              name: replica
+            - selector: ceph_osd_numpg_stray
+              name: stray
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Space and Memory
+          context: space
+          units: bytes
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_stat_bytes
+              name: bytes
+            - selector: ceph_osd_stat_bytes_avail
+              name: avail
+            - selector: ceph_osd_stat_bytes_used
+              name: used
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Heartbeat Peers
+          context: heartbeat_peers
+          units: peers
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_heartbeat_to_peers
+              name: heartbeat_to_peers
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: OSD Load Average
+          context: load_average
+          units: load
+          label_promotion: []
+          dimensions:
+            - selector: ceph_osd_loadavg
+              name: loadavg
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: OSD Scrubbing - Ceph 19
+      context_namespace: osd_scrubbing_ceph_19
+      groups:
+        - family: Elapsed Time
+          context_namespace: elapsed_time
+          metrics:
+            - ceph_osd_scrub_dp_ec_failed_reservations_elapsed_count
+            - ceph_osd_scrub_dp_ec_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_count
+            - ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_sum
+            - ceph_osd_scrub_dp_ec_successful_reservations_elapsed_count
+            - ceph_osd_scrub_dp_ec_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_count
+            - ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_sum
+            - ceph_osd_scrub_dp_repl_failed_reservations_elapsed_count
+            - ceph_osd_scrub_dp_repl_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_count
+            - ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_sum
+            - ceph_osd_scrub_dp_repl_successful_reservations_elapsed_count
+            - ceph_osd_scrub_dp_repl_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_count
+            - ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_sum
+            - ceph_osd_scrub_sh_ec_failed_reservations_elapsed_count
+            - ceph_osd_scrub_sh_ec_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_count
+            - ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_sum
+            - ceph_osd_scrub_sh_ec_successful_reservations_elapsed_count
+            - ceph_osd_scrub_sh_ec_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_count
+            - ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_sum
+            - ceph_osd_scrub_sh_repl_failed_reservations_elapsed_count
+            - ceph_osd_scrub_sh_repl_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_count
+            - ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_sum
+            - ceph_osd_scrub_sh_repl_successful_reservations_elapsed_count
+            - ceph_osd_scrub_sh_repl_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_count
+            - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
+          charts:
+            - title: Scrub Elapsed-Time Measurements
+              context: scrub_latency_measurements
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_count
+                  name: dp_ec_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_count
+                  name: dp_ec_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_count
+                  name: dp_repl_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_count
+                  name: dp_repl_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_count
+                  name: sh_ec_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_count
+                  name: sh_ec_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_count
+                  name: sh_repl_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_count
+                  name: sh_repl_successful_scrubs_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Reservation Elapsed-Time Measurements
+              context: reservation_latency_measurements
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_reservations_elapsed_count
+                  name: dp_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_ec_successful_reservations_elapsed_count
+                  name: dp_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_repl_failed_reservations_elapsed_count
+                  name: dp_repl_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_repl_successful_reservations_elapsed_count
+                  name: dp_repl_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_ec_failed_reservations_elapsed_count
+                  name: sh_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_ec_successful_reservations_elapsed_count
+                  name: sh_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_repl_failed_reservations_elapsed_count
+                  name: sh_repl_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_repl_successful_reservations_elapsed_count
+                  name: sh_repl_successful_reservations_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Accumulated Scrub Elapsed Time
+              context: accumulated_scrub_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_sum
+                  name: dp_ec_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_sum
+                  name: dp_ec_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_sum
+                  name: dp_repl_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_sum
+                  name: dp_repl_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_sum
+                  name: sh_ec_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_sum
+                  name: sh_ec_successful_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_sum
+                  name: sh_repl_failed_scrubs_elapsed
+                - selector: ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
+                  name: sh_repl_successful_scrubs_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Reservation Elapsed Time
+              context: accumulated_reservation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_reservations_elapsed_sum
+                  name: dp_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_ec_successful_reservations_elapsed_sum
+                  name: dp_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_repl_failed_reservations_elapsed_sum
+                  name: dp_repl_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_dp_repl_successful_reservations_elapsed_sum
+                  name: dp_repl_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_ec_failed_reservations_elapsed_sum
+                  name: sh_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_ec_successful_reservations_elapsed_sum
+                  name: sh_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_repl_failed_reservations_elapsed_sum
+                  name: sh_repl_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_sh_repl_successful_reservations_elapsed_sum
+                  name: sh_repl_successful_reservations_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Outcomes
+          context_namespace: outcomes
+          metrics:
+            - ceph_osd_scrub_dp_ec_failed_scrubs
+            - ceph_osd_scrub_dp_ec_num_scrubs_started
+            - ceph_osd_scrub_dp_ec_successful_scrubs
+            - ceph_osd_scrub_dp_repl_failed_scrubs
+            - ceph_osd_scrub_dp_repl_num_scrubs_started
+            - ceph_osd_scrub_dp_repl_successful_scrubs
+            - ceph_osd_scrub_sh_ec_failed_scrubs
+            - ceph_osd_scrub_sh_ec_num_scrubs_started
+            - ceph_osd_scrub_sh_ec_successful_scrubs
+            - ceph_osd_scrub_sh_repl_failed_scrubs
+            - ceph_osd_scrub_sh_repl_num_scrubs_started
+            - ceph_osd_scrub_sh_repl_successful_scrubs
+          charts:
+            - title: Scrub Work
+              context: scrub_work
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_failed_scrubs
+                  name: dp_ec_failed_scrubs
+                - selector: ceph_osd_scrub_dp_ec_num_scrubs_started
+                  name: dp_ec_num_scrubs_started
+                - selector: ceph_osd_scrub_dp_ec_successful_scrubs
+                  name: dp_ec_successful_scrubs
+                - selector: ceph_osd_scrub_dp_repl_failed_scrubs
+                  name: dp_repl_failed_scrubs
+                - selector: ceph_osd_scrub_dp_repl_num_scrubs_started
+                  name: dp_repl_num_scrubs_started
+                - selector: ceph_osd_scrub_dp_repl_successful_scrubs
+                  name: dp_repl_successful_scrubs
+                - selector: ceph_osd_scrub_sh_ec_failed_scrubs
+                  name: sh_ec_failed_scrubs
+                - selector: ceph_osd_scrub_sh_ec_num_scrubs_started
+                  name: sh_ec_num_scrubs_started
+                - selector: ceph_osd_scrub_sh_ec_successful_scrubs
+                  name: sh_ec_successful_scrubs
+                - selector: ceph_osd_scrub_sh_repl_failed_scrubs
+                  name: sh_repl_failed_scrubs
+                - selector: ceph_osd_scrub_sh_repl_num_scrubs_started
+                  name: sh_repl_num_scrubs_started
+                - selector: ceph_osd_scrub_sh_repl_successful_scrubs
+                  name: sh_repl_successful_scrubs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+        - family: Reservations
+          context_namespace: reservations
+          metrics:
+            - ceph_osd_scrub_dp_ec_num_scrubs_past_reservation
+            - ceph_osd_scrub_dp_ec_replicas_in_reservation
+            - ceph_osd_scrub_dp_ec_reservation_process_aborted
+            - ceph_osd_scrub_dp_ec_reservation_process_failure
+            - ceph_osd_scrub_dp_ec_reservation_process_skipped
+            - ceph_osd_scrub_dp_repl_num_scrubs_past_reservation
+            - ceph_osd_scrub_dp_repl_replicas_in_reservation
+            - ceph_osd_scrub_dp_repl_reservation_process_aborted
+            - ceph_osd_scrub_dp_repl_reservation_process_failure
+            - ceph_osd_scrub_dp_repl_reservation_process_skipped
+            - ceph_osd_scrub_sh_ec_num_scrubs_past_reservation
+            - ceph_osd_scrub_sh_ec_replicas_in_reservation
+            - ceph_osd_scrub_sh_ec_reservation_process_aborted
+            - ceph_osd_scrub_sh_ec_reservation_process_failure
+            - ceph_osd_scrub_sh_ec_reservation_process_skipped
+            - ceph_osd_scrub_sh_repl_num_scrubs_past_reservation
+            - ceph_osd_scrub_sh_repl_replicas_in_reservation
+            - ceph_osd_scrub_sh_repl_reservation_process_aborted
+            - ceph_osd_scrub_sh_repl_reservation_process_failure
+            - ceph_osd_scrub_sh_repl_reservation_process_skipped
+          charts:
+            - title: Replicas in Reservation
+              context: replicas_in_reservation
+              units: replicas
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_replicas_in_reservation
+                  name: dp_ec_replicas_in_reservation
+                - selector: ceph_osd_scrub_dp_repl_replicas_in_reservation
+                  name: dp_repl_replicas_in_reservation
+                - selector: ceph_osd_scrub_sh_ec_replicas_in_reservation
+                  name: sh_ec_replicas_in_reservation
+                - selector: ceph_osd_scrub_sh_repl_replicas_in_reservation
+                  name: sh_repl_replicas_in_reservation
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Scrubs Past Reservation
+              context: scrubs_past_reservation
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_num_scrubs_past_reservation
+                  name: dp_ec_num_scrubs_past_reservation
+                - selector: ceph_osd_scrub_dp_repl_num_scrubs_past_reservation
+                  name: dp_repl_num_scrubs_past_reservation
+                - selector: ceph_osd_scrub_sh_ec_num_scrubs_past_reservation
+                  name: sh_ec_num_scrubs_past_reservation
+                - selector: ceph_osd_scrub_sh_repl_num_scrubs_past_reservation
+                  name: sh_repl_num_scrubs_past_reservation
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Reservation Process Outcomes
+              context: reservation_process_outcomes
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_reservation_process_aborted
+                  name: dp_ec_reservation_process_aborted
+                - selector: ceph_osd_scrub_dp_ec_reservation_process_failure
+                  name: dp_ec_reservation_process_failure
+                - selector: ceph_osd_scrub_dp_ec_reservation_process_skipped
+                  name: dp_ec_reservation_process_skipped
+                - selector: ceph_osd_scrub_dp_repl_reservation_process_aborted
+                  name: dp_repl_reservation_process_aborted
+                - selector: ceph_osd_scrub_dp_repl_reservation_process_failure
+                  name: dp_repl_reservation_process_failure
+                - selector: ceph_osd_scrub_dp_repl_reservation_process_skipped
+                  name: dp_repl_reservation_process_skipped
+                - selector: ceph_osd_scrub_sh_ec_reservation_process_aborted
+                  name: sh_ec_reservation_process_aborted
+                - selector: ceph_osd_scrub_sh_ec_reservation_process_failure
+                  name: sh_ec_reservation_process_failure
+                - selector: ceph_osd_scrub_sh_ec_reservation_process_skipped
+                  name: sh_ec_reservation_process_skipped
+                - selector: ceph_osd_scrub_sh_repl_reservation_process_aborted
+                  name: sh_repl_reservation_process_aborted
+                - selector: ceph_osd_scrub_sh_repl_reservation_process_failure
+                  name: sh_repl_reservation_process_failure
+                - selector: ceph_osd_scrub_sh_repl_reservation_process_skipped
+                  name: sh_repl_reservation_process_skipped
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+    - family: OSD Scrubbing - Ceph 20
+      context_namespace: osd_scrubbing_ceph_20
+      groups:
+        - family: Elapsed Time
+          context_namespace: elapsed_time
+          metrics:
+            - ceph_osd_failed_scrubs_ec_elapsed_count
+            - ceph_osd_failed_scrubs_ec_elapsed_sum
+            - ceph_osd_failed_scrubs_replicated_elapsed_count
+            - ceph_osd_failed_scrubs_replicated_elapsed_sum
+            - ceph_osd_scrub_ec_failed_reservations_elapsed_count
+            - ceph_osd_scrub_ec_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_ec_successful_reservations_elapsed_count
+            - ceph_osd_scrub_ec_successful_reservations_elapsed_sum
+            - ceph_osd_scrub_replicated_failed_reservations_elapsed_count
+            - ceph_osd_scrub_replicated_failed_reservations_elapsed_sum
+            - ceph_osd_scrub_replicated_successful_reservations_elapsed_count
+            - ceph_osd_scrub_replicated_successful_reservations_elapsed_sum
+            - ceph_osd_successful_scrubs_ec_elapsed_count
+            - ceph_osd_successful_scrubs_ec_elapsed_sum
+            - ceph_osd_successful_scrubs_replicated_elapsed_count
+            - ceph_osd_successful_scrubs_replicated_elapsed_sum
+          charts:
+            - title: Scrub Elapsed-Time Measurements
+              context: scrub_latency_measurements
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_failed_scrubs_ec_elapsed_count
+                  name: failed_scrubs_ec_elapsed
+                - selector: ceph_osd_failed_scrubs_replicated_elapsed_count
+                  name: failed_scrubs_replicated_elapsed
+                - selector: ceph_osd_successful_scrubs_ec_elapsed_count
+                  name: successful_scrubs_ec_elapsed
+                - selector: ceph_osd_successful_scrubs_replicated_elapsed_count
+                  name: successful_scrubs_replicated_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Reservation Elapsed-Time Measurements
+              context: reservation_latency_measurements
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_failed_reservations_elapsed_count
+                  name: scrub_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_ec_successful_reservations_elapsed_count
+                  name: scrub_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_replicated_failed_reservations_elapsed_count
+                  name: scrub_replicated_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_replicated_successful_reservations_elapsed_count
+                  name: scrub_replicated_successful_reservations_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Scrub Elapsed Time
+              context: accumulated_scrub_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_failed_scrubs_ec_elapsed_sum
+                  name: failed_scrubs_ec_elapsed
+                - selector: ceph_osd_failed_scrubs_replicated_elapsed_sum
+                  name: failed_scrubs_replicated_elapsed
+                - selector: ceph_osd_successful_scrubs_ec_elapsed_sum
+                  name: successful_scrubs_ec_elapsed
+                - selector: ceph_osd_successful_scrubs_replicated_elapsed_sum
+                  name: successful_scrubs_replicated_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Reservation Elapsed Time
+              context: accumulated_reservation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_failed_reservations_elapsed_sum
+                  name: scrub_ec_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_ec_successful_reservations_elapsed_sum
+                  name: scrub_ec_successful_reservations_elapsed
+                - selector: ceph_osd_scrub_replicated_failed_reservations_elapsed_sum
+                  name: scrub_replicated_failed_reservations_elapsed
+                - selector: ceph_osd_scrub_replicated_successful_reservations_elapsed_sum
+                  name: scrub_replicated_successful_reservations_elapsed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: Interference and Scheduling
+          context_namespace: interference_and_scheduling
+          metrics:
+            - ceph_osd_scrub_ec_io_blocked
+            - ceph_osd_scrub_ec_io_intersects
+            - ceph_osd_scrub_replicated_io_blocked
+            - ceph_osd_scrub_replicated_io_intersects
+          charts:
+            - title: Client Write Interference
+              context: client_write_interference
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_io_blocked
+                  name: ec_io_blocked
+                - selector: ceph_osd_scrub_ec_io_intersects
+                  name: ec_io_intersects
+                - selector: ceph_osd_scrub_replicated_io_blocked
+                  name: replicated_io_blocked
+                - selector: ceph_osd_scrub_replicated_io_intersects
+                  name: replicated_io_intersects
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Outcomes
+          context_namespace: outcomes
+          metrics:
+            - ceph_osd_failed_scrubs_ec
+            - ceph_osd_failed_scrubs_replicated
+            - ceph_osd_num_scrubs_started_ec
+            - ceph_osd_num_scrubs_started_replicated
+            - ceph_osd_successful_scrubs_ec
+            - ceph_osd_successful_scrubs_replicated
+          charts:
+            - title: Scrub Work
+              context: scrub_work
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_failed_scrubs_ec
+                  name: failed_scrubs_ec
+                - selector: ceph_osd_failed_scrubs_replicated
+                  name: failed_scrubs_replicated
+                - selector: ceph_osd_num_scrubs_started_ec
+                  name: num_scrubs_started_ec
+                - selector: ceph_osd_num_scrubs_started_replicated
+                  name: num_scrubs_started_replicated
+                - selector: ceph_osd_successful_scrubs_ec
+                  name: successful_scrubs_ec
+                - selector: ceph_osd_successful_scrubs_replicated
+                  name: successful_scrubs_replicated
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Reservations
+          context_namespace: reservations
+          metrics:
+            - ceph_osd_num_scrubs_past_reservation_ec
+            - ceph_osd_num_scrubs_past_reservation_replicated
+            - ceph_osd_scrub_ec_replicas_in_reservation
+            - ceph_osd_scrub_ec_reservation_process_aborted
+            - ceph_osd_scrub_ec_reservation_process_failure
+            - ceph_osd_scrub_ec_reservation_process_skipped
+            - ceph_osd_scrub_ec_reservations_completed
+            - ceph_osd_scrub_replicated_replicas_in_reservation
+            - ceph_osd_scrub_replicated_reservation_process_aborted
+            - ceph_osd_scrub_replicated_reservation_process_failure
+            - ceph_osd_scrub_replicated_reservation_process_skipped
+            - ceph_osd_scrub_replicated_scrub_reservations_completed
+          charts:
+            - title: Replicas in Reservation
+              context: replicas_in_reservation
+              units: replicas
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_replicas_in_reservation
+                  name: ec_replicas_in_reservation
+                - selector: ceph_osd_scrub_replicated_replicas_in_reservation
+                  name: replicated_replicas_in_reservation
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Scrubs Past Reservation
+              context: scrubs_past_reservation
+              units: scrubs/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_num_scrubs_past_reservation_ec
+                  name: num_scrubs_past_reservation_ec
+                - selector: ceph_osd_num_scrubs_past_reservation_replicated
+                  name: num_scrubs_past_reservation_replicated
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Reservation Process Outcomes
+              context: reservation_process_outcomes
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_reservation_process_aborted
+                  name: scrub_ec_reservation_process_aborted
+                - selector: ceph_osd_scrub_ec_reservation_process_failure
+                  name: scrub_ec_reservation_process_failure
+                - selector: ceph_osd_scrub_ec_reservation_process_skipped
+                  name: scrub_ec_reservation_process_skipped
+                - selector: ceph_osd_scrub_ec_reservations_completed
+                  name: scrub_ec_reservations_completed
+                - selector: ceph_osd_scrub_replicated_reservation_process_aborted
+                  name: scrub_replicated_reservation_process_aborted
+                - selector: ceph_osd_scrub_replicated_reservation_process_failure
+                  name: scrub_replicated_reservation_process_failure
+                - selector: ceph_osd_scrub_replicated_reservation_process_skipped
+                  name: scrub_replicated_reservation_process_skipped
+                - selector: ceph_osd_scrub_replicated_scrub_reservations_completed
+                  name: scrub_replicated_scrub_reservations_completed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Scrub Work
+          context_namespace: scrub_work
+          metrics:
+            - ceph_osd_scrub_ec_getattr_cnt
+            - ceph_osd_scrub_ec_read_bytes
+            - ceph_osd_scrub_ec_read_cnt
+            - ceph_osd_scrub_ec_stats_cnt
+            - ceph_osd_scrub_replicated_getattr_cnt
+            - ceph_osd_scrub_replicated_read_bytes
+            - ceph_osd_scrub_replicated_read_cnt
+            - ceph_osd_scrub_replicated_stats_cnt
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_read_bytes
+                  name: ec_read_bytes
+                - selector: ceph_osd_scrub_replicated_read_bytes
+                  name: replicated_read_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Scrub Calls
+              context: scrub_calls
+              units: calls/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_ec_getattr_cnt
+                  name: ec_getattr_cnt
+                - selector: ceph_osd_scrub_ec_read_cnt
+                  name: ec_read_cnt
+                - selector: ceph_osd_scrub_ec_stats_cnt
+                  name: ec_stats_cnt
+                - selector: ceph_osd_scrub_replicated_getattr_cnt
+                  name: replicated_getattr_cnt
+                - selector: ceph_osd_scrub_replicated_read_cnt
+                  name: replicated_read_cnt
+                - selector: ceph_osd_scrub_replicated_stats_cnt
+                  name: replicated_stats_cnt
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: OSD Scrubbing - Common Work
+      context_namespace: osd_scrubbing_common_work
+      groups:
+        - family: Interference and Scheduling
+          context_namespace: interference_and_scheduling
+          metrics:
+            - ceph_osd_scrub_dp_ec_chunk_busy
+            - ceph_osd_scrub_dp_ec_chunk_selected
+            - ceph_osd_scrub_dp_ec_locked_object
+            - ceph_osd_scrub_dp_ec_preemptions
+            - ceph_osd_scrub_dp_ec_write_blocked_by_scrub
+            - ceph_osd_scrub_dp_repl_chunk_busy
+            - ceph_osd_scrub_dp_repl_chunk_selected
+            - ceph_osd_scrub_dp_repl_locked_object
+            - ceph_osd_scrub_dp_repl_preemptions
+            - ceph_osd_scrub_dp_repl_write_blocked_by_scrub
+            - ceph_osd_scrub_sh_ec_chunk_busy
+            - ceph_osd_scrub_sh_ec_chunk_selected
+            - ceph_osd_scrub_sh_ec_locked_object
+            - ceph_osd_scrub_sh_ec_preemptions
+            - ceph_osd_scrub_sh_ec_write_blocked_by_scrub
+            - ceph_osd_scrub_sh_repl_chunk_busy
+            - ceph_osd_scrub_sh_repl_chunk_selected
+            - ceph_osd_scrub_sh_repl_locked_object
+            - ceph_osd_scrub_sh_repl_preemptions
+            - ceph_osd_scrub_sh_repl_write_blocked_by_scrub
+          charts:
+            - title: Object-Lock Waits
+              context: object_lock_waits
+              units: waits/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_locked_object
+                  name: dp_ec_locked_object
+                - selector: ceph_osd_scrub_dp_repl_locked_object
+                  name: dp_repl_locked_object
+                - selector: ceph_osd_scrub_sh_ec_locked_object
+                  name: sh_ec_locked_object
+                - selector: ceph_osd_scrub_sh_repl_locked_object
+                  name: sh_repl_locked_object
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Chunk Selection Outcomes
+              context: chunk_selection_outcomes
+              units: chunks/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_chunk_busy
+                  name: dp_ec_chunk_busy
+                - selector: ceph_osd_scrub_dp_ec_chunk_selected
+                  name: dp_ec_chunk_selected
+                - selector: ceph_osd_scrub_dp_repl_chunk_busy
+                  name: dp_repl_chunk_busy
+                - selector: ceph_osd_scrub_dp_repl_chunk_selected
+                  name: dp_repl_chunk_selected
+                - selector: ceph_osd_scrub_sh_ec_chunk_busy
+                  name: sh_ec_chunk_busy
+                - selector: ceph_osd_scrub_sh_ec_chunk_selected
+                  name: sh_ec_chunk_selected
+                - selector: ceph_osd_scrub_sh_repl_chunk_busy
+                  name: sh_repl_chunk_busy
+                - selector: ceph_osd_scrub_sh_repl_chunk_selected
+                  name: sh_repl_chunk_selected
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Scrub Preemptions
+              context: preemptions
+              units: preemptions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_preemptions
+                  name: dp_ec_preemptions
+                - selector: ceph_osd_scrub_dp_repl_preemptions
+                  name: dp_repl_preemptions
+                - selector: ceph_osd_scrub_sh_ec_preemptions
+                  name: sh_ec_preemptions
+                - selector: ceph_osd_scrub_sh_repl_preemptions
+                  name: sh_repl_preemptions
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+            - title: Client Writes Blocked by Scrub
+              context: blocked_client_writes
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_write_blocked_by_scrub
+                  name: dp_ec_write_blocked_by_scrub
+                - selector: ceph_osd_scrub_dp_repl_write_blocked_by_scrub
+                  name: dp_repl_write_blocked_by_scrub
+                - selector: ceph_osd_scrub_sh_ec_write_blocked_by_scrub
+                  name: sh_ec_write_blocked_by_scrub
+                - selector: ceph_osd_scrub_sh_repl_write_blocked_by_scrub
+                  name: sh_repl_write_blocked_by_scrub
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+        - family: Reservations
+          context_namespace: reservations
+          metrics:
+            - ceph_osd_scrub_dp_ec_scrub_reservations_completed
+            - ceph_osd_scrub_dp_repl_scrub_reservations_completed
+            - ceph_osd_scrub_sh_ec_scrub_reservations_completed
+            - ceph_osd_scrub_sh_repl_scrub_reservations_completed
+          charts:
+            - title: Completed Scrub Reservations
+              context: completed_reservations
+              units: reservations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_dp_ec_scrub_reservations_completed
+                  name: dp_ec_scrub_reservations_completed
+                - selector: ceph_osd_scrub_dp_repl_scrub_reservations_completed
+                  name: dp_repl_scrub_reservations_completed
+                - selector: ceph_osd_scrub_sh_ec_scrub_reservations_completed
+                  name: sh_ec_scrub_reservations_completed
+                - selector: ceph_osd_scrub_sh_repl_scrub_reservations_completed
+                  name: sh_repl_scrub_reservations_completed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - level
+                  - pooltype
+                optional_by_labels: []
+        - family: Scrub Work
+          context_namespace: scrub_work
+          metrics:
+            - ceph_osd_scrub_omapget_bytes
+            - ceph_osd_scrub_omapget_cnt
+            - ceph_osd_scrub_omapgetheader_bytes
+            - ceph_osd_scrub_omapgetheader_cnt
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_omapget_bytes
+                  name: omapget_bytes
+                - selector: ceph_osd_scrub_omapgetheader_bytes
+                  name: omapgetheader_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OMAP Scrub Calls
+              context: omap_calls
+              units: calls/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_osd_scrub_omapget_cnt
+                  name: omapget_cnt
+                - selector: ceph_osd_scrub_omapgetheader_cnt
+                  name: omapgetheader_cnt
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Object Gateway
+      context_namespace: object_gateway
+      groups:
+        - family: Lifecycle
+          context_namespace: lifecycle
+          metrics:
+            - ceph_rgw_lc_abort_mpu
+            - ceph_rgw_lc_expire_current
+            - ceph_rgw_lc_expire_dm
+            - ceph_rgw_lc_expire_noncurrent
+            - ceph_rgw_lc_transition_current
+            - ceph_rgw_lc_transition_noncurrent
+          charts:
+            - title: Lifecycle Actions
+              context: lifecycle_actions
+              units: actions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_lc_expire_current
+                  name: expire_current
+                - selector: ceph_rgw_lc_expire_dm
+                  name: expire_dm
+                - selector: ceph_rgw_lc_expire_noncurrent
+                  name: expire_noncurrent
+                - selector: ceph_rgw_lc_transition_current
+                  name: transition_current
+                - selector: ceph_rgw_lc_transition_noncurrent
+                  name: transition_noncurrent
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Aborted Multipart Uploads
+              context: aborted_multipart_uploads
+              units: uploads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_lc_abort_mpu
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+        - family: Lua
+          context_namespace: lua
+          metrics:
+            - ceph_rgw_lua_current_vms
+            - ceph_rgw_lua_script_fail
+            - ceph_rgw_lua_script_ok
+          charts:
+            - title: Current Lua Virtual Machines
+              context: current_vms
+              units: VMs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_lua_current_vms
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Lua Script Executions
+              context: script_executions
+              units: executions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_lua_script_ok
+                  name: success
+                - selector: ceph_rgw_lua_script_fail
+                  name: failure
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+        - family: Notifications
+          context_namespace: notifications
+          metrics:
+            - ceph_rgw_pubsub_event_lost
+            - ceph_rgw_pubsub_event_triggered
+            - ceph_rgw_pubsub_events
+            - ceph_rgw_pubsub_missing_conf
+            - ceph_rgw_pubsub_push_failed
+            - ceph_rgw_pubsub_push_ok
+            - ceph_rgw_pubsub_push_pending
+            - ceph_rgw_pubsub_store_fail
+            - ceph_rgw_pubsub_store_ok
+          charts:
+            - title: Pending Notification Events
+              context: pending_events
+              units: events
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_push_pending
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Stored Events
+              context: event_state
+              units: events
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_events
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Events
+              context: events
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_event_lost
+                  name: event_lost
+                - selector: ceph_rgw_pubsub_event_triggered
+                  name: event_triggered
+                - selector: ceph_rgw_pubsub_push_ok
+                  name: push_ok
+                - selector: ceph_rgw_pubsub_store_ok
+                  name: store_ok
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Failure and Delay Outcomes
+              context: failure_outcomes
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_push_failed
+                  name: push_failed
+                - selector: ceph_rgw_pubsub_store_fail
+                  name: store_fail
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Missing Notification Configurations
+              context: missing_configurations
+              units: events/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_pubsub_missing_conf
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+        - family: Requests and Queue
+          context_namespace: requests_and_queue
+          metrics:
+            - ceph_rgw_failed_req
+            - ceph_rgw_gc_retire_object
+            - ceph_rgw_get
+            - ceph_rgw_get_b
+            - ceph_rgw_get_initial_lat_count
+            - ceph_rgw_get_initial_lat_sum
+            - ceph_rgw_put
+            - ceph_rgw_put_b
+            - ceph_rgw_put_initial_lat_count
+            - ceph_rgw_put_initial_lat_sum
+            - ceph_rgw_qactive
+            - ceph_rgw_qlen
+            - ceph_rgw_req
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_get_initial_lat_count
+                  name: get_initial_lat
+                - selector: ceph_rgw_put_initial_lat_count
+                  name: put_initial_lat
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_get_initial_lat_sum
+                  name: get_initial_lat
+                - selector: ceph_rgw_put_initial_lat_sum
+                  name: put_initial_lat
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_get_b
+                  name: get_b
+                - selector: ceph_rgw_put_b
+                  name: put_b
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Queued and Active Requests
+              context: current_requests
+              units: requests
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_qactive
+                  name: qactive
+                - selector: ceph_rgw_qlen
+                  name: qlen
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Failed Requests
+              context: failed_requests
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_failed_req
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Object Work
+              context: object_work
+              units: objects/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_gc_retire_object
+                  name: value
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+            - title: Requests
+              context: requests
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_get
+                  name: get
+                - selector: ceph_rgw_put
+                  name: put
+                - selector: ceph_rgw_req
+                  name: req
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels: []
+    - family: Object Gateway Cache
+      context_namespace: object_gateway_cache
       metrics:
-      - ceph_pool_metadata
+        - ceph_rgw_cache_hit
+        - ceph_rgw_cache_miss
+        - ceph_rgw_keystone_token_cache_hit
+        - ceph_rgw_keystone_token_cache_miss
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_metadata
-          name: value
-        instances:
-          by_labels:
-          - application
-          - compression_mode
-          - description
-          - name
-          - pool_id
-          - type
-          optional_by_labels: []
-    - family: Objects
-      context_namespace: objects
+        - title: Keystone Token Cache Lookup Outcomes
+          context: keystone_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_keystone_token_cache_hit
+              name: hit
+            - selector: ceph_rgw_keystone_token_cache_miss
+              name: miss
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels: []
+        - title: Lookup Outcomes
+          context: lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_cache_hit
+              name: cache_hit
+            - selector: ceph_rgw_cache_miss
+              name: cache_miss
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels: []
+    - family: Object Gateway Multisite
+      context_namespace: object_gateway_multisite
       metrics:
-      - ceph_pool_dirty
-      - ceph_pool_objects
+        - ceph_data_sync_from_zone_fetch_bytes_count
+        - ceph_data_sync_from_zone_fetch_bytes_sum
+        - ceph_data_sync_from_zone_fetch_errors
+        - ceph_data_sync_from_zone_fetch_not_modified
+        - ceph_data_sync_from_zone_lock_latency_count
+        - ceph_data_sync_from_zone_lock_latency_sum
+        - ceph_data_sync_from_zone_poll_errors
+        - ceph_data_sync_from_zone_poll_latency_count
+        - ceph_data_sync_from_zone_poll_latency_sum
       charts:
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_dirty
-          name: dirty
-        - selector: ceph_pool_objects
-          name: objects
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-    - family: Recovery
-      context_namespace: recovery
+        - title: Replicated Objects
+          context: replicated_objects
+          units: objects/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_fetch_bytes_count
+              name: value
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+        - title: Accumulated Byte Measurement
+          context: accumulated_bytes
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_fetch_bytes_sum
+              name: value
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+          algorithm: incremental
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_lock_latency_count
+              name: lock_latency
+            - selector: ceph_data_sync_from_zone_poll_latency_count
+              name: poll_latency
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_lock_latency_sum
+              name: lock_latency
+            - selector: ceph_data_sync_from_zone_poll_latency_sum
+              name: poll_latency
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+          algorithm: incremental
+        - title: Replication-Log Request Errors
+          context: replication_log_request_errors
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_poll_errors
+              name: value
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+        - title: Object Work
+          context: object_work
+          units: objects/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_data_sync_from_zone_fetch_errors
+              name: errors
+            - selector: ceph_data_sync_from_zone_fetch_not_modified
+              name: not_modified
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels:
+              - source_zone
+    - family: Objecter
+      context_namespace: objecter
       metrics:
-      - ceph_pool_num_bytes_recovered
-      - ceph_pool_num_objects_recovered
-      - ceph_pool_objects_repaired
-      - ceph_pool_recovering_bytes_per_sec
-      - ceph_pool_recovering_keys_per_sec
-      - ceph_pool_recovering_objects_per_sec
+        - ceph_objecter_command_active
+        - ceph_objecter_command_resend
+        - ceph_objecter_command_send
+        - ceph_objecter_linger_active
+        - ceph_objecter_linger_ping
+        - ceph_objecter_linger_resend
+        - ceph_objecter_linger_send
+        - ceph_objecter_map_epoch
+        - ceph_objecter_map_full
+        - ceph_objecter_map_inc
+        - ceph_objecter_omap_del
+        - ceph_objecter_omap_rd
+        - ceph_objecter_omap_wr
+        - ceph_objecter_op
+        - ceph_objecter_op_active
+        - ceph_objecter_op_inflight
+        - ceph_objecter_op_laggy
+        - ceph_objecter_op_latency_count
+        - ceph_objecter_op_latency_sum
+        - ceph_objecter_op_pg
+        - ceph_objecter_op_r
+        - ceph_objecter_op_reply
+        - ceph_objecter_op_resend
+        - ceph_objecter_op_rmw
+        - ceph_objecter_op_send
+        - ceph_objecter_op_send_bytes
+        - ceph_objecter_op_w
+        - ceph_objecter_oplen_avg_count
+        - ceph_objecter_oplen_avg_sum
+        - ceph_objecter_osd_laggy
+        - ceph_objecter_osd_session_close
+        - ceph_objecter_osd_session_open
+        - ceph_objecter_osd_sessions
+        - ceph_objecter_osdop_append
+        - ceph_objecter_osdop_call
+        - ceph_objecter_osdop_clonerange
+        - ceph_objecter_osdop_cmpxattr
+        - ceph_objecter_osdop_create
+        - ceph_objecter_osdop_delete
+        - ceph_objecter_osdop_getxattr
+        - ceph_objecter_osdop_mapext
+        - ceph_objecter_osdop_notify
+        - ceph_objecter_osdop_other
+        - ceph_objecter_osdop_pgls
+        - ceph_objecter_osdop_pgls_filter
+        - ceph_objecter_osdop_read
+        - ceph_objecter_osdop_resetxattrs
+        - ceph_objecter_osdop_rmxattr
+        - ceph_objecter_osdop_setxattr
+        - ceph_objecter_osdop_sparse_read
+        - ceph_objecter_osdop_src_cmpxattr
+        - ceph_objecter_osdop_stat
+        - ceph_objecter_osdop_truncate
+        - ceph_objecter_osdop_watch
+        - ceph_objecter_osdop_write
+        - ceph_objecter_osdop_writefull
+        - ceph_objecter_osdop_writesame
+        - ceph_objecter_osdop_zero
+        - ceph_objecter_poolop_active
+        - ceph_objecter_poolop_resend
+        - ceph_objecter_poolop_send
+        - ceph_objecter_poolstat_active
+        - ceph_objecter_poolstat_resend
+        - ceph_objecter_poolstat_send
+        - ceph_objecter_replica_read_bounced
+        - ceph_objecter_replica_read_completed
+        - ceph_objecter_replica_read_sent
+        - ceph_objecter_statfs_active
+        - ceph_objecter_statfs_resend
+        - ceph_objecter_statfs_send
       charts:
-      - title: Current Throughput
-        context: current_throughput_bytes_s
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_recovering_bytes_per_sec
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Current Throughput
-        context: current_throughput_keys_s
-        units: keys/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_recovering_keys_per_sec
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Current Throughput
-        context: current_throughput_objects_s
-        units: objects/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_recovering_objects_per_sec
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_num_objects_recovered
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Object Work
-        context: object_work
-        units: objects/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_objects_repaired
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-      - title: Pool Capacity and Data Volume
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_pool_num_bytes_recovered
-          name: value
-        instances:
-          by_labels:
-          - pool_id
-          optional_by_labels: []
-  - family: RBD Images
-    context_namespace: rbd_images
-    groups:
-    - family: I/O
-      context_namespace: i_o
+        - title: Latency Measurements
+          context: latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_op_latency_count
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Accumulated Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_op_latency_sum
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          algorithm: incremental
+          aggregation: sum
+        - title: Submitted Top-Level Operations
+          context: submitted_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_oplen_avg_count
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Operation-Vector Entries
+          context: operation_vector_entries
+          units: entries/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_oplen_avg_sum
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          algorithm: incremental
+          aggregation: sum
+        - title: Byte Throughput
+          context: byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_op_send_bytes
+              name: value
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active Commands
+          context: active_commands
+          units: commands
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_command_active
+              name: command_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active Lingering Operations
+          context: active_lingering_operations
+          units: operations
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_linger_active
+              name: linger_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: OSD-Map Epoch
+          context: map_epoch
+          units: epoch
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_map_epoch
+              name: map_epoch
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: min
+        - title: Objecter Operations
+          context: active_operations
+          units: operations
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_op_active
+              name: op_active
+            - selector: ceph_objecter_op_inflight
+              name: op_inflight
+            - selector: ceph_objecter_op_laggy
+              name: op_laggy
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active Pool Operations
+          context: active_pool_operations
+          units: operations
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_poolop_active
+              name: poolop_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active Pool-Stat Requests
+          context: active_poolstat_requests
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_poolstat_active
+              name: poolstat_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Active StatFS Requests
+          context: active_statfs_requests
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_statfs_active
+              name: statfs_active
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Commands
+          context: commands
+          units: commands/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_command_resend
+              name: command_resend
+            - selector: ceph_objecter_command_send
+              name: command_send
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Lingering Operations
+          context: lingering_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_linger_ping
+              name: linger_ping
+            - selector: ceph_objecter_linger_resend
+              name: linger_resend
+            - selector: ceph_objecter_linger_send
+              name: linger_send
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: OSD Maps
+          context: maps
+          units: maps/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_map_full
+              name: map_full
+            - selector: ceph_objecter_map_inc
+              name: map_inc
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Object Operations
+          context: operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_omap_del
+              name: omap_del
+            - selector: ceph_objecter_omap_rd
+              name: omap_rd
+            - selector: ceph_objecter_omap_wr
+              name: omap_wr
+            - selector: ceph_objecter_op
+              name: op
+            - selector: ceph_objecter_op_pg
+              name: op_pg
+            - selector: ceph_objecter_op_r
+              name: op_r
+            - selector: ceph_objecter_op_reply
+              name: op_reply
+            - selector: ceph_objecter_op_resend
+              name: op_resend
+            - selector: ceph_objecter_op_rmw
+              name: op_rmw
+            - selector: ceph_objecter_op_send
+              name: op_send
+            - selector: ceph_objecter_op_w
+              name: op_w
+            - selector: ceph_objecter_osdop_append
+              name: osdop_append
+            - selector: ceph_objecter_osdop_call
+              name: osdop_call
+            - selector: ceph_objecter_osdop_clonerange
+              name: osdop_clonerange
+            - selector: ceph_objecter_osdop_cmpxattr
+              name: osdop_cmpxattr
+            - selector: ceph_objecter_osdop_create
+              name: osdop_create
+            - selector: ceph_objecter_osdop_delete
+              name: osdop_delete
+            - selector: ceph_objecter_osdop_getxattr
+              name: osdop_getxattr
+            - selector: ceph_objecter_osdop_mapext
+              name: osdop_mapext
+            - selector: ceph_objecter_osdop_notify
+              name: osdop_notify
+            - selector: ceph_objecter_osdop_other
+              name: osdop_other
+            - selector: ceph_objecter_osdop_pgls
+              name: osdop_pgls
+            - selector: ceph_objecter_osdop_pgls_filter
+              name: osdop_pgls_filter
+            - selector: ceph_objecter_osdop_read
+              name: osdop_read
+            - selector: ceph_objecter_osdop_resetxattrs
+              name: osdop_resetxattrs
+            - selector: ceph_objecter_osdop_rmxattr
+              name: osdop_rmxattr
+            - selector: ceph_objecter_osdop_setxattr
+              name: osdop_setxattr
+            - selector: ceph_objecter_osdop_sparse_read
+              name: osdop_sparse_read
+            - selector: ceph_objecter_osdop_src_cmpxattr
+              name: osdop_src_cmpxattr
+            - selector: ceph_objecter_osdop_stat
+              name: osdop_stat
+            - selector: ceph_objecter_osdop_truncate
+              name: osdop_truncate
+            - selector: ceph_objecter_osdop_watch
+              name: osdop_watch
+            - selector: ceph_objecter_osdop_write
+              name: osdop_write
+            - selector: ceph_objecter_osdop_writefull
+              name: osdop_writefull
+            - selector: ceph_objecter_osdop_writesame
+              name: osdop_writesame
+            - selector: ceph_objecter_osdop_zero
+              name: osdop_zero
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Replica Reads
+          context: replica_reads
+          units: reads/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_replica_read_sent
+              name: replica_read_sent
+            - selector: ceph_objecter_replica_read_bounced
+              name: replica_read_bounced
+            - selector: ceph_objecter_replica_read_completed
+              name: replica_read_completed
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: OSD Sessions
+          context: osd_sessions
+          units: sessions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_osd_session_close
+              name: osd_session_close
+            - selector: ceph_objecter_osd_session_open
+              name: osd_session_open
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Pool Operations
+          context: pool_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_poolop_resend
+              name: poolop_resend
+            - selector: ceph_objecter_poolop_send
+              name: poolop_send
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Pool-Stat and StatFS Requests
+          context: stat_requests
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_poolstat_resend
+              name: poolstat_resend
+            - selector: ceph_objecter_poolstat_send
+              name: poolstat_send
+            - selector: ceph_objecter_statfs_resend
+              name: statfs_resend
+            - selector: ceph_objecter_statfs_send
+              name: statfs_send
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+        - title: Sessions
+          context: session_state
+          units: sessions
+          label_promotion: []
+          dimensions:
+            - selector: ceph_objecter_osd_laggy
+              name: laggy
+            - selector: ceph_objecter_osd_sessions
+              name: sessions
+          instances:
+            by_labels: []
+            optional_by_labels:
+              - ceph_daemon
+              - instance_id
+          aggregation: sum
+    - family: RBD Client Images
+      context_namespace: rbd_client_images
       metrics:
-      - ceph_rbd_read_bytes
-      - ceph_rbd_read_ops
-      - ceph_rbd_write_bytes
-      - ceph_rbd_write_ops
+        - ceph_rbd_librbd_image_cmp
+        - ceph_rbd_librbd_image_cmp_bytes
+        - ceph_rbd_librbd_image_cmp_latency_count
+        - ceph_rbd_librbd_image_cmp_latency_sum
+        - ceph_rbd_librbd_image_discard
+        - ceph_rbd_librbd_image_discard_bytes
+        - ceph_rbd_librbd_image_discard_latency_count
+        - ceph_rbd_librbd_image_discard_latency_sum
+        - ceph_rbd_librbd_image_flush
+        - ceph_rbd_librbd_image_flush_latency_count
+        - ceph_rbd_librbd_image_flush_latency_sum
+        - ceph_rbd_librbd_image_invalidate_cache
+        - ceph_rbd_librbd_image_lock_acquired_time
+        - ceph_rbd_librbd_image_notify
+        - ceph_rbd_librbd_image_opened_time
+        - ceph_rbd_librbd_image_rd
+        - ceph_rbd_librbd_image_rd_bytes
+        - ceph_rbd_librbd_image_rd_latency_count
+        - ceph_rbd_librbd_image_rd_latency_sum
+        - ceph_rbd_librbd_image_readahead
+        - ceph_rbd_librbd_image_readahead_bytes
+        - ceph_rbd_librbd_image_resize
+        - ceph_rbd_librbd_image_snap_create
+        - ceph_rbd_librbd_image_snap_remove
+        - ceph_rbd_librbd_image_snap_rename
+        - ceph_rbd_librbd_image_snap_rollback
+        - ceph_rbd_librbd_image_wr
+        - ceph_rbd_librbd_image_wr_bytes
+        - ceph_rbd_librbd_image_wr_latency_count
+        - ceph_rbd_librbd_image_wr_latency_sum
+        - ceph_rbd_librbd_image_ws
+        - ceph_rbd_librbd_image_ws_bytes
+        - ceph_rbd_librbd_image_ws_latency_count
+        - ceph_rbd_librbd_image_ws_latency_sum
       charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_read_bytes
-          name: read_bytes
-        - selector: ceph_rbd_write_bytes
-          name: write_bytes
-        instances:
-          by_labels:
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_read_ops
-          name: read_ops
-        - selector: ceph_rbd_write_ops
-          name: write_ops
-        instances:
-          by_labels:
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-    - family: Image Metadata
-      context_namespace: image_metadata
+        - title: I/O Operations
+          context: io_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_rd
+              name: read
+            - selector: ceph_rbd_librbd_image_wr
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: I/O Byte Throughput
+          context: io_byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_rd_bytes
+              name: read
+            - selector: ceph_rbd_librbd_image_wr_bytes
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: I/O Latency Measurements
+          context: io_latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_rd_latency_count
+              name: read
+            - selector: ceph_rbd_librbd_image_wr_latency_count
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Accumulated I/O Latency
+          context: accumulated_io_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_rd_latency_sum
+              name: read
+            - selector: ceph_rbd_librbd_image_wr_latency_sum
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+          algorithm: incremental
+        - title: Lifecycle Timestamps
+          context: lifecycle_timestamps
+          units: seconds since epoch
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_opened_time
+              name: opened
+            - selector: ceph_rbd_librbd_image_lock_acquired_time
+              name: lock_acquired
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Data Operations
+          context: data_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_discard
+              name: discard
+            - selector: ceph_rbd_librbd_image_ws
+              name: write_same
+            - selector: ceph_rbd_librbd_image_cmp
+              name: compare_and_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Data Operation Byte Throughput
+          context: data_operation_byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_discard_bytes
+              name: discard
+            - selector: ceph_rbd_librbd_image_ws_bytes
+              name: write_same
+            - selector: ceph_rbd_librbd_image_cmp_bytes
+              name: compare_and_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Data Operation Latency Measurements
+          context: data_operation_latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_discard_latency_count
+              name: discard
+            - selector: ceph_rbd_librbd_image_ws_latency_count
+              name: write_same
+            - selector: ceph_rbd_librbd_image_cmp_latency_count
+              name: compare_and_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Accumulated Data Operation Latency
+          context: accumulated_data_operation_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_discard_latency_sum
+              name: discard
+            - selector: ceph_rbd_librbd_image_ws_latency_sum
+              name: write_same
+            - selector: ceph_rbd_librbd_image_cmp_latency_sum
+              name: compare_and_write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+          algorithm: incremental
+        - title: Flush Operations
+          context: flush_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_flush
+              name: flush
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Flush Latency Measurements
+          context: flush_latency_measurements
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_flush_latency_count
+              name: flush
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Accumulated Flush Latency
+          context: accumulated_flush_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_flush_latency_sum
+              name: flush
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+          algorithm: incremental
+        - title: Snapshot Mutations
+          context: snapshot_mutations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_snap_create
+              name: create
+            - selector: ceph_rbd_librbd_image_snap_remove
+              name: remove
+            - selector: ceph_rbd_librbd_image_snap_rollback
+              name: rollback
+            - selector: ceph_rbd_librbd_image_snap_rename
+              name: rename
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Maintenance Operations
+          context: maintenance_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_notify
+              name: notify
+            - selector: ceph_rbd_librbd_image_resize
+              name: resize
+            - selector: ceph_rbd_librbd_image_readahead
+              name: readahead
+            - selector: ceph_rbd_librbd_image_invalidate_cache
+              name: invalidate_cache
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+        - title: Readahead Byte Throughput
+          context: readahead_byte_throughput
+          units: bytes/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rbd_librbd_image_readahead_bytes
+              name: readahead
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels:
+              - librbd_image_key
+    - family: RBD Mirror
+      context_namespace: rbd_mirror
+      groups:
+        - family: Journal
+          context_namespace: journal
+          metrics:
+            - ceph_rbd_mirror_journal_entries
+            - ceph_rbd_mirror_journal_image_entries
+            - ceph_rbd_mirror_journal_image_replay_bytes
+            - ceph_rbd_mirror_journal_image_replay_latency_count
+            - ceph_rbd_mirror_journal_image_replay_latency_sum
+            - ceph_rbd_mirror_journal_replay_bytes
+            - ceph_rbd_mirror_journal_replay_latency_count
+            - ceph_rbd_mirror_journal_replay_latency_sum
+          charts:
+            - title: Journal Replay Latency Measurements
+              context: latency_measurements
+              units: entries/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_replay_latency_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Image Journal Replay Latency Measurements
+              context: image_latency_measurements
+              units: entries/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_image_replay_latency_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_replay_latency_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Image Journal Replay Latency
+              context: image_accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_image_replay_latency_sum
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_replay_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Image Journal Replay Byte Throughput
+              context: image_byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_image_replay_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Journal Entries
+              context: journal_entries
+              units: entries/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_entries
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Journal Entries Queued for Replay
+              context: image_journal_entries
+              units: entries/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_journal_image_entries
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+        - family: Snapshot Replication
+          context_namespace: snapshot_replication
+          metrics:
+            - ceph_rbd_mirror_snapshot_image_last_sync_bytes
+            - ceph_rbd_mirror_snapshot_image_last_sync_time
+            - ceph_rbd_mirror_snapshot_image_local_timestamp
+            - ceph_rbd_mirror_snapshot_image_remote_timestamp
+            - ceph_rbd_mirror_snapshot_image_snapshots
+            - ceph_rbd_mirror_snapshot_image_sync_bytes
+            - ceph_rbd_mirror_snapshot_image_sync_time_count
+            - ceph_rbd_mirror_snapshot_image_sync_time_sum
+            - ceph_rbd_mirror_snapshot_snapshots
+            - ceph_rbd_mirror_snapshot_sync_bytes
+            - ceph_rbd_mirror_snapshot_sync_time_count
+            - ceph_rbd_mirror_snapshot_sync_time_sum
+          charts:
+            - title: Snapshot Sync Latency Measurements — Image Sync Time
+              context: latency_measurements_image_sync_time
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_sync_time_count
+                  name: image_sync_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Snapshot Sync Latency Measurements — Sync Time
+              context: latency_measurements_sync_time
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_sync_time_count
+                  name: sync_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency — Image Sync Time
+              context: accumulated_latency_image_sync_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_sync_time_sum
+                  name: image_sync_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Latency — Sync Time
+              context: accumulated_latency_sync_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_sync_time_sum
+                  name: sync_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Byte Throughput — Image Sync Bytes
+              context: byte_throughput_image_sync_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_sync_bytes
+                  name: image_sync_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Byte Throughput — Sync Bytes
+              context: byte_throughput_sync_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_sync_bytes
+                  name: sync_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Last Snapshot Sync Duration
+              context: last_sync_duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_last_sync_time
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Last Snapshot Sync Size
+              context: last_sync_size
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_last_sync_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Snapshot Work — Image Snapshots
+              context: snapshot_work_image_snapshots
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_snapshots
+                  name: image_snapshots
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+            - title: Snapshot Work — Snapshots
+              context: snapshot_work_snapshots
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_snapshots
+                  name: snapshots
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Timestamps
+              context: timestamp
+              units: seconds since epoch
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_mirror_snapshot_image_local_timestamp
+                  name: local_timestamp
+                - selector: ceph_rbd_mirror_snapshot_image_remote_timestamp
+                  name: remote_timestamp
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - image
+                  - namespace
+                  - pool
+                optional_by_labels: []
+    - family: Runtime
+      context_namespace: runtime
+      groups:
+        - family: Shared Daemon
+          context_namespace: shared_daemon
+          metrics:
+            - ceph_KStore_state_done_lat_count
+            - ceph_KStore_state_done_lat_sum
+            - ceph_KStore_state_finishing_lat_count
+            - ceph_KStore_state_finishing_lat_sum
+            - ceph_KStore_state_kv_done_lat_count
+            - ceph_KStore_state_kv_done_lat_sum
+            - ceph_KStore_state_kv_queued_lat_count
+            - ceph_KStore_state_kv_queued_lat_sum
+            - ceph_KStore_state_prepare_lat_count
+            - ceph_KStore_state_prepare_lat_sum
+            - ceph_cct_total_workers
+            - ceph_cct_unhealthy_workers
+            - ceph_client_fsync_count
+            - ceph_client_fsync_sum
+            - ceph_client_lat_count
+            - ceph_client_lat_sum
+            - ceph_client_mdavg
+            - ceph_client_mdsqsum
+            - ceph_client_rdlat_count
+            - ceph_client_rdlat_sum
+            - ceph_client_readavg
+            - ceph_client_readsqsum
+            - ceph_client_reply_count
+            - ceph_client_reply_sum
+            - ceph_client_writeavg
+            - ceph_client_writesqsum
+            - ceph_client_wrlat_count
+            - ceph_client_wrlat_sum
+            - ceph_cluster_num_bytes
+            - ceph_cluster_num_mon
+            - ceph_cluster_num_mon_quorum
+            - ceph_cluster_num_object
+            - ceph_cluster_num_object_degraded
+            - ceph_cluster_num_object_misplaced
+            - ceph_cluster_num_object_unfound
+            - ceph_cluster_num_osd
+            - ceph_cluster_num_osd_in
+            - ceph_cluster_num_osd_up
+            - ceph_cluster_num_pg
+            - ceph_cluster_num_pg_active
+            - ceph_cluster_num_pg_active_clean
+            - ceph_cluster_num_pg_peering
+            - ceph_cluster_num_pool
+            - ceph_cluster_osd_bytes
+            - ceph_cluster_osd_bytes_avail
+            - ceph_cluster_osd_bytes_used
+            - ceph_cluster_osd_epoch
+            - ceph_ipv4_dpdk_ip_linearize_operations
+            - ceph_libcephsqlite_vfs_op_access_count
+            - ceph_libcephsqlite_vfs_op_access_sum
+            - ceph_libcephsqlite_vfs_op_currenttime_count
+            - ceph_libcephsqlite_vfs_op_currenttime_sum
+            - ceph_libcephsqlite_vfs_op_delete_count
+            - ceph_libcephsqlite_vfs_op_delete_sum
+            - ceph_libcephsqlite_vfs_op_fullpathname_count
+            - ceph_libcephsqlite_vfs_op_fullpathname_sum
+            - ceph_libcephsqlite_vfs_op_open_count
+            - ceph_libcephsqlite_vfs_op_open_sum
+            - ceph_libcephsqlite_vfs_opf_checkreservedlock_count
+            - ceph_libcephsqlite_vfs_opf_checkreservedlock_sum
+            - ceph_libcephsqlite_vfs_opf_close_count
+            - ceph_libcephsqlite_vfs_opf_close_sum
+            - ceph_libcephsqlite_vfs_opf_devicecharacteristics_count
+            - ceph_libcephsqlite_vfs_opf_devicecharacteristics_sum
+            - ceph_libcephsqlite_vfs_opf_filecontrol_count
+            - ceph_libcephsqlite_vfs_opf_filecontrol_sum
+            - ceph_libcephsqlite_vfs_opf_filesize_count
+            - ceph_libcephsqlite_vfs_opf_filesize_sum
+            - ceph_libcephsqlite_vfs_opf_lock_count
+            - ceph_libcephsqlite_vfs_opf_lock_sum
+            - ceph_libcephsqlite_vfs_opf_read_count
+            - ceph_libcephsqlite_vfs_opf_read_sum
+            - ceph_libcephsqlite_vfs_opf_sectorsize_count
+            - ceph_libcephsqlite_vfs_opf_sectorsize_sum
+            - ceph_libcephsqlite_vfs_opf_sync_count
+            - ceph_libcephsqlite_vfs_opf_sync_sum
+            - ceph_libcephsqlite_vfs_opf_truncate_count
+            - ceph_libcephsqlite_vfs_opf_truncate_sum
+            - ceph_libcephsqlite_vfs_opf_unlock_count
+            - ceph_libcephsqlite_vfs_opf_unlock_sum
+            - ceph_libcephsqlite_vfs_opf_write_count
+            - ceph_libcephsqlite_vfs_opf_write_sum
+            - ceph_oft_omap_total_kv_pairs
+            - ceph_oft_omap_total_objs
+            - ceph_oft_omap_total_removes
+            - ceph_oft_omap_total_updates
+            - ceph_recoverystate_perf_activating_latency_count
+            - ceph_recoverystate_perf_activating_latency_sum
+            - ceph_recoverystate_perf_active_latency_count
+            - ceph_recoverystate_perf_active_latency_sum
+            - ceph_recoverystate_perf_backfilling_latency_count
+            - ceph_recoverystate_perf_backfilling_latency_sum
+            - ceph_recoverystate_perf_clean_latency_count
+            - ceph_recoverystate_perf_clean_latency_sum
+            - ceph_recoverystate_perf_down_latency_count
+            - ceph_recoverystate_perf_down_latency_sum
+            - ceph_recoverystate_perf_getinfo_latency_count
+            - ceph_recoverystate_perf_getinfo_latency_sum
+            - ceph_recoverystate_perf_getlog_latency_count
+            - ceph_recoverystate_perf_getlog_latency_sum
+            - ceph_recoverystate_perf_getmissing_latency_count
+            - ceph_recoverystate_perf_getmissing_latency_sum
+            - ceph_recoverystate_perf_incomplete_latency_count
+            - ceph_recoverystate_perf_incomplete_latency_sum
+            - ceph_recoverystate_perf_initial_latency_count
+            - ceph_recoverystate_perf_initial_latency_sum
+            - ceph_recoverystate_perf_notbackfilling_latency_count
+            - ceph_recoverystate_perf_notbackfilling_latency_sum
+            - ceph_recoverystate_perf_notrecovering_latency_count
+            - ceph_recoverystate_perf_notrecovering_latency_sum
+            - ceph_recoverystate_perf_peering_latency_count
+            - ceph_recoverystate_perf_peering_latency_sum
+            - ceph_recoverystate_perf_primary_latency_count
+            - ceph_recoverystate_perf_primary_latency_sum
+            - ceph_recoverystate_perf_recovered_latency_count
+            - ceph_recoverystate_perf_recovered_latency_sum
+            - ceph_recoverystate_perf_recovering_latency_count
+            - ceph_recoverystate_perf_recovering_latency_sum
+            - ceph_recoverystate_perf_replicaactive_latency_count
+            - ceph_recoverystate_perf_replicaactive_latency_sum
+            - ceph_recoverystate_perf_repnotrecovering_latency_count
+            - ceph_recoverystate_perf_repnotrecovering_latency_sum
+            - ceph_recoverystate_perf_reprecovering_latency_count
+            - ceph_recoverystate_perf_reprecovering_latency_sum
+            - ceph_recoverystate_perf_repwaitbackfillreserved_latency_count
+            - ceph_recoverystate_perf_repwaitbackfillreserved_latency_sum
+            - ceph_recoverystate_perf_repwaitrecoveryreserved_latency_count
+            - ceph_recoverystate_perf_repwaitrecoveryreserved_latency_sum
+            - ceph_recoverystate_perf_reset_latency_count
+            - ceph_recoverystate_perf_reset_latency_sum
+            - ceph_recoverystate_perf_start_latency_count
+            - ceph_recoverystate_perf_start_latency_sum
+            - ceph_recoverystate_perf_started_latency_count
+            - ceph_recoverystate_perf_started_latency_sum
+            - ceph_recoverystate_perf_stats_invalidated
+            - ceph_recoverystate_perf_stray_latency_count
+            - ceph_recoverystate_perf_stray_latency_sum
+            - ceph_recoverystate_perf_waitactingchange_latency_count
+            - ceph_recoverystate_perf_waitactingchange_latency_sum
+            - ceph_recoverystate_perf_waitlocalbackfillreserved_latency_count
+            - ceph_recoverystate_perf_waitlocalbackfillreserved_latency_sum
+            - ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_count
+            - ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_sum
+            - ceph_recoverystate_perf_waitremotebackfillreserved_latency_count
+            - ceph_recoverystate_perf_waitremotebackfillreserved_latency_sum
+            - ceph_recoverystate_perf_waitremoterecoveryreserved_latency_count
+            - ceph_recoverystate_perf_waitremoterecoveryreserved_latency_sum
+            - ceph_recoverystate_perf_waitupthru_latency_count
+            - ceph_recoverystate_perf_waitupthru_latency_sum
+          charts:
+            - title: KStore Transaction Latency Measurements
+              context: kstore_latency_measurements
+              units: transactions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_KStore_state_done_lat_count
+                  name: kstore_state_done_lat
+                - selector: ceph_KStore_state_finishing_lat_count
+                  name: kstore_state_finishing_lat
+                - selector: ceph_KStore_state_kv_done_lat_count
+                  name: kstore_state_kv_done_lat
+                - selector: ceph_KStore_state_kv_queued_lat_count
+                  name: kstore_state_kv_queued_lat
+                - selector: ceph_KStore_state_prepare_lat_count
+                  name: kstore_state_prepare_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Client Request Latency Measurements
+              context: client_latency_measurements
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_lat_count
+                  name: client_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Recovery-State Transition Latency Measurements
+              context: recovery_state_latency_measurements
+              units: state transitions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_recoverystate_perf_activating_latency_count
+                  name: recoverystate_perf_activating_latency
+                - selector: ceph_recoverystate_perf_active_latency_count
+                  name: recoverystate_perf_active_latency
+                - selector: ceph_recoverystate_perf_backfilling_latency_count
+                  name: recoverystate_perf_backfilling_latency
+                - selector: ceph_recoverystate_perf_clean_latency_count
+                  name: recoverystate_perf_clean_latency
+                - selector: ceph_recoverystate_perf_down_latency_count
+                  name: recoverystate_perf_down_latency
+                - selector: ceph_recoverystate_perf_getinfo_latency_count
+                  name: recoverystate_perf_getinfo_latency
+                - selector: ceph_recoverystate_perf_getlog_latency_count
+                  name: recoverystate_perf_getlog_latency
+                - selector: ceph_recoverystate_perf_getmissing_latency_count
+                  name: recoverystate_perf_getmissing_latency
+                - selector: ceph_recoverystate_perf_incomplete_latency_count
+                  name: recoverystate_perf_incomplete_latency
+                - selector: ceph_recoverystate_perf_initial_latency_count
+                  name: recoverystate_perf_initial_latency
+                - selector: ceph_recoverystate_perf_notbackfilling_latency_count
+                  name: recoverystate_perf_notbackfilling_latency
+                - selector: ceph_recoverystate_perf_notrecovering_latency_count
+                  name: recoverystate_perf_notrecovering_latency
+                - selector: ceph_recoverystate_perf_peering_latency_count
+                  name: recoverystate_perf_peering_latency
+                - selector: ceph_recoverystate_perf_primary_latency_count
+                  name: recoverystate_perf_primary_latency
+                - selector: ceph_recoverystate_perf_recovered_latency_count
+                  name: recoverystate_perf_recovered_latency
+                - selector: ceph_recoverystate_perf_recovering_latency_count
+                  name: recoverystate_perf_recovering_latency
+                - selector: ceph_recoverystate_perf_replicaactive_latency_count
+                  name: recoverystate_perf_replicaactive_latency
+                - selector: ceph_recoverystate_perf_repnotrecovering_latency_count
+                  name: recoverystate_perf_repnotrecovering_latency
+                - selector: ceph_recoverystate_perf_reprecovering_latency_count
+                  name: recoverystate_perf_reprecovering_latency
+                - selector: ceph_recoverystate_perf_repwaitbackfillreserved_latency_count
+                  name: recoverystate_perf_repwaitbackfillreserved_latency
+                - selector: ceph_recoverystate_perf_repwaitrecoveryreserved_latency_count
+                  name: recoverystate_perf_repwaitrecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_reset_latency_count
+                  name: recoverystate_perf_reset_latency
+                - selector: ceph_recoverystate_perf_start_latency_count
+                  name: recoverystate_perf_start_latency
+                - selector: ceph_recoverystate_perf_started_latency_count
+                  name: recoverystate_perf_started_latency
+                - selector: ceph_recoverystate_perf_stray_latency_count
+                  name: recoverystate_perf_stray_latency
+                - selector: ceph_recoverystate_perf_waitactingchange_latency_count
+                  name: recoverystate_perf_waitactingchange_latency
+                - selector: ceph_recoverystate_perf_waitlocalbackfillreserved_latency_count
+                  name: recoverystate_perf_waitlocalbackfillreserved_latency
+                - selector: ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_count
+                  name: recoverystate_perf_waitlocalrecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_waitremotebackfillreserved_latency_count
+                  name: recoverystate_perf_waitremotebackfillreserved_latency
+                - selector: ceph_recoverystate_perf_waitremoterecoveryreserved_latency_count
+                  name: recoverystate_perf_waitremoterecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_waitupthru_latency_count
+                  name: recoverystate_perf_waitupthru_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated KStore Transaction Latency
+              context: accumulated_kstore_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_KStore_state_done_lat_sum
+                  name: kstore_state_done_lat
+                - selector: ceph_KStore_state_finishing_lat_sum
+                  name: kstore_state_finishing_lat
+                - selector: ceph_KStore_state_kv_done_lat_sum
+                  name: kstore_state_kv_done_lat
+                - selector: ceph_KStore_state_kv_queued_lat_sum
+                  name: kstore_state_kv_queued_lat
+                - selector: ceph_KStore_state_prepare_lat_sum
+                  name: kstore_state_prepare_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Client Request Latency
+              context: accumulated_client_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_lat_sum
+                  name: client_lat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated Recovery-State Transition Latency
+              context: accumulated_recovery_state_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_recoverystate_perf_activating_latency_sum
+                  name: recoverystate_perf_activating_latency
+                - selector: ceph_recoverystate_perf_active_latency_sum
+                  name: recoverystate_perf_active_latency
+                - selector: ceph_recoverystate_perf_backfilling_latency_sum
+                  name: recoverystate_perf_backfilling_latency
+                - selector: ceph_recoverystate_perf_clean_latency_sum
+                  name: recoverystate_perf_clean_latency
+                - selector: ceph_recoverystate_perf_down_latency_sum
+                  name: recoverystate_perf_down_latency
+                - selector: ceph_recoverystate_perf_getinfo_latency_sum
+                  name: recoverystate_perf_getinfo_latency
+                - selector: ceph_recoverystate_perf_getlog_latency_sum
+                  name: recoverystate_perf_getlog_latency
+                - selector: ceph_recoverystate_perf_getmissing_latency_sum
+                  name: recoverystate_perf_getmissing_latency
+                - selector: ceph_recoverystate_perf_incomplete_latency_sum
+                  name: recoverystate_perf_incomplete_latency
+                - selector: ceph_recoverystate_perf_initial_latency_sum
+                  name: recoverystate_perf_initial_latency
+                - selector: ceph_recoverystate_perf_notbackfilling_latency_sum
+                  name: recoverystate_perf_notbackfilling_latency
+                - selector: ceph_recoverystate_perf_notrecovering_latency_sum
+                  name: recoverystate_perf_notrecovering_latency
+                - selector: ceph_recoverystate_perf_peering_latency_sum
+                  name: recoverystate_perf_peering_latency
+                - selector: ceph_recoverystate_perf_primary_latency_sum
+                  name: recoverystate_perf_primary_latency
+                - selector: ceph_recoverystate_perf_recovered_latency_sum
+                  name: recoverystate_perf_recovered_latency
+                - selector: ceph_recoverystate_perf_recovering_latency_sum
+                  name: recoverystate_perf_recovering_latency
+                - selector: ceph_recoverystate_perf_replicaactive_latency_sum
+                  name: recoverystate_perf_replicaactive_latency
+                - selector: ceph_recoverystate_perf_repnotrecovering_latency_sum
+                  name: recoverystate_perf_repnotrecovering_latency
+                - selector: ceph_recoverystate_perf_reprecovering_latency_sum
+                  name: recoverystate_perf_reprecovering_latency
+                - selector: ceph_recoverystate_perf_repwaitbackfillreserved_latency_sum
+                  name: recoverystate_perf_repwaitbackfillreserved_latency
+                - selector: ceph_recoverystate_perf_repwaitrecoveryreserved_latency_sum
+                  name: recoverystate_perf_repwaitrecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_reset_latency_sum
+                  name: recoverystate_perf_reset_latency
+                - selector: ceph_recoverystate_perf_start_latency_sum
+                  name: recoverystate_perf_start_latency
+                - selector: ceph_recoverystate_perf_started_latency_sum
+                  name: recoverystate_perf_started_latency
+                - selector: ceph_recoverystate_perf_stray_latency_sum
+                  name: recoverystate_perf_stray_latency
+                - selector: ceph_recoverystate_perf_waitactingchange_latency_sum
+                  name: recoverystate_perf_waitactingchange_latency
+                - selector: ceph_recoverystate_perf_waitlocalbackfillreserved_latency_sum
+                  name: recoverystate_perf_waitlocalbackfillreserved_latency
+                - selector: ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_sum
+                  name: recoverystate_perf_waitlocalrecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_waitremotebackfillreserved_latency_sum
+                  name: recoverystate_perf_waitremotebackfillreserved_latency
+                - selector: ceph_recoverystate_perf_waitremoterecoveryreserved_latency_sum
+                  name: recoverystate_perf_waitremoterecoveryreserved_latency
+                - selector: ceph_recoverystate_perf_waitupthru_latency_sum
+                  name: recoverystate_perf_waitupthru_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Client Operation Latency Measurements
+              context: client_operation_latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_fsync_count
+                  name: client_fsync
+                - selector: ceph_client_rdlat_count
+                  name: client_rdlat
+                - selector: ceph_client_reply_count
+                  name: client_reply
+                - selector: ceph_client_wrlat_count
+                  name: client_wrlat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: SQLite VFS Operation Latency Measurements
+              context: sqlite_vfs_latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_libcephsqlite_vfs_op_access_count
+                  name: libcephsqlite_vfs_op_access
+                - selector: ceph_libcephsqlite_vfs_op_currenttime_count
+                  name: libcephsqlite_vfs_op_currenttime
+                - selector: ceph_libcephsqlite_vfs_op_delete_count
+                  name: libcephsqlite_vfs_op_delete
+                - selector: ceph_libcephsqlite_vfs_op_fullpathname_count
+                  name: libcephsqlite_vfs_op_fullpathname
+                - selector: ceph_libcephsqlite_vfs_op_open_count
+                  name: libcephsqlite_vfs_op_open
+                - selector: ceph_libcephsqlite_vfs_opf_checkreservedlock_count
+                  name: libcephsqlite_vfs_opf_checkreservedlock
+                - selector: ceph_libcephsqlite_vfs_opf_close_count
+                  name: libcephsqlite_vfs_opf_close
+                - selector: ceph_libcephsqlite_vfs_opf_devicecharacteristics_count
+                  name: libcephsqlite_vfs_opf_devicecharacteristics
+                - selector: ceph_libcephsqlite_vfs_opf_filecontrol_count
+                  name: libcephsqlite_vfs_opf_filecontrol
+                - selector: ceph_libcephsqlite_vfs_opf_filesize_count
+                  name: libcephsqlite_vfs_opf_filesize
+                - selector: ceph_libcephsqlite_vfs_opf_lock_count
+                  name: libcephsqlite_vfs_opf_lock
+                - selector: ceph_libcephsqlite_vfs_opf_read_count
+                  name: libcephsqlite_vfs_opf_read
+                - selector: ceph_libcephsqlite_vfs_opf_sectorsize_count
+                  name: libcephsqlite_vfs_opf_sectorsize
+                - selector: ceph_libcephsqlite_vfs_opf_sync_count
+                  name: libcephsqlite_vfs_opf_sync
+                - selector: ceph_libcephsqlite_vfs_opf_truncate_count
+                  name: libcephsqlite_vfs_opf_truncate
+                - selector: ceph_libcephsqlite_vfs_opf_unlock_count
+                  name: libcephsqlite_vfs_opf_unlock
+                - selector: ceph_libcephsqlite_vfs_opf_write_count
+                  name: libcephsqlite_vfs_opf_write
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Client Operation Latency
+              context: accumulated_client_operation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_fsync_sum
+                  name: client_fsync
+                - selector: ceph_client_rdlat_sum
+                  name: client_rdlat
+                - selector: ceph_client_reply_sum
+                  name: client_reply
+                - selector: ceph_client_wrlat_sum
+                  name: client_wrlat
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Accumulated SQLite VFS Operation Latency
+              context: accumulated_sqlite_vfs_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_libcephsqlite_vfs_op_access_sum
+                  name: libcephsqlite_vfs_op_access
+                - selector: ceph_libcephsqlite_vfs_op_currenttime_sum
+                  name: libcephsqlite_vfs_op_currenttime
+                - selector: ceph_libcephsqlite_vfs_op_delete_sum
+                  name: libcephsqlite_vfs_op_delete
+                - selector: ceph_libcephsqlite_vfs_op_fullpathname_sum
+                  name: libcephsqlite_vfs_op_fullpathname
+                - selector: ceph_libcephsqlite_vfs_op_open_sum
+                  name: libcephsqlite_vfs_op_open
+                - selector: ceph_libcephsqlite_vfs_opf_checkreservedlock_sum
+                  name: libcephsqlite_vfs_opf_checkreservedlock
+                - selector: ceph_libcephsqlite_vfs_opf_close_sum
+                  name: libcephsqlite_vfs_opf_close
+                - selector: ceph_libcephsqlite_vfs_opf_devicecharacteristics_sum
+                  name: libcephsqlite_vfs_opf_devicecharacteristics
+                - selector: ceph_libcephsqlite_vfs_opf_filecontrol_sum
+                  name: libcephsqlite_vfs_opf_filecontrol
+                - selector: ceph_libcephsqlite_vfs_opf_filesize_sum
+                  name: libcephsqlite_vfs_opf_filesize
+                - selector: ceph_libcephsqlite_vfs_opf_lock_sum
+                  name: libcephsqlite_vfs_opf_lock
+                - selector: ceph_libcephsqlite_vfs_opf_read_sum
+                  name: libcephsqlite_vfs_opf_read
+                - selector: ceph_libcephsqlite_vfs_opf_sectorsize_sum
+                  name: libcephsqlite_vfs_opf_sectorsize
+                - selector: ceph_libcephsqlite_vfs_opf_sync_sum
+                  name: libcephsqlite_vfs_opf_sync
+                - selector: ceph_libcephsqlite_vfs_opf_truncate_sum
+                  name: libcephsqlite_vfs_opf_truncate
+                - selector: ceph_libcephsqlite_vfs_opf_unlock_sum
+                  name: libcephsqlite_vfs_opf_unlock
+                - selector: ceph_libcephsqlite_vfs_opf_write_sum
+                  name: libcephsqlite_vfs_opf_write
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Monitors
+              context: monitor_state
+              units: monitors
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_mon
+                  name: num_mon
+                - selector: ceph_cluster_num_mon_quorum
+                  name: cluster_num_mon_quorum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OSDs
+              context: osd_state
+              units: OSDs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_osd
+                  name: num_osd
+                - selector: ceph_cluster_num_osd_in
+                  name: cluster_num_osd_in
+                - selector: ceph_cluster_num_osd_up
+                  name: cluster_num_osd_up
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Pools
+              context: pool_state
+              units: pools
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_pool
+                  name: num_pool
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OSD-Map Epoch
+              context: osd_map_epoch
+              units: epoch
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_osd_epoch
+                  name: osd_epoch
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Duration and Time
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_mdavg
+                  name: mdavg
+                - selector: ceph_client_readavg
+                  name: readavg
+                - selector: ceph_client_writeavg
+                  name: writeavg
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Invalidated Recovery Statistics
+              context: invalidations
+              units: invalidations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_recoverystate_perf_stats_invalidated
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Objects
+              context: object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_object
+                  name: object
+                - selector: ceph_cluster_num_object_degraded
+                  name: degraded
+                - selector: ceph_cluster_num_object_misplaced
+                  name: misplaced
+                - selector: ceph_cluster_num_object_unfound
+                  name: unfound
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_ipv4_dpdk_ip_linearize_operations
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_bytes
+                  name: num_bytes
+                - selector: ceph_cluster_osd_bytes
+                  name: osd_bytes
+                - selector: ceph_cluster_osd_bytes_avail
+                  name: osd_bytes_avail
+                - selector: ceph_cluster_osd_bytes_used
+                  name: osd_bytes_used
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Placement Groups
+              context: pg_state
+              units: PGs
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cluster_num_pg
+                  name: cluster_num_pg
+                - selector: ceph_cluster_num_pg_active
+                  name: cluster_num_pg_active
+                - selector: ceph_cluster_num_pg_active_clean
+                  name: cluster_num_pg_active_clean
+                - selector: ceph_cluster_num_pg_peering
+                  name: cluster_num_pg_peering
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Client Latency Squared-Deviation Accumulators
+              context: client_latency_sqsum
+              units: microseconds²/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_client_mdsqsum
+                  name: client_mdsqsum
+                - selector: ceph_client_readsqsum
+                  name: client_readsqsum
+                - selector: ceph_client_writesqsum
+                  name: client_writesqsum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: OpenFileTable OMAP Mutations
+              context: oft_omap_mutations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_oft_omap_total_updates
+                  name: oft_omap_total_updates
+                - selector: ceph_oft_omap_total_removes
+                  name: oft_omap_total_removes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Context Workers
+              context: worker_state
+              units: workers
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cct_total_workers
+                  name: cct_total_workers
+                - selector: ceph_cct_unhealthy_workers
+                  name: cct_unhealthy_workers
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OpenFileTable Objects
+              context: oft_object_state
+              units: objects
+              label_promotion: []
+              dimensions:
+                - selector: ceph_oft_omap_total_objs
+                  name: oft_omap_total_objs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: OpenFileTable Key-Value Pairs
+              context: oft_entry_state
+              units: entries
+              label_promotion: []
+              dimensions:
+                - selector: ceph_oft_omap_total_kv_pairs
+                  name: oft_omap_total_kv_pairs
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Slow Operations
+          context_namespace: slow_operations
+          metrics:
+            - ceph_trackedop_slow_ops_count
+          charts:
+            - title: Slow Operations
+              context: slow_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_trackedop_slow_ops_count
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Storage Engine
+      context_namespace: storage_engine
+      groups:
+        - family: Priority Cache Full
+          context_namespace: priority_cache_full
+          metrics:
+            - ceph_prioritycache:full_committed_bytes
+            - ceph_prioritycache:full_pri0_bytes
+            - ceph_prioritycache:full_pri10_bytes
+            - ceph_prioritycache:full_pri11_bytes
+            - ceph_prioritycache:full_pri1_bytes
+            - ceph_prioritycache:full_pri2_bytes
+            - ceph_prioritycache:full_pri3_bytes
+            - ceph_prioritycache:full_pri4_bytes
+            - ceph_prioritycache:full_pri5_bytes
+            - ceph_prioritycache:full_pri6_bytes
+            - ceph_prioritycache:full_pri7_bytes
+            - ceph_prioritycache:full_pri8_bytes
+            - ceph_prioritycache:full_pri9_bytes
+            - ceph_prioritycache:full_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_prioritycache:full_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_prioritycache:full_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_prioritycache:full_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_prioritycache:full_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_prioritycache:full_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_prioritycache:full_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_prioritycache:full_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_prioritycache:full_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_prioritycache:full_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_prioritycache:full_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_prioritycache:full_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_prioritycache:full_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_prioritycache:full_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_prioritycache:full_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Incremental
+          context_namespace: priority_cache_incremental
+          metrics:
+            - ceph_prioritycache:inc_committed_bytes
+            - ceph_prioritycache:inc_pri0_bytes
+            - ceph_prioritycache:inc_pri10_bytes
+            - ceph_prioritycache:inc_pri11_bytes
+            - ceph_prioritycache:inc_pri1_bytes
+            - ceph_prioritycache:inc_pri2_bytes
+            - ceph_prioritycache:inc_pri3_bytes
+            - ceph_prioritycache:inc_pri4_bytes
+            - ceph_prioritycache:inc_pri5_bytes
+            - ceph_prioritycache:inc_pri6_bytes
+            - ceph_prioritycache:inc_pri7_bytes
+            - ceph_prioritycache:inc_pri8_bytes
+            - ceph_prioritycache:inc_pri9_bytes
+            - ceph_prioritycache:inc_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_prioritycache:inc_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_prioritycache:inc_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_prioritycache:inc_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_prioritycache:inc_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_prioritycache:inc_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_prioritycache:inc_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_prioritycache:inc_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_prioritycache:inc_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_prioritycache:inc_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_prioritycache:inc_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_prioritycache:inc_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_prioritycache:inc_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_prioritycache:inc_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_prioritycache:inc_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache KV
+          context_namespace: priority_cache_kv
+          metrics:
+            - ceph_prioritycache:kv_committed_bytes
+            - ceph_prioritycache:kv_pri0_bytes
+            - ceph_prioritycache:kv_pri10_bytes
+            - ceph_prioritycache:kv_pri11_bytes
+            - ceph_prioritycache:kv_pri1_bytes
+            - ceph_prioritycache:kv_pri2_bytes
+            - ceph_prioritycache:kv_pri3_bytes
+            - ceph_prioritycache:kv_pri4_bytes
+            - ceph_prioritycache:kv_pri5_bytes
+            - ceph_prioritycache:kv_pri6_bytes
+            - ceph_prioritycache:kv_pri7_bytes
+            - ceph_prioritycache:kv_pri8_bytes
+            - ceph_prioritycache:kv_pri9_bytes
+            - ceph_prioritycache:kv_reserved_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_prioritycache:kv_committed_bytes
+                  name: committed_bytes
+                - selector: ceph_prioritycache:kv_pri0_bytes
+                  name: pri0_bytes
+                - selector: ceph_prioritycache:kv_pri10_bytes
+                  name: pri10_bytes
+                - selector: ceph_prioritycache:kv_pri11_bytes
+                  name: pri11_bytes
+                - selector: ceph_prioritycache:kv_pri1_bytes
+                  name: pri1_bytes
+                - selector: ceph_prioritycache:kv_pri2_bytes
+                  name: pri2_bytes
+                - selector: ceph_prioritycache:kv_pri3_bytes
+                  name: pri3_bytes
+                - selector: ceph_prioritycache:kv_pri4_bytes
+                  name: pri4_bytes
+                - selector: ceph_prioritycache:kv_pri5_bytes
+                  name: pri5_bytes
+                - selector: ceph_prioritycache:kv_pri6_bytes
+                  name: pri6_bytes
+                - selector: ceph_prioritycache:kv_pri7_bytes
+                  name: pri7_bytes
+                - selector: ceph_prioritycache:kv_pri8_bytes
+                  name: pri8_bytes
+                - selector: ceph_prioritycache:kv_pri9_bytes
+                  name: pri9_bytes
+                - selector: ceph_prioritycache:kv_reserved_bytes
+                  name: reserved_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Priority Cache Runtime
+          context_namespace: priority_cache_runtime
+          metrics:
+            - ceph_prioritycache_cache_bytes
+            - ceph_prioritycache_heap_bytes
+            - ceph_prioritycache_mapped_bytes
+            - ceph_prioritycache_target_bytes
+            - ceph_prioritycache_unmapped_bytes
+          charts:
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_prioritycache_cache_bytes
+                  name: cache_bytes
+                - selector: ceph_prioritycache_heap_bytes
+                  name: heap_bytes
+                - selector: ceph_prioritycache_mapped_bytes
+                  name: mapped_bytes
+                - selector: ceph_prioritycache_target_bytes
+                  name: target_bytes
+                - selector: ceph_prioritycache_unmapped_bytes
+                  name: unmapped_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: RocksDB Compaction
+          context_namespace: rocksdb_compaction
+          metrics:
+            - ceph_rocksdb_compact
+            - ceph_rocksdb_compact_completed
+            - ceph_rocksdb_compact_lasted
+            - ceph_rocksdb_compact_queue_len
+            - ceph_rocksdb_compact_queue_merge
+            - ceph_rocksdb_compact_running
+          charts:
+            - title: Compaction Work
+              context: compaction_state
+              units: compactions
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_compact_queue_len
+                  name: queue_len
+                - selector: ceph_rocksdb_compact_running
+                  name: running
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: absolute
+            - title: Duration and Time
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_compact_lasted
+                  name: value
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Compactions
+              context: compactions
+              units: compactions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_compact
+                  name: compact
+                - selector: ceph_rocksdb_compact_completed
+                  name: completed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Compaction Queue Merges
+              context: queue_merges
+              units: merges/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_compact_queue_merge
+                  name: queue_merge
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: RocksDB Requests
+          context_namespace: rocksdb_requests
+          metrics:
+            - ceph_rocksdb_get_latency_count
+            - ceph_rocksdb_get_latency_sum
+            - ceph_rocksdb_submit_latency_count
+            - ceph_rocksdb_submit_latency_sum
+            - ceph_rocksdb_submit_sync_latency_count
+            - ceph_rocksdb_submit_sync_latency_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_get_latency_count
+                  name: get_latency
+                - selector: ceph_rocksdb_submit_latency_count
+                  name: submit_latency
+                - selector: ceph_rocksdb_submit_sync_latency_count
+                  name: submit_sync_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_get_latency_sum
+                  name: get_latency
+                - selector: ceph_rocksdb_submit_latency_sum
+                  name: submit_latency
+                - selector: ceph_rocksdb_submit_sync_latency_sum
+                  name: submit_sync_latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+        - family: RocksDB Write Path
+          context_namespace: rocksdb_write_path
+          metrics:
+            - ceph_rocksdb_rocksdb_write_delay_time_count
+            - ceph_rocksdb_rocksdb_write_delay_time_sum
+            - ceph_rocksdb_rocksdb_write_memtable_time_count
+            - ceph_rocksdb_rocksdb_write_memtable_time_sum
+            - ceph_rocksdb_rocksdb_write_pre_and_post_time_count
+            - ceph_rocksdb_rocksdb_write_pre_and_post_time_sum
+            - ceph_rocksdb_rocksdb_write_wal_time_count
+            - ceph_rocksdb_rocksdb_write_wal_time_sum
+          charts:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_rocksdb_write_delay_time_count
+                  name: delay_time
+                - selector: ceph_rocksdb_rocksdb_write_memtable_time_count
+                  name: memtable_time
+                - selector: ceph_rocksdb_rocksdb_write_pre_and_post_time_count
+                  name: pre_and_post_time
+                - selector: ceph_rocksdb_rocksdb_write_wal_time_count
+                  name: wal_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_rocksdb_write_delay_time_sum
+                  name: delay_time
+                - selector: ceph_rocksdb_rocksdb_write_memtable_time_sum
+                  name: memtable_time
+                - selector: ceph_rocksdb_rocksdb_write_pre_and_post_time_sum
+                  name: pre_and_post_time
+                - selector: ceph_rocksdb_rocksdb_write_wal_time_sum
+                  name: wal_time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+              algorithm: incremental
+    - family: Runtime and Client Components
+      context_namespace: runtime_and_client_components
+      groups:
+        - family: RBD Persistent Write Log
+          context_namespace: rbd_persistent_write_log
+          metrics:
+            - ceph_rbd_librbd_pwl_aio_flush
+            - ceph_rbd_librbd_pwl_aio_flush_def
+            - ceph_rbd_librbd_pwl_aio_flush_lat_count
+            - ceph_rbd_librbd_pwl_aio_flush_lat_sum
+            - ceph_rbd_librbd_pwl_append_tx_lat_count
+            - ceph_rbd_librbd_pwl_append_tx_lat_sum
+            - ceph_rbd_librbd_pwl_caller_wr_latency_count
+            - ceph_rbd_librbd_pwl_caller_wr_latency_nw_count
+            - ceph_rbd_librbd_pwl_caller_wr_latency_nw_sum
+            - ceph_rbd_librbd_pwl_caller_wr_latency_sum
+            - ceph_rbd_librbd_pwl_cmp
+            - ceph_rbd_librbd_pwl_cmp_bytes
+            - ceph_rbd_librbd_pwl_cmp_fails
+            - ceph_rbd_librbd_pwl_cmp_lat_count
+            - ceph_rbd_librbd_pwl_cmp_lat_sum
+            - ceph_rbd_librbd_pwl_discard
+            - ceph_rbd_librbd_pwl_discard_bytes
+            - ceph_rbd_librbd_pwl_discard_lat_count
+            - ceph_rbd_librbd_pwl_discard_lat_sum
+            - ceph_rbd_librbd_pwl_hit_rd
+            - ceph_rbd_librbd_pwl_hit_rd_latency_count
+            - ceph_rbd_librbd_pwl_hit_rd_latency_sum
+            - ceph_rbd_librbd_pwl_internal_flush
+            - ceph_rbd_librbd_pwl_invalidate
+            - ceph_rbd_librbd_pwl_log_op_bytes_count
+            - ceph_rbd_librbd_pwl_log_op_bytes_sum
+            - ceph_rbd_librbd_pwl_log_ops
+            - ceph_rbd_librbd_pwl_op_alloc_t_count
+            - ceph_rbd_librbd_pwl_op_alloc_t_sum
+            - ceph_rbd_librbd_pwl_op_app_to_appc_t_count
+            - ceph_rbd_librbd_pwl_op_app_to_appc_t_sum
+            - ceph_rbd_librbd_pwl_op_app_to_cmp_t_count
+            - ceph_rbd_librbd_pwl_op_app_to_cmp_t_sum
+            - ceph_rbd_librbd_pwl_op_buf_to_app_t_count
+            - ceph_rbd_librbd_pwl_op_buf_to_app_t_sum
+            - ceph_rbd_librbd_pwl_op_buf_to_bufc_t_count
+            - ceph_rbd_librbd_pwl_op_buf_to_bufc_t_sum
+            - ceph_rbd_librbd_pwl_op_dis_to_app_t_count
+            - ceph_rbd_librbd_pwl_op_dis_to_app_t_sum
+            - ceph_rbd_librbd_pwl_op_dis_to_buf_t_count
+            - ceph_rbd_librbd_pwl_op_dis_to_buf_t_sum
+            - ceph_rbd_librbd_pwl_op_dis_to_cmp_t_count
+            - ceph_rbd_librbd_pwl_op_dis_to_cmp_t_sum
+            - ceph_rbd_librbd_pwl_part_hit_rd
+            - ceph_rbd_librbd_pwl_rd
+            - ceph_rbd_librbd_pwl_rd_bytes
+            - ceph_rbd_librbd_pwl_rd_hit_bytes
+            - ceph_rbd_librbd_pwl_rd_latency_count
+            - ceph_rbd_librbd_pwl_rd_latency_sum
+            - ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_count
+            - ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_sum
+            - ceph_rbd_librbd_pwl_req_all_to_dis_t_count
+            - ceph_rbd_librbd_pwl_req_all_to_dis_t_sum
+            - ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_count
+            - ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_sum
+            - ceph_rbd_librbd_pwl_req_arr_to_all_t_count
+            - ceph_rbd_librbd_pwl_req_arr_to_all_t_sum
+            - ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_count
+            - ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
+            - ceph_rbd_librbd_pwl_req_arr_to_dis_t_count
+            - ceph_rbd_librbd_pwl_req_arr_to_dis_t_sum
+            - ceph_rbd_librbd_pwl_retire_tx_lat_count
+            - ceph_rbd_librbd_pwl_retire_tx_lat_sum
+            - ceph_rbd_librbd_pwl_wr
+            - ceph_rbd_librbd_pwl_wr_bytes
+            - ceph_rbd_librbd_pwl_wr_def
+            - ceph_rbd_librbd_pwl_wr_def_buf
+            - ceph_rbd_librbd_pwl_wr_def_lanes
+            - ceph_rbd_librbd_pwl_wr_def_log
+            - ceph_rbd_librbd_pwl_wr_latency_count
+            - ceph_rbd_librbd_pwl_wr_latency_nw_count
+            - ceph_rbd_librbd_pwl_wr_latency_nw_sum
+            - ceph_rbd_librbd_pwl_wr_latency_sum
+            - ceph_rbd_librbd_pwl_wr_overlap
+            - ceph_rbd_librbd_pwl_wr_q_barrier
+            - ceph_rbd_librbd_pwl_writeback_lat_count
+            - ceph_rbd_librbd_pwl_writeback_lat_sum
+            - ceph_rbd_librbd_pwl_ws
+            - ceph_rbd_librbd_pwl_ws_bytes
+            - ceph_rbd_librbd_pwl_ws_lat_count
+            - ceph_rbd_librbd_pwl_ws_lat_sum
+          charts:
+            - title: Reads
+              context: reads
+              units: reads/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_rd
+                  name: rd
+                - selector: ceph_rbd_librbd_pwl_hit_rd
+                  name: hit_rd
+                - selector: ceph_rbd_librbd_pwl_part_hit_rd
+                  name: part_hit_rd
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Writes
+              context: writes
+              units: writes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_wr
+                  name: wr
+                - selector: ceph_rbd_librbd_pwl_wr_def
+                  name: wr_def
+                - selector: ceph_rbd_librbd_pwl_wr_def_lanes
+                  name: wr_def_lanes
+                - selector: ceph_rbd_librbd_pwl_wr_def_log
+                  name: wr_def_log
+                - selector: ceph_rbd_librbd_pwl_wr_def_buf
+                  name: wr_def_buf
+                - selector: ceph_rbd_librbd_pwl_wr_overlap
+                  name: wr_overlap
+                - selector: ceph_rbd_librbd_pwl_wr_q_barrier
+                  name: wr_q_barrier
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Log Appends
+              context: log_appends
+              units: appends/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_log_ops
+                  name: log_ops
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Cache and Image Operations
+              context: cache_image_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_discard
+                  name: discard
+                - selector: ceph_rbd_librbd_pwl_aio_flush
+                  name: aio_flush
+                - selector: ceph_rbd_librbd_pwl_aio_flush_def
+                  name: aio_flush_def
+                - selector: ceph_rbd_librbd_pwl_ws
+                  name: ws
+                - selector: ceph_rbd_librbd_pwl_cmp
+                  name: cmp
+                - selector: ceph_rbd_librbd_pwl_cmp_fails
+                  name: cmp_fails
+                - selector: ceph_rbd_librbd_pwl_internal_flush
+                  name: internal_flush
+                - selector: ceph_rbd_librbd_pwl_invalidate
+                  name: invalidate
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Read Throughput
+              context: read_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_rd_bytes
+                  name: rd_bytes
+                - selector: ceph_rbd_librbd_pwl_rd_hit_bytes
+                  name: rd_hit_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Write Throughput
+              context: write_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_wr_bytes
+                  name: wr_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Data-Operation Throughput
+              context: data_operation_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_discard_bytes
+                  name: discard_bytes
+                - selector: ceph_rbd_librbd_pwl_ws_bytes
+                  name: ws_bytes
+                - selector: ceph_rbd_librbd_pwl_cmp_bytes
+                  name: cmp_bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Log-Append Throughput
+              context: log_append_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_log_op_bytes_sum
+                  name: log_op_bytes_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Read Request Latency Measurements
+              context: read_latency_measurements
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_rd_latency_count
+                  name: rd_latency_count
+                - selector: ceph_rbd_librbd_pwl_hit_rd_latency_count
+                  name: hit_rd_latency_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Log-Append Size Measurements
+              context: log_append_size_measurements
+              units: appends/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_log_op_bytes_count
+                  name: log_op_bytes_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Write Request Latency Measurements
+              context: write_latency_measurements
+              units: requests/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_all_t_count
+                  name: req_arr_to_all_t_count
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_t_count
+                  name: req_arr_to_dis_t_count
+                - selector: ceph_rbd_librbd_pwl_req_all_to_dis_t_count
+                  name: req_all_to_dis_t_count
+                - selector: ceph_rbd_librbd_pwl_wr_latency_count
+                  name: wr_latency_count
+                - selector: ceph_rbd_librbd_pwl_caller_wr_latency_count
+                  name: caller_wr_latency_count
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_count
+                  name: req_arr_to_all_nw_t_count
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_count
+                  name: req_arr_to_dis_nw_t_count
+                - selector: ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_count
+                  name: req_all_to_dis_nw_t_count
+                - selector: ceph_rbd_librbd_pwl_wr_latency_nw_count
+                  name: wr_latency_nw_count
+                - selector: ceph_rbd_librbd_pwl_caller_wr_latency_nw_count
+                  name: caller_wr_latency_nw_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Log Operation Latency Measurements
+              context: log_operation_latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_op_alloc_t_count
+                  name: op_alloc_t_count
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_buf_t_count
+                  name: op_dis_to_buf_t_count
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_app_t_count
+                  name: op_dis_to_app_t_count
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_cmp_t_count
+                  name: op_dis_to_cmp_t_count
+                - selector: ceph_rbd_librbd_pwl_op_buf_to_app_t_count
+                  name: op_buf_to_app_t_count
+                - selector: ceph_rbd_librbd_pwl_op_buf_to_bufc_t_count
+                  name: op_buf_to_bufc_t_count
+                - selector: ceph_rbd_librbd_pwl_op_app_to_cmp_t_count
+                  name: op_app_to_cmp_t_count
+                - selector: ceph_rbd_librbd_pwl_op_app_to_appc_t_count
+                  name: op_app_to_appc_t_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Data Operation Latency Measurements
+              context: data_operation_latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_discard_lat_count
+                  name: discard_lat_count
+                - selector: ceph_rbd_librbd_pwl_aio_flush_lat_count
+                  name: aio_flush_lat_count
+                - selector: ceph_rbd_librbd_pwl_ws_lat_count
+                  name: ws_lat_count
+                - selector: ceph_rbd_librbd_pwl_cmp_lat_count
+                  name: cmp_lat_count
+                - selector: ceph_rbd_librbd_pwl_writeback_lat_count
+                  name: writeback_lat_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Transaction Latency Measurements
+              context: transaction_latency_measurements
+              units: transactions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_append_tx_lat_count
+                  name: append_tx_lat_count
+                - selector: ceph_rbd_librbd_pwl_retire_tx_lat_count
+                  name: retire_tx_lat_count
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+            - title: Accumulated Read Request Latency
+              context: accumulated_read_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_rd_latency_sum
+                  name: rd_latency_sum
+                - selector: ceph_rbd_librbd_pwl_hit_rd_latency_sum
+                  name: hit_rd_latency_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Accumulated Write Request Latency
+              context: accumulated_write_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_all_t_sum
+                  name: req_arr_to_all_t_sum
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_t_sum
+                  name: req_arr_to_dis_t_sum
+                - selector: ceph_rbd_librbd_pwl_req_all_to_dis_t_sum
+                  name: req_all_to_dis_t_sum
+                - selector: ceph_rbd_librbd_pwl_wr_latency_sum
+                  name: wr_latency_sum
+                - selector: ceph_rbd_librbd_pwl_caller_wr_latency_sum
+                  name: caller_wr_latency_sum
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_sum
+                  name: req_arr_to_all_nw_t_sum
+                - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
+                  name: req_arr_to_dis_nw_t_sum
+                - selector: ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_sum
+                  name: req_all_to_dis_nw_t_sum
+                - selector: ceph_rbd_librbd_pwl_wr_latency_nw_sum
+                  name: wr_latency_nw_sum
+                - selector: ceph_rbd_librbd_pwl_caller_wr_latency_nw_sum
+                  name: caller_wr_latency_nw_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Accumulated Log Operation Latency
+              context: accumulated_log_operation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_op_alloc_t_sum
+                  name: op_alloc_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_buf_t_sum
+                  name: op_dis_to_buf_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_app_t_sum
+                  name: op_dis_to_app_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_dis_to_cmp_t_sum
+                  name: op_dis_to_cmp_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_buf_to_app_t_sum
+                  name: op_buf_to_app_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_buf_to_bufc_t_sum
+                  name: op_buf_to_bufc_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_app_to_cmp_t_sum
+                  name: op_app_to_cmp_t_sum
+                - selector: ceph_rbd_librbd_pwl_op_app_to_appc_t_sum
+                  name: op_app_to_appc_t_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Accumulated Data Operation Latency
+              context: accumulated_data_operation_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_discard_lat_sum
+                  name: discard_lat_sum
+                - selector: ceph_rbd_librbd_pwl_aio_flush_lat_sum
+                  name: aio_flush_lat_sum
+                - selector: ceph_rbd_librbd_pwl_ws_lat_sum
+                  name: ws_lat_sum
+                - selector: ceph_rbd_librbd_pwl_cmp_lat_sum
+                  name: cmp_lat_sum
+                - selector: ceph_rbd_librbd_pwl_writeback_lat_sum
+                  name: writeback_lat_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+            - title: Accumulated Transaction Latency
+              context: accumulated_transaction_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rbd_librbd_pwl_append_tx_lat_sum
+                  name: append_tx_lat_sum
+                - selector: ceph_rbd_librbd_pwl_retire_tx_lat_sum
+                  name: retire_tx_lat_sum
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - librbd_pwl_key
+              algorithm: incremental
+        - family: Object Caches
+          context_namespace: object_caches
+          metrics:
+            - ceph_objectcacher_cache_bytes_hit
+            - ceph_objectcacher_cache_bytes_miss
+            - ceph_objectcacher_cache_ops_hit
+            - ceph_objectcacher_cache_ops_miss
+            - ceph_objectcacher_data_flushed
+            - ceph_objectcacher_data_overwritten_while_flushing
+            - ceph_objectcacher_data_read
+            - ceph_objectcacher_data_written
+            - ceph_objectcacher_write_bytes_blocked
+            - ceph_objectcacher_write_ops_blocked
+            - ceph_objectcacher_write_time_blocked
+          charts:
+            - title: Cache Outcomes
+              context: cache_outcomes
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_cache_ops_hit
+                  name: hit
+                - selector: ceph_objectcacher_cache_ops_miss
+                  name: miss
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Cache Byte Outcomes
+              context: cache_byte_outcomes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_cache_bytes_hit
+                  name: hit
+                - selector: ceph_objectcacher_cache_bytes_miss
+                  name: miss
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Data Throughput
+              context: data_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_data_read
+                  name: read
+                - selector: ceph_objectcacher_data_written
+                  name: written
+                - selector: ceph_objectcacher_data_flushed
+                  name: flushed
+                - selector: ceph_objectcacher_data_overwritten_while_flushing
+                  name: overwritten_while_flushing
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Blocked Writes
+              context: blocked_writes
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_write_ops_blocked
+                  name: operations
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Blocked Write Throughput
+              context: blocked_write_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_write_bytes_blocked
+                  name: bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+            - title: Blocked Write Time
+              context: blocked_write_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_objectcacher_write_time_blocked
+                  name: time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - objectcacher_key
+              algorithm: incremental
+        - family: Finishers
+          context_namespace: finishers
+          metrics:
+            - ceph_finisher_complete_latency_count
+            - ceph_finisher_complete_latency_sum
+            - ceph_finisher_queue_len
+          charts:
+            - title: Queued Callbacks
+              context: queue_depth
+              units: callbacks
+              label_promotion: []
+              dimensions:
+                - selector: ceph_finisher_queue_len
+                  name: queued
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - finisher_key
+            - title: Drained Completion Batches
+              context: completions
+              units: batches/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_finisher_complete_latency_count
+                  name: completed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - finisher_key
+            - title: Accumulated Completion Latency
+              context: accumulated_completion_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_finisher_complete_latency_sum
+                  name: latency
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - finisher_key
+              algorithm: incremental
+        - family: Throttles
+          context_namespace: throttles
+          metrics:
+            - ceph_throttle_get
+            - ceph_throttle_get_or_fail_fail
+            - ceph_throttle_get_or_fail_success
+            - ceph_throttle_get_started
+            - ceph_throttle_get_sum
+            - ceph_throttle_max
+            - ceph_throttle_put
+            - ceph_throttle_put_sum
+            - ceph_throttle_take
+            - ceph_throttle_take_sum
+            - ceph_throttle_val
+            - ceph_throttle_wait_count
+            - ceph_throttle_wait_sum
+          charts:
+            - title: Utilization
+              context: utilization
+              units: slots
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_val
+                  name: val
+                - selector: ceph_throttle_max
+                  name: max
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - throttle_key
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_get_started
+                  name: get_started
+                - selector: ceph_throttle_get
+                  name: get
+                - selector: ceph_throttle_get_or_fail_fail
+                  name: get_or_fail_fail
+                - selector: ceph_throttle_get_or_fail_success
+                  name: get_or_fail_success
+                - selector: ceph_throttle_take
+                  name: take
+                - selector: ceph_throttle_put
+                  name: put
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - throttle_key
+            - title: Slot Throughput
+              context: slot_throughput
+              units: slots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_get_sum
+                  name: get_sum
+                - selector: ceph_throttle_take_sum
+                  name: take_sum
+                - selector: ceph_throttle_put_sum
+                  name: put_sum
+              instances:
+                by_labels: []
+                optional_by_labels:
+                  - throttle_key
+            - title: Waits
+              context: wait_measurements
+              units: waits/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_wait_count
+                  name: waits
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - throttle_key
+            - title: Accumulated Wait Time
+              context: accumulated_wait_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_throttle_wait_sum
+                  name: wait
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - throttle_key
+              algorithm: incremental
+        - family: Kernel Devices
+          context_namespace: kernel_devices
+          metrics:
+            - ceph_kernel_device_discard_op
+            - ceph_kernel_device_discard_threads
+          charts:
+            - title: Discard Operations
+              context: discard_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_kernel_device_discard_op
+                  name: discard
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - kernel_device_key
+            - title: Discard Threads
+              context: discard_threads
+              units: threads
+              label_promotion: []
+              dimensions:
+                - selector: ceph_kernel_device_discard_threads
+                  name: threads
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - kernel_device_key
+              algorithm: absolute
+        - family: mClock Shards
+          context_namespace: mclock_shards
+          metrics:
+            - ceph_mclock_shard_mclock_all_type_queue_len
+            - ceph_mclock_shard_mclock_best_effort_queue_len
+            - ceph_mclock_shard_mclock_client_queue_len
+            - ceph_mclock_shard_mclock_immediate_queue_len
+            - ceph_mclock_shard_mclock_recovery_queue_len
+          charts:
+            - title: Queue Depth
+              context: queue_depth
+              units: operations
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mclock_shard_mclock_immediate_queue_len
+                  name: immediate
+                - selector: ceph_mclock_shard_mclock_client_queue_len
+                  name: client
+                - selector: ceph_mclock_shard_mclock_recovery_queue_len
+                  name: recovery
+                - selector: ceph_mclock_shard_mclock_best_effort_queue_len
+                  name: best_effort
+                - selector: ceph_mclock_shard_mclock_all_type_queue_len
+                  name: all_type
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - mclock_shard
+              algorithm: absolute
+        - family: Messenger Workers
+          context_namespace: messenger_workers
+          metrics:
+            - ceph_async_messenger_worker_msgr_active_connections
+            - ceph_async_messenger_worker_msgr_created_connections
+            - ceph_async_messenger_worker_msgr_handle_ack_lat_count
+            - ceph_async_messenger_worker_msgr_handle_ack_lat_sum
+            - ceph_async_messenger_worker_msgr_recv_bytes
+            - ceph_async_messenger_worker_msgr_recv_encrypted_bytes
+            - ceph_async_messenger_worker_msgr_recv_messages
+            - ceph_async_messenger_worker_msgr_running_fast_dispatch_time
+            - ceph_async_messenger_worker_msgr_running_recv_time
+            - ceph_async_messenger_worker_msgr_running_send_time
+            - ceph_async_messenger_worker_msgr_running_total_time
+            - ceph_async_messenger_worker_msgr_send_bytes
+            - ceph_async_messenger_worker_msgr_send_encrypted_bytes
+            - ceph_async_messenger_worker_msgr_send_messages
+            - ceph_async_messenger_worker_msgr_send_messages_queue_lat_count
+            - ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
+          charts:
+            - title: Messages
+              context: messages
+              units: messages/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_recv_messages
+                  name: recv
+                - selector: ceph_async_messenger_worker_msgr_send_messages
+                  name: send
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_recv_bytes
+                  name: recv
+                - selector: ceph_async_messenger_worker_msgr_send_bytes
+                  name: send
+                - selector: ceph_async_messenger_worker_msgr_recv_encrypted_bytes
+                  name: recv_encrypted
+                - selector: ceph_async_messenger_worker_msgr_send_encrypted_bytes
+                  name: send_encrypted
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Connections
+              context: connections
+              units: connections
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_active_connections
+                  name: active
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+              algorithm: absolute
+            - title: Created Connections
+              context: created_connections
+              units: connections/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_created_connections
+                  name: created
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Accumulated Worker Time
+              context: accumulated_worker_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_running_total_time
+                  name: total
+                - selector: ceph_async_messenger_worker_msgr_running_send_time
+                  name: send
+                - selector: ceph_async_messenger_worker_msgr_running_recv_time
+                  name: recv
+                - selector: ceph_async_messenger_worker_msgr_running_fast_dispatch_time
+                  name: fast_dispatch
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+              algorithm: incremental
+            - title: Send-Queue Latency Measurements
+              context: send_queue_latency_measurements
+              units: messages/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_send_messages_queue_lat_count
+                  name: send_messages_queue
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Acknowledgement Latency Measurements
+              context: ack_latency_measurements
+              units: acknowledgements/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_handle_ack_lat_count
+                  name: handle_ack
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+            - title: Accumulated Send-Queue Latency
+              context: accumulated_send_queue_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
+                  name: send_messages_queue
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+              algorithm: incremental
+            - title: Accumulated Acknowledgement Latency
+              context: accumulated_ack_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_worker_msgr_handle_ack_lat_sum
+                  name: handle_ack
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - messenger_worker
+              algorithm: incremental
+        - family: RDMA Workers
+          context_namespace: rdma_workers
+          metrics:
+            - ceph_async_messenger_rdma_worker_pending_sent_conns
+            - ceph_async_messenger_rdma_worker_rx_bytes
+            - ceph_async_messenger_rdma_worker_rx_chunks
+            - ceph_async_messenger_rdma_worker_tx_bytes
+            - ceph_async_messenger_rdma_worker_tx_chunks
+            - ceph_async_messenger_rdma_worker_tx_failed_post
+            - ceph_async_messenger_rdma_worker_tx_no_mem
+            - ceph_async_messenger_rdma_worker_tx_parital_mem
+          charts:
+            - title: RDMA Transfer Errors
+              context: transfer_errors
+              units: errors/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_rdma_worker_tx_no_mem
+                  name: tx_no_mem
+                - selector: ceph_async_messenger_rdma_worker_tx_parital_mem
+                  name: tx_parital_mem
+                - selector: ceph_async_messenger_rdma_worker_tx_failed_post
+                  name: tx_failed_post
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rdma_worker
+            - title: Chunk Throughput
+              context: chunk_throughput
+              units: chunks/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_rdma_worker_tx_chunks
+                  name: tx
+                - selector: ceph_async_messenger_rdma_worker_rx_chunks
+                  name: rx
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rdma_worker
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_rdma_worker_tx_bytes
+                  name: tx
+                - selector: ceph_async_messenger_rdma_worker_rx_bytes
+                  name: rx
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rdma_worker
+            - title: Pending Connections
+              context: pending_connections
+              units: connections
+              label_promotion: []
+              dimensions:
+                - selector: ceph_async_messenger_rdma_worker_pending_sent_conns
+                  name: pending
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rdma_worker
+              algorithm: absolute
+        - family: DPDK Queues
+          context_namespace: dpdk_queues
+          metrics:
+            - ceph_dpdk_queue_dpdk_receive_bad_checksum_errors
+            - ceph_dpdk_queue_dpdk_receive_bytes
+            - ceph_dpdk_queue_dpdk_receive_copy_bytes
+            - ceph_dpdk_queue_dpdk_receive_copy_ops
+            - ceph_dpdk_queue_dpdk_receive_fragments
+            - ceph_dpdk_queue_dpdk_receive_last_bunch
+            - ceph_dpdk_queue_dpdk_receive_linearize_ops
+            - ceph_dpdk_queue_dpdk_receive_no_memory_errors
+            - ceph_dpdk_queue_dpdk_receive_packets
+            - ceph_dpdk_queue_dpdk_send_bytes
+            - ceph_dpdk_queue_dpdk_send_copy_bytes
+            - ceph_dpdk_queue_dpdk_send_copy_ops
+            - ceph_dpdk_queue_dpdk_send_fragments
+            - ceph_dpdk_queue_dpdk_send_last_bunch
+            - ceph_dpdk_queue_dpdk_send_linearize_ops
+            - ceph_dpdk_queue_dpdk_send_packets
+            - ceph_dpdk_queue_dpdk_send_queue_length
+          charts:
+            - title: Packets
+              context: packets
+              units: packets/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_packets
+                  name: receive
+                - selector: ceph_dpdk_queue_dpdk_send_packets
+                  name: send
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_bytes
+                  name: receive
+                - selector: ceph_dpdk_queue_dpdk_send_bytes
+                  name: send
+                - selector: ceph_dpdk_queue_dpdk_receive_copy_bytes
+                  name: receive_copy
+                - selector: ceph_dpdk_queue_dpdk_send_copy_bytes
+                  name: send_copy
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Packet Fragments
+              context: packet_fragments
+              units: fragments/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_fragments
+                  name: receive_fragments
+                - selector: ceph_dpdk_queue_dpdk_send_fragments
+                  name: send_fragments
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Copy and Linearize Operations
+              context: copy_linearize_operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_copy_ops
+                  name: receive_copy_ops
+                - selector: ceph_dpdk_queue_dpdk_send_copy_ops
+                  name: send_copy_ops
+                - selector: ceph_dpdk_queue_dpdk_receive_linearize_ops
+                  name: receive_linearize_ops
+                - selector: ceph_dpdk_queue_dpdk_send_linearize_ops
+                  name: send_linearize_ops
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Receive Errors
+              context: receive_errors
+              units: errors/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_bad_checksum_errors
+                  name: bad_checksum
+                - selector: ceph_dpdk_queue_dpdk_receive_no_memory_errors
+                  name: no_memory
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+            - title: Last Batch Size
+              context: last_batch_size
+              units: packets
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_receive_last_bunch
+                  name: receive
+                - selector: ceph_dpdk_queue_dpdk_send_last_bunch
+                  name: send
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+              algorithm: absolute
+            - title: Send Queue Depth
+              context: send_queue_depth
+              units: packets
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_queue_dpdk_send_queue_length
+                  name: queued
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_queue
+              algorithm: absolute
+        - family: DPDK Ports
+          context_namespace: dpdk_ports
+          metrics:
+            - ceph_dpdk_port_dpdk_device_receive_badcrc_errors
+            - ceph_dpdk_port_dpdk_device_receive_dropped_errors
+            - ceph_dpdk_port_dpdk_device_receive_multicast_packets
+            - ceph_dpdk_port_dpdk_device_receive_nombuf_errors
+            - ceph_dpdk_port_dpdk_device_receive_total_errors
+            - ceph_dpdk_port_dpdk_device_send_total_errors
+          charts:
+            - title: Multicast Packets
+              context: multicast_packets
+              units: packets/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_port_dpdk_device_receive_multicast_packets
+                  name: received
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_port
+            - title: Receive Errors
+              context: receive_errors
+              units: errors/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_port_dpdk_device_receive_badcrc_errors
+                  name: badcrc
+                - selector: ceph_dpdk_port_dpdk_device_receive_total_errors
+                  name: total
+                - selector: ceph_dpdk_port_dpdk_device_receive_dropped_errors
+                  name: dropped
+                - selector: ceph_dpdk_port_dpdk_device_receive_nombuf_errors
+                  name: nombuf
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_port
+            - title: Send Errors
+              context: send_errors
+              units: errors/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_dpdk_port_dpdk_device_send_total_errors
+                  name: total
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - dpdk_port
+        - family: Service Identity
+          context_namespace: service_identity
+          metrics:
+            - ceph_service_unique_id
+          charts:
+            - title: Service Identity Metadata Sentinel
+              context: identity_metadata
+              units: identifier
+              label_promotion: []
+              dimensions:
+                - selector: ceph_service_unique_id
+                  name: present
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - service_unique_id
+        - family: RADOS Striper
+          context_namespace: rados_striper
+          metrics:
+            - ceph_libcephsqlite_striper_lock
+            - ceph_libcephsqlite_striper_shrink
+            - ceph_libcephsqlite_striper_shrink_bytes
+            - ceph_libcephsqlite_striper_unlock
+            - ceph_libcephsqlite_striper_update_allocated
+            - ceph_libcephsqlite_striper_update_metadata
+            - ceph_libcephsqlite_striper_update_size
+            - ceph_libcephsqlite_striper_update_version
+          charts:
+            - title: Metadata and Lock Work
+              context: metadata_and_lock_work
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_libcephsqlite_striper_update_metadata
+                  name: update_metadata
+                - selector: ceph_libcephsqlite_striper_update_allocated
+                  name: update_allocated
+                - selector: ceph_libcephsqlite_striper_update_size
+                  name: update_size
+                - selector: ceph_libcephsqlite_striper_update_version
+                  name: update_version
+                - selector: ceph_libcephsqlite_striper_shrink
+                  name: shrink
+                - selector: ceph_libcephsqlite_striper_lock
+                  name: lock
+                - selector: ceph_libcephsqlite_striper_unlock
+                  name: unlock
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Shrink Throughput
+              context: shrink_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_libcephsqlite_striper_shrink_bytes
+                  name: bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Memory Pools
+          context_namespace: memory_pools
+          metrics:
+            - ceph_mempool_bloom_filter_bytes
+            - ceph_mempool_bloom_filter_items
+            - ceph_mempool_bluefs_bytes
+            - ceph_mempool_bluefs_file_reader_bytes
+            - ceph_mempool_bluefs_file_reader_items
+            - ceph_mempool_bluefs_file_writer_bytes
+            - ceph_mempool_bluefs_file_writer_items
+            - ceph_mempool_bluefs_items
+            - ceph_mempool_bluestore_alloc_bytes
+            - ceph_mempool_bluestore_alloc_items
+            - ceph_mempool_bluestore_blob_bytes
+            - ceph_mempool_bluestore_blob_items
+            - ceph_mempool_bluestore_cache_buffer_bytes
+            - ceph_mempool_bluestore_cache_buffer_items
+            - ceph_mempool_bluestore_cache_data_bytes
+            - ceph_mempool_bluestore_cache_data_items
+            - ceph_mempool_bluestore_cache_meta_bytes
+            - ceph_mempool_bluestore_cache_meta_items
+            - ceph_mempool_bluestore_cache_onode_bytes
+            - ceph_mempool_bluestore_cache_onode_items
+            - ceph_mempool_bluestore_cache_other_bytes
+            - ceph_mempool_bluestore_cache_other_items
+            - ceph_mempool_bluestore_extent_bytes
+            - ceph_mempool_bluestore_extent_items
+            - ceph_mempool_bluestore_fsck_bytes
+            - ceph_mempool_bluestore_fsck_items
+            - ceph_mempool_bluestore_inline_bl_bytes
+            - ceph_mempool_bluestore_inline_bl_items
+            - ceph_mempool_bluestore_shared_blob_bytes
+            - ceph_mempool_bluestore_shared_blob_items
+            - ceph_mempool_bluestore_txc_bytes
+            - ceph_mempool_bluestore_txc_items
+            - ceph_mempool_bluestore_writing_bytes
+            - ceph_mempool_bluestore_writing_deferred_bytes
+            - ceph_mempool_bluestore_writing_deferred_items
+            - ceph_mempool_bluestore_writing_items
+            - ceph_mempool_buffer_anon_bytes
+            - ceph_mempool_buffer_anon_items
+            - ceph_mempool_buffer_meta_bytes
+            - ceph_mempool_buffer_meta_items
+            - ceph_mempool_ec_extent_cache_bytes
+            - ceph_mempool_ec_extent_cache_items
+            - ceph_mempool_mds_co_bytes
+            - ceph_mempool_mds_co_items
+            - ceph_mempool_osd_bytes
+            - ceph_mempool_osd_items
+            - ceph_mempool_osd_mapbl_bytes
+            - ceph_mempool_osd_mapbl_items
+            - ceph_mempool_osd_pglog_bytes
+            - ceph_mempool_osd_pglog_items
+            - ceph_mempool_osdmap_bytes
+            - ceph_mempool_osdmap_items
+            - ceph_mempool_osdmap_mapping_bytes
+            - ceph_mempool_osdmap_mapping_items
+            - ceph_mempool_pgmap_bytes
+            - ceph_mempool_pgmap_items
+            - ceph_mempool_unittest_1_bytes
+            - ceph_mempool_unittest_1_items
+            - ceph_mempool_unittest_2_bytes
+            - ceph_mempool_unittest_2_items
+          charts:
+            - title: Memory Use
+              context: memory_use
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mempool_bloom_filter_bytes
+                  name: bloom_filter
+                - selector: ceph_mempool_bluestore_alloc_bytes
+                  name: bluestore_alloc
+                - selector: ceph_mempool_bluestore_cache_data_bytes
+                  name: bluestore_cache_data
+                - selector: ceph_mempool_bluestore_cache_onode_bytes
+                  name: bluestore_cache_onode
+                - selector: ceph_mempool_bluestore_cache_meta_bytes
+                  name: bluestore_cache_meta
+                - selector: ceph_mempool_bluestore_cache_other_bytes
+                  name: bluestore_cache_other
+                - selector: ceph_mempool_bluestore_cache_buffer_bytes
+                  name: bluestore_cache_buffer
+                - selector: ceph_mempool_bluestore_extent_bytes
+                  name: bluestore_extent
+                - selector: ceph_mempool_bluestore_blob_bytes
+                  name: bluestore_blob
+                - selector: ceph_mempool_bluestore_shared_blob_bytes
+                  name: bluestore_shared_blob
+                - selector: ceph_mempool_bluestore_inline_bl_bytes
+                  name: bluestore_inline_bl
+                - selector: ceph_mempool_bluestore_fsck_bytes
+                  name: bluestore_fsck
+                - selector: ceph_mempool_bluestore_txc_bytes
+                  name: bluestore_txc
+                - selector: ceph_mempool_bluestore_writing_deferred_bytes
+                  name: bluestore_writing_deferred
+                - selector: ceph_mempool_bluestore_writing_bytes
+                  name: bluestore_writing
+                - selector: ceph_mempool_bluefs_bytes
+                  name: bluefs
+                - selector: ceph_mempool_bluefs_file_reader_bytes
+                  name: bluefs_file_reader
+                - selector: ceph_mempool_bluefs_file_writer_bytes
+                  name: bluefs_file_writer
+                - selector: ceph_mempool_buffer_anon_bytes
+                  name: buffer_anon
+                - selector: ceph_mempool_buffer_meta_bytes
+                  name: buffer_meta
+                - selector: ceph_mempool_osd_bytes
+                  name: osd
+                - selector: ceph_mempool_osd_mapbl_bytes
+                  name: osd_mapbl
+                - selector: ceph_mempool_osd_pglog_bytes
+                  name: osd_pglog
+                - selector: ceph_mempool_osdmap_bytes
+                  name: osdmap
+                - selector: ceph_mempool_osdmap_mapping_bytes
+                  name: osdmap_mapping
+                - selector: ceph_mempool_pgmap_bytes
+                  name: pgmap
+                - selector: ceph_mempool_mds_co_bytes
+                  name: mds_co
+                - selector: ceph_mempool_unittest_1_bytes
+                  name: unittest_1
+                - selector: ceph_mempool_unittest_2_bytes
+                  name: unittest_2
+                - selector: ceph_mempool_ec_extent_cache_bytes
+                  name: ec_extent_cache
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Item Count
+              context: item_count
+              units: items
+              label_promotion: []
+              dimensions:
+                - selector: ceph_mempool_bloom_filter_items
+                  name: bloom_filter
+                - selector: ceph_mempool_bluestore_alloc_items
+                  name: bluestore_alloc
+                - selector: ceph_mempool_bluestore_cache_data_items
+                  name: bluestore_cache_data
+                - selector: ceph_mempool_bluestore_cache_onode_items
+                  name: bluestore_cache_onode
+                - selector: ceph_mempool_bluestore_cache_meta_items
+                  name: bluestore_cache_meta
+                - selector: ceph_mempool_bluestore_cache_other_items
+                  name: bluestore_cache_other
+                - selector: ceph_mempool_bluestore_cache_buffer_items
+                  name: bluestore_cache_buffer
+                - selector: ceph_mempool_bluestore_extent_items
+                  name: bluestore_extent
+                - selector: ceph_mempool_bluestore_blob_items
+                  name: bluestore_blob
+                - selector: ceph_mempool_bluestore_shared_blob_items
+                  name: bluestore_shared_blob
+                - selector: ceph_mempool_bluestore_inline_bl_items
+                  name: bluestore_inline_bl
+                - selector: ceph_mempool_bluestore_fsck_items
+                  name: bluestore_fsck
+                - selector: ceph_mempool_bluestore_txc_items
+                  name: bluestore_txc
+                - selector: ceph_mempool_bluestore_writing_deferred_items
+                  name: bluestore_writing_deferred
+                - selector: ceph_mempool_bluestore_writing_items
+                  name: bluestore_writing
+                - selector: ceph_mempool_bluefs_items
+                  name: bluefs
+                - selector: ceph_mempool_bluefs_file_reader_items
+                  name: bluefs_file_reader
+                - selector: ceph_mempool_bluefs_file_writer_items
+                  name: bluefs_file_writer
+                - selector: ceph_mempool_buffer_anon_items
+                  name: buffer_anon
+                - selector: ceph_mempool_buffer_meta_items
+                  name: buffer_meta
+                - selector: ceph_mempool_osd_items
+                  name: osd
+                - selector: ceph_mempool_osd_mapbl_items
+                  name: osd_mapbl
+                - selector: ceph_mempool_osd_pglog_items
+                  name: osd_pglog
+                - selector: ceph_mempool_osdmap_items
+                  name: osdmap
+                - selector: ceph_mempool_osdmap_mapping_items
+                  name: osdmap_mapping
+                - selector: ceph_mempool_pgmap_items
+                  name: pgmap
+                - selector: ceph_mempool_mds_co_items
+                  name: mds_co
+                - selector: ceph_mempool_unittest_1_items
+                  name: unittest_1
+                - selector: ceph_mempool_unittest_2_items
+                  name: unittest_2
+                - selector: ceph_mempool_ec_extent_cache_items
+                  name: ec_extent_cache
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: CephFS Mirror
+      context_namespace: cephfs_mirror
+      groups:
+        - family: Service
+          context_namespace: service
+          metrics:
+            - ceph_cephfs_mirror_mirror_enable_failures
+            - ceph_cephfs_mirror_mirrored_filesystems
+          charts:
+            - title: Mirrored Filesystems
+              context: filesystems
+              units: filesystems
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_mirrored_filesystems
+                  name: mirrored
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Mirroring Enable Failures
+              context: enable_failures
+              units: failures/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_mirror_enable_failures
+                  name: failures
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+        - family: Filesystems
+          context_namespace: filesystems
+          metrics:
+            - ceph_cephfs_mirror_mirrored_filesystems_directory_count
+            - ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
+          charts:
+            - title: Mirroring Peers
+              context: peers
+              units: peers
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
+                  name: peers
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - filesystem
+                optional_by_labels: []
+            - title: Mirrored Directories
+              context: directories
+              units: directories
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_mirrored_filesystems_directory_count
+                  name: directories
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - filesystem
+                optional_by_labels: []
+        - family: Peers
+          context_namespace: peers
+          metrics:
+            - ceph_cephfs_mirror_peers_avg_sync_time_count
+            - ceph_cephfs_mirror_peers_avg_sync_time_sum
+            - ceph_cephfs_mirror_peers_last_synced_bytes
+            - ceph_cephfs_mirror_peers_last_synced_duration
+            - ceph_cephfs_mirror_peers_last_synced_end
+            - ceph_cephfs_mirror_peers_last_synced_start
+            - ceph_cephfs_mirror_peers_snaps_deleted
+            - ceph_cephfs_mirror_peers_snaps_renamed
+            - ceph_cephfs_mirror_peers_snaps_synced
+            - ceph_cephfs_mirror_peers_sync_bytes
+            - ceph_cephfs_mirror_peers_sync_failures
+          charts:
+            - title: Snapshot Outcomes
+              context: snapshot_outcomes
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_snaps_synced
+                  name: synced
+                - selector: ceph_cephfs_mirror_peers_snaps_deleted
+                  name: deleted
+                - selector: ceph_cephfs_mirror_peers_snaps_renamed
+                  name: renamed
+                - selector: ceph_cephfs_mirror_peers_sync_failures
+                  name: failed
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Sync-Time Measurements
+              context: sync_time_measurements
+              units: snapshots/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_avg_sync_time_count
+                  name: snapshots
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Accumulated Sync Time
+              context: accumulated_sync_time
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_avg_sync_time_sum
+                  name: time
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+              algorithm: incremental
+            - title: Sync Throughput
+              context: sync_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_sync_bytes
+                  name: bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Last Sync Timestamps
+              context: last_sync_timestamps
+              units: seconds since epoch
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_last_synced_start
+                  name: started
+                - selector: ceph_cephfs_mirror_peers_last_synced_end
+                  name: ended
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Last Sync Duration
+              context: last_sync_duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_last_synced_duration
+                  name: duration
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+            - title: Last Sync Size
+              context: last_sync_size
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_cephfs_mirror_peers_last_synced_bytes
+                  name: bytes
+              instances:
+                by_labels:
+                  - ceph_daemon
+                  - peer_cluster_filesystem
+                  - peer_cluster_name
+                  - source_filesystem
+                  - source_fscid
+                optional_by_labels: []
+              algorithm: absolute
+    - family: Object Gateway Scheduling
+      context_namespace: object_gateway_scheduling
       metrics:
-      - ceph_rbd_image_metadata
+        - ceph_dmclock_admin_cancel
+        - ceph_dmclock_admin_cancel_cost
+        - ceph_dmclock_admin_cost
+        - ceph_dmclock_admin_limit
+        - ceph_dmclock_admin_limit_cost
+        - ceph_dmclock_admin_prio
+        - ceph_dmclock_admin_prio_cost
+        - ceph_dmclock_admin_prio_latency_count
+        - ceph_dmclock_admin_prio_latency_sum
+        - ceph_dmclock_admin_qlen
+        - ceph_dmclock_admin_res
+        - ceph_dmclock_admin_res_cost
+        - ceph_dmclock_admin_res_latency_count
+        - ceph_dmclock_admin_res_latency_sum
+        - ceph_dmclock_auth_cancel
+        - ceph_dmclock_auth_cancel_cost
+        - ceph_dmclock_auth_cost
+        - ceph_dmclock_auth_limit
+        - ceph_dmclock_auth_limit_cost
+        - ceph_dmclock_auth_prio
+        - ceph_dmclock_auth_prio_cost
+        - ceph_dmclock_auth_prio_latency_count
+        - ceph_dmclock_auth_prio_latency_sum
+        - ceph_dmclock_auth_qlen
+        - ceph_dmclock_auth_res
+        - ceph_dmclock_auth_res_cost
+        - ceph_dmclock_auth_res_latency_count
+        - ceph_dmclock_auth_res_latency_sum
+        - ceph_dmclock_data_cancel
+        - ceph_dmclock_data_cancel_cost
+        - ceph_dmclock_data_cost
+        - ceph_dmclock_data_limit
+        - ceph_dmclock_data_limit_cost
+        - ceph_dmclock_data_prio
+        - ceph_dmclock_data_prio_cost
+        - ceph_dmclock_data_prio_latency_count
+        - ceph_dmclock_data_prio_latency_sum
+        - ceph_dmclock_data_qlen
+        - ceph_dmclock_data_res
+        - ceph_dmclock_data_res_cost
+        - ceph_dmclock_data_res_latency_count
+        - ceph_dmclock_data_res_latency_sum
+        - ceph_dmclock_metadata_cancel
+        - ceph_dmclock_metadata_cancel_cost
+        - ceph_dmclock_metadata_cost
+        - ceph_dmclock_metadata_limit
+        - ceph_dmclock_metadata_limit_cost
+        - ceph_dmclock_metadata_prio
+        - ceph_dmclock_metadata_prio_cost
+        - ceph_dmclock_metadata_prio_latency_count
+        - ceph_dmclock_metadata_prio_latency_sum
+        - ceph_dmclock_metadata_qlen
+        - ceph_dmclock_metadata_res
+        - ceph_dmclock_metadata_res_cost
+        - ceph_dmclock_metadata_res_latency_count
+        - ceph_dmclock_metadata_res_latency_sum
+        - ceph_dmclock_scheduler_outstanding
+        - ceph_dmclock_scheduler_throttle
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_image_metadata
-          name: value
-        instances:
-          by_labels:
-          - image_name
-          - pool_id
-          optional_by_labels: []
-    - family: Latency
-      context_namespace: latency
+        - title: Queue Depth
+          context: queue_depth
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_qlen
+              name: admin
+            - selector: ceph_dmclock_auth_qlen
+              name: auth
+            - selector: ceph_dmclock_data_qlen
+              name: data
+            - selector: ceph_dmclock_metadata_qlen
+              name: metadata
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Queued Request Cost
+          context: queue_cost
+          units: cost
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_cost
+              name: admin
+            - selector: ceph_dmclock_auth_cost
+              name: auth
+            - selector: ceph_dmclock_data_cost
+              name: data
+            - selector: ceph_dmclock_metadata_cost
+              name: metadata
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Scheduled Requests
+          context: scheduled_requests
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_res
+              name: admin_reservation
+            - selector: ceph_dmclock_admin_prio
+              name: admin_priority
+            - selector: ceph_dmclock_auth_res
+              name: auth_reservation
+            - selector: ceph_dmclock_auth_prio
+              name: auth_priority
+            - selector: ceph_dmclock_data_res
+              name: data_reservation
+            - selector: ceph_dmclock_data_prio
+              name: data_priority
+            - selector: ceph_dmclock_metadata_res
+              name: metadata_reservation
+            - selector: ceph_dmclock_metadata_prio
+              name: metadata_priority
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Rejected and Cancelled Requests
+          context: rejected_and_cancelled_requests
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_limit
+              name: admin_limited
+            - selector: ceph_dmclock_admin_cancel
+              name: admin_cancelled
+            - selector: ceph_dmclock_auth_limit
+              name: auth_limited
+            - selector: ceph_dmclock_auth_cancel
+              name: auth_cancelled
+            - selector: ceph_dmclock_data_limit
+              name: data_limited
+            - selector: ceph_dmclock_data_cancel
+              name: data_cancelled
+            - selector: ceph_dmclock_metadata_limit
+              name: metadata_limited
+            - selector: ceph_dmclock_metadata_cancel
+              name: metadata_cancelled
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Scheduled and Rejected Cost
+          context: scheduled_and_rejected_cost
+          units: cost/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_res_cost
+              name: admin_reservation
+            - selector: ceph_dmclock_admin_prio_cost
+              name: admin_priority
+            - selector: ceph_dmclock_admin_limit_cost
+              name: admin_limited
+            - selector: ceph_dmclock_admin_cancel_cost
+              name: admin_cancelled
+            - selector: ceph_dmclock_auth_res_cost
+              name: auth_reservation
+            - selector: ceph_dmclock_auth_prio_cost
+              name: auth_priority
+            - selector: ceph_dmclock_auth_limit_cost
+              name: auth_limited
+            - selector: ceph_dmclock_auth_cancel_cost
+              name: auth_cancelled
+            - selector: ceph_dmclock_data_res_cost
+              name: data_reservation
+            - selector: ceph_dmclock_data_prio_cost
+              name: data_priority
+            - selector: ceph_dmclock_data_limit_cost
+              name: data_limited
+            - selector: ceph_dmclock_data_cancel_cost
+              name: data_cancelled
+            - selector: ceph_dmclock_metadata_res_cost
+              name: metadata_reservation
+            - selector: ceph_dmclock_metadata_prio_cost
+              name: metadata_priority
+            - selector: ceph_dmclock_metadata_limit_cost
+              name: metadata_limited
+            - selector: ceph_dmclock_metadata_cancel_cost
+              name: metadata_cancelled
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Scheduling-Latency Measurements
+          context: latency_measurements
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_res_latency_count
+              name: admin_reservation
+            - selector: ceph_dmclock_admin_prio_latency_count
+              name: admin_priority
+            - selector: ceph_dmclock_auth_res_latency_count
+              name: auth_reservation
+            - selector: ceph_dmclock_auth_prio_latency_count
+              name: auth_priority
+            - selector: ceph_dmclock_data_res_latency_count
+              name: data_reservation
+            - selector: ceph_dmclock_data_prio_latency_count
+              name: data_priority
+            - selector: ceph_dmclock_metadata_res_latency_count
+              name: metadata_reservation
+            - selector: ceph_dmclock_metadata_prio_latency_count
+              name: metadata_priority
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+        - title: Accumulated Scheduling Latency
+          context: accumulated_latency
+          units: seconds/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_admin_res_latency_sum
+              name: admin_reservation
+            - selector: ceph_dmclock_admin_prio_latency_sum
+              name: admin_priority
+            - selector: ceph_dmclock_auth_res_latency_sum
+              name: auth_reservation
+            - selector: ceph_dmclock_auth_prio_latency_sum
+              name: auth_priority
+            - selector: ceph_dmclock_data_res_latency_sum
+              name: data_reservation
+            - selector: ceph_dmclock_data_prio_latency_sum
+              name: data_priority
+            - selector: ceph_dmclock_metadata_res_latency_sum
+              name: metadata_reservation
+            - selector: ceph_dmclock_metadata_prio_latency_sum
+              name: metadata_priority
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Throttled Requests
+          context: throttled_requests
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_scheduler_throttle
+              name: throttled
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+        - title: Outstanding Requests
+          context: outstanding_requests
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_dmclock_scheduler_outstanding
+              name: outstanding
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+    - family: Storage Engine Extensions
+      context_namespace: storage_engine_extensions
+      groups:
+        - family: RocksDB Binned Cache
+          context_namespace: rocksdb_binned_cache
+          metrics:
+            - ceph_rocksdb_binned_cache_capacity
+            - ceph_rocksdb_binned_cache_elems
+            - ceph_rocksdb_binned_cache_hits
+            - ceph_rocksdb_binned_cache_inserts
+            - ceph_rocksdb_binned_cache_lookups
+            - ceph_rocksdb_binned_cache_misses
+            - ceph_rocksdb_binned_cache_pinned
+            - ceph_rocksdb_binned_cache_usage
+          charts:
+            - title: Cache Memory
+              context: memory
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_capacity
+                  name: capacity
+                - selector: ceph_rocksdb_binned_cache_usage
+                  name: used
+                - selector: ceph_rocksdb_binned_cache_pinned
+                  name: pinned
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+            - title: Cache Entries
+              context: entries
+              units: entries
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_elems
+                  name: items
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+            - title: Cache Insertions
+              context: insertions
+              units: insertions/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_inserts
+                  name: insertions
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+              algorithm: incremental
+            - title: Cache Lookups
+              context: lookups
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_lookups
+                  name: lookups
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+              algorithm: incremental
+            - title: Cache Lookup Outcomes
+              context: lookup_outcomes
+              units: lookups/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rocksdb_binned_cache_hits
+                  name: hits
+                - selector: ceph_rocksdb_binned_cache_misses
+                  name: misses
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels:
+                  - rocksdb_cache_key
+              algorithm: incremental
+        - family: External Block Devices
+          context_namespace: external_block_devices
+          metrics:
+            - ceph_extblkdev_dev_log_size
+            - ceph_extblkdev_dev_log_util
+            - ceph_extblkdev_dev_phy_size
+            - ceph_extblkdev_dev_phy_util
+            - ceph_extblkdev_fcm
+            - ceph_extblkdev_part_log_avail
+            - ceph_extblkdev_part_log_size
+            - ceph_extblkdev_part_phy_avail
+            - ceph_extblkdev_part_phy_size
+          charts:
+            - title: FCM Plugin State
+              context: plugin_state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_extblkdev_fcm
+                  name: fcm
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Device Size
+              context: device_size
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_extblkdev_dev_phy_size
+                  name: physical
+                - selector: ceph_extblkdev_dev_log_size
+                  name: logical
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Device Utilization
+              context: device_utilization
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_extblkdev_dev_phy_util
+                  name: physical
+                - selector: ceph_extblkdev_dev_log_util
+                  name: logical
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+            - title: Partition Space
+              context: partition_space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_extblkdev_part_phy_size
+                  name: physical_size
+                - selector: ceph_extblkdev_part_log_size
+                  name: logical_size
+                - selector: ceph_extblkdev_part_phy_avail
+                  name: physical_available
+                - selector: ceph_extblkdev_part_log_avail
+                  name: logical_available
+              instances:
+                by_labels:
+                  - ceph_daemon
+                optional_by_labels: []
+    - family: Ceph Clients
+      context_namespace: ceph_clients
       metrics:
-      - ceph_rbd_read_latency_count
-      - ceph_rbd_read_latency_sum
-      - ceph_rbd_write_latency_count
-      - ceph_rbd_write_latency_sum
+        - ceph_client_mdops
+        - ceph_client_rdops
+        - ceph_client_wrops
       charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_read_latency_count
-          name: read_latency
-        - selector: ceph_rbd_write_latency_count
-          name: write_latency
-        instances:
-          by_labels:
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_read_latency_sum
-          name: read_latency
-        - selector: ceph_rbd_write_latency_sum
-          name: write_latency
-        instances:
-          by_labels:
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-    - family: Mirror Metadata
-      context_namespace: mirror_metadata
-      metrics:
-      - ceph_rbd_mirror_metadata
-      charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_metadata
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - ceph_version
-          - hostname
-          - id
-          - instance_id
-          optional_by_labels: []
-  - family: SMB Metadata
-    context_namespace: smb_metadata
-    metrics:
-    - ceph_smb_metadata
-    charts:
-    - title: State and Metadata
-      context: state
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_smb_metadata
-        name: value
-      instances:
-        by_labels:
-        - netbiosname
-        - share
-        - smb_version
-        - subvolume
-        - subvolume_group
-        - volume
-        optional_by_labels: []
-  - family: BlueFS
-    context_namespace: bluefs
-    groups:
-    - family: Allocation
-      context_namespace: allocation
-      metrics:
-      - ceph_bluefs_alloc_db_max_lat
-      - ceph_bluefs_alloc_slow_fallback
-      - ceph_bluefs_alloc_slow_max_lat
-      - ceph_bluefs_alloc_slow_size_fallback
-      - ceph_bluefs_alloc_unit_db
-      - ceph_bluefs_alloc_unit_slow
-      - ceph_bluefs_alloc_unit_wal
-      - ceph_bluefs_alloc_wal_max_lat
-      - ceph_bluefs_db_alloc_lat_count
-      - ceph_bluefs_db_alloc_lat_sum
-      - ceph_bluefs_slow_alloc_lat_count
-      - ceph_bluefs_slow_alloc_lat_sum
-      - ceph_bluefs_wal_alloc_lat_count
-      - ceph_bluefs_wal_alloc_lat_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_db_alloc_lat_count
-          name: db_alloc_lat
-        - selector: ceph_bluefs_slow_alloc_lat_count
-          name: slow_alloc_lat
-        - selector: ceph_bluefs_wal_alloc_lat_count
-          name: wal_alloc_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_db_alloc_lat_sum
-          name: db_alloc_lat
-        - selector: ceph_bluefs_slow_alloc_lat_sum
-          name: slow_alloc_lat
-        - selector: ceph_bluefs_wal_alloc_lat_sum
-          name: wal_alloc_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Allocation Sizes and High-Water Marks
-        context: allocation_high_water
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_alloc_unit_db
-          name: db
-        - selector: ceph_bluefs_alloc_unit_slow
-          name: slow
-        - selector: ceph_bluefs_alloc_unit_wal
-          name: wal
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: absolute
-      - title: Duration and Time
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_alloc_db_max_lat
-          name: db_max_lat
-        - selector: ceph_bluefs_alloc_slow_max_lat
-          name: slow_max_lat
-        - selector: ceph_bluefs_alloc_wal_max_lat
-          name: wal_max_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_alloc_slow_fallback
-          name: fallback
-        - selector: ceph_bluefs_alloc_slow_size_fallback
-          name: size_fallback
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Compaction
-      context_namespace: compaction
-      metrics:
-      - ceph_bluefs_compact_lat_count
-      - ceph_bluefs_compact_lat_sum
-      - ceph_bluefs_compact_lock_lat_count
-      - ceph_bluefs_compact_lock_lat_sum
-      - ceph_bluefs_log_compactions
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_compact_lat_count
-          name: lat
-        - selector: ceph_bluefs_compact_lock_lat_count
-          name: lock_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_compact_lat_sum
-          name: lat
-        - selector: ceph_bluefs_compact_lock_lat_sum
-          name: lock_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_log_compactions
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: I/O and Files
-      context_namespace: i_o_and_files
-      metrics:
-      - ceph_bluefs_flush_lat_count
-      - ceph_bluefs_flush_lat_sum
-      - ceph_bluefs_fsync_lat_count
-      - ceph_bluefs_fsync_lat_sum
-      - ceph_bluefs_log_write_count
-      - ceph_bluefs_read_bytes
-      - ceph_bluefs_read_count
-      - ceph_bluefs_read_disk_bytes
-      - ceph_bluefs_read_disk_bytes_db
-      - ceph_bluefs_read_disk_bytes_slow
-      - ceph_bluefs_read_disk_bytes_wal
-      - ceph_bluefs_read_disk_count
-      - ceph_bluefs_read_lat_count
-      - ceph_bluefs_read_lat_sum
-      - ceph_bluefs_read_prefetch_bytes
-      - ceph_bluefs_read_prefetch_count
-      - ceph_bluefs_read_random_buffer_bytes
-      - ceph_bluefs_read_random_buffer_count
-      - ceph_bluefs_read_random_bytes
-      - ceph_bluefs_read_random_count
-      - ceph_bluefs_read_random_disk_bytes
-      - ceph_bluefs_read_random_disk_bytes_db
-      - ceph_bluefs_read_random_disk_bytes_slow
-      - ceph_bluefs_read_random_disk_bytes_wal
-      - ceph_bluefs_read_random_disk_count
-      - ceph_bluefs_read_random_lat_count
-      - ceph_bluefs_read_random_lat_sum
-      - ceph_bluefs_read_zeros_candidate
-      - ceph_bluefs_read_zeros_errors
-      - ceph_bluefs_truncate_lat_count
-      - ceph_bluefs_truncate_lat_sum
-      - ceph_bluefs_unlink_lat_count
-      - ceph_bluefs_unlink_lat_sum
-      - ceph_bluefs_write_bytes
-      - ceph_bluefs_write_count
-      - ceph_bluefs_write_count_sst
-      - ceph_bluefs_write_count_wal
-      - ceph_bluefs_write_disk_count
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_flush_lat_count
-          name: flush_lat
-        - selector: ceph_bluefs_fsync_lat_count
-          name: fsync_lat
-        - selector: ceph_bluefs_read_lat_count
-          name: read_lat
-        - selector: ceph_bluefs_read_random_lat_count
-          name: read_random_lat
-        - selector: ceph_bluefs_truncate_lat_count
-          name: truncate_lat
-        - selector: ceph_bluefs_unlink_lat_count
-          name: unlink_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_flush_lat_sum
-          name: flush_lat
-        - selector: ceph_bluefs_fsync_lat_sum
-          name: fsync_lat
-        - selector: ceph_bluefs_read_lat_sum
-          name: read_lat
-        - selector: ceph_bluefs_read_random_lat_sum
-          name: read_random_lat
-        - selector: ceph_bluefs_truncate_lat_sum
-          name: truncate_lat
-        - selector: ceph_bluefs_unlink_lat_sum
-          name: unlink_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_read_bytes
-          name: read_bytes
-        - selector: ceph_bluefs_read_disk_bytes
-          name: read_disk_bytes
-        - selector: ceph_bluefs_read_disk_bytes_db
-          name: read_disk_bytes_db
-        - selector: ceph_bluefs_read_disk_bytes_slow
-          name: read_disk_bytes_slow
-        - selector: ceph_bluefs_read_disk_bytes_wal
-          name: read_disk_bytes_wal
-        - selector: ceph_bluefs_read_prefetch_bytes
-          name: read_prefetch_bytes
-        - selector: ceph_bluefs_read_random_buffer_bytes
-          name: read_random_buffer_bytes
-        - selector: ceph_bluefs_read_random_bytes
-          name: read_random_bytes
-        - selector: ceph_bluefs_read_random_disk_bytes
-          name: read_random_disk_bytes
-        - selector: ceph_bluefs_read_random_disk_bytes_db
-          name: read_random_disk_bytes_db
-        - selector: ceph_bluefs_read_random_disk_bytes_slow
-          name: read_random_disk_bytes_slow
-        - selector: ceph_bluefs_read_random_disk_bytes_wal
-          name: read_random_disk_bytes_wal
-        - selector: ceph_bluefs_write_bytes
-          name: write_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_log_write_count
-          name: log_write
-        - selector: ceph_bluefs_read_count
-          name: read
-        - selector: ceph_bluefs_read_disk_count
-          name: read_disk
-        - selector: ceph_bluefs_read_prefetch_count
-          name: read_prefetch
-        - selector: ceph_bluefs_read_random_buffer_count
-          name: read_random_buffer
-        - selector: ceph_bluefs_read_random_count
-          name: read_random
-        - selector: ceph_bluefs_read_random_disk_count
-          name: read_random_disk
-        - selector: ceph_bluefs_write_count
-          name: write
-        - selector: ceph_bluefs_write_count_sst
-          name: write_count_sst
-        - selector: ceph_bluefs_write_count_wal
-          name: write_count_wal
-        - selector: ceph_bluefs_write_disk_count
-          name: write_disk
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Zero-Read Outcomes
-        context: zero_read_outcomes
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_read_zeros_candidate
-          name: candidate
-        - selector: ceph_bluefs_read_zeros_errors
-          name: errors
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Space and Files
-      context_namespace: space_and_files
-      metrics:
-      - ceph_bluefs_bytes_written_slow
-      - ceph_bluefs_bytes_written_sst
-      - ceph_bluefs_bytes_written_wal
-      - ceph_bluefs_db_total_bytes
-      - ceph_bluefs_db_used_bytes
-      - ceph_bluefs_files_written_sst
-      - ceph_bluefs_files_written_wal
-      - ceph_bluefs_log_bytes
-      - ceph_bluefs_logged_bytes
-      - ceph_bluefs_max_bytes_db
-      - ceph_bluefs_max_bytes_slow
-      - ceph_bluefs_max_bytes_wal
-      - ceph_bluefs_num_files
-      - ceph_bluefs_slow_total_bytes
-      - ceph_bluefs_slow_used_bytes
-      - ceph_bluefs_wal_total_bytes
-      - ceph_bluefs_wal_used_bytes
-      charts:
-      - title: Allocation Sizes and High-Water Marks
-        context: allocation_high_water
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_max_bytes_db
-          name: db
-        - selector: ceph_bluefs_max_bytes_slow
-          name: slow
-        - selector: ceph_bluefs_max_bytes_wal
-          name: wal
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: absolute
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_bytes_written_slow
-          name: bytes_written_slow
-        - selector: ceph_bluefs_bytes_written_sst
-          name: bytes_written_sst
-        - selector: ceph_bluefs_bytes_written_wal
-          name: bytes_written_wal
-        - selector: ceph_bluefs_logged_bytes
-          name: logged_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Files
-        context: file_state
-        units: files
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_num_files
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: File Work
-        context: file_work
-        units: files/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_files_written_sst
-          name: sst
-        - selector: ceph_bluefs_files_written_wal
-          name: wal
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluefs_db_total_bytes
-          name: db_total_bytes
-        - selector: ceph_bluefs_db_used_bytes
-          name: db_used_bytes
-        - selector: ceph_bluefs_log_bytes
-          name: log_bytes
-        - selector: ceph_bluefs_slow_total_bytes
-          name: slow_total_bytes
-        - selector: ceph_bluefs_slow_used_bytes
-          name: slow_used_bytes
-        - selector: ceph_bluefs_wal_total_bytes
-          name: wal_total_bytes
-        - selector: ceph_bluefs_wal_used_bytes
-          name: wal_used_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: BlueStore
-    context_namespace: bluestore
-    groups:
-    - family: Allocation
-      context_namespace: allocation
-      metrics:
-      - ceph_bluestore_alloc_unit
-      - ceph_bluestore_allocated
-      - ceph_bluestore_allocator_lat_count
-      - ceph_bluestore_allocator_lat_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_allocator_lat_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_allocator_lat_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Allocation Unit
-        context: allocation_unit
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_alloc_unit
-          name: alloc_unit
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Allocated Space
-        context: allocated_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_allocated
-          name: allocated
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Compression and Checksums
-      context_namespace: compression_and_checksums
-      metrics:
-      - ceph_bluestore_compress_lat_count
-      - ceph_bluestore_compress_lat_sum
-      - ceph_bluestore_compress_rejected_count
-      - ceph_bluestore_compress_success_count
-      - ceph_bluestore_compressed
-      - ceph_bluestore_compressed_allocated
-      - ceph_bluestore_compressed_original
-      - ceph_bluestore_csum_lat_count
-      - ceph_bluestore_csum_lat_sum
-      - ceph_bluestore_decompress_lat_count
-      - ceph_bluestore_decompress_lat_sum
-      - ceph_bluestore_extent_compress
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_compress_lat_count
-          name: compress_lat
-        - selector: ceph_bluestore_csum_lat_count
-          name: csum_lat
-        - selector: ceph_bluestore_decompress_lat_count
-          name: decompress_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_compress_lat_sum
-          name: compress_lat
-        - selector: ceph_bluestore_csum_lat_sum
-          name: csum_lat
-        - selector: ceph_bluestore_decompress_lat_sum
-          name: decompress_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Compression Operations
-        context: compression_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_compress_rejected_count
-          name: compress_rejected
-        - selector: ceph_bluestore_compress_success_count
-          name: compress_success
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Compressed Extents
-        context: compressed_extents
-        units: extents/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_extent_compress
-          name: extent_compress
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_compressed
-          name: compressed
-        - selector: ceph_bluestore_compressed_allocated
-          name: allocated
-        - selector: ceph_bluestore_compressed_original
-          name: original
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: I/O
-      context_namespace: i_o
-      metrics:
-      - ceph_bluestore_issued_deferred_write_bytes
-      - ceph_bluestore_issued_deferred_writes
-      - ceph_bluestore_read_eio
-      - ceph_bluestore_read_lat_count
-      - ceph_bluestore_read_lat_sum
-      - ceph_bluestore_read_onode_meta_lat_count
-      - ceph_bluestore_read_onode_meta_lat_sum
-      - ceph_bluestore_read_wait_aio_lat_count
-      - ceph_bluestore_read_wait_aio_lat_sum
-      - ceph_bluestore_reads_with_retries
-      - ceph_bluestore_remove_lat_count
-      - ceph_bluestore_remove_lat_sum
-      - ceph_bluestore_slow_aio_wait_count
-      - ceph_bluestore_slow_read_onode_meta_count
-      - ceph_bluestore_slow_read_wait_aio_count
-      - ceph_bluestore_submitted_deferred_write_bytes
-      - ceph_bluestore_submitted_deferred_writes
-      - ceph_bluestore_truncate_lat_count
-      - ceph_bluestore_truncate_lat_sum
-      - ceph_bluestore_write_big
-      - ceph_bluestore_write_big_blobs
-      - ceph_bluestore_write_big_bytes
-      - ceph_bluestore_write_big_deferred
-      - ceph_bluestore_write_big_skipped_blobs
-      - ceph_bluestore_write_big_skipped_bytes
-      - ceph_bluestore_write_lat_count
-      - ceph_bluestore_write_lat_sum
-      - ceph_bluestore_write_new
-      - ceph_bluestore_write_pad_bytes
-      - ceph_bluestore_write_penalty_read_ops
-      - ceph_bluestore_write_small
-      - ceph_bluestore_write_small_bytes
-      - ceph_bluestore_write_small_pre_read
-      - ceph_bluestore_write_small_skipped
-      - ceph_bluestore_write_small_skipped_bytes
-      - ceph_bluestore_write_small_unused
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_read_lat_count
-          name: read_lat
-        - selector: ceph_bluestore_read_onode_meta_lat_count
-          name: read_onode_meta_lat
-        - selector: ceph_bluestore_read_wait_aio_lat_count
-          name: read_wait_aio_lat
-        - selector: ceph_bluestore_remove_lat_count
-          name: remove_lat
-        - selector: ceph_bluestore_truncate_lat_count
-          name: truncate_lat
-        - selector: ceph_bluestore_write_lat_count
-          name: write_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_read_lat_sum
-          name: read_lat
-        - selector: ceph_bluestore_read_onode_meta_lat_sum
-          name: read_onode_meta_lat
-        - selector: ceph_bluestore_read_wait_aio_lat_sum
-          name: read_wait_aio_lat
-        - selector: ceph_bluestore_remove_lat_sum
-          name: remove_lat
-        - selector: ceph_bluestore_truncate_lat_sum
-          name: truncate_lat
-        - selector: ceph_bluestore_write_lat_sum
-          name: write_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_issued_deferred_write_bytes
-          name: issued_deferred_write_bytes
-        - selector: ceph_bluestore_submitted_deferred_write_bytes
-          name: submitted_deferred_write_bytes
-        - selector: ceph_bluestore_write_big_bytes
-          name: write_big_bytes
-        - selector: ceph_bluestore_write_big_skipped_bytes
-          name: write_big_skipped_bytes
-        - selector: ceph_bluestore_write_pad_bytes
-          name: write_pad_bytes
-        - selector: ceph_bluestore_write_small_bytes
-          name: write_small_bytes
-        - selector: ceph_bluestore_write_small_skipped_bytes
-          name: write_small_skipped_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Read Outcomes
-        context: read_outcomes
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_read_eio
-          name: read_eio
-        - selector: ceph_bluestore_reads_with_retries
-          name: reads_with_retries
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Slow Reads
-        context: slow_reads
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_slow_read_onode_meta_count
-          name: slow_read_onode_meta
-        - selector: ceph_bluestore_slow_read_wait_aio_count
-          name: slow_read_wait_aio
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Slow AIO Waits
-        context: slow_aio_waits
-        units: waits/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_slow_aio_wait_count
-          name: slow_aio_wait
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Skipped Blobs
-        context: skipped_blobs
-        units: blobs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_write_big_skipped_blobs
-          name: write_big_skipped_blobs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Skipped Writes
-        context: skipped_writes
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_write_small_skipped
-          name: write_small_skipped
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Write Operations
-        context: write_operations
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_issued_deferred_writes
-          name: issued_deferred_writes
-        - selector: ceph_bluestore_submitted_deferred_writes
-          name: submitted_deferred_writes
-        - selector: ceph_bluestore_write_big
-          name: write_big
-        - selector: ceph_bluestore_write_big_deferred
-          name: write_big_deferred
-        - selector: ceph_bluestore_write_new
-          name: write_new
-        - selector: ceph_bluestore_write_small
-          name: write_small
-        - selector: ceph_bluestore_write_small_pre_read
-          name: write_small_pre_read
-        - selector: ceph_bluestore_write_small_unused
-          name: write_small_unused
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Written Blobs
-        context: written_blobs
-        units: blobs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_write_big_blobs
-          name: write_big_blobs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Penalty Reads
-        context: penalty_reads
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_write_penalty_read_ops
-          name: write_penalty_read_ops
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: OMAP
-      context_namespace: omap
-      metrics:
-      - ceph_bluestore_omap_clear_lat_count
-      - ceph_bluestore_omap_clear_lat_sum
-      - ceph_bluestore_omap_get_keys_lat_count
-      - ceph_bluestore_omap_get_keys_lat_sum
-      - ceph_bluestore_omap_get_values_lat_count
-      - ceph_bluestore_omap_get_values_lat_sum
-      - ceph_bluestore_omap_iterator_count
-      - ceph_bluestore_omap_lower_bound_lat_count
-      - ceph_bluestore_omap_lower_bound_lat_sum
-      - ceph_bluestore_omap_next_lat_count
-      - ceph_bluestore_omap_next_lat_sum
-      - ceph_bluestore_omap_rmkey_range_count
-      - ceph_bluestore_omap_rmkeys_count
-      - ceph_bluestore_omap_seek_to_first_lat_count
-      - ceph_bluestore_omap_seek_to_first_lat_sum
-      - ceph_bluestore_omap_setheader_bytes
-      - ceph_bluestore_omap_setheader_count
-      - ceph_bluestore_omap_setkeys_bytes
-      - ceph_bluestore_omap_setkeys_count
-      - ceph_bluestore_omap_setkeys_records
-      - ceph_bluestore_omap_upper_bound_lat_count
-      - ceph_bluestore_omap_upper_bound_lat_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_clear_lat_count
-          name: clear_lat
-        - selector: ceph_bluestore_omap_get_keys_lat_count
-          name: get_keys_lat
-        - selector: ceph_bluestore_omap_get_values_lat_count
-          name: get_values_lat
-        - selector: ceph_bluestore_omap_lower_bound_lat_count
-          name: lower_bound_lat
-        - selector: ceph_bluestore_omap_next_lat_count
-          name: next_lat
-        - selector: ceph_bluestore_omap_seek_to_first_lat_count
-          name: seek_to_first_lat
-        - selector: ceph_bluestore_omap_upper_bound_lat_count
-          name: upper_bound_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_clear_lat_sum
-          name: clear_lat
-        - selector: ceph_bluestore_omap_get_keys_lat_sum
-          name: get_keys_lat
-        - selector: ceph_bluestore_omap_get_values_lat_sum
-          name: get_values_lat
-        - selector: ceph_bluestore_omap_lower_bound_lat_sum
-          name: lower_bound_lat
-        - selector: ceph_bluestore_omap_next_lat_sum
-          name: next_lat
-        - selector: ceph_bluestore_omap_seek_to_first_lat_sum
-          name: seek_to_first_lat
-        - selector: ceph_bluestore_omap_upper_bound_lat_sum
-          name: upper_bound_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_setheader_bytes
-          name: setheader_bytes
-        - selector: ceph_bluestore_omap_setkeys_bytes
-          name: setkeys_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Open Iterators
-        context: open_iterators
-        units: iterators
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_iterator_count
-          name: iterator
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: absolute
-      - title: Mutation Calls
-        context: mutation_calls
-        units: calls/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_setheader_count
-          name: setheader
-        - selector: ceph_bluestore_omap_setkeys_count
-          name: setkeys
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Removed Key Ranges
-        context: removed_key_ranges
-        units: ranges/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_rmkey_range_count
-          name: rmkey_range
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Key Mutations
-        context: key_mutations
-        units: keys/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_omap_rmkeys_count
-          name: rmkeys
-        - selector: ceph_bluestore_omap_setkeys_records
-          name: setkeys_records
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Onode Cache
-      context_namespace: onode_cache
-      metrics:
-      - ceph_bluestore_onode_blobs
-      - ceph_bluestore_onode_extents
-      - ceph_bluestore_onode_hits
-      - ceph_bluestore_onode_misses
-      - ceph_bluestore_onode_reshard
-      - ceph_bluestore_onode_shard_hits
-      - ceph_bluestore_onode_shard_misses
-      - ceph_bluestore_onode_spanning_blobs
-      - ceph_bluestore_onodes
-      - ceph_bluestore_onodes_pinned
-      charts:
-      - title: Onode Blobs
-        context: blob_state
-        units: blobs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_blobs
-          name: onode_blobs
-        - selector: ceph_bluestore_onode_spanning_blobs
-          name: onode_spanning_blobs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Onode Extents
-        context: extent_state
-        units: extents
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_extents
-          name: onode_extents
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Onodes
-        context: onode_state
-        units: onodes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onodes
-          name: onodes
-        - selector: ceph_bluestore_onodes_pinned
-          name: onodes_pinned
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_reshard
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Onode Lookup Outcomes
-        context: onode_lookup_outcomes
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_hits
-          name: hits
-        - selector: ceph_bluestore_onode_misses
-          name: misses
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Onode Shard Lookup Outcomes
-        context: shard_lookup_outcomes
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_onode_shard_hits
-          name: shard_hits
-        - selector: ceph_bluestore_onode_shard_misses
-          name: shard_misses
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Data
-      context_namespace: priority_cache_data
-      metrics:
-      - ceph_bluestore_pricache:data_committed_bytes
-      - ceph_bluestore_pricache:data_pri0_bytes
-      - ceph_bluestore_pricache:data_pri10_bytes
-      - ceph_bluestore_pricache:data_pri11_bytes
-      - ceph_bluestore_pricache:data_pri1_bytes
-      - ceph_bluestore_pricache:data_pri2_bytes
-      - ceph_bluestore_pricache:data_pri3_bytes
-      - ceph_bluestore_pricache:data_pri4_bytes
-      - ceph_bluestore_pricache:data_pri5_bytes
-      - ceph_bluestore_pricache:data_pri6_bytes
-      - ceph_bluestore_pricache:data_pri7_bytes
-      - ceph_bluestore_pricache:data_pri8_bytes
-      - ceph_bluestore_pricache:data_pri9_bytes
-      - ceph_bluestore_pricache:data_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache:data_committed_bytes
-          name: committed_bytes
-        - selector: ceph_bluestore_pricache:data_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_bluestore_pricache:data_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_bluestore_pricache:data_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_bluestore_pricache:data_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_bluestore_pricache:data_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_bluestore_pricache:data_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_bluestore_pricache:data_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_bluestore_pricache:data_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_bluestore_pricache:data_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_bluestore_pricache:data_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_bluestore_pricache:data_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_bluestore_pricache:data_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_bluestore_pricache:data_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache KV
-      context_namespace: priority_cache_kv
-      metrics:
-      - ceph_bluestore_pricache:kv_committed_bytes
-      - ceph_bluestore_pricache:kv_pri0_bytes
-      - ceph_bluestore_pricache:kv_pri10_bytes
-      - ceph_bluestore_pricache:kv_pri11_bytes
-      - ceph_bluestore_pricache:kv_pri1_bytes
-      - ceph_bluestore_pricache:kv_pri2_bytes
-      - ceph_bluestore_pricache:kv_pri3_bytes
-      - ceph_bluestore_pricache:kv_pri4_bytes
-      - ceph_bluestore_pricache:kv_pri5_bytes
-      - ceph_bluestore_pricache:kv_pri6_bytes
-      - ceph_bluestore_pricache:kv_pri7_bytes
-      - ceph_bluestore_pricache:kv_pri8_bytes
-      - ceph_bluestore_pricache:kv_pri9_bytes
-      - ceph_bluestore_pricache:kv_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache:kv_committed_bytes
-          name: committed_bytes
-        - selector: ceph_bluestore_pricache:kv_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_bluestore_pricache:kv_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_bluestore_pricache:kv_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_bluestore_pricache:kv_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_bluestore_pricache:kv_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_bluestore_pricache:kv_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_bluestore_pricache:kv_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_bluestore_pricache:kv_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_bluestore_pricache:kv_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_bluestore_pricache:kv_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_bluestore_pricache:kv_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_bluestore_pricache:kv_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_bluestore_pricache:kv_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache KV Onode
-      context_namespace: priority_cache_kv_onode
-      metrics:
-      - ceph_bluestore_pricache:kv_onode_committed_bytes
-      - ceph_bluestore_pricache:kv_onode_pri0_bytes
-      - ceph_bluestore_pricache:kv_onode_pri10_bytes
-      - ceph_bluestore_pricache:kv_onode_pri11_bytes
-      - ceph_bluestore_pricache:kv_onode_pri1_bytes
-      - ceph_bluestore_pricache:kv_onode_pri2_bytes
-      - ceph_bluestore_pricache:kv_onode_pri3_bytes
-      - ceph_bluestore_pricache:kv_onode_pri4_bytes
-      - ceph_bluestore_pricache:kv_onode_pri5_bytes
-      - ceph_bluestore_pricache:kv_onode_pri6_bytes
-      - ceph_bluestore_pricache:kv_onode_pri7_bytes
-      - ceph_bluestore_pricache:kv_onode_pri8_bytes
-      - ceph_bluestore_pricache:kv_onode_pri9_bytes
-      - ceph_bluestore_pricache:kv_onode_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache:kv_onode_committed_bytes
-          name: committed_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_bluestore_pricache:kv_onode_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Metadata
-      context_namespace: priority_cache_metadata
-      metrics:
-      - ceph_bluestore_pricache:meta_committed_bytes
-      - ceph_bluestore_pricache:meta_pri0_bytes
-      - ceph_bluestore_pricache:meta_pri10_bytes
-      - ceph_bluestore_pricache:meta_pri11_bytes
-      - ceph_bluestore_pricache:meta_pri1_bytes
-      - ceph_bluestore_pricache:meta_pri2_bytes
-      - ceph_bluestore_pricache:meta_pri3_bytes
-      - ceph_bluestore_pricache:meta_pri4_bytes
-      - ceph_bluestore_pricache:meta_pri5_bytes
-      - ceph_bluestore_pricache:meta_pri6_bytes
-      - ceph_bluestore_pricache:meta_pri7_bytes
-      - ceph_bluestore_pricache:meta_pri8_bytes
-      - ceph_bluestore_pricache:meta_pri9_bytes
-      - ceph_bluestore_pricache:meta_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache:meta_committed_bytes
-          name: committed_bytes
-        - selector: ceph_bluestore_pricache:meta_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_bluestore_pricache:meta_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_bluestore_pricache:meta_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_bluestore_pricache:meta_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_bluestore_pricache:meta_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_bluestore_pricache:meta_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_bluestore_pricache:meta_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_bluestore_pricache:meta_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_bluestore_pricache:meta_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_bluestore_pricache:meta_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_bluestore_pricache:meta_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_bluestore_pricache:meta_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_bluestore_pricache:meta_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Runtime
-      context_namespace: priority_cache_runtime
-      metrics:
-      - ceph_bluestore_pricache_cache_bytes
-      - ceph_bluestore_pricache_heap_bytes
-      - ceph_bluestore_pricache_mapped_bytes
-      - ceph_bluestore_pricache_target_bytes
-      - ceph_bluestore_pricache_unmapped_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_pricache_cache_bytes
-          name: cache_bytes
-        - selector: ceph_bluestore_pricache_heap_bytes
-          name: heap_bytes
-        - selector: ceph_bluestore_pricache_mapped_bytes
-          name: mapped_bytes
-        - selector: ceph_bluestore_pricache_target_bytes
-          name: target_bytes
-        - selector: ceph_bluestore_pricache_unmapped_bytes
-          name: unmapped_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Space and Core State
-      context_namespace: space_and_core_state
-      metrics:
-      - ceph_bluestore_blob_split
-      - ceph_bluestore_buffer_bytes
-      - ceph_bluestore_buffer_hit_bytes
-      - ceph_bluestore_buffer_miss_bytes
-      - ceph_bluestore_buffers
-      - ceph_bluestore_clist_lat_count
-      - ceph_bluestore_clist_lat_sum
-      - ceph_bluestore_fragmentation_micros
-      - ceph_bluestore_gc_merged
-      - ceph_bluestore_kv_commit_lat_count
-      - ceph_bluestore_kv_commit_lat_sum
-      - ceph_bluestore_kv_final_lat_count
-      - ceph_bluestore_kv_final_lat_sum
-      - ceph_bluestore_kv_flush_lat_count
-      - ceph_bluestore_kv_flush_lat_sum
-      - ceph_bluestore_kv_sync_lat_count
-      - ceph_bluestore_kv_sync_lat_sum
-      - ceph_bluestore_slow_committed_kv_count
-      - ceph_bluestore_stored
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_clist_lat_count
-          name: clist_lat
-        - selector: ceph_bluestore_kv_commit_lat_count
-          name: kv_commit_lat
-        - selector: ceph_bluestore_kv_final_lat_count
-          name: kv_final_lat
-        - selector: ceph_bluestore_kv_flush_lat_count
-          name: kv_flush_lat
-        - selector: ceph_bluestore_kv_sync_lat_count
-          name: kv_sync_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_clist_lat_sum
-          name: clist_lat
-        - selector: ceph_bluestore_kv_commit_lat_sum
-          name: kv_commit_lat
-        - selector: ceph_bluestore_kv_final_lat_sum
-          name: kv_final_lat
-        - selector: ceph_bluestore_kv_flush_lat_sum
-          name: kv_flush_lat
-        - selector: ceph_bluestore_kv_sync_lat_sum
-          name: kv_sync_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_buffer_hit_bytes
-          name: hit_bytes
-        - selector: ceph_bluestore_buffer_miss_bytes
-          name: miss_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Current Work
-        context: current_work
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_buffers
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Blob Splits
-        context: blob_splits
-        units: blobs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_blob_split
-          name: blob_split
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Garbage-Collection Merge Throughput
-        context: gc_merge_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_gc_merged
-          name: gc_merged
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_slow_committed_kv_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Fragmentation
-        context: fragmentation
-        units: per mille
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_fragmentation_micros
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Buffer Cache Residency
-        context: buffer_cache_residency
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_buffer_bytes
-          name: buffer_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Logical Stored Data
-        context: logical_stored_data
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_stored
-          name: stored
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Transaction Pipeline
-      context_namespace: transaction_pipeline
-      metrics:
-      - ceph_bluestore_state_aio_wait_lat_count
-      - ceph_bluestore_state_aio_wait_lat_sum
-      - ceph_bluestore_state_deferred_aio_wait_lat_count
-      - ceph_bluestore_state_deferred_aio_wait_lat_sum
-      - ceph_bluestore_state_deferred_cleanup_lat_count
-      - ceph_bluestore_state_deferred_cleanup_lat_sum
-      - ceph_bluestore_state_deferred_queued_lat_count
-      - ceph_bluestore_state_deferred_queued_lat_sum
-      - ceph_bluestore_state_done_lat_count
-      - ceph_bluestore_state_done_lat_sum
-      - ceph_bluestore_state_finishing_lat_count
-      - ceph_bluestore_state_finishing_lat_sum
-      - ceph_bluestore_state_io_done_lat_count
-      - ceph_bluestore_state_io_done_lat_sum
-      - ceph_bluestore_state_kv_commiting_lat_count
-      - ceph_bluestore_state_kv_commiting_lat_sum
-      - ceph_bluestore_state_kv_done_lat_count
-      - ceph_bluestore_state_kv_done_lat_sum
-      - ceph_bluestore_state_kv_queued_lat_count
-      - ceph_bluestore_state_kv_queued_lat_sum
-      - ceph_bluestore_state_prepare_lat_count
-      - ceph_bluestore_state_prepare_lat_sum
-      - ceph_bluestore_txc_commit_lat_count
-      - ceph_bluestore_txc_commit_lat_sum
-      - ceph_bluestore_txc_count
-      - ceph_bluestore_txc_submit_lat_count
-      - ceph_bluestore_txc_submit_lat_sum
-      - ceph_bluestore_txc_throttle_lat_count
-      - ceph_bluestore_txc_throttle_lat_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_state_aio_wait_lat_count
-          name: state_aio_wait_lat
-        - selector: ceph_bluestore_state_deferred_aio_wait_lat_count
-          name: state_deferred_aio_wait_lat
-        - selector: ceph_bluestore_state_deferred_cleanup_lat_count
-          name: state_deferred_cleanup_lat
-        - selector: ceph_bluestore_state_deferred_queued_lat_count
-          name: state_deferred_queued_lat
-        - selector: ceph_bluestore_state_done_lat_count
-          name: state_done_lat
-        - selector: ceph_bluestore_state_finishing_lat_count
-          name: state_finishing_lat
-        - selector: ceph_bluestore_state_io_done_lat_count
-          name: state_io_done_lat
-        - selector: ceph_bluestore_state_kv_commiting_lat_count
-          name: state_kv_commiting_lat
-        - selector: ceph_bluestore_state_kv_done_lat_count
-          name: state_kv_done_lat
-        - selector: ceph_bluestore_state_kv_queued_lat_count
-          name: state_kv_queued_lat
-        - selector: ceph_bluestore_state_prepare_lat_count
-          name: state_prepare_lat
-        - selector: ceph_bluestore_txc_commit_lat_count
-          name: txc_commit_lat
-        - selector: ceph_bluestore_txc_submit_lat_count
-          name: txc_submit_lat
-        - selector: ceph_bluestore_txc_throttle_lat_count
-          name: txc_throttle_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_state_aio_wait_lat_sum
-          name: state_aio_wait_lat
-        - selector: ceph_bluestore_state_deferred_aio_wait_lat_sum
-          name: state_deferred_aio_wait_lat
-        - selector: ceph_bluestore_state_deferred_cleanup_lat_sum
-          name: state_deferred_cleanup_lat
-        - selector: ceph_bluestore_state_deferred_queued_lat_sum
-          name: state_deferred_queued_lat
-        - selector: ceph_bluestore_state_done_lat_sum
-          name: state_done_lat
-        - selector: ceph_bluestore_state_finishing_lat_sum
-          name: state_finishing_lat
-        - selector: ceph_bluestore_state_io_done_lat_sum
-          name: state_io_done_lat
-        - selector: ceph_bluestore_state_kv_commiting_lat_sum
-          name: state_kv_commiting_lat
-        - selector: ceph_bluestore_state_kv_done_lat_sum
-          name: state_kv_done_lat
-        - selector: ceph_bluestore_state_kv_queued_lat_sum
-          name: state_kv_queued_lat
-        - selector: ceph_bluestore_state_prepare_lat_sum
-          name: state_prepare_lat
-        - selector: ceph_bluestore_txc_commit_lat_sum
-          name: txc_commit_lat
-        - selector: ceph_bluestore_txc_submit_lat_sum
-          name: txc_submit_lat
-        - selector: ceph_bluestore_txc_throttle_lat_sum
-          name: txc_throttle_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_bluestore_txc_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: CephFS MDS
-    context_namespace: cephfs_mds
-    groups:
-    - family: Attribute and Layout Mutation Latency
-      context_namespace: attribute_and_layout_mutation_latency
-      metrics:
-      - ceph_mds_server_req_rmxattr_latency_count
-      - ceph_mds_server_req_rmxattr_latency_sum
-      - ceph_mds_server_req_setattr_latency_count
-      - ceph_mds_server_req_setattr_latency_sum
-      - ceph_mds_server_req_setdirlayout_latency_count
-      - ceph_mds_server_req_setdirlayout_latency_sum
-      - ceph_mds_server_req_setfilelock_latency_count
-      - ceph_mds_server_req_setfilelock_latency_sum
-      - ceph_mds_server_req_setlayout_latency_count
-      - ceph_mds_server_req_setlayout_latency_sum
-      - ceph_mds_server_req_setxattr_latency_count
-      - ceph_mds_server_req_setxattr_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_rmxattr_latency_count
-          name: rmxattr_latency
-        - selector: ceph_mds_server_req_setattr_latency_count
-          name: setattr_latency
-        - selector: ceph_mds_server_req_setdirlayout_latency_count
-          name: setdirlayout_latency
-        - selector: ceph_mds_server_req_setfilelock_latency_count
-          name: setfilelock_latency
-        - selector: ceph_mds_server_req_setlayout_latency_count
-          name: setlayout_latency
-        - selector: ceph_mds_server_req_setxattr_latency_count
-          name: setxattr_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_rmxattr_latency_sum
-          name: rmxattr_latency
-        - selector: ceph_mds_server_req_setattr_latency_sum
-          name: setattr_latency
-        - selector: ceph_mds_server_req_setdirlayout_latency_sum
-          name: setdirlayout_latency
-        - selector: ceph_mds_server_req_setfilelock_latency_sum
-          name: setfilelock_latency
-        - selector: ceph_mds_server_req_setlayout_latency_sum
-          name: setlayout_latency
-        - selector: ceph_mds_server_req_setxattr_latency_sum
-          name: setxattr_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Capabilities
-      context_namespace: capabilities
-      metrics:
-      - ceph_mds_caps
-      - ceph_mds_ceph_cap_op_flush_ack
-      - ceph_mds_ceph_cap_op_flushsnap_ack
-      - ceph_mds_ceph_cap_op_grant
-      - ceph_mds_ceph_cap_op_revoke
-      - ceph_mds_ceph_cap_op_trunc
-      - ceph_mds_handle_client_cap_release
-      - ceph_mds_handle_client_caps
-      - ceph_mds_handle_client_caps_dirty
-      - ceph_mds_handle_inode_file_caps
-      - ceph_mds_inodes_with_caps
-      - ceph_mds_process_request_cap_release
-      - ceph_mds_server_cap_acquisition_throttle
-      - ceph_mds_server_cap_revoke_eviction
-      charts:
-      - title: Capabilities
-        context: capability_state
-        units: capabilities
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_caps
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Capability Messages
-        context: capability_messages
-        units: messages/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_handle_client_cap_release
-          name: handle_client_cap_release
-        - selector: ceph_mds_handle_client_caps
-          name: handle_client_caps
-        - selector: ceph_mds_handle_client_caps_dirty
-          name: handle_client_caps_dirty
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Capability-Throttled Requests
-        context: throttled_requests
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_cap_acquisition_throttle
-          name: server_cap_acquisition_throttle
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Capability-Revoke Evictions
-        context: evicted_clients
-        units: clients/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_cap_revoke_eviction
-          name: server_cap_revoke_eviction
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inodes
-        context: inode_state
-        units: inodes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_inodes_with_caps
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inode Work
-        context: inode_work
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_handle_inode_file_caps
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_ceph_cap_op_flush_ack
-          name: ceph_cap_op_flush_ack
-        - selector: ceph_mds_ceph_cap_op_flushsnap_ack
-          name: ceph_cap_op_flushsnap_ack
-        - selector: ceph_mds_ceph_cap_op_grant
-          name: ceph_cap_op_grant
-        - selector: ceph_mds_ceph_cap_op_revoke
-          name: ceph_cap_op_revoke
-        - selector: ceph_mds_ceph_cap_op_trunc
-          name: ceph_cap_op_trunc
-        - selector: ceph_mds_process_request_cap_release
-          name: process_request_cap_release
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Journal
-      context_namespace: journal
-      metrics:
-      - ceph_mds_log_ev
-      - ceph_mds_log_evadd
-      - ceph_mds_log_evex
-      - ceph_mds_log_evexd
-      - ceph_mds_log_evexg
-      - ceph_mds_log_evlrg
-      - ceph_mds_log_evtrm
-      - ceph_mds_log_expos
-      - ceph_mds_log_jlat_count
-      - ceph_mds_log_jlat_sum
-      - ceph_mds_log_rdpos
-      - ceph_mds_log_replayed
-      - ceph_mds_log_seg
-      - ceph_mds_log_segadd
-      - ceph_mds_log_segex
-      - ceph_mds_log_segexd
-      - ceph_mds_log_segexg
-      - ceph_mds_log_segmjr
-      - ceph_mds_log_segtrm
-      - ceph_mds_log_wrpos
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_jlat_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_jlat_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Current Journal Events
-        context: events_current
-        units: events
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_ev
-          name: ev
-        - selector: ceph_mds_log_evexd
-          name: evexd
-        - selector: ceph_mds_log_evexg
-          name: evexg
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Large Journal Events
-        context: large_events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_evlrg
-          name: evlrg
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Journal Events
-        context: journal_events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_evadd
-          name: evadd
-        - selector: ceph_mds_log_evex
-          name: evex
-        - selector: ceph_mds_log_evtrm
-          name: evtrm
-        - selector: ceph_mds_log_replayed
-          name: replayed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Journal Positions
-        context: journal_positions
-        units: position
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_expos
-          name: expos
-        - selector: ceph_mds_log_rdpos
-          name: rdpos
-        - selector: ceph_mds_log_wrpos
-          name: wrpos
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Journal Segments
-        context: journal_segments
-        units: segments/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_segadd
-          name: segadd
-        - selector: ceph_mds_log_segex
-          name: segex
-        - selector: ceph_mds_log_segtrm
-          name: segtrm
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Journal Segments
-        context: segments_current
-        units: segments
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_log_seg
-          name: seg
-        - selector: ceph_mds_log_segexd
-          name: segexd
-        - selector: ceph_mds_log_segexg
-          name: segexg
-        - selector: ceph_mds_log_segmjr
-          name: segmjr
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Metadata Cache Directory
-      context_namespace: metadata_cache_directory
-      metrics:
-      - ceph_mds_cache_dir_handle_discover
-      - ceph_mds_cache_dir_send_discover
-      - ceph_mds_cache_dir_try_discover
-      - ceph_mds_cache_dir_update
-      - ceph_mds_cache_dir_update_receipt
-      charts:
-      - title: Discovery Messages
-        context: discovery_messages
-        units: messages/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_dir_handle_discover
-          name: handle_discover
-        - selector: ceph_mds_cache_dir_send_discover
-          name: send_discover
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Discovery Attempts
-        context: discovery_attempts
-        units: attempts/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_dir_try_discover
-          name: try_discover
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Replication Directives
-        context: replication_directives
-        units: directives/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_dir_update
-          name: update
-        - selector: ceph_mds_cache_dir_update_receipt
-          name: update_receipt
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Metadata Cache Internal Requests
-      context_namespace: metadata_cache_internal_requests
-      metrics:
-      - ceph_mds_cache_ireq_enqueue_scrub
-      - ceph_mds_cache_ireq_exportdir
-      - ceph_mds_cache_ireq_flush
-      - ceph_mds_cache_ireq_fragmentdir
-      - ceph_mds_cache_ireq_fragstats
-      - ceph_mds_cache_ireq_inodestats
-      - ceph_mds_cache_ireq_quiesce_inode
-      - ceph_mds_cache_ireq_quiesce_path
-      charts:
-      - title: Inode Work
-        context: inode_work
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_ireq_inodestats
-          name: inodestats
-        - selector: ceph_mds_cache_ireq_quiesce_inode
-          name: quiesce_inode
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_ireq_exportdir
-          name: exportdir
-        - selector: ceph_mds_cache_ireq_flush
-          name: flush
-        - selector: ceph_mds_cache_ireq_fragmentdir
-          name: fragmentdir
-        - selector: ceph_mds_cache_ireq_fragstats
-          name: fragstats
-        - selector: ceph_mds_cache_ireq_quiesce_path
-          name: quiesce_path
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Scrub Work
-        context: scrub_work
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_ireq_enqueue_scrub
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Metadata Cache Recovery
-      context_namespace: metadata_cache_recovery
-      metrics:
-      - ceph_mds_cache_num_recovering_enqueued
-      - ceph_mds_cache_num_recovering_prioritized
-      - ceph_mds_cache_num_recovering_processing
-      - ceph_mds_cache_num_strays
-      - ceph_mds_cache_num_strays_delayed
-      - ceph_mds_cache_num_strays_enqueuing
-      - ceph_mds_cache_recovery_completed
-      - ceph_mds_cache_recovery_started
-      - ceph_mds_cache_strays_created
-      - ceph_mds_cache_strays_enqueued
-      - ceph_mds_cache_strays_migrated
-      - ceph_mds_cache_strays_reintegrated
-      charts:
-      - title: Current Work
-        context: current_work
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_num_strays
-          name: strays
-        - selector: ceph_mds_cache_num_strays_delayed
-          name: delayed
-        - selector: ceph_mds_cache_num_strays_enqueuing
-          name: enqueuing
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_strays_created
-          name: created
-        - selector: ceph_mds_cache_strays_enqueued
-          name: enqueued
-        - selector: ceph_mds_cache_strays_migrated
-          name: migrated
-        - selector: ceph_mds_cache_strays_reintegrated
-          name: reintegrated
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Files
-        context: file_state
-        units: files
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_num_recovering_enqueued
-          name: enqueued
-        - selector: ceph_mds_cache_num_recovering_prioritized
-          name: prioritized
-        - selector: ceph_mds_cache_num_recovering_processing
-          name: processing
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: File Work
-        context: file_work
-        units: files/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_recovery_completed
-          name: completed
-        - selector: ceph_mds_cache_recovery_started
-          name: started
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Metadata Cache Uninline
-      context_namespace: metadata_cache_uninline
-      metrics:
-      - ceph_mds_cache_uninline_started
-      - ceph_mds_cache_uninline_succeeded
-      - ceph_mds_cache_uninline_write_failed
-      charts:
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_uninline_started
-          name: started
-        - selector: ceph_mds_cache_uninline_succeeded
-          name: succeeded
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_cache_uninline_write_failed
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Namespace Mutation Latency
-      context_namespace: namespace_mutation_latency
-      metrics:
-      - ceph_mds_server_req_create_latency_count
-      - ceph_mds_server_req_create_latency_sum
-      - ceph_mds_server_req_link_latency_count
-      - ceph_mds_server_req_link_latency_sum
-      - ceph_mds_server_req_mkdir_latency_count
-      - ceph_mds_server_req_mkdir_latency_sum
-      - ceph_mds_server_req_mknod_latency_count
-      - ceph_mds_server_req_mknod_latency_sum
-      - ceph_mds_server_req_rename_latency_count
-      - ceph_mds_server_req_rename_latency_sum
-      - ceph_mds_server_req_rmdir_latency_count
-      - ceph_mds_server_req_rmdir_latency_sum
-      - ceph_mds_server_req_symlink_latency_count
-      - ceph_mds_server_req_symlink_latency_sum
-      - ceph_mds_server_req_unlink_latency_count
-      - ceph_mds_server_req_unlink_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_create_latency_count
-          name: create_latency
-        - selector: ceph_mds_server_req_link_latency_count
-          name: link_latency
-        - selector: ceph_mds_server_req_mkdir_latency_count
-          name: mkdir_latency
-        - selector: ceph_mds_server_req_mknod_latency_count
-          name: mknod_latency
-        - selector: ceph_mds_server_req_rename_latency_count
-          name: rename_latency
-        - selector: ceph_mds_server_req_rmdir_latency_count
-          name: rmdir_latency
-        - selector: ceph_mds_server_req_symlink_latency_count
-          name: symlink_latency
-        - selector: ceph_mds_server_req_unlink_latency_count
-          name: unlink_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_create_latency_sum
-          name: create_latency
-        - selector: ceph_mds_server_req_link_latency_sum
-          name: link_latency
-        - selector: ceph_mds_server_req_mkdir_latency_sum
-          name: mkdir_latency
-        - selector: ceph_mds_server_req_mknod_latency_sum
-          name: mknod_latency
-        - selector: ceph_mds_server_req_rename_latency_sum
-          name: rename_latency
-        - selector: ceph_mds_server_req_rmdir_latency_sum
-          name: rmdir_latency
-        - selector: ceph_mds_server_req_symlink_latency_sum
-          name: symlink_latency
-        - selector: ceph_mds_server_req_unlink_latency_sum
-          name: unlink_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Namespace Traversal
-      context_namespace: namespace_traversal
-      metrics:
-      - ceph_mds_dir_commit
-      - ceph_mds_dir_fetch_complete
-      - ceph_mds_dir_fetch_keys
-      - ceph_mds_dir_merge
-      - ceph_mds_dir_split
-      - ceph_mds_openino_backtrace_fetch
-      - ceph_mds_openino_dir_fetch
-      - ceph_mds_openino_peer_discover
-      - ceph_mds_traverse
-      - ceph_mds_traverse_dir_fetch
-      - ceph_mds_traverse_discover
-      - ceph_mds_traverse_forward
-      - ceph_mds_traverse_hit
-      - ceph_mds_traverse_lock
-      - ceph_mds_traverse_remote_ino
-      charts:
-      - title: Directory-Fragment Lifecycle
-        context: dirfrag_lifecycle
-        units: dirfrags/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_dir_fetch_complete
-          name: dir_fetch_complete
-        - selector: ceph_mds_dir_merge
-          name: dir_merge
-        - selector: ceph_mds_dir_split
-          name: dir_split
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Namespace Traversals
-        context: traversals
-        units: traversals/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_traverse
-          name: traverse
-        - selector: ceph_mds_traverse_dir_fetch
-          name: traverse_dir_fetch
-        - selector: ceph_mds_traverse_discover
-          name: traverse_discover
-        - selector: ceph_mds_traverse_forward
-          name: traverse_forward
-        - selector: ceph_mds_traverse_lock
-          name: traverse_lock
-        - selector: ceph_mds_traverse_remote_ino
-          name: traverse_remote_ino
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inode Work
-        context: inode_work
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_openino_peer_discover
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Key Work
-        context: key_work
-        units: keys/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_dir_fetch_keys
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Lookup Outcomes
-        context: lookup_outcomes
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_traverse_hit
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_dir_commit
-          name: dir_commit
-        - selector: ceph_mds_openino_backtrace_fetch
-          name: openino_backtrace_fetch
-        - selector: ceph_mds_openino_dir_fetch
-          name: openino_dir_fetch
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Purge Queue
-      context_namespace: purge_queue
-      metrics:
-      - ceph_purge_queue_pq_executed
-      - ceph_purge_queue_pq_executed_ops
-      - ceph_purge_queue_pq_executing
-      - ceph_purge_queue_pq_executing_high_water
-      - ceph_purge_queue_pq_executing_ops
-      - ceph_purge_queue_pq_executing_ops_high_water
-      - ceph_purge_queue_pq_item_in_journal
-      charts:
-      - title: Current Work
-        context: current_work
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_item_in_journal
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Executed Purge Operations
-        context: purge_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_executed_ops
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Purge Operations in Flight
-        context: purge_operations_state
-        units: operations
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_executing_ops
-          name: ops
-        - selector: ceph_purge_queue_pq_executing_ops_high_water
-          name: high_water
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Executed Purge Tasks
-        context: purge_tasks
-        units: tasks/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_executed
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Purge Tasks in Flight
-        context: purge_tasks_state
-        units: tasks
-        label_promotion: []
-        dimensions:
-        - selector: ceph_purge_queue_pq_executing
-          name: executing
-        - selector: ceph_purge_queue_pq_executing_high_water
-          name: high_water
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Rank Migration
-      context_namespace: rank_migration
-      metrics:
-      - ceph_mds_exported
-      - ceph_mds_exported_inodes
-      - ceph_mds_imported
-      - ceph_mds_imported_inodes
-      charts:
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_exported
-          name: exported
-        - selector: ceph_mds_imported
-          name: imported
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inode Work
-        context: inode_work
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_exported_inodes
-          name: exported_inodes
-        - selector: ceph_mds_imported_inodes
-          name: imported_inodes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Read Request Latency
-      context_namespace: read_request_latency
-      metrics:
-      - ceph_mds_server_req_blockdiff_latency_count
-      - ceph_mds_server_req_blockdiff_latency_sum
-      - ceph_mds_server_req_getattr_latency_count
-      - ceph_mds_server_req_getattr_latency_sum
-      - ceph_mds_server_req_getfilelock_latency_count
-      - ceph_mds_server_req_getfilelock_latency_sum
-      - ceph_mds_server_req_getvxattr_latency_count
-      - ceph_mds_server_req_getvxattr_latency_sum
-      - ceph_mds_server_req_lookup_latency_count
-      - ceph_mds_server_req_lookup_latency_sum
-      - ceph_mds_server_req_lookuphash_latency_count
-      - ceph_mds_server_req_lookuphash_latency_sum
-      - ceph_mds_server_req_lookupino_latency_count
-      - ceph_mds_server_req_lookupino_latency_sum
-      - ceph_mds_server_req_lookupname_latency_count
-      - ceph_mds_server_req_lookupname_latency_sum
-      - ceph_mds_server_req_lookupparent_latency_count
-      - ceph_mds_server_req_lookupparent_latency_sum
-      - ceph_mds_server_req_lookupsnap_latency_count
-      - ceph_mds_server_req_lookupsnap_latency_sum
-      - ceph_mds_server_req_open_latency_count
-      - ceph_mds_server_req_open_latency_sum
-      - ceph_mds_server_req_readdir_latency_count
-      - ceph_mds_server_req_readdir_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_blockdiff_latency_count
-          name: blockdiff_latency
-        - selector: ceph_mds_server_req_getattr_latency_count
-          name: getattr_latency
-        - selector: ceph_mds_server_req_getfilelock_latency_count
-          name: getfilelock_latency
-        - selector: ceph_mds_server_req_getvxattr_latency_count
-          name: getvxattr_latency
-        - selector: ceph_mds_server_req_lookup_latency_count
-          name: lookup_latency
-        - selector: ceph_mds_server_req_lookuphash_latency_count
-          name: lookuphash_latency
-        - selector: ceph_mds_server_req_lookupino_latency_count
-          name: lookupino_latency
-        - selector: ceph_mds_server_req_lookupname_latency_count
-          name: lookupname_latency
-        - selector: ceph_mds_server_req_lookupparent_latency_count
-          name: lookupparent_latency
-        - selector: ceph_mds_server_req_lookupsnap_latency_count
-          name: lookupsnap_latency
-        - selector: ceph_mds_server_req_open_latency_count
-          name: open_latency
-        - selector: ceph_mds_server_req_readdir_latency_count
-          name: readdir_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_blockdiff_latency_sum
-          name: blockdiff_latency
-        - selector: ceph_mds_server_req_getattr_latency_sum
-          name: getattr_latency
-        - selector: ceph_mds_server_req_getfilelock_latency_sum
-          name: getfilelock_latency
-        - selector: ceph_mds_server_req_getvxattr_latency_sum
-          name: getvxattr_latency
-        - selector: ceph_mds_server_req_lookup_latency_sum
-          name: lookup_latency
-        - selector: ceph_mds_server_req_lookuphash_latency_sum
-          name: lookuphash_latency
-        - selector: ceph_mds_server_req_lookupino_latency_sum
-          name: lookupino_latency
-        - selector: ceph_mds_server_req_lookupname_latency_sum
-          name: lookupname_latency
-        - selector: ceph_mds_server_req_lookupparent_latency_sum
-          name: lookupparent_latency
-        - selector: ceph_mds_server_req_lookupsnap_latency_sum
-          name: lookupsnap_latency
-        - selector: ceph_mds_server_req_open_latency_sum
-          name: open_latency
-        - selector: ceph_mds_server_req_readdir_latency_sum
-          name: readdir_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Request Handling and State
-      context_namespace: request_handling_and_state
-      metrics:
-      - ceph_mds_client_metrics_num_clients
-      - ceph_mds_forward
-      - ceph_mds_inodes
-      - ceph_mds_inodes_bottom
-      - ceph_mds_inodes_expired
-      - ceph_mds_inodes_pin_tail
-      - ceph_mds_inodes_pinned
-      - ceph_mds_inodes_top
-      - ceph_mds_load_cent
-      - ceph_mds_q
-      - ceph_mds_reply
-      - ceph_mds_reply_latency_count
-      - ceph_mds_reply_latency_sum
-      - ceph_mds_request
-      - ceph_mds_root_rbytes
-      - ceph_mds_root_rfiles
-      - ceph_mds_root_rsnaps
-      - ceph_mds_server_dispatch_client_request
-      - ceph_mds_server_dispatch_server_request
-      - ceph_mds_server_handle_client_request
-      - ceph_mds_server_handle_client_session
-      - ceph_mds_server_handle_peer_request
-      - ceph_mds_slow_reply
-      - ceph_mds_subtrees
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_reply_latency_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_reply_latency_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Connected Clients
-        context: connected_clients
-        units: clients
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_client_metrics_num_clients
-          name: client_metrics_num_clients
-        instances:
-          by_labels:
-          - ceph_daemon
-          - fs_name
-          - id
-          optional_by_labels: []
-      - title: Queued Requests
-        context: queued_requests
-        units: requests
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_q
-          name: q
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_reply
-          name: reply
-        - selector: ceph_mds_server_handle_client_session
-          name: server_handle_client_session
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_slow_reply
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Files
-        context: file_state
-        units: files
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_root_rfiles
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Inodes
-        context: inode_state
-        units: inodes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_inodes
-          name: inodes
-        - selector: ceph_mds_inodes_bottom
-          name: bottom
-        - selector: ceph_mds_inodes_pin_tail
-          name: pin_tail
-        - selector: ceph_mds_inodes_pinned
-          name: pinned
-        - selector: ceph_mds_inodes_top
-          name: top
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Expired Inodes
-        context: expired_inodes
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_inodes_expired
-          name: expired
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Load
-        context: load
-        units: load
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_load_cent
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_forward
-          name: forward
-        - selector: ceph_mds_request
-          name: request
-        - selector: ceph_mds_server_dispatch_client_request
-          name: server_dispatch_client_request
-        - selector: ceph_mds_server_dispatch_server_request
-          name: server_dispatch_server_request
-        - selector: ceph_mds_server_handle_client_request
-          name: server_handle_client_request
-        - selector: ceph_mds_server_handle_peer_request
-          name: server_handle_peer_request
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Snapshots
-        context: snapshot_state
-        units: snapshots
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_root_rsnaps
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_root_rbytes
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Subtrees
-        context: subtrees
-        units: subtrees
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_subtrees
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Scrubbing
-      context_namespace: scrubbing
-      metrics:
-      - ceph_mds_scrub_backtrace_fetch
-      - ceph_mds_scrub_backtrace_repaired
-      - ceph_mds_scrub_dir_base_inodes
-      - ceph_mds_scrub_dir_inodes
-      - ceph_mds_scrub_dirfrag_rstats
-      - ceph_mds_scrub_file_inodes
-      - ceph_mds_scrub_inotable_repaired
-      - ceph_mds_scrub_set_tag
-      charts:
-      - title: Scrubbed Inodes
-        context: scrubbed_inodes
-        units: inodes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_dir_base_inodes
-          name: dir_base_inodes
-        - selector: ceph_mds_scrub_dir_inodes
-          name: dir_inodes
-        - selector: ceph_mds_scrub_file_inodes
-          name: file_inodes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Backtrace Work
-        context: backtrace_work
-        units: backtraces/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_backtrace_fetch
-          name: backtrace_fetch
-        - selector: ceph_mds_scrub_backtrace_repaired
-          name: backtrace_repaired
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Repaired Inotables
-        context: repaired_inotables
-        units: inotables/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_inotable_repaired
-          name: inotable_repaired
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Applied Scrub Tags
-        context: applied_tags
-        units: tags/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_set_tag
-          name: set_tag
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Directory-Fragment Recursive-Stat Updates
-        context: dirfrag_rstat_updates
-        units: dirfrags/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_scrub_dirfrag_rstats
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Snapshot Mutation Latency
-      context_namespace: snapshot_mutation_latency
-      metrics:
-      - ceph_mds_server_req_lssnap_latency_count
-      - ceph_mds_server_req_lssnap_latency_sum
-      - ceph_mds_server_req_mksnap_latency_count
-      - ceph_mds_server_req_mksnap_latency_sum
-      - ceph_mds_server_req_renamesnap_latency_count
-      - ceph_mds_server_req_renamesnap_latency_sum
-      - ceph_mds_server_req_rmsnap_latency_count
-      - ceph_mds_server_req_rmsnap_latency_sum
-      - ceph_mds_server_req_snapdiff_latency_count
-      - ceph_mds_server_req_snapdiff_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_lssnap_latency_count
-          name: lssnap_latency
-        - selector: ceph_mds_server_req_mksnap_latency_count
-          name: mksnap_latency
-        - selector: ceph_mds_server_req_renamesnap_latency_count
-          name: renamesnap_latency
-        - selector: ceph_mds_server_req_rmsnap_latency_count
-          name: rmsnap_latency
-        - selector: ceph_mds_server_req_snapdiff_latency_count
-          name: snapdiff_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mds_server_req_lssnap_latency_sum
-          name: lssnap_latency
-        - selector: ceph_mds_server_req_mksnap_latency_sum
-          name: mksnap_latency
-        - selector: ceph_mds_server_req_renamesnap_latency_sum
-          name: renamesnap_latency
-        - selector: ceph_mds_server_req_rmsnap_latency_sum
-          name: rmsnap_latency
-        - selector: ceph_mds_server_req_snapdiff_latency_sum
-          name: snapdiff_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-  - family: CephFS MDS Memory
-    context_namespace: cephfs_mds_memory
-    metrics:
-    - ceph_mds_mem_cap
-    - ceph_mds_mem_cap_minus
-    - ceph_mds_mem_cap_plus
-    - ceph_mds_mem_dir
-    - ceph_mds_mem_dir_minus
-    - ceph_mds_mem_dir_plus
-    - ceph_mds_mem_dn
-    - ceph_mds_mem_dn_minus
-    - ceph_mds_mem_dn_plus
-    - ceph_mds_mem_heap
-    - ceph_mds_mem_ino
-    - ceph_mds_mem_ino_minus
-    - ceph_mds_mem_ino_plus
-    - ceph_mds_mem_rss
-    charts:
-    - title: Capabilities
-      context: capability_state
-      units: capabilities
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_cap
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Capability Work
-      context: capability_work
-      units: capabilities/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_cap_minus
-        name: minus
-      - selector: ceph_mds_mem_cap_plus
-        name: plus
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Dentries
-      context: dentry_state
-      units: dentries
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_dn
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Dentry Cache Churn
-      context: dentry_work
-      units: dentries/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_dn_minus
-        name: minus
-      - selector: ceph_mds_mem_dn_plus
-        name: plus
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Directories
-      context: directory_state
-      units: directories
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_dir
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Directory Cache Churn
-      context: directory_work
-      units: directories/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_dir_minus
-        name: minus
-      - selector: ceph_mds_mem_dir_plus
-        name: plus
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Inodes
-      context: inode_state
-      units: inodes
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_ino
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Inode Work
-      context: inode_work
-      units: inodes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_ino_minus
-        name: minus
-      - selector: ceph_mds_mem_ino_plus
-        name: plus
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Space and Memory
-      context: space
-      units: bytes
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_mem_heap
-        name: heap
-      - selector: ceph_mds_mem_rss
-        name: rss
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: CephFS MDS Sessions
-    context_namespace: cephfs_mds_sessions
-    metrics:
-    - ceph_mds_sessions_average_load
-    - ceph_mds_sessions_avg_session_uptime
-    - ceph_mds_sessions_mdthresh_evicted
-    - ceph_mds_sessions_session_add
-    - ceph_mds_sessions_session_count
-    - ceph_mds_sessions_session_remove
-    - ceph_mds_sessions_sessions_open
-    - ceph_mds_sessions_sessions_stale
-    - ceph_mds_sessions_total_load
-    charts:
-    - title: Duration and Time
-      context: duration
-      units: seconds
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_avg_session_uptime
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Events
-      context: events
-      units: events/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_session_add
-        name: add
-      - selector: ceph_mds_sessions_session_remove
-        name: remove
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Average Session Load
-      context: average_load
-      units: load
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_average_load
-        name: average_load
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Total Session Load
-      context: total_load
-      units: load
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_total_load
-        name: total_load
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Metadata-Threshold Evictions
-      context: metadata_threshold_evictions
-      units: sessions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_mdthresh_evicted
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Sessions
-      context: session_state
-      units: sessions
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_sessions_session_count
-        name: session
-      - selector: ceph_mds_sessions_sessions_open
-        name: sessions_open
-      - selector: ceph_mds_sessions_sessions_stale
-        name: sessions_stale
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: CephFS MDS Clients
-    context_namespace: cephfs_mds_clients
-    metrics:
-    - ceph_mds_per_client_avg_metadata_latency
-    - ceph_mds_per_client_avg_read_latency
-    - ceph_mds_per_client_avg_write_latency
-    - ceph_mds_per_client_cap_hits
-    - ceph_mds_per_client_cap_miss
-    - ceph_mds_per_client_dentry_lease_hits
-    - ceph_mds_per_client_dentry_lease_miss
-    - ceph_mds_per_client_opened_files
-    - ceph_mds_per_client_opened_inodes
-    - ceph_mds_per_client_pinned_icaps
-    - ceph_mds_per_client_total_inodes
-    - ceph_mds_per_client_total_read_ops
-    - ceph_mds_per_client_total_read_size
-    - ceph_mds_per_client_total_write_ops
-    - ceph_mds_per_client_total_write_size
-    charts:
-    - title: Capability Access Outcomes
-      context: capability_outcomes
-      units: accesses/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_cap_hits
-        name: hits
-      - selector: ceph_mds_per_client_cap_miss
-        name: misses
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-      algorithm: incremental
-    - title: Dentry Lease Lookup Outcomes
-      context: dentry_lease_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_dentry_lease_hits
-        name: hits
-      - selector: ceph_mds_per_client_dentry_lease_miss
-        name: misses
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-      algorithm: incremental
-    - title: Average Operation Latency
-      context: average_operation_latency
-      units: seconds
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_avg_read_latency
-        name: read
-      - selector: ceph_mds_per_client_avg_write_latency
-        name: write
-      - selector: ceph_mds_per_client_avg_metadata_latency
-        name: metadata
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-    - title: Open Files
-      context: open_files
-      units: files
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_opened_files
-        name: open
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-    - title: Inode State
-      context: inode_state
-      units: inodes
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_opened_inodes
-        name: open
-      - selector: ceph_mds_per_client_total_inodes
-        name: total
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-    - title: Pinned Inode Capabilities
-      context: pinned_inode_capabilities
-      units: capabilities
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_pinned_icaps
-        name: pinned
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-    - title: Reported I/O Operations
-      context: reported_io_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_total_read_ops
-        name: read
-      - selector: ceph_mds_per_client_total_write_ops
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-      algorithm: incremental
-    - title: Reported I/O Volume
-      context: reported_io_volume
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mds_per_client_total_read_size
-        name: read
-      - selector: ceph_mds_per_client_total_write_size
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        - client
-        - rank
-        optional_by_labels:
-        - mds_filesystem_key
-      algorithm: incremental
-  - family: Exporter and Process Runtime
-    context_namespace: exporter_and_process_runtime
-    groups:
-    - family: Collection
-      context_namespace: collection
-      metrics:
-      - ceph_exporter_scrape_time
-      charts:
-      - title: Collection Duration
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_scrape_time
-          name: duration
-        instances:
-          by_labels:
-          - function
-          - host
-          optional_by_labels: []
-    - family: Daemon Availability
-      context_namespace: daemon_availability
-      metrics:
-      - ceph_daemon_socket_up
-      charts:
-      - title: Daemon Socket State
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_daemon_socket_up
-          name: reachable
-        instances:
-          by_labels:
-          - ceph_daemon
-          - hostname
-          optional_by_labels: []
-    - family: Daemon Processes
-      context_namespace: daemon_processes
-      metrics:
-      - ceph_exporter_cpu_total
-      - ceph_exporter_cpu_usage
-      - ceph_exporter_majflt_total
-      - ceph_exporter_minflt_total
-      - ceph_exporter_num_threads
-      - ceph_exporter_resident_size
-      - ceph_exporter_vm_size
-      charts:
-      - title: Page Faults
-        context: page_faults
-        units: faults/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_minflt_total
-          name: minor
-        - selector: ceph_exporter_majflt_total
-          name: major
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Threads
-        context: threads
-        units: threads
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_num_threads
-          name: threads
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: CPU Utilization
-        context: cpu_utilization
-        units: percentage
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_cpu_usage
-          name: utilization
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: CPU Time
-        context: cpu_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_cpu_total
-          name_from_label: mode
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Memory
-        context: memory
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_exporter_vm_size
-          name: virtual
-        - selector: ceph_exporter_resident_size
-          name: resident
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Manager Daemons
-    context_namespace: manager_daemons
-    metrics:
-    - ceph_mgr_cache_hit
-    - ceph_mgr_cache_miss
-    charts:
-    - title: Lookup Outcomes
-      context: lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mgr_cache_hit
-        name: hit
-      - selector: ceph_mgr_cache_miss
-        name: miss
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: Messenger
-    context_namespace: messenger
-    metrics:
-    - ceph_AsyncMessenger_RDMADispatcher_active_queue_pair
-    - ceph_AsyncMessenger_RDMADispatcher_async_last_wqe_events
-    - ceph_AsyncMessenger_RDMADispatcher_created_queue_pair
-    - ceph_AsyncMessenger_RDMADispatcher_handshake_errors
-    - ceph_AsyncMessenger_RDMADispatcher_inflight_tx_chunks
-    - ceph_AsyncMessenger_RDMADispatcher_polling
-    - ceph_AsyncMessenger_RDMADispatcher_rx_bufs_in_use
-    - ceph_AsyncMessenger_RDMADispatcher_rx_bufs_total
-    - ceph_AsyncMessenger_RDMADispatcher_rx_fin
-    - ceph_AsyncMessenger_RDMADispatcher_rx_total_wc
-    - ceph_AsyncMessenger_RDMADispatcher_rx_total_wc_errors
-    - ceph_AsyncMessenger_RDMADispatcher_total_async_events
-    - ceph_AsyncMessenger_RDMADispatcher_tx_retry_errors
-    - ceph_AsyncMessenger_RDMADispatcher_tx_total_wc
-    - ceph_AsyncMessenger_RDMADispatcher_tx_total_wc_errors
-    - ceph_AsyncMessenger_RDMADispatcher_tx_wr_flush_errors
-    - ceph_AsyncMessenger_Worker_msgr_connection_idle_timeouts
-    - ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
-    charts:
-    - title: RDMA Errors
-      context: rdma_errors
-      units: errors/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_handshake_errors
-        name: rdmadispatcher_handshake_errors
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_total_wc_errors
-        name: rdmadispatcher_rx_total_wc_errors
-      - selector: ceph_AsyncMessenger_RDMADispatcher_tx_retry_errors
-        name: rdmadispatcher_tx_retry_errors
-      - selector: ceph_AsyncMessenger_RDMADispatcher_tx_total_wc_errors
-        name: rdmadispatcher_tx_total_wc_errors
-      - selector: ceph_AsyncMessenger_RDMADispatcher_tx_wr_flush_errors
-        name: rdmadispatcher_tx_wr_flush_errors
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Connection Timeouts
-      context: connection_timeouts
-      units: connections/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_Worker_msgr_connection_idle_timeouts
-        name: worker_msgr_connection_idle_timeouts
-      - selector: ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
-        name: worker_msgr_connection_ready_timeouts
-      instances:
-        by_labels:
-        - ceph_daemon
-        - id
-        - instance_id
-        optional_by_labels: []
-    - title: Active Queue Pairs
-      context: active_queue_pairs
-      units: queue pairs
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_active_queue_pair
-        name: active_queue_pair
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: absolute
-    - title: Created Queue Pairs
-      context: created_queue_pairs
-      units: queue pairs/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_created_queue_pair
-        name: created_queue_pair
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: In-Flight Transmit Chunks
-      context: inflight_tx_chunks
-      units: chunks
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_inflight_tx_chunks
-        name: inflight_tx_chunks
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: absolute
-    - title: Polling State
-      context: polling_state
-      units: '{status}'
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_polling
-        name: polling
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: absolute
-    - title: Receive Buffers
-      context: receive_buffers
-      units: buffers
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_bufs_in_use
-        name: rx_bufs_in_use
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_bufs_total
-        name: rx_bufs
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: absolute
-    - title: Asynchronous Events
-      context: async_events
-      units: events/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_async_last_wqe_events
-        name: async_last_wqe_events
-      - selector: ceph_AsyncMessenger_RDMADispatcher_total_async_events
-        name: total_async_events
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Work Completions
-      context: work_completions
-      units: completions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_total_wc
-        name: rx_total_wc
-      - selector: ceph_AsyncMessenger_RDMADispatcher_tx_total_wc
-        name: tx_total_wc
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Received FIN Messages
-      context: received_fin_messages
-      units: messages/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_AsyncMessenger_RDMADispatcher_rx_fin
-        name: rx_fin
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: Monitor Daemons
-    context_namespace: monitor_daemons
-    metrics:
-    - ceph_mon_election_call
-    - ceph_mon_election_lose
-    - ceph_mon_election_win
-    - ceph_mon_num_elections
-    - ceph_mon_num_sessions
-    - ceph_mon_session_add
-    - ceph_mon_session_rm
-    - ceph_mon_session_trim
-    charts:
-    - title: Elections
-      context: elections
-      units: elections/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mon_election_call
-        name: election_call
-      - selector: ceph_mon_election_lose
-        name: election_lose
-      - selector: ceph_mon_election_win
-        name: election_win
-      - selector: ceph_mon_num_elections
-        name: num_elections
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Sessions
-      context: session_state
-      units: sessions
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mon_num_sessions
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Session Churn
-      context: session_work
-      units: sessions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_mon_session_add
-        name: add
-      - selector: ceph_mon_session_rm
-        name: rm
-      - selector: ceph_mon_session_trim
-        name: trim
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: OSD Client I/O
-    context_namespace: osd_client_i_o
-    metrics:
-    - ceph_osd_op
-    - ceph_osd_op_before_dequeue_op_lat_count
-    - ceph_osd_op_before_dequeue_op_lat_sum
-    - ceph_osd_op_before_queue_op_lat_count
-    - ceph_osd_op_before_queue_op_lat_sum
-    - ceph_osd_op_cache_hit
-    - ceph_osd_op_delayed_degraded
-    - ceph_osd_op_delayed_unreadable
-    - ceph_osd_op_in_bytes
-    - ceph_osd_op_latency_count
-    - ceph_osd_op_latency_sum
-    - ceph_osd_op_out_bytes
-    - ceph_osd_op_prepare_latency_count
-    - ceph_osd_op_prepare_latency_sum
-    - ceph_osd_op_process_latency_count
-    - ceph_osd_op_process_latency_sum
-    - ceph_osd_op_r
-    - ceph_osd_op_r_latency_count
-    - ceph_osd_op_r_latency_sum
-    - ceph_osd_op_r_out_bytes
-    - ceph_osd_op_r_prepare_latency_count
-    - ceph_osd_op_r_prepare_latency_sum
-    - ceph_osd_op_r_process_latency_count
-    - ceph_osd_op_r_process_latency_sum
-    - ceph_osd_op_rw
-    - ceph_osd_op_rw_in_bytes
-    - ceph_osd_op_rw_latency_count
-    - ceph_osd_op_rw_latency_sum
-    - ceph_osd_op_rw_out_bytes
-    - ceph_osd_op_rw_prepare_latency_count
-    - ceph_osd_op_rw_prepare_latency_sum
-    - ceph_osd_op_rw_process_latency_count
-    - ceph_osd_op_rw_process_latency_sum
-    - ceph_osd_op_w
-    - ceph_osd_op_w_in_bytes
-    - ceph_osd_op_w_latency_count
-    - ceph_osd_op_w_latency_sum
-    - ceph_osd_op_w_prepare_latency_count
-    - ceph_osd_op_w_prepare_latency_sum
-    - ceph_osd_op_w_process_latency_count
-    - ceph_osd_op_w_process_latency_sum
-    - ceph_osd_op_wip
-    - ceph_osd_replica_read
-    - ceph_osd_replica_read_redirect_conflict
-    - ceph_osd_replica_read_redirect_missing
-    - ceph_osd_replica_read_served
-    - ceph_osd_slow_ops_slow_ops_count
-    - ceph_osd_subop_in_bytes
-    - ceph_osd_subop_latency_count
-    - ceph_osd_subop_latency_sum
-    - ceph_osd_subop_pull
-    - ceph_osd_subop_pull_latency_count
-    - ceph_osd_subop_pull_latency_sum
-    - ceph_osd_subop_push
-    - ceph_osd_subop_push_in_bytes
-    - ceph_osd_subop_push_latency_count
-    - ceph_osd_subop_push_latency_sum
-    - ceph_osd_subop_w
-    - ceph_osd_subop_w_in_bytes
-    - ceph_osd_subop_w_latency_count
-    - ceph_osd_subop_w_latency_sum
-    - ceph_osd_tier_proxy_read
-    - ceph_osd_tier_proxy_write
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_before_dequeue_op_lat_count
-        name: op_before_dequeue_op_lat
-      - selector: ceph_osd_op_before_queue_op_lat_count
-        name: op_before_queue_op_lat
-      - selector: ceph_osd_op_latency_count
-        name: op_latency
-      - selector: ceph_osd_op_prepare_latency_count
-        name: op_prepare_latency
-      - selector: ceph_osd_op_process_latency_count
-        name: op_process_latency
-      - selector: ceph_osd_op_r_latency_count
-        name: op_r_latency
-      - selector: ceph_osd_op_r_prepare_latency_count
-        name: op_r_prepare_latency
-      - selector: ceph_osd_op_r_process_latency_count
-        name: op_r_process_latency
-      - selector: ceph_osd_op_rw_latency_count
-        name: op_rw_latency
-      - selector: ceph_osd_op_rw_prepare_latency_count
-        name: op_rw_prepare_latency
-      - selector: ceph_osd_op_rw_process_latency_count
-        name: op_rw_process_latency
-      - selector: ceph_osd_op_w_latency_count
-        name: op_w_latency
-      - selector: ceph_osd_op_w_prepare_latency_count
-        name: op_w_prepare_latency
-      - selector: ceph_osd_op_w_process_latency_count
-        name: op_w_process_latency
-      - selector: ceph_osd_subop_latency_count
-        name: subop_latency
-      - selector: ceph_osd_subop_pull_latency_count
-        name: subop_pull_latency
-      - selector: ceph_osd_subop_push_latency_count
-        name: subop_push_latency
-      - selector: ceph_osd_subop_w_latency_count
-        name: subop_w_latency
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_before_dequeue_op_lat_sum
-        name: op_before_dequeue_op_lat
-      - selector: ceph_osd_op_before_queue_op_lat_sum
-        name: op_before_queue_op_lat
-      - selector: ceph_osd_op_latency_sum
-        name: op_latency
-      - selector: ceph_osd_op_prepare_latency_sum
-        name: op_prepare_latency
-      - selector: ceph_osd_op_process_latency_sum
-        name: op_process_latency
-      - selector: ceph_osd_op_r_latency_sum
-        name: op_r_latency
-      - selector: ceph_osd_op_r_prepare_latency_sum
-        name: op_r_prepare_latency
-      - selector: ceph_osd_op_r_process_latency_sum
-        name: op_r_process_latency
-      - selector: ceph_osd_op_rw_latency_sum
-        name: op_rw_latency
-      - selector: ceph_osd_op_rw_prepare_latency_sum
-        name: op_rw_prepare_latency
-      - selector: ceph_osd_op_rw_process_latency_sum
-        name: op_rw_process_latency
-      - selector: ceph_osd_op_w_latency_sum
-        name: op_w_latency
-      - selector: ceph_osd_op_w_prepare_latency_sum
-        name: op_w_prepare_latency
-      - selector: ceph_osd_op_w_process_latency_sum
-        name: op_w_process_latency
-      - selector: ceph_osd_subop_latency_sum
-        name: subop_latency
-      - selector: ceph_osd_subop_pull_latency_sum
-        name: subop_pull_latency
-      - selector: ceph_osd_subop_push_latency_sum
-        name: subop_push_latency
-      - selector: ceph_osd_subop_w_latency_sum
-        name: subop_w_latency
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Byte Throughput
-      context: byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_in_bytes
-        name: op_in_bytes
-      - selector: ceph_osd_op_out_bytes
-        name: op_out_bytes
-      - selector: ceph_osd_op_r_out_bytes
-        name: op_r_out_bytes
-      - selector: ceph_osd_op_rw_in_bytes
-        name: op_rw_in_bytes
-      - selector: ceph_osd_op_rw_out_bytes
-        name: op_rw_out_bytes
-      - selector: ceph_osd_op_w_in_bytes
-        name: op_w_in_bytes
-      - selector: ceph_osd_subop_in_bytes
-        name: subop_in_bytes
-      - selector: ceph_osd_subop_push_in_bytes
-        name: subop_push_in_bytes
-      - selector: ceph_osd_subop_w_in_bytes
-        name: subop_w_in_bytes
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Operations in Progress
-      context: current_operations
-      units: operations
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_wip
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Events
-      context: events
-      units: events/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_subop_push
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Failure and Delay Outcomes
-      context: failure_outcomes
-      units: events/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_slow_ops_slow_ops_count
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Lookup Outcomes
-      context: lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_cache_hit
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Object Work
-      context: object_work
-      units: objects/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op_delayed_degraded
-        name: op_delayed_degraded
-      - selector: ceph_osd_op_delayed_unreadable
-        name: op_delayed_unreadable
-      - selector: ceph_osd_replica_read_redirect_missing
-        name: replica_read_redirect_missing
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Operations
-      context: operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_op
-        name: op
-      - selector: ceph_osd_op_r
-        name: op_r
-      - selector: ceph_osd_op_rw
-        name: op_rw
-      - selector: ceph_osd_op_w
-        name: op_w
-      - selector: ceph_osd_replica_read
-        name: replica_read
-      - selector: ceph_osd_replica_read_redirect_conflict
-        name: replica_read_redirect_conflict
-      - selector: ceph_osd_replica_read_served
-        name: replica_read_served
-      - selector: ceph_osd_subop_pull
-        name: subop_pull
-      - selector: ceph_osd_subop_w
-        name: subop_w
-      - selector: ceph_osd_tier_proxy_read
-        name: tier_proxy_read
-      - selector: ceph_osd_tier_proxy_write
-        name: tier_proxy_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: OSD Recovery
-    context_namespace: osd_recovery
-    metrics:
-    - ceph_osd_l_osd_recovery_backfill_queue_latency_count
-    - ceph_osd_l_osd_recovery_backfill_queue_latency_sum
-    - ceph_osd_l_osd_recovery_backfill_remove_queue_latency_count
-    - ceph_osd_l_osd_recovery_backfill_remove_queue_latency_sum
-    - ceph_osd_l_osd_recovery_context_queue_latency_count
-    - ceph_osd_l_osd_recovery_context_queue_latency_sum
-    - ceph_osd_l_osd_recovery_pull_queue_latency_count
-    - ceph_osd_l_osd_recovery_pull_queue_latency_sum
-    - ceph_osd_l_osd_recovery_push_queue_latency_count
-    - ceph_osd_l_osd_recovery_push_queue_latency_sum
-    - ceph_osd_l_osd_recovery_push_reply_queue_latency_count
-    - ceph_osd_l_osd_recovery_push_reply_queue_latency_sum
-    - ceph_osd_l_osd_recovery_queue_latency_count
-    - ceph_osd_l_osd_recovery_queue_latency_sum
-    - ceph_osd_l_osd_recovery_scan_queue_latency_count
-    - ceph_osd_l_osd_recovery_scan_queue_latency_sum
-    - ceph_osd_recovery_bytes
-    - ceph_osd_recovery_ops
-    - ceph_recoverystate_perf_pg_rebuild_duration_count
-    - ceph_recoverystate_perf_pg_rebuild_duration_sum
-    - ceph_recoverystate_perf_pg_rebuild_max_secs
-    - ceph_recoverystate_perf_pg_rebuild_min_secs
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_l_osd_recovery_backfill_queue_latency_count
-        name: backfill_queue_latency
-      - selector: ceph_osd_l_osd_recovery_backfill_remove_queue_latency_count
-        name: backfill_remove_queue_latency
-      - selector: ceph_osd_l_osd_recovery_context_queue_latency_count
-        name: context_queue_latency
-      - selector: ceph_osd_l_osd_recovery_pull_queue_latency_count
-        name: pull_queue_latency
-      - selector: ceph_osd_l_osd_recovery_push_queue_latency_count
-        name: push_queue_latency
-      - selector: ceph_osd_l_osd_recovery_push_reply_queue_latency_count
-        name: push_reply_queue_latency
-      - selector: ceph_osd_l_osd_recovery_queue_latency_count
-        name: queue_latency
-      - selector: ceph_osd_l_osd_recovery_scan_queue_latency_count
-        name: scan_queue_latency
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_l_osd_recovery_backfill_queue_latency_sum
-        name: backfill_queue_latency
-      - selector: ceph_osd_l_osd_recovery_backfill_remove_queue_latency_sum
-        name: backfill_remove_queue_latency
-      - selector: ceph_osd_l_osd_recovery_context_queue_latency_sum
-        name: context_queue_latency
-      - selector: ceph_osd_l_osd_recovery_pull_queue_latency_sum
-        name: pull_queue_latency
-      - selector: ceph_osd_l_osd_recovery_push_queue_latency_sum
-        name: push_queue_latency
-      - selector: ceph_osd_l_osd_recovery_push_reply_queue_latency_sum
-        name: push_reply_queue_latency
-      - selector: ceph_osd_l_osd_recovery_queue_latency_sum
-        name: queue_latency
-      - selector: ceph_osd_l_osd_recovery_scan_queue_latency_sum
-        name: scan_queue_latency
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Byte Throughput
-      context: byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_recovery_bytes
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Operations
-      context: operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_recovery_ops
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: PG Rebuild Duration Measurements
-      context: pg_rebuild_duration_measurements
-      units: duration measurements/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_recoverystate_perf_pg_rebuild_duration_count
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: PG Rebuild Accumulated Duration
-      context: pg_rebuild_accumulated_duration
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_recoverystate_perf_pg_rebuild_duration_sum
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: PG Rebuild Duration Range
-      context: pg_rebuild_duration_range
-      units: seconds
-      label_promotion: []
-      dimensions:
-      - selector: ceph_recoverystate_perf_pg_rebuild_max_secs
-        name: maximum
-      - selector: ceph_recoverystate_perf_pg_rebuild_min_secs
-        name: minimum
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: OSD Runtime
-    context_namespace: osd_runtime
-    metrics:
-    - ceph_osd_agent_evict
-    - ceph_osd_agent_flush
-    - ceph_osd_agent_skip
-    - ceph_osd_agent_wake
-    - ceph_osd_cached_crc
-    - ceph_osd_cached_crc_adjusted
-    - ceph_osd_copyfrom
-    - ceph_osd_heartbeat_to_peers
-    - ceph_osd_loadavg
-    - ceph_osd_map_message_epoch_dups
-    - ceph_osd_map_message_epochs
-    - ceph_osd_map_messages
-    - ceph_osd_messages_delayed_for_map
-    - ceph_osd_missed_crc
-    - ceph_osd_numpg
-    - ceph_osd_numpg_primary
-    - ceph_osd_numpg_removing
-    - ceph_osd_numpg_replica
-    - ceph_osd_numpg_stray
-    - ceph_osd_object_ctx_cache_hit
-    - ceph_osd_object_ctx_cache_total
-    - ceph_osd_osd_map_bl_cache_hit
-    - ceph_osd_osd_map_bl_cache_miss
-    - ceph_osd_osd_map_cache_hit
-    - ceph_osd_osd_map_cache_miss
-    - ceph_osd_osd_map_cache_miss_low
-    - ceph_osd_osd_map_cache_miss_low_avg_count
-    - ceph_osd_osd_map_cache_miss_low_avg_sum
-    - ceph_osd_osd_pg_biginfo
-    - ceph_osd_osd_pg_fastinfo
-    - ceph_osd_osd_pg_info
-    - ceph_osd_osd_tier_flush_lat_count
-    - ceph_osd_osd_tier_flush_lat_sum
-    - ceph_osd_osd_tier_promote_lat_count
-    - ceph_osd_osd_tier_promote_lat_sum
-    - ceph_osd_osd_tier_r_lat_count
-    - ceph_osd_osd_tier_r_lat_sum
-    - ceph_osd_pull
-    - ceph_osd_push
-    - ceph_osd_push_out_bytes
-    - ceph_osd_stat_bytes
-    - ceph_osd_stat_bytes_avail
-    - ceph_osd_stat_bytes_used
-    - ceph_osd_subop
-    - ceph_osd_tier_clean
-    - ceph_osd_tier_delay
-    - ceph_osd_tier_dirty
-    - ceph_osd_tier_evict
-    - ceph_osd_tier_flush
-    - ceph_osd_tier_flush_fail
-    - ceph_osd_tier_promote
-    - ceph_osd_tier_try_flush
-    - ceph_osd_tier_try_flush_fail
-    - ceph_osd_tier_whiteout
-    - ceph_osd_watch_timeouts
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_tier_flush_lat_count
-        name: flush_lat
-      - selector: ceph_osd_osd_tier_promote_lat_count
-        name: promote_lat
-      - selector: ceph_osd_osd_tier_r_lat_count
-        name: r_lat
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_tier_flush_lat_sum
-        name: flush_lat
-      - selector: ceph_osd_osd_tier_promote_lat_sum
-        name: promote_lat
-      - selector: ceph_osd_osd_tier_r_lat_sum
-        name: r_lat
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Value Measurement Measurements
-      context: value_measurements
-      units: measurements/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_map_cache_miss_low_avg_count
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Value Measurement
-      context: accumulated_value
-      units: value/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_map_cache_miss_low_avg_sum
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Byte Throughput
-      context: byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_push_out_bytes
-        name: value
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: CRC Cache Lookup Outcomes
-      context: crc_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_cached_crc
-        name: cached_crc
-      - selector: ceph_osd_cached_crc_adjusted
-        name: cached_crc_adjusted
-      - selector: ceph_osd_missed_crc
-        name: missed_crc
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Tier-Agent Actions
-      context: tier_agent_actions
-      units: actions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_agent_evict
-        name: agent_evict
-      - selector: ceph_osd_agent_wake
-        name: agent_wake
-      - selector: ceph_osd_tier_clean
-        name: tier_clean
-      - selector: ceph_osd_tier_delay
-        name: tier_delay
-      - selector: ceph_osd_tier_dirty
-        name: tier_dirty
-      - selector: ceph_osd_tier_evict
-        name: tier_evict
-      - selector: ceph_osd_tier_promote
-        name: tier_promote
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Copy-From Operations
-      context: copyfrom_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_copyfrom
-        name: copyfrom
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: OSD-Map Messages
-      context: map_messages
-      units: messages/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_map_messages
-        name: map_messages
-      - selector: ceph_osd_messages_delayed_for_map
-        name: messages_delayed_for_map
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: OSD-Map Epochs
-      context: map_epochs
-      units: epochs/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_map_message_epochs
-        name: map_message_epochs
-      - selector: ceph_osd_map_message_epoch_dups
-        name: map_message_epoch_dups
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Placement-Group Updates
-      context: pg_updates
-      units: updates/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_pg_biginfo
-        name: osd_pg_biginfo
-      - selector: ceph_osd_osd_pg_fastinfo
-        name: osd_pg_fastinfo
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Total Placement-Group Updates
-      context: pg_updates_total
-      units: placement group updates/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_pg_info
-        name: total
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Pushes
-      context: pushes
-      units: pushes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_push
-        name: push
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Suboperations
-      context: suboperations
-      units: suboperations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_subop
-        name: subop
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Failed Tier Flush Attempts
-      context: failed_tier_flush_attempts
-      units: attempts/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_tier_flush_fail
-        name: tier_flush_fail
-      - selector: ceph_osd_tier_try_flush_fail
-        name: tier_try_flush_fail
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Watch Timeouts
-      context: watch_timeouts
-      units: watches/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_watch_timeouts
-        name: watch_timeouts
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: OSD-Map Buffer-Cache Lookup Outcomes
-      context: map_buffer_cache_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_map_bl_cache_hit
-        name: osd_map_bl_cache_hit
-      - selector: ceph_osd_osd_map_bl_cache_miss
-        name: osd_map_bl_cache_miss
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Decoded OSD-Map Cache Lookup Outcomes
-      context: map_cache_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_osd_map_cache_hit
-        name: osd_map_cache_hit
-      - selector: ceph_osd_osd_map_cache_miss
-        name: osd_map_cache_miss
-      - selector: ceph_osd_osd_map_cache_miss_low
-        name: osd_map_cache_miss_low
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Tier Whiteouts
-      context: tier_whiteouts
-      units: whiteouts/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_tier_whiteout
-        name: tier_whiteout
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Skipped Objects
-      context: skipped_objects
-      units: objects/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_agent_skip
-        name: agent_skip
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Object-Context Cache Lookup Outcomes
-      context: object_context_cache_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_object_ctx_cache_hit
-        name: object_ctx_cache_hit
-      - selector: ceph_osd_object_ctx_cache_total
-        name: object_ctx_cache
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Tier Flush Attempts
-      context: tier_flush_attempts
-      units: attempts/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_agent_flush
-        name: agent_flush
-      - selector: ceph_osd_tier_flush
-        name: tier_flush
-      - selector: ceph_osd_tier_try_flush
-        name: tier_try_flush
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Pulls
-      context: pulls
-      units: pulls/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_pull
-        name: pull
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Placement Groups
-      context: pg_state
-      units: PGs
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_numpg
-        name: numpg
-      - selector: ceph_osd_numpg_primary
-        name: primary
-      - selector: ceph_osd_numpg_removing
-        name: removing
-      - selector: ceph_osd_numpg_replica
-        name: replica
-      - selector: ceph_osd_numpg_stray
-        name: stray
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Space and Memory
-      context: space
-      units: bytes
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_stat_bytes
-        name: bytes
-      - selector: ceph_osd_stat_bytes_avail
-        name: avail
-      - selector: ceph_osd_stat_bytes_used
-        name: used
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Heartbeat Peers
-      context: heartbeat_peers
-      units: peers
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_heartbeat_to_peers
-        name: heartbeat_to_peers
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: OSD Load Average
-      context: load_average
-      units: load
-      label_promotion: []
-      dimensions:
-      - selector: ceph_osd_loadavg
-        name: loadavg
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: OSD Scrubbing - Ceph 19
-    context_namespace: osd_scrubbing_ceph_19
-    groups:
-    - family: Elapsed Time
-      context_namespace: elapsed_time
-      metrics:
-      - ceph_osd_scrub_dp_ec_failed_reservations_elapsed_count
-      - ceph_osd_scrub_dp_ec_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_count
-      - ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_sum
-      - ceph_osd_scrub_dp_ec_successful_reservations_elapsed_count
-      - ceph_osd_scrub_dp_ec_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_count
-      - ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_sum
-      - ceph_osd_scrub_dp_repl_failed_reservations_elapsed_count
-      - ceph_osd_scrub_dp_repl_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_count
-      - ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_sum
-      - ceph_osd_scrub_dp_repl_successful_reservations_elapsed_count
-      - ceph_osd_scrub_dp_repl_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_count
-      - ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_sum
-      - ceph_osd_scrub_sh_ec_failed_reservations_elapsed_count
-      - ceph_osd_scrub_sh_ec_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_count
-      - ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_sum
-      - ceph_osd_scrub_sh_ec_successful_reservations_elapsed_count
-      - ceph_osd_scrub_sh_ec_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_count
-      - ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_sum
-      - ceph_osd_scrub_sh_repl_failed_reservations_elapsed_count
-      - ceph_osd_scrub_sh_repl_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_count
-      - ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_sum
-      - ceph_osd_scrub_sh_repl_successful_reservations_elapsed_count
-      - ceph_osd_scrub_sh_repl_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_count
-      - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
-      charts:
-      - title: Scrub Elapsed-Time Measurements
-        context: scrub_latency_measurements
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_count
-          name: dp_ec_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_count
-          name: dp_ec_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_count
-          name: dp_repl_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_count
-          name: dp_repl_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_count
-          name: sh_ec_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_count
-          name: sh_ec_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_count
-          name: sh_repl_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_count
-          name: sh_repl_successful_scrubs_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Reservation Elapsed-Time Measurements
-        context: reservation_latency_measurements
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_reservations_elapsed_count
-          name: dp_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_ec_successful_reservations_elapsed_count
-          name: dp_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_repl_failed_reservations_elapsed_count
-          name: dp_repl_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_repl_successful_reservations_elapsed_count
-          name: dp_repl_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_ec_failed_reservations_elapsed_count
-          name: sh_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_ec_successful_reservations_elapsed_count
-          name: sh_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_repl_failed_reservations_elapsed_count
-          name: sh_repl_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_repl_successful_reservations_elapsed_count
-          name: sh_repl_successful_reservations_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Accumulated Scrub Elapsed Time
-        context: accumulated_scrub_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_scrubs_elapsed_sum
-          name: dp_ec_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_ec_successful_scrubs_elapsed_sum
-          name: dp_ec_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_repl_failed_scrubs_elapsed_sum
-          name: dp_repl_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_dp_repl_successful_scrubs_elapsed_sum
-          name: dp_repl_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_ec_failed_scrubs_elapsed_sum
-          name: sh_ec_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_ec_successful_scrubs_elapsed_sum
-          name: sh_ec_successful_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_repl_failed_scrubs_elapsed_sum
-          name: sh_repl_failed_scrubs_elapsed
-        - selector: ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
-          name: sh_repl_successful_scrubs_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Reservation Elapsed Time
-        context: accumulated_reservation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_reservations_elapsed_sum
-          name: dp_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_ec_successful_reservations_elapsed_sum
-          name: dp_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_repl_failed_reservations_elapsed_sum
-          name: dp_repl_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_dp_repl_successful_reservations_elapsed_sum
-          name: dp_repl_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_ec_failed_reservations_elapsed_sum
-          name: sh_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_ec_successful_reservations_elapsed_sum
-          name: sh_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_repl_failed_reservations_elapsed_sum
-          name: sh_repl_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_sh_repl_successful_reservations_elapsed_sum
-          name: sh_repl_successful_reservations_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Outcomes
-      context_namespace: outcomes
-      metrics:
-      - ceph_osd_scrub_dp_ec_failed_scrubs
-      - ceph_osd_scrub_dp_ec_num_scrubs_started
-      - ceph_osd_scrub_dp_ec_successful_scrubs
-      - ceph_osd_scrub_dp_repl_failed_scrubs
-      - ceph_osd_scrub_dp_repl_num_scrubs_started
-      - ceph_osd_scrub_dp_repl_successful_scrubs
-      - ceph_osd_scrub_sh_ec_failed_scrubs
-      - ceph_osd_scrub_sh_ec_num_scrubs_started
-      - ceph_osd_scrub_sh_ec_successful_scrubs
-      - ceph_osd_scrub_sh_repl_failed_scrubs
-      - ceph_osd_scrub_sh_repl_num_scrubs_started
-      - ceph_osd_scrub_sh_repl_successful_scrubs
-      charts:
-      - title: Scrub Work
-        context: scrub_work
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_failed_scrubs
-          name: dp_ec_failed_scrubs
-        - selector: ceph_osd_scrub_dp_ec_num_scrubs_started
-          name: dp_ec_num_scrubs_started
-        - selector: ceph_osd_scrub_dp_ec_successful_scrubs
-          name: dp_ec_successful_scrubs
-        - selector: ceph_osd_scrub_dp_repl_failed_scrubs
-          name: dp_repl_failed_scrubs
-        - selector: ceph_osd_scrub_dp_repl_num_scrubs_started
-          name: dp_repl_num_scrubs_started
-        - selector: ceph_osd_scrub_dp_repl_successful_scrubs
-          name: dp_repl_successful_scrubs
-        - selector: ceph_osd_scrub_sh_ec_failed_scrubs
-          name: sh_ec_failed_scrubs
-        - selector: ceph_osd_scrub_sh_ec_num_scrubs_started
-          name: sh_ec_num_scrubs_started
-        - selector: ceph_osd_scrub_sh_ec_successful_scrubs
-          name: sh_ec_successful_scrubs
-        - selector: ceph_osd_scrub_sh_repl_failed_scrubs
-          name: sh_repl_failed_scrubs
-        - selector: ceph_osd_scrub_sh_repl_num_scrubs_started
-          name: sh_repl_num_scrubs_started
-        - selector: ceph_osd_scrub_sh_repl_successful_scrubs
-          name: sh_repl_successful_scrubs
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-    - family: Reservations
-      context_namespace: reservations
-      metrics:
-      - ceph_osd_scrub_dp_ec_num_scrubs_past_reservation
-      - ceph_osd_scrub_dp_ec_replicas_in_reservation
-      - ceph_osd_scrub_dp_ec_reservation_process_aborted
-      - ceph_osd_scrub_dp_ec_reservation_process_failure
-      - ceph_osd_scrub_dp_ec_reservation_process_skipped
-      - ceph_osd_scrub_dp_repl_num_scrubs_past_reservation
-      - ceph_osd_scrub_dp_repl_replicas_in_reservation
-      - ceph_osd_scrub_dp_repl_reservation_process_aborted
-      - ceph_osd_scrub_dp_repl_reservation_process_failure
-      - ceph_osd_scrub_dp_repl_reservation_process_skipped
-      - ceph_osd_scrub_sh_ec_num_scrubs_past_reservation
-      - ceph_osd_scrub_sh_ec_replicas_in_reservation
-      - ceph_osd_scrub_sh_ec_reservation_process_aborted
-      - ceph_osd_scrub_sh_ec_reservation_process_failure
-      - ceph_osd_scrub_sh_ec_reservation_process_skipped
-      - ceph_osd_scrub_sh_repl_num_scrubs_past_reservation
-      - ceph_osd_scrub_sh_repl_replicas_in_reservation
-      - ceph_osd_scrub_sh_repl_reservation_process_aborted
-      - ceph_osd_scrub_sh_repl_reservation_process_failure
-      - ceph_osd_scrub_sh_repl_reservation_process_skipped
-      charts:
-      - title: Replicas in Reservation
-        context: replicas_in_reservation
-        units: replicas
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_replicas_in_reservation
-          name: dp_ec_replicas_in_reservation
-        - selector: ceph_osd_scrub_dp_repl_replicas_in_reservation
-          name: dp_repl_replicas_in_reservation
-        - selector: ceph_osd_scrub_sh_ec_replicas_in_reservation
-          name: sh_ec_replicas_in_reservation
-        - selector: ceph_osd_scrub_sh_repl_replicas_in_reservation
-          name: sh_repl_replicas_in_reservation
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Scrubs Past Reservation
-        context: scrubs_past_reservation
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_num_scrubs_past_reservation
-          name: dp_ec_num_scrubs_past_reservation
-        - selector: ceph_osd_scrub_dp_repl_num_scrubs_past_reservation
-          name: dp_repl_num_scrubs_past_reservation
-        - selector: ceph_osd_scrub_sh_ec_num_scrubs_past_reservation
-          name: sh_ec_num_scrubs_past_reservation
-        - selector: ceph_osd_scrub_sh_repl_num_scrubs_past_reservation
-          name: sh_repl_num_scrubs_past_reservation
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Reservation Process Outcomes
-        context: reservation_process_outcomes
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_reservation_process_aborted
-          name: dp_ec_reservation_process_aborted
-        - selector: ceph_osd_scrub_dp_ec_reservation_process_failure
-          name: dp_ec_reservation_process_failure
-        - selector: ceph_osd_scrub_dp_ec_reservation_process_skipped
-          name: dp_ec_reservation_process_skipped
-        - selector: ceph_osd_scrub_dp_repl_reservation_process_aborted
-          name: dp_repl_reservation_process_aborted
-        - selector: ceph_osd_scrub_dp_repl_reservation_process_failure
-          name: dp_repl_reservation_process_failure
-        - selector: ceph_osd_scrub_dp_repl_reservation_process_skipped
-          name: dp_repl_reservation_process_skipped
-        - selector: ceph_osd_scrub_sh_ec_reservation_process_aborted
-          name: sh_ec_reservation_process_aborted
-        - selector: ceph_osd_scrub_sh_ec_reservation_process_failure
-          name: sh_ec_reservation_process_failure
-        - selector: ceph_osd_scrub_sh_ec_reservation_process_skipped
-          name: sh_ec_reservation_process_skipped
-        - selector: ceph_osd_scrub_sh_repl_reservation_process_aborted
-          name: sh_repl_reservation_process_aborted
-        - selector: ceph_osd_scrub_sh_repl_reservation_process_failure
-          name: sh_repl_reservation_process_failure
-        - selector: ceph_osd_scrub_sh_repl_reservation_process_skipped
-          name: sh_repl_reservation_process_skipped
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-  - family: OSD Scrubbing - Ceph 20
-    context_namespace: osd_scrubbing_ceph_20
-    groups:
-    - family: Elapsed Time
-      context_namespace: elapsed_time
-      metrics:
-      - ceph_osd_failed_scrubs_ec_elapsed_count
-      - ceph_osd_failed_scrubs_ec_elapsed_sum
-      - ceph_osd_failed_scrubs_replicated_elapsed_count
-      - ceph_osd_failed_scrubs_replicated_elapsed_sum
-      - ceph_osd_scrub_ec_failed_reservations_elapsed_count
-      - ceph_osd_scrub_ec_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_ec_successful_reservations_elapsed_count
-      - ceph_osd_scrub_ec_successful_reservations_elapsed_sum
-      - ceph_osd_scrub_replicated_failed_reservations_elapsed_count
-      - ceph_osd_scrub_replicated_failed_reservations_elapsed_sum
-      - ceph_osd_scrub_replicated_successful_reservations_elapsed_count
-      - ceph_osd_scrub_replicated_successful_reservations_elapsed_sum
-      - ceph_osd_successful_scrubs_ec_elapsed_count
-      - ceph_osd_successful_scrubs_ec_elapsed_sum
-      - ceph_osd_successful_scrubs_replicated_elapsed_count
-      - ceph_osd_successful_scrubs_replicated_elapsed_sum
-      charts:
-      - title: Scrub Elapsed-Time Measurements
-        context: scrub_latency_measurements
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_failed_scrubs_ec_elapsed_count
-          name: failed_scrubs_ec_elapsed
-        - selector: ceph_osd_failed_scrubs_replicated_elapsed_count
-          name: failed_scrubs_replicated_elapsed
-        - selector: ceph_osd_successful_scrubs_ec_elapsed_count
-          name: successful_scrubs_ec_elapsed
-        - selector: ceph_osd_successful_scrubs_replicated_elapsed_count
-          name: successful_scrubs_replicated_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Reservation Elapsed-Time Measurements
-        context: reservation_latency_measurements
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_failed_reservations_elapsed_count
-          name: scrub_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_ec_successful_reservations_elapsed_count
-          name: scrub_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_replicated_failed_reservations_elapsed_count
-          name: scrub_replicated_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_replicated_successful_reservations_elapsed_count
-          name: scrub_replicated_successful_reservations_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Scrub Elapsed Time
-        context: accumulated_scrub_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_failed_scrubs_ec_elapsed_sum
-          name: failed_scrubs_ec_elapsed
-        - selector: ceph_osd_failed_scrubs_replicated_elapsed_sum
-          name: failed_scrubs_replicated_elapsed
-        - selector: ceph_osd_successful_scrubs_ec_elapsed_sum
-          name: successful_scrubs_ec_elapsed
-        - selector: ceph_osd_successful_scrubs_replicated_elapsed_sum
-          name: successful_scrubs_replicated_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Reservation Elapsed Time
-        context: accumulated_reservation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_failed_reservations_elapsed_sum
-          name: scrub_ec_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_ec_successful_reservations_elapsed_sum
-          name: scrub_ec_successful_reservations_elapsed
-        - selector: ceph_osd_scrub_replicated_failed_reservations_elapsed_sum
-          name: scrub_replicated_failed_reservations_elapsed
-        - selector: ceph_osd_scrub_replicated_successful_reservations_elapsed_sum
-          name: scrub_replicated_successful_reservations_elapsed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: Interference and Scheduling
-      context_namespace: interference_and_scheduling
-      metrics:
-      - ceph_osd_scrub_ec_io_blocked
-      - ceph_osd_scrub_ec_io_intersects
-      - ceph_osd_scrub_replicated_io_blocked
-      - ceph_osd_scrub_replicated_io_intersects
-      charts:
-      - title: Client Write Interference
-        context: client_write_interference
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_io_blocked
-          name: ec_io_blocked
-        - selector: ceph_osd_scrub_ec_io_intersects
-          name: ec_io_intersects
-        - selector: ceph_osd_scrub_replicated_io_blocked
-          name: replicated_io_blocked
-        - selector: ceph_osd_scrub_replicated_io_intersects
-          name: replicated_io_intersects
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Outcomes
-      context_namespace: outcomes
-      metrics:
-      - ceph_osd_failed_scrubs_ec
-      - ceph_osd_failed_scrubs_replicated
-      - ceph_osd_num_scrubs_started_ec
-      - ceph_osd_num_scrubs_started_replicated
-      - ceph_osd_successful_scrubs_ec
-      - ceph_osd_successful_scrubs_replicated
-      charts:
-      - title: Scrub Work
-        context: scrub_work
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_failed_scrubs_ec
-          name: failed_scrubs_ec
-        - selector: ceph_osd_failed_scrubs_replicated
-          name: failed_scrubs_replicated
-        - selector: ceph_osd_num_scrubs_started_ec
-          name: num_scrubs_started_ec
-        - selector: ceph_osd_num_scrubs_started_replicated
-          name: num_scrubs_started_replicated
-        - selector: ceph_osd_successful_scrubs_ec
-          name: successful_scrubs_ec
-        - selector: ceph_osd_successful_scrubs_replicated
-          name: successful_scrubs_replicated
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Reservations
-      context_namespace: reservations
-      metrics:
-      - ceph_osd_num_scrubs_past_reservation_ec
-      - ceph_osd_num_scrubs_past_reservation_replicated
-      - ceph_osd_scrub_ec_replicas_in_reservation
-      - ceph_osd_scrub_ec_reservation_process_aborted
-      - ceph_osd_scrub_ec_reservation_process_failure
-      - ceph_osd_scrub_ec_reservation_process_skipped
-      - ceph_osd_scrub_ec_reservations_completed
-      - ceph_osd_scrub_replicated_replicas_in_reservation
-      - ceph_osd_scrub_replicated_reservation_process_aborted
-      - ceph_osd_scrub_replicated_reservation_process_failure
-      - ceph_osd_scrub_replicated_reservation_process_skipped
-      - ceph_osd_scrub_replicated_scrub_reservations_completed
-      charts:
-      - title: Replicas in Reservation
-        context: replicas_in_reservation
-        units: replicas
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_replicas_in_reservation
-          name: ec_replicas_in_reservation
-        - selector: ceph_osd_scrub_replicated_replicas_in_reservation
-          name: replicated_replicas_in_reservation
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Scrubs Past Reservation
-        context: scrubs_past_reservation
-        units: scrubs/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_num_scrubs_past_reservation_ec
-          name: num_scrubs_past_reservation_ec
-        - selector: ceph_osd_num_scrubs_past_reservation_replicated
-          name: num_scrubs_past_reservation_replicated
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Reservation Process Outcomes
-        context: reservation_process_outcomes
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_reservation_process_aborted
-          name: scrub_ec_reservation_process_aborted
-        - selector: ceph_osd_scrub_ec_reservation_process_failure
-          name: scrub_ec_reservation_process_failure
-        - selector: ceph_osd_scrub_ec_reservation_process_skipped
-          name: scrub_ec_reservation_process_skipped
-        - selector: ceph_osd_scrub_ec_reservations_completed
-          name: scrub_ec_reservations_completed
-        - selector: ceph_osd_scrub_replicated_reservation_process_aborted
-          name: scrub_replicated_reservation_process_aborted
-        - selector: ceph_osd_scrub_replicated_reservation_process_failure
-          name: scrub_replicated_reservation_process_failure
-        - selector: ceph_osd_scrub_replicated_reservation_process_skipped
-          name: scrub_replicated_reservation_process_skipped
-        - selector: ceph_osd_scrub_replicated_scrub_reservations_completed
-          name: scrub_replicated_scrub_reservations_completed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Scrub Work
-      context_namespace: scrub_work
-      metrics:
-      - ceph_osd_scrub_ec_getattr_cnt
-      - ceph_osd_scrub_ec_read_bytes
-      - ceph_osd_scrub_ec_read_cnt
-      - ceph_osd_scrub_ec_stats_cnt
-      - ceph_osd_scrub_replicated_getattr_cnt
-      - ceph_osd_scrub_replicated_read_bytes
-      - ceph_osd_scrub_replicated_read_cnt
-      - ceph_osd_scrub_replicated_stats_cnt
-      charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_read_bytes
-          name: ec_read_bytes
-        - selector: ceph_osd_scrub_replicated_read_bytes
-          name: replicated_read_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Scrub Calls
-        context: scrub_calls
-        units: calls/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_ec_getattr_cnt
-          name: ec_getattr_cnt
-        - selector: ceph_osd_scrub_ec_read_cnt
-          name: ec_read_cnt
-        - selector: ceph_osd_scrub_ec_stats_cnt
-          name: ec_stats_cnt
-        - selector: ceph_osd_scrub_replicated_getattr_cnt
-          name: replicated_getattr_cnt
-        - selector: ceph_osd_scrub_replicated_read_cnt
-          name: replicated_read_cnt
-        - selector: ceph_osd_scrub_replicated_stats_cnt
-          name: replicated_stats_cnt
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: OSD Scrubbing - Common Work
-    context_namespace: osd_scrubbing_common_work
-    groups:
-    - family: Interference and Scheduling
-      context_namespace: interference_and_scheduling
-      metrics:
-      - ceph_osd_scrub_dp_ec_chunk_busy
-      - ceph_osd_scrub_dp_ec_chunk_selected
-      - ceph_osd_scrub_dp_ec_locked_object
-      - ceph_osd_scrub_dp_ec_preemptions
-      - ceph_osd_scrub_dp_ec_write_blocked_by_scrub
-      - ceph_osd_scrub_dp_repl_chunk_busy
-      - ceph_osd_scrub_dp_repl_chunk_selected
-      - ceph_osd_scrub_dp_repl_locked_object
-      - ceph_osd_scrub_dp_repl_preemptions
-      - ceph_osd_scrub_dp_repl_write_blocked_by_scrub
-      - ceph_osd_scrub_sh_ec_chunk_busy
-      - ceph_osd_scrub_sh_ec_chunk_selected
-      - ceph_osd_scrub_sh_ec_locked_object
-      - ceph_osd_scrub_sh_ec_preemptions
-      - ceph_osd_scrub_sh_ec_write_blocked_by_scrub
-      - ceph_osd_scrub_sh_repl_chunk_busy
-      - ceph_osd_scrub_sh_repl_chunk_selected
-      - ceph_osd_scrub_sh_repl_locked_object
-      - ceph_osd_scrub_sh_repl_preemptions
-      - ceph_osd_scrub_sh_repl_write_blocked_by_scrub
-      charts:
-      - title: Object-Lock Waits
-        context: object_lock_waits
-        units: waits/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_locked_object
-          name: dp_ec_locked_object
-        - selector: ceph_osd_scrub_dp_repl_locked_object
-          name: dp_repl_locked_object
-        - selector: ceph_osd_scrub_sh_ec_locked_object
-          name: sh_ec_locked_object
-        - selector: ceph_osd_scrub_sh_repl_locked_object
-          name: sh_repl_locked_object
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Chunk Selection Outcomes
-        context: chunk_selection_outcomes
-        units: chunks/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_chunk_busy
-          name: dp_ec_chunk_busy
-        - selector: ceph_osd_scrub_dp_ec_chunk_selected
-          name: dp_ec_chunk_selected
-        - selector: ceph_osd_scrub_dp_repl_chunk_busy
-          name: dp_repl_chunk_busy
-        - selector: ceph_osd_scrub_dp_repl_chunk_selected
-          name: dp_repl_chunk_selected
-        - selector: ceph_osd_scrub_sh_ec_chunk_busy
-          name: sh_ec_chunk_busy
-        - selector: ceph_osd_scrub_sh_ec_chunk_selected
-          name: sh_ec_chunk_selected
-        - selector: ceph_osd_scrub_sh_repl_chunk_busy
-          name: sh_repl_chunk_busy
-        - selector: ceph_osd_scrub_sh_repl_chunk_selected
-          name: sh_repl_chunk_selected
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Scrub Preemptions
-        context: preemptions
-        units: preemptions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_preemptions
-          name: dp_ec_preemptions
-        - selector: ceph_osd_scrub_dp_repl_preemptions
-          name: dp_repl_preemptions
-        - selector: ceph_osd_scrub_sh_ec_preemptions
-          name: sh_ec_preemptions
-        - selector: ceph_osd_scrub_sh_repl_preemptions
-          name: sh_repl_preemptions
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-      - title: Client Writes Blocked by Scrub
-        context: blocked_client_writes
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_write_blocked_by_scrub
-          name: dp_ec_write_blocked_by_scrub
-        - selector: ceph_osd_scrub_dp_repl_write_blocked_by_scrub
-          name: dp_repl_write_blocked_by_scrub
-        - selector: ceph_osd_scrub_sh_ec_write_blocked_by_scrub
-          name: sh_ec_write_blocked_by_scrub
-        - selector: ceph_osd_scrub_sh_repl_write_blocked_by_scrub
-          name: sh_repl_write_blocked_by_scrub
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-    - family: Reservations
-      context_namespace: reservations
-      metrics:
-      - ceph_osd_scrub_dp_ec_scrub_reservations_completed
-      - ceph_osd_scrub_dp_repl_scrub_reservations_completed
-      - ceph_osd_scrub_sh_ec_scrub_reservations_completed
-      - ceph_osd_scrub_sh_repl_scrub_reservations_completed
-      charts:
-      - title: Completed Scrub Reservations
-        context: completed_reservations
-        units: reservations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_dp_ec_scrub_reservations_completed
-          name: dp_ec_scrub_reservations_completed
-        - selector: ceph_osd_scrub_dp_repl_scrub_reservations_completed
-          name: dp_repl_scrub_reservations_completed
-        - selector: ceph_osd_scrub_sh_ec_scrub_reservations_completed
-          name: sh_ec_scrub_reservations_completed
-        - selector: ceph_osd_scrub_sh_repl_scrub_reservations_completed
-          name: sh_repl_scrub_reservations_completed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - level
-          - pooltype
-          optional_by_labels: []
-    - family: Scrub Work
-      context_namespace: scrub_work
-      metrics:
-      - ceph_osd_scrub_omapget_bytes
-      - ceph_osd_scrub_omapget_cnt
-      - ceph_osd_scrub_omapgetheader_bytes
-      - ceph_osd_scrub_omapgetheader_cnt
-      charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_omapget_bytes
-          name: omapget_bytes
-        - selector: ceph_osd_scrub_omapgetheader_bytes
-          name: omapgetheader_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OMAP Scrub Calls
-        context: omap_calls
-        units: calls/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_osd_scrub_omapget_cnt
-          name: omapget_cnt
-        - selector: ceph_osd_scrub_omapgetheader_cnt
-          name: omapgetheader_cnt
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Object Gateway
-    context_namespace: object_gateway
-    groups:
-    - family: Lifecycle
-      context_namespace: lifecycle
-      metrics:
-      - ceph_rgw_lc_abort_mpu
-      - ceph_rgw_lc_expire_current
-      - ceph_rgw_lc_expire_dm
-      - ceph_rgw_lc_expire_noncurrent
-      - ceph_rgw_lc_transition_current
-      - ceph_rgw_lc_transition_noncurrent
-      charts:
-      - title: Lifecycle Actions
-        context: lifecycle_actions
-        units: actions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_lc_expire_current
-          name: expire_current
-        - selector: ceph_rgw_lc_expire_dm
-          name: expire_dm
-        - selector: ceph_rgw_lc_expire_noncurrent
-          name: expire_noncurrent
-        - selector: ceph_rgw_lc_transition_current
-          name: transition_current
-        - selector: ceph_rgw_lc_transition_noncurrent
-          name: transition_noncurrent
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Aborted Multipart Uploads
-        context: aborted_multipart_uploads
-        units: uploads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_lc_abort_mpu
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-    - family: Lua
-      context_namespace: lua
-      metrics:
-      - ceph_rgw_lua_current_vms
-      - ceph_rgw_lua_script_fail
-      - ceph_rgw_lua_script_ok
-      charts:
-      - title: Current Lua Virtual Machines
-        context: current_vms
-        units: VMs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_lua_current_vms
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Lua Script Executions
-        context: script_executions
-        units: executions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_lua_script_ok
-          name: success
-        - selector: ceph_rgw_lua_script_fail
-          name: failure
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-    - family: Notifications
-      context_namespace: notifications
-      metrics:
-      - ceph_rgw_pubsub_event_lost
-      - ceph_rgw_pubsub_event_triggered
-      - ceph_rgw_pubsub_events
-      - ceph_rgw_pubsub_missing_conf
-      - ceph_rgw_pubsub_push_failed
-      - ceph_rgw_pubsub_push_ok
-      - ceph_rgw_pubsub_push_pending
-      - ceph_rgw_pubsub_store_fail
-      - ceph_rgw_pubsub_store_ok
-      charts:
-      - title: Pending Notification Events
-        context: pending_events
-        units: events
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_push_pending
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Stored Events
-        context: event_state
-        units: events
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_events
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Events
-        context: events
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_event_lost
-          name: event_lost
-        - selector: ceph_rgw_pubsub_event_triggered
-          name: event_triggered
-        - selector: ceph_rgw_pubsub_push_ok
-          name: push_ok
-        - selector: ceph_rgw_pubsub_store_ok
-          name: store_ok
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Failure and Delay Outcomes
-        context: failure_outcomes
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_push_failed
-          name: push_failed
-        - selector: ceph_rgw_pubsub_store_fail
-          name: store_fail
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Missing Notification Configurations
-        context: missing_configurations
-        units: events/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_pubsub_missing_conf
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-    - family: Requests and Queue
-      context_namespace: requests_and_queue
-      metrics:
-      - ceph_rgw_failed_req
-      - ceph_rgw_gc_retire_object
-      - ceph_rgw_get
-      - ceph_rgw_get_b
-      - ceph_rgw_get_initial_lat_count
-      - ceph_rgw_get_initial_lat_sum
-      - ceph_rgw_put
-      - ceph_rgw_put_b
-      - ceph_rgw_put_initial_lat_count
-      - ceph_rgw_put_initial_lat_sum
-      - ceph_rgw_qactive
-      - ceph_rgw_qlen
-      - ceph_rgw_req
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_get_initial_lat_count
-          name: get_initial_lat
-        - selector: ceph_rgw_put_initial_lat_count
-          name: put_initial_lat
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_get_initial_lat_sum
-          name: get_initial_lat
-        - selector: ceph_rgw_put_initial_lat_sum
-          name: put_initial_lat
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_get_b
-          name: get_b
-        - selector: ceph_rgw_put_b
-          name: put_b
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Queued and Active Requests
-        context: current_requests
-        units: requests
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_qactive
-          name: qactive
-        - selector: ceph_rgw_qlen
-          name: qlen
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Failed Requests
-        context: failed_requests
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_failed_req
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Object Work
-        context: object_work
-        units: objects/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_gc_retire_object
-          name: value
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-      - title: Requests
-        context: requests
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rgw_get
-          name: get
-        - selector: ceph_rgw_put
-          name: put
-        - selector: ceph_rgw_req
-          name: req
-        instances:
-          by_labels:
-          - instance_id
-          optional_by_labels: []
-  - family: Object Gateway Cache
-    context_namespace: object_gateway_cache
-    metrics:
-    - ceph_rgw_cache_hit
-    - ceph_rgw_cache_miss
-    - ceph_rgw_keystone_token_cache_hit
-    - ceph_rgw_keystone_token_cache_miss
-    charts:
-    - title: Keystone Token Cache Lookup Outcomes
-      context: keystone_lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rgw_keystone_token_cache_hit
-        name: hit
-      - selector: ceph_rgw_keystone_token_cache_miss
-        name: miss
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels: []
-    - title: Lookup Outcomes
-      context: lookup_outcomes
-      units: lookups/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rgw_cache_hit
-        name: cache_hit
-      - selector: ceph_rgw_cache_miss
-        name: cache_miss
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels: []
-  - family: Object Gateway Multisite
-    context_namespace: object_gateway_multisite
-    metrics:
-    - ceph_data_sync_from_zone_fetch_bytes_count
-    - ceph_data_sync_from_zone_fetch_bytes_sum
-    - ceph_data_sync_from_zone_fetch_errors
-    - ceph_data_sync_from_zone_fetch_not_modified
-    - ceph_data_sync_from_zone_lock_latency_count
-    - ceph_data_sync_from_zone_lock_latency_sum
-    - ceph_data_sync_from_zone_poll_errors
-    - ceph_data_sync_from_zone_poll_latency_count
-    - ceph_data_sync_from_zone_poll_latency_sum
-    charts:
-    - title: Replicated Objects
-      context: replicated_objects
-      units: objects/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_fetch_bytes_count
-        name: value
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-    - title: Accumulated Byte Measurement
-      context: accumulated_bytes
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_fetch_bytes_sum
-        name: value
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-      algorithm: incremental
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_lock_latency_count
-        name: lock_latency
-      - selector: ceph_data_sync_from_zone_poll_latency_count
-        name: poll_latency
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_lock_latency_sum
-        name: lock_latency
-      - selector: ceph_data_sync_from_zone_poll_latency_sum
-        name: poll_latency
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-      algorithm: incremental
-    - title: Replication-Log Request Errors
-      context: replication_log_request_errors
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_poll_errors
-        name: value
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-    - title: Object Work
-      context: object_work
-      units: objects/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_data_sync_from_zone_fetch_errors
-        name: errors
-      - selector: ceph_data_sync_from_zone_fetch_not_modified
-        name: not_modified
-      instances:
-        by_labels:
-        - instance_id
-        optional_by_labels:
-        - source_zone
-  - family: Objecter
-    context_namespace: objecter
-    metrics:
-    - ceph_objecter_command_active
-    - ceph_objecter_command_resend
-    - ceph_objecter_command_send
-    - ceph_objecter_linger_active
-    - ceph_objecter_linger_ping
-    - ceph_objecter_linger_resend
-    - ceph_objecter_linger_send
-    - ceph_objecter_map_epoch
-    - ceph_objecter_map_full
-    - ceph_objecter_map_inc
-    - ceph_objecter_omap_del
-    - ceph_objecter_omap_rd
-    - ceph_objecter_omap_wr
-    - ceph_objecter_op
-    - ceph_objecter_op_active
-    - ceph_objecter_op_inflight
-    - ceph_objecter_op_laggy
-    - ceph_objecter_op_latency_count
-    - ceph_objecter_op_latency_sum
-    - ceph_objecter_op_pg
-    - ceph_objecter_op_r
-    - ceph_objecter_op_reply
-    - ceph_objecter_op_resend
-    - ceph_objecter_op_rmw
-    - ceph_objecter_op_send
-    - ceph_objecter_op_send_bytes
-    - ceph_objecter_op_w
-    - ceph_objecter_oplen_avg_count
-    - ceph_objecter_oplen_avg_sum
-    - ceph_objecter_osd_laggy
-    - ceph_objecter_osd_session_close
-    - ceph_objecter_osd_session_open
-    - ceph_objecter_osd_sessions
-    - ceph_objecter_osdop_append
-    - ceph_objecter_osdop_call
-    - ceph_objecter_osdop_clonerange
-    - ceph_objecter_osdop_cmpxattr
-    - ceph_objecter_osdop_create
-    - ceph_objecter_osdop_delete
-    - ceph_objecter_osdop_getxattr
-    - ceph_objecter_osdop_mapext
-    - ceph_objecter_osdop_notify
-    - ceph_objecter_osdop_other
-    - ceph_objecter_osdop_pgls
-    - ceph_objecter_osdop_pgls_filter
-    - ceph_objecter_osdop_read
-    - ceph_objecter_osdop_resetxattrs
-    - ceph_objecter_osdop_rmxattr
-    - ceph_objecter_osdop_setxattr
-    - ceph_objecter_osdop_sparse_read
-    - ceph_objecter_osdop_src_cmpxattr
-    - ceph_objecter_osdop_stat
-    - ceph_objecter_osdop_truncate
-    - ceph_objecter_osdop_watch
-    - ceph_objecter_osdop_write
-    - ceph_objecter_osdop_writefull
-    - ceph_objecter_osdop_writesame
-    - ceph_objecter_osdop_zero
-    - ceph_objecter_poolop_active
-    - ceph_objecter_poolop_resend
-    - ceph_objecter_poolop_send
-    - ceph_objecter_poolstat_active
-    - ceph_objecter_poolstat_resend
-    - ceph_objecter_poolstat_send
-    - ceph_objecter_replica_read_bounced
-    - ceph_objecter_replica_read_completed
-    - ceph_objecter_replica_read_sent
-    - ceph_objecter_statfs_active
-    - ceph_objecter_statfs_resend
-    - ceph_objecter_statfs_send
-    charts:
-    - title: Latency Measurements
-      context: latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_op_latency_count
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Accumulated Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_op_latency_sum
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      algorithm: incremental
-      aggregation: sum
-    - title: Submitted Top-Level Operations
-      context: submitted_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_oplen_avg_count
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Operation-Vector Entries
-      context: operation_vector_entries
-      units: entries/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_oplen_avg_sum
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      algorithm: incremental
-      aggregation: sum
-    - title: Byte Throughput
-      context: byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_op_send_bytes
-        name: value
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active Commands
-      context: active_commands
-      units: commands
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_command_active
-        name: command_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active Lingering Operations
-      context: active_lingering_operations
-      units: operations
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_linger_active
-        name: linger_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: OSD-Map Epoch
-      context: map_epoch
-      units: epoch
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_map_epoch
-        name: map_epoch
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: min
-    - title: Objecter Operations
-      context: active_operations
-      units: operations
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_op_active
-        name: op_active
-      - selector: ceph_objecter_op_inflight
-        name: op_inflight
-      - selector: ceph_objecter_op_laggy
-        name: op_laggy
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active Pool Operations
-      context: active_pool_operations
-      units: operations
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_poolop_active
-        name: poolop_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active Pool-Stat Requests
-      context: active_poolstat_requests
-      units: requests
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_poolstat_active
-        name: poolstat_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Active StatFS Requests
-      context: active_statfs_requests
-      units: requests
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_statfs_active
-        name: statfs_active
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Commands
-      context: commands
-      units: commands/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_command_resend
-        name: command_resend
-      - selector: ceph_objecter_command_send
-        name: command_send
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Lingering Operations
-      context: lingering_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_linger_ping
-        name: linger_ping
-      - selector: ceph_objecter_linger_resend
-        name: linger_resend
-      - selector: ceph_objecter_linger_send
-        name: linger_send
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: OSD Maps
-      context: maps
-      units: maps/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_map_full
-        name: map_full
-      - selector: ceph_objecter_map_inc
-        name: map_inc
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Object Operations
-      context: operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_omap_del
-        name: omap_del
-      - selector: ceph_objecter_omap_rd
-        name: omap_rd
-      - selector: ceph_objecter_omap_wr
-        name: omap_wr
-      - selector: ceph_objecter_op
-        name: op
-      - selector: ceph_objecter_op_pg
-        name: op_pg
-      - selector: ceph_objecter_op_r
-        name: op_r
-      - selector: ceph_objecter_op_reply
-        name: op_reply
-      - selector: ceph_objecter_op_resend
-        name: op_resend
-      - selector: ceph_objecter_op_rmw
-        name: op_rmw
-      - selector: ceph_objecter_op_send
-        name: op_send
-      - selector: ceph_objecter_op_w
-        name: op_w
-      - selector: ceph_objecter_osdop_append
-        name: osdop_append
-      - selector: ceph_objecter_osdop_call
-        name: osdop_call
-      - selector: ceph_objecter_osdop_clonerange
-        name: osdop_clonerange
-      - selector: ceph_objecter_osdop_cmpxattr
-        name: osdop_cmpxattr
-      - selector: ceph_objecter_osdop_create
-        name: osdop_create
-      - selector: ceph_objecter_osdop_delete
-        name: osdop_delete
-      - selector: ceph_objecter_osdop_getxattr
-        name: osdop_getxattr
-      - selector: ceph_objecter_osdop_mapext
-        name: osdop_mapext
-      - selector: ceph_objecter_osdop_notify
-        name: osdop_notify
-      - selector: ceph_objecter_osdop_other
-        name: osdop_other
-      - selector: ceph_objecter_osdop_pgls
-        name: osdop_pgls
-      - selector: ceph_objecter_osdop_pgls_filter
-        name: osdop_pgls_filter
-      - selector: ceph_objecter_osdop_read
-        name: osdop_read
-      - selector: ceph_objecter_osdop_resetxattrs
-        name: osdop_resetxattrs
-      - selector: ceph_objecter_osdop_rmxattr
-        name: osdop_rmxattr
-      - selector: ceph_objecter_osdop_setxattr
-        name: osdop_setxattr
-      - selector: ceph_objecter_osdop_sparse_read
-        name: osdop_sparse_read
-      - selector: ceph_objecter_osdop_src_cmpxattr
-        name: osdop_src_cmpxattr
-      - selector: ceph_objecter_osdop_stat
-        name: osdop_stat
-      - selector: ceph_objecter_osdop_truncate
-        name: osdop_truncate
-      - selector: ceph_objecter_osdop_watch
-        name: osdop_watch
-      - selector: ceph_objecter_osdop_write
-        name: osdop_write
-      - selector: ceph_objecter_osdop_writefull
-        name: osdop_writefull
-      - selector: ceph_objecter_osdop_writesame
-        name: osdop_writesame
-      - selector: ceph_objecter_osdop_zero
-        name: osdop_zero
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Replica Reads
-      context: replica_reads
-      units: reads/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_replica_read_sent
-        name: replica_read_sent
-      - selector: ceph_objecter_replica_read_bounced
-        name: replica_read_bounced
-      - selector: ceph_objecter_replica_read_completed
-        name: replica_read_completed
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: OSD Sessions
-      context: osd_sessions
-      units: sessions/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_osd_session_close
-        name: osd_session_close
-      - selector: ceph_objecter_osd_session_open
-        name: osd_session_open
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Pool Operations
-      context: pool_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_poolop_resend
-        name: poolop_resend
-      - selector: ceph_objecter_poolop_send
-        name: poolop_send
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Pool-Stat and StatFS Requests
-      context: stat_requests
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_poolstat_resend
-        name: poolstat_resend
-      - selector: ceph_objecter_poolstat_send
-        name: poolstat_send
-      - selector: ceph_objecter_statfs_resend
-        name: statfs_resend
-      - selector: ceph_objecter_statfs_send
-        name: statfs_send
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-    - title: Sessions
-      context: session_state
-      units: sessions
-      label_promotion: []
-      dimensions:
-      - selector: ceph_objecter_osd_laggy
-        name: laggy
-      - selector: ceph_objecter_osd_sessions
-        name: sessions
-      instances:
-        by_labels: []
-        optional_by_labels:
-        - ceph_daemon
-        - instance_id
-      aggregation: sum
-  - family: RBD Client Images
-    context_namespace: rbd_client_images
-    metrics:
-    - ceph_rbd_librbd_image_cmp
-    - ceph_rbd_librbd_image_cmp_bytes
-    - ceph_rbd_librbd_image_cmp_latency_count
-    - ceph_rbd_librbd_image_cmp_latency_sum
-    - ceph_rbd_librbd_image_discard
-    - ceph_rbd_librbd_image_discard_bytes
-    - ceph_rbd_librbd_image_discard_latency_count
-    - ceph_rbd_librbd_image_discard_latency_sum
-    - ceph_rbd_librbd_image_flush
-    - ceph_rbd_librbd_image_flush_latency_count
-    - ceph_rbd_librbd_image_flush_latency_sum
-    - ceph_rbd_librbd_image_invalidate_cache
-    - ceph_rbd_librbd_image_lock_acquired_time
-    - ceph_rbd_librbd_image_notify
-    - ceph_rbd_librbd_image_opened_time
-    - ceph_rbd_librbd_image_rd
-    - ceph_rbd_librbd_image_rd_bytes
-    - ceph_rbd_librbd_image_rd_latency_count
-    - ceph_rbd_librbd_image_rd_latency_sum
-    - ceph_rbd_librbd_image_readahead
-    - ceph_rbd_librbd_image_readahead_bytes
-    - ceph_rbd_librbd_image_resize
-    - ceph_rbd_librbd_image_snap_create
-    - ceph_rbd_librbd_image_snap_remove
-    - ceph_rbd_librbd_image_snap_rename
-    - ceph_rbd_librbd_image_snap_rollback
-    - ceph_rbd_librbd_image_wr
-    - ceph_rbd_librbd_image_wr_bytes
-    - ceph_rbd_librbd_image_wr_latency_count
-    - ceph_rbd_librbd_image_wr_latency_sum
-    - ceph_rbd_librbd_image_ws
-    - ceph_rbd_librbd_image_ws_bytes
-    - ceph_rbd_librbd_image_ws_latency_count
-    - ceph_rbd_librbd_image_ws_latency_sum
-    charts:
-    - title: I/O Operations
-      context: io_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_rd
-        name: read
-      - selector: ceph_rbd_librbd_image_wr
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: I/O Byte Throughput
-      context: io_byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_rd_bytes
-        name: read
-      - selector: ceph_rbd_librbd_image_wr_bytes
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: I/O Latency Measurements
-      context: io_latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_rd_latency_count
-        name: read
-      - selector: ceph_rbd_librbd_image_wr_latency_count
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Accumulated I/O Latency
-      context: accumulated_io_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_rd_latency_sum
-        name: read
-      - selector: ceph_rbd_librbd_image_wr_latency_sum
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-      algorithm: incremental
-    - title: Lifecycle Timestamps
-      context: lifecycle_timestamps
-      units: seconds since epoch
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_opened_time
-        name: opened
-      - selector: ceph_rbd_librbd_image_lock_acquired_time
-        name: lock_acquired
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Data Operations
-      context: data_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_discard
-        name: discard
-      - selector: ceph_rbd_librbd_image_ws
-        name: write_same
-      - selector: ceph_rbd_librbd_image_cmp
-        name: compare_and_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Data Operation Byte Throughput
-      context: data_operation_byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_discard_bytes
-        name: discard
-      - selector: ceph_rbd_librbd_image_ws_bytes
-        name: write_same
-      - selector: ceph_rbd_librbd_image_cmp_bytes
-        name: compare_and_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Data Operation Latency Measurements
-      context: data_operation_latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_discard_latency_count
-        name: discard
-      - selector: ceph_rbd_librbd_image_ws_latency_count
-        name: write_same
-      - selector: ceph_rbd_librbd_image_cmp_latency_count
-        name: compare_and_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Accumulated Data Operation Latency
-      context: accumulated_data_operation_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_discard_latency_sum
-        name: discard
-      - selector: ceph_rbd_librbd_image_ws_latency_sum
-        name: write_same
-      - selector: ceph_rbd_librbd_image_cmp_latency_sum
-        name: compare_and_write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-      algorithm: incremental
-    - title: Flush Operations
-      context: flush_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_flush
-        name: flush
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Flush Latency Measurements
-      context: flush_latency_measurements
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_flush_latency_count
-        name: flush
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Accumulated Flush Latency
-      context: accumulated_flush_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_flush_latency_sum
-        name: flush
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-      algorithm: incremental
-    - title: Snapshot Mutations
-      context: snapshot_mutations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_snap_create
-        name: create
-      - selector: ceph_rbd_librbd_image_snap_remove
-        name: remove
-      - selector: ceph_rbd_librbd_image_snap_rollback
-        name: rollback
-      - selector: ceph_rbd_librbd_image_snap_rename
-        name: rename
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Maintenance Operations
-      context: maintenance_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_notify
-        name: notify
-      - selector: ceph_rbd_librbd_image_resize
-        name: resize
-      - selector: ceph_rbd_librbd_image_readahead
-        name: readahead
-      - selector: ceph_rbd_librbd_image_invalidate_cache
-        name: invalidate_cache
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-    - title: Readahead Byte Throughput
-      context: readahead_byte_throughput
-      units: bytes/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_rbd_librbd_image_readahead_bytes
-        name: readahead
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels:
-        - librbd_image_key
-  - family: RBD Mirror
-    context_namespace: rbd_mirror
-    groups:
-    - family: Journal
-      context_namespace: journal
-      metrics:
-      - ceph_rbd_mirror_journal_entries
-      - ceph_rbd_mirror_journal_image_entries
-      - ceph_rbd_mirror_journal_image_replay_bytes
-      - ceph_rbd_mirror_journal_image_replay_latency_count
-      - ceph_rbd_mirror_journal_image_replay_latency_sum
-      - ceph_rbd_mirror_journal_replay_bytes
-      - ceph_rbd_mirror_journal_replay_latency_count
-      - ceph_rbd_mirror_journal_replay_latency_sum
-      charts:
-      - title: Journal Replay Latency Measurements
-        context: latency_measurements
-        units: entries/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_replay_latency_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Image Journal Replay Latency Measurements
-        context: image_latency_measurements
-        units: entries/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_image_replay_latency_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_replay_latency_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Image Journal Replay Latency
-        context: image_accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_image_replay_latency_sum
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_replay_bytes
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Image Journal Replay Byte Throughput
-        context: image_byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_image_replay_bytes
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Journal Entries
-        context: journal_entries
-        units: entries/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_entries
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Journal Entries Queued for Replay
-        context: image_journal_entries
-        units: entries/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_journal_image_entries
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-    - family: Snapshot Replication
-      context_namespace: snapshot_replication
-      metrics:
-      - ceph_rbd_mirror_snapshot_image_last_sync_bytes
-      - ceph_rbd_mirror_snapshot_image_last_sync_time
-      - ceph_rbd_mirror_snapshot_image_local_timestamp
-      - ceph_rbd_mirror_snapshot_image_remote_timestamp
-      - ceph_rbd_mirror_snapshot_image_snapshots
-      - ceph_rbd_mirror_snapshot_image_sync_bytes
-      - ceph_rbd_mirror_snapshot_image_sync_time_count
-      - ceph_rbd_mirror_snapshot_image_sync_time_sum
-      - ceph_rbd_mirror_snapshot_snapshots
-      - ceph_rbd_mirror_snapshot_sync_bytes
-      - ceph_rbd_mirror_snapshot_sync_time_count
-      - ceph_rbd_mirror_snapshot_sync_time_sum
-      charts:
-      - title: Snapshot Sync Latency Measurements — Image Sync Time
-        context: latency_measurements_image_sync_time
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_sync_time_count
-          name: image_sync_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Snapshot Sync Latency Measurements — Sync Time
-        context: latency_measurements_sync_time
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_sync_time_count
-          name: sync_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency — Image Sync Time
-        context: accumulated_latency_image_sync_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_sync_time_sum
-          name: image_sync_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Latency — Sync Time
-        context: accumulated_latency_sync_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_sync_time_sum
-          name: sync_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Byte Throughput — Image Sync Bytes
-        context: byte_throughput_image_sync_bytes
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_sync_bytes
-          name: image_sync_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Byte Throughput — Sync Bytes
-        context: byte_throughput_sync_bytes
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_sync_bytes
-          name: sync_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Last Snapshot Sync Duration
-        context: last_sync_duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_last_sync_time
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Last Snapshot Sync Size
-        context: last_sync_size
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_last_sync_bytes
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Snapshot Work — Image Snapshots
-        context: snapshot_work_image_snapshots
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_snapshots
-          name: image_snapshots
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-      - title: Snapshot Work — Snapshots
-        context: snapshot_work_snapshots
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_snapshots
-          name: snapshots
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Timestamps
-        context: timestamp
-        units: seconds since epoch
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_mirror_snapshot_image_local_timestamp
-          name: local_timestamp
-        - selector: ceph_rbd_mirror_snapshot_image_remote_timestamp
-          name: remote_timestamp
-        instances:
-          by_labels:
-          - ceph_daemon
-          - image
-          - namespace
-          - pool
-          optional_by_labels: []
-  - family: Runtime
-    context_namespace: runtime
-    groups:
-    - family: Shared Daemon
-      context_namespace: shared_daemon
-      metrics:
-      - ceph_KStore_state_done_lat_count
-      - ceph_KStore_state_done_lat_sum
-      - ceph_KStore_state_finishing_lat_count
-      - ceph_KStore_state_finishing_lat_sum
-      - ceph_KStore_state_kv_done_lat_count
-      - ceph_KStore_state_kv_done_lat_sum
-      - ceph_KStore_state_kv_queued_lat_count
-      - ceph_KStore_state_kv_queued_lat_sum
-      - ceph_KStore_state_prepare_lat_count
-      - ceph_KStore_state_prepare_lat_sum
-      - ceph_cct_total_workers
-      - ceph_cct_unhealthy_workers
-      - ceph_client_fsync_count
-      - ceph_client_fsync_sum
-      - ceph_client_lat_count
-      - ceph_client_lat_sum
-      - ceph_client_mdavg
-      - ceph_client_mdsqsum
-      - ceph_client_rdlat_count
-      - ceph_client_rdlat_sum
-      - ceph_client_readavg
-      - ceph_client_readsqsum
-      - ceph_client_reply_count
-      - ceph_client_reply_sum
-      - ceph_client_writeavg
-      - ceph_client_writesqsum
-      - ceph_client_wrlat_count
-      - ceph_client_wrlat_sum
-      - ceph_cluster_num_bytes
-      - ceph_cluster_num_mon
-      - ceph_cluster_num_mon_quorum
-      - ceph_cluster_num_object
-      - ceph_cluster_num_object_degraded
-      - ceph_cluster_num_object_misplaced
-      - ceph_cluster_num_object_unfound
-      - ceph_cluster_num_osd
-      - ceph_cluster_num_osd_in
-      - ceph_cluster_num_osd_up
-      - ceph_cluster_num_pg
-      - ceph_cluster_num_pg_active
-      - ceph_cluster_num_pg_active_clean
-      - ceph_cluster_num_pg_peering
-      - ceph_cluster_num_pool
-      - ceph_cluster_osd_bytes
-      - ceph_cluster_osd_bytes_avail
-      - ceph_cluster_osd_bytes_used
-      - ceph_cluster_osd_epoch
-      - ceph_ipv4_dpdk_ip_linearize_operations
-      - ceph_libcephsqlite_vfs_op_access_count
-      - ceph_libcephsqlite_vfs_op_access_sum
-      - ceph_libcephsqlite_vfs_op_currenttime_count
-      - ceph_libcephsqlite_vfs_op_currenttime_sum
-      - ceph_libcephsqlite_vfs_op_delete_count
-      - ceph_libcephsqlite_vfs_op_delete_sum
-      - ceph_libcephsqlite_vfs_op_fullpathname_count
-      - ceph_libcephsqlite_vfs_op_fullpathname_sum
-      - ceph_libcephsqlite_vfs_op_open_count
-      - ceph_libcephsqlite_vfs_op_open_sum
-      - ceph_libcephsqlite_vfs_opf_checkreservedlock_count
-      - ceph_libcephsqlite_vfs_opf_checkreservedlock_sum
-      - ceph_libcephsqlite_vfs_opf_close_count
-      - ceph_libcephsqlite_vfs_opf_close_sum
-      - ceph_libcephsqlite_vfs_opf_devicecharacteristics_count
-      - ceph_libcephsqlite_vfs_opf_devicecharacteristics_sum
-      - ceph_libcephsqlite_vfs_opf_filecontrol_count
-      - ceph_libcephsqlite_vfs_opf_filecontrol_sum
-      - ceph_libcephsqlite_vfs_opf_filesize_count
-      - ceph_libcephsqlite_vfs_opf_filesize_sum
-      - ceph_libcephsqlite_vfs_opf_lock_count
-      - ceph_libcephsqlite_vfs_opf_lock_sum
-      - ceph_libcephsqlite_vfs_opf_read_count
-      - ceph_libcephsqlite_vfs_opf_read_sum
-      - ceph_libcephsqlite_vfs_opf_sectorsize_count
-      - ceph_libcephsqlite_vfs_opf_sectorsize_sum
-      - ceph_libcephsqlite_vfs_opf_sync_count
-      - ceph_libcephsqlite_vfs_opf_sync_sum
-      - ceph_libcephsqlite_vfs_opf_truncate_count
-      - ceph_libcephsqlite_vfs_opf_truncate_sum
-      - ceph_libcephsqlite_vfs_opf_unlock_count
-      - ceph_libcephsqlite_vfs_opf_unlock_sum
-      - ceph_libcephsqlite_vfs_opf_write_count
-      - ceph_libcephsqlite_vfs_opf_write_sum
-      - ceph_oft_omap_total_kv_pairs
-      - ceph_oft_omap_total_objs
-      - ceph_oft_omap_total_removes
-      - ceph_oft_omap_total_updates
-      - ceph_recoverystate_perf_activating_latency_count
-      - ceph_recoverystate_perf_activating_latency_sum
-      - ceph_recoverystate_perf_active_latency_count
-      - ceph_recoverystate_perf_active_latency_sum
-      - ceph_recoverystate_perf_backfilling_latency_count
-      - ceph_recoverystate_perf_backfilling_latency_sum
-      - ceph_recoverystate_perf_clean_latency_count
-      - ceph_recoverystate_perf_clean_latency_sum
-      - ceph_recoverystate_perf_down_latency_count
-      - ceph_recoverystate_perf_down_latency_sum
-      - ceph_recoverystate_perf_getinfo_latency_count
-      - ceph_recoverystate_perf_getinfo_latency_sum
-      - ceph_recoverystate_perf_getlog_latency_count
-      - ceph_recoverystate_perf_getlog_latency_sum
-      - ceph_recoverystate_perf_getmissing_latency_count
-      - ceph_recoverystate_perf_getmissing_latency_sum
-      - ceph_recoverystate_perf_incomplete_latency_count
-      - ceph_recoverystate_perf_incomplete_latency_sum
-      - ceph_recoverystate_perf_initial_latency_count
-      - ceph_recoverystate_perf_initial_latency_sum
-      - ceph_recoverystate_perf_notbackfilling_latency_count
-      - ceph_recoverystate_perf_notbackfilling_latency_sum
-      - ceph_recoverystate_perf_notrecovering_latency_count
-      - ceph_recoverystate_perf_notrecovering_latency_sum
-      - ceph_recoverystate_perf_peering_latency_count
-      - ceph_recoverystate_perf_peering_latency_sum
-      - ceph_recoverystate_perf_primary_latency_count
-      - ceph_recoverystate_perf_primary_latency_sum
-      - ceph_recoverystate_perf_recovered_latency_count
-      - ceph_recoverystate_perf_recovered_latency_sum
-      - ceph_recoverystate_perf_recovering_latency_count
-      - ceph_recoverystate_perf_recovering_latency_sum
-      - ceph_recoverystate_perf_replicaactive_latency_count
-      - ceph_recoverystate_perf_replicaactive_latency_sum
-      - ceph_recoverystate_perf_repnotrecovering_latency_count
-      - ceph_recoverystate_perf_repnotrecovering_latency_sum
-      - ceph_recoverystate_perf_reprecovering_latency_count
-      - ceph_recoverystate_perf_reprecovering_latency_sum
-      - ceph_recoverystate_perf_repwaitbackfillreserved_latency_count
-      - ceph_recoverystate_perf_repwaitbackfillreserved_latency_sum
-      - ceph_recoverystate_perf_repwaitrecoveryreserved_latency_count
-      - ceph_recoverystate_perf_repwaitrecoveryreserved_latency_sum
-      - ceph_recoverystate_perf_reset_latency_count
-      - ceph_recoverystate_perf_reset_latency_sum
-      - ceph_recoverystate_perf_start_latency_count
-      - ceph_recoverystate_perf_start_latency_sum
-      - ceph_recoverystate_perf_started_latency_count
-      - ceph_recoverystate_perf_started_latency_sum
-      - ceph_recoverystate_perf_stats_invalidated
-      - ceph_recoverystate_perf_stray_latency_count
-      - ceph_recoverystate_perf_stray_latency_sum
-      - ceph_recoverystate_perf_waitactingchange_latency_count
-      - ceph_recoverystate_perf_waitactingchange_latency_sum
-      - ceph_recoverystate_perf_waitlocalbackfillreserved_latency_count
-      - ceph_recoverystate_perf_waitlocalbackfillreserved_latency_sum
-      - ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_count
-      - ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_sum
-      - ceph_recoverystate_perf_waitremotebackfillreserved_latency_count
-      - ceph_recoverystate_perf_waitremotebackfillreserved_latency_sum
-      - ceph_recoverystate_perf_waitremoterecoveryreserved_latency_count
-      - ceph_recoverystate_perf_waitremoterecoveryreserved_latency_sum
-      - ceph_recoverystate_perf_waitupthru_latency_count
-      - ceph_recoverystate_perf_waitupthru_latency_sum
-      charts:
-      - title: KStore Transaction Latency Measurements
-        context: kstore_latency_measurements
-        units: transactions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_KStore_state_done_lat_count
-          name: kstore_state_done_lat
-        - selector: ceph_KStore_state_finishing_lat_count
-          name: kstore_state_finishing_lat
-        - selector: ceph_KStore_state_kv_done_lat_count
-          name: kstore_state_kv_done_lat
-        - selector: ceph_KStore_state_kv_queued_lat_count
-          name: kstore_state_kv_queued_lat
-        - selector: ceph_KStore_state_prepare_lat_count
-          name: kstore_state_prepare_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Client Request Latency Measurements
-        context: client_latency_measurements
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_lat_count
-          name: client_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Recovery-State Transition Latency Measurements
-        context: recovery_state_latency_measurements
-        units: state transitions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_recoverystate_perf_activating_latency_count
-          name: recoverystate_perf_activating_latency
-        - selector: ceph_recoverystate_perf_active_latency_count
-          name: recoverystate_perf_active_latency
-        - selector: ceph_recoverystate_perf_backfilling_latency_count
-          name: recoverystate_perf_backfilling_latency
-        - selector: ceph_recoverystate_perf_clean_latency_count
-          name: recoverystate_perf_clean_latency
-        - selector: ceph_recoverystate_perf_down_latency_count
-          name: recoverystate_perf_down_latency
-        - selector: ceph_recoverystate_perf_getinfo_latency_count
-          name: recoverystate_perf_getinfo_latency
-        - selector: ceph_recoverystate_perf_getlog_latency_count
-          name: recoverystate_perf_getlog_latency
-        - selector: ceph_recoverystate_perf_getmissing_latency_count
-          name: recoverystate_perf_getmissing_latency
-        - selector: ceph_recoverystate_perf_incomplete_latency_count
-          name: recoverystate_perf_incomplete_latency
-        - selector: ceph_recoverystate_perf_initial_latency_count
-          name: recoverystate_perf_initial_latency
-        - selector: ceph_recoverystate_perf_notbackfilling_latency_count
-          name: recoverystate_perf_notbackfilling_latency
-        - selector: ceph_recoverystate_perf_notrecovering_latency_count
-          name: recoverystate_perf_notrecovering_latency
-        - selector: ceph_recoverystate_perf_peering_latency_count
-          name: recoverystate_perf_peering_latency
-        - selector: ceph_recoverystate_perf_primary_latency_count
-          name: recoverystate_perf_primary_latency
-        - selector: ceph_recoverystate_perf_recovered_latency_count
-          name: recoverystate_perf_recovered_latency
-        - selector: ceph_recoverystate_perf_recovering_latency_count
-          name: recoverystate_perf_recovering_latency
-        - selector: ceph_recoverystate_perf_replicaactive_latency_count
-          name: recoverystate_perf_replicaactive_latency
-        - selector: ceph_recoverystate_perf_repnotrecovering_latency_count
-          name: recoverystate_perf_repnotrecovering_latency
-        - selector: ceph_recoverystate_perf_reprecovering_latency_count
-          name: recoverystate_perf_reprecovering_latency
-        - selector: ceph_recoverystate_perf_repwaitbackfillreserved_latency_count
-          name: recoverystate_perf_repwaitbackfillreserved_latency
-        - selector: ceph_recoverystate_perf_repwaitrecoveryreserved_latency_count
-          name: recoverystate_perf_repwaitrecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_reset_latency_count
-          name: recoverystate_perf_reset_latency
-        - selector: ceph_recoverystate_perf_start_latency_count
-          name: recoverystate_perf_start_latency
-        - selector: ceph_recoverystate_perf_started_latency_count
-          name: recoverystate_perf_started_latency
-        - selector: ceph_recoverystate_perf_stray_latency_count
-          name: recoverystate_perf_stray_latency
-        - selector: ceph_recoverystate_perf_waitactingchange_latency_count
-          name: recoverystate_perf_waitactingchange_latency
-        - selector: ceph_recoverystate_perf_waitlocalbackfillreserved_latency_count
-          name: recoverystate_perf_waitlocalbackfillreserved_latency
-        - selector: ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_count
-          name: recoverystate_perf_waitlocalrecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_waitremotebackfillreserved_latency_count
-          name: recoverystate_perf_waitremotebackfillreserved_latency
-        - selector: ceph_recoverystate_perf_waitremoterecoveryreserved_latency_count
-          name: recoverystate_perf_waitremoterecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_waitupthru_latency_count
-          name: recoverystate_perf_waitupthru_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated KStore Transaction Latency
-        context: accumulated_kstore_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_KStore_state_done_lat_sum
-          name: kstore_state_done_lat
-        - selector: ceph_KStore_state_finishing_lat_sum
-          name: kstore_state_finishing_lat
-        - selector: ceph_KStore_state_kv_done_lat_sum
-          name: kstore_state_kv_done_lat
-        - selector: ceph_KStore_state_kv_queued_lat_sum
-          name: kstore_state_kv_queued_lat
-        - selector: ceph_KStore_state_prepare_lat_sum
-          name: kstore_state_prepare_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Client Request Latency
-        context: accumulated_client_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_lat_sum
-          name: client_lat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated Recovery-State Transition Latency
-        context: accumulated_recovery_state_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_recoverystate_perf_activating_latency_sum
-          name: recoverystate_perf_activating_latency
-        - selector: ceph_recoverystate_perf_active_latency_sum
-          name: recoverystate_perf_active_latency
-        - selector: ceph_recoverystate_perf_backfilling_latency_sum
-          name: recoverystate_perf_backfilling_latency
-        - selector: ceph_recoverystate_perf_clean_latency_sum
-          name: recoverystate_perf_clean_latency
-        - selector: ceph_recoverystate_perf_down_latency_sum
-          name: recoverystate_perf_down_latency
-        - selector: ceph_recoverystate_perf_getinfo_latency_sum
-          name: recoverystate_perf_getinfo_latency
-        - selector: ceph_recoverystate_perf_getlog_latency_sum
-          name: recoverystate_perf_getlog_latency
-        - selector: ceph_recoverystate_perf_getmissing_latency_sum
-          name: recoverystate_perf_getmissing_latency
-        - selector: ceph_recoverystate_perf_incomplete_latency_sum
-          name: recoverystate_perf_incomplete_latency
-        - selector: ceph_recoverystate_perf_initial_latency_sum
-          name: recoverystate_perf_initial_latency
-        - selector: ceph_recoverystate_perf_notbackfilling_latency_sum
-          name: recoverystate_perf_notbackfilling_latency
-        - selector: ceph_recoverystate_perf_notrecovering_latency_sum
-          name: recoverystate_perf_notrecovering_latency
-        - selector: ceph_recoverystate_perf_peering_latency_sum
-          name: recoverystate_perf_peering_latency
-        - selector: ceph_recoverystate_perf_primary_latency_sum
-          name: recoverystate_perf_primary_latency
-        - selector: ceph_recoverystate_perf_recovered_latency_sum
-          name: recoverystate_perf_recovered_latency
-        - selector: ceph_recoverystate_perf_recovering_latency_sum
-          name: recoverystate_perf_recovering_latency
-        - selector: ceph_recoverystate_perf_replicaactive_latency_sum
-          name: recoverystate_perf_replicaactive_latency
-        - selector: ceph_recoverystate_perf_repnotrecovering_latency_sum
-          name: recoverystate_perf_repnotrecovering_latency
-        - selector: ceph_recoverystate_perf_reprecovering_latency_sum
-          name: recoverystate_perf_reprecovering_latency
-        - selector: ceph_recoverystate_perf_repwaitbackfillreserved_latency_sum
-          name: recoverystate_perf_repwaitbackfillreserved_latency
-        - selector: ceph_recoverystate_perf_repwaitrecoveryreserved_latency_sum
-          name: recoverystate_perf_repwaitrecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_reset_latency_sum
-          name: recoverystate_perf_reset_latency
-        - selector: ceph_recoverystate_perf_start_latency_sum
-          name: recoverystate_perf_start_latency
-        - selector: ceph_recoverystate_perf_started_latency_sum
-          name: recoverystate_perf_started_latency
-        - selector: ceph_recoverystate_perf_stray_latency_sum
-          name: recoverystate_perf_stray_latency
-        - selector: ceph_recoverystate_perf_waitactingchange_latency_sum
-          name: recoverystate_perf_waitactingchange_latency
-        - selector: ceph_recoverystate_perf_waitlocalbackfillreserved_latency_sum
-          name: recoverystate_perf_waitlocalbackfillreserved_latency
-        - selector: ceph_recoverystate_perf_waitlocalrecoveryreserved_latency_sum
-          name: recoverystate_perf_waitlocalrecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_waitremotebackfillreserved_latency_sum
-          name: recoverystate_perf_waitremotebackfillreserved_latency
-        - selector: ceph_recoverystate_perf_waitremoterecoveryreserved_latency_sum
-          name: recoverystate_perf_waitremoterecoveryreserved_latency
-        - selector: ceph_recoverystate_perf_waitupthru_latency_sum
-          name: recoverystate_perf_waitupthru_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Client Operation Latency Measurements
-        context: client_operation_latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_fsync_count
-          name: client_fsync
-        - selector: ceph_client_rdlat_count
-          name: client_rdlat
-        - selector: ceph_client_reply_count
-          name: client_reply
-        - selector: ceph_client_wrlat_count
-          name: client_wrlat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: SQLite VFS Operation Latency Measurements
-        context: sqlite_vfs_latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_libcephsqlite_vfs_op_access_count
-          name: libcephsqlite_vfs_op_access
-        - selector: ceph_libcephsqlite_vfs_op_currenttime_count
-          name: libcephsqlite_vfs_op_currenttime
-        - selector: ceph_libcephsqlite_vfs_op_delete_count
-          name: libcephsqlite_vfs_op_delete
-        - selector: ceph_libcephsqlite_vfs_op_fullpathname_count
-          name: libcephsqlite_vfs_op_fullpathname
-        - selector: ceph_libcephsqlite_vfs_op_open_count
-          name: libcephsqlite_vfs_op_open
-        - selector: ceph_libcephsqlite_vfs_opf_checkreservedlock_count
-          name: libcephsqlite_vfs_opf_checkreservedlock
-        - selector: ceph_libcephsqlite_vfs_opf_close_count
-          name: libcephsqlite_vfs_opf_close
-        - selector: ceph_libcephsqlite_vfs_opf_devicecharacteristics_count
-          name: libcephsqlite_vfs_opf_devicecharacteristics
-        - selector: ceph_libcephsqlite_vfs_opf_filecontrol_count
-          name: libcephsqlite_vfs_opf_filecontrol
-        - selector: ceph_libcephsqlite_vfs_opf_filesize_count
-          name: libcephsqlite_vfs_opf_filesize
-        - selector: ceph_libcephsqlite_vfs_opf_lock_count
-          name: libcephsqlite_vfs_opf_lock
-        - selector: ceph_libcephsqlite_vfs_opf_read_count
-          name: libcephsqlite_vfs_opf_read
-        - selector: ceph_libcephsqlite_vfs_opf_sectorsize_count
-          name: libcephsqlite_vfs_opf_sectorsize
-        - selector: ceph_libcephsqlite_vfs_opf_sync_count
-          name: libcephsqlite_vfs_opf_sync
-        - selector: ceph_libcephsqlite_vfs_opf_truncate_count
-          name: libcephsqlite_vfs_opf_truncate
-        - selector: ceph_libcephsqlite_vfs_opf_unlock_count
-          name: libcephsqlite_vfs_opf_unlock
-        - selector: ceph_libcephsqlite_vfs_opf_write_count
-          name: libcephsqlite_vfs_opf_write
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Client Operation Latency
-        context: accumulated_client_operation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_fsync_sum
-          name: client_fsync
-        - selector: ceph_client_rdlat_sum
-          name: client_rdlat
-        - selector: ceph_client_reply_sum
-          name: client_reply
-        - selector: ceph_client_wrlat_sum
-          name: client_wrlat
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Accumulated SQLite VFS Operation Latency
-        context: accumulated_sqlite_vfs_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_libcephsqlite_vfs_op_access_sum
-          name: libcephsqlite_vfs_op_access
-        - selector: ceph_libcephsqlite_vfs_op_currenttime_sum
-          name: libcephsqlite_vfs_op_currenttime
-        - selector: ceph_libcephsqlite_vfs_op_delete_sum
-          name: libcephsqlite_vfs_op_delete
-        - selector: ceph_libcephsqlite_vfs_op_fullpathname_sum
-          name: libcephsqlite_vfs_op_fullpathname
-        - selector: ceph_libcephsqlite_vfs_op_open_sum
-          name: libcephsqlite_vfs_op_open
-        - selector: ceph_libcephsqlite_vfs_opf_checkreservedlock_sum
-          name: libcephsqlite_vfs_opf_checkreservedlock
-        - selector: ceph_libcephsqlite_vfs_opf_close_sum
-          name: libcephsqlite_vfs_opf_close
-        - selector: ceph_libcephsqlite_vfs_opf_devicecharacteristics_sum
-          name: libcephsqlite_vfs_opf_devicecharacteristics
-        - selector: ceph_libcephsqlite_vfs_opf_filecontrol_sum
-          name: libcephsqlite_vfs_opf_filecontrol
-        - selector: ceph_libcephsqlite_vfs_opf_filesize_sum
-          name: libcephsqlite_vfs_opf_filesize
-        - selector: ceph_libcephsqlite_vfs_opf_lock_sum
-          name: libcephsqlite_vfs_opf_lock
-        - selector: ceph_libcephsqlite_vfs_opf_read_sum
-          name: libcephsqlite_vfs_opf_read
-        - selector: ceph_libcephsqlite_vfs_opf_sectorsize_sum
-          name: libcephsqlite_vfs_opf_sectorsize
-        - selector: ceph_libcephsqlite_vfs_opf_sync_sum
-          name: libcephsqlite_vfs_opf_sync
-        - selector: ceph_libcephsqlite_vfs_opf_truncate_sum
-          name: libcephsqlite_vfs_opf_truncate
-        - selector: ceph_libcephsqlite_vfs_opf_unlock_sum
-          name: libcephsqlite_vfs_opf_unlock
-        - selector: ceph_libcephsqlite_vfs_opf_write_sum
-          name: libcephsqlite_vfs_opf_write
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Monitors
-        context: monitor_state
-        units: monitors
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_mon
-          name: num_mon
-        - selector: ceph_cluster_num_mon_quorum
-          name: cluster_num_mon_quorum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OSDs
-        context: osd_state
-        units: OSDs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_osd
-          name: num_osd
-        - selector: ceph_cluster_num_osd_in
-          name: cluster_num_osd_in
-        - selector: ceph_cluster_num_osd_up
-          name: cluster_num_osd_up
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Pools
-        context: pool_state
-        units: pools
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_pool
-          name: num_pool
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OSD-Map Epoch
-        context: osd_map_epoch
-        units: epoch
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_osd_epoch
-          name: osd_epoch
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Duration and Time
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_mdavg
-          name: mdavg
-        - selector: ceph_client_readavg
-          name: readavg
-        - selector: ceph_client_writeavg
-          name: writeavg
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Invalidated Recovery Statistics
-        context: invalidations
-        units: invalidations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_recoverystate_perf_stats_invalidated
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Objects
-        context: object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_object
-          name: object
-        - selector: ceph_cluster_num_object_degraded
-          name: degraded
-        - selector: ceph_cluster_num_object_misplaced
-          name: misplaced
-        - selector: ceph_cluster_num_object_unfound
-          name: unfound
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_ipv4_dpdk_ip_linearize_operations
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_bytes
-          name: num_bytes
-        - selector: ceph_cluster_osd_bytes
-          name: osd_bytes
-        - selector: ceph_cluster_osd_bytes_avail
-          name: osd_bytes_avail
-        - selector: ceph_cluster_osd_bytes_used
-          name: osd_bytes_used
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Placement Groups
-        context: pg_state
-        units: PGs
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cluster_num_pg
-          name: cluster_num_pg
-        - selector: ceph_cluster_num_pg_active
-          name: cluster_num_pg_active
-        - selector: ceph_cluster_num_pg_active_clean
-          name: cluster_num_pg_active_clean
-        - selector: ceph_cluster_num_pg_peering
-          name: cluster_num_pg_peering
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Client Latency Squared-Deviation Accumulators
-        context: client_latency_sqsum
-        units: microseconds²/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_client_mdsqsum
-          name: client_mdsqsum
-        - selector: ceph_client_readsqsum
-          name: client_readsqsum
-        - selector: ceph_client_writesqsum
-          name: client_writesqsum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: OpenFileTable OMAP Mutations
-        context: oft_omap_mutations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_oft_omap_total_updates
-          name: oft_omap_total_updates
-        - selector: ceph_oft_omap_total_removes
-          name: oft_omap_total_removes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Context Workers
-        context: worker_state
-        units: workers
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cct_total_workers
-          name: cct_total_workers
-        - selector: ceph_cct_unhealthy_workers
-          name: cct_unhealthy_workers
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OpenFileTable Objects
-        context: oft_object_state
-        units: objects
-        label_promotion: []
-        dimensions:
-        - selector: ceph_oft_omap_total_objs
-          name: oft_omap_total_objs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: OpenFileTable Key-Value Pairs
-        context: oft_entry_state
-        units: entries
-        label_promotion: []
-        dimensions:
-        - selector: ceph_oft_omap_total_kv_pairs
-          name: oft_omap_total_kv_pairs
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Slow Operations
-      context_namespace: slow_operations
-      metrics:
-      - ceph_trackedop_slow_ops_count
-      charts:
-      - title: Slow Operations
-        context: slow_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_trackedop_slow_ops_count
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Storage Engine
-    context_namespace: storage_engine
-    groups:
-    - family: Priority Cache Full
-      context_namespace: priority_cache_full
-      metrics:
-      - ceph_prioritycache:full_committed_bytes
-      - ceph_prioritycache:full_pri0_bytes
-      - ceph_prioritycache:full_pri10_bytes
-      - ceph_prioritycache:full_pri11_bytes
-      - ceph_prioritycache:full_pri1_bytes
-      - ceph_prioritycache:full_pri2_bytes
-      - ceph_prioritycache:full_pri3_bytes
-      - ceph_prioritycache:full_pri4_bytes
-      - ceph_prioritycache:full_pri5_bytes
-      - ceph_prioritycache:full_pri6_bytes
-      - ceph_prioritycache:full_pri7_bytes
-      - ceph_prioritycache:full_pri8_bytes
-      - ceph_prioritycache:full_pri9_bytes
-      - ceph_prioritycache:full_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_prioritycache:full_committed_bytes
-          name: committed_bytes
-        - selector: ceph_prioritycache:full_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_prioritycache:full_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_prioritycache:full_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_prioritycache:full_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_prioritycache:full_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_prioritycache:full_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_prioritycache:full_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_prioritycache:full_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_prioritycache:full_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_prioritycache:full_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_prioritycache:full_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_prioritycache:full_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_prioritycache:full_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Incremental
-      context_namespace: priority_cache_incremental
-      metrics:
-      - ceph_prioritycache:inc_committed_bytes
-      - ceph_prioritycache:inc_pri0_bytes
-      - ceph_prioritycache:inc_pri10_bytes
-      - ceph_prioritycache:inc_pri11_bytes
-      - ceph_prioritycache:inc_pri1_bytes
-      - ceph_prioritycache:inc_pri2_bytes
-      - ceph_prioritycache:inc_pri3_bytes
-      - ceph_prioritycache:inc_pri4_bytes
-      - ceph_prioritycache:inc_pri5_bytes
-      - ceph_prioritycache:inc_pri6_bytes
-      - ceph_prioritycache:inc_pri7_bytes
-      - ceph_prioritycache:inc_pri8_bytes
-      - ceph_prioritycache:inc_pri9_bytes
-      - ceph_prioritycache:inc_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_prioritycache:inc_committed_bytes
-          name: committed_bytes
-        - selector: ceph_prioritycache:inc_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_prioritycache:inc_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_prioritycache:inc_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_prioritycache:inc_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_prioritycache:inc_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_prioritycache:inc_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_prioritycache:inc_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_prioritycache:inc_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_prioritycache:inc_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_prioritycache:inc_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_prioritycache:inc_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_prioritycache:inc_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_prioritycache:inc_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache KV
-      context_namespace: priority_cache_kv
-      metrics:
-      - ceph_prioritycache:kv_committed_bytes
-      - ceph_prioritycache:kv_pri0_bytes
-      - ceph_prioritycache:kv_pri10_bytes
-      - ceph_prioritycache:kv_pri11_bytes
-      - ceph_prioritycache:kv_pri1_bytes
-      - ceph_prioritycache:kv_pri2_bytes
-      - ceph_prioritycache:kv_pri3_bytes
-      - ceph_prioritycache:kv_pri4_bytes
-      - ceph_prioritycache:kv_pri5_bytes
-      - ceph_prioritycache:kv_pri6_bytes
-      - ceph_prioritycache:kv_pri7_bytes
-      - ceph_prioritycache:kv_pri8_bytes
-      - ceph_prioritycache:kv_pri9_bytes
-      - ceph_prioritycache:kv_reserved_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_prioritycache:kv_committed_bytes
-          name: committed_bytes
-        - selector: ceph_prioritycache:kv_pri0_bytes
-          name: pri0_bytes
-        - selector: ceph_prioritycache:kv_pri10_bytes
-          name: pri10_bytes
-        - selector: ceph_prioritycache:kv_pri11_bytes
-          name: pri11_bytes
-        - selector: ceph_prioritycache:kv_pri1_bytes
-          name: pri1_bytes
-        - selector: ceph_prioritycache:kv_pri2_bytes
-          name: pri2_bytes
-        - selector: ceph_prioritycache:kv_pri3_bytes
-          name: pri3_bytes
-        - selector: ceph_prioritycache:kv_pri4_bytes
-          name: pri4_bytes
-        - selector: ceph_prioritycache:kv_pri5_bytes
-          name: pri5_bytes
-        - selector: ceph_prioritycache:kv_pri6_bytes
-          name: pri6_bytes
-        - selector: ceph_prioritycache:kv_pri7_bytes
-          name: pri7_bytes
-        - selector: ceph_prioritycache:kv_pri8_bytes
-          name: pri8_bytes
-        - selector: ceph_prioritycache:kv_pri9_bytes
-          name: pri9_bytes
-        - selector: ceph_prioritycache:kv_reserved_bytes
-          name: reserved_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Priority Cache Runtime
-      context_namespace: priority_cache_runtime
-      metrics:
-      - ceph_prioritycache_cache_bytes
-      - ceph_prioritycache_heap_bytes
-      - ceph_prioritycache_mapped_bytes
-      - ceph_prioritycache_target_bytes
-      - ceph_prioritycache_unmapped_bytes
-      charts:
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_prioritycache_cache_bytes
-          name: cache_bytes
-        - selector: ceph_prioritycache_heap_bytes
-          name: heap_bytes
-        - selector: ceph_prioritycache_mapped_bytes
-          name: mapped_bytes
-        - selector: ceph_prioritycache_target_bytes
-          name: target_bytes
-        - selector: ceph_prioritycache_unmapped_bytes
-          name: unmapped_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: RocksDB Compaction
-      context_namespace: rocksdb_compaction
-      metrics:
-      - ceph_rocksdb_compact
-      - ceph_rocksdb_compact_completed
-      - ceph_rocksdb_compact_lasted
-      - ceph_rocksdb_compact_queue_len
-      - ceph_rocksdb_compact_queue_merge
-      - ceph_rocksdb_compact_running
-      charts:
-      - title: Compaction Work
-        context: compaction_state
-        units: compactions
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_compact_queue_len
-          name: queue_len
-        - selector: ceph_rocksdb_compact_running
-          name: running
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: absolute
-      - title: Duration and Time
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_compact_lasted
-          name: value
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Compactions
-        context: compactions
-        units: compactions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_compact
-          name: compact
-        - selector: ceph_rocksdb_compact_completed
-          name: completed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Compaction Queue Merges
-        context: queue_merges
-        units: merges/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_compact_queue_merge
-          name: queue_merge
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: RocksDB Requests
-      context_namespace: rocksdb_requests
-      metrics:
-      - ceph_rocksdb_get_latency_count
-      - ceph_rocksdb_get_latency_sum
-      - ceph_rocksdb_submit_latency_count
-      - ceph_rocksdb_submit_latency_sum
-      - ceph_rocksdb_submit_sync_latency_count
-      - ceph_rocksdb_submit_sync_latency_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_get_latency_count
-          name: get_latency
-        - selector: ceph_rocksdb_submit_latency_count
-          name: submit_latency
-        - selector: ceph_rocksdb_submit_sync_latency_count
-          name: submit_sync_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_get_latency_sum
-          name: get_latency
-        - selector: ceph_rocksdb_submit_latency_sum
-          name: submit_latency
-        - selector: ceph_rocksdb_submit_sync_latency_sum
-          name: submit_sync_latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-    - family: RocksDB Write Path
-      context_namespace: rocksdb_write_path
-      metrics:
-      - ceph_rocksdb_rocksdb_write_delay_time_count
-      - ceph_rocksdb_rocksdb_write_delay_time_sum
-      - ceph_rocksdb_rocksdb_write_memtable_time_count
-      - ceph_rocksdb_rocksdb_write_memtable_time_sum
-      - ceph_rocksdb_rocksdb_write_pre_and_post_time_count
-      - ceph_rocksdb_rocksdb_write_pre_and_post_time_sum
-      - ceph_rocksdb_rocksdb_write_wal_time_count
-      - ceph_rocksdb_rocksdb_write_wal_time_sum
-      charts:
-      - title: Latency Measurements
-        context: latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_rocksdb_write_delay_time_count
-          name: delay_time
-        - selector: ceph_rocksdb_rocksdb_write_memtable_time_count
-          name: memtable_time
-        - selector: ceph_rocksdb_rocksdb_write_pre_and_post_time_count
-          name: pre_and_post_time
-        - selector: ceph_rocksdb_rocksdb_write_wal_time_count
-          name: wal_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Accumulated Latency
-        context: accumulated_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_rocksdb_write_delay_time_sum
-          name: delay_time
-        - selector: ceph_rocksdb_rocksdb_write_memtable_time_sum
-          name: memtable_time
-        - selector: ceph_rocksdb_rocksdb_write_pre_and_post_time_sum
-          name: pre_and_post_time
-        - selector: ceph_rocksdb_rocksdb_write_wal_time_sum
-          name: wal_time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-        algorithm: incremental
-  - family: Runtime and Client Components
-    context_namespace: runtime_and_client_components
-    groups:
-    - family: RBD Persistent Write Log
-      context_namespace: rbd_persistent_write_log
-      metrics:
-      - ceph_rbd_librbd_pwl_aio_flush
-      - ceph_rbd_librbd_pwl_aio_flush_def
-      - ceph_rbd_librbd_pwl_aio_flush_lat_count
-      - ceph_rbd_librbd_pwl_aio_flush_lat_sum
-      - ceph_rbd_librbd_pwl_append_tx_lat_count
-      - ceph_rbd_librbd_pwl_append_tx_lat_sum
-      - ceph_rbd_librbd_pwl_caller_wr_latency_count
-      - ceph_rbd_librbd_pwl_caller_wr_latency_nw_count
-      - ceph_rbd_librbd_pwl_caller_wr_latency_nw_sum
-      - ceph_rbd_librbd_pwl_caller_wr_latency_sum
-      - ceph_rbd_librbd_pwl_cmp
-      - ceph_rbd_librbd_pwl_cmp_bytes
-      - ceph_rbd_librbd_pwl_cmp_fails
-      - ceph_rbd_librbd_pwl_cmp_lat_count
-      - ceph_rbd_librbd_pwl_cmp_lat_sum
-      - ceph_rbd_librbd_pwl_discard
-      - ceph_rbd_librbd_pwl_discard_bytes
-      - ceph_rbd_librbd_pwl_discard_lat_count
-      - ceph_rbd_librbd_pwl_discard_lat_sum
-      - ceph_rbd_librbd_pwl_hit_rd
-      - ceph_rbd_librbd_pwl_hit_rd_latency_count
-      - ceph_rbd_librbd_pwl_hit_rd_latency_sum
-      - ceph_rbd_librbd_pwl_internal_flush
-      - ceph_rbd_librbd_pwl_invalidate
-      - ceph_rbd_librbd_pwl_log_op_bytes_count
-      - ceph_rbd_librbd_pwl_log_op_bytes_sum
-      - ceph_rbd_librbd_pwl_log_ops
-      - ceph_rbd_librbd_pwl_op_alloc_t_count
-      - ceph_rbd_librbd_pwl_op_alloc_t_sum
-      - ceph_rbd_librbd_pwl_op_app_to_appc_t_count
-      - ceph_rbd_librbd_pwl_op_app_to_appc_t_sum
-      - ceph_rbd_librbd_pwl_op_app_to_cmp_t_count
-      - ceph_rbd_librbd_pwl_op_app_to_cmp_t_sum
-      - ceph_rbd_librbd_pwl_op_buf_to_app_t_count
-      - ceph_rbd_librbd_pwl_op_buf_to_app_t_sum
-      - ceph_rbd_librbd_pwl_op_buf_to_bufc_t_count
-      - ceph_rbd_librbd_pwl_op_buf_to_bufc_t_sum
-      - ceph_rbd_librbd_pwl_op_dis_to_app_t_count
-      - ceph_rbd_librbd_pwl_op_dis_to_app_t_sum
-      - ceph_rbd_librbd_pwl_op_dis_to_buf_t_count
-      - ceph_rbd_librbd_pwl_op_dis_to_buf_t_sum
-      - ceph_rbd_librbd_pwl_op_dis_to_cmp_t_count
-      - ceph_rbd_librbd_pwl_op_dis_to_cmp_t_sum
-      - ceph_rbd_librbd_pwl_part_hit_rd
-      - ceph_rbd_librbd_pwl_rd
-      - ceph_rbd_librbd_pwl_rd_bytes
-      - ceph_rbd_librbd_pwl_rd_hit_bytes
-      - ceph_rbd_librbd_pwl_rd_latency_count
-      - ceph_rbd_librbd_pwl_rd_latency_sum
-      - ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_count
-      - ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_sum
-      - ceph_rbd_librbd_pwl_req_all_to_dis_t_count
-      - ceph_rbd_librbd_pwl_req_all_to_dis_t_sum
-      - ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_count
-      - ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_sum
-      - ceph_rbd_librbd_pwl_req_arr_to_all_t_count
-      - ceph_rbd_librbd_pwl_req_arr_to_all_t_sum
-      - ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_count
-      - ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
-      - ceph_rbd_librbd_pwl_req_arr_to_dis_t_count
-      - ceph_rbd_librbd_pwl_req_arr_to_dis_t_sum
-      - ceph_rbd_librbd_pwl_retire_tx_lat_count
-      - ceph_rbd_librbd_pwl_retire_tx_lat_sum
-      - ceph_rbd_librbd_pwl_wr
-      - ceph_rbd_librbd_pwl_wr_bytes
-      - ceph_rbd_librbd_pwl_wr_def
-      - ceph_rbd_librbd_pwl_wr_def_buf
-      - ceph_rbd_librbd_pwl_wr_def_lanes
-      - ceph_rbd_librbd_pwl_wr_def_log
-      - ceph_rbd_librbd_pwl_wr_latency_count
-      - ceph_rbd_librbd_pwl_wr_latency_nw_count
-      - ceph_rbd_librbd_pwl_wr_latency_nw_sum
-      - ceph_rbd_librbd_pwl_wr_latency_sum
-      - ceph_rbd_librbd_pwl_wr_overlap
-      - ceph_rbd_librbd_pwl_wr_q_barrier
-      - ceph_rbd_librbd_pwl_writeback_lat_count
-      - ceph_rbd_librbd_pwl_writeback_lat_sum
-      - ceph_rbd_librbd_pwl_ws
-      - ceph_rbd_librbd_pwl_ws_bytes
-      - ceph_rbd_librbd_pwl_ws_lat_count
-      - ceph_rbd_librbd_pwl_ws_lat_sum
-      charts:
-      - title: Reads
-        context: reads
-        units: reads/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_rd
-          name: rd
-        - selector: ceph_rbd_librbd_pwl_hit_rd
-          name: hit_rd
-        - selector: ceph_rbd_librbd_pwl_part_hit_rd
-          name: part_hit_rd
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Writes
-        context: writes
-        units: writes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_wr
-          name: wr
-        - selector: ceph_rbd_librbd_pwl_wr_def
-          name: wr_def
-        - selector: ceph_rbd_librbd_pwl_wr_def_lanes
-          name: wr_def_lanes
-        - selector: ceph_rbd_librbd_pwl_wr_def_log
-          name: wr_def_log
-        - selector: ceph_rbd_librbd_pwl_wr_def_buf
-          name: wr_def_buf
-        - selector: ceph_rbd_librbd_pwl_wr_overlap
-          name: wr_overlap
-        - selector: ceph_rbd_librbd_pwl_wr_q_barrier
-          name: wr_q_barrier
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Log Appends
-        context: log_appends
-        units: appends/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_log_ops
-          name: log_ops
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Cache and Image Operations
-        context: cache_image_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_discard
-          name: discard
-        - selector: ceph_rbd_librbd_pwl_aio_flush
-          name: aio_flush
-        - selector: ceph_rbd_librbd_pwl_aio_flush_def
-          name: aio_flush_def
-        - selector: ceph_rbd_librbd_pwl_ws
-          name: ws
-        - selector: ceph_rbd_librbd_pwl_cmp
-          name: cmp
-        - selector: ceph_rbd_librbd_pwl_cmp_fails
-          name: cmp_fails
-        - selector: ceph_rbd_librbd_pwl_internal_flush
-          name: internal_flush
-        - selector: ceph_rbd_librbd_pwl_invalidate
-          name: invalidate
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Read Throughput
-        context: read_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_rd_bytes
-          name: rd_bytes
-        - selector: ceph_rbd_librbd_pwl_rd_hit_bytes
-          name: rd_hit_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Write Throughput
-        context: write_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_wr_bytes
-          name: wr_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Data-Operation Throughput
-        context: data_operation_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_discard_bytes
-          name: discard_bytes
-        - selector: ceph_rbd_librbd_pwl_ws_bytes
-          name: ws_bytes
-        - selector: ceph_rbd_librbd_pwl_cmp_bytes
-          name: cmp_bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Log-Append Throughput
-        context: log_append_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_log_op_bytes_sum
-          name: log_op_bytes_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Read Request Latency Measurements
-        context: read_latency_measurements
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_rd_latency_count
-          name: rd_latency_count
-        - selector: ceph_rbd_librbd_pwl_hit_rd_latency_count
-          name: hit_rd_latency_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Log-Append Size Measurements
-        context: log_append_size_measurements
-        units: appends/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_log_op_bytes_count
-          name: log_op_bytes_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Write Request Latency Measurements
-        context: write_latency_measurements
-        units: requests/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_all_t_count
-          name: req_arr_to_all_t_count
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_t_count
-          name: req_arr_to_dis_t_count
-        - selector: ceph_rbd_librbd_pwl_req_all_to_dis_t_count
-          name: req_all_to_dis_t_count
-        - selector: ceph_rbd_librbd_pwl_wr_latency_count
-          name: wr_latency_count
-        - selector: ceph_rbd_librbd_pwl_caller_wr_latency_count
-          name: caller_wr_latency_count
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_count
-          name: req_arr_to_all_nw_t_count
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_count
-          name: req_arr_to_dis_nw_t_count
-        - selector: ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_count
-          name: req_all_to_dis_nw_t_count
-        - selector: ceph_rbd_librbd_pwl_wr_latency_nw_count
-          name: wr_latency_nw_count
-        - selector: ceph_rbd_librbd_pwl_caller_wr_latency_nw_count
-          name: caller_wr_latency_nw_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Log Operation Latency Measurements
-        context: log_operation_latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_op_alloc_t_count
-          name: op_alloc_t_count
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_buf_t_count
-          name: op_dis_to_buf_t_count
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_app_t_count
-          name: op_dis_to_app_t_count
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_cmp_t_count
-          name: op_dis_to_cmp_t_count
-        - selector: ceph_rbd_librbd_pwl_op_buf_to_app_t_count
-          name: op_buf_to_app_t_count
-        - selector: ceph_rbd_librbd_pwl_op_buf_to_bufc_t_count
-          name: op_buf_to_bufc_t_count
-        - selector: ceph_rbd_librbd_pwl_op_app_to_cmp_t_count
-          name: op_app_to_cmp_t_count
-        - selector: ceph_rbd_librbd_pwl_op_app_to_appc_t_count
-          name: op_app_to_appc_t_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Data Operation Latency Measurements
-        context: data_operation_latency_measurements
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_discard_lat_count
-          name: discard_lat_count
-        - selector: ceph_rbd_librbd_pwl_aio_flush_lat_count
-          name: aio_flush_lat_count
-        - selector: ceph_rbd_librbd_pwl_ws_lat_count
-          name: ws_lat_count
-        - selector: ceph_rbd_librbd_pwl_cmp_lat_count
-          name: cmp_lat_count
-        - selector: ceph_rbd_librbd_pwl_writeback_lat_count
-          name: writeback_lat_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Transaction Latency Measurements
-        context: transaction_latency_measurements
-        units: transactions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_append_tx_lat_count
-          name: append_tx_lat_count
-        - selector: ceph_rbd_librbd_pwl_retire_tx_lat_count
-          name: retire_tx_lat_count
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-      - title: Accumulated Read Request Latency
-        context: accumulated_read_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_rd_latency_sum
-          name: rd_latency_sum
-        - selector: ceph_rbd_librbd_pwl_hit_rd_latency_sum
-          name: hit_rd_latency_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Accumulated Write Request Latency
-        context: accumulated_write_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_all_t_sum
-          name: req_arr_to_all_t_sum
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_t_sum
-          name: req_arr_to_dis_t_sum
-        - selector: ceph_rbd_librbd_pwl_req_all_to_dis_t_sum
-          name: req_all_to_dis_t_sum
-        - selector: ceph_rbd_librbd_pwl_wr_latency_sum
-          name: wr_latency_sum
-        - selector: ceph_rbd_librbd_pwl_caller_wr_latency_sum
-          name: caller_wr_latency_sum
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_all_nw_t_sum
-          name: req_arr_to_all_nw_t_sum
-        - selector: ceph_rbd_librbd_pwl_req_arr_to_dis_nw_t_sum
-          name: req_arr_to_dis_nw_t_sum
-        - selector: ceph_rbd_librbd_pwl_req_all_to_dis_nw_t_sum
-          name: req_all_to_dis_nw_t_sum
-        - selector: ceph_rbd_librbd_pwl_wr_latency_nw_sum
-          name: wr_latency_nw_sum
-        - selector: ceph_rbd_librbd_pwl_caller_wr_latency_nw_sum
-          name: caller_wr_latency_nw_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Accumulated Log Operation Latency
-        context: accumulated_log_operation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_op_alloc_t_sum
-          name: op_alloc_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_buf_t_sum
-          name: op_dis_to_buf_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_app_t_sum
-          name: op_dis_to_app_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_dis_to_cmp_t_sum
-          name: op_dis_to_cmp_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_buf_to_app_t_sum
-          name: op_buf_to_app_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_buf_to_bufc_t_sum
-          name: op_buf_to_bufc_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_app_to_cmp_t_sum
-          name: op_app_to_cmp_t_sum
-        - selector: ceph_rbd_librbd_pwl_op_app_to_appc_t_sum
-          name: op_app_to_appc_t_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Accumulated Data Operation Latency
-        context: accumulated_data_operation_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_discard_lat_sum
-          name: discard_lat_sum
-        - selector: ceph_rbd_librbd_pwl_aio_flush_lat_sum
-          name: aio_flush_lat_sum
-        - selector: ceph_rbd_librbd_pwl_ws_lat_sum
-          name: ws_lat_sum
-        - selector: ceph_rbd_librbd_pwl_cmp_lat_sum
-          name: cmp_lat_sum
-        - selector: ceph_rbd_librbd_pwl_writeback_lat_sum
-          name: writeback_lat_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-      - title: Accumulated Transaction Latency
-        context: accumulated_transaction_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rbd_librbd_pwl_append_tx_lat_sum
-          name: append_tx_lat_sum
-        - selector: ceph_rbd_librbd_pwl_retire_tx_lat_sum
-          name: retire_tx_lat_sum
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - librbd_pwl_key
-        algorithm: incremental
-    - family: Object Caches
-      context_namespace: object_caches
-      metrics:
-      - ceph_objectcacher_cache_bytes_hit
-      - ceph_objectcacher_cache_bytes_miss
-      - ceph_objectcacher_cache_ops_hit
-      - ceph_objectcacher_cache_ops_miss
-      - ceph_objectcacher_data_flushed
-      - ceph_objectcacher_data_overwritten_while_flushing
-      - ceph_objectcacher_data_read
-      - ceph_objectcacher_data_written
-      - ceph_objectcacher_write_bytes_blocked
-      - ceph_objectcacher_write_ops_blocked
-      - ceph_objectcacher_write_time_blocked
-      charts:
-      - title: Cache Outcomes
-        context: cache_outcomes
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_cache_ops_hit
-          name: hit
-        - selector: ceph_objectcacher_cache_ops_miss
-          name: miss
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Cache Byte Outcomes
-        context: cache_byte_outcomes
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_cache_bytes_hit
-          name: hit
-        - selector: ceph_objectcacher_cache_bytes_miss
-          name: miss
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Data Throughput
-        context: data_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_data_read
-          name: read
-        - selector: ceph_objectcacher_data_written
-          name: written
-        - selector: ceph_objectcacher_data_flushed
-          name: flushed
-        - selector: ceph_objectcacher_data_overwritten_while_flushing
-          name: overwritten_while_flushing
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Blocked Writes
-        context: blocked_writes
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_write_ops_blocked
-          name: operations
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Blocked Write Throughput
-        context: blocked_write_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_write_bytes_blocked
-          name: bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-      - title: Blocked Write Time
-        context: blocked_write_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_objectcacher_write_time_blocked
-          name: time
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - objectcacher_key
-        algorithm: incremental
-    - family: Finishers
-      context_namespace: finishers
-      metrics:
-      - ceph_finisher_complete_latency_count
-      - ceph_finisher_complete_latency_sum
-      - ceph_finisher_queue_len
-      charts:
-      - title: Queued Callbacks
-        context: queue_depth
-        units: callbacks
-        label_promotion: []
-        dimensions:
-        - selector: ceph_finisher_queue_len
-          name: queued
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - finisher_key
-      - title: Drained Completion Batches
-        context: completions
-        units: batches/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_finisher_complete_latency_count
-          name: completed
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - finisher_key
-      - title: Accumulated Completion Latency
-        context: accumulated_completion_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_finisher_complete_latency_sum
-          name: latency
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - finisher_key
-        algorithm: incremental
-    - family: Throttles
-      context_namespace: throttles
-      metrics:
-      - ceph_throttle_get
-      - ceph_throttle_get_or_fail_fail
-      - ceph_throttle_get_or_fail_success
-      - ceph_throttle_get_started
-      - ceph_throttle_get_sum
-      - ceph_throttle_max
-      - ceph_throttle_put
-      - ceph_throttle_put_sum
-      - ceph_throttle_take
-      - ceph_throttle_take_sum
-      - ceph_throttle_val
-      - ceph_throttle_wait_count
-      - ceph_throttle_wait_sum
-      charts:
-      - title: Utilization
-        context: utilization
-        units: slots
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_val
-          name: val
-        - selector: ceph_throttle_max
-          name: max
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - throttle_key
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_get_started
-          name: get_started
-        - selector: ceph_throttle_get
-          name: get
-        - selector: ceph_throttle_get_or_fail_fail
-          name: get_or_fail_fail
-        - selector: ceph_throttle_get_or_fail_success
-          name: get_or_fail_success
-        - selector: ceph_throttle_take
-          name: take
-        - selector: ceph_throttle_put
-          name: put
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - throttle_key
-      - title: Slot Throughput
-        context: slot_throughput
-        units: slots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_get_sum
-          name: get_sum
-        - selector: ceph_throttle_take_sum
-          name: take_sum
-        - selector: ceph_throttle_put_sum
-          name: put_sum
-        instances:
-          by_labels: []
-          optional_by_labels:
-          - throttle_key
-      - title: Waits
-        context: wait_measurements
-        units: waits/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_wait_count
-          name: waits
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - throttle_key
-      - title: Accumulated Wait Time
-        context: accumulated_wait_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_throttle_wait_sum
-          name: wait
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - throttle_key
-        algorithm: incremental
-    - family: Kernel Devices
-      context_namespace: kernel_devices
-      metrics:
-      - ceph_kernel_device_discard_op
-      - ceph_kernel_device_discard_threads
-      charts:
-      - title: Discard Operations
-        context: discard_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_kernel_device_discard_op
-          name: discard
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - kernel_device_key
-      - title: Discard Threads
-        context: discard_threads
-        units: threads
-        label_promotion: []
-        dimensions:
-        - selector: ceph_kernel_device_discard_threads
-          name: threads
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - kernel_device_key
-        algorithm: absolute
-    - family: mClock Shards
-      context_namespace: mclock_shards
-      metrics:
-      - ceph_mclock_shard_mclock_all_type_queue_len
-      - ceph_mclock_shard_mclock_best_effort_queue_len
-      - ceph_mclock_shard_mclock_client_queue_len
-      - ceph_mclock_shard_mclock_immediate_queue_len
-      - ceph_mclock_shard_mclock_recovery_queue_len
-      charts:
-      - title: Queue Depth
-        context: queue_depth
-        units: operations
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mclock_shard_mclock_immediate_queue_len
-          name: immediate
-        - selector: ceph_mclock_shard_mclock_client_queue_len
-          name: client
-        - selector: ceph_mclock_shard_mclock_recovery_queue_len
-          name: recovery
-        - selector: ceph_mclock_shard_mclock_best_effort_queue_len
-          name: best_effort
-        - selector: ceph_mclock_shard_mclock_all_type_queue_len
-          name: all_type
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - mclock_shard
-        algorithm: absolute
-    - family: Messenger Workers
-      context_namespace: messenger_workers
-      metrics:
-      - ceph_async_messenger_worker_msgr_active_connections
-      - ceph_async_messenger_worker_msgr_created_connections
-      - ceph_async_messenger_worker_msgr_handle_ack_lat_count
-      - ceph_async_messenger_worker_msgr_handle_ack_lat_sum
-      - ceph_async_messenger_worker_msgr_recv_bytes
-      - ceph_async_messenger_worker_msgr_recv_encrypted_bytes
-      - ceph_async_messenger_worker_msgr_recv_messages
-      - ceph_async_messenger_worker_msgr_running_fast_dispatch_time
-      - ceph_async_messenger_worker_msgr_running_recv_time
-      - ceph_async_messenger_worker_msgr_running_send_time
-      - ceph_async_messenger_worker_msgr_running_total_time
-      - ceph_async_messenger_worker_msgr_send_bytes
-      - ceph_async_messenger_worker_msgr_send_encrypted_bytes
-      - ceph_async_messenger_worker_msgr_send_messages
-      - ceph_async_messenger_worker_msgr_send_messages_queue_lat_count
-      - ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
-      charts:
-      - title: Messages
-        context: messages
-        units: messages/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_recv_messages
-          name: recv
-        - selector: ceph_async_messenger_worker_msgr_send_messages
-          name: send
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_recv_bytes
-          name: recv
-        - selector: ceph_async_messenger_worker_msgr_send_bytes
-          name: send
-        - selector: ceph_async_messenger_worker_msgr_recv_encrypted_bytes
-          name: recv_encrypted
-        - selector: ceph_async_messenger_worker_msgr_send_encrypted_bytes
-          name: send_encrypted
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Connections
-        context: connections
-        units: connections
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_active_connections
-          name: active
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-        algorithm: absolute
-      - title: Created Connections
-        context: created_connections
-        units: connections/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_created_connections
-          name: created
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Accumulated Worker Time
-        context: accumulated_worker_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_running_total_time
-          name: total
-        - selector: ceph_async_messenger_worker_msgr_running_send_time
-          name: send
-        - selector: ceph_async_messenger_worker_msgr_running_recv_time
-          name: recv
-        - selector: ceph_async_messenger_worker_msgr_running_fast_dispatch_time
-          name: fast_dispatch
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-        algorithm: incremental
-      - title: Send-Queue Latency Measurements
-        context: send_queue_latency_measurements
-        units: messages/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_send_messages_queue_lat_count
-          name: send_messages_queue
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Acknowledgement Latency Measurements
-        context: ack_latency_measurements
-        units: acknowledgements/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_handle_ack_lat_count
-          name: handle_ack
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-      - title: Accumulated Send-Queue Latency
-        context: accumulated_send_queue_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
-          name: send_messages_queue
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-        algorithm: incremental
-      - title: Accumulated Acknowledgement Latency
-        context: accumulated_ack_latency
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_worker_msgr_handle_ack_lat_sum
-          name: handle_ack
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - messenger_worker
-        algorithm: incremental
-    - family: RDMA Workers
-      context_namespace: rdma_workers
-      metrics:
-      - ceph_async_messenger_rdma_worker_pending_sent_conns
-      - ceph_async_messenger_rdma_worker_rx_bytes
-      - ceph_async_messenger_rdma_worker_rx_chunks
-      - ceph_async_messenger_rdma_worker_tx_bytes
-      - ceph_async_messenger_rdma_worker_tx_chunks
-      - ceph_async_messenger_rdma_worker_tx_failed_post
-      - ceph_async_messenger_rdma_worker_tx_no_mem
-      - ceph_async_messenger_rdma_worker_tx_parital_mem
-      charts:
-      - title: RDMA Transfer Errors
-        context: transfer_errors
-        units: errors/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_rdma_worker_tx_no_mem
-          name: tx_no_mem
-        - selector: ceph_async_messenger_rdma_worker_tx_parital_mem
-          name: tx_parital_mem
-        - selector: ceph_async_messenger_rdma_worker_tx_failed_post
-          name: tx_failed_post
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rdma_worker
-      - title: Chunk Throughput
-        context: chunk_throughput
-        units: chunks/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_rdma_worker_tx_chunks
-          name: tx
-        - selector: ceph_async_messenger_rdma_worker_rx_chunks
-          name: rx
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rdma_worker
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_rdma_worker_tx_bytes
-          name: tx
-        - selector: ceph_async_messenger_rdma_worker_rx_bytes
-          name: rx
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rdma_worker
-      - title: Pending Connections
-        context: pending_connections
-        units: connections
-        label_promotion: []
-        dimensions:
-        - selector: ceph_async_messenger_rdma_worker_pending_sent_conns
-          name: pending
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rdma_worker
-        algorithm: absolute
-    - family: DPDK Queues
-      context_namespace: dpdk_queues
-      metrics:
-      - ceph_dpdk_queue_dpdk_receive_bad_checksum_errors
-      - ceph_dpdk_queue_dpdk_receive_bytes
-      - ceph_dpdk_queue_dpdk_receive_copy_bytes
-      - ceph_dpdk_queue_dpdk_receive_copy_ops
-      - ceph_dpdk_queue_dpdk_receive_fragments
-      - ceph_dpdk_queue_dpdk_receive_last_bunch
-      - ceph_dpdk_queue_dpdk_receive_linearize_ops
-      - ceph_dpdk_queue_dpdk_receive_no_memory_errors
-      - ceph_dpdk_queue_dpdk_receive_packets
-      - ceph_dpdk_queue_dpdk_send_bytes
-      - ceph_dpdk_queue_dpdk_send_copy_bytes
-      - ceph_dpdk_queue_dpdk_send_copy_ops
-      - ceph_dpdk_queue_dpdk_send_fragments
-      - ceph_dpdk_queue_dpdk_send_last_bunch
-      - ceph_dpdk_queue_dpdk_send_linearize_ops
-      - ceph_dpdk_queue_dpdk_send_packets
-      - ceph_dpdk_queue_dpdk_send_queue_length
-      charts:
-      - title: Packets
-        context: packets
-        units: packets/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_packets
-          name: receive
-        - selector: ceph_dpdk_queue_dpdk_send_packets
-          name: send
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_bytes
-          name: receive
-        - selector: ceph_dpdk_queue_dpdk_send_bytes
-          name: send
-        - selector: ceph_dpdk_queue_dpdk_receive_copy_bytes
-          name: receive_copy
-        - selector: ceph_dpdk_queue_dpdk_send_copy_bytes
-          name: send_copy
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Packet Fragments
-        context: packet_fragments
-        units: fragments/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_fragments
-          name: receive_fragments
-        - selector: ceph_dpdk_queue_dpdk_send_fragments
-          name: send_fragments
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Copy and Linearize Operations
-        context: copy_linearize_operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_copy_ops
-          name: receive_copy_ops
-        - selector: ceph_dpdk_queue_dpdk_send_copy_ops
-          name: send_copy_ops
-        - selector: ceph_dpdk_queue_dpdk_receive_linearize_ops
-          name: receive_linearize_ops
-        - selector: ceph_dpdk_queue_dpdk_send_linearize_ops
-          name: send_linearize_ops
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Receive Errors
-        context: receive_errors
-        units: errors/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_bad_checksum_errors
-          name: bad_checksum
-        - selector: ceph_dpdk_queue_dpdk_receive_no_memory_errors
-          name: no_memory
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-      - title: Last Batch Size
-        context: last_batch_size
-        units: packets
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_receive_last_bunch
-          name: receive
-        - selector: ceph_dpdk_queue_dpdk_send_last_bunch
-          name: send
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-        algorithm: absolute
-      - title: Send Queue Depth
-        context: send_queue_depth
-        units: packets
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_queue_dpdk_send_queue_length
-          name: queued
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_queue
-        algorithm: absolute
-    - family: DPDK Ports
-      context_namespace: dpdk_ports
-      metrics:
-      - ceph_dpdk_port_dpdk_device_receive_badcrc_errors
-      - ceph_dpdk_port_dpdk_device_receive_dropped_errors
-      - ceph_dpdk_port_dpdk_device_receive_multicast_packets
-      - ceph_dpdk_port_dpdk_device_receive_nombuf_errors
-      - ceph_dpdk_port_dpdk_device_receive_total_errors
-      - ceph_dpdk_port_dpdk_device_send_total_errors
-      charts:
-      - title: Multicast Packets
-        context: multicast_packets
-        units: packets/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_port_dpdk_device_receive_multicast_packets
-          name: received
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_port
-      - title: Receive Errors
-        context: receive_errors
-        units: errors/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_port_dpdk_device_receive_badcrc_errors
-          name: badcrc
-        - selector: ceph_dpdk_port_dpdk_device_receive_total_errors
-          name: total
-        - selector: ceph_dpdk_port_dpdk_device_receive_dropped_errors
-          name: dropped
-        - selector: ceph_dpdk_port_dpdk_device_receive_nombuf_errors
-          name: nombuf
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_port
-      - title: Send Errors
-        context: send_errors
-        units: errors/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_dpdk_port_dpdk_device_send_total_errors
-          name: total
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - dpdk_port
-    - family: Service Identity
-      context_namespace: service_identity
-      metrics:
-      - ceph_service_unique_id
-      charts:
-      - title: Service Identity Metadata Sentinel
-        context: identity_metadata
-        units: identifier
-        label_promotion: []
-        dimensions:
-        - selector: ceph_service_unique_id
-          name: present
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - service_unique_id
-    - family: RADOS Striper
-      context_namespace: rados_striper
-      metrics:
-      - ceph_libcephsqlite_striper_lock
-      - ceph_libcephsqlite_striper_shrink
-      - ceph_libcephsqlite_striper_shrink_bytes
-      - ceph_libcephsqlite_striper_unlock
-      - ceph_libcephsqlite_striper_update_allocated
-      - ceph_libcephsqlite_striper_update_metadata
-      - ceph_libcephsqlite_striper_update_size
-      - ceph_libcephsqlite_striper_update_version
-      charts:
-      - title: Metadata and Lock Work
-        context: metadata_and_lock_work
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_libcephsqlite_striper_update_metadata
-          name: update_metadata
-        - selector: ceph_libcephsqlite_striper_update_allocated
-          name: update_allocated
-        - selector: ceph_libcephsqlite_striper_update_size
-          name: update_size
-        - selector: ceph_libcephsqlite_striper_update_version
-          name: update_version
-        - selector: ceph_libcephsqlite_striper_shrink
-          name: shrink
-        - selector: ceph_libcephsqlite_striper_lock
-          name: lock
-        - selector: ceph_libcephsqlite_striper_unlock
-          name: unlock
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Shrink Throughput
-        context: shrink_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_libcephsqlite_striper_shrink_bytes
-          name: bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Memory Pools
-      context_namespace: memory_pools
-      metrics:
-      - ceph_mempool_bloom_filter_bytes
-      - ceph_mempool_bloom_filter_items
-      - ceph_mempool_bluefs_bytes
-      - ceph_mempool_bluefs_file_reader_bytes
-      - ceph_mempool_bluefs_file_reader_items
-      - ceph_mempool_bluefs_file_writer_bytes
-      - ceph_mempool_bluefs_file_writer_items
-      - ceph_mempool_bluefs_items
-      - ceph_mempool_bluestore_alloc_bytes
-      - ceph_mempool_bluestore_alloc_items
-      - ceph_mempool_bluestore_blob_bytes
-      - ceph_mempool_bluestore_blob_items
-      - ceph_mempool_bluestore_cache_buffer_bytes
-      - ceph_mempool_bluestore_cache_buffer_items
-      - ceph_mempool_bluestore_cache_data_bytes
-      - ceph_mempool_bluestore_cache_data_items
-      - ceph_mempool_bluestore_cache_meta_bytes
-      - ceph_mempool_bluestore_cache_meta_items
-      - ceph_mempool_bluestore_cache_onode_bytes
-      - ceph_mempool_bluestore_cache_onode_items
-      - ceph_mempool_bluestore_cache_other_bytes
-      - ceph_mempool_bluestore_cache_other_items
-      - ceph_mempool_bluestore_extent_bytes
-      - ceph_mempool_bluestore_extent_items
-      - ceph_mempool_bluestore_fsck_bytes
-      - ceph_mempool_bluestore_fsck_items
-      - ceph_mempool_bluestore_inline_bl_bytes
-      - ceph_mempool_bluestore_inline_bl_items
-      - ceph_mempool_bluestore_shared_blob_bytes
-      - ceph_mempool_bluestore_shared_blob_items
-      - ceph_mempool_bluestore_txc_bytes
-      - ceph_mempool_bluestore_txc_items
-      - ceph_mempool_bluestore_writing_bytes
-      - ceph_mempool_bluestore_writing_deferred_bytes
-      - ceph_mempool_bluestore_writing_deferred_items
-      - ceph_mempool_bluestore_writing_items
-      - ceph_mempool_buffer_anon_bytes
-      - ceph_mempool_buffer_anon_items
-      - ceph_mempool_buffer_meta_bytes
-      - ceph_mempool_buffer_meta_items
-      - ceph_mempool_ec_extent_cache_bytes
-      - ceph_mempool_ec_extent_cache_items
-      - ceph_mempool_mds_co_bytes
-      - ceph_mempool_mds_co_items
-      - ceph_mempool_osd_bytes
-      - ceph_mempool_osd_items
-      - ceph_mempool_osd_mapbl_bytes
-      - ceph_mempool_osd_mapbl_items
-      - ceph_mempool_osd_pglog_bytes
-      - ceph_mempool_osd_pglog_items
-      - ceph_mempool_osdmap_bytes
-      - ceph_mempool_osdmap_items
-      - ceph_mempool_osdmap_mapping_bytes
-      - ceph_mempool_osdmap_mapping_items
-      - ceph_mempool_pgmap_bytes
-      - ceph_mempool_pgmap_items
-      - ceph_mempool_unittest_1_bytes
-      - ceph_mempool_unittest_1_items
-      - ceph_mempool_unittest_2_bytes
-      - ceph_mempool_unittest_2_items
-      charts:
-      - title: Memory Use
-        context: memory_use
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mempool_bloom_filter_bytes
-          name: bloom_filter
-        - selector: ceph_mempool_bluestore_alloc_bytes
-          name: bluestore_alloc
-        - selector: ceph_mempool_bluestore_cache_data_bytes
-          name: bluestore_cache_data
-        - selector: ceph_mempool_bluestore_cache_onode_bytes
-          name: bluestore_cache_onode
-        - selector: ceph_mempool_bluestore_cache_meta_bytes
-          name: bluestore_cache_meta
-        - selector: ceph_mempool_bluestore_cache_other_bytes
-          name: bluestore_cache_other
-        - selector: ceph_mempool_bluestore_cache_buffer_bytes
-          name: bluestore_cache_buffer
-        - selector: ceph_mempool_bluestore_extent_bytes
-          name: bluestore_extent
-        - selector: ceph_mempool_bluestore_blob_bytes
-          name: bluestore_blob
-        - selector: ceph_mempool_bluestore_shared_blob_bytes
-          name: bluestore_shared_blob
-        - selector: ceph_mempool_bluestore_inline_bl_bytes
-          name: bluestore_inline_bl
-        - selector: ceph_mempool_bluestore_fsck_bytes
-          name: bluestore_fsck
-        - selector: ceph_mempool_bluestore_txc_bytes
-          name: bluestore_txc
-        - selector: ceph_mempool_bluestore_writing_deferred_bytes
-          name: bluestore_writing_deferred
-        - selector: ceph_mempool_bluestore_writing_bytes
-          name: bluestore_writing
-        - selector: ceph_mempool_bluefs_bytes
-          name: bluefs
-        - selector: ceph_mempool_bluefs_file_reader_bytes
-          name: bluefs_file_reader
-        - selector: ceph_mempool_bluefs_file_writer_bytes
-          name: bluefs_file_writer
-        - selector: ceph_mempool_buffer_anon_bytes
-          name: buffer_anon
-        - selector: ceph_mempool_buffer_meta_bytes
-          name: buffer_meta
-        - selector: ceph_mempool_osd_bytes
-          name: osd
-        - selector: ceph_mempool_osd_mapbl_bytes
-          name: osd_mapbl
-        - selector: ceph_mempool_osd_pglog_bytes
-          name: osd_pglog
-        - selector: ceph_mempool_osdmap_bytes
-          name: osdmap
-        - selector: ceph_mempool_osdmap_mapping_bytes
-          name: osdmap_mapping
-        - selector: ceph_mempool_pgmap_bytes
-          name: pgmap
-        - selector: ceph_mempool_mds_co_bytes
-          name: mds_co
-        - selector: ceph_mempool_unittest_1_bytes
-          name: unittest_1
-        - selector: ceph_mempool_unittest_2_bytes
-          name: unittest_2
-        - selector: ceph_mempool_ec_extent_cache_bytes
-          name: ec_extent_cache
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Item Count
-        context: item_count
-        units: items
-        label_promotion: []
-        dimensions:
-        - selector: ceph_mempool_bloom_filter_items
-          name: bloom_filter
-        - selector: ceph_mempool_bluestore_alloc_items
-          name: bluestore_alloc
-        - selector: ceph_mempool_bluestore_cache_data_items
-          name: bluestore_cache_data
-        - selector: ceph_mempool_bluestore_cache_onode_items
-          name: bluestore_cache_onode
-        - selector: ceph_mempool_bluestore_cache_meta_items
-          name: bluestore_cache_meta
-        - selector: ceph_mempool_bluestore_cache_other_items
-          name: bluestore_cache_other
-        - selector: ceph_mempool_bluestore_cache_buffer_items
-          name: bluestore_cache_buffer
-        - selector: ceph_mempool_bluestore_extent_items
-          name: bluestore_extent
-        - selector: ceph_mempool_bluestore_blob_items
-          name: bluestore_blob
-        - selector: ceph_mempool_bluestore_shared_blob_items
-          name: bluestore_shared_blob
-        - selector: ceph_mempool_bluestore_inline_bl_items
-          name: bluestore_inline_bl
-        - selector: ceph_mempool_bluestore_fsck_items
-          name: bluestore_fsck
-        - selector: ceph_mempool_bluestore_txc_items
-          name: bluestore_txc
-        - selector: ceph_mempool_bluestore_writing_deferred_items
-          name: bluestore_writing_deferred
-        - selector: ceph_mempool_bluestore_writing_items
-          name: bluestore_writing
-        - selector: ceph_mempool_bluefs_items
-          name: bluefs
-        - selector: ceph_mempool_bluefs_file_reader_items
-          name: bluefs_file_reader
-        - selector: ceph_mempool_bluefs_file_writer_items
-          name: bluefs_file_writer
-        - selector: ceph_mempool_buffer_anon_items
-          name: buffer_anon
-        - selector: ceph_mempool_buffer_meta_items
-          name: buffer_meta
-        - selector: ceph_mempool_osd_items
-          name: osd
-        - selector: ceph_mempool_osd_mapbl_items
-          name: osd_mapbl
-        - selector: ceph_mempool_osd_pglog_items
-          name: osd_pglog
-        - selector: ceph_mempool_osdmap_items
-          name: osdmap
-        - selector: ceph_mempool_osdmap_mapping_items
-          name: osdmap_mapping
-        - selector: ceph_mempool_pgmap_items
-          name: pgmap
-        - selector: ceph_mempool_mds_co_items
-          name: mds_co
-        - selector: ceph_mempool_unittest_1_items
-          name: unittest_1
-        - selector: ceph_mempool_unittest_2_items
-          name: unittest_2
-        - selector: ceph_mempool_ec_extent_cache_items
-          name: ec_extent_cache
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: CephFS Mirror
-    context_namespace: cephfs_mirror
-    groups:
-    - family: Service
-      context_namespace: service
-      metrics:
-      - ceph_cephfs_mirror_mirror_enable_failures
-      - ceph_cephfs_mirror_mirrored_filesystems
-      charts:
-      - title: Mirrored Filesystems
-        context: filesystems
-        units: filesystems
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_mirrored_filesystems
-          name: mirrored
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Mirroring Enable Failures
-        context: enable_failures
-        units: failures/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_mirror_enable_failures
-          name: failures
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-    - family: Filesystems
-      context_namespace: filesystems
-      metrics:
-      - ceph_cephfs_mirror_mirrored_filesystems_directory_count
-      - ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
-      charts:
-      - title: Mirroring Peers
-        context: peers
-        units: peers
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
-          name: peers
-        instances:
-          by_labels:
-          - ceph_daemon
-          - filesystem
-          optional_by_labels: []
-      - title: Mirrored Directories
-        context: directories
-        units: directories
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_mirrored_filesystems_directory_count
-          name: directories
-        instances:
-          by_labels:
-          - ceph_daemon
-          - filesystem
-          optional_by_labels: []
-    - family: Peers
-      context_namespace: peers
-      metrics:
-      - ceph_cephfs_mirror_peers_avg_sync_time_count
-      - ceph_cephfs_mirror_peers_avg_sync_time_sum
-      - ceph_cephfs_mirror_peers_last_synced_bytes
-      - ceph_cephfs_mirror_peers_last_synced_duration
-      - ceph_cephfs_mirror_peers_last_synced_end
-      - ceph_cephfs_mirror_peers_last_synced_start
-      - ceph_cephfs_mirror_peers_snaps_deleted
-      - ceph_cephfs_mirror_peers_snaps_renamed
-      - ceph_cephfs_mirror_peers_snaps_synced
-      - ceph_cephfs_mirror_peers_sync_bytes
-      - ceph_cephfs_mirror_peers_sync_failures
-      charts:
-      - title: Snapshot Outcomes
-        context: snapshot_outcomes
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_snaps_synced
-          name: synced
-        - selector: ceph_cephfs_mirror_peers_snaps_deleted
-          name: deleted
-        - selector: ceph_cephfs_mirror_peers_snaps_renamed
-          name: renamed
-        - selector: ceph_cephfs_mirror_peers_sync_failures
-          name: failed
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Sync-Time Measurements
-        context: sync_time_measurements
-        units: snapshots/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_avg_sync_time_count
-          name: snapshots
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Accumulated Sync Time
-        context: accumulated_sync_time
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_avg_sync_time_sum
-          name: time
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-        algorithm: incremental
-      - title: Sync Throughput
-        context: sync_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_sync_bytes
-          name: bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Last Sync Timestamps
-        context: last_sync_timestamps
-        units: seconds since epoch
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_last_synced_start
-          name: started
-        - selector: ceph_cephfs_mirror_peers_last_synced_end
-          name: ended
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Last Sync Duration
-        context: last_sync_duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_last_synced_duration
-          name: duration
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-      - title: Last Sync Size
-        context: last_sync_size
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_cephfs_mirror_peers_last_synced_bytes
-          name: bytes
-        instances:
-          by_labels:
-          - ceph_daemon
-          - peer_cluster_filesystem
-          - peer_cluster_name
-          - source_filesystem
-          - source_fscid
-          optional_by_labels: []
-        algorithm: absolute
-  - family: Object Gateway Scheduling
-    context_namespace: object_gateway_scheduling
-    metrics:
-    - ceph_dmclock_admin_cancel
-    - ceph_dmclock_admin_cancel_cost
-    - ceph_dmclock_admin_cost
-    - ceph_dmclock_admin_limit
-    - ceph_dmclock_admin_limit_cost
-    - ceph_dmclock_admin_prio
-    - ceph_dmclock_admin_prio_cost
-    - ceph_dmclock_admin_prio_latency_count
-    - ceph_dmclock_admin_prio_latency_sum
-    - ceph_dmclock_admin_qlen
-    - ceph_dmclock_admin_res
-    - ceph_dmclock_admin_res_cost
-    - ceph_dmclock_admin_res_latency_count
-    - ceph_dmclock_admin_res_latency_sum
-    - ceph_dmclock_auth_cancel
-    - ceph_dmclock_auth_cancel_cost
-    - ceph_dmclock_auth_cost
-    - ceph_dmclock_auth_limit
-    - ceph_dmclock_auth_limit_cost
-    - ceph_dmclock_auth_prio
-    - ceph_dmclock_auth_prio_cost
-    - ceph_dmclock_auth_prio_latency_count
-    - ceph_dmclock_auth_prio_latency_sum
-    - ceph_dmclock_auth_qlen
-    - ceph_dmclock_auth_res
-    - ceph_dmclock_auth_res_cost
-    - ceph_dmclock_auth_res_latency_count
-    - ceph_dmclock_auth_res_latency_sum
-    - ceph_dmclock_data_cancel
-    - ceph_dmclock_data_cancel_cost
-    - ceph_dmclock_data_cost
-    - ceph_dmclock_data_limit
-    - ceph_dmclock_data_limit_cost
-    - ceph_dmclock_data_prio
-    - ceph_dmclock_data_prio_cost
-    - ceph_dmclock_data_prio_latency_count
-    - ceph_dmclock_data_prio_latency_sum
-    - ceph_dmclock_data_qlen
-    - ceph_dmclock_data_res
-    - ceph_dmclock_data_res_cost
-    - ceph_dmclock_data_res_latency_count
-    - ceph_dmclock_data_res_latency_sum
-    - ceph_dmclock_metadata_cancel
-    - ceph_dmclock_metadata_cancel_cost
-    - ceph_dmclock_metadata_cost
-    - ceph_dmclock_metadata_limit
-    - ceph_dmclock_metadata_limit_cost
-    - ceph_dmclock_metadata_prio
-    - ceph_dmclock_metadata_prio_cost
-    - ceph_dmclock_metadata_prio_latency_count
-    - ceph_dmclock_metadata_prio_latency_sum
-    - ceph_dmclock_metadata_qlen
-    - ceph_dmclock_metadata_res
-    - ceph_dmclock_metadata_res_cost
-    - ceph_dmclock_metadata_res_latency_count
-    - ceph_dmclock_metadata_res_latency_sum
-    - ceph_dmclock_scheduler_outstanding
-    - ceph_dmclock_scheduler_throttle
-    charts:
-    - title: Queue Depth
-      context: queue_depth
-      units: requests
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_qlen
-        name: admin
-      - selector: ceph_dmclock_auth_qlen
-        name: auth
-      - selector: ceph_dmclock_data_qlen
-        name: data
-      - selector: ceph_dmclock_metadata_qlen
-        name: metadata
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Queued Request Cost
-      context: queue_cost
-      units: cost
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_cost
-        name: admin
-      - selector: ceph_dmclock_auth_cost
-        name: auth
-      - selector: ceph_dmclock_data_cost
-        name: data
-      - selector: ceph_dmclock_metadata_cost
-        name: metadata
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Scheduled Requests
-      context: scheduled_requests
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_res
-        name: admin_reservation
-      - selector: ceph_dmclock_admin_prio
-        name: admin_priority
-      - selector: ceph_dmclock_auth_res
-        name: auth_reservation
-      - selector: ceph_dmclock_auth_prio
-        name: auth_priority
-      - selector: ceph_dmclock_data_res
-        name: data_reservation
-      - selector: ceph_dmclock_data_prio
-        name: data_priority
-      - selector: ceph_dmclock_metadata_res
-        name: metadata_reservation
-      - selector: ceph_dmclock_metadata_prio
-        name: metadata_priority
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Rejected and Cancelled Requests
-      context: rejected_and_cancelled_requests
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_limit
-        name: admin_limited
-      - selector: ceph_dmclock_admin_cancel
-        name: admin_cancelled
-      - selector: ceph_dmclock_auth_limit
-        name: auth_limited
-      - selector: ceph_dmclock_auth_cancel
-        name: auth_cancelled
-      - selector: ceph_dmclock_data_limit
-        name: data_limited
-      - selector: ceph_dmclock_data_cancel
-        name: data_cancelled
-      - selector: ceph_dmclock_metadata_limit
-        name: metadata_limited
-      - selector: ceph_dmclock_metadata_cancel
-        name: metadata_cancelled
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Scheduled and Rejected Cost
-      context: scheduled_and_rejected_cost
-      units: cost/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_res_cost
-        name: admin_reservation
-      - selector: ceph_dmclock_admin_prio_cost
-        name: admin_priority
-      - selector: ceph_dmclock_admin_limit_cost
-        name: admin_limited
-      - selector: ceph_dmclock_admin_cancel_cost
-        name: admin_cancelled
-      - selector: ceph_dmclock_auth_res_cost
-        name: auth_reservation
-      - selector: ceph_dmclock_auth_prio_cost
-        name: auth_priority
-      - selector: ceph_dmclock_auth_limit_cost
-        name: auth_limited
-      - selector: ceph_dmclock_auth_cancel_cost
-        name: auth_cancelled
-      - selector: ceph_dmclock_data_res_cost
-        name: data_reservation
-      - selector: ceph_dmclock_data_prio_cost
-        name: data_priority
-      - selector: ceph_dmclock_data_limit_cost
-        name: data_limited
-      - selector: ceph_dmclock_data_cancel_cost
-        name: data_cancelled
-      - selector: ceph_dmclock_metadata_res_cost
-        name: metadata_reservation
-      - selector: ceph_dmclock_metadata_prio_cost
-        name: metadata_priority
-      - selector: ceph_dmclock_metadata_limit_cost
-        name: metadata_limited
-      - selector: ceph_dmclock_metadata_cancel_cost
-        name: metadata_cancelled
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Scheduling-Latency Measurements
-      context: latency_measurements
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_res_latency_count
-        name: admin_reservation
-      - selector: ceph_dmclock_admin_prio_latency_count
-        name: admin_priority
-      - selector: ceph_dmclock_auth_res_latency_count
-        name: auth_reservation
-      - selector: ceph_dmclock_auth_prio_latency_count
-        name: auth_priority
-      - selector: ceph_dmclock_data_res_latency_count
-        name: data_reservation
-      - selector: ceph_dmclock_data_prio_latency_count
-        name: data_priority
-      - selector: ceph_dmclock_metadata_res_latency_count
-        name: metadata_reservation
-      - selector: ceph_dmclock_metadata_prio_latency_count
-        name: metadata_priority
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-    - title: Accumulated Scheduling Latency
-      context: accumulated_latency
-      units: seconds/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_admin_res_latency_sum
-        name: admin_reservation
-      - selector: ceph_dmclock_admin_prio_latency_sum
-        name: admin_priority
-      - selector: ceph_dmclock_auth_res_latency_sum
-        name: auth_reservation
-      - selector: ceph_dmclock_auth_prio_latency_sum
-        name: auth_priority
-      - selector: ceph_dmclock_data_res_latency_sum
-        name: data_reservation
-      - selector: ceph_dmclock_data_prio_latency_sum
-        name: data_priority
-      - selector: ceph_dmclock_metadata_res_latency_sum
-        name: metadata_reservation
-      - selector: ceph_dmclock_metadata_prio_latency_sum
-        name: metadata_priority
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Throttled Requests
-      context: throttled_requests
-      units: requests/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_scheduler_throttle
-        name: throttled
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-    - title: Outstanding Requests
-      context: outstanding_requests
-      units: requests
-      label_promotion: []
-      dimensions:
-      - selector: ceph_dmclock_scheduler_outstanding
-        name: outstanding
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-  - family: Storage Engine Extensions
-    context_namespace: storage_engine_extensions
-    groups:
-    - family: RocksDB Binned Cache
-      context_namespace: rocksdb_binned_cache
-      metrics:
-      - ceph_rocksdb_binned_cache_capacity
-      - ceph_rocksdb_binned_cache_elems
-      - ceph_rocksdb_binned_cache_hits
-      - ceph_rocksdb_binned_cache_inserts
-      - ceph_rocksdb_binned_cache_lookups
-      - ceph_rocksdb_binned_cache_misses
-      - ceph_rocksdb_binned_cache_pinned
-      - ceph_rocksdb_binned_cache_usage
-      charts:
-      - title: Cache Memory
-        context: memory
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_capacity
-          name: capacity
-        - selector: ceph_rocksdb_binned_cache_usage
-          name: used
-        - selector: ceph_rocksdb_binned_cache_pinned
-          name: pinned
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-      - title: Cache Entries
-        context: entries
-        units: entries
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_elems
-          name: items
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-      - title: Cache Insertions
-        context: insertions
-        units: insertions/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_inserts
-          name: insertions
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-        algorithm: incremental
-      - title: Cache Lookups
-        context: lookups
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_lookups
-          name: lookups
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-        algorithm: incremental
-      - title: Cache Lookup Outcomes
-        context: lookup_outcomes
-        units: lookups/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_rocksdb_binned_cache_hits
-          name: hits
-        - selector: ceph_rocksdb_binned_cache_misses
-          name: misses
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels:
-          - rocksdb_cache_key
-        algorithm: incremental
-    - family: External Block Devices
-      context_namespace: external_block_devices
-      metrics:
-      - ceph_extblkdev_dev_log_size
-      - ceph_extblkdev_dev_log_util
-      - ceph_extblkdev_dev_phy_size
-      - ceph_extblkdev_dev_phy_util
-      - ceph_extblkdev_fcm
-      - ceph_extblkdev_part_log_avail
-      - ceph_extblkdev_part_log_size
-      - ceph_extblkdev_part_phy_avail
-      - ceph_extblkdev_part_phy_size
-      charts:
-      - title: FCM Plugin State
-        context: plugin_state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_extblkdev_fcm
-          name: fcm
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Device Size
-        context: device_size
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_extblkdev_dev_phy_size
-          name: physical
-        - selector: ceph_extblkdev_dev_log_size
-          name: logical
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Device Utilization
-        context: device_utilization
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_extblkdev_dev_phy_util
-          name: physical
-        - selector: ceph_extblkdev_dev_log_util
-          name: logical
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-      - title: Partition Space
-        context: partition_space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_extblkdev_part_phy_size
-          name: physical_size
-        - selector: ceph_extblkdev_part_log_size
-          name: logical_size
-        - selector: ceph_extblkdev_part_phy_avail
-          name: physical_available
-        - selector: ceph_extblkdev_part_log_avail
-          name: logical_available
-        instances:
-          by_labels:
-          - ceph_daemon
-          optional_by_labels: []
-  - family: Ceph Clients
-    context_namespace: ceph_clients
-    metrics:
-    - ceph_client_mdops
-    - ceph_client_rdops
-    - ceph_client_wrops
-    charts:
-    - title: Client I/O Operations
-      context: io_operations
-      units: operations/s
-      label_promotion: []
-      dimensions:
-      - selector: ceph_client_mdops
-        name: metadata
-      - selector: ceph_client_rdops
-        name: read
-      - selector: ceph_client_wrops
-        name: write
-      instances:
-        by_labels:
-        - ceph_daemon
-        optional_by_labels: []
-      algorithm: incremental
-  - family: NVMe-oF
-    context_namespace: nvme_of
-    groups:
-    - family: Block Devices
-      context_namespace: block_devices
-      metrics:
-      - ceph_nvmeof_bdev_capacity_bytes
-      - ceph_nvmeof_bdev_metadata
-      - ceph_nvmeof_bdev_read_bytes_total
-      - ceph_nvmeof_bdev_read_seconds_total
-      - ceph_nvmeof_bdev_reads_completed_total
-      - ceph_nvmeof_bdev_write_seconds_total
-      - ceph_nvmeof_bdev_writes_completed_total
-      - ceph_nvmeof_bdev_written_bytes_total
-      charts:
-      - title: Byte Throughput
-        context: byte_throughput
-        units: bytes/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_read_bytes_total
-          name: read_bytes
-        - selector: ceph_nvmeof_bdev_written_bytes_total
-          name: written_bytes
-        instances:
-          by_labels:
-          - bdev_name
-          optional_by_labels: []
-      - title: Operations
-        context: operations
-        units: operations/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_reads_completed_total
-          name: reads_completed
-        - selector: ceph_nvmeof_bdev_writes_completed_total
-          name: writes_completed
-        instances:
-          by_labels:
-          - bdev_name
-          optional_by_labels: []
-      - title: Space and Memory
-        context: space
-        units: bytes
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_capacity_bytes
-          name: value
-        instances:
-          by_labels:
-          - bdev_name
-          optional_by_labels: []
-      - title: State and Metadata
-        context: state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_metadata
-          name: value
-        instances:
-          by_labels:
-          - bdev_name
-          - block_size
-          - namespace
-          - pool_name
-          - rbd_name
-          optional_by_labels: []
-      - title: Accumulated Time
-        context: time_accumulation
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_bdev_read_seconds_total
-          name: read_seconds
-        - selector: ceph_nvmeof_bdev_write_seconds_total
-          name: write_seconds
-        instances:
-          by_labels:
-          - bdev_name
-          optional_by_labels: []
-    - family: Gateways
-      context_namespace: gateways
-      metrics:
-      - ceph_nvmeof_reactor_seconds_total
-      - ceph_nvmeof_rpc_method_seconds
-      - ceph_nvmeof_subsystem_namespace_count
-      charts:
-      - title: Collection Duration
-        context: duration
-        units: seconds
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_rpc_method_seconds
-          name: value
-        instances:
-          by_labels:
-          - method
-          optional_by_labels: []
-      - title: Accumulated Time
-        context: time_accumulation
-        units: seconds/s
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_reactor_seconds_total
-          name_from_label: mode
-        instances:
-          by_labels:
-          - name
-          optional_by_labels: []
-      - title: Namespace Count
-        context: namespace_count
-        units: namespaces
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_namespace_count
-          name: namespace_count
-        aggregation: sum
-    - family: Hosts
-      context_namespace: hosts
-      metrics:
-      - ceph_nvmeof_host_connection_state
-      - ceph_nvmeof_host_keepalive_timeout
-      charts:
-      - title: Host Connection State
-        context: connection_state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_host_connection_state
-          name: value
-        instances:
-          by_labels:
-          - gw_name
-          - host_addr
-          - host_nqn
-          - nqn
-          optional_by_labels: []
-      - title: Keepalive Timeout State
-        context: keepalive_timeout_state
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_host_keepalive_timeout
-          name: value
-        instances:
-          by_labels:
-          - gw_name
-          - host_nqn
-          - nqn
-          optional_by_labels: []
-    - family: Subsystems
-      context_namespace: subsystems
-      metrics:
-      - ceph_nvmeof_subsystem_host_count
-      - ceph_nvmeof_subsystem_listener_count
-      - ceph_nvmeof_subsystem_listener_iface_speed_bytes
-      - ceph_nvmeof_subsystem_metadata
-      - ceph_nvmeof_subsystem_namespace_count
-      - ceph_nvmeof_subsystem_namespace_limit
-      - ceph_nvmeof_subsystem_namespace_metadata
-      charts:
-      - title: Configured Hosts
-        context: host_state
-        units: hosts
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_host_count
-          name: value
-        instances:
-          by_labels:
-          - nqn
-          optional_by_labels: []
-      - title: Listener Interface Link Speed
-        context: link_speed
-        units: Mbps
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_listener_iface_speed_bytes
-          name: value
-        instances:
-          by_labels:
-          - device
-          optional_by_labels: []
-      - title: Listener Addresses
-        context: listener_state
-        units: listeners
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_listener_count
-          name: value
-        instances:
-          by_labels:
-          - nqn
-          optional_by_labels: []
-      - title: Namespaces
-        context: namespace_count
-        units: namespaces
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_namespace_count
-          name: nvmeof_subsystem_namespace_count
-        instances:
-          by_labels:
-          - nqn
-          optional_by_labels: []
-      - title: Namespace Capacity
-        context: namespace_capacity
-        units: namespaces
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_namespace_count
-          name: count
-        - selector: ceph_nvmeof_subsystem_namespace_limit
-          name: limit
-        instances:
-          by_labels:
-          - nqn
-          optional_by_labels: []
-      - title: State and Metadata — Metadata
-        context: state_metadata
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_metadata
-          name: metadata
-        instances:
-          by_labels:
-          - allow_any_host
-          - group
-          - ha_enabled
-          - model_number
-          - nqn
-          - serial_number
-          optional_by_labels: []
-      - title: State and Metadata — Namespace Metadata
-        context: state_namespace_metadata
-        units: '{status}'
-        label_promotion: []
-        dimensions:
-        - selector: ceph_nvmeof_subsystem_namespace_metadata
-          name: namespace_metadata
-        instances:
-          by_labels:
-          - anagrpid
-          - bdev_name
-          - nqn
-          - nsid
-          - rados_namespace_name
-          optional_by_labels: []
+        - title: Client I/O Operations
+          context: io_operations
+          units: operations/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_client_mdops
+              name: metadata
+            - selector: ceph_client_rdops
+              name: read
+            - selector: ceph_client_wrops
+              name: write
+          instances:
+            by_labels:
+              - ceph_daemon
+            optional_by_labels: []
+          algorithm: incremental
+    - family: NVMe-oF
+      context_namespace: nvme_of
+      groups:
+        - family: Block Devices
+          context_namespace: block_devices
+          metrics:
+            - ceph_nvmeof_bdev_capacity_bytes
+            - ceph_nvmeof_bdev_metadata
+            - ceph_nvmeof_bdev_read_bytes_total
+            - ceph_nvmeof_bdev_read_seconds_total
+            - ceph_nvmeof_bdev_reads_completed_total
+            - ceph_nvmeof_bdev_write_seconds_total
+            - ceph_nvmeof_bdev_writes_completed_total
+            - ceph_nvmeof_bdev_written_bytes_total
+          charts:
+            - title: Byte Throughput
+              context: byte_throughput
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_read_bytes_total
+                  name: read_bytes
+                - selector: ceph_nvmeof_bdev_written_bytes_total
+                  name: written_bytes
+              instances:
+                by_labels:
+                  - bdev_name
+                optional_by_labels: []
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_reads_completed_total
+                  name: reads_completed
+                - selector: ceph_nvmeof_bdev_writes_completed_total
+                  name: writes_completed
+              instances:
+                by_labels:
+                  - bdev_name
+                optional_by_labels: []
+            - title: Space and Memory
+              context: space
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_capacity_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - bdev_name
+                optional_by_labels: []
+            - title: State and Metadata
+              context: state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_metadata
+                  name: value
+              instances:
+                by_labels:
+                  - bdev_name
+                  - block_size
+                  - namespace
+                  - pool_name
+                  - rbd_name
+                optional_by_labels: []
+            - title: Accumulated Time
+              context: time_accumulation
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_bdev_read_seconds_total
+                  name: read_seconds
+                - selector: ceph_nvmeof_bdev_write_seconds_total
+                  name: write_seconds
+              instances:
+                by_labels:
+                  - bdev_name
+                optional_by_labels: []
+        - family: Gateways
+          context_namespace: gateways
+          metrics:
+            - ceph_nvmeof_reactor_seconds_total
+            - ceph_nvmeof_rpc_method_seconds
+            - ceph_nvmeof_subsystem_namespace_count
+          charts:
+            - title: Collection Duration
+              context: duration
+              units: seconds
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_rpc_method_seconds
+                  name: value
+              instances:
+                by_labels:
+                  - method
+                optional_by_labels: []
+            - title: Accumulated Time
+              context: time_accumulation
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_reactor_seconds_total
+                  name_from_label: mode
+              instances:
+                by_labels:
+                  - name
+                optional_by_labels: []
+            - title: Namespace Count
+              context: namespace_count
+              units: namespaces
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_namespace_count
+                  name: namespace_count
+              aggregation: sum
+        - family: Hosts
+          context_namespace: hosts
+          metrics:
+            - ceph_nvmeof_host_connection_state
+            - ceph_nvmeof_host_keepalive_timeout
+          charts:
+            - title: Host Connection State
+              context: connection_state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_host_connection_state
+                  name: value
+              instances:
+                by_labels:
+                  - gw_name
+                  - host_addr
+                  - host_nqn
+                  - nqn
+                optional_by_labels: []
+            - title: Keepalive Timeout State
+              context: keepalive_timeout_state
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_host_keepalive_timeout
+                  name: value
+              instances:
+                by_labels:
+                  - gw_name
+                  - host_nqn
+                  - nqn
+                optional_by_labels: []
+        - family: Subsystems
+          context_namespace: subsystems
+          metrics:
+            - ceph_nvmeof_subsystem_host_count
+            - ceph_nvmeof_subsystem_listener_count
+            - ceph_nvmeof_subsystem_listener_iface_speed_bytes
+            - ceph_nvmeof_subsystem_metadata
+            - ceph_nvmeof_subsystem_namespace_count
+            - ceph_nvmeof_subsystem_namespace_limit
+            - ceph_nvmeof_subsystem_namespace_metadata
+          charts:
+            - title: Configured Hosts
+              context: host_state
+              units: hosts
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_host_count
+                  name: value
+              instances:
+                by_labels:
+                  - nqn
+                optional_by_labels: []
+            - title: Listener Interface Link Speed
+              context: link_speed
+              units: Mbps
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_listener_iface_speed_bytes
+                  name: value
+              instances:
+                by_labels:
+                  - device
+                optional_by_labels: []
+            - title: Listener Addresses
+              context: listener_state
+              units: listeners
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_listener_count
+                  name: value
+              instances:
+                by_labels:
+                  - nqn
+                optional_by_labels: []
+            - title: Namespaces
+              context: namespace_count
+              units: namespaces
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_namespace_count
+                  name: nvmeof_subsystem_namespace_count
+              instances:
+                by_labels:
+                  - nqn
+                optional_by_labels: []
+            - title: Namespace Capacity
+              context: namespace_capacity
+              units: namespaces
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_namespace_count
+                  name: count
+                - selector: ceph_nvmeof_subsystem_namespace_limit
+                  name: limit
+              instances:
+                by_labels:
+                  - nqn
+                optional_by_labels: []
+            - title: State and Metadata — Metadata
+              context: state_metadata
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_metadata
+                  name: metadata
+              instances:
+                by_labels:
+                  - allow_any_host
+                  - group
+                  - ha_enabled
+                  - model_number
+                  - nqn
+                  - serial_number
+                optional_by_labels: []
+            - title: State and Metadata — Namespace Metadata
+              context: state_namespace_metadata
+              units: '{status}'
+              label_promotion: []
+              dimensions:
+                - selector: ceph_nvmeof_subsystem_namespace_metadata
+                  name: namespace_metadata
+              instances:
+                by_labels:
+                  - anagrpid
+                  - bdev_name
+                  - nqn
+                  - nsid
+                  - rados_namespace_name
+                optional_by_labels: []

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -6728,7 +6728,7 @@ template:
               instances:
                 by_labels:
                   - instance_id
-                optional_by_labels:
+                optional_by_labels: []
             - title: Object Bytes
               context: object_bytes
               units: bytes/s
@@ -6745,7 +6745,7 @@ template:
               instances:
                 by_labels:
                   - instance_id
-                optional_by_labels:
+                optional_by_labels: []
             - title: Latency Measurements
               context: latency_measurements
               units: operations/s
@@ -6768,7 +6768,7 @@ template:
               instances:
                 by_labels:
                   - instance_id
-                optional_by_labels:
+                optional_by_labels: []
             - title: Accumulated Latency
               context: accumulated_latency
               units: seconds/s
@@ -6791,7 +6791,7 @@ template:
               instances:
                 by_labels:
                   - instance_id
-                optional_by_labels:
+                optional_by_labels: []
               algorithm: incremental
         - family: User Operations
           context_namespace: user_operations

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -36,6 +36,42 @@ relabeling:
         replacement: ceph_instance
       - regex: instance
         action: labeldrop
+  - match: ceph_rgw_topic_*_persistent_topic_len
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_rgw_topic_(.+?)_persistent_topic_len
+        target_label: topic
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_rgw_topic_(.+?)_persistent_topic_len
+        target_label: __name__
+        replacement: ceph_rgw_topic_persistent_topic_len
+  - match: ceph_rgw_topic_*_persistent_topic_size
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_rgw_topic_(.+?)_persistent_topic_size
+        target_label: topic
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_rgw_topic_(.+?)_persistent_topic_size
+        target_label: __name__
+        replacement: ceph_rgw_topic_persistent_topic_size
+  - match: ceph_rgw_sync_delta_*_sync_delta
+    metric_relabel_configs:
+      - source_labels:
+          - __name__
+        regex: ceph_rgw_sync_delta_(.+?)_sync_delta
+        target_label: sync_shard
+        replacement: ${1}
+      - source_labels:
+          - __name__
+        regex: ceph_rgw_sync_delta_(.+?)_sync_delta
+        target_label: __name__
+        replacement: ceph_rgw_sync_delta_sync_delta
   - match: '!ceph_data_sync_from_zone_* ceph_data_sync_from_*'
     metric_relabel_configs:
       - source_labels:
@@ -398,12 +434,12 @@ template:
             by_labels:
               - ceph_daemon
               - ceph_instance
-              - db_device
               - device
               - device_ids
               - devices
+            optional_by_labels:
+              - db_device
               - wal_device
-            optional_by_labels: []
         - title: State and Metadata — Human
           context: state_human
           units: '{status}'
@@ -1414,13 +1450,13 @@ template:
                   name: value
               instances:
                 by_labels:
-                  - application
                   - compression_mode
                   - description
                   - name
                   - pool_id
                   - type
-                optional_by_labels: []
+                optional_by_labels:
+                  - application
         - family: Objects
           context_namespace: objects
           metrics:
@@ -4925,10 +4961,10 @@ template:
               name: worker_msgr_connection_ready_timeouts
           instances:
             by_labels:
-              - ceph_daemon
               - id
+            optional_by_labels:
+              - ceph_daemon
               - instance_id
-            optional_by_labels: []
         - title: Active Queue Pairs
           context: active_queue_pairs
           units: queue pairs
@@ -6641,6 +6677,370 @@ template:
     - family: Object Gateway
       context_namespace: object_gateway
       groups:
+        - family: Global Operations
+          context_namespace: global_operations
+          metrics:
+            - ceph_rgw_op_copy_obj_bytes
+            - ceph_rgw_op_copy_obj_lat_count
+            - ceph_rgw_op_copy_obj_lat_sum
+            - ceph_rgw_op_copy_obj_ops
+            - ceph_rgw_op_del_bucket_lat_count
+            - ceph_rgw_op_del_bucket_lat_sum
+            - ceph_rgw_op_del_bucket_ops
+            - ceph_rgw_op_del_obj_bytes
+            - ceph_rgw_op_del_obj_lat_count
+            - ceph_rgw_op_del_obj_lat_sum
+            - ceph_rgw_op_del_obj_ops
+            - ceph_rgw_op_get_obj_bytes
+            - ceph_rgw_op_get_obj_lat_count
+            - ceph_rgw_op_get_obj_lat_sum
+            - ceph_rgw_op_get_obj_ops
+            - ceph_rgw_op_list_buckets_lat_count
+            - ceph_rgw_op_list_buckets_lat_sum
+            - ceph_rgw_op_list_buckets_ops
+            - ceph_rgw_op_list_obj_lat_count
+            - ceph_rgw_op_list_obj_lat_sum
+            - ceph_rgw_op_list_obj_ops
+            - ceph_rgw_op_put_obj_bytes
+            - ceph_rgw_op_put_obj_lat_count
+            - ceph_rgw_op_put_obj_lat_sum
+            - ceph_rgw_op_put_obj_ops
+          charts:
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_copy_obj_ops
+                  name: copy_obj
+                - selector: ceph_rgw_op_del_bucket_ops
+                  name: del_bucket
+                - selector: ceph_rgw_op_del_obj_ops
+                  name: del_obj
+                - selector: ceph_rgw_op_get_obj_ops
+                  name: get_obj
+                - selector: ceph_rgw_op_list_buckets_ops
+                  name: list_buckets
+                - selector: ceph_rgw_op_list_obj_ops
+                  name: list_obj
+                - selector: ceph_rgw_op_put_obj_ops
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels:
+            - title: Object Bytes
+              context: object_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_copy_obj_bytes
+                  name: copy_obj
+                - selector: ceph_rgw_op_del_obj_bytes
+                  name: del_obj
+                - selector: ceph_rgw_op_get_obj_bytes
+                  name: get_obj
+                - selector: ceph_rgw_op_put_obj_bytes
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels:
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_copy_obj_lat_count
+                  name: copy_obj
+                - selector: ceph_rgw_op_del_bucket_lat_count
+                  name: del_bucket
+                - selector: ceph_rgw_op_del_obj_lat_count
+                  name: del_obj
+                - selector: ceph_rgw_op_get_obj_lat_count
+                  name: get_obj
+                - selector: ceph_rgw_op_list_buckets_lat_count
+                  name: list_buckets
+                - selector: ceph_rgw_op_list_obj_lat_count
+                  name: list_obj
+                - selector: ceph_rgw_op_put_obj_lat_count
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels:
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_copy_obj_lat_sum
+                  name: copy_obj
+                - selector: ceph_rgw_op_del_bucket_lat_sum
+                  name: del_bucket
+                - selector: ceph_rgw_op_del_obj_lat_sum
+                  name: del_obj
+                - selector: ceph_rgw_op_get_obj_lat_sum
+                  name: get_obj
+                - selector: ceph_rgw_op_list_buckets_lat_sum
+                  name: list_buckets
+                - selector: ceph_rgw_op_list_obj_lat_sum
+                  name: list_obj
+                - selector: ceph_rgw_op_put_obj_lat_sum
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels:
+              algorithm: incremental
+        - family: User Operations
+          context_namespace: user_operations
+          metrics:
+            - ceph_rgw_op_per_user_copy_obj_bytes
+            - ceph_rgw_op_per_user_copy_obj_lat_count
+            - ceph_rgw_op_per_user_copy_obj_lat_sum
+            - ceph_rgw_op_per_user_copy_obj_ops
+            - ceph_rgw_op_per_user_del_bucket_lat_count
+            - ceph_rgw_op_per_user_del_bucket_lat_sum
+            - ceph_rgw_op_per_user_del_bucket_ops
+            - ceph_rgw_op_per_user_del_obj_bytes
+            - ceph_rgw_op_per_user_del_obj_lat_count
+            - ceph_rgw_op_per_user_del_obj_lat_sum
+            - ceph_rgw_op_per_user_del_obj_ops
+            - ceph_rgw_op_per_user_get_obj_bytes
+            - ceph_rgw_op_per_user_get_obj_lat_count
+            - ceph_rgw_op_per_user_get_obj_lat_sum
+            - ceph_rgw_op_per_user_get_obj_ops
+            - ceph_rgw_op_per_user_list_buckets_lat_count
+            - ceph_rgw_op_per_user_list_buckets_lat_sum
+            - ceph_rgw_op_per_user_list_buckets_ops
+            - ceph_rgw_op_per_user_list_obj_lat_count
+            - ceph_rgw_op_per_user_list_obj_lat_sum
+            - ceph_rgw_op_per_user_list_obj_ops
+            - ceph_rgw_op_per_user_put_obj_bytes
+            - ceph_rgw_op_per_user_put_obj_lat_count
+            - ceph_rgw_op_per_user_put_obj_lat_sum
+            - ceph_rgw_op_per_user_put_obj_ops
+          charts:
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_per_user_copy_obj_ops
+                  name: copy_obj
+                - selector: ceph_rgw_op_per_user_del_bucket_ops
+                  name: del_bucket
+                - selector: ceph_rgw_op_per_user_del_obj_ops
+                  name: del_obj
+                - selector: ceph_rgw_op_per_user_get_obj_ops
+                  name: get_obj
+                - selector: ceph_rgw_op_per_user_list_buckets_ops
+                  name: list_buckets
+                - selector: ceph_rgw_op_per_user_list_obj_ops
+                  name: list_obj
+                - selector: ceph_rgw_op_per_user_put_obj_ops
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                  - user
+                optional_by_labels:
+                  - tenant
+            - title: Object Bytes
+              context: object_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_per_user_copy_obj_bytes
+                  name: copy_obj
+                - selector: ceph_rgw_op_per_user_del_obj_bytes
+                  name: del_obj
+                - selector: ceph_rgw_op_per_user_get_obj_bytes
+                  name: get_obj
+                - selector: ceph_rgw_op_per_user_put_obj_bytes
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                  - user
+                optional_by_labels:
+                  - tenant
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_per_user_copy_obj_lat_count
+                  name: copy_obj
+                - selector: ceph_rgw_op_per_user_del_bucket_lat_count
+                  name: del_bucket
+                - selector: ceph_rgw_op_per_user_del_obj_lat_count
+                  name: del_obj
+                - selector: ceph_rgw_op_per_user_get_obj_lat_count
+                  name: get_obj
+                - selector: ceph_rgw_op_per_user_list_buckets_lat_count
+                  name: list_buckets
+                - selector: ceph_rgw_op_per_user_list_obj_lat_count
+                  name: list_obj
+                - selector: ceph_rgw_op_per_user_put_obj_lat_count
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                  - user
+                optional_by_labels:
+                  - tenant
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_per_user_copy_obj_lat_sum
+                  name: copy_obj
+                - selector: ceph_rgw_op_per_user_del_bucket_lat_sum
+                  name: del_bucket
+                - selector: ceph_rgw_op_per_user_del_obj_lat_sum
+                  name: del_obj
+                - selector: ceph_rgw_op_per_user_get_obj_lat_sum
+                  name: get_obj
+                - selector: ceph_rgw_op_per_user_list_buckets_lat_sum
+                  name: list_buckets
+                - selector: ceph_rgw_op_per_user_list_obj_lat_sum
+                  name: list_obj
+                - selector: ceph_rgw_op_per_user_put_obj_lat_sum
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                  - user
+                optional_by_labels:
+                  - tenant
+              algorithm: incremental
+        - family: Bucket Operations
+          context_namespace: bucket_operations
+          metrics:
+            - ceph_rgw_op_per_bucket_copy_obj_bytes
+            - ceph_rgw_op_per_bucket_copy_obj_lat_count
+            - ceph_rgw_op_per_bucket_copy_obj_lat_sum
+            - ceph_rgw_op_per_bucket_copy_obj_ops
+            - ceph_rgw_op_per_bucket_del_bucket_lat_count
+            - ceph_rgw_op_per_bucket_del_bucket_lat_sum
+            - ceph_rgw_op_per_bucket_del_bucket_ops
+            - ceph_rgw_op_per_bucket_del_obj_bytes
+            - ceph_rgw_op_per_bucket_del_obj_lat_count
+            - ceph_rgw_op_per_bucket_del_obj_lat_sum
+            - ceph_rgw_op_per_bucket_del_obj_ops
+            - ceph_rgw_op_per_bucket_get_obj_bytes
+            - ceph_rgw_op_per_bucket_get_obj_lat_count
+            - ceph_rgw_op_per_bucket_get_obj_lat_sum
+            - ceph_rgw_op_per_bucket_get_obj_ops
+            - ceph_rgw_op_per_bucket_list_buckets_lat_count
+            - ceph_rgw_op_per_bucket_list_buckets_lat_sum
+            - ceph_rgw_op_per_bucket_list_buckets_ops
+            - ceph_rgw_op_per_bucket_list_obj_lat_count
+            - ceph_rgw_op_per_bucket_list_obj_lat_sum
+            - ceph_rgw_op_per_bucket_list_obj_ops
+            - ceph_rgw_op_per_bucket_put_obj_bytes
+            - ceph_rgw_op_per_bucket_put_obj_lat_count
+            - ceph_rgw_op_per_bucket_put_obj_lat_sum
+            - ceph_rgw_op_per_bucket_put_obj_ops
+          charts:
+            - title: Operations
+              context: operations
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_per_bucket_copy_obj_ops
+                  name: copy_obj
+                - selector: ceph_rgw_op_per_bucket_del_bucket_ops
+                  name: del_bucket
+                - selector: ceph_rgw_op_per_bucket_del_obj_ops
+                  name: del_obj
+                - selector: ceph_rgw_op_per_bucket_get_obj_ops
+                  name: get_obj
+                - selector: ceph_rgw_op_per_bucket_list_buckets_ops
+                  name: list_buckets
+                - selector: ceph_rgw_op_per_bucket_list_obj_ops
+                  name: list_obj
+                - selector: ceph_rgw_op_per_bucket_put_obj_ops
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                  - bucket
+                optional_by_labels:
+                  - tenant
+            - title: Object Bytes
+              context: object_bytes
+              units: bytes/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_per_bucket_copy_obj_bytes
+                  name: copy_obj
+                - selector: ceph_rgw_op_per_bucket_del_obj_bytes
+                  name: del_obj
+                - selector: ceph_rgw_op_per_bucket_get_obj_bytes
+                  name: get_obj
+                - selector: ceph_rgw_op_per_bucket_put_obj_bytes
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                  - bucket
+                optional_by_labels:
+                  - tenant
+            - title: Latency Measurements
+              context: latency_measurements
+              units: operations/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_per_bucket_copy_obj_lat_count
+                  name: copy_obj
+                - selector: ceph_rgw_op_per_bucket_del_bucket_lat_count
+                  name: del_bucket
+                - selector: ceph_rgw_op_per_bucket_del_obj_lat_count
+                  name: del_obj
+                - selector: ceph_rgw_op_per_bucket_get_obj_lat_count
+                  name: get_obj
+                - selector: ceph_rgw_op_per_bucket_list_buckets_lat_count
+                  name: list_buckets
+                - selector: ceph_rgw_op_per_bucket_list_obj_lat_count
+                  name: list_obj
+                - selector: ceph_rgw_op_per_bucket_put_obj_lat_count
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                  - bucket
+                optional_by_labels:
+                  - tenant
+            - title: Accumulated Latency
+              context: accumulated_latency
+              units: seconds/s
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_op_per_bucket_copy_obj_lat_sum
+                  name: copy_obj
+                - selector: ceph_rgw_op_per_bucket_del_bucket_lat_sum
+                  name: del_bucket
+                - selector: ceph_rgw_op_per_bucket_del_obj_lat_sum
+                  name: del_obj
+                - selector: ceph_rgw_op_per_bucket_get_obj_lat_sum
+                  name: get_obj
+                - selector: ceph_rgw_op_per_bucket_list_buckets_lat_sum
+                  name: list_buckets
+                - selector: ceph_rgw_op_per_bucket_list_obj_lat_sum
+                  name: list_obj
+                - selector: ceph_rgw_op_per_bucket_put_obj_lat_sum
+                  name: put_obj
+              instances:
+                by_labels:
+                  - instance_id
+                  - bucket
+                optional_by_labels:
+                  - tenant
+              algorithm: incremental
         - family: Lifecycle
           context_namespace: lifecycle
           metrics:
@@ -6788,6 +7188,36 @@ template:
                 by_labels:
                   - instance_id
                 optional_by_labels: []
+        - family: Persistent Topics
+          context_namespace: persistent_topics
+          metrics:
+            - ceph_rgw_topic_persistent_topic_len
+            - ceph_rgw_topic_persistent_topic_size
+          charts:
+            - title: Persistent Topic Queue Length
+              context: queue_length
+              units: entries
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_topic_persistent_topic_len
+                  name: entries
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels:
+                  - topic
+            - title: Persistent Topic Queue Size
+              context: queue_size
+              units: bytes
+              label_promotion: []
+              dimensions:
+                - selector: ceph_rgw_topic_persistent_topic_size
+                  name: bytes
+              instances:
+                by_labels:
+                  - instance_id
+                optional_by_labels:
+                  - topic
         - family: Requests and Queue
           context_namespace: requests_and_queue
           metrics:
@@ -6898,6 +7328,9 @@ template:
     - family: Object Gateway/Cache
       context_namespace: object_gateway_cache
       metrics:
+        - ceph_rgw_d4n_cache_evictions
+        - ceph_rgw_d4n_cache_hits
+        - ceph_rgw_d4n_cache_misses
         - ceph_rgw_cache_hit
         - ceph_rgw_cache_miss
         - ceph_rgw_keystone_token_cache_hit
@@ -6912,6 +7345,30 @@ template:
               name: hit
             - selector: ceph_rgw_keystone_token_cache_miss
               name: miss
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels: []
+        - title: D4N Cache Lookup Outcomes
+          context: d4n_lookup_outcomes
+          units: lookups/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_d4n_cache_hits
+              name: hit
+            - selector: ceph_rgw_d4n_cache_misses
+              name: miss
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels: []
+        - title: D4N Cache Evictions
+          context: d4n_cache_evictions
+          units: evictions/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_d4n_cache_evictions
+              name: eviction
           instances:
             by_labels:
               - instance_id
@@ -6932,6 +7389,7 @@ template:
     - family: Object Gateway/Multisite
       context_namespace: object_gateway_multisite
       metrics:
+        - ceph_rgw_sync_delta_sync_delta
         - ceph_data_sync_from_zone_fetch_bytes_count
         - ceph_data_sync_from_zone_fetch_bytes_sum
         - ceph_data_sync_from_zone_fetch_errors
@@ -6954,6 +7412,21 @@ template:
               - instance_id
             optional_by_labels:
               - source_zone
+        - title: Data Log Shard Delay
+          context: data_log_shard_delay
+          units: seconds
+          label_promotion: []
+          dimensions:
+            - selector: ceph_rgw_sync_delta_sync_delta
+              name: sync_delta
+          instances:
+            by_labels:
+              - instance_id
+              - local_zone_id
+              - source_zone_id
+              - shard_id
+            optional_by_labels:
+              - sync_shard
         - title: Accumulated Byte Measurement
           context: accumulated_bytes
           units: bytes/s
@@ -10659,6 +11132,8 @@ template:
     - family: Object Gateway/Scheduling
       context_namespace: object_gateway_scheduling
       metrics:
+        - ceph_simple_throttler_outstanding
+        - ceph_simple_throttler_throttle
         - ceph_dmclock_admin_cancel
         - ceph_dmclock_admin_cancel_cost
         - ceph_dmclock_admin_cost
@@ -10735,6 +11210,29 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
+        - title: Simple Throttler Outstanding Requests
+          context: simple_throttler_outstanding
+          units: requests
+          label_promotion: []
+          dimensions:
+            - selector: ceph_simple_throttler_outstanding
+              name: outstanding
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels: []
+        - title: Simple Throttler Rejections
+          context: simple_throttler_rejections
+          units: requests/s
+          label_promotion: []
+          dimensions:
+            - selector: ceph_simple_throttler_throttle
+              name: throttled
+          instances:
+            by_labels:
+              - instance_id
+            optional_by_labels: []
+          algorithm: incremental
         - title: Queued Request Cost
           context: queue_cost
           units: cost

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -1366,7 +1366,7 @@ template:
                 by_labels:
                   - pool_id
                 optional_by_labels: []
-        - family: Client I/O
+        - family: Client IO
           context_namespace: client_i_o
           metrics:
             - ceph_pool_rd
@@ -1519,7 +1519,7 @@ template:
     - family: RBD Images
       context_namespace: rbd_images
       groups:
-        - family: I/O
+        - family: IO
           context_namespace: i_o
           metrics:
             - ceph_rbd_read_bytes
@@ -1796,7 +1796,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-        - family: I/O and Files
+        - family: IO and Files
           context_namespace: i_o_and_files
           metrics:
             - ceph_bluefs_flush_lat_count
@@ -2204,7 +2204,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-        - family: I/O
+        - family: IO
           context_namespace: i_o
           metrics:
             - ceph_bluestore_issued_deferred_write_bytes
@@ -5082,7 +5082,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: OSD Client I/O
+    - family: OSD Client IO
       context_namespace: osd_client_i_o
       metrics:
         - ceph_osd_op

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -507,6 +507,16 @@ template:
       - ceph_mon_metadata
       - ceph_mon_quorum_status
       charts:
+      - title: Cluster Summary
+        context: cluster_summary
+        units: monitors
+        label_promotion: []
+        dimensions:
+        - selector: ceph_mon_metadata
+          name: total
+        - selector: ceph_mon_quorum_status
+          name: in_quorum
+        aggregation: sum
       - title: State and Metadata — Metadata
         context: state_metadata
         units: '{status}'
@@ -907,10 +917,21 @@ template:
     - family: OSD State
       context_namespace: osd_state
       metrics:
+      - ceph_osd_metadata
       - ceph_osd_in
       - ceph_osd_up
       - ceph_osd_weight
       charts:
+      - title: Cluster Summary
+        context: cluster_summary
+        units: OSDs
+        label_promotion: []
+        dimensions:
+        - selector: ceph_osd_metadata
+          name: total
+        - selector: ceph_osd_up
+          name: up
+        aggregation: sum
       - title: OSD State
         context: state
         units: '{status}'

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -306,7 +306,7 @@ template:
                 by_labels:
                   - device_class
                 optional_by_labels: []
-    - family: CephFS Metadata
+    - family: CephFS/Metadata
       context_namespace: cephfs_metadata
       groups:
         - family: Filesystem Metadata
@@ -829,7 +829,7 @@ template:
               dimensions:
                 - selector: ceph_healthcheck_slow_ops
                   name: value
-    - family: OSD Capacity and State
+    - family: OSDs/Capacity and State
       context_namespace: osd_capacity_and_state
       groups:
         - family: Cluster Flags
@@ -943,7 +943,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-    - family: Node Hardware
+    - family: Hardware
       context_namespace: node_hardware
       groups:
         - family: Processors
@@ -1058,7 +1058,7 @@ template:
                   - hostname
                   - sensor_name
                 optional_by_labels: []
-    - family: OSD Overview
+    - family: OSDs/Overview
       context_namespace: osd_overview
       metrics:
         - ceph_osd_apply_latency_ms
@@ -1077,7 +1077,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: Object Gateway Metadata
+    - family: Object Gateway/Metadata
       context_namespace: object_gateway_metadata
       metrics:
         - ceph_rgw_metadata
@@ -1096,7 +1096,7 @@ template:
               - hostname
               - instance_id
             optional_by_labels: []
-    - family: Placement Groups and Recovery
+    - family: Placement Groups
       context_namespace: placement_groups_and_recovery
       groups:
         - family: Backfill
@@ -1632,7 +1632,7 @@ template:
                   - id
                   - instance_id
                 optional_by_labels: []
-    - family: SMB Metadata
+    - family: CephFS/SMB/Metadata
       context_namespace: smb_metadata
       metrics:
         - ceph_smb_metadata
@@ -3158,7 +3158,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-    - family: CephFS MDS
+    - family: CephFS/MDS
       context_namespace: cephfs_mds
       groups:
         - family: Attribute and Layout Mutation Latency
@@ -4385,7 +4385,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
               algorithm: incremental
-    - family: CephFS MDS Memory
+    - family: CephFS/MDS/Memory
       context_namespace: cephfs_mds_memory
       metrics:
         - ceph_mds_mem_cap
@@ -4512,7 +4512,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: CephFS MDS Sessions
+    - family: CephFS/MDS/Sessions
       context_namespace: cephfs_mds_sessions
       metrics:
         - ceph_mds_sessions_average_load
@@ -4598,7 +4598,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: CephFS MDS Clients
+    - family: CephFS/MDS/Clients
       context_namespace: cephfs_mds_clients
       metrics:
         - ceph_mds_per_client_avg_metadata_latency
@@ -4747,7 +4747,7 @@ template:
             optional_by_labels:
               - mds_filesystem_key
           algorithm: incremental
-    - family: Exporter and Process Runtime
+    - family: Exporter and Process
       context_namespace: exporter_and_process_runtime
       groups:
         - family: Collection
@@ -4854,7 +4854,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-    - family: Manager Daemons
+    - family: Managers/Daemons
       context_namespace: manager_daemons
       metrics:
         - ceph_mgr_cache_hit
@@ -5027,7 +5027,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: Monitor Daemons
+    - family: Monitors/Daemons
       context_namespace: monitor_daemons
       metrics:
         - ceph_mon_election_call
@@ -5082,7 +5082,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: OSD Client IO
+    - family: OSDs/Client IO
       context_namespace: osd_client_i_o
       metrics:
         - ceph_osd_op
@@ -5357,7 +5357,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: OSD Recovery
+    - family: OSDs/Recovery
       context_namespace: osd_recovery
       metrics:
         - ceph_osd_l_osd_recovery_backfill_queue_latency_count
@@ -5492,7 +5492,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: OSD Runtime
+    - family: OSDs/Runtime
       context_namespace: osd_runtime
       metrics:
         - ceph_osd_agent_evict
@@ -5907,7 +5907,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: OSD Scrubbing - Ceph 19
+    - family: OSDs/Scrubbing/Ceph 19
       context_namespace: osd_scrubbing_ceph_19
       groups:
         - family: Elapsed Time
@@ -6204,7 +6204,7 @@ template:
                   - level
                   - pooltype
                 optional_by_labels: []
-    - family: OSD Scrubbing - Ceph 20
+    - family: OSDs/Scrubbing/Ceph 20
       context_namespace: osd_scrubbing_ceph_20
       groups:
         - family: Elapsed Time
@@ -6466,7 +6466,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-    - family: OSD Scrubbing - Common Work
+    - family: OSDs/Scrubbing/Common Work
       context_namespace: osd_scrubbing_common_work
       groups:
         - family: Interference and Scheduling
@@ -6895,7 +6895,7 @@ template:
                 by_labels:
                   - instance_id
                 optional_by_labels: []
-    - family: Object Gateway Cache
+    - family: Object Gateway/Cache
       context_namespace: object_gateway_cache
       metrics:
         - ceph_rgw_cache_hit
@@ -6929,7 +6929,7 @@ template:
             by_labels:
               - instance_id
             optional_by_labels: []
-    - family: Object Gateway Multisite
+    - family: Object Gateway/Multisite
       context_namespace: object_gateway_multisite
       metrics:
         - ceph_data_sync_from_zone_fetch_bytes_count
@@ -7022,7 +7022,7 @@ template:
               - instance_id
             optional_by_labels:
               - source_zone
-    - family: Objecter
+    - family: Runtime and Clients/Objecter
       context_namespace: objecter
       metrics:
         - ceph_objecter_command_active
@@ -7469,7 +7469,7 @@ template:
               - ceph_daemon
               - instance_id
           aggregation: sum
-    - family: RBD Client Images
+    - family: RBD Images/Client Images
       context_namespace: rbd_client_images
       metrics:
         - ceph_rbd_librbd_image_cmp
@@ -7728,7 +7728,7 @@ template:
               - ceph_daemon
             optional_by_labels:
               - librbd_image_key
-    - family: RBD Mirror
+    - family: RBD Images/Mirror
       context_namespace: rbd_mirror
       groups:
         - family: Journal
@@ -9064,7 +9064,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
               algorithm: incremental
-    - family: Runtime and Client Components
+    - family: Runtime and Clients
       context_namespace: runtime_and_client_components
       groups:
         - family: RBD Persistent Write Log
@@ -10465,7 +10465,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-    - family: CephFS Mirror
+    - family: CephFS/Mirror
       context_namespace: cephfs_mirror
       groups:
         - family: Service
@@ -10656,7 +10656,7 @@ template:
                   - source_fscid
                 optional_by_labels: []
               algorithm: absolute
-    - family: Object Gateway Scheduling
+    - family: Object Gateway/Scheduling
       context_namespace: object_gateway_scheduling
       metrics:
         - ceph_dmclock_admin_cancel
@@ -10917,7 +10917,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: Storage Engine Extensions
+    - family: Storage Engine/Extensions
       context_namespace: storage_engine_extensions
       groups:
         - family: RocksDB Binned Cache
@@ -11068,7 +11068,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-    - family: Ceph Clients
+    - family: Clients
       context_namespace: ceph_clients
       metrics:
         - ceph_client_mdops

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -11144,7 +11144,6 @@ template:
         instances:
           by_labels:
           - bdev_name
-          - ceph_instance
           optional_by_labels: []
       - title: Space and Memory
         context: space
@@ -11168,7 +11167,6 @@ template:
           by_labels:
           - bdev_name
           - block_size
-          - ceph_instance
           - namespace
           - pool_name
           - rbd_name
@@ -11185,13 +11183,13 @@ template:
         instances:
           by_labels:
           - bdev_name
-          - ceph_instance
           optional_by_labels: []
     - family: Gateways
       context_namespace: gateways
       metrics:
       - ceph_nvmeof_reactor_seconds_total
       - ceph_nvmeof_rpc_method_seconds
+      - ceph_nvmeof_subsystem_namespace_count
       charts:
       - title: Collection Duration
         context: duration
@@ -11210,13 +11208,19 @@ template:
         label_promotion: []
         dimensions:
         - selector: ceph_nvmeof_reactor_seconds_total
-          name: value
+          name_from_label: mode
         instances:
           by_labels:
-          - ceph_instance
-          - mode
           - name
           optional_by_labels: []
+      - title: Namespace Count
+        context: namespace_count
+        units: namespaces
+        label_promotion: []
+        dimensions:
+        - selector: ceph_nvmeof_subsystem_namespace_count
+          name: namespace_count
+        aggregation: sum
     - family: Hosts
       context_namespace: hosts
       metrics:
@@ -11246,7 +11250,6 @@ template:
           name: value
         instances:
           by_labels:
-          - ceph_instance
           - gw_name
           - host_nqn
           - nqn
@@ -11293,7 +11296,6 @@ template:
           name: value
         instances:
           by_labels:
-          - ceph_instance
           - nqn
           optional_by_labels: []
       - title: Namespaces
@@ -11305,14 +11307,15 @@ template:
           name: nvmeof_subsystem_namespace_count
         instances:
           by_labels:
-          - ceph_instance
           - nqn
           optional_by_labels: []
-      - title: Namespace Limit
-        context: namespace_limit
+      - title: Namespace Capacity
+        context: namespace_capacity
         units: namespaces
         label_promotion: []
         dimensions:
+        - selector: ceph_nvmeof_subsystem_namespace_count
+          name: count
         - selector: ceph_nvmeof_subsystem_namespace_limit
           name: limit
         instances:
@@ -11329,7 +11332,6 @@ template:
         instances:
           by_labels:
           - allow_any_host
-          - ceph_instance
           - group
           - ha_enabled
           - model_number
@@ -11347,7 +11349,6 @@ template:
           by_labels:
           - anagrpid
           - bdev_name
-          - ceph_instance
           - nqn
           - nsid
           - rados_namespace_name

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -28,6 +28,19 @@ fallback_type:
   - ceph_rbd_mirror_metadata
   - ceph_rgw_metadata
   - ceph_smb_metadata
+autogen:
+  selector:
+    deny:
+    - ceph_hardware_cpu_cores
+    - ceph_hardware_fan_rpm
+    - ceph_hardware_health
+    - ceph_hardware_memory_capacity_bytes
+    - ceph_hardware_storage_capacity_bytes
+    - ceph_hardware_temperature_celsius
+    - ceph_recoverystate_perf_pg_rebuild_duration_count
+    - ceph_recoverystate_perf_pg_rebuild_duration_sum
+    - ceph_recoverystate_perf_pg_rebuild_max_secs
+    - ceph_recoverystate_perf_pg_rebuild_min_secs
 relabeling:
 - match: ceph_*
   metric_relabel_configs:
@@ -778,9 +791,9 @@ template:
       metrics:
       - ceph_daemon_health_metrics
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
+      - title: Health Metric Count
+        context: item_count
+        units: items
         label_promotion: []
         dimensions:
         - selector: ceph_daemon_health_metrics
@@ -798,23 +811,23 @@ template:
       - title: State and Metadata
         context: state
         units: '{status}'
-        label_promotion: []
+        label_promotion:
+        - severity
         dimensions:
         - selector: ceph_health_detail
           name: value
         instances:
           by_labels:
           - name
-          - severity
           optional_by_labels: []
     - family: Slow Operations
       context_namespace: slow_operations
       metrics:
       - ceph_healthcheck_slow_ops
       charts:
-      - title: State and Metadata
-        context: state
-        units: '{status}'
+      - title: Slow Operations
+        context: current_operations
+        units: operations
         label_promotion: []
         dimensions:
         - selector: ceph_healthcheck_slow_ops

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -483,6 +483,227 @@ component: Ceph
     info: Every available sample in the 1-minute observation window reports a recognized processor temperature sensor above 80°C.
       to: silent
 
+ template: ceph_osd_all_up
+       on: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($total == nan or $total == inf or $up == nan or $up == inf or $total <= 0 or $up < 0 or $up > $total) ? (nan) : ($up == $total)
+    units: status
+    every: 10s
+    warn: $this == 999999999
+ summary: Internal Ceph OSD all-up state
+    info: Internal helper holding the current all-configured-OSDs-up state; it does not notify.
+      to: silent
+
+ template: ceph_object_missing
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OBJECT_UNFOUND
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($value == nan or $value == inf or $value == 0 or $ceph_osd_all_up == nan or $ceph_osd_all_up == inf) ? (nan) : ($ceph_osd_all_up == 1)
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph objects are unfound while every configured OSD is up
+    info: The current unfound condition is active while every configured OSD is up; client I/O for affected objects can block.
+      to: sysadmin
+
+ template: ceph_pg_backfill_at_risk
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=PG_BACKFILL_FULL
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph backfill is blocked by fullness
+    info: Every available sample in the 1-minute observation window reports placement-group backfill blocked by fullness.
+      to: sysadmin
+
+ template: ceph_pg_not_deep_scrubbed
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=PG_NOT_DEEP_SCRUBBED
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph placement groups are overdue for deep scrub
+    info: Every available sample in the 5-minute observation window reports placement groups overdue for deep scrub.
+      to: silent
+
+ template: ceph_pg_not_scrubbed
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=PG_NOT_SCRUBBED
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph placement groups are overdue for scrub
+    info: Every available sample in the 5-minute observation window reports placement groups overdue for scrub.
+      to: silent
+
+ template: ceph_pg_recovery_at_risk
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=PG_RECOVERY_FULL
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph recovery is blocked by fullness
+    info: Every available sample in the 1-minute observation window reports recovery blocked by OSD fullness.
+      to: sysadmin
+
+ template: ceph_osd_down_current
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_DOWN
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: $value
+    units: status
+    every: 10s
+    warn: $this == 999999999
+ summary: Internal Ceph OSD-down state
+    info: Internal helper holding the current OSD-down health state; it does not notify.
+      to: silent
+
+ template: ceph_pg_unavailable_blocking_io
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=PG_AVAILABILITY
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($value == nan or $value == inf or $ceph_osd_down_current == nan or $ceph_osd_down_current == inf) ? (nan) : ($value == 1 and $ceph_osd_down_current != 1)
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph placement groups are blocking I/O
+    info: The current PG-unavailable condition is active while the separate OSD-down condition is not.
+      to: sysadmin
+
+ template: ceph_pgs_damaged
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=PG_DAMAGED
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph placement-group data is damaged
+    info: Every available sample in the 5-minute observation window reports damaged placement-group data.
+      to: sysadmin
+
+ template: ceph_osd_scrub_errors
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_SCRUB_ERRORS !PG_DAMAGED *
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph scrub reports placement-group data errors
+    info: Every available sample in the 5-minute observation window reports scrub errors when PG-damage is not already active.
+      to: silent
+
+ template: ceph_pgs_high_per_osd
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=TOO_MANY_PGS
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: Ceph placement-group density is too high
+    info: Every available sample in the 1-minute observation window reports excessive placement groups per OSD.
+      to: silent
+
+ template: ceph_pgs_inactive
+       on: prometheus.ceph.placement_groups_and_recovery.healthy_state.pg_state
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($pg_total == nan or $pg_total == inf or $active == nan or $active == inf or $pg_total < 0 or $active < 0 or $active > $pg_total) ? (nan) : ($pg_total - $active)
+    units: PGs
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph placement groups are inactive in this pool
+    info: The current per-pool count reports fewer active placement groups than the pool total.
+      to: sysadmin
+
+ template: ceph_pgs_unclean
+       on: prometheus.ceph.placement_groups_and_recovery.healthy_state.pg_state
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($pg_total == nan or $pg_total == inf or $clean == nan or $clean == inf or $pg_total < 0 or $clean < 0 or $clean > $pg_total) ? (nan) : ($pg_total - $clean)
+    units: PGs
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph placement groups are unclean in this pool
+    info: The current per-pool count reports fewer clean placement groups than the pool total.
+      to: silent
+
+ template: ceph_pool_backfill_full
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=POOL_BACKFILLFULL
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -10s unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph pool is too full for backfill
+    info: Every available sample in the 10-second observation window reports a pool at its backfill-full threshold.
+      to: sysadmin
+
+ template: ceph_pool_full
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=POOL_FULL
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph pool is full and writes are blocked
+    info: Every available sample in the 1-minute observation window reports a full pool.
+      to: sysadmin
+
+ template: ceph_pool_near_full
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=POOL_NEAR_FULL
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph pool is near full
+    info: Every available sample in the 5-minute observation window reports a near-full pool.
+      to: silent
+
  template: ceph_mon_clock_skew
        on: prometheus.ceph.health.health_checks.state
 chart labels: name=MON_CLOCK_SKEW
@@ -755,5 +976,5 @@ component: Ceph
     crit: $this > (($status == $CRITICAL) ? (90) : (98))
    delay: down 5m multiplier 1.2 max 1h
  summary: Ceph cluster ${label:fsid} disk space utilization
-    info: Ceph cluster ${label:fsid} disk space utilization
-      to: sysadmin
+    info: Ceph cluster ${label:fsid} disk space utilization. This stock capacity policy is silent by default; explicitly route it when notifications are required.
+      to: silent

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -19,8 +19,8 @@ component: Ceph
     units: status
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
- summary: Ceph cluster is in the error state
-    info: Every available Ceph MGR health sample in the 5-minute observation window is HEALTH_ERR. Use `ceph health detail` for the current cause.
+ summary: Ceph cluster remains in the error state
+    info: Every available Ceph MGR health sample in the 5-minute observation window is HEALTH_ERR. Review active cause-specific Ceph alerts and use `ceph health detail` for the current cause.
       to: sysadmin
 
  template: ceph_health_warning
@@ -185,8 +185,8 @@ component: Ceph
     units: status
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
- summary: A Ceph hardware cooling component is degraded
-    info: Every available sample in the 1-minute observation window reports warning health for a reported fan component.
+ summary: Ceph cooling component ${label:component} on host ${label:hostname} is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect fan health, airflow, and the system event log.
       to: sysadmin
 
  template: ceph_cooling_failed
@@ -199,8 +199,8 @@ component: Ceph
     units: status
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
- summary: A Ceph hardware cooling component has failed
-    info: Every available sample in the 1-minute observation window reports error health for a reported fan component.
+ summary: Ceph cooling component ${label:component} on host ${label:hostname} has failed
+    info: Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect fan health, airflow, and the system event log.
       to: sysadmin
 
  template: ceph_dimm_temperature_high
@@ -311,8 +311,8 @@ component: Ceph
     units: status
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
- summary: A Ceph hardware memory module is degraded
-    info: Every available sample in the 1-minute observation window reports warning health for a reported memory component.
+ summary: Ceph memory module ${label:component} on host ${label:hostname} is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect DIMM health and memory errors.
       to: sysadmin
 
  template: ceph_memory_failed
@@ -325,8 +325,8 @@ component: Ceph
     units: status
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
- summary: A Ceph hardware memory module has failed
-    info: Every available sample in the 1-minute observation window reports error health for a reported memory component.
+ summary: Ceph memory module ${label:component} on host ${label:hostname} has failed
+    info: Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect DIMM health and memory errors.
       to: sysadmin
 
  template: ceph_motherboard_temperature_high
@@ -353,8 +353,8 @@ component: Ceph
     units: status
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
- summary: A Ceph hardware NVMe drive is degraded
-    info: Every available sample in the 1-minute observation window reports warning health for a reported storage component.
+ summary: Ceph storage component ${label:component} on host ${label:hostname} is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect drive health and kernel logs.
       to: sysadmin
 
  template: ceph_nvme_drive_failed
@@ -367,8 +367,8 @@ component: Ceph
     units: status
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
- summary: A Ceph hardware NVMe drive has failed
-    info: Every available sample in the 1-minute observation window reports error health for a reported storage component.
+ summary: Ceph storage component ${label:component} on host ${label:hostname} has failed
+    info: Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect drive health and kernel logs.
       to: sysadmin
 
  template: ceph_nvme_temperature_high
@@ -395,8 +395,8 @@ component: Ceph
     units: status
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
- summary: A Ceph hardware network interface is degraded
-    info: Every available sample in the 1-minute observation window reports warning health for a reported network component.
+ summary: Ceph network component ${label:component} on host ${label:hostname} is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect the interface, link state, and network errors.
       to: sysadmin
 
  template: ceph_network_failed
@@ -409,8 +409,8 @@ component: Ceph
     units: status
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
- summary: A Ceph hardware network interface has failed
-    info: Every available sample in the 1-minute observation window reports error health for a reported network component.
+ summary: Ceph network component ${label:component} on host ${label:hostname} has failed
+    info: Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect the interface, link state, and network errors.
       to: sysadmin
 
  template: ceph_power_supply_degraded
@@ -423,8 +423,8 @@ component: Ceph
     units: status
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
- summary: A Ceph hardware power supply is degraded
-    info: Every available sample in the 1-minute observation window reports warning health for a reported power component.
+ summary: Ceph power component ${label:component} on host ${label:hostname} is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect the host power supply and system event log.
       to: sysadmin
 
  template: ceph_power_supply_failed
@@ -437,8 +437,8 @@ component: Ceph
     units: status
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
- summary: A Ceph hardware power supply has failed
-    info: Every available sample in the 1-minute observation window reports error health for a reported power component.
+ summary: Ceph power component ${label:component} on host ${label:hostname} has failed
+    info: Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect the host power supply and system event log.
       to: sysadmin
 
  template: ceph_processor_degraded
@@ -451,8 +451,8 @@ component: Ceph
     units: status
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
- summary: A Ceph hardware processor is degraded
-    info: Every available sample in the 1-minute observation window reports warning health for a reported processor component.
+ summary: Ceph processor ${label:component} on host ${label:hostname} is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for ${label:component} on ${label:hostname}. Inspect processor health and thermals.
       to: sysadmin
 
  template: ceph_processor_failed
@@ -465,8 +465,8 @@ component: Ceph
     units: status
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
- summary: A Ceph hardware processor has failed
-    info: Every available sample in the 1-minute observation window reports error health for a reported processor component.
+ summary: Ceph processor ${label:component} on host ${label:hostname} has failed
+    info: Every available sample in the 1-minute observation window reports error health for ${label:component} on ${label:hostname}. Inspect processor health and thermals.
       to: sysadmin
 
  template: ceph_processor_temperature_high
@@ -583,8 +583,8 @@ component: Ceph
 
 # Local NVMe-oF exporter alerts.
 #
-# These rules remain inside one exporter endpoint. Gateway-wide means the local
-# exporter `ceph_instance` identity, not a cluster-wide inventory aggregate.
+# These rules remain inside one direct gateway-exporter endpoint collected by one
+# local Prometheus job. Gateway-wide means that local endpoint, not a cluster-wide inventory aggregate.
 # Per-bdev latency is deliberately more local than the exporter-wide average in
 # the source rule. Helpers hold database-window values so consuming current
 # rules can preserve the source persistence intent without duplicating lookups.
@@ -716,8 +716,8 @@ component: Ceph
     units: status
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
- summary: An NVMe-oF host connection was disconnected by keepalive timeout
-    info: The exporter currently reports a host disconnected by keepalive timeout. Exporter refresh reads and clears this one-shot state.
+ summary: NVMe-oF host ${label:host_nqn} disconnected from ${label:nqn} by keepalive timeout
+    info: The gateway exporter currently reports host ${label:host_nqn} disconnected from subsystem ${label:nqn}. Inspect the initiator link and reconnect behavior. Exporter refresh reads and clears this one-shot state.
       to: silent
 
  template: ceph_nvmeof_subsystem_namespace_limit
@@ -768,39 +768,39 @@ component: Ceph
     class: Errors
      type: Storage
 component: Ceph
-   lookup: min -1m unaligned of event_lost
+   lookup: max -1m unaligned of event_lost
     units: events/s
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
  summary: Ceph RGW notification events were lost
-    info: Every available sample in the 1-minute observation window reports a non-zero final notification-event loss rate.
-      to: silent
+    info: One or more final notification-event losses occurred in the 1-minute observation window. Inspect the affected RGW instance and notification endpoint.
+      to: sysadmin
 
  template: rgw_notification_missing_configuration
        on: prometheus.ceph.object_gateway.notifications.missing_configurations
     class: Errors
      type: Storage
 component: Ceph
-   lookup: min -1m unaligned of value
+   lookup: max -1m unaligned of value
     units: events/s
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
  summary: Ceph RGW notifications are missing configuration
-    info: Every available sample in the 1-minute observation window reports a non-zero notification missing-configuration rate.
-      to: silent
+    info: One or more notifications were rejected for missing configuration in the 1-minute observation window. Inspect the affected RGW instance and notification configuration.
+      to: sysadmin
 
  template: rgw_lua_script_failed
        on: prometheus.ceph.object_gateway.lua.script_executions
     class: Errors
      type: Storage
 component: Ceph
-   lookup: min -1m unaligned of failure
+   lookup: max -1m unaligned of failure
     units: executions/s
     every: 10s
     warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
  summary: Ceph RGW Lua scripts are failing
-    info: Every available sample in the 1-minute observation window reports a non-zero Lua script failure rate.
-      to: silent
+    info: One or more configured Lua request scripts failed in the 1-minute observation window. Inspect the affected RGW instance and script error logs.
+      to: sysadmin
 
  template: rgw_failed_request_rate_fallback
        on: prometheus.ceph.object_gateway.requests_and_queue.failed_requests

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -759,6 +759,140 @@ component: Ceph
     info: The current local exporter namespace inventory is at or above the supported maximum of 4096.
       to: silent
 
+# RGW aggregate telemetry. Rates are read over observation windows so a
+# historical cumulative counter does not keep an incident active after recovery.
+# Backlog/queue thresholds are deliberately operator policy and silent.
+
+ template: rgw_notification_event_lost
+       on: prometheus.ceph.object_gateway.notifications.events
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of event_lost
+    units: events/s
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph RGW notification events were lost
+    info: Every available sample in the 1-minute observation window reports a non-zero final notification-event loss rate.
+      to: silent
+
+ template: rgw_notification_missing_configuration
+       on: prometheus.ceph.object_gateway.notifications.missing_configurations
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: events/s
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph RGW notifications are missing configuration
+    info: Every available sample in the 1-minute observation window reports a non-zero notification missing-configuration rate.
+      to: silent
+
+ template: rgw_lua_script_failed
+       on: prometheus.ceph.object_gateway.lua.script_executions
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of failure
+    units: executions/s
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph RGW Lua scripts are failing
+    info: Every available sample in the 1-minute observation window reports a non-zero Lua script failure rate.
+      to: silent
+
+ template: rgw_failed_request_rate_fallback
+       on: prometheus.ceph.object_gateway.requests_and_queue.failed_requests
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: requests/s
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph RGW requests are aborting
+    info: Every available sample in the 5-minute observation window reports a non-zero aborted-request rate. This is a fallback signal and does not identify HTTP 5xx responses.
+      to: silent
+
+ template: rgw_notification_push_or_store_failures
+       on: prometheus.ceph.object_gateway.notifications.failure_outcomes
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of push_failed,store_fail
+    units: events/s
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph RGW notification delivery is failing
+    info: Every available sample in the 5-minute observation window reports non-zero retryable notification push or store failures.
+      to: silent
+
+ template: rgw_notification_inflight_pressure
+       on: prometheus.ceph.object_gateway.notifications.pending_events
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: events
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)
+ summary: Ceph RGW notification in-flight pressure is high
+    info: Every available sample in the 5-minute observation window reports at least 1000 notification events pending endpoint reply. Tune this policy threshold for the endpoint.
+      to: silent
+
+ template: rgw_notification_store_backlog
+       on: prometheus.ceph.object_gateway.notifications.event_state
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: events
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)
+ summary: Ceph RGW notification store backlog is high
+    info: Every available sample in the 5-minute observation window reports at least 1000 events stored in the persistent notification store. Tune this policy threshold for the workload.
+      to: silent
+
+ template: rgw_request_queue_pressure
+       on: prometheus.ceph.object_gateway.requests_and_queue.current_requests
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of qlen
+    units: requests
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this >= 1000)
+ summary: Ceph RGW request queue pressure is high
+    info: Every available sample in the 5-minute observation window reports at least 1000 queued requests. Tune this policy threshold for the RGW instance.
+      to: silent
+
+ template: rgw_multisite_fetch_errors
+       on: prometheus.ceph.object_gateway_multisite.object_work
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of errors
+    units: objects/s
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph RGW multisite fetch errors are occurring
+    info: Every available sample in the 5-minute observation window reports a non-zero multisite data-fetch error rate.
+      to: silent
+
+ template: rgw_multisite_poll_errors
+       on: prometheus.ceph.object_gateway_multisite.replication_log_request_errors
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: requests/s
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph RGW multisite poll errors are occurring
+    info: Every available sample in the 5-minute observation window reports a non-zero replication-log poll error rate.
+      to: silent
+
  template: ceph_rbd_mirror_images_not_in_sync
        on: prometheus.ceph.rbd_mirror.snapshot_replication.timestamp
     class: Errors

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -1009,7 +1009,7 @@ chart labels: name=PG_AVAILABILITY
     class: Errors
      type: Storage
 component: Ceph
-     calc: ($value == nan or $value == inf or $ceph_osd_down_current == nan or $ceph_osd_down_current == inf) ? (nan) : ($value == 1 and $ceph_osd_down_current != 1)
+     calc: ($value == nan or $value == inf) ? (nan) : (($value == 1) ? (($ceph_osd_down_current == nan or $ceph_osd_down_current == inf) ? (nan) : (($ceph_osd_down_current == 1) ? (0) : (1))) : (0))
     units: status
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -612,8 +612,8 @@ component: Ceph
     units: status
     every: 10s
     warn: $this == 999999999
- summary: Internal persistent NVMe-oF gateway reactor busy state
-    info: Internal helper holding the lowest local reactor busy-rate sample observed over ten minutes; it does not notify.
+ summary: Persistent NVMe-oF gateway reactor busy state
+    info: Holds the lowest local reactor busy-rate sample observed over ten minutes for the gateway CPU policy.
       to: silent
 
  template: ceph_nvmeof_gateway_cpu
@@ -638,8 +638,8 @@ component: Ceph
     units: seconds
     every: 10s
     warn: $this == 999999999
- summary: Internal NVMe-oF per-bdev read service time
-    info: Internal helper holding the local one-minute per-block-device read service-time rate; it does not notify.
+ summary: NVMe-oF block-device read service time
+    info: Holds the local one-minute per-block-device read service-time rate.
       to: silent
 
  template: ceph_nvmeof_read_operations_1m
@@ -651,8 +651,8 @@ component: Ceph
     units: operations
     every: 10s
     warn: $this == 999999999
- summary: Internal NVMe-oF per-bdev completed reads
-    info: Internal helper holding the local one-minute per-block-device completed-read rate; it does not notify.
+ summary: NVMe-oF block-device completed reads
+    info: Holds the local one-minute per-block-device completed-read rate.
       to: silent
 
  template: ceph_nvmeof_high_read_latency
@@ -677,8 +677,8 @@ component: Ceph
     units: seconds
     every: 10s
     warn: $this == 999999999
- summary: Internal NVMe-oF per-bdev write service time
-    info: Internal helper holding the local one-minute per-block-device write service-time rate; it does not notify.
+ summary: NVMe-oF block-device write service time
+    info: Holds the local one-minute per-block-device write service-time rate.
       to: silent
 
  template: ceph_nvmeof_write_operations_1m
@@ -690,8 +690,8 @@ component: Ceph
     units: operations
     every: 10s
     warn: $this == 999999999
- summary: Internal NVMe-oF per-bdev completed writes
-    info: Internal helper holding the local one-minute per-block-device completed-write rate; it does not notify.
+ summary: NVMe-oF block-device completed writes
+    info: Holds the local one-minute per-block-device completed-write rate.
       to: silent
 
  template: ceph_nvmeof_high_write_latency
@@ -742,8 +742,8 @@ component: Ceph
     units: namespaces
     every: 10s
     warn: $this == 999999999
- summary: Internal local NVMe-oF gateway namespace count
-    info: Internal helper summing subsystem namespace counts inside the local exporter endpoint; it does not notify.
+ summary: Local NVMe-oF gateway namespace count
+    info: Sums subsystem namespace counts inside the local exporter endpoint.
       to: silent
 
  template: ceph_nvmeof_too_many_namespaces
@@ -915,8 +915,8 @@ component: Ceph
     units: status
     every: 10s
     warn: $this == 999999999
- summary: Internal Ceph OSD all-up state
-    info: Internal helper holding the current all-configured-OSDs-up state; it does not notify.
+ summary: Ceph OSD all-up state
+    info: Holds the current all-configured-OSDs-up state.
       to: silent
 
  template: ceph_object_missing
@@ -999,8 +999,8 @@ component: Ceph
     units: status
     every: 10s
     warn: $this == 999999999
- summary: Internal Ceph OSD-down state
-    info: Internal helper holding the current OSD-down health state; it does not notify.
+ summary: Ceph OSD-down state
+    info: Holds the current OSD-down health state.
       to: silent
 
  template: ceph_pg_unavailable_blocking_io

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -133,6 +133,273 @@ component: Ceph
     info: Every available sample in the 30-second observation window reports a cephadm upgrade exception. Use `ceph health detail` for the failed upgrade step.
       to: sysadmin
 
+ template: ceph_device_failure_predicted
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=DEVICE_HEALTH
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph predicts a storage device failure
+    info: Every available sample in the 1-minute observation window reports a device predicted to fail. Use `ceph health detail` and `ceph device ls` to identify it.
+      to: silent
+
+ template: ceph_device_failure_prediction_too_high
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=DEVICE_HEALTH_TOOMANY
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph predicts too many storage device failures for automatic remediation
+    info: Every available sample in the 1-minute observation window reports that removing all predicted failures would compromise availability. Add capacity before relocating data.
+      to: silent
+
+ template: ceph_device_failure_relocation_incomplete
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=DEVICE_HEALTH_IN_USE
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph cannot complete data relocation from a predicted device failure
+    info: Every available sample in the 1-minute observation window reports blocked relocation from a predicted device failure. Check free capacity and the balancer.
+      to: sysadmin
+
+ template: ceph_mon_clock_skew
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=MON_CLOCK_SKEW
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph monitors have excessive clock skew
+    info: Every available sample in the 1-minute observation window reports monitor clock skew. Use `ceph time-sync-status` and inspect the monitors' time synchronization services.
+      to: sysadmin
+
+ template: ceph_mon_diskspace_critical
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=MON_DISK_CRIT
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph monitor store is critically low on space
+    info: Every available sample in the 1-minute observation window reports critically low monitor-store space. Use `ceph health detail` to identify the affected monitor.
+      to: sysadmin
+
+ template: ceph_mon_diskspace_low
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=MON_DISK_LOW
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph monitor store is running low on space
+    info: Every available sample in the 5-minute observation window reports low monitor-store space. Use `ceph health detail` to identify the affected monitor.
+      to: silent
+
+# These cluster-population alerts use dimensions reduced within one MGR job.
+# They intentionally evaluate current stored dimensions on each health beat;
+# the generic go.d collection alert owns scrape failure and chart obsoletion
+# removes the cluster instance.
+ template: ceph_mon_down
+       on: prometheus.ceph.control_plane.monitor.cluster_summary
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($total == nan or $total == inf or $in_quorum == nan or $in_quorum == inf or $total <= 0 or $in_quorum < 0 or $in_quorum > $total) ? (nan) : ($in_quorum < $total and $in_quorum * 2 > $total)
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: One or more Ceph monitors are down while quorum remains
+    info: The current MGR cluster summary reports fewer monitors in quorum than configured, while a majority still remains.
+      to: silent
+
+ template: ceph_mon_quorum_at_risk
+       on: prometheus.ceph.control_plane.monitor.cluster_summary
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($total == nan or $total == inf or $in_quorum == nan or $in_quorum == inf or $total <= 0 or $in_quorum < 0 or $in_quorum > $total) ? (nan) : ($in_quorum < $total and $in_quorum * 2 > $total and ($in_quorum - 1) * 2 <= $total)
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph monitor quorum is at risk
+    info: The current MGR cluster summary reports exactly the minimum surviving monitor majority; one more monitor loss would remove quorum.
+      to: sysadmin
+
+ template: ceph_osd_backfill_full
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_BACKFILLFULL
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph OSD is too full for backfill
+    info: Every available sample in the 1-minute observation window reports that an OSD has reached its backfill-full threshold and rebalance cannot complete.
+      to: sysadmin
+
+ template: ceph_osd_down
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_DOWN
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: One or more Ceph OSDs are down
+    info: Every available sample in the 5-minute observation window reports a down OSD. Use `ceph health detail` to identify affected OSDs and hosts.
+      to: sysadmin
+
+ template: ceph_osd_down_high
+       on: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($total == nan or $total == inf or $up == nan or $up == inf or $total <= 0 or $up < 0 or $up > $total) ? (nan) : (($total - $up) * 100 / $total)
+    units: %
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this >= 10)
+ summary: At least 10% of Ceph OSDs are down
+    info: The current MGR cluster summary reports that at least 10% of configured OSDs are down.
+      to: silent
+
+ template: ceph_osd_full
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_FULL
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph OSD is full and writes are blocked
+    info: Every available sample in the 1-minute observation window reports an OSD at its full threshold. Use `ceph health detail` and `ceph osd df` to identify it.
+      to: sysadmin
+
+ template: ceph_osd_host_down
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_HOST_DOWN
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph OSD host is down
+    info: Every available sample in the 5-minute observation window reports an offline OSD host. Use `ceph health detail` to identify the host and its OSDs.
+      to: sysadmin
+
+ template: ceph_osd_internal_disk_size_mismatch
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=BLUESTORE_DISK_SIZE_MISMATCH
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph OSD has inconsistent internal device size metadata
+    info: Every available sample in the 1-minute observation window reports a BlueStore device-size mismatch that can cause the affected OSD to crash.
+      to: sysadmin
+
+ template: ceph_osd_near_full
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_NEARFULL
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph OSD is near full
+    info: Every available sample in the 5-minute observation window reports an OSD at its near-full threshold. Use `ceph health detail` and `ceph osd df` to identify it.
+      to: silent
+
+ template: ceph_osd_read_errors
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=BLUESTORE_SPURIOUS_READ_ERRORS
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph OSD reports recovered device read errors
+    info: Every available sample in the 30-second observation window reports BlueStore read errors that succeeded only after retries. Inspect the affected hardware and kernel.
+      to: sysadmin
+
+ template: ceph_osd_timeouts_cluster_network
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_SLOW_PING_TIME_BACK
+    class: Latency
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph OSD heartbeats are slow on the cluster network
+    info: Every available sample in the 1-minute observation window reports slow backend OSD heartbeats. Inspect the cluster network for latency or loss.
+      to: silent
+
+ template: ceph_osd_timeouts_public_network
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_SLOW_PING_TIME_FRONT
+    class: Latency
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph OSD heartbeats are slow on the public network
+    info: Every available sample in the 1-minute observation window reports slow frontend OSD heartbeats. Inspect the public network for latency or loss.
+      to: silent
+
+ template: ceph_osd_too_many_repairs
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=OSD_TOO_MANY_REPAIRS
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph OSD reports too many repaired reads
+    info: Every available sample in the 30-second observation window reports excessive repaired reads, which may indicate a failing drive.
+      to: silent
+
 # Future ordinary Ceph health checks are actionable even before a dedicated
 # rule is curated. Keep this set exact so it does not duplicate current named
 # rules, and exclude certificate checks whose current source lifecycle lacks a

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -1033,7 +1033,7 @@ component: Ceph
 
  template: ceph_osd_scrub_errors
        on: prometheus.ceph.health.health_checks.state
-chart labels: name=OSD_SCRUB_ERRORS !PG_DAMAGED *
+chart labels: name=OSD_SCRUB_ERRORS
     class: Errors
      type: Storage
 component: Ceph
@@ -1042,7 +1042,7 @@ component: Ceph
     every: 10s
     crit: ($this == nan or $this == inf) ? (nan) : ($this == 1)
  summary: Ceph scrub reports placement-group data errors
-    info: Every available sample in the 5-minute observation window reports scrub errors when PG-damage is not already active.
+    info: Every available sample in the 5-minute observation window reports OSD scrub errors. `PG_DAMAGED` remains owned by the separate Ceph damaged-placement-group alert.
       to: silent
 
  template: ceph_pgs_high_per_osd

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -581,6 +581,184 @@ component: Ceph
     info: Every available sample in the 1-minute observation window reports a Ceph filesystem forced read-only.
       to: sysadmin
 
+# Local NVMe-oF exporter alerts.
+#
+# These rules remain inside one exporter endpoint. Gateway-wide means the local
+# exporter `ceph_instance` identity, not a cluster-wide inventory aggregate.
+# Per-bdev latency is deliberately more local than the exporter-wide average in
+# the source rule. Helpers hold database-window values so consuming current
+# rules can preserve the source persistence intent without duplicating lookups.
+
+ template: ceph_nvmeof_subsystem_open_security
+       on: prometheus.ceph.nvme_of.subsystems.state_metadata
+chart labels: allow_any_host=yes
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of metadata
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: An NVMe-oF subsystem accepts any host
+    info: Every available sample in the 5-minute observation window reports an NVMe-oF subsystem configured without host security.
+      to: silent
+
+ template: ceph_nvmeof_gateway_cpu_10m
+       on: prometheus.ceph.nvme_of.gateways.time_accumulation
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -10m unaligned of busy
+    units: status
+    every: 10s
+    warn: $this == 999999999
+ summary: Internal persistent NVMe-oF gateway reactor busy state
+    info: Internal helper holding the lowest local reactor busy-rate sample observed over ten minutes; it does not notify.
+      to: silent
+
+ template: ceph_nvmeof_gateway_cpu
+       on: prometheus.ceph.nvme_of.gateways.time_accumulation
+    class: Utilization
+     type: Storage
+component: Ceph
+   calc: ($ceph_nvmeof_gateway_cpu_10m == nan or $ceph_nvmeof_gateway_cpu_10m == inf) ? (nan) : ($ceph_nvmeof_gateway_cpu_10m * 100)
+    units: %
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 80)
+ summary: NVMe-oF gateway reactor use is high
+    info: The current lowest local reactor busy-rate sample in the 10-minute observation window is above 80 percent.
+      to: silent
+
+ template: ceph_nvmeof_read_latency_1m
+       on: prometheus.ceph.nvme_of.block_devices.time_accumulation
+    class: Latency
+     type: Storage
+component: Ceph
+   lookup: average -1m unaligned of read_seconds
+    units: seconds
+    every: 10s
+    warn: $this == 999999999
+ summary: Internal NVMe-oF per-bdev read service time
+    info: Internal helper holding the local one-minute per-block-device read service-time rate; it does not notify.
+      to: silent
+
+ template: ceph_nvmeof_read_operations_1m
+       on: prometheus.ceph.nvme_of.block_devices.operations
+    class: Latency
+     type: Storage
+component: Ceph
+   lookup: average -1m unaligned of reads_completed
+    units: operations
+    every: 10s
+    warn: $this == 999999999
+ summary: Internal NVMe-oF per-bdev completed reads
+    info: Internal helper holding the local one-minute per-block-device completed-read rate; it does not notify.
+      to: silent
+
+ template: ceph_nvmeof_high_read_latency
+       on: prometheus.ceph.nvme_of.block_devices.time_accumulation
+    class: Latency
+     type: Storage
+component: Ceph
+   calc: ($ceph_nvmeof_read_latency_1m == nan or $ceph_nvmeof_read_latency_1m == inf or $ceph_nvmeof_read_operations_1m == nan or $ceph_nvmeof_read_operations_1m == inf or $ceph_nvmeof_read_operations_1m <= 0) ? (nan) : ($ceph_nvmeof_read_latency_1m / $ceph_nvmeof_read_operations_1m)
+    units: seconds
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0.01)
+ summary: NVMe-oF block-device read latency is high
+    info: The current local one-minute read service-time ratio exceeds 10 milliseconds per completed read.
+      to: silent
+
+ template: ceph_nvmeof_write_latency_1m
+       on: prometheus.ceph.nvme_of.block_devices.time_accumulation
+    class: Latency
+     type: Storage
+component: Ceph
+   lookup: average -1m unaligned of write_seconds
+    units: seconds
+    every: 10s
+    warn: $this == 999999999
+ summary: Internal NVMe-oF per-bdev write service time
+    info: Internal helper holding the local one-minute per-block-device write service-time rate; it does not notify.
+      to: silent
+
+ template: ceph_nvmeof_write_operations_1m
+       on: prometheus.ceph.nvme_of.block_devices.operations
+    class: Latency
+     type: Storage
+component: Ceph
+   lookup: average -1m unaligned of writes_completed
+    units: operations
+    every: 10s
+    warn: $this == 999999999
+ summary: Internal NVMe-oF per-bdev completed writes
+    info: Internal helper holding the local one-minute per-block-device completed-write rate; it does not notify.
+      to: silent
+
+ template: ceph_nvmeof_high_write_latency
+       on: prometheus.ceph.nvme_of.block_devices.time_accumulation
+    class: Latency
+     type: Storage
+component: Ceph
+   calc: ($ceph_nvmeof_write_latency_1m == nan or $ceph_nvmeof_write_latency_1m == inf or $ceph_nvmeof_write_operations_1m == nan or $ceph_nvmeof_write_operations_1m == inf or $ceph_nvmeof_write_operations_1m <= 0) ? (nan) : ($ceph_nvmeof_write_latency_1m / $ceph_nvmeof_write_operations_1m)
+    units: seconds
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0.02)
+ summary: NVMe-oF block-device write latency is high
+    info: The current local one-minute write service-time ratio exceeds 20 milliseconds per completed write.
+      to: silent
+
+ template: ceph_nvmeof_host_keepalive_timeout
+       on: prometheus.ceph.nvme_of.hosts.keepalive_timeout_state
+    class: Errors
+     type: Storage
+component: Ceph
+    calc: $value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: An NVMe-oF host connection was disconnected by keepalive timeout
+    info: The exporter currently reports a host disconnected by keepalive timeout. Exporter refresh reads and clears this one-shot state.
+      to: silent
+
+ template: ceph_nvmeof_subsystem_namespace_limit
+       on: prometheus.ceph.nvme_of.subsystems.namespace_capacity
+    class: Utilization
+     type: Storage
+component: Ceph
+   calc: ($count == nan or $count == inf or $limit == nan or $limit == inf or $limit < 0) ? (nan) : ($count >= $limit)
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: NVMe-oF subsystem reached its namespace limit
+    info: The current subsystem namespace count is at or above its configured limit.
+      to: silent
+
+ template: ceph_nvmeof_gateway_namespaces
+       on: prometheus.ceph.nvme_of.gateways.namespace_count
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: average -1m unaligned of namespace_count
+    units: namespaces
+    every: 10s
+    warn: $this == 999999999
+ summary: Internal local NVMe-oF gateway namespace count
+    info: Internal helper summing subsystem namespace counts inside the local exporter endpoint; it does not notify.
+      to: silent
+
+ template: ceph_nvmeof_too_many_namespaces
+       on: prometheus.ceph.nvme_of.gateways.namespace_count
+    class: Utilization
+     type: Storage
+component: Ceph
+   calc: ($ceph_nvmeof_gateway_namespaces == nan or $ceph_nvmeof_gateway_namespaces == inf) ? (nan) : ($ceph_nvmeof_gateway_namespaces)
+    units: namespaces
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this >= 4096)
+ summary: Local NVMe-oF gateway namespace count reached the supported maximum
+    info: The current local exporter namespace inventory is at or above the supported maximum of 4096.
+      to: silent
+
  template: ceph_rbd_mirror_images_not_in_sync
        on: prometheus.ceph.rbd_mirror.snapshot_replication.timestamp
     class: Errors

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -483,6 +483,117 @@ component: Ceph
     info: Every available sample in the 1-minute observation window reports a recognized processor temperature sensor above 80°C.
       to: silent
 
+ template: ceph_filesystem_damaged
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=MDS_DAMAGE
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph filesystem metadata damage condition is active
+    info: Every available sample in the 1-minute observation window reports filesystem metadata damage.
+      to: sysadmin
+
+ template: ceph_filesystem_degraded
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=FS_DEGRADED
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph filesystem is degraded
+    info: Every available sample in the 1-minute observation window reports a degraded Ceph filesystem.
+      to: sysadmin
+
+ template: ceph_filesystem_failure_no_standby
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=FS_WITH_FAILED_MDS
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph filesystem MDS rank has failed with no standby
+    info: Every available sample in the 1-minute observation window reports a failed MDS rank with no standby.
+      to: sysadmin
+
+ template: ceph_filesystem_insufficient_standby
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=MDS_INSUFFICIENT_STANDBY
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph filesystem standby count is insufficient
+    info: Every available sample in the 1-minute observation window reports insufficient CephFS standby daemons.
+      to: silent
+
+ template: ceph_filesystem_mds_ranks_low
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=MDS_UP_LESS_THAN_MAX
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Active Ceph filesystem MDS ranks are below maximum
+    info: Every available sample in the 1-minute observation window reports fewer active MDS ranks than configured.
+      to: silent
+
+ template: ceph_filesystem_offline
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=MDS_ALL_DOWN
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph filesystem is offline
+    info: Every available sample in the 1-minute observation window reports all MDS ranks unavailable.
+      to: sysadmin
+
+ template: ceph_filesystem_read_only
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=MDS_HEALTH_READ_ONLY
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: A Ceph filesystem is read-only
+    info: Every available sample in the 1-minute observation window reports a Ceph filesystem forced read-only.
+      to: sysadmin
+
+ template: ceph_rbd_mirror_images_not_in_sync
+       on: prometheus.ceph.rbd_mirror.snapshot_replication.timestamp
+    class: Errors
+     type: Storage
+component: Ceph
+     calc: ($local_timestamp == nan or $local_timestamp == inf or $remote_timestamp == nan or $remote_timestamp == inf or $local_timestamp < 0 or $remote_timestamp < 0) ? (nan) : ($local_timestamp - $remote_timestamp)
+    units: seconds
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this != 0)
+ summary: A Ceph RBD mirror image is not synchronized
+    info: The current local and remote snapshot timestamps differ for this mirrored image.
+      to: sysadmin
+
  template: ceph_osd_all_up
        on: prometheus.ceph.osd_capacity_and_state.osd_state.cluster_summary
     class: Errors

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -175,6 +175,314 @@ component: Ceph
     info: Every available sample in the 1-minute observation window reports blocked relocation from a predicted device failure. Check free capacity and the balancer.
       to: sysadmin
 
+ template: ceph_cooling_degraded
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=fans
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: A Ceph hardware cooling component is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for a reported fan component.
+      to: sysadmin
+
+ template: ceph_cooling_failed
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=fans
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
+ summary: A Ceph hardware cooling component has failed
+    info: Every available sample in the 1-minute observation window reports error health for a reported fan component.
+      to: sysadmin
+
+ template: ceph_dimm_temperature_high
+       on: prometheus.ceph.node_hardware.temperature.temperature
+chart labels: sensor_name=*DIMM*_TEMP
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: celsius
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 80)
+ summary: A Ceph hardware DIMM temperature sensor is high
+    info: Every available sample in the 1-minute observation window reports a recognized DIMM temperature sensor above 80°C.
+      to: silent
+
+ template: ceph_hardware_fan_error
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=HARDWARE_FANS
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph reports fan hardware errors
+    info: Every available sample in the 30-second observation window reports a Ceph fan hardware error.
+      to: sysadmin
+
+ template: ceph_hardware_memory_error
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=HARDWARE_MEMORY
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph reports DIMM hardware errors
+    info: Every available sample in the 30-second observation window reports a Ceph memory hardware error.
+      to: sysadmin
+
+ template: ceph_hardware_network_error
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=HARDWARE_NETWORK
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph reports network hardware errors
+    info: Every available sample in the 30-second observation window reports a Ceph network hardware error.
+      to: sysadmin
+
+ template: ceph_hardware_power_error
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=HARDWARE_POWER
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph reports power-supply hardware errors
+    info: Every available sample in the 30-second observation window reports a Ceph power hardware error.
+      to: sysadmin
+
+ template: ceph_hardware_processor_error
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=HARDWARE_PROCESSOR
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph reports processor hardware errors
+    info: Every available sample in the 30-second observation window reports a Ceph processor hardware error.
+      to: sysadmin
+
+ template: ceph_hardware_storage_error
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=HARDWARE_STORAGE
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph reports storage hardware errors
+    info: Every available sample in the 30-second observation window reports a Ceph storage hardware error.
+      to: sysadmin
+
+ template: ceph_memory_degraded
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=memory
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: A Ceph hardware memory module is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for a reported memory component.
+      to: sysadmin
+
+ template: ceph_memory_failed
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=memory
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
+ summary: A Ceph hardware memory module has failed
+    info: Every available sample in the 1-minute observation window reports error health for a reported memory component.
+      to: sysadmin
+
+ template: ceph_motherboard_temperature_high
+       on: prometheus.ceph.node_hardware.temperature.temperature
+chart labels: sensor_name=*MB_TEMP*
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: celsius
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 60)
+ summary: A Ceph hardware motherboard temperature sensor is high
+    info: Every available sample in the 1-minute observation window reports a recognized motherboard temperature sensor above 60°C.
+      to: silent
+
+ template: ceph_nvme_drive_degraded
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=storage
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: A Ceph hardware NVMe drive is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for a reported storage component.
+      to: sysadmin
+
+ template: ceph_nvme_drive_failed
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=storage
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
+ summary: A Ceph hardware NVMe drive has failed
+    info: Every available sample in the 1-minute observation window reports error health for a reported storage component.
+      to: sysadmin
+
+ template: ceph_nvme_temperature_high
+       on: prometheus.ceph.node_hardware.temperature.temperature
+chart labels: sensor_name=NVME*_TEMP
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: celsius
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 70)
+ summary: A Ceph hardware NVMe temperature sensor is high
+    info: Every available sample in the 1-minute observation window reports a recognized NVMe temperature sensor above 70°C.
+      to: silent
+
+ template: ceph_network_degraded
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=network
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: A Ceph hardware network interface is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for a reported network component.
+      to: sysadmin
+
+ template: ceph_network_failed
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=network
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
+ summary: A Ceph hardware network interface has failed
+    info: Every available sample in the 1-minute observation window reports error health for a reported network component.
+      to: sysadmin
+
+ template: ceph_power_supply_degraded
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=power
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: A Ceph hardware power supply is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for a reported power component.
+      to: sysadmin
+
+ template: ceph_power_supply_failed
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=power
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
+ summary: A Ceph hardware power supply has failed
+    info: Every available sample in the 1-minute observation window reports error health for a reported power component.
+      to: sysadmin
+
+ template: ceph_processor_degraded
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=processors
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 1)
+ summary: A Ceph hardware processor is degraded
+    info: Every available sample in the 1-minute observation window reports warning health for a reported processor component.
+      to: sysadmin
+
+ template: ceph_processor_failed
+       on: prometheus.ceph.node_hardware.health.state
+chart labels: category=processors
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
+ summary: A Ceph hardware processor has failed
+    info: Every available sample in the 1-minute observation window reports error health for a reported processor component.
+      to: sysadmin
+
+ template: ceph_processor_temperature_high
+       on: prometheus.ceph.node_hardware.temperature.temperature
+chart labels: sensor_name=*CPU_TEMP
+    class: Utilization
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: celsius
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 80)
+ summary: A Ceph hardware processor temperature sensor is high
+    info: Every available sample in the 1-minute observation window reports a recognized processor temperature sensor above 80°C.
+      to: silent
+
  template: ceph_mon_clock_skew
        on: prometheus.ceph.health.health_checks.state
 chart labels: name=MON_CLOCK_SKEW

--- a/src/health/health.d/ceph.conf
+++ b/src/health/health.d/ceph.conf
@@ -1,3 +1,156 @@
+# MGR Prometheus health checks.
+#
+# These alerts adapt the Ceph mixin's persistence intent to Netdata observation
+# windows. Binary sources use a minimum lookup. The tri-state cluster status
+# uses countif so an ERROR-to-WARN transition cannot satisfy the warning window.
+# Lookups aggregate the numeric samples available in the window; a partial gap
+# does not reset it. A stale lookup can stop evaluating, an all-null lookup is
+# preserved as UNDEFINED, ordinary zero clears, and an obsolete chart is REMOVED.
+# Ceph retains ordinary `ceph_health_detail` checks and emits zero on recovery,
+# allowing the alert to clear normally. The native collector below owns API
+# component collection failures and remains complementary to this MGR layer.
+
+ template: ceph_health_error
+       on: prometheus.ceph.health.cluster_status.state
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this == 2)
+ summary: Ceph cluster is in the error state
+    info: Every available Ceph MGR health sample in the 5-minute observation window is HEALTH_ERR. Use `ceph health detail` for the current cause.
+      to: sysadmin
+
+ template: ceph_health_warning
+       on: prometheus.ceph.health.cluster_status.state
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: countif(!=1) -15m unaligned of value
+    units: %
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this == 0)
+ summary: Ceph cluster is in the warning state
+    info: Every available Ceph MGR health sample in the 15-minute observation window is HEALTH_WARN. Use `ceph health detail` for the current cause.
+      to: silent
+
+ template: ceph_daemon_crash
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=RECENT_CRASH
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph daemon crash reported
+    info: Every available sample in the 1-minute observation window reports a recent daemon crash. Use `ceph health detail` for the affected daemon and crash details.
+      to: sysadmin
+
+ template: ceph_mgr_module_crash
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=RECENT_MGR_MODULE_CRASH
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -5m unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph manager module crash reported
+    info: Every available sample in the 5-minute observation window reports a recent manager-module crash. Use `ceph health detail` for the affected module and crash details.
+      to: sysadmin
+
+ template: ceph_daemon_slow_ops
+       on: prometheus.ceph.health.daemon_health.item_count
+chart labels: type=SLOW_OPS
+    class: Latency
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: operations
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph daemon ${label:ceph_daemon} has slow operations
+    info: Every available sample in the 30-second observation window reports one or more slow operations for this daemon.
+      to: silent
+
+ template: ceph_slow_ops
+       on: prometheus.ceph.health.slow_operations.current_operations
+    class: Latency
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: operations
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph cluster has slow operations
+    info: Every available sample in the 30-second observation window reports one or more cluster slow operations. Use `ceph health detail` to identify the cause.
+      to: silent
+
+ template: cephadm_daemon_failed
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=CEPHADM_FAILED_DAEMON
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Cephadm daemon deployment failed
+    info: Every available sample in the 30-second observation window reports a failed cephadm daemon. Use `ceph health detail` for the affected daemon and failure details.
+      to: sysadmin
+
+ template: cephadm_paused
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=CEPHADM_PAUSED
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Cephadm is paused
+    info: Every available sample in the 1-minute observation window reports that cephadm is paused. Resume cephadm or use `ceph health detail` to determine why it was paused.
+      to: silent
+
+ template: cephadm_upgrade_failed
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=UPGRADE_EXCEPTION
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -30s unaligned of value
+    units: status
+    every: 10s
+    crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Cephadm upgrade failed
+    info: Every available sample in the 30-second observation window reports a cephadm upgrade exception. Use `ceph health detail` for the failed upgrade step.
+      to: sysadmin
+
+# Future ordinary Ceph health checks are actionable even before a dedicated
+# rule is curated. Keep this set exact so it does not duplicate current named
+# rules, and exclude certificate checks whose current source lifecycle lacks a
+# resolved zero sample.
+ template: ceph_unknown_health_check
+       on: prometheus.ceph.health.health_checks.state
+chart labels: name=!BLUESTORE_DISK_SIZE_MISMATCH !BLUESTORE_SPURIOUS_READ_ERRORS !CEPHADM_CERT_ERROR !CEPHADM_CERT_WARNING !CEPHADM_FAILED_DAEMON !CEPHADM_PAUSED !DEVICE_HEALTH !DEVICE_HEALTH_IN_USE !DEVICE_HEALTH_TOOMANY !FS_DEGRADED !FS_WITH_FAILED_MDS !HARDWARE_FANS !HARDWARE_MEMORY !HARDWARE_NETWORK !HARDWARE_POWER !HARDWARE_PROCESSOR !HARDWARE_STORAGE !MDS_ALL_DOWN !MDS_DAMAGE !MDS_HEALTH_READ_ONLY !MDS_INSUFFICIENT_STANDBY !MDS_UP_LESS_THAN_MAX !MON_CLOCK_SKEW !MON_DISK_CRIT !MON_DISK_LOW !MON_DOWN !OBJECT_UNFOUND !OSD_BACKFILLFULL !OSD_DOWN !OSD_FULL !OSD_HOST_DOWN !OSD_NEARFULL !OSD_SCRUB_ERRORS !OSD_SLOW_PING_TIME_BACK !OSD_SLOW_PING_TIME_FRONT !OSD_TOO_MANY_REPAIRS !PG_AVAILABILITY !PG_BACKFILL_FULL !PG_DAMAGED !PG_NOT_DEEP_SCRUBBED !PG_NOT_SCRUBBED !PG_RECOVERY_FULL !POOL_BACKFILLFULL !POOL_FULL !POOL_NEAR_FULL !RECENT_CRASH !RECENT_MGR_MODULE_CRASH !SLOW_OPS !TOO_MANY_PGS !UPGRADE_EXCEPTION *
+    class: Errors
+     type: Storage
+component: Ceph
+   lookup: min -1m unaligned of value
+    units: status
+    every: 10s
+    warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
+ summary: Ceph health check ${label:name} is active
+    info: Every available sample in the 1-minute observation window reports the unclassified health check ${label:name}. Use `ceph health detail` for its recorded explanation.
+      to: silent
+
 # Partial Ceph metric collection failure while other components continue to report data.
 
  template: ceph_component_collection_failed

--- a/src/libnetdata/eval/eval-unittest.c
+++ b/src/libnetdata/eval/eval-unittest.c
@@ -680,8 +680,10 @@ static TestCase special_value_tests[] = {
     {"$nan_var || 0", 0.0, EVAL_ERROR_OK, true},
     {"!$nan_var", 1.0, EVAL_ERROR_OK, true},
 
-    // Ternary with NaN
+    // Ternary branches that deliberately preserve non-finite input
     {"($nan_var) ? 1 : 2", 2.0, EVAL_ERROR_OK, true},
+    {"($nan_var == nan or $nan_var == inf) ? (nan) : ($nan_var == 2)", NAN, EVAL_ERROR_VALUE_IS_NAN, true},
+    {"($inf_var == nan or $inf_var == inf) ? (nan) : ($inf_var == 2)", NAN, EVAL_ERROR_VALUE_IS_NAN, true},
 
     // Infinity tests - Netdata rejects with VALUE_IS_INFINITE error
     {"$inf_var", 0.0, EVAL_ERROR_VALUE_IS_INFINITE, true},

--- a/src/web/api/queries/countif/README.md
+++ b/src/web/api/queries/countif/README.md
@@ -18,7 +18,7 @@ The target number and the desired condition can be set using the `group_options`
 - `!0`, to match any number except zero.
 - `>=-3` to match any number bigger or equal to -3.
 
-. When an invalid condition is given, the web server can deliver an inaccurate response.
+An invalid condition is rejected with an API error rather than returning an inaccurate response.
 
 ## How to use
 

--- a/src/web/api/queries/countif/README.md
+++ b/src/web/api/queries/countif/README.md
@@ -18,14 +18,14 @@ The target number and the desired condition can be set using the `group_options`
 - `!0`, to match any number except zero.
 - `>=-3` to match any number bigger or equal to -3.
 
-. When an invalid condition is given, the web server can deliver a not accurate response.
+. When an invalid condition is given, the web server can deliver an inaccurate response.
 
-## how to use
+## How to use
 
-This query cannot be used in alerts.
+CountIf can be used in APIs and badges, and in health lookup expressions.
 
-`countif` changes the units of charts. The result of the calculation is always from zero to 1, expressing the percentage of database points that matched the condition. 
+For a non-empty group, `countif` returns the percentage of database points that matched the condition, from zero to 100.
+For example, with one or more observed values, the health lookup `countif(!=1) -15m unaligned of value` returns zero only
+when every observed value in the 15-minute lookup is exactly `1`.
 
-In APIs and badges can be used like this: `&group=countif&group_options=>10` in the URL.
-
-
+In APIs and badges, use `&group=countif&group_options=>10` in the URL.


### PR DESCRIPTION
# Summary

Adds the first five Phase-1 milestones of source-pinned Ceph monitoring and alert coverage.

- Adds source-pinned Ceph MGR health, MON/OSD, Tentacle hardware, PG/pool, and CephFS/RBD-mirror alerts.
- Adds bounded same-scrape MON/OSD cluster summary charts.
- Adds Tentacle hardware health and temperature charts.
- Reuses generic host collection/filesystem/packet-drop owners instead of duplicating incidents.
- Changes native Ceph physical-capacity alerting to silent-by-default, preserving thresholds and documenting the compatibility impact.
- Records rejected invalid or redundant upstream rules with exact source pins and rationale.
- Expands profile proof, collector tests, source-alert reconciliation, metadata, and source semantics.

**Milestones included**

1. MGR health alerts
2. MON/OSD cluster alerts
3. Tentacle hardware alerts
4. PG, object-integrity, pool, recovery, scrub, and capacity alerts
5. CephFS/MDS and RBD mirror alerts

# Notes for Reviewers

- The branch intentionally contains one commit per completed milestone.
- Generated integration pages are not committed; repository automation owns those post-merge.
- The companion `netdata/testdata` changes remain local and will be submitted separately as required.
- Draft is for inspection; later Phase-1 milestones remain in progress locally.

# Test Plan

- Full Prometheus and native Ceph collector package tests.
- Prometheus profile validation and stock-profile proof replay.
- Go vet for affected packages.
- `/usr/sbin/netdata -W healthconfigtest` (273 passed, 0 failed).
- Integration generation and taxonomy checks.
- Companion source-registry verification.
- Generated-document validation in an isolated clone.
- Outer and companion whitespace checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Phase‑1 Ceph monitoring and alerts across MGR, MON/OSD, PG/pools, CephFS/MDS, RBD mirror, RGW, and NVMe‑oF, with source‑pinned mappings and lifecycle‑safe health checks. Behavior changes: the native Ceph physical‑capacity alert now routes to silent by default (was notifying); cluster‑status WARN no longer clears on an ERROR→WARN transition because tri‑state health uses `countif`.

- Review
  - `src/health/health.d/ceph.conf`: Phase‑1 alert templates for MGR, MON/OSD, PG/pools, CephFS/MDS, RBD mirror, RGW, and NVMe‑oF; tri‑state cluster status via `countif`; PG‑unavailable helper fixed; capacity alert defined and routed to `silent`.
  - Prometheus profile and tests: Ceph mixin alerts mapped from source‑pinned snapshots (`reef`, `squid`, `tentacle`) with hermetic mapping/lifecycle tests; profile families regrouped and I/O hierarchy corrected; display registry adds fan RPM; proof‑fixture series limit raised; Ceph YAML formatting normalized.
  - Docs and examples: distributed Ceph guide; `httpcheck` and `x509check` add RGW liveness/certificate examples; `weblog` parses RGW access‑log latency and supports custom fields; `countif` docs include health lookups.

- Rollout
  - If you relied on automatic physical‑capacity notifications, route `ceph_cluster_physical_capacity_utilization` after upgrade by changing `to: silent` to your channel or by adding a route.
  - Optional RGW liveness and certificate checks are available; enable if desired.

<sup>Written for commit 415c49b701df31bd70f1b3c8cf2e2b38c9fe62a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Ceph monitoring for cluster health, OSDs, monitors, pools, CephFS, RGW, NVMe-oF gateways, hardware, and performance.
  * Added configuration examples for Prometheus, RGW logs, HTTP endpoints, and HTTPS certificate checks.
  * Added customizable web-log fields and fan-speed display in revolutions per minute.

* **Documentation**
  * Expanded Ceph alerting, lifecycle, routing, troubleshooting, and CountIf guidance.
  * Added guidance for authoring health alerts and Prometheus monitoring profiles.

* **Bug Fixes**
  * Improved alert identity and lifecycle handling across severity changes, resolution, and metric expiration.
  * Capacity alerts are now silent by default unless explicitly routed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->