### PR TITLE
Fix coverity 

### DIFF
--- a/src/database/engine/mrg-unittest.c
+++ b/src/database/engine/mrg-unittest.c
@@ -634,7 +634,7 @@ static int mrg_stale_peeked_id_unittest(void) {
         // Without a borrowed id there is nothing that can go stale, and the
         // assertion below would look up id 0 and pass vacuously. Stop here.
         fprintf(stderr, "ERROR: peek could not resolve a uuid that has a metric\n");
-        mrg_metric_release_and_delete(mrg, metric);
+        (void) mrg_metric_release_and_delete(mrg, metric);
         (void)mrg_destroy(mrg);
         fprintf(stderr, "Stale peeked id test: 1 ERROR(S)\n");
         return 1;


### PR DESCRIPTION
##### Summary
- Silence coverity issue 505482 (unchecked return value in unittest)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup handling in a stale ID test when UUID lookup fails.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->