### PR TITLE
Update version parsing in the updater script.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -929,13 +929,13 @@ parse_version() {
   echo "${v}" | tr '.' ' ' > "${tmpfile}"
   read -r maj min patch _ < "${tmpfile}"
 
+  rm -f "${tmpfile}"
+
   if [ "${#maj}" -gt 3 ] || [ "${#min}" -gt 3 ] || [ "${#patch}" -gt 3 ] || [ "${#rc}" -gt 3 ] || [ "${#b}" -gt 5 ]; then
     warning "Failed to parse version ${r}"
     printf "%s" "${vmax}"
     return 0
   fi
-
-  rm -f "${tmpfile}"
 
   printf "%03d%03d%03d%01d%03d%05d" "${maj}" "${min}" "${patch}" "${t}" "${rc}" "${b}"
 }

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -873,12 +873,20 @@ self_update() {
   fi
 }
 
+# Parse the version into a (large) integer for easy comparison.
+#
+# The resultant integer consists of three groups of three digits encoding the major, minor, and patch versions,
+# followed by a single digit encoding the version type (0 for nightly builds and git builds based on a stable or
+# nightly version, 1 for release candidate builds, 2 for git builds based on a release candidate version, 3 for
+# stable versions, and 9 for unknown), three digits for the release candidate number (all zeroes if the build
+# isn’t a release candidate build), and five digits for the commit number for git builds (all zeroes if the
+# build isn’t a git build).
 parse_version() {
   r="${1}"
   if [ "${r}" = "latest" ]; then
     # If we get ‘latest’ as a version, return the largest possible
     # version value.
-    printf "999999999999999"
+    printf "999999999999999999"
     return 0
   elif echo "${r}" | grep -q '^v.*'; then
     # shellcheck disable=SC2001
@@ -888,10 +896,33 @@ parse_version() {
 
   tmpfile="$(mktemp)"
   echo "${r}" | tr '-' ' ' > "${tmpfile}"
-  read -r v b _ < "${tmpfile}"
+  read -r v b1 b2 _ < "${tmpfile}"
 
-  if echo "${b}" | grep -vEq "^[0-9]+$"; then
-    b="0"
+  if echo "${b1}" | grep -Eq "^rc[0-9]+$"; then
+    rc="$(echo "${b1}" | tr -d 'rc')"
+
+    if echo "${b2}" | grep -Eq "^[0-9]+$"; then
+      t=2
+      b="${b2}"
+    elif [ -z "${b2}" ]; then
+      t=1
+      b=0
+    else
+      t=9
+      b=99999
+    fi
+  elif echo "${b1}" | grep -Eq "^[0-9]+$"; then
+    t=0
+    rc=0
+    b="${b1}"
+  elif [ -z "${b1}" ]; then
+    t=3
+    rc=0
+    b=0
+  else
+    t=9
+    rc=999
+    b=99999
   fi
 
   echo "${v}" | tr '.' ' ' > "${tmpfile}"
@@ -899,7 +930,7 @@ parse_version() {
 
   rm -f "${tmpfile}"
 
-  printf "%04d%03d%03d%05d" "${maj}" "${min}" "${patch}" "${b}"
+  printf "%03d%03d%03d%01d%03d%05d" "${maj}" "${min}" "${patch}" "${t}" "${rc}" "${b}"
 }
 
 get_latest_tag() {
@@ -963,8 +994,8 @@ update_available() {
     info "Update available"
 
     if [ "${current_version}" -ne 0 ] && [ "${latest_version}" -ne 0 ]; then
-      current_major="$(echo "${current_version}" | head -c 4)"
-      latest_major="$(echo "${latest_version}" | head -c 4)"
+      current_major="$(echo "${current_version}" | head -c 3)"
+      latest_major="$(echo "${latest_version}" | head -c 3)"
 
       if [ "${current_major}" -ne "${latest_major}" ]; then
         update_safe=0
@@ -1293,13 +1324,21 @@ update_binpkg() {
   elif ${pkg_installed_check} netdata-repo-edge > /dev/null 2>&1; then
     RELEASE_CHANNEL="nightly"
     repopkg="netdata-repo-edge"
-  elif echo "${initial_version}" | grep -Eq -- '^[0-9]*[1-9][0-9]*0{5}$'; then # All five final digits are zero and at least one preceeding digit is non-zero.
-    RELEASE_CHANNEL="stable"
-  elif echo "${initial_version}" | grep -Eq -- '^[0-9]*[1-9][0-9]{0,4}$'; then # At least one of the final five digits is non-zero.
-    RELEASE_CHANNEL="nightly"
   else
-    RELEASE_CHANNEL="none"
-    warning "Unable to determine which release channel is being used on this system, cannot check if packages are still being published."
+    case "$(echo "${initial_version}" | cut -c 10)" in
+      0)
+        RELEASE_CHANNEL="nightly"
+        repopkg="netdata-repo-edge"
+        ;;
+      3)
+        RELEASE_CHANNEL="stable"
+        repopkg="netdata-repo"
+        ;;
+      *)
+        RELEASE_CHANNEL="none"
+        warning "Unable to determine which release channel is being used on this system, cannot check if packages are still being published."
+        ;;
+    esac
   fi
 
   if [ -n "${repo_path}" ]; then
@@ -1348,7 +1387,7 @@ update_binpkg() {
     fi
   fi
 
-  current_major="$(get_current_version | head -c 4 | awk '{ print $1 + 0 }')"
+  current_major="$(get_current_version | head -c 3 | awk '{ print $1 + 0 }')"
   latest_major="$(get_new_binpkg_major)"
 
   # current_major == 0 means we could not determine the installed version

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -883,10 +883,11 @@ self_update() {
 # build isn’t a git build).
 parse_version() {
   r="${1}"
+  vmax="999999999999999999"
   if [ "${r}" = "latest" ]; then
     # If we get ‘latest’ as a version, return the largest possible
     # version value.
-    printf "999999999999999999"
+    printf "%s" "${vmax}"
     return 0
   elif echo "${r}" | grep -q '^v.*'; then
     # shellcheck disable=SC2001
@@ -927,6 +928,12 @@ parse_version() {
 
   echo "${v}" | tr '.' ' ' > "${tmpfile}"
   read -r maj min patch _ < "${tmpfile}"
+
+  if [ "${#maj}" -gt 3 ] || [ "${#min}" -gt 3 ] || [ "${#patch}" -gt 3 ] || [ "${#rc}" -gt 3 ] || [ "${#b}" -gt 5 ]; then
+    warning "Failed to parse version ${r}"
+    printf "%s" "${vmax}"
+    return 0
+  fi
 
   rm -f "${tmpfile}"
 


### PR DESCRIPTION
##### Summary

This updates the code used to parse versions into integers for direct comparison to handle release candidate versions.

The new parsed version format is a 18 digit integer that encodes information about both the numerical version and the inferred release channel for the version. Sorting is such that nighly builds sort before release candidates with the same major/minor/patch, which in turn sort before stable releases with the same major/minor/patch.

##### Test Plan

n/a


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles release candidate and git build versions in the updater by switching to an 18‑digit sortable version key, adding overflow protection, and cleaning up temporary files. Nightly builds now sort before release candidates, which sort before stable for the same major.minor.patch.

- parse_version now returns 18 digits: major(3) minor(3) patch(3) type(1) rc(3) commit(5). "latest" and parse/overflow failures return all 9s; overflow triggers a warning.
- Major extraction uses head -c 3 (was -c 4); update safety checks adjusted accordingly.
- Release channel detection uses the type digit (position 10): 0 nightly (`netdata-repo-edge`), 3 stable (`netdata-repo`); others warn.
- Recognizes vX.Y.Z-rcN[-C] and vX.Y.Z[-C]; types: 0 nightly/git on nightly or stable, 1 rc, 2 git on rc, 3 stable, 9 unknown.
- Ensures temporary files created during parsing are removed.
- Migration: Update any tooling consuming parse_version output to expect 18 digits with major at 1–3, type at 10, rc at 11–13, commit at 14–18.

<sup>Written for commit 501c4bc1301ee9baa6cd2471cbfb674b5e84ab3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version handling when checking for the latest available release.
  * Added safeguards for version components that exceed supported limits, with a warning provided when this occurs.
  * Ensured temporary update-check files are cleaned up even when version validation encounters oversized components.
  * Improved reliability of update checks across a broader range of software versions.
  * Improved detection of release channels for binary packages, helping ensure the correct updates are identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->