### PR TITLE
refactor(aclk): clean up manifest publication record

### DIFF
--- a/src/aclk/aclk_contexts_api.c
+++ b/src/aclk/aclk_contexts_api.c
@@ -41,18 +41,16 @@ void aclk_update_node_info(struct update_node_info *info, struct aclk_sync_compl
     QUEUE_IF_PAYLOAD_PRESENT(query);
 }
 
-// The caller has already recorded `suppression_key` under `token` on the host identified by
+// The caller has already recorded this enqueue under `token` on the host identified by
 // `machine_guid`. They are carried on the query so that a message which never reaches the mqtt layer
 // can have that record invalidated again - see aclk_node_manifest_publish_result().
 void aclk_update_node_instance_manifest(
     struct update_node_instance_manifest *manifest,
     const char *machine_guid,
-    uint64_t suppression_key,
     uint64_t token)
 {
     aclk_query_t *query = aclk_query_new(UPDATE_NODE_MANIFEST);
     strncpyz(query->manifest.machine_guid, machine_guid, sizeof(query->manifest.machine_guid) - 1);
-    query->manifest.key = suppression_key;
     query->manifest.token = token;
     query->data.bin_payload.topic = ACLK_TOPICID_NODE_MANIFEST;
     query->data.bin_payload.payload =

--- a/src/aclk/aclk_contexts_api.h
+++ b/src/aclk/aclk_contexts_api.h
@@ -14,7 +14,6 @@ void aclk_update_node_info(struct update_node_info *info, struct aclk_sync_compl
 void aclk_update_node_instance_manifest(
     struct update_node_instance_manifest *manifest,
     const char *machine_guid,
-    uint64_t suppression_key,
     uint64_t token);
 
 #endif /* ACLK_CONTEXTS_API_H */

--- a/src/aclk/aclk_query_queue.h
+++ b/src/aclk/aclk_query_queue.h
@@ -49,9 +49,11 @@ struct aclk_bin_payload {
 // The host is identified by machine_guid, not by the node_id the manifest is keyed under at the
 // cloud: node_id is mutable and host->node_id can disagree with the ACLK config's copy, so it does
 // not identify the config to write back to. machine_guid is immutable for the host's lifetime.
+// The record is identified by token alone, never by the suppression key it was stored beside: two
+// distinct enqueues of identical content share a key, so a key comparison would let a stale drop
+// invalidate a later enqueue's record. The token is unique per enqueue and is strictly stronger.
 struct aclk_manifest_publication {
     char machine_guid[GUID_LEN + 1]; // the host whose config recorded this send
-    uint64_t key;                    // suppression key of this payload; 0 when not a manifest query
     uint64_t token;                  // identifies THIS enqueue, so a drop cannot invalidate a later one
     bool published;                  // set once the message reached the mqtt layer
 };

--- a/src/database/rrdfunctions-unittest.c
+++ b/src/database/rrdfunctions-unittest.c
@@ -277,15 +277,10 @@ int rrdfunctions_manifest_unittest(void) {
     //    standalone dictionaries keep this independent of whatever live functions localhost has.
     //    The other half of the suppression - scoping the record to one ACLK session - is folded
     //    into the same value by manifest_publication_key(), covered at the end of this block.
-    //    What is NOT covered here is the recording side: build_node_manifest() records the key under a
-    //    per-enqueue token as it enqueues, and aclk_node_manifest_publish_result() invalidates that
-    //    token if the message was dropped. Invalidation is pure atomics on the host's ACLK config, so
-    //    it does NOT need a live ACLK connection - but it does need a host that HAS a config, and this
-    //    test's localhost does not: sql_load_node_id() only calls set_host_node_id() when the query
-    //    returns a row, so an unregistered host reaches neither it nor create_aclk_config(), the only
-    //    place host->aclk_host_config is ever set. A test would have to call create_aclk_config()
-    //    itself (a plain callocz plus a publish CAS, no ACLK thread needed) and include
-    //    aclk/aclk_query_queue.h for struct aclk_manifest_publication. Untested; tracked in the SOW.
+    //    The recording side - build_node_manifest() storing the key under a per-enqueue token, and
+    //    aclk_node_manifest_publish_result() invalidating that token when the message was dropped -
+    //    is covered separately by block 5 below, which creates the ACLK config this test's localhost
+    //    does not have.
     {
         int hash_errors_before = errors;
         const char *node1 = "11111111-2222-3333-4444-555555555555";
@@ -459,7 +454,7 @@ int rrdfunctions_manifest_unittest(void) {
             const uint64_t K = 0x0123456789abcdefULL; // any content key; the record is content-blind
             const uint64_t T1 = 1111, T2 = 2222, T3 = 3333;
 
-            struct aclk_manifest_publication pub = { .key = K, .token = T1, .published = false };
+            struct aclk_manifest_publication pub = { .token = T1, .published = false };
             strncpyz(pub.machine_guid, host->machine_guid, sizeof(pub.machine_guid) - 1);
 
             // a dropped manifest invalidates its own record and re-arms, so the content is rebuilt

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -410,10 +410,15 @@ static void aclk_run_query(struct aclk_sync_config_s *config, aclk_query_t *quer
     }
 
     if (ok_to_send) {
-        // aclk_query_free() reports the outcome to whoever tracks what the cloud has been told;
-        // leaving it unset here is what makes a dropped message recoverable.
-        if (client)
-            query->manifest.published = (send_bin_msg(client, query) == 0);
+        if (client) {
+            bool sent = (send_bin_msg(client, query) == 0);
+
+            // aclk_query_free() reports the outcome to whoever tracks what the cloud has been told;
+            // leaving it unset here is what makes a dropped message recoverable. Only the manifest
+            // carries a publication record, so it is the only type with an outcome to record here.
+            if (query->type == UPDATE_NODE_MANIFEST)
+                query->manifest.published = sent;
+        }
         else
             nd_log_daemon(NDLP_ERR, "No client to send message %u", query->type);
     }
@@ -1432,12 +1437,31 @@ void aclk_arm_node_manifest(RRDHOST *host)
 // session is server-side behaviour this repository cannot verify, so treat "once per session" as an
 // assumption, not a guarantee; the suppression below is what makes repeats cheap either way.
 //
-// It is needed because publishing is never acked: what the previous session sent may have been
-// dropped after the send call - no mqtt client left by the time the query executed, or shutdown
-// reached before it ran - and the cloud may have lost it. build_node_manifest() scopes its
-// suppression to one session for exactly this reason, so the pair publishes one manifest per host
-// per session. A redundant arm costs one manifest build (rrd_rdlock plus a dictionary of string
-// copies) and one hash; the content hash then drops the publish.
+// It is needed because a successful send is NOT a delivery. send_bin_msg() returning 0 means only
+// that the PUBLISH was appended to mqtt_ng's transaction buffer, and that is exactly when the
+// publication record is kept (published = true). Three windows then lose the message with no
+// agent-side signal at all:
+//   1. disconnect before the bytes reach the socket - the fragment is still queued, and
+//      mqtt_ng_connect() purges the whole tx buffer on the next connect (buffer_purge()).
+//   2. disconnect after the write but before the PUBACK - QoS1, but mqtt_ng_connect() also calls
+//      destroy_timeout_monitor_list(), so nothing is retransmitted and there is no MQTT session
+//      continuation.
+//   3. no PUBACK within PACKET_ACK_TIMEOUT_SECS (60s) while still connected -
+//      check_packet_monitor_list_for_timeouts() calls mark_packet_acked(), the same path a real
+//      PUBACK takes, and the message is garbage collected as if it had been delivered.
+// Nothing correlates an ack back to a query in any case: send_bin_msg() passes NULL for the packet
+// id and puback_callback() only counts pubacks. build_node_manifest() scopes its suppression to one
+// session for exactly this reason, so the pair publishes one manifest per host per session. A
+// redundant arm costs one manifest build (rrd_rdlock plus a dictionary of string copies) and one
+// hash; the content hash then drops the publish.
+//
+// Note what this does NOT cover: a new session lets a rebuild through, but it does not cause one.
+// Something still has to arm the host. Every other arm is event-driven - a function registration,
+// pluginsd, a child reconnecting, host creation, an ingestion-status change, or a node info send
+// (build_node_info() arms too, and aclk_queue_node_info() is reached independently of this message,
+// from metadata load, label updates, streaming reconnect and pluginsd). None of them is tied to an
+// ACLK reconnect, so on a node whose functions and labels are stable this ask is what triggers the
+// rebuild, and without it a manifest lost above stays lost for the whole session.
 void aclk_arm_node_manifest_all_hosts(void)
 {
     RRDHOST *host;

--- a/src/database/sqlite/sqlite_aclk.h
+++ b/src/database/sqlite/sqlite_aclk.h
@@ -97,8 +97,10 @@ typedef struct aclk_sync_cfg_t {
     // its content. A 0 token means nothing is outstanding, which is what callocz() leaves and what a
     // drop restores, so the first manifest of a config always sends.
     //
-    // The key folds the ACLK session into the content hash because publishing is never acked - a new
-    // session re-sends once, which is also what a cloud that lost the manifest needs.
+    // The key folds the ACLK session into the content hash because publishing is never acked, so a
+    // new session can no longer be suppressed by what the previous one recorded - which is what a
+    // cloud that lost the manifest needs. It only removes the suppression, though; something still
+    // has to arm the rebuild. See aclk_arm_node_manifest_all_hosts().
     uint64_t node_manifest_sent_key;   // manifest_publication_key() of the newest manifest enqueued
     uint64_t node_manifest_sent_token; // its per-enqueue token; 0 when nothing is outstanding
 } aclk_sync_cfg_t;

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -127,7 +127,7 @@ static void manifest_publication_apply(RRDHOST *host, void *data)
 //
 // On the event loop, then, a lost race leaves the dropped manifest's key recorded as if it had been
 // sent, so that content is not re-sent until it changes again or the ACLK session does. That is the
-// original defect of this SOW, reduced to: an allocation failure that drops a manifest, on the one
+// whole residual exposure, reduced to: an allocation failure that drops a manifest, on the one
 // thread that cannot wait, while a teardown happens to hold rrd_wrlock(). At shutdown it is moot -
 // the next start is a new session, and every key carries the session.
 //
@@ -226,7 +226,7 @@ static bool build_node_manifest(RRDHOST *host, aclk_sync_cfg_t *aclk_host_config
         uint64_t token = manifest_publication_token_next();
         __atomic_store_n(&aclk_host_config->node_manifest_sent_key, key, __ATOMIC_RELEASE);
         __atomic_store_n(&aclk_host_config->node_manifest_sent_token, token, __ATOMIC_RELEASE);
-        aclk_update_node_instance_manifest(&manifest, host->machine_guid, key, token);
+        aclk_update_node_instance_manifest(&manifest, host->machine_guid, token);
     }
 
     dictionary_destroy(manifest.functions);


### PR DESCRIPTION
##### Summary
- Remove the unused suppression key from queued node-manifest publications.
- Keep manifest send-result tracking scoped to manifest queries only.
- Clarify the token-based invalidation and reconnect re-publication behavior.
- Update the manifest unit-test comments and initializer to match the streamlined record.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node manifest publication tracking so unrelated query activity no longer changes manifest status.
  * Refined manifest deduplication and suppression behavior across ACLK sessions.
  * Improved handling and documentation of publication acknowledgments and potential delivery loss.

* **Tests**
  * Updated manifest publication coverage and test fixtures to reflect the streamlined publication tracking behavior.

* **Documentation**
  * Clarified session-specific suppression and manifest rebuild requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->