### PR TITLE
fix(build): make AddressSanitizer detect pooled allocator use-after-free

### DIFF
--- a/.github/workflows/topology-container-tests.yml
+++ b/.github/workflows/topology-container-tests.yml
@@ -126,12 +126,15 @@ jobs:
             libprotobuf-dev protobuf-compiler
 
       - name: Configure
-        env:
-          CFLAGS: -fsanitize=address -fno-omit-frame-pointer
-          CXXFLAGS: -fsanitize=address -fno-omit-frame-pointer
-          LDFLAGS: -fsanitize=address
         run: |
+          # ENABLE_ADDRESS_SANITIZER adds the sanitizer flags AND defines
+          # FSANITIZE_ADDRESS, which is what makes libnetdata's pooled
+          # allocators fall back to plain malloc/free. Setting the flags by hand
+          # (as this step used to) instruments the build but leaves the pools
+          # intact, so ASan cannot see a use-after-free inside ARAL, the
+          # dictionary allocators, STRING or onewayalloc.
           cmake -S . -B build -G Ninja \
+            -DENABLE_ADDRESS_SANITIZER=On \
             -DCMAKE_BUILD_TYPE=Debug \
             -DENABLE_PLUGIN_GO=OFF \
             -DENABLE_PLUGIN_XENSTAT=OFF \

--- a/packaging/cmake/Modules/NetdataCompilerFlags.cmake
+++ b/packaging/cmake/Modules/NetdataCompilerFlags.cmake
@@ -97,8 +97,21 @@ option(ENABLE_ADDRESS_SANITIZER "Build with address sanitizer enabled" False)
 mark_as_advanced(ENABLE_ADDRESS_SANITIZER)
 
 if(ENABLE_ADDRESS_SANITIZER)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+
+  # Instrumentation alone is not enough. Large parts of libnetdata allocate from
+  # pools (ARAL, the dictionary allocators, STRING, onewayalloc), so a freed
+  # object stays inside a page that is still allocated and AddressSanitizer sees
+  # nothing. Those subsystems fall back to plain malloc/free only when
+  # FSANITIZE_ADDRESS is defined, which nothing set until now - so an
+  # ENABLE_ADDRESS_SANITIZER build was blind to use-after-free in every pooled
+  # allocator. Define it here so the option means what its name implies.
+  add_compile_definitions(FSANITIZE_ADDRESS)
 endif()
+
+# CMAKE_CXX_FLAGS picks the above up further down this file, and CMake uses
+# CMAKE_CXX_FLAGS on the link line too, so no separate CXX or linker flag is
+# needed here.
 
 if(STATIC_BUILD)
   add_required_compiler_flag("-static")

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -2507,6 +2507,16 @@ int aral_stress_test(size_t threads, size_t elements, size_t seconds) {
 }
 
 int aral_unittest(size_t elements) {
+#if defined(FSANITIZE_ADDRESS)
+    // Under address sanitizer ARAL is bypassed entirely: aral_mallocz() and
+    // aral_freez() delegate straight to glibc, so there is no pool to stress.
+    // The stress loop below would still run and still report PASSED, but with
+    // "did 0 malloc, 0 free" - a green result that proves nothing. Skip
+    // explicitly instead, the same way aral_unittest_concurrency() does.
+    (void)elements;
+    fprintf(stderr, "ARAL unittest: SKIPPED (ARAL is disabled under FSANITIZE_ADDRESS)\n");
+    return 0;
+#else
     const char *cache_dir = "/tmp/";
 #ifdef NETDATA_INTERNAL_CHECKS
     int errors = aral_detect_acquire_to_page_lock_race();
@@ -2544,4 +2554,5 @@ int aral_unittest(size_t elements) {
     fprintf(stderr, "ARAL unittest: %s (%d errors)\n", total_errors ? "FAILED" : "PASSED", total_errors);
 
     return total_errors;
+#endif // FSANITIZE_ADDRESS
 }


### PR DESCRIPTION
##### Summary 
- Define FSANITIZE_ADDRESS when ENABLE_ADDRESS_SANITIZER is enabled, so pooled allocators fall back to malloc()/free() and ASan can detect their memory errors.
- Preserve frame pointers in ASan builds for actionable stack traces.
- Configure the ASan CI job through CMake’s sanitizer option instead of manually injecting compiler/linker flags.
- Skip the ARAL pool stress test under ASan, since ARAL is intentionally bypassed and the test would otherwise report a meaningless pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AddressSanitizer build configuration for more reliable memory-error detection.
  * Preserved frame pointers and enabled sanitizer-compatible memory allocation behavior.
  * Updated sanitizer test workflows to use the standard CMake configuration.

* **Tests**
  * ARAL stress tests now skip safely when AddressSanitizer bypasses the related allocator, reporting the skip without marking the run as failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->