### PR TITLE
feat(health): index alerts by name for faster variable lookups

### DIFF
--- a/src/database/rrdhost.h
+++ b/src/database/rrdhost.h
@@ -331,6 +331,16 @@ struct rrdhost {
     // all RRDCALCs are primarily allocated and linked here
     DICTIONARY *rrdcalc_root_index;
 
+    // Secondary index of the above, keyed by the interned STRING* of
+    // rc->config.name, so health expression variable lookups can resolve an
+    // alert name without scanning every alert of the host. Alert names are not
+    // unique per host (the primary key is "{alert},on[{chart}]"), so each entry
+    // is the head of a list threaded through RRDCALC.name_next / name_prev.
+    struct {
+        RW_SPINLOCK spinlock;
+        Pvoid_t JudyL;
+    } rrdcalc_by_name;
+
     ALARM_LOG health_log;                           // alarms historical events (event log)
     uint32_t health_last_processed_id;              // the last processed health id from the log
     uint32_t health_max_unique_id;                  // the max alarm log unique id given for the host

--- a/src/health/health_variable.c
+++ b/src/health/health_variable.c
@@ -170,89 +170,75 @@ static bool variable_lookup_context(struct variable_lookup_job *vbd, const char 
 // Resolves an alert-name variable through the host's name index instead of
 // scanning every alert of the host.
 //
-// The host's alert dictionary read lock is held across the whole function: that
-// is what keeps the snapshotted RRDCALCs alive, exactly as the full traversal
-// this replaced did. The name-index lock is taken and released inside
-// rrdcalc_by_name_snapshot() and is deliberately NOT held while scoring, because
-// scoring acquires chart locks while rrdcalc_name_index_del() runs with
-// st->alerts.spinlock already held - holding both in the opposite order would be
-// a lock-order inversion.
+// Lifetime: rrdcalc_by_name_snapshot() returns ACQUIRED dictionary items, and
+// that reference - not any dictionary lock - is what keeps each RRDCALC alive
+// while we score it. A dictionary lock would not be enough: the free in
+// dict_item_free_or_mark_deleted() runs after item_linked_list_remove() has
+// already released the items write lock.
+//
+// The name-index lock is taken and released inside the snapshot and is
+// deliberately NOT held while scoring, because scoring acquires chart locks
+// while rrdcalc_name_index_del() runs with st->alerts.spinlock already held -
+// holding both in the opposite order would be a lock-order inversion.
+//
+// No dictionary lock is taken in this path at all.
 static bool alert_variable_from_running_alerts(struct variable_lookup_job *vbd, bool snapshot_values) {
     bool found = false;
 
-    RRDCALC *onstack[ALERT_NAME_MATCHES_ONSTACK];
-    RRDCALC **matches = onstack, **allocated = NULL;
+    const DICTIONARY_ITEM *onstack[ALERT_NAME_MATCHES_ONSTACK];
+    const DICTIONARY_ITEM **matches = onstack, **allocated = NULL;
     size_t matches_size = ALERT_NAME_MATCHES_ONSTACK;
 
-    dictionary_read_lock(vbd->host->rrdcalc_root_index);
-
+    // Grow until the whole set fits. When it does not fit the snapshot acquires
+    // nothing, so there is never a partial set to release. This can only repeat
+    // if alerts of this name were added in between, so it terminates.
     size_t count = rrdcalc_by_name_snapshot(vbd->host, vbd->variable, matches, matches_size);
-    if(unlikely(count > matches_size)) {
-        // more alerts carry this name than the on-stack buffer holds
-        allocated = mallocz(sizeof(RRDCALC *) * count);
-        matches = allocated;
+    while(unlikely(count > matches_size)) {
         matches_size = count;
+        freez(allocated);
+        allocated = mallocz(sizeof(const DICTIONARY_ITEM *) * matches_size);
+        matches = allocated;
 
         count = rrdcalc_by_name_snapshot(vbd->host, vbd->variable, matches, matches_size);
-        if(unlikely(count > matches_size))
-            count = matches_size;
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    // A stale or missing index entry does not crash - it silently makes the
-    // variable unresolvable and takes the alert to UNDEFINED. Verify loudly here.
+    // Verify every alert of this name that the dictionary knows about against the
+    // index. Each alert is checked on its own, at one instant, under the index
+    // lock - see rrdcalc_name_index_verify() for why this must not be a
+    // set-versus-set comparison against the snapshot taken above.
     {
-        size_t scanned = 0;
         RRDCALC *check;
         foreach_rrdcalc_in_rrdhost_read(vbd->host, check) {
-            if(check->config.name != vbd->variable)
-                continue;
-
-            scanned++;
-
-            bool indexed = false;
-            for(size_t i = 0; i < count ; i++) {
-                if(matches[i] == check) {
-                    indexed = true;
-                    break;
-                }
-            }
-
-            if(!indexed)
-                fatal("HEALTH: alert name index on host '%s' is missing alert '%s' of chart '%s'",
-                      rrdhost_hostname(vbd->host), rrdcalc_name(check), rrdcalc_chart_name(check));
+            if(check->config.name == vbd->variable)
+                rrdcalc_name_index_verify(vbd->host, check);
         }
         foreach_rrdcalc_in_rrdhost_done(check);
-
-        if(scanned != count)
-            fatal("HEALTH: alert name index on host '%s' has %zu entries for '%s', full scan found %zu",
-                  rrdhost_hostname(vbd->host), count, string2str(vbd->variable), scanned);
     }
 #endif
 
     for(size_t i = 0; i < count ; i++) {
-        RRDCALC *rc = matches[i];
+        RRDCALC *rc = dictionary_acquired_item_value(matches[i]);
 
         RRDSET *st = NULL;
         RRDSET_ACQUIRED *rsa = rrdcalc_rrdset_acquire_linked(vbd->host, rc, &st);
-        if(!rsa)
-            continue;
+        if(rsa) {
+            NETDATA_DOUBLE value;
+            if(snapshot_values) {
+                RRDCALC_RUNTIME_SNAPSHOT snapshot;
+                rrdcalc_runtime_snapshot_get(rc, &snapshot);
+                value = snapshot.value;
+            }
+            else
+                value = rc->value;
 
-        NETDATA_DOUBLE value;
-        if(snapshot_values) {
-            RRDCALC_RUNTIME_SNAPSHOT snapshot;
-            rrdcalc_runtime_snapshot_get(rc, &snapshot);
-            value = snapshot.value;
+            variable_lookup_add_result_with_score(vbd, value, st, "alarm value");
+            rrdset_acquired_release(rsa);
+            found = true;
         }
-        else
-            value = rc->value;
 
-        variable_lookup_add_result_with_score(vbd, value, st, "alarm value");
-        rrdset_acquired_release(rsa);
-        found = true;
+        dictionary_acquired_item_release(vbd->host->rrdcalc_root_index, matches[i]);
     }
-
-    dictionary_read_unlock(vbd->host->rrdcalc_root_index);
 
     freez(allocated);
     return found;

--- a/src/health/health_variable.c
+++ b/src/health/health_variable.c
@@ -162,31 +162,99 @@ static bool variable_lookup_context(struct variable_lookup_job *vbd, const char 
     return found;
 }
 
+// Alerts sharing one name on a single host - one per matching chart. Sized to
+// cover the usual case (an alert templated over every disk, interface, mount)
+// without allocating.
+#define ALERT_NAME_MATCHES_ONSTACK 64
+
+// Resolves an alert-name variable through the host's name index instead of
+// scanning every alert of the host.
+//
+// The host's alert dictionary read lock is held across the whole function: that
+// is what keeps the snapshotted RRDCALCs alive, exactly as the full traversal
+// this replaced did. The name-index lock is taken and released inside
+// rrdcalc_by_name_snapshot() and is deliberately NOT held while scoring, because
+// scoring acquires chart locks while rrdcalc_name_index_del() runs with
+// st->alerts.spinlock already held - holding both in the opposite order would be
+// a lock-order inversion.
 static bool alert_variable_from_running_alerts(struct variable_lookup_job *vbd, bool snapshot_values) {
     bool found = false;
-    RRDCALC *rc;
-    foreach_rrdcalc_in_rrdhost_read(vbd->host, rc) {
-        if(rc->config.name == vbd->variable) {
-            RRDSET *st = NULL;
-            RRDSET_ACQUIRED *rsa = rrdcalc_rrdset_acquire_linked(vbd->host, rc, &st);
-            if(!rsa)
+
+    RRDCALC *onstack[ALERT_NAME_MATCHES_ONSTACK];
+    RRDCALC **matches = onstack, **allocated = NULL;
+    size_t matches_size = ALERT_NAME_MATCHES_ONSTACK;
+
+    dictionary_read_lock(vbd->host->rrdcalc_root_index);
+
+    size_t count = rrdcalc_by_name_snapshot(vbd->host, vbd->variable, matches, matches_size);
+    if(unlikely(count > matches_size)) {
+        // more alerts carry this name than the on-stack buffer holds
+        allocated = mallocz(sizeof(RRDCALC *) * count);
+        matches = allocated;
+        matches_size = count;
+
+        count = rrdcalc_by_name_snapshot(vbd->host, vbd->variable, matches, matches_size);
+        if(unlikely(count > matches_size))
+            count = matches_size;
+    }
+
+#ifdef NETDATA_INTERNAL_CHECKS
+    // A stale or missing index entry does not crash - it silently makes the
+    // variable unresolvable and takes the alert to UNDEFINED. Verify loudly here.
+    {
+        size_t scanned = 0;
+        RRDCALC *check;
+        foreach_rrdcalc_in_rrdhost_read(vbd->host, check) {
+            if(check->config.name != vbd->variable)
                 continue;
 
-            NETDATA_DOUBLE value;
-            if(snapshot_values) {
-                RRDCALC_RUNTIME_SNAPSHOT snapshot;
-                rrdcalc_runtime_snapshot_get(rc, &snapshot);
-                value = snapshot.value;
-            }
-            else
-                value = rc->value;
+            scanned++;
 
-            variable_lookup_add_result_with_score(vbd, value, st, "alarm value");
-            rrdset_acquired_release(rsa);
-            found = true;
+            bool indexed = false;
+            for(size_t i = 0; i < count ; i++) {
+                if(matches[i] == check) {
+                    indexed = true;
+                    break;
+                }
+            }
+
+            if(!indexed)
+                fatal("HEALTH: alert name index on host '%s' is missing alert '%s' of chart '%s'",
+                      rrdhost_hostname(vbd->host), rrdcalc_name(check), rrdcalc_chart_name(check));
         }
+        foreach_rrdcalc_in_rrdhost_done(check);
+
+        if(scanned != count)
+            fatal("HEALTH: alert name index on host '%s' has %zu entries for '%s', full scan found %zu",
+                  rrdhost_hostname(vbd->host), count, string2str(vbd->variable), scanned);
     }
-    foreach_rrdcalc_in_rrdhost_done(rc);
+#endif
+
+    for(size_t i = 0; i < count ; i++) {
+        RRDCALC *rc = matches[i];
+
+        RRDSET *st = NULL;
+        RRDSET_ACQUIRED *rsa = rrdcalc_rrdset_acquire_linked(vbd->host, rc, &st);
+        if(!rsa)
+            continue;
+
+        NETDATA_DOUBLE value;
+        if(snapshot_values) {
+            RRDCALC_RUNTIME_SNAPSHOT snapshot;
+            rrdcalc_runtime_snapshot_get(rc, &snapshot);
+            value = snapshot.value;
+        }
+        else
+            value = rc->value;
+
+        variable_lookup_add_result_with_score(vbd, value, st, "alarm value");
+        rrdset_acquired_release(rsa);
+        found = true;
+    }
+
+    dictionary_read_unlock(vbd->host->rrdcalc_root_index);
+
+    freez(allocated);
     return found;
 }
 

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -387,6 +387,10 @@ struct rrdcalc_constructor {
     } react_action;
 };
 
+// defined further down, next to the rest of the name-index implementation
+static void rrdcalc_name_index_add(RRDHOST *host, RRDCALC *rc);
+static void rrdcalc_name_index_del(RRDHOST *host, RRDCALC *rc);
+
 static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, void *rrdcalc, void *constructor_data) {
     RRDCALC *rc = rrdcalc;
     struct rrdcalc_constructor *ctr = constructor_data;
@@ -434,6 +438,8 @@ static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item __maybe_
     rrdcalc_update_info_using_rrdset_labels(rc);
     rrdcalc_runtime_snapshot_publish(rc, 0, NULL);
 
+    rrdcalc_name_index_add(host, rc);
+
     ctr->react_action = RRDCALC_REACT_NEW;
 }
 
@@ -456,9 +462,14 @@ static void rrdcalc_rrdhost_react_callback(const DICTIONARY_ITEM *item __maybe_u
 
 static __thread bool thread_having_ll_wrlock = false;
 
-static void rrdcalc_rrdhost_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *rrdcalc, void *rrdhost __maybe_unused) {
+static void rrdcalc_rrdhost_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *rrdcalc, void *rrdhost) {
     RRDCALC *rc = rrdcalc;
-    //RRDHOST *host = rrdhost;
+    RRDHOST *host = rrdhost;
+
+    // safety net: rrdcalc_unlink_and_delete() already did this, but the
+    // dictionary can reach the delete callback by other routes. Idempotent.
+    if(likely(host))
+        rrdcalc_name_index_del(host, rc);
 
     rrdcalc_unlink_from_rrdset(rc, thread_having_ll_wrlock);
 
@@ -477,10 +488,96 @@ static void rrdcalc_rrdhost_delete_callback(const DICTIONARY_ITEM *item __maybe_
 }
 
 // ----------------------------------------------------------------------------
+// RRDCALC rrdhost index management - secondary index by alert name
+//
+// Keyed by the interned STRING* of rc->config.name, which is assigned once in
+// rrdcalc_rrdhost_insert_callback() and never mutated afterwards (the conflict
+// callback returns false and the dictionary is DICT_OPTION_DONT_OVERWRITE_VALUE),
+// so the key is stable for the lifetime of the RRDCALC.
+//
+// Locking: this index has its own spinlock rather than relying on the alert
+// dictionary lock, because rrdcalc_unlink_and_delete() is reached with only the
+// dictionary READ lock held from health_prototype_apply_to_all_hosts(), which
+// iterates reentrantly.
+
+static void rrdcalc_name_index_add(RRDHOST *host, RRDCALC *rc) {
+    if(unlikely(!rc->config.name))
+        return;
+
+    rw_spinlock_write_lock(&host->rrdcalc_by_name.spinlock);
+
+    Pvoid_t *PValue = JudyLIns(&host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
+    if(likely(PValue && PValue != PJERR && !rc->name_indexed)) {
+        RRDCALC *head = (RRDCALC *)*PValue;
+        DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(head, rc, name_prev, name_next);
+        rc->name_indexed = true;
+        *PValue = head;
+    }
+
+    rw_spinlock_write_unlock(&host->rrdcalc_by_name.spinlock);
+}
+
+// Removing takes the index lock while the caller may already hold
+// st->alerts.spinlock (rrdcalc_unlink_and_delete_all_rrdset_alerts() holds it
+// write across its loop). That fixes the writer order as
+// alerts.spinlock -> name index, so readers must never take the name index and
+// then a chart lock - see rrdcalc_by_name_snapshot().
+static void rrdcalc_name_index_del(RRDHOST *host, RRDCALC *rc) {
+    if(unlikely(!rc->config.name))
+        return;
+
+    rw_spinlock_write_lock(&host->rrdcalc_by_name.spinlock);
+
+    // name_indexed makes this idempotent, which matters because both
+    // rrdcalc_unlink_and_delete() and the dictionary delete callback call it.
+    // It also avoids inferring membership from the list links, which would be
+    // wrong: DOUBLE_LINKED_LIST keeps head->prev pointing at the tail, so a
+    // single-item list has item->prev == item rather than NULL.
+    Pvoid_t *PValue = JudyLGet(host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
+    if(likely(PValue && PValue != PJERR && *PValue && rc->name_indexed)) {
+        RRDCALC *head = (RRDCALC *)*PValue;
+
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(head, rc, name_prev, name_next);
+        rc->name_indexed = false;
+        rc->name_prev = rc->name_next = NULL;
+
+        if(head)
+            *PValue = head;
+        else
+            JudyLDel(&host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
+    }
+
+    rw_spinlock_write_unlock(&host->rrdcalc_by_name.spinlock);
+}
+
+size_t rrdcalc_by_name_snapshot(RRDHOST *host, STRING *name, RRDCALC **dst, size_t dst_size) {
+    size_t found = 0;
+
+    rw_spinlock_read_lock(&host->rrdcalc_by_name.spinlock);
+
+    Pvoid_t *PValue = JudyLGet(host->rrdcalc_by_name.JudyL, (Word_t)name, PJE0);
+    if(PValue && PValue != PJERR) {
+        for(RRDCALC *rc = (RRDCALC *)*PValue; rc ; rc = rc->name_next) {
+            if(found < dst_size)
+                dst[found] = rc;
+            found++;
+        }
+    }
+
+    rw_spinlock_read_unlock(&host->rrdcalc_by_name.spinlock);
+
+    return found;
+}
+
+// ----------------------------------------------------------------------------
 // RRDCALC rrdhost index management - index API
 
 void rrdcalc_rrdhost_index_init(RRDHOST *host) {
+    // called more than once per host (rrdhost.c:499 and :739), so everything
+    // here must stay behind the same idempotency guard as the dictionary
     if(!host->rrdcalc_root_index) {
+        rw_spinlock_init(&host->rrdcalc_by_name.spinlock);
+
         host->rrdcalc_root_index = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE,
                                                               &dictionary_stats_category_rrdhealth, sizeof(RRDCALC));
 
@@ -495,6 +592,19 @@ void rrdcalc_rrdhost_index_destroy(RRDHOST *host) {
     rrdcalc_delete_all(host);
     dictionary_destroy(host->rrdcalc_root_index);
     host->rrdcalc_root_index = NULL;
+
+    // every alert is gone, so the name index must be empty; free whatever the
+    // Judy array itself still holds and report residue, which would mean a
+    // deletion path bypassed rrdcalc_name_index_del()
+    rw_spinlock_write_lock(&host->rrdcalc_by_name.spinlock);
+    Word_t idx = 0;
+    Pvoid_t *PValue = JudyLFirst(host->rrdcalc_by_name.JudyL, &idx, PJE0);
+    if(unlikely(PValue))
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "HEALTH: host '%s' still has entries in the alert name index at teardown",
+               rrdhost_hostname(host));
+    JudyLFreeArray(&host->rrdcalc_by_name.JudyL, PJE0);
+    rw_spinlock_write_unlock(&host->rrdcalc_by_name.spinlock);
 }
 
 bool rrdcalc_add_from_prototype(RRDHOST *host, RRDSET *st, RRD_ALERT_PROTOTYPE *ap) {
@@ -520,6 +630,11 @@ bool rrdcalc_add_from_prototype(RRDHOST *host, RRDSET *st, RRD_ALERT_PROTOTYPE *
 }
 
 void rrdcalc_unlink_and_delete(RRDHOST *host, RRDCALC *rc, bool having_ll_wrlock) {
+    // remove from the name index first, while rc and host are both in hand and
+    // the caller's lock state is known; the delete callback repeats this
+    // defensively for any path that does not come through here
+    rrdcalc_name_index_del(host, rc);
+
     rrdcalc_unlink_from_rrdset(rc, having_ll_wrlock);
 
     thread_having_ll_wrlock = having_ll_wrlock;

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -388,10 +388,10 @@ struct rrdcalc_constructor {
 };
 
 // defined further down, next to the rest of the name-index implementation
-static void rrdcalc_name_index_add(RRDHOST *host, RRDCALC *rc);
+static void rrdcalc_name_index_add(RRDHOST *host, RRDCALC *rc, const DICTIONARY_ITEM *item);
 static void rrdcalc_name_index_del(RRDHOST *host, RRDCALC *rc);
 
-static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, void *rrdcalc, void *constructor_data) {
+static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item, void *rrdcalc, void *constructor_data) {
     RRDCALC *rc = rrdcalc;
     struct rrdcalc_constructor *ctr = constructor_data;
     RRDSET *st = ctr->rrdset;
@@ -438,7 +438,7 @@ static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item __maybe_
     rrdcalc_update_info_using_rrdset_labels(rc);
     rrdcalc_runtime_snapshot_publish(rc, 0, NULL);
 
-    rrdcalc_name_index_add(host, rc);
+    rrdcalc_name_index_add(host, rc, item);
 
     ctr->react_action = RRDCALC_REACT_NEW;
 }
@@ -500,17 +500,18 @@ static void rrdcalc_rrdhost_delete_callback(const DICTIONARY_ITEM *item __maybe_
 // dictionary READ lock held from health_prototype_apply_to_all_hosts(), which
 // iterates reentrantly.
 
-static void rrdcalc_name_index_add(RRDHOST *host, RRDCALC *rc) {
-    if(unlikely(!rc->config.name))
+static void rrdcalc_name_index_add(RRDHOST *host, RRDCALC *rc, const DICTIONARY_ITEM *item) {
+    if(unlikely(!rc->config.name || !item))
         return;
 
     rw_spinlock_write_lock(&host->rrdcalc_by_name.spinlock);
 
     Pvoid_t *PValue = JudyLIns(&host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
-    if(likely(PValue && PValue != PJERR && !rc->name_indexed)) {
+    if(likely(PValue && PValue != PJERR && rc->name_index_state != RRDCALC_NAME_INDEX_LINKED)) {
         RRDCALC *head = (RRDCALC *)*PValue;
         DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(head, rc, name_prev, name_next);
-        rc->name_indexed = true;
+        rc->name_item = item;
+        rc->name_index_state = RRDCALC_NAME_INDEX_LINKED;
         *PValue = head;
     }
 
@@ -528,18 +529,19 @@ static void rrdcalc_name_index_del(RRDHOST *host, RRDCALC *rc) {
 
     rw_spinlock_write_lock(&host->rrdcalc_by_name.spinlock);
 
-    // name_indexed makes this idempotent, which matters because both
+    // name_index_state makes this idempotent, which matters because both
     // rrdcalc_unlink_and_delete() and the dictionary delete callback call it.
     // It also avoids inferring membership from the list links, which would be
     // wrong: DOUBLE_LINKED_LIST keeps head->prev pointing at the tail, so a
     // single-item list has item->prev == item rather than NULL.
     Pvoid_t *PValue = JudyLGet(host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
-    if(likely(PValue && PValue != PJERR && *PValue && rc->name_indexed)) {
+    if(likely(PValue && PValue != PJERR && *PValue && rc->name_index_state == RRDCALC_NAME_INDEX_LINKED)) {
         RRDCALC *head = (RRDCALC *)*PValue;
 
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(head, rc, name_prev, name_next);
-        rc->name_indexed = false;
+        rc->name_index_state = RRDCALC_NAME_INDEX_UNLINKED;
         rc->name_prev = rc->name_next = NULL;
+        rc->name_item = NULL;
 
         if(head)
             *PValue = head;
@@ -550,17 +552,34 @@ static void rrdcalc_name_index_del(RRDHOST *host, RRDCALC *rc) {
     rw_spinlock_write_unlock(&host->rrdcalc_by_name.spinlock);
 }
 
-size_t rrdcalc_by_name_snapshot(RRDHOST *host, STRING *name, RRDCALC **dst, size_t dst_size) {
+size_t rrdcalc_by_name_snapshot(RRDHOST *host, STRING *name, const DICTIONARY_ITEM **dst, size_t dst_size) {
     size_t found = 0;
 
+    // The index lock is what makes acquiring safe: every route that frees an
+    // RRDCALC removes it from this index first (rrdcalc_unlink_and_delete(), or
+    // the delete callback as a safety net), so an entry visible here still
+    // points at live memory for as long as we hold the lock.
     rw_spinlock_read_lock(&host->rrdcalc_by_name.spinlock);
 
     Pvoid_t *PValue = JudyLGet(host->rrdcalc_by_name.JudyL, (Word_t)name, PJE0);
     if(PValue && PValue != PJERR) {
-        for(RRDCALC *rc = (RRDCALC *)*PValue; rc ; rc = rc->name_next) {
-            if(found < dst_size)
-                dst[found] = rc;
+        // count first, so we never acquire references we would have to throw
+        // away when the caller retries with a bigger buffer
+        for(RRDCALC *rc = (RRDCALC *)*PValue; rc ; rc = rc->name_next)
             found++;
+
+        if(likely(found <= dst_size)) {
+            size_t used = 0;
+            for(RRDCALC *rc = (RRDCALC *)*PValue; rc ; rc = rc->name_next) {
+                const DICTIONARY_ITEM *item =
+                    dictionary_item_acquire_if_not_deleted(host->rrdcalc_root_index, rc->name_item);
+
+                if(likely(item))
+                    dst[used++] = item;
+            }
+
+            // alerts being deleted were skipped
+            found = used;
         }
     }
 
@@ -568,6 +587,55 @@ size_t rrdcalc_by_name_snapshot(RRDHOST *host, STRING *name, RRDCALC **dst, size
 
     return found;
 }
+
+#ifdef NETDATA_INTERNAL_CHECKS
+// A missing index entry does not crash: it silently makes the alert's name
+// unresolvable as a variable and takes dependent alerts to UNDEFINED. Verify it
+// loudly instead.
+//
+// This checks one alert against the index at one instant, under the index lock.
+// It deliberately does NOT compare a name-index snapshot against a full
+// dictionary traversal: nothing serializes those two views (the reapplication
+// paths in health_prototypes.c and health_dyncfg.c delete alerts from reentrant
+// traversals, which hold no dictionary lock in the loop body), so any difference
+// between them is as likely to be a legitimate concurrent transition as a bug.
+void rrdcalc_name_index_verify(RRDHOST *host, RRDCALC *rc) {
+    if(unlikely(!rc->config.name))
+        return;
+
+    rw_spinlock_read_lock(&host->rrdcalc_by_name.spinlock);
+
+    RRDCALC_NAME_INDEX_STATE state = rc->name_index_state;
+    bool linked = false;
+
+    if(state == RRDCALC_NAME_INDEX_LINKED) {
+        Pvoid_t *PValue = JudyLGet(host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
+        if(PValue && PValue != PJERR) {
+            for(RRDCALC *t = (RRDCALC *)*PValue; t ; t = t->name_next) {
+                if(t == rc) {
+                    linked = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    rw_spinlock_read_unlock(&host->rrdcalc_by_name.spinlock);
+
+    // UNLINKED is legitimate here: rrdcalc_unlink_and_delete() removes the alert
+    // from the index before it removes it from the dictionary, so a caller
+    // holding a dictionary reference can legally see an alert in that window.
+    if(unlikely(state == RRDCALC_NAME_INDEX_NEVER))
+        fatal("HEALTH: alert '%s' of chart '%s' on host '%s' is in the alert dictionary "
+              "but was never added to the alert name index",
+              rrdcalc_name(rc), rrdcalc_chart_name(rc), rrdhost_hostname(host));
+
+    if(unlikely(state == RRDCALC_NAME_INDEX_LINKED && !linked))
+        fatal("HEALTH: alert '%s' of chart '%s' on host '%s' is flagged as indexed "
+              "but is not in the alert name index",
+              rrdcalc_name(rc), rrdcalc_chart_name(rc), rrdhost_hostname(host));
+}
+#endif
 
 // ----------------------------------------------------------------------------
 // RRDCALC rrdhost index management - index API

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -509,14 +509,24 @@ static void rrdcalc_name_index_add(RRDHOST *host, RRDCALC *rc, const DICTIONARY_
     // Decide before touching the JudyL: inserting first would leave a
     // name -> NULL slot behind if we then declined to link.
     if(likely(rc->name_index_state != RRDCALC_NAME_INDEX_LINKED)) {
-        Pvoid_t *PValue = JudyLIns(&host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
-        if(likely(PValue && PValue != PJERR)) {
-            RRDCALC *head = (RRDCALC *)*PValue;
-            DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(head, rc, name_prev, name_next);
-            rc->name_item = item;
-            rc->name_index_state = RRDCALC_NAME_INDEX_LINKED;
-            *PValue = head;
-        }
+        JError_t J_Error;
+        Pvoid_t *PValue = JudyLIns(&host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, &J_Error);
+
+        // A failed insert cannot be recovered from and nothing retries it: the
+        // alert would stay invisible to every name lookup, silently taking
+        // dependent alerts to UNDEFINED. Same handling as the other structural
+        // Judy indexes (see string.c and uuidmap.c).
+        if(unlikely(!PValue || PValue == PJERR))
+            fatal("HEALTH: cannot insert alert '%s' of chart '%s' on host '%s' into the alert name index, "
+                  "JU_ERRNO_* == %u, ID == %d",
+                  rrdcalc_name(rc), rrdcalc_chart_name(rc), rrdhost_hostname(host),
+                  JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
+
+        RRDCALC *head = (RRDCALC *)*PValue;
+        DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(head, rc, name_prev, name_next);
+        rc->name_item = item;
+        rc->name_index_state = RRDCALC_NAME_INDEX_LINKED;
+        *PValue = head;
     }
 
     rw_spinlock_write_unlock(&host->rrdcalc_by_name.spinlock);
@@ -670,8 +680,15 @@ void rrdcalc_rrdhost_index_destroy(RRDHOST *host) {
     // deletion path bypassed rrdcalc_name_index_del()
     rw_spinlock_write_lock(&host->rrdcalc_by_name.spinlock);
     Word_t idx = 0;
-    Pvoid_t *PValue = JudyLFirst(host->rrdcalc_by_name.JudyL, &idx, PJE0);
-    if(unlikely(PValue))
+    JError_t J_Error;
+    Pvoid_t *PValue = JudyLFirst(host->rrdcalc_by_name.JudyL, &idx, &J_Error);
+    if(unlikely(PValue == PJERR))
+        // a corrupted index is not residue - do not report it as such
+        nd_log(NDLS_DAEMON, NDLP_ERR,
+               "HEALTH: cannot walk the alert name index of host '%s' at teardown, "
+               "JU_ERRNO_* == %u, ID == %d",
+               rrdhost_hostname(host), JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
+    else if(unlikely(PValue))
         nd_log(NDLS_DAEMON, NDLP_ERR,
                "HEALTH: host '%s' still has entries in the alert name index at teardown",
                rrdhost_hostname(host));

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -506,13 +506,17 @@ static void rrdcalc_name_index_add(RRDHOST *host, RRDCALC *rc, const DICTIONARY_
 
     rw_spinlock_write_lock(&host->rrdcalc_by_name.spinlock);
 
-    Pvoid_t *PValue = JudyLIns(&host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
-    if(likely(PValue && PValue != PJERR && rc->name_index_state != RRDCALC_NAME_INDEX_LINKED)) {
-        RRDCALC *head = (RRDCALC *)*PValue;
-        DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(head, rc, name_prev, name_next);
-        rc->name_item = item;
-        rc->name_index_state = RRDCALC_NAME_INDEX_LINKED;
-        *PValue = head;
+    // Decide before touching the JudyL: inserting first would leave a
+    // name -> NULL slot behind if we then declined to link.
+    if(likely(rc->name_index_state != RRDCALC_NAME_INDEX_LINKED)) {
+        Pvoid_t *PValue = JudyLIns(&host->rrdcalc_by_name.JudyL, (Word_t)rc->config.name, PJE0);
+        if(likely(PValue && PValue != PJERR)) {
+            RRDCALC *head = (RRDCALC *)*PValue;
+            DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(head, rc, name_prev, name_next);
+            rc->name_item = item;
+            rc->name_index_state = RRDCALC_NAME_INDEX_LINKED;
+            *PValue = head;
+        }
     }
 
     rw_spinlock_write_unlock(&host->rrdcalc_by_name.spinlock);

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -60,6 +60,16 @@ typedef struct rrdcalc_runtime_snapshot {
     uint32_t times_repeat;
 } RRDCALC_RUNTIME_SNAPSHOT;
 
+// Tracks this alert's membership in host->rrdcalc_by_name. Three states, not a
+// bool: an alert that has been unlinked must be distinguishable from one that was
+// never linked, otherwise the internal-checks verification cannot tell a
+// legitimate in-flight removal from an alert insert() forgot to index.
+typedef enum __attribute__((packed)) {
+    RRDCALC_NAME_INDEX_NEVER = 0,   // never linked into the index
+    RRDCALC_NAME_INDEX_LINKED,      // currently linked
+    RRDCALC_NAME_INDEX_UNLINKED,    // was linked, then removed
+} RRDCALC_NAME_INDEX_STATE;
+
 struct rrdcalc {
     uint32_t id;                    // the unique id of this alarm
     uint32_t next_event_id;         // the next event id that will be used for this alarm
@@ -118,7 +128,12 @@ struct rrdcalc {
 
     struct rrdcalc *name_next;
     struct rrdcalc *name_prev;
-    bool name_indexed;              // true while linked into host->rrdcalc_by_name
+    RRDCALC_NAME_INDEX_STATE name_index_state;
+
+    // The rrdcalc_root_index item owning this RRDCALC, captured in the insert
+    // callback. Readers reaching this alert through the name index acquire a
+    // reference on it, which is what keeps the RRDCALC alive for them.
+    const DICTIONARY_ITEM *name_item;
 };
 
 #define rrdcalc_name(rc) string2str((rc)->config.name)
@@ -228,15 +243,28 @@ void rrdcalc_delete_all(RRDHOST *host);
 void rrdcalc_rrdhost_index_init(RRDHOST *host);
 void rrdcalc_rrdhost_index_destroy(RRDHOST *host);
 
-// Snapshot every RRDCALC of the host whose config.name is `name` into `dst`,
-// returning how many exist. Up to `dst_size` are written; the return value may
-// exceed dst_size, in which case the caller should retry with a larger buffer.
+// Snapshot the host's alerts whose config.name is `name`, returning how many
+// exist. Each returned entry is an ACQUIRED rrdcalc_root_index item that the
+// caller MUST release with dictionary_acquired_item_release(); use
+// dictionary_acquired_item_value() to reach the RRDCALC.
 //
-// The caller MUST hold the host's alert dictionary read lock for as long as it
-// uses the returned pointers - that is what keeps them alive. The name-index
-// lock is taken and released inside, deliberately: it must not be held while
-// the caller acquires chart locks (see rrdcalc_name_index_del()).
-size_t rrdcalc_by_name_snapshot(RRDHOST *host, STRING *name, RRDCALC **dst, size_t dst_size);
+// If the count exceeds dst_size nothing is acquired and nothing is written - the
+// caller retries with a larger buffer - so there is never a partial set to
+// release.
+//
+// Alerts being deleted are skipped, so the count can be lower than the number of
+// links in the index.
+//
+// The name-index lock is taken and released inside, deliberately: it must not be
+// held while the caller acquires chart locks (see rrdcalc_name_index_del()).
+size_t rrdcalc_by_name_snapshot(RRDHOST *host, STRING *name, const DICTIONARY_ITEM **dst, size_t dst_size);
+
+#ifdef NETDATA_INTERNAL_CHECKS
+// Verifies that `rc` and the name index agree about `rc`, and fatal()s if they do
+// not. `rc` must be alive for the duration of the call (the caller holds a
+// reference on it).
+void rrdcalc_name_index_verify(RRDHOST *host, RRDCALC *rc);
+#endif
 
 void rrdcalc_unlink_and_delete(RRDHOST *host, RRDCALC *rc, bool having_ll_wrlock);
 

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -111,6 +111,14 @@ struct rrdcalc {
 
     struct rrdcalc *next;
     struct rrdcalc *prev;
+
+    // ------------------------------------------------------------------------
+    // host->rrdcalc_by_name list links
+    // Distinct from next/prev above, which thread the chart's alert list.
+
+    struct rrdcalc *name_next;
+    struct rrdcalc *name_prev;
+    bool name_indexed;              // true while linked into host->rrdcalc_by_name
 };
 
 #define rrdcalc_name(rc) string2str((rc)->config.name)
@@ -219,6 +227,16 @@ void rrdcalc_delete_all(RRDHOST *host);
 
 void rrdcalc_rrdhost_index_init(RRDHOST *host);
 void rrdcalc_rrdhost_index_destroy(RRDHOST *host);
+
+// Snapshot every RRDCALC of the host whose config.name is `name` into `dst`,
+// returning how many exist. Up to `dst_size` are written; the return value may
+// exceed dst_size, in which case the caller should retry with a larger buffer.
+//
+// The caller MUST hold the host's alert dictionary read lock for as long as it
+// uses the returned pointers - that is what keeps them alive. The name-index
+// lock is taken and released inside, deliberately: it must not be held while
+// the caller acquires chart locks (see rrdcalc_name_index_del()).
+size_t rrdcalc_by_name_snapshot(RRDHOST *host, STRING *name, RRDCALC **dst, size_t dst_size);
 
 void rrdcalc_unlink_and_delete(RRDHOST *host, RRDCALC *rc, bool having_ll_wrlock);
 

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -12,6 +12,14 @@ struct dictionary_stats dictionary_stats_category_other = {
 // ----------------------------------------------------------------------------
 // public locks API
 
+inline void dictionary_read_lock(DICTIONARY *dict) {
+    ll_recursive_lock(dict, DICTIONARY_LOCK_READ);
+}
+
+inline void dictionary_read_unlock(DICTIONARY *dict) {
+    ll_recursive_unlock(dict, DICTIONARY_LOCK_READ);
+}
+
 inline void dictionary_write_lock(DICTIONARY *dict) {
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 }

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -12,14 +12,6 @@ struct dictionary_stats dictionary_stats_category_other = {
 // ----------------------------------------------------------------------------
 // public locks API
 
-inline void dictionary_read_lock(DICTIONARY *dict) {
-    ll_recursive_lock(dict, DICTIONARY_LOCK_READ);
-}
-
-inline void dictionary_read_unlock(DICTIONARY *dict) {
-    ll_recursive_unlock(dict, DICTIONARY_LOCK_READ);
-}
-
 inline void dictionary_write_lock(DICTIONARY *dict) {
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 }
@@ -857,6 +849,17 @@ void *dictionary_get_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
 
 // ----------------------------------------------------------------------------
 // DUP/REL an item (increase/decrease its reference counter)
+
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_item_acquire_if_not_deleted(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item) {
+    if(unlikely(!dict || !item))
+        return NULL;
+
+    if(unlikely(!item_check_and_acquire(dict, item)))
+        return NULL;
+
+    api_internal_check(dict, item, false, false);
+    return item;
+}
 
 ALWAYS_INLINE
 DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_acquired_item_dup(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item) {

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -265,6 +265,11 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough
 #define DICTIONARY_LOCK_WRITE     'w'
 #define DICTIONARY_LOCK_REENTRANT 'z'
 
+// Hold the dictionary's items lock without traversing it. Useful to keep values
+// alive while resolving them through a secondary index. Read mode is recursive.
+void dictionary_read_lock(DICTIONARY *dict);
+void dictionary_read_unlock(DICTIONARY *dict);
+
 void dictionary_write_lock(DICTIONARY *dict);
 void dictionary_write_unlock(DICTIONARY *dict);
 

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -214,6 +214,17 @@ bool dictionary_del_advanced(DICTIONARY *dict, const char *name, ssize_t name_le
 
 void dictionary_acquired_item_release(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item);
 
+// Acquire a reference on an item reached through a secondary index rather than
+// through a dictionary lookup, so its value stays alive until it is released.
+// Returns NULL if the item is deleted or is currently being deleted.
+//
+// Unlike dictionary_acquired_item_dup(), the caller does not need to already
+// hold a reference. It MUST however serialize this call against the item's
+// removal from that secondary index, so the item memory is still valid here:
+// holding a dictionary lock is NOT enough, because dict_item_free_with_hooks()
+// runs after item_linked_list_remove() has released the items write lock.
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_item_acquire_if_not_deleted(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item);
+
 DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_acquired_item_dup(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item);
 
 const char *dictionary_acquired_item_name(DICT_ITEM_CONST DICTIONARY_ITEM *item);
@@ -264,11 +275,6 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough
 #define DICTIONARY_LOCK_READ      'r'
 #define DICTIONARY_LOCK_WRITE     'w'
 #define DICTIONARY_LOCK_REENTRANT 'z'
-
-// Hold the dictionary's items lock without traversing it. Useful to keep values
-// alive while resolving them through a secondary index. Read mode is recursive.
-void dictionary_read_lock(DICTIONARY *dict);
-void dictionary_read_unlock(DICTIONARY *dict);
 
 void dictionary_write_lock(DICTIONARY *dict);
 void dictionary_write_unlock(DICTIONARY *dict);


### PR DESCRIPTION
##### Summary
- Add a per-host secondary index grouping alerts by their interned alert name.
- Replace full-host alert scans during health-variable resolution with indexed snapshots.
- Preserve safe alert lifetimes and avoid chart/index lock-order inversions.
- Maintain the index across alert creation and all deletion paths, with teardown residue checks.
- Expose dictionary read-lock helpers needed to safely use secondary-index results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved alert-name lookups for faster matching of related alerts.
  * Added safer handling when alerts are added, removed, or deleted during lookups.
* **Performance**
  * Reduced the need to scan all alerts when evaluating running-alert variables.
  * Improved lookup efficiency for hosts with many alerts.
* **Reliability**
  * Added validation to prevent stale or deleted alerts from being used during evaluation.
  * Strengthened consistency checks for alert indexing and lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->