### PR TITLE
fix(go.d/snmp): honor scalar fallback order

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -29,11 +29,12 @@ type Config struct {
 
 func New(cfg Config) *Collector {
 	coll := &Collector{
-		log:           cfg.Log.With(slog.String("ddsnmp", "collector")),
-		profiles:      make(map[string]*profileState),
-		missingOIDs:   make(map[string]bool),
-		tableCache:    newTableCache(30*time.Minute, 1),
-		tableIdentity: buildTableIdentity(cfg.Profiles),
+		log:                       cfg.Log.With(slog.String("ddsnmp", "collector")),
+		profiles:                  make(map[string]*profileState),
+		missingOIDs:               make(map[string]bool),
+		regularScalarNamesScratch: make(map[string]struct{}),
+		tableCache:                newTableCache(30*time.Minute, 1),
+		tableIdentity:             buildTableIdentity(cfg.Profiles),
 	}
 
 	for _, prof := range cfg.Profiles {
@@ -51,11 +52,12 @@ func New(cfg Config) *Collector {
 
 type (
 	Collector struct {
-		log           *logger.Logger
-		profiles      map[string]*profileState
-		missingOIDs   map[string]bool
-		tableCache    *tableCache
-		tableIdentity *tableIdentity
+		log                       *logger.Logger
+		profiles                  map[string]*profileState
+		missingOIDs               map[string]bool
+		regularScalarNamesScratch map[string]struct{}
+		tableCache                *tableCache
+		tableIdentity             *tableIdentity
 
 		globalTagsCollector     *globalTagsCollector
 		deviceMetadataCollector *deviceMetadataCollector
@@ -183,6 +185,25 @@ func (c *Collector) sortedProfileStates() []*profileState {
 	return profiles
 }
 
+func (c *Collector) keepFirstRegularScalarMetricByName(metrics []ddsnmp.Metric) []ddsnmp.Metric {
+	if len(metrics) < 2 {
+		return metrics
+	}
+	if c.regularScalarNamesScratch == nil {
+		c.regularScalarNamesScratch = make(map[string]struct{})
+	} else {
+		clear(c.regularScalarNamesScratch)
+	}
+
+	return slices.DeleteFunc(metrics, func(metric ddsnmp.Metric) bool {
+		if _, ok := c.regularScalarNamesScratch[metric.Name]; ok {
+			return true
+		}
+		c.regularScalarNamesScratch[metric.Name] = struct{}{}
+		return false
+	})
+}
+
 func collectHiddenMetrics(metrics []ddsnmp.Metric) []ddsnmp.Metric {
 	var hidden []ddsnmp.Metric
 	for _, metric := range metrics {
@@ -234,6 +255,7 @@ func (c *Collector) prepareProfileCollection(ps *profileState) (*preparedProfile
 	if err != nil {
 		return nil, err
 	}
+	scalarMetrics = c.keepFirstRegularScalarMetricByName(scalarMetrics)
 	pm.Metrics = append(pm.Metrics, scalarMetrics...)
 	pm.Stats.Timing.Scalar = time.Since(now)
 	pm.Stats.Metrics.Scalar += int64(len(scalarMetrics))

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_fallback_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_fallback_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gosnmp/gosnmp"
+	snmpmock "github.com/gosnmp/gosnmp/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestCollector_Collect_RegularScalarFallbackKeepsFirstSuccessfulMetric(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	const (
+		primaryOID  = "1.3.6.1.4.1.99999.1.0"
+		fallbackOID = "1.3.6.1.4.1.99999.2.0"
+	)
+
+	expectSNMPGet(mockHandler, []string{primaryOID, fallbackOID}, []gosnmp.SnmpPDU{
+		createGauge32PDU(primaryOID, 10),
+		createGauge32PDU(fallbackOID, 20),
+	})
+
+	profile := createTestProfile("scalar-fallback.yaml", []ddprofiledefinition.MetricsConfig{
+		createScalarMetric(primaryOID, "systemUptime"),
+		createScalarMetric(fallbackOID, "systemUptime"),
+	})
+	profile.Definition.VirtualMetrics = []ddprofiledefinition.VirtualMetricConfig{
+		{
+			Name: "selectedUptime",
+			Sources: []ddprofiledefinition.VirtualMetricSourceConfig{
+				{Metric: "systemUptime"},
+			},
+		},
+	}
+
+	collector := New(Config{
+		SnmpClient: mockHandler,
+		Profiles:   []*ddsnmp.Profile{profile},
+		Log:        logger.New(),
+	})
+	results, err := collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	pm := results[0]
+	require.Len(t, pm.Metrics, 2)
+	assert.Equal(t, ddsnmp.Metric{Name: "systemUptime", Value: 10, MetricType: "gauge", Profile: pm}, pm.Metrics[0])
+	assert.Equal(t, ddsnmp.Metric{Name: "selectedUptime", Value: 10, MetricType: "gauge", Profile: pm}, pm.Metrics[1])
+	assert.Equal(t, int64(1), pm.Stats.Metrics.Scalar)
+	assert.Equal(t, int64(1), pm.Stats.Metrics.Virtual)
+	assert.Equal(t, int64(2), pm.Stats.SNMP.GetOIDs)
+}
+
+func TestSystemBaseProfile_ScalarFallbackOrder(t *testing.T) {
+	profile, err := ddsnmp.LoadProfileByName("_system-base")
+	require.NoError(t, err)
+
+	var uptimeOIDs []string
+	for _, metric := range profile.Definition.Metrics {
+		if metric.IsScalar() && metric.Symbol.Name == "systemUptime" {
+			uptimeOIDs = append(uptimeOIDs, metric.Symbol.OID)
+		}
+	}
+	assert.Equal(t, []string{
+		"1.3.6.1.6.3.10.2.1.3.0", // snmpEngineTime
+		"1.3.6.1.2.1.25.1.1.0",   // hrSystemUptime
+		"1.3.6.1.2.1.1.3.0",      // sysUpTime
+	}, uptimeOIDs)
+}
+
+func TestCollector_Collect_RegularScalarFallbackFallsThrough(t *testing.T) {
+	const (
+		primaryOID  = "1.3.6.1.4.1.99999.3.0"
+		fallbackOID = "1.3.6.1.4.1.99999.4.0"
+	)
+
+	tests := map[string]struct {
+		primaryConfig   ddprofiledefinition.MetricsConfig
+		primaryPDU      gosnmp.SnmpPDU
+		missingErrors   int64
+		processingError int64
+	}{
+		"missing primary": {
+			primaryConfig: createScalarMetric(primaryOID, "systemUptime"),
+			primaryPDU:    createNoSuchObjectPDU(primaryOID),
+			missingErrors: 1,
+		},
+		"unusable primary": {
+			primaryConfig:   createScalarMetric(primaryOID, "systemUptime"),
+			primaryPDU:      createStringPDU(primaryOID, "not-a-number"),
+			processingError: 1,
+		},
+		"soft-skipped primary": {
+			primaryConfig: ddprofiledefinition.MetricsConfig{
+				Symbol: ddprofiledefinition.SymbolConfig{
+					OID:    primaryOID,
+					Name:   "systemUptime",
+					Format: "text_date",
+				},
+			},
+			primaryPDU: createStringPDU(primaryOID, "never"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl, mockHandler := setupMockHandler(t)
+			defer ctrl.Finish()
+
+			expectSNMPGet(mockHandler, []string{primaryOID, fallbackOID}, []gosnmp.SnmpPDU{
+				test.primaryPDU,
+				createGauge32PDU(fallbackOID, 20),
+			})
+
+			profile := createTestProfile("scalar-fallback.yaml", []ddprofiledefinition.MetricsConfig{
+				test.primaryConfig,
+				createScalarMetric(fallbackOID, "systemUptime"),
+			})
+			collector := New(Config{
+				SnmpClient: mockHandler,
+				Profiles:   []*ddsnmp.Profile{profile},
+				Log:        logger.New(),
+			})
+			results, err := collector.Collect()
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+
+			pm := results[0]
+			require.Len(t, pm.Metrics, 1)
+			assert.Equal(t, "systemUptime", pm.Metrics[0].Name)
+			assert.EqualValues(t, 20, pm.Metrics[0].Value)
+			assert.Equal(t, int64(1), pm.Stats.Metrics.Scalar)
+			assert.Equal(t, test.missingErrors, pm.Stats.Errors.MissingOIDs)
+			assert.Equal(t, test.processingError, pm.Stats.Errors.Processing.Scalar)
+			assert.Equal(t, int64(2), pm.Stats.SNMP.GetOIDs)
+		})
+	}
+}
+
+func TestCollector_KeepFirstRegularScalarMetricByName(t *testing.T) {
+	collector := &Collector{}
+
+	first := []ddsnmp.Metric{
+		{Name: "fallback", Value: 1},
+		{Name: "distinct", Value: 2},
+		{Name: "fallback", Value: 3},
+	}
+	assert.Equal(t, []ddsnmp.Metric{
+		{Name: "fallback", Value: 1},
+		{Name: "distinct", Value: 2},
+	}, collector.keepFirstRegularScalarMetricByName(first))
+
+	second := []ddsnmp.Metric{
+		{Name: "fallback", Value: 4},
+		{Name: "fallback", Value: 5},
+	}
+	assert.Equal(t, []ddsnmp.Metric{
+		{Name: "fallback", Value: 4},
+	}, collector.keepFirstRegularScalarMetricByName(second), "winner state must reset for each profile")
+}
+
+func TestCollector_Collect_RegularScalarFallbackDoesNotAffectTopologyScalars(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	const (
+		firstOID  = "1.3.6.1.4.1.99999.10.0"
+		secondOID = "1.3.6.1.4.1.99999.11.0"
+	)
+
+	expectSNMPGet(mockHandler, []string{firstOID, secondOID}, []gosnmp.SnmpPDU{
+		createGauge32PDU(firstOID, 1),
+		createGauge32PDU(secondOID, 2),
+	})
+
+	profile := &ddsnmp.Profile{
+		SourceFile: "topology-scalars.yaml",
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Topology: []ddprofiledefinition.TopologyConfig{
+				{
+					Kind: ddprofiledefinition.KindIfStatus,
+					MetricsConfig: ddprofiledefinition.MetricsConfig{
+						Symbol: ddprofiledefinition.SymbolConfig{OID: firstOID, Name: "if_status"},
+					},
+				},
+				{
+					Kind: ddprofiledefinition.KindIfStatus,
+					MetricsConfig: ddprofiledefinition.MetricsConfig{
+						Symbol: ddprofiledefinition.SymbolConfig{OID: secondOID, Name: "if_status"},
+					},
+				},
+			},
+		},
+	}
+
+	collector := New(Config{
+		SnmpClient: mockHandler,
+		Profiles:   []*ddsnmp.Profile{profile},
+		Log:        logger.New(),
+	})
+	results, err := collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Metrics)
+	require.Len(t, results[0].TopologyMetrics, 2)
+	assert.EqualValues(t, 1, results[0].TopologyMetrics[0].Value)
+	assert.EqualValues(t, 2, results[0].TopologyMetrics[1].Value)
+}
+
+func BenchmarkCollector_CollectScalarFallbacks(b *testing.B) {
+	for _, names := range []int{16, 64, 256} {
+		b.Run(fmt.Sprintf("names=%d/alternatives=3", names), func(b *testing.B) {
+			ctrl := gomock.NewController(b)
+			defer ctrl.Finish()
+
+			mockHandler := snmpmock.NewMockHandler(ctrl)
+			mockHandler.EXPECT().MaxOids().Return(4096).AnyTimes()
+			device := newStatefulSNMPDevice()
+			device.install(mockHandler)
+
+			metrics := make([]ddprofiledefinition.MetricsConfig, 0, names*3)
+			for i := range names {
+				name := fmt.Sprintf("metric_%d", i)
+				for alt := range 3 {
+					oid := fmt.Sprintf("1.3.6.1.4.1.99999.%d.%d.0", i+1, alt+1)
+					metrics = append(metrics, createScalarMetric(oid, name))
+					device.set(createGauge32PDU(oid, uint(i+alt+1)))
+				}
+			}
+
+			collector := New(Config{
+				SnmpClient: mockHandler,
+				Profiles:   []*ddsnmp.Profile{createTestProfile("benchmark-fallbacks.yaml", metrics)},
+				Log:        logger.New(),
+			})
+
+			_, err := collector.Collect()
+			require.NoError(b, err)
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(names), "names/op")
+			b.ResetTimer()
+			for range b.N {
+				results, err := collector.Collect()
+				if err != nil || len(results) != 1 {
+					b.Fatalf("collect: results=%d err=%v", len(results), err)
+				}
+				runtime.KeepAlive(results)
+			}
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -492,7 +492,10 @@ manual_profiles:
 
 #### Scalar symbol fallbacks
 
-You can express “try this OID, otherwise try that OID” by declaring **multiple scalar metrics with the same** `symbol.name`, each pointing to a different OID. At runtime the collector **GETs** all declared scalar OIDs, marks missing ones, and **emits** the metric from whichever OID returns data. Missing OIDs are skipped cleanly.
+You can express “try this OID, otherwise try that OID” by declaring **multiple scalar metrics with the same**
+`symbol.name`, each pointing to a different OID. At runtime the collector **GETs** all declared scalar OIDs, processes them
+in declaration order, and **emits only the first successfully processed metric**. Missing or unusable earlier OIDs fall
+through to the next declaration.
 
 ```yaml
 metrics:

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/hpe-nimble.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/hpe-nimble.yaml
@@ -151,14 +151,6 @@ metrics:
         unit: "By/s"
   - MIB: NIMBLE-MIB
     symbol:
-      OID: 1.3.6.1.4.1.37447.1.3.11.0
-      name: nimble.ioSeqWriteBytes
-      chart_meta:
-        description: Total cumulative number of Sequential Write I/O bytes.
-        family: 'Storage/Throughput/Write/Sequential'
-        unit: "By/s"
-  - MIB: NIMBLE-MIB
-    symbol:
       OID: 1.3.6.1.4.1.37447.1.3.12.0
       name: nimble.diskVolBytesUsedLow
       chart_meta:


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors scalar fallback order in `go.d/snmp` by emitting only the first successfully processed scalar metric per name, in the order declared. Previously, multiple same-name scalars could produce duplicates or prefer a later alternative; now the earliest successful alternative wins, improving determinism and avoiding duplicate metrics.

- Implements per-profile deduplication of regular scalars by name, preserving declaration order; topology scalars are unaffected.
- Adds targeted tests for fallback order, fall-through scenarios, system-base profile order, and a micro-benchmark.
- Updates `profile-format.md` to document declaration-order semantics for scalar fallbacks.
- Cleans up `hpe-nimble.yaml` by removing a redundant same-name scalar.
- Migration: If a profile relied on a later alternative winning, reorder scalar alternatives so the preferred OID is declared first.

<sup>Written for commit 8a90ff7705b64be0bdaf2d14e53c79e8e8303bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SNMP metric fallback handling so the first successfully processed metric is reported when earlier alternatives are unavailable or unusable.
  * Prevented regular scalar fallback handling from affecting topology metrics.
  * Corrected HPE Nimble sequential write throughput metric reporting.

* **Documentation**
  * Clarified scalar metric fallback behavior and processing order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->