### PR TITLE
fix(go.d/snmp): correct Synology profile detection and metrics

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_synology_profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_synology_profile_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestCollector_CollectDeviceMetadata_SynologyProfile(t *testing.T) {
+	const sysObjectID = "1.3.6.1.4.1.8072.3.2.10"
+
+	profile := mustLoadSynologyProfile(t)
+	device := profile.Definition.Metadata[ddprofiledefinition.MetadataDeviceResource]
+	for name := range device.Fields {
+		if !slices.Contains([]string{"vendor", "type", "model", "serial_number", "version"}, name) {
+			delete(device.Fields, name)
+		}
+	}
+	profile.Definition.Metadata = ddprofiledefinition.MetadataConfig{
+		ddprofiledefinition.MetadataDeviceResource: device,
+	}
+
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	expectSNMPGet(mockHandler, []string{
+		"1.3.6.1.4.1.6574.1.5.1.0",
+		"1.3.6.1.4.1.6574.1.5.2.0",
+		"1.3.6.1.4.1.6574.1.5.3.0",
+	}, []gosnmp.SnmpPDU{
+		createStringPDU("1.3.6.1.4.1.6574.1.5.1.0", "Test NAS"),
+		createStringPDU("1.3.6.1.4.1.6574.1.5.2.0", "TEST-SERIAL"),
+		createStringPDU("1.3.6.1.4.1.6574.1.5.3.0", "DSM test"),
+	})
+
+	collector := New(Config{
+		SnmpClient:  mockHandler,
+		Profiles:    []*ddsnmp.Profile{profile},
+		Log:         logger.New(),
+		SysObjectID: sysObjectID,
+	})
+
+	got, err := collector.CollectDeviceMetadata()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]ddsnmp.MetaTag{
+		"vendor":        {Value: "Synology", IsExactMatch: true},
+		"type":          {Value: "Storage", IsExactMatch: true},
+		"model":         {Value: "Test NAS", IsExactMatch: true},
+		"serial_number": {Value: "TEST-SERIAL", IsExactMatch: true},
+		"version":       {Value: "DSM test", IsExactMatch: true},
+	}, got)
+}
+
+func TestScalarCollector_Collect_SynologyUtilizationProfile(t *testing.T) {
+	const (
+		cpuOID    = "1.3.6.1.4.1.6574.1.7.1.0"
+		memoryOID = "1.3.6.1.4.1.6574.1.7.2.0"
+	)
+
+	profile := mustLoadSynologyProfile(t)
+	profile.Definition.Metrics = slices.DeleteFunc(profile.Definition.Metrics, func(metric ddprofiledefinition.MetricsConfig) bool {
+		return !slices.Contains([]string{"cpu.usage", "memory.usage"}, metric.Symbol.Name)
+	})
+	require.Len(t, profile.Definition.Metrics, 2)
+
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	expectSNMPGet(mockHandler, []string{cpuOID, memoryOID}, []gosnmp.SnmpPDU{
+		createIntegerPDU(cpuOID, 6),
+		createIntegerPDU(memoryOID, 4),
+	})
+
+	collector := newScalarCollector(mockHandler, make(map[string]bool), logger.New())
+	got, err := collector.collect(profile, &ddsnmp.CollectionStats{})
+	require.NoError(t, err)
+	assertMetricsEqual(t, []ddsnmp.Metric{
+		{
+			Name:        "cpu.usage",
+			Description: "The current CPU utilization",
+			Family:      "System/CPU/Usage",
+			Unit:        "%",
+			MetricType:  ddprofiledefinition.ProfileMetricTypeGauge,
+			Value:       6,
+		},
+		{
+			Name:        "memory.usage",
+			Description: "Memory utilization",
+			Family:      "System/Memory/Usage",
+			Unit:        "%",
+			MetricType:  ddprofiledefinition.ProfileMetricTypeGauge,
+			Value:       4,
+		},
+	}, got)
+}
+
+func mustLoadSynologyProfile(t *testing.T) *ddsnmp.Profile {
+	t.Helper()
+
+	profile, err := ddsnmp.LoadProfileByName("synology-disk-station")
+	require.NoError(t, err)
+	return profile
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -45,6 +45,7 @@ func Test_loadDDSnmpProfiles(t *testing.T) {
 func Test_FindProfiles(t *testing.T) {
 	test := map[string]struct {
 		sysObjOId      string
+		sysDescr       string
 		manualProfiles []string
 		wanProfiles    []string
 	}{
@@ -55,6 +56,15 @@ func Test_FindProfiles(t *testing.T) {
 		"net-snmp linux": {
 			sysObjOId:   "1.3.6.1.4.1.8072.3.2.10",
 			wanProfiles: []string{"net-snmp", "generic-device"},
+		},
+		"Synology NAS using generic net-snmp identity": {
+			sysObjOId:   "1.3.6.1.4.1.8072.3.2.10",
+			sysDescr:    "Linux Synology appliance",
+			wanProfiles: []string{"synology-disk-station", "net-snmp", "generic-device"},
+		},
+		"Synology NAS using enterprise identity": {
+			sysObjOId:   "1.3.6.1.4.1.6574.1",
+			wanProfiles: []string{"synology-disk-station", "generic-device"},
 		},
 		"Kyocera printer": {
 			sysObjOId:   "1.3.6.1.4.1.1347.41",
@@ -162,7 +172,7 @@ func Test_FindProfiles(t *testing.T) {
 
 	for name, test := range test {
 		t.Run(name, func(t *testing.T) {
-			profiles := FindProfiles(test.sysObjOId, "", test.manualProfiles)
+			profiles := FindProfiles(test.sysObjOId, test.sysDescr, test.manualProfiles)
 
 			var names []string
 			for _, p := range profiles {

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/synology-disk-station.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/synology-disk-station.yaml
@@ -6,6 +6,13 @@ selector:
   - sysobjectid:
       include:
         - 1.3.6.1.4.1.6574.*
+  # Stock Synology DSM uses the generic Net-SNMP Linux identity.
+  - sysobjectid:
+      include:
+        - 1.3.6.1.4.1.8072.3.2.10
+    sysdescr:
+      include:
+        - synology
 
 metadata:
   device:
@@ -14,6 +21,21 @@ metadata:
         value: "Synology"
       type:
         value: "Storage"
+      model:
+        symbol:
+          MIB: SYNOLOGY-SYSTEM-MIB
+          OID: 1.3.6.1.4.1.6574.1.5.1.0
+          name: modelName
+      serial_number:
+        symbol:
+          MIB: SYNOLOGY-SYSTEM-MIB
+          OID: 1.3.6.1.4.1.6574.1.5.2.0
+          name: serialNumber
+      version:
+        symbol:
+          MIB: SYNOLOGY-SYSTEM-MIB
+          OID: 1.3.6.1.4.1.6574.1.5.3.0
+          name: version
 
 metric_tags:
   - tag: synology_model_name
@@ -57,14 +79,22 @@ metric_tags:
 #    https://github.com/DanielleHuisman/observium-community-edition/blob/main/mibs/synology/SYNOLOGY-GPUINFO-MIB
 
 metrics:
-  - MIB: UCD-SNMP-MIB
+  - MIB: SYNOLOGY-SYSTEM-MIB
     symbol:
       name: cpu.usage
-      OID: 1.3.6.1.4.1.2021.10.1.5.1
+      OID: 1.3.6.1.4.1.6574.1.7.1.0
       chart_meta:
-        description: The 1,5 and 15 minute load averages
-        family: 'System/CPU/Load'
-        unit: "{load_average}"
+        description: The current CPU utilization
+        family: 'System/CPU/Usage'
+        unit: "%"
+  - MIB: SYNOLOGY-SYSTEM-MIB
+    symbol:
+      name: memory.usage
+      OID: 1.3.6.1.4.1.6574.1.7.2.0
+      chart_meta:
+        description: Memory utilization
+        family: 'System/Memory/Usage'
+        unit: "%"
   # TODO support for units like this is not yet implemented
   # - MIB: HOST-RESOURCES-MIB
   #   symbol:


### PR DESCRIPTION
##### Summary

Fixes: #23466

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Synology DiskStation detection in `go.d/snmp` and switches the profile to use Synology MIB CPU and memory utilization, adding device metadata. Previously many Synology devices were classified as generic Net-SNMP and `cpu.usage` reported a load average; now Synology devices are detected reliably and `cpu.usage` reports percent CPU usage, with a new `memory.usage` metric.

**Key changes**
- Extend profile selector: also match `1.3.6.1.4.1.8072.3.2.10` when `sysDescr` contains "synology"; keep `1.3.6.1.4.1.6574.*` enterprise match.
- Collect device metadata from `SYNOLOGY-SYSTEM-MIB`: add `model`, `serial_number`, and `version` (retain `vendor` and `type`).
- Replace `UCD-SNMP-MIB` load-average–based `cpu.usage` with `SYNOLOGY-SYSTEM-MIB` CPU usage (%), and add `memory.usage` (%); update chart descriptions and families accordingly.
- Add tests covering profile selection, metadata collection, and Synology CPU/memory metrics.

<sup>Written for commit 8aa07a2e2fb1502f5e91d6ce38effa9137b3c0c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying stock Synology DSM devices.
  * Device details now include model, serial number, and DSM version.
  * Added Synology-specific CPU and memory utilization monitoring.

* **Bug Fixes**
  * Improved Synology device profile matching across supported SNMP identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->