### PR TITLE
fix(go.d/snmp_topology): enable UniFi topology profiles

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/topology_profile_resolution_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/topology_profile_resolution_test.go
@@ -137,7 +137,7 @@ func TestTopologyRoleProfiles_AllExactSelectorsResolve(t *testing.T) {
 		},
 		{
 			profile: "topology-role-l3-neighbor",
-			count:   53,
+			count:   54,
 			kinds: []ddprofiledefinition.TopologyKind{
 				ddprofiledefinition.KindArpEntry,
 				ddprofiledefinition.KindArpLegacyEntry,
@@ -177,30 +177,98 @@ func TestTopologyRoleProfiles_AllExactSelectorsResolve(t *testing.T) {
 }
 
 func TestTopologyRoleProfiles_QualifiedSelectors(t *testing.T) {
-	t.Run("Ubiquiti enterprise root", func(t *testing.T) {
-		names, kinds := resolvedTopologyProfileFacts("1.3.6.1.4.1", "Ubiquiti USW-Flex-XG")
-		assert.Contains(t, names, "topology-role-qbridge")
-		assert.Contains(t, names, "topology-role-l3-neighbor")
-		assert.Contains(t, kinds, ddprofiledefinition.KindQbridgeFdbEntry)
-		assert.Contains(t, kinds, ddprofiledefinition.KindArpEntry)
+	tests := map[string]struct {
+		oid            string
+		sysDescr       string
+		wantProfiles   []string
+		absentProfiles []string
+		wantKinds      []ddprofiledefinition.TopologyKind
+		absentKinds    []ddprofiledefinition.TopologyKind
+	}{
+		"Ubiquiti enterprise-root Flex switch": {
+			oid:          "1.3.6.1.4.1",
+			sysDescr:     "Ubiquiti USW-Flex-XG",
+			wantProfiles: []string{"topology-role-qbridge", "topology-role-l3-neighbor"},
+			wantKinds:    []ddprofiledefinition.TopologyKind{ddprofiledefinition.KindQbridgeFdbEntry, ddprofiledefinition.KindArpEntry},
+		},
+		"unrelated enterprise-root device": {
+			oid:            "1.3.6.1.4.1",
+			sysDescr:       "unrelated enterprise device",
+			absentProfiles: []string{"topology-role-qbridge", "topology-role-l3-neighbor"},
+			absentKinds:    []ddprofiledefinition.TopologyKind{ddprofiledefinition.KindQbridgeFdbEntry, ddprofiledefinition.KindArpEntry},
+		},
+		"SONiC Net-SNMP": {
+			oid:          "1.3.6.1.4.1.8072.3.2.10",
+			sysDescr:     "SONiC Software Version",
+			wantProfiles: []string{"topology-role-l3-neighbor"},
+			wantKinds:    []ddprofiledefinition.TopologyKind{ddprofiledefinition.KindArpEntry},
+		},
+		"UniFi switch with generic Net-SNMP identity": {
+			oid:          "1.3.6.1.4.1.8072.3.2.10",
+			sysDescr:     "linux ubnt UniFi Switch",
+			wantProfiles: []string{"topology-role-qbridge", "topology-role-l3-neighbor"},
+			wantKinds: []ddprofiledefinition.TopologyKind{
+				ddprofiledefinition.KindIfName,
+				ddprofiledefinition.KindQbridgeFdbEntry,
+				ddprofiledefinition.KindArpEntry,
+			},
+			absentKinds: []ddprofiledefinition.TopologyKind{
+				ddprofiledefinition.KindFdbEntry,
+				ddprofiledefinition.KindStpPort,
+				ddprofiledefinition.KindLldpRem,
+			},
+		},
+		"UniFi gateway with generic Net-SNMP identity": {
+			oid:            "1.3.6.1.4.1.8072.3.2.10",
+			sysDescr:       "Linux Router 6.6.43-ui-ipq9574",
+			wantProfiles:   []string{"topology-role-l3-neighbor"},
+			absentProfiles: []string{"topology-role-qbridge"},
+			wantKinds:      []ddprofiledefinition.TopologyKind{ddprofiledefinition.KindArpEntry},
+			absentKinds: []ddprofiledefinition.TopologyKind{
+				ddprofiledefinition.KindFdbEntry,
+				ddprofiledefinition.KindQbridgeFdbEntry,
+				ddprofiledefinition.KindStpPort,
+				ddprofiledefinition.KindLldpRem,
+			},
+		},
+		"UniFi AP with exact enterprise identity": {
+			oid:            "1.3.6.1.4.1.41112",
+			sysDescr:       "Ubiquiti UniFi U6 Mesh",
+			wantProfiles:   []string{"topology-role-l3-neighbor"},
+			absentProfiles: []string{"topology-role-qbridge"},
+			wantKinds:      []ddprofiledefinition.TopologyKind{ddprofiledefinition.KindArpLegacyEntry},
+			absentKinds: []ddprofiledefinition.TopologyKind{
+				ddprofiledefinition.KindFdbEntry,
+				ddprofiledefinition.KindQbridgeFdbEntry,
+				ddprofiledefinition.KindStpPort,
+				ddprofiledefinition.KindLldpRem,
+			},
+		},
+		"unrelated generic Net-SNMP agent": {
+			oid:            "1.3.6.1.4.1.8072.3.2.10",
+			sysDescr:       "Linux Net-SNMP agent",
+			absentProfiles: []string{"topology-role-qbridge", "topology-role-l3-neighbor"},
+			absentKinds:    []ddprofiledefinition.TopologyKind{ddprofiledefinition.KindQbridgeFdbEntry, ddprofiledefinition.KindArpEntry},
+		},
+	}
 
-		names, kinds = resolvedTopologyProfileFacts("1.3.6.1.4.1", "unrelated enterprise device")
-		assert.NotContains(t, names, "topology-role-qbridge")
-		assert.NotContains(t, names, "topology-role-l3-neighbor")
-		assert.NotContains(t, kinds, ddprofiledefinition.KindQbridgeFdbEntry)
-		assert.NotContains(t, kinds, ddprofiledefinition.KindArpEntry)
-	})
-
-	t.Run("SONiC Net-SNMP", func(t *testing.T) {
-		const oid = "1.3.6.1.4.1.8072.3.2.10"
-		names, kinds := resolvedTopologyProfileFacts(oid, "SONiC Software Version")
-		assert.Contains(t, names, "topology-role-l3-neighbor")
-		assert.Contains(t, kinds, ddprofiledefinition.KindArpEntry)
-
-		names, kinds = resolvedTopologyProfileFacts(oid, "Linux Net-SNMP agent")
-		assert.NotContains(t, names, "topology-role-l3-neighbor")
-		assert.NotContains(t, kinds, ddprofiledefinition.KindArpEntry)
-	})
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			names, kinds := resolvedTopologyProfileFacts(tc.oid, tc.sysDescr)
+			for _, profile := range tc.wantProfiles {
+				assert.Contains(t, names, profile)
+			}
+			for _, profile := range tc.absentProfiles {
+				assert.NotContains(t, names, profile)
+			}
+			for _, kind := range tc.wantKinds {
+				assert.Contains(t, kinds, kind)
+			}
+			for _, kind := range tc.absentKinds {
+				assert.NotContains(t, kinds, kind)
+			}
+		})
+	}
 }
 
 func TestTopologyRoleProfiles_ArubaGuard(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
@@ -160,13 +160,6 @@ func TestTopologyProductionPath_LegacyARPPhysicalOnly(t *testing.T) {
 	require.Equal(t, "dynamic", observation.ARPNDEntries[0].State)
 }
 
-type topologySNMPRecHandler struct {
-	gosnmp.Handler
-	entries           []gosnmp.SnmpPDU
-	byOID             map[string]gosnmp.SnmpPDU
-	hiddenOIDPrefixes []string
-}
-
 func loadTopologySNMPRecHandler(t *testing.T, path string) *topologySNMPRecHandler {
 	t.Helper()
 
@@ -174,10 +167,7 @@ func loadTopologySNMPRecHandler(t *testing.T, path string) *topologySNMPRecHandl
 	require.NoError(t, err)
 	defer file.Close()
 
-	handler := &topologySNMPRecHandler{
-		Handler: gosnmp.NewHandler(),
-		byOID:   make(map[string]gosnmp.SnmpPDU),
-	}
+	var entries []gosnmp.SnmpPDU
 	scanner := bufio.NewScanner(file)
 	for lineNumber := 1; scanner.Scan(); lineNumber++ {
 		line := strings.TrimSpace(scanner.Text())
@@ -188,73 +178,11 @@ func loadTopologySNMPRecHandler(t *testing.T, path string) *topologySNMPRecHandl
 		require.Lenf(t, parts, 3, "invalid snmprec line %d", lineNumber)
 		pdu, err := topologySNMPRecPDU(parts[0], parts[1], parts[2])
 		require.NoErrorf(t, err, "invalid snmprec line %d", lineNumber)
-		handler.entries = append(handler.entries, pdu)
-		handler.byOID[strings.TrimPrefix(pdu.Name, ".")] = pdu
+		entries = append(entries, pdu)
 	}
 	require.NoError(t, scanner.Err())
-	return handler
+	return newTopologySNMPHandler(entries)
 }
-
-func (h *topologySNMPRecHandler) Get(oids []string) (*gosnmp.SnmpPacket, error) {
-	variables := make([]gosnmp.SnmpPDU, 0, len(oids))
-	for _, oid := range oids {
-		key := strings.TrimPrefix(strings.TrimSpace(oid), ".")
-		if h.isHiddenOID(key) {
-			variables = append(variables, gosnmp.SnmpPDU{Name: key, Type: gosnmp.NoSuchObject})
-			continue
-		}
-		if pdu, ok := h.byOID[key]; ok {
-			variables = append(variables, pdu)
-			continue
-		}
-		variables = append(variables, gosnmp.SnmpPDU{Name: key, Type: gosnmp.NoSuchObject})
-	}
-	return &gosnmp.SnmpPacket{Variables: variables}, nil
-}
-
-func (h *topologySNMPRecHandler) WalkAll(root string) ([]gosnmp.SnmpPDU, error) {
-	return h.walkAll(root), nil
-}
-
-func (h *topologySNMPRecHandler) BulkWalkAll(root string) ([]gosnmp.SnmpPDU, error) {
-	return h.walkAll(root), nil
-}
-
-func (h *topologySNMPRecHandler) walkAll(root string) []gosnmp.SnmpPDU {
-	root = strings.TrimPrefix(strings.TrimSpace(root), ".")
-	prefix := root + "."
-	var out []gosnmp.SnmpPDU
-	for _, pdu := range h.entries {
-		name := strings.TrimPrefix(pdu.Name, ".")
-		if h.isHiddenOID(name) {
-			continue
-		}
-		if name == root || strings.HasPrefix(name, prefix) {
-			out = append(out, pdu)
-		}
-	}
-	return out
-}
-
-func (h *topologySNMPRecHandler) hideOIDPrefix(prefix string) {
-	prefix = strings.TrimPrefix(strings.TrimSpace(prefix), ".")
-	if prefix != "" {
-		h.hiddenOIDPrefixes = append(h.hiddenOIDPrefixes, prefix)
-	}
-}
-
-func (h *topologySNMPRecHandler) isHiddenOID(oid string) bool {
-	oid = strings.TrimPrefix(strings.TrimSpace(oid), ".")
-	for _, prefix := range h.hiddenOIDPrefixes {
-		if oid == prefix || strings.HasPrefix(oid, prefix+".") {
-			return true
-		}
-	}
-	return false
-}
-
-func (h *topologySNMPRecHandler) Version() gosnmp.SnmpVersion { return gosnmp.Version2c }
-func (h *topologySNMPRecHandler) MaxOids() int                { return 60 }
 
 func TestTopologySNMPRecPDURejectsMalformedValues(t *testing.T) {
 	tests := map[string]struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmp_handler_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmp_handler_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+type topologySNMPRecHandler struct {
+	gosnmp.Handler
+	entries           []gosnmp.SnmpPDU
+	byOID             map[string]gosnmp.SnmpPDU
+	hiddenOIDPrefixes []string
+}
+
+func newTopologySNMPHandler(entries []gosnmp.SnmpPDU) *topologySNMPRecHandler {
+	handler := &topologySNMPRecHandler{
+		Handler: gosnmp.NewHandler(),
+		entries: entries,
+		byOID:   make(map[string]gosnmp.SnmpPDU, len(entries)),
+	}
+	for _, pdu := range entries {
+		handler.byOID[strings.TrimPrefix(pdu.Name, ".")] = pdu
+	}
+	return handler
+}
+
+func (h *topologySNMPRecHandler) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	variables := make([]gosnmp.SnmpPDU, 0, len(oids))
+	for _, oid := range oids {
+		key := strings.TrimPrefix(strings.TrimSpace(oid), ".")
+		if h.isHiddenOID(key) {
+			variables = append(variables, gosnmp.SnmpPDU{Name: key, Type: gosnmp.NoSuchObject})
+			continue
+		}
+		if pdu, ok := h.byOID[key]; ok {
+			variables = append(variables, pdu)
+			continue
+		}
+		variables = append(variables, gosnmp.SnmpPDU{Name: key, Type: gosnmp.NoSuchObject})
+	}
+	return &gosnmp.SnmpPacket{Variables: variables}, nil
+}
+
+func (h *topologySNMPRecHandler) WalkAll(root string) ([]gosnmp.SnmpPDU, error) {
+	return h.walkAll(root), nil
+}
+
+func (h *topologySNMPRecHandler) BulkWalkAll(root string) ([]gosnmp.SnmpPDU, error) {
+	return h.walkAll(root), nil
+}
+
+func (h *topologySNMPRecHandler) walkAll(root string) []gosnmp.SnmpPDU {
+	root = strings.TrimPrefix(strings.TrimSpace(root), ".")
+	prefix := root + "."
+	var out []gosnmp.SnmpPDU
+	for _, pdu := range h.entries {
+		name := strings.TrimPrefix(pdu.Name, ".")
+		if h.isHiddenOID(name) {
+			continue
+		}
+		if name == root || strings.HasPrefix(name, prefix) {
+			out = append(out, pdu)
+		}
+	}
+	return out
+}
+
+func (h *topologySNMPRecHandler) hideOIDPrefix(prefix string) {
+	prefix = strings.TrimPrefix(strings.TrimSpace(prefix), ".")
+	if prefix != "" {
+		h.hiddenOIDPrefixes = append(h.hiddenOIDPrefixes, prefix)
+	}
+}
+
+func (h *topologySNMPRecHandler) isHiddenOID(oid string) bool {
+	oid = strings.TrimPrefix(strings.TrimSpace(oid), ".")
+	for _, prefix := range h.hiddenOIDPrefixes {
+		if oid == prefix || strings.HasPrefix(oid, prefix+".") {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *topologySNMPRecHandler) Version() gosnmp.SnmpVersion { return gosnmp.Version2c }
+func (h *topologySNMPRecHandler) MaxOids() int                { return 60 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+)
+
+func TestTopologyProductionPath_UniFiCapabilityProfiles(t *testing.T) {
+	tests := map[string]struct {
+		device      ddsnmp.DeviceConnectionInfo
+		pdus        []gosnmp.SnmpPDU
+		wantKinds   []ddsnmp.TopologyKind
+		absentKinds []ddsnmp.TopologyKind
+	}{
+		"access point collects legacy ARP only": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Hostname:    "192.0.2.20",
+				SysObjectID: "1.3.6.1.4.1.41112",
+				SysDescr:    "Ubiquiti UniFi U6 Mesh",
+			},
+			pdus:        topologyUniFiAPPDUs(),
+			wantKinds:   []ddsnmp.TopologyKind{ddsnmp.KindArpLegacyEntry},
+			absentKinds: []ddsnmp.TopologyKind{ddsnmp.KindQbridgeFdbEntry, ddsnmp.KindFdbEntry, ddsnmp.KindStpPort, ddsnmp.KindLldpRem},
+		},
+		"switch collects Q-BRIDGE interface and legacy ARP": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Hostname:    "192.0.2.10",
+				SysObjectID: "1.3.6.1.4.1.8072.3.2.10",
+				SysDescr:    "Linux UBNT UniFi Switch",
+			},
+			pdus:        topologyUniFiSwitchPDUs(),
+			wantKinds:   []ddsnmp.TopologyKind{ddsnmp.KindIfName, ddsnmp.KindQbridgeFdbEntry, ddsnmp.KindQbridgeVlanEntry, ddsnmp.KindArpLegacyEntry},
+			absentKinds: []ddsnmp.TopologyKind{ddsnmp.KindFdbEntry, ddsnmp.KindStpPort, ddsnmp.KindLldpRem},
+		},
+		"gateway collects modern and legacy ARP only": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Hostname:    "192.0.2.1",
+				SysObjectID: "1.3.6.1.4.1.8072.3.2.10",
+				SysDescr:    "Linux Router 6.6.43-ui-ipq9574",
+			},
+			pdus:        topologyUniFiGatewayPDUs(),
+			wantKinds:   []ddsnmp.TopologyKind{ddsnmp.KindArpEntry, ddsnmp.KindArpLegacyEntry},
+			absentKinds: []ddsnmp.TopologyKind{ddsnmp.KindQbridgeFdbEntry, ddsnmp.KindFdbEntry, ddsnmp.KindStpPort, ddsnmp.KindLldpRem},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			metrics := collectTopologyProfileMetrics(t, tc.device, tc.pdus)
+			kinds := collectedTopologyKinds(metrics)
+			for _, kind := range tc.wantKinds {
+				assert.Contains(t, kinds, kind)
+			}
+			for _, kind := range tc.absentKinds {
+				assert.NotContains(t, kinds, kind)
+			}
+		})
+	}
+}
+
+func TestTopologyProductionPath_UniFiQBridgeRendersDefaultManagedFabric(t *testing.T) {
+	switchDevice := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		SysObjectID: "1.3.6.1.4.1.8072.3.2.10",
+		SysName:     "unifi-switch",
+		SysDescr:    "Linux UBNT UniFi Switch",
+	}
+	switchMetrics := collectTopologyProfileMetrics(t, switchDevice, topologyUniFiSwitchPDUs())
+	switchCache := newTestTopologyCache(switchDevice)
+	switchCache.updateTopologyProfileTags(switchMetrics)
+	switchCache.ingestTopologyProfileMetrics(switchMetrics)
+	switchCache.finalizeTopologyCache()
+
+	switchObservation := switchCache.buildEngineObservation(switchCache.localDevice)
+	require.Len(t, switchObservation.FDBEntries, 2)
+	for _, entry := range switchObservation.FDBEntries {
+		assert.Equal(t, "7", entry.BridgePort)
+		assert.Zero(t, entry.IfIndex, "an unmapped bridge base-port must remain outside the ifIndex namespace")
+		assert.Equal(t, "20", entry.VLANID)
+	}
+	require.NotEmpty(t, switchObservation.ARPNDEntries)
+
+	gatewayDevice := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.1",
+		SysObjectID: "1.3.6.1.4.1.8072.3.2.10",
+		SysName:     "unifi-gateway",
+		SysDescr:    "Linux Router 6.6.43-ui-ipq9574",
+	}
+	gatewayMetrics := collectTopologyProfileMetrics(t, gatewayDevice, topologyUniFiGatewayPDUs())
+	gatewayCache := newTestTopologyCache(gatewayDevice)
+	gatewayCache.ingestTopologyProfileMetrics(gatewayMetrics)
+	gatewayCache.finalizeTopologyCache()
+	apDevice := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.20",
+		SysObjectID: "1.3.6.1.4.1.41112",
+		SysName:     "unifi-ap",
+		SysDescr:    "Ubiquiti UniFi U6 Mesh",
+	}
+	apMetrics := collectTopologyProfileMetrics(t, apDevice, topologyUniFiAPPDUs())
+	apCache := newTestTopologyCache(apDevice)
+	apCache.ingestTopologyProfileMetrics(apMetrics)
+	apCache.finalizeTopologyCache()
+
+	registry := newTopologyRegistry()
+	registry.register(switchCache)
+	registry.register(gatewayCache)
+	registry.register(apCache)
+	data, ok := snapshotTopologyRegistryForTest(registry)
+	require.True(t, ok)
+	assert.GreaterOrEqual(t, testCountTopologyLinksByType(data.Links, "bridge"), 1)
+	assert.GreaterOrEqual(t, testCountTopologyLinksByType(data.Links, "fdb"), 1)
+}
+
+func collectTopologyProfileMetrics(
+	t *testing.T,
+	device ddsnmp.DeviceConnectionInfo,
+	pdus []gosnmp.SnmpPDU,
+) []*ddsnmp.ProfileMetrics {
+	t.Helper()
+
+	profiles := (&Collector{}).findTopologyProfiles(device)
+	require.NotEmpty(t, profiles)
+	metrics, err := ddsnmpcollector.New(ddsnmpcollector.Config{
+		SnmpClient:  newTopologySNMPHandler(pdus),
+		Profiles:    profiles,
+		Log:         newTestSNMPTopologyCollector().Logger,
+		SysObjectID: device.SysObjectID,
+	}).Collect()
+	require.NoError(t, err)
+	return metrics
+}
+
+func collectedTopologyKinds(metrics []*ddsnmp.ProfileMetrics) map[ddsnmp.TopologyKind]struct{} {
+	kinds := make(map[ddsnmp.TopologyKind]struct{})
+	for _, profileMetrics := range metrics {
+		for _, metric := range profileMetrics.TopologyMetrics {
+			kinds[metric.TopologyKind] = struct{}{}
+		}
+	}
+	return kinds
+}
+
+func topologyUniFiSwitchPDUs() []gosnmp.SnmpPDU {
+	return []gosnmp.SnmpPDU{
+		// The bridge identity is present, while dot1dBasePortIfIndex is intentionally absent.
+		topologyOctetPDU("1.3.6.1.2.1.17.1.1.0", 0x02, 0, 0, 0, 0, 0x10),
+		topologyOctetStringPDU("1.3.6.1.2.1.31.1.1.1.1.7", "Port 7"),
+		topologyIntegerPDU("1.3.6.1.2.1.31.1.1.1.15.7", 1000),
+		topologyOctetStringPDU("1.3.6.1.2.1.2.2.1.2.7", "Port 7"),
+		topologyIntegerPDU("1.3.6.1.2.1.2.2.1.7.7", 1),
+		topologyIntegerPDU("1.3.6.1.2.1.2.2.1.8.7", 1),
+		topologyIntegerPDU("1.3.6.1.2.1.17.7.1.2.2.1.2.100.2.0.0.0.0.1", 7),
+		topologyIntegerPDU("1.3.6.1.2.1.17.7.1.2.2.1.3.100.2.0.0.0.0.1", 3),
+		topologyIntegerPDU("1.3.6.1.2.1.17.7.1.2.2.1.2.100.2.0.0.0.0.2", 7),
+		topologyIntegerPDU("1.3.6.1.2.1.17.7.1.2.2.1.3.100.2.0.0.0.0.2", 3),
+		topologyIntegerPDU("1.3.6.1.2.1.17.7.1.4.2.1.3.0.20", 100),
+		topologyOctetPDU("1.3.6.1.2.1.4.22.1.2.7.192.0.2.1", 0x02, 0, 0, 0, 0, 1),
+		topologyIntegerPDU("1.3.6.1.2.1.4.22.1.4.7.192.0.2.1", 3),
+		topologyOctetPDU("1.3.6.1.2.1.4.22.1.2.7.192.0.2.20", 0x02, 0, 0, 0, 0, 2),
+		topologyIntegerPDU("1.3.6.1.2.1.4.22.1.4.7.192.0.2.20", 3),
+	}
+}
+
+func topologyUniFiAPPDUs() []gosnmp.SnmpPDU {
+	return []gosnmp.SnmpPDU{
+		topologyOctetPDU("1.3.6.1.2.1.4.22.1.2.17.192.0.2.1", 0x02, 0, 0, 0, 0, 1),
+		topologyIntegerPDU("1.3.6.1.2.1.4.22.1.4.17.192.0.2.1", 3),
+	}
+}
+
+func topologyUniFiGatewayPDUs() []gosnmp.SnmpPDU {
+	return []gosnmp.SnmpPDU{
+		topologyOctetPDU("1.3.6.1.2.1.4.35.1.4.3.1.4.192.0.2.10", 0x02, 0, 0, 0, 0, 0x10),
+		topologyIntegerPDU("1.3.6.1.2.1.4.35.1.6.3.1.4.192.0.2.10", 3),
+		topologyIntegerPDU("1.3.6.1.2.1.4.35.1.7.3.1.4.192.0.2.10", 1),
+		topologyOctetPDU("1.3.6.1.2.1.4.22.1.2.3.192.0.2.10", 0x02, 0, 0, 0, 0, 0x10),
+		topologyIntegerPDU("1.3.6.1.2.1.4.22.1.4.3.192.0.2.10", 3),
+	}
+}
+
+func topologyIntegerPDU(name string, value int) gosnmp.SnmpPDU {
+	return gosnmp.SnmpPDU{Name: name, Type: gosnmp.Integer, Value: value}
+}
+
+func topologyOctetPDU(name string, value ...byte) gosnmp.SnmpPDU {
+	return gosnmp.SnmpPDU{Name: name, Type: gosnmp.OctetString, Value: value}
+}
+
+func topologyOctetStringPDU(name, value string) gosnmp.SnmpPDU {
+	return topologyOctetPDU(name, []byte(value)...)
+}

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/topology-role-l3-neighbor.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/topology-role-l3-neighbor.yaml
@@ -1,4 +1,4 @@
-# Topology capabilities for devices with fixture-backed IP-MIB neighbor tables.
+# Topology capabilities for devices with evidence-backed IP-MIB neighbor tables.
 
 extends:
   - _std-topology-arp-mib.yaml
@@ -57,6 +57,7 @@ selector:
         - 1.3.6.1.4.1.35265.1.83
         - 1.3.6.1.4.1.35265.1.92
         - 1.3.6.1.4.1.35265.1.176
+        - 1.3.6.1.4.1.41112
         - 1.3.6.1.4.1.52642.1.99.5802
         - 1.3.6.1.4.1.52642.2.1.45.101
   - sysobjectid:
@@ -71,6 +72,14 @@ selector:
     sysdescr:
       include:
         - SONiC
+  # UniFi switches and gateways share the generic Net-SNMP identity.
+  - sysobjectid:
+      include:
+        - 1.3.6.1.4.1.8072.3.2.10
+    sysdescr:
+      include:
+        - Linux UBNT
+        - ui-ipq9574
   # Profile extends does not merge selectors, so this guard is repeated by each Aruba switch role.
   - sysobjectid:
       include:

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/topology-role-qbridge.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/topology-role-qbridge.yaml
@@ -1,4 +1,4 @@
-# Topology capabilities for devices with fixture-backed Q-BRIDGE-MIB FDB support.
+# Topology capabilities for devices with evidence-backed Q-BRIDGE-MIB FDB support.
 
 extends:
   - _std-topology-interface-mib.yaml
@@ -61,6 +61,13 @@ selector:
     sysdescr:
       include:
         - USW-Flex-XG
+  # UniFi switches expose the generic Net-SNMP identity, so the vendor marker is required.
+  - sysobjectid:
+      include:
+        - 1.3.6.1.4.1.8072.3.2.10
+    sysdescr:
+      include:
+        - Linux UBNT
   # Profile extends does not merge selectors, so this guard is repeated by each Aruba switch role.
   - sysobjectid:
       include:


### PR DESCRIPTION
##### Summary

Related: [#23480](https://github.com/netdata/netdata/issues/23480#issuecomment-5341848271)

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded SNMP topology profile detection for UniFi devices, including access points, switches, and gateways.
  * Added support for identifying UniFi devices through additional system identifiers and descriptions.
  * Improved topology and managed-fabric rendering, including bridge-port, ARP/ND, and registry link data.

* **Bug Fixes**
  * Improved evidence-based neighbor and Q-BRIDGE-MIB profile matching.
  * Expanded validation to prevent unrelated devices from receiving UniFi-specific topology profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->