### PR TITLE
Point the notifications README at the current Netdata AI troubleshooting page

### DIFF
--- a/docs/alerts-and-notifications/notifications/README.md
+++ b/docs/alerts-and-notifications/notifications/README.md
@@ -78,7 +78,7 @@ When you receive an alert, Netdata provides tools to help you understand and res
 
 ### Netdata Assistant
 
-The [Netdata Assistant](https://learn.netdata.cloud/docs/machine-learning-and-anomaly-detection/ai-powered-troubleshooting-assistant) is an AI-powered feature that guides you through troubleshooting alerts by providing:
+The [Netdata Assistant](/docs/netdata-ai/troubleshooting/index.md) is an AI-powered feature that guides you through troubleshooting alerts by providing:
 
 - Clear explanations of what the alert means
 - Assessment of potential causes


### PR DESCRIPTION
## Summary

`docs/alerts-and-notifications/notifications/README.md` linked the Netdata Assistant to a Learn URL that no longer exists (`/docs/machine-learning-and-anomaly-detection/ai-powered-troubleshooting-assistant` returns 404). The link now points at the repository path of the current page for AI-assisted alert troubleshooting, `docs/netdata-ai/troubleshooting/index.md`, using the same repository-path style as the other internal links in this file.

## Why

Learn resolves repository-path links to the live page. The old Learn URL is a legacy route that Learn's redirect catalogue is being repaired to redirect (netdata/learn#2993); Learn's rendered-links gate rejects published pages that link to a redirect source, so this link must point at the current page.

## Validation

- Target file exists on `master`: `docs/netdata-ai/troubleshooting/index.md`.
- One link changed; no other content touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Netdata Assistant link in `docs/alerts-and-notifications/notifications/README.md` to a repo-relative URL for the current troubleshooting page. This fixes a broken link and avoids Learn’s rendered-links gate by not pointing at a redirect source.

- One link changed; no other content modified.
- Target page exists on `master` and resolves correctly via repo-path linking.
- No rollout or migration required.

<sup>Written for commit 3028316d1f2969e2de4ac97af918059735e57714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Netdata Assistant documentation link to point to the relevant troubleshooting guide within the product documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->