### PR TITLE
Improve updater commit date handling.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -807,7 +807,7 @@ newer_commit_date() {
   fi
 
   if command -v jq > /dev/null 2>&1 ; then
-    commit_date="$(jq -r '.[0].commit.committer.date' 2>/dev/null < "${commit_check_file}")"
+    commit_date="$(jq -r '.[0].commit.committer.date' 2>/dev/null < "${commit_check_file}" || true)"
   elif command -v python > /dev/null 2>&1 || command -v python3 > /dev/null 2>&1 ; then
     python="$(command -v python3 2>/dev/null)"
     [ -z "${python}" ] && python="$(command -v python 2>/dev/null)"
@@ -821,24 +821,46 @@ newer_commit_date() {
 	else:
 	    print(data[0]['commit']['committer']['date'] if isinstance(data, list) and data else '')
 	EOF
-    commit_date="$("${python}" "${ndtmpdir}/parse_commit_date.py" < "${commit_check_file}")"
+    commit_date="$("${python}" "${ndtmpdir}/parse_commit_date.py" < "${commit_check_file}" 2>/dev/null || true)"
   elif command -v node > /dev/null 2>&1 || command -v deno > /dev/null 2>&1 ; then
     cat > "${ndtmpdir}/parse_commit_date.js" <<-EOF
-	const fs = require('node:fs');
-	const data = fs.readFileSync(0, 'utf-8');
-	try {
-	  const json = JSON.parse(data);
-	  const date = json[0].commit.committer.date;
-	  process.stdout.write(String(date));
-	} catch (err) {
-	  process.stderr.write(err.message + '\\n');
-	  process.exit(1);
-	}
+	(function () {
+	  function writeOut(s) {
+	    if (typeof Deno !== 'undefined' && Deno.stdout && Deno.stdout.writeSync) {
+	      Deno.stdout.writeSync(new TextEncoder().encode(s));
+	      return;
+	    }
+	    if (typeof process !== 'undefined' && process.stdout && process.stdout.write) {
+	      process.stdout.write(s);
+	    }
+	  }
+	  async function readStdin() {
+	    if (typeof Deno !== 'undefined' && Deno.stdin && Deno.stdin.readable) {
+	      return await new Response(Deno.stdin.readable).text();
+	    }
+	    const fs = require('fs');
+	    return fs.readFileSync(0, 'utf8');
+	  }
+	  readStdin().then((data) => {
+	    let date = '';
+	    try {
+	      const json = JSON.parse(data);
+	      if (Array.isArray(json) && json[0] && json[0].commit && json[0].commit.committer && json[0].commit.committer.date) {
+	        date = json[0].commit.committer.date;
+	      }
+	    } catch (_) {
+	      date = '';
+	    }
+	    writeOut(String(date || ''));
+	  }).catch(() => {
+	    writeOut('');
+	  });
+	})();
 	EOF
     if command -v deno > /dev/null 2>&1 ; then
-      commit_date="$(deno run -A "${ndtmpdir}/parse_commit_date.js" < "${commit_check_file}")"
+      commit_date="$(deno run "${ndtmpdir}/parse_commit_date.js" < "${commit_check_file}" 2>/dev/null || true)"
     else
-      commit_date="$(node "${ndtmpdir}/parse_commit_date.js" < "${commit_check_file}")"
+      commit_date="$(node "${ndtmpdir}/parse_commit_date.js" < "${commit_check_file}" 2>/dev/null || true)"
     fi
   fi
 
@@ -854,7 +876,7 @@ newer_commit_date() {
     commit_date="$(/bin/date -j -f "%Y-%m-%dT%H:%M:%SZ" "${commit_date}" +%s 2>/dev/null)"
 
     if [ -z "${commit_date}" ]; then
-        return 0
+      return 0
     fi
   fi
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -807,7 +807,7 @@ newer_commit_date() {
   fi
 
   if command -v jq > /dev/null 2>&1 ; then
-    commit_date="$(jq -r -b '.[0].commit.committer.date' 2>/dev/null < "${commit_check_file}")"
+    commit_date="$(jq -r '.[0].commit.committer.date' 2>/dev/null < "${commit_check_file}")"
   elif command -v python > /dev/null 2>&1 || command -v python3 > /dev/null 2>&1 ; then
     python="$(command -v python3 2>/dev/null)"
     [ -z "${python}" ] && python="$(command -v python 2>/dev/null)"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -799,17 +799,6 @@ newer_commit_date() {
   create_exec_tmp_directory
   commit_check_file="${ndtmpdir}/latest-commit.json"
   commit_check_url="https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1"
-  python_version_check="
-from __future__ import print_function
-import sys, json
-
-try:
-    data = json.load(sys.stdin)
-except:
-    print('')
-else:
-    print(data[0]['commit']['committer']['date'] if isinstance(data, list) and data else '')
-"
 
   if ! _safe_download "${commit_check_url}" "${commit_check_file}"; then
     warning "Failed to check for an updated updater script, skipping self-update check."
@@ -817,12 +806,40 @@ else:
     return 1
   fi
 
-  if command -v jq > /dev/null 2>&1; then
-    commit_date="$(jq '.[0].commit.committer.date' 2>/dev/null < "${commit_check_file}" | tr -d '"')"
-  elif command -v python > /dev/null 2>&1;then
-    commit_date="$(python -c "${python_version_check}" < "${commit_check_file}")"
-  elif command -v python3 > /dev/null 2>&1;then
-    commit_date="$(python3 -c "${python_version_check}" < "${commit_check_file}")"
+  if command -v jq > /dev/null 2>&1 ; then
+    commit_date="$(jq -r -b '.[0].commit.committer.date' 2>/dev/null < "${commit_check_file}")"
+  elif command -v python > /dev/null 2>&1 || command -v python3 > /dev/null 2>&1 ; then
+    python="$(command -v python3 2>/dev/null)"
+    [ -z "${python}" ] && python="$(command -v python 2>/dev/null)"
+    cat > "${ndtmpdir}/parse_commit_date.py" <<-EOF
+	from __future__ import print_function
+	import sys, json
+	try:
+	    data = json.load(sys.stdin)
+	except:
+	    print('')
+	else:
+	    print(data[0]['commit']['committer']['date'] if isinstance(data, list) and data else '')
+	EOF
+    commit_date="$("${python}" "${ndtmpdir}/parse_commit_date.py" < "${commit_check_file}")"
+  elif command -v node > /dev/null 2>&1 || command -v deno > /dev/null 2>&1 ; then
+    cat > "${ndtmpdir}/parse_commit_date.js" <<-EOF
+	const fs = require('node:fs');
+	const data = fs.readFileSync(0, 'utf-8');
+	try {
+	  const json = JSON.parse(data);
+	  const date = json[0].commit.committer.date;
+	  process.stdout.write(String(date));
+	} catch (err) {
+	  process.stderr.write(err.message + '\\n');
+	  process.exit(1);
+	}
+	EOF
+    if command -v deno > /dev/null 2>&1 ; then
+      commit_date="$(deno run -A "${ndtmpdir}/parse_commit_date.js" < "${commit_check_file}")"
+    else
+      commit_date="$(node "${ndtmpdir}/parse_commit_date.js" < "${commit_check_file}")"
+    fi
   fi
 
   if [ -z "${NETDATA_TMPDIR_PATH}" ]; then


### PR DESCRIPTION
##### Summary

This updates handling of GitHub API interactions in the updater script when checking if a newer version of the script is available:

- Make the `jq` command work a bit more portably.
- Avoid the need for `tr` with the `jq` invocation.
- Change the Python case to use a file instead of the command line.
- Add a JavaScript option for systems without `jq` or Python, supporting both Node.JS and Deno.

##### Test Plan

Requires some manual testing to verify that the updated parsing works. To test the new parsing logic, fetch the updater itself, set the file timestamp to a time before 2026-08-17T07:12:12-0400 (the timestamp of the most recent commit in master for it), and attempt to run it and see if it downloads the version from the master branch or not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the updater’s commit-date check more portable and resilient. Previously it required `jq`+`tr` or an inline Python one-liner; now it prefers `jq -r`, uses a temp-file Python parser, adds a JS fallback with proper `deno`/`node` support, improves error handling, and drops the non-portable `jq` `-b` option.

- Uses `jq -r`; removes `tr`; drops `-b` for portability.
- Prefers `python3`, falls back to `python`; runs a temp-file parser; tolerates parse errors.
- Adds JavaScript parser runnable via `deno` or `node`; handles stdin/stdout and failures cleanly.
- To verify: set the updater file’s mtime before the latest upstream commit and run; it should fetch the latest script when appropriate.

<sup>Written for commit be8425f284ed2815da03a09f42c078b38b89ec70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved updater compatibility across supported environments when processing commit dates.
  * Increased reliability when commit metadata is malformed, incomplete, or cannot be parsed.
  * Prevented parser diagnostics and failures from interrupting update processing.
  * Improved date parsing consistency across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->