### PR TITLE
fix(go.d/snmp_topology): report correct device metadata

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -140,7 +140,7 @@ func (c *Collector) ensureInitialized() error {
 		c.addPingCharts()
 	}
 
-	c.registerDeviceState(si)
+	c.registerDeviceState(si, nil)
 
 	return nil
 }
@@ -187,13 +187,7 @@ func (c *Collector) setupVnode(si *snmputils.SysInfo, deviceMeta map[string]ddsn
 		labels["model"] = si.Model
 	}
 
-	for k, val := range deviceMeta {
-		if v, ok := labels[k]; !ok || v == "" || val.IsExactMatch {
-			labels[k] = val.Value
-		}
-	}
-
-	maps.Copy(labels, c.Vnode.Labels)
+	labels = ddsnmp.ResolveDeviceMetadata(labels, deviceMeta, c.Vnode.Labels)
 
 	return &vnodes.VirtualNode{
 		GUID:     c.Vnode.GUID,

--- a/src/go/plugin/go.d/collector/snmp/collect_snmp.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_snmp.go
@@ -21,6 +21,7 @@ func (c *Collector) collectSNMP(mx map[string]int64) error {
 		c.markBGPCollectFailed(err)
 		return err
 	}
+	c.syncDeviceMetadata(pms)
 	if c.bgp == nil && profileMetricsHaveBGP(pms) {
 		c.enableBGPIntegration()
 	}

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -127,8 +127,9 @@ type (
 		ddSnmpColl    ddCollector
 		newDdSnmpColl func(ddsnmpcollector.Config) ddCollector
 
-		sysInfo      *snmputils.SysInfo
-		snmpProfiles []*ddsnmp.Profile
+		sysInfo              *snmputils.SysInfo
+		snmpProfiles         []*ddsnmp.Profile
+		deviceMetadataSynced bool
 
 		adjMaxRepetitions uint32
 

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -224,6 +224,84 @@ func TestCollector_CollectRegistersAndCleanupUnregistersDevice(t *testing.T) {
 	require.Empty(t, deviceStore.Devices())
 }
 
+func TestCollector_CollectSynchronizesDeviceMetadataOnceWithoutVnode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSNMP := snmpmock.NewMockHandler(ctrl)
+	setMockClientInitExpect(mockSNMP)
+	setMockClientSysInfoExpect(mockSNMP)
+
+	profileMetrics := &ddsnmp.ProfileMetrics{
+		Source: "dynamic-device.yaml",
+		DeviceMetadata: map[string]ddsnmp.MetaTag{
+			"vendor": {Value: "profile-vendor", IsExactMatch: true},
+			"model":  {Value: "profile-model", IsExactMatch: true},
+		},
+	}
+	mockCollector := &mockDdSnmpCollector{pms: []*ddsnmp.ProfileMetrics{profileMetrics}}
+
+	deviceStore := ddsnmp.NewDeviceStore()
+	collr := New(deviceStore)
+	collr.Config = prepareV2Config()
+	collr.CreateVnode = false
+	collr.Ping.Enabled = false
+	collr.snmpProfiles = []*ddsnmp.Profile{{}}
+	collr.newSnmpClient = func() gosnmp.Handler { return mockSNMP }
+	collr.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector { return mockCollector }
+
+	require.NoError(t, collr.Init(context.Background()))
+	require.NoError(t, collr.Check(context.Background()))
+	require.NotNil(t, collr.Collect(context.Background()))
+
+	devices := deviceStore.Devices()
+	require.Len(t, devices, 1)
+	assert.Equal(t, "profile-vendor", devices[0].Vendor)
+	assert.Equal(t, "profile-model", devices[0].Model)
+	assert.Zero(t, mockCollector.metadataCalls, "normal collection metadata must be reused without a separate request")
+
+	profileMetrics.DeviceMetadata["vendor"] = ddsnmp.MetaTag{Value: "later-vendor", IsExactMatch: true}
+	profileMetrics.DeviceMetadata["model"] = ddsnmp.MetaTag{Value: "later-model", IsExactMatch: true}
+	require.NotNil(t, collr.Collect(context.Background()))
+
+	devices = deviceStore.Devices()
+	require.Len(t, devices, 1)
+	assert.Equal(t, "profile-vendor", devices[0].Vendor)
+	assert.Equal(t, "profile-model", devices[0].Model)
+	assert.Equal(t, 2, mockCollector.collectCalls)
+	assert.Zero(t, mockCollector.metadataCalls)
+}
+
+func TestCollector_SetupVnodeAndRegisterDeviceStateShareResolvedMetadata(t *testing.T) {
+	deviceStore := ddsnmp.NewDeviceStore()
+	collr := New(deviceStore)
+	collr.Config = prepareV2Config()
+	collr.Vnode.Labels = map[string]string{
+		"model": "operator-model",
+	}
+
+	si := &snmputils.SysInfo{
+		SysObjectID: "1.3.6.1.4.1.41112",
+		Name:        "unifi-ap",
+		Vendor:      "static-vendor",
+		Model:       "static-model",
+	}
+	profileMetadata := map[string]ddsnmp.MetaTag{
+		"vendor": {Value: "profile-vendor", IsExactMatch: true},
+		"model":  {Value: "profile-model", IsExactMatch: true},
+	}
+
+	collr.vnode = collr.setupVnode(si, profileMetadata)
+	collr.registerDeviceState(si, nil)
+
+	devices := deviceStore.Devices()
+	require.Len(t, devices, 1)
+	assert.Equal(t, "profile-vendor", devices[0].VnodeLabels["vendor"])
+	assert.Equal(t, "operator-model", devices[0].VnodeLabels["model"])
+	assert.Equal(t, "profile-vendor", devices[0].Vendor)
+	assert.Equal(t, "operator-model", devices[0].Model)
+}
+
 func TestCollector_Check(t *testing.T) {
 	tests := map[string]struct {
 		prepare func(m *snmpmock.MockHandler) *Collector
@@ -983,7 +1061,8 @@ type mockDdSnmpCollector struct {
 	meta map[string]ddsnmp.MetaTag
 	err  error
 
-	collectCalls int
+	collectCalls  int
+	metadataCalls int
 }
 
 func (m *mockDdSnmpCollector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
@@ -992,6 +1071,7 @@ func (m *mockDdSnmpCollector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 }
 
 func (m *mockDdSnmpCollector) CollectDeviceMetadata() (map[string]ddsnmp.MetaTag, error) {
+	m.metadataCalls++
 	return m.meta, nil
 }
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -93,7 +93,7 @@ func (c *Collector) CollectDeviceMetadata() (map[string]ddsnmp.MetaTag, error) {
 		}
 
 		for k, v := range profDeviceMeta {
-			mergeMetaTagIfAbsent(meta, k, v)
+			ddsnmp.MergeMetaTag(meta, k, v)
 		}
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
@@ -86,7 +86,7 @@ func (dc *deviceMetadataCollector) collectStaticAndIdentifyOIDs(fields map[strin
 	for name, field := range fields {
 		switch {
 		case field.Value != "":
-			mergeMetaTagIfAbsent(metadata, name, ddsnmp.MetaTag{Value: field.Value, IsExactMatch: isExactMatch})
+			ddsnmp.MergeMetaTag(metadata, name, ddsnmp.MetaTag{Value: field.Value, IsExactMatch: isExactMatch})
 		case field.Symbol.OID != "":
 			if !dc.missingOIDs[trimOID(field.Symbol.OID)] {
 				oids = append(oids, field.Symbol.OID)
@@ -142,7 +142,7 @@ func (dc *deviceMetadataCollector) processDynamicFields(fields map[string]ddprof
 				continue
 			}
 			if v != "" {
-				mergeMetaTagIfAbsent(metadata, name, ddsnmp.MetaTag{Value: v, IsExactMatch: isExactMatch})
+				ddsnmp.MergeMetaTag(metadata, name, ddsnmp.MetaTag{Value: v, IsExactMatch: isExactMatch})
 			}
 		case len(field.Symbols) > 0:
 			// Multiple symbols - try each until one succeeds
@@ -154,7 +154,7 @@ func (dc *deviceMetadataCollector) processDynamicFields(fields map[string]ddprof
 					continue
 				}
 				if v != "" {
-					mergeMetaTagIfAbsent(metadata, name, ddsnmp.MetaTag{Value: v, IsExactMatch: isExactMatch})
+					ddsnmp.MergeMetaTag(metadata, name, ddsnmp.MetaTag{Value: v, IsExactMatch: isExactMatch})
 					break // Use first successful value
 				}
 			}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/utils.go
@@ -313,9 +313,3 @@ func isInt(s string) bool {
 	_, err := strconv.ParseInt(s, 10, 64)
 	return err == nil
 }
-
-func mergeMetaTagIfAbsent(dest map[string]ddsnmp.MetaTag, key string, tag ddsnmp.MetaTag) {
-	if existing, ok := dest[key]; !ok || existing.Value == "" || (!existing.IsExactMatch && tag.IsExactMatch) {
-		dest[key] = tag
-	}
-}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/metadata.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/metadata.go
@@ -4,6 +4,11 @@ package ddsnmp
 
 import "maps"
 
+const (
+	deviceMetadataVendorKey = "vendor"
+	deviceMetadataModelKey  = "model"
+)
+
 // MergeMetaTag keeps the first value at equal specificity and lets an exact
 // profile value replace a non-exact value.
 func MergeMetaTag(dest map[string]MetaTag, key string, tag MetaTag) {
@@ -19,6 +24,17 @@ func MergeMetaTags(dest, src map[string]MetaTag) {
 	}
 }
 
+// MergeDeviceIdentityMetadata merges only the fields stored as the shared
+// device's structured identity.
+func MergeDeviceIdentityMetadata(dest, src map[string]MetaTag) {
+	if tag, ok := src[deviceMetadataVendorKey]; ok {
+		MergeMetaTag(dest, deviceMetadataVendorKey, tag)
+	}
+	if tag, ok := src[deviceMetadataModelKey]; ok {
+		MergeMetaTag(dest, deviceMetadataModelKey, tag)
+	}
+}
+
 // ResolveDeviceMetadata applies static fallback, profile metadata, and final
 // vnode labels in that order without modifying its inputs.
 func ResolveDeviceMetadata(base map[string]string, profile map[string]MetaTag, final map[string]string) map[string]string {
@@ -26,11 +42,34 @@ func ResolveDeviceMetadata(base map[string]string, profile map[string]MetaTag, f
 	maps.Copy(resolved, base)
 
 	for key, tag := range profile {
-		if current, ok := resolved[key]; !ok || current == "" || tag.IsExactMatch {
-			resolved[key] = tag.Value
-		}
+		resolved[key] = resolveProfileMetadataValue(resolved[key], tag)
 	}
 	maps.Copy(resolved, final)
 
 	return resolved
+}
+
+// ResolveDeviceIdentity applies metadata precedence to the shared device's
+// structured vendor and model without copying unrelated labels.
+func ResolveDeviceIdentity(vendor, model string, profile map[string]MetaTag, final map[string]string) (string, string) {
+	vendor = resolveDeviceMetadataValue(deviceMetadataVendorKey, vendor, profile, final)
+	model = resolveDeviceMetadataValue(deviceMetadataModelKey, model, profile, final)
+	return vendor, model
+}
+
+func resolveDeviceMetadataValue(key, base string, profile map[string]MetaTag, final map[string]string) string {
+	if tag, ok := profile[key]; ok {
+		base = resolveProfileMetadataValue(base, tag)
+	}
+	if value, ok := final[key]; ok {
+		base = value
+	}
+	return base
+}
+
+func resolveProfileMetadataValue(base string, profile MetaTag) string {
+	if base == "" || profile.IsExactMatch {
+		return profile.Value
+	}
+	return base
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/metadata.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/metadata.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmp
+
+import "maps"
+
+// MergeMetaTag keeps the first value at equal specificity and lets an exact
+// profile value replace a non-exact value.
+func MergeMetaTag(dest map[string]MetaTag, key string, tag MetaTag) {
+	if existing, ok := dest[key]; !ok || existing.Value == "" || (!existing.IsExactMatch && tag.IsExactMatch) {
+		dest[key] = tag
+	}
+}
+
+// MergeMetaTags merges profile metadata without losing exact-match provenance.
+func MergeMetaTags(dest, src map[string]MetaTag) {
+	for key, tag := range src {
+		MergeMetaTag(dest, key, tag)
+	}
+}
+
+// ResolveDeviceMetadata applies static fallback, profile metadata, and final
+// vnode labels in that order without modifying its inputs.
+func ResolveDeviceMetadata(base map[string]string, profile map[string]MetaTag, final map[string]string) map[string]string {
+	resolved := make(map[string]string, len(base)+len(profile)+len(final))
+	maps.Copy(resolved, base)
+
+	for key, tag := range profile {
+		if current, ok := resolved[key]; !ok || current == "" || tag.IsExactMatch {
+			resolved[key] = tag.Value
+		}
+	}
+	maps.Copy(resolved, final)
+
+	return resolved
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/metadata_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/metadata_test.go
@@ -60,6 +60,24 @@ func TestMergeMetaTags(t *testing.T) {
 	}
 }
 
+func TestMergeDeviceIdentityMetadata(t *testing.T) {
+	dest := map[string]MetaTag{
+		"vendor": {Value: "wildcard-vendor"},
+	}
+	src := map[string]MetaTag{
+		"vendor":        {Value: "exact-vendor", IsExactMatch: true},
+		"model":         {Value: "profile-model"},
+		"serial_number": {Value: "ignored-serial", IsExactMatch: true},
+	}
+
+	MergeDeviceIdentityMetadata(dest, src)
+
+	require.Equal(t, map[string]MetaTag{
+		"vendor": {Value: "exact-vendor", IsExactMatch: true},
+		"model":  {Value: "profile-model"},
+	}, dest)
+}
+
 func TestResolveDeviceMetadata(t *testing.T) {
 	base := map[string]string{
 		"vendor": "static-vendor",
@@ -103,4 +121,23 @@ func TestResolveDeviceMetadataFinalEmptyValueRemainsAuthoritative(t *testing.T) 
 	value, ok := resolved["model"]
 	require.True(t, ok)
 	require.Empty(t, value)
+}
+
+func TestResolveDeviceIdentity(t *testing.T) {
+	vendor, model := ResolveDeviceIdentity(
+		"static-vendor",
+		"static-model",
+		map[string]MetaTag{
+			"vendor":        {Value: "wildcard-vendor"},
+			"model":         {Value: "exact-model", IsExactMatch: true},
+			"serial_number": {Value: "ignored-serial", IsExactMatch: true},
+		},
+		map[string]string{
+			"model":         "final-model",
+			"serial_number": "ignored-final-serial",
+		},
+	)
+
+	require.Equal(t, "static-vendor", vendor)
+	require.Equal(t, "final-model", model)
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/metadata_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/metadata_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmp
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeMetaTags(t *testing.T) {
+	tests := map[string]struct {
+		dest map[string]MetaTag
+		src  map[string]MetaTag
+		want map[string]MetaTag
+	}{
+		"fills missing and empty values": {
+			dest: map[string]MetaTag{
+				"vendor": {Value: ""},
+			},
+			src: map[string]MetaTag{
+				"vendor": {Value: "profile-vendor"},
+				"model":  {Value: "profile-model"},
+			},
+			want: map[string]MetaTag{
+				"vendor": {Value: "profile-vendor"},
+				"model":  {Value: "profile-model"},
+			},
+		},
+		"exact value replaces non-exact value": {
+			dest: map[string]MetaTag{
+				"model": {Value: "wildcard-model"},
+			},
+			src: map[string]MetaTag{
+				"model": {Value: "exact-model", IsExactMatch: true},
+			},
+			want: map[string]MetaTag{
+				"model": {Value: "exact-model", IsExactMatch: true},
+			},
+		},
+		"first value wins at equal specificity": {
+			dest: map[string]MetaTag{
+				"vendor": {Value: "first-vendor", IsExactMatch: true},
+			},
+			src: map[string]MetaTag{
+				"vendor": {Value: "second-vendor", IsExactMatch: true},
+			},
+			want: map[string]MetaTag{
+				"vendor": {Value: "first-vendor", IsExactMatch: true},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			MergeMetaTags(tc.dest, tc.src)
+			require.Equal(t, tc.want, tc.dest)
+		})
+	}
+}
+
+func TestResolveDeviceMetadata(t *testing.T) {
+	base := map[string]string{
+		"vendor": "static-vendor",
+		"model":  "static-model",
+		"type":   "static-type",
+	}
+	profile := map[string]MetaTag{
+		"vendor": {Value: "wildcard-vendor"},
+		"model":  {Value: "exact-model", IsExactMatch: true},
+		"serial": {Value: "profile-serial"},
+	}
+	final := map[string]string{
+		"model": "operator-model",
+		"type":  "operator-type",
+	}
+
+	baseBefore := maps.Clone(base)
+	profileBefore := maps.Clone(profile)
+	finalBefore := maps.Clone(final)
+
+	resolved := ResolveDeviceMetadata(base, profile, final)
+
+	require.Equal(t, map[string]string{
+		"vendor": "static-vendor",
+		"model":  "operator-model",
+		"type":   "operator-type",
+		"serial": "profile-serial",
+	}, resolved)
+	require.Equal(t, baseBefore, base)
+	require.Equal(t, profileBefore, profile)
+	require.Equal(t, finalBefore, final)
+}
+
+func TestResolveDeviceMetadataFinalEmptyValueRemainsAuthoritative(t *testing.T) {
+	resolved := ResolveDeviceMetadata(
+		map[string]string{"model": "static-model"},
+		map[string]MetaTag{"model": {Value: "profile-model", IsExactMatch: true}},
+		map[string]string{"model": ""},
+	)
+
+	value, ok := resolved["model"]
+	require.True(t, ok)
+	require.Empty(t, value)
+}

--- a/src/go/plugin/go.d/collector/snmp/device_state.go
+++ b/src/go/plugin/go.d/collector/snmp/device_state.go
@@ -10,8 +10,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 )
 
-var deviceIdentityMetadataKeys = [...]string{"vendor", "model"}
-
 func firstVendor(values ...string) string {
 	for _, v := range values {
 		if v != "" {
@@ -55,10 +53,12 @@ func (c *Collector) registerDeviceState(si *snmputils.SysInfo, profileMetadata m
 		return
 	}
 	vnodeLabels := c.vnodeLabels()
-	identity := ddsnmp.ResolveDeviceMetadata(map[string]string{
-		"vendor": firstVendor(si.Vendor, si.Organization),
-		"model":  si.Model,
-	}, profileMetadata, vnodeLabels)
+	vendor, model := ddsnmp.ResolveDeviceIdentity(
+		firstVendor(si.Vendor, si.Organization),
+		si.Model,
+		profileMetadata,
+		vnodeLabels,
+	)
 
 	c.deviceStore.Register(c.deviceStoreKey(), ddsnmp.DeviceConnectionInfo{
 		Hostname:        c.Hostname,
@@ -81,8 +81,8 @@ func (c *Collector) registerDeviceState(si *snmputils.SysInfo, profileMetadata m
 		SysName:         si.Name,
 		SysContact:      si.Contact,
 		SysLocation:     si.Location,
-		Vendor:          identity["vendor"],
-		Model:           identity["model"],
+		Vendor:          vendor,
+		Model:           model,
 
 		DisableBulkWalk: c.disableBulkWalk,
 		ManualProfiles:  c.ManualProfiles,
@@ -97,13 +97,9 @@ func (c *Collector) syncDeviceMetadata(pms []*ddsnmp.ProfileMetrics) {
 		return
 	}
 
-	metadata := make(map[string]ddsnmp.MetaTag, len(deviceIdentityMetadataKeys))
+	metadata := make(map[string]ddsnmp.MetaTag, 2)
 	for _, pm := range pms {
-		for _, key := range deviceIdentityMetadataKeys {
-			if tag, ok := pm.DeviceMetadata[key]; ok {
-				ddsnmp.MergeMetaTag(metadata, key, tag)
-			}
-		}
+		ddsnmp.MergeDeviceIdentityMetadata(metadata, pm.DeviceMetadata)
 	}
 
 	c.registerDeviceState(c.sysInfo, metadata)

--- a/src/go/plugin/go.d/collector/snmp/device_state.go
+++ b/src/go/plugin/go.d/collector/snmp/device_state.go
@@ -10,6 +10,8 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 )
 
+var deviceIdentityMetadataKeys = [...]string{"vendor", "model"}
+
 func firstVendor(values ...string) string {
 	for _, v := range values {
 		if v != "" {
@@ -48,10 +50,16 @@ func (c *Collector) deviceStoreKey() string {
 
 // registerDeviceState exposes the already-configured SNMP job to SNMP-family
 // consumers without duplicating job configuration.
-func (c *Collector) registerDeviceState(si *snmputils.SysInfo) {
+func (c *Collector) registerDeviceState(si *snmputils.SysInfo, profileMetadata map[string]ddsnmp.MetaTag) {
 	if c.deviceStore == nil {
 		return
 	}
+	vnodeLabels := c.vnodeLabels()
+	identity := ddsnmp.ResolveDeviceMetadata(map[string]string{
+		"vendor": firstVendor(si.Vendor, si.Organization),
+		"model":  si.Model,
+	}, profileMetadata, vnodeLabels)
+
 	c.deviceStore.Register(c.deviceStoreKey(), ddsnmp.DeviceConnectionInfo{
 		Hostname:        c.Hostname,
 		Port:            c.Options.Port,
@@ -73,13 +81,31 @@ func (c *Collector) registerDeviceState(si *snmputils.SysInfo) {
 		SysName:         si.Name,
 		SysContact:      si.Contact,
 		SysLocation:     si.Location,
-		Vendor:          firstVendor(si.Vendor, si.Organization),
-		Model:           si.Model,
+		Vendor:          identity["vendor"],
+		Model:           identity["model"],
 
 		DisableBulkWalk: c.disableBulkWalk,
 		ManualProfiles:  c.ManualProfiles,
 		VnodeGUID:       c.vnodeGUID(),
 		VnodeHostname:   c.vnodeHostname(),
-		VnodeLabels:     c.vnodeLabels(),
+		VnodeLabels:     vnodeLabels,
 	})
+}
+
+func (c *Collector) syncDeviceMetadata(pms []*ddsnmp.ProfileMetrics) {
+	if c.deviceMetadataSynced || c.vnode != nil || c.sysInfo == nil {
+		return
+	}
+
+	metadata := make(map[string]ddsnmp.MetaTag, len(deviceIdentityMetadataKeys))
+	for _, pm := range pms {
+		for _, key := range deviceIdentityMetadataKeys {
+			if tag, ok := pm.DeviceMetadata[key]; ok {
+				ddsnmp.MergeMetaTag(metadata, key, tag)
+			}
+		}
+	}
+
+	c.registerDeviceState(c.sysInfo, metadata)
+	c.deviceMetadataSynced = true
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_ingest.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_ingest.go
@@ -16,6 +16,18 @@ func (c *topologyCache) updateTopologyProfileTags(pms []*ddsnmp.ProfileMetrics) 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	profileIdentity := make(map[string]ddsnmp.MetaTag, 2)
+	for _, pm := range pms {
+		for _, key := range []string{"vendor", "model"} {
+			if tag, ok := pm.DeviceMetadata[key]; ok {
+				ddsnmp.MergeMetaTag(profileIdentity, key, tag)
+			}
+		}
+	}
+	local := c.localDevice
+	local.Vendor, local.Model = resolveTopologyDeviceIdentity(local.Vendor, local.Model, profileIdentity, local.Labels)
+	c.localDevice = local
+
 	for _, pm := range pms {
 		tags := topologyMetadataValues(pm.DeviceMetadata)
 		if len(pm.Tags) > 0 {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_ingest.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_ingest.go
@@ -18,14 +18,10 @@ func (c *topologyCache) updateTopologyProfileTags(pms []*ddsnmp.ProfileMetrics) 
 
 	profileIdentity := make(map[string]ddsnmp.MetaTag, 2)
 	for _, pm := range pms {
-		for _, key := range []string{"vendor", "model"} {
-			if tag, ok := pm.DeviceMetadata[key]; ok {
-				ddsnmp.MergeMetaTag(profileIdentity, key, tag)
-			}
-		}
+		ddsnmp.MergeDeviceIdentityMetadata(profileIdentity, pm.DeviceMetadata)
 	}
 	local := c.localDevice
-	local.Vendor, local.Model = resolveTopologyDeviceIdentity(local.Vendor, local.Model, profileIdentity, local.Labels)
+	local.Vendor, local.Model = ddsnmp.ResolveDeviceIdentity(local.Vendor, local.Model, profileIdentity, local.Labels)
 	c.localDevice = local
 
 	for _, pm := range pms {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -163,6 +163,88 @@ func TestTopologyCache_UpdateTopologyProfileTags_BridgeAddressSetsSNMPIdentity(t
 	require.Equal(t, "macAddress", cache.localDevice.ChassisIDType)
 }
 
+func TestTopologyCache_UpdateTopologyProfileTagsResolvesDeviceMetadata(t *testing.T) {
+	tests := map[string]struct {
+		device     ddsnmp.DeviceConnectionInfo
+		metrics    []*ddsnmp.ProfileMetrics
+		wantVendor string
+		wantModel  string
+	}{
+		"exact profile metadata replaces stale static values": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Vendor: "static-vendor",
+				Model:  "static-model",
+			},
+			metrics: []*ddsnmp.ProfileMetrics{
+				{
+					DeviceMetadata: map[string]ddsnmp.MetaTag{
+						"vendor": {Value: "wildcard-vendor"},
+						"model":  {Value: "wildcard-model"},
+					},
+				},
+				{
+					DeviceMetadata: map[string]ddsnmp.MetaTag{
+						"vendor": {Value: "profile-vendor", IsExactMatch: true},
+						"model":  {Value: "profile-model", IsExactMatch: true},
+					},
+					Tags: map[string]string{
+						"vendor": "generic-tag-vendor",
+						"model":  "generic-tag-model",
+					},
+				},
+			},
+			wantVendor: "profile-vendor",
+			wantModel:  "profile-model",
+		},
+		"non-exact profile metadata preserves non-empty static values": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Vendor: "static-vendor",
+				Model:  "static-model",
+			},
+			metrics: []*ddsnmp.ProfileMetrics{
+				{
+					DeviceMetadata: map[string]ddsnmp.MetaTag{
+						"vendor": {Value: "wildcard-vendor"},
+						"model":  {Value: "wildcard-model"},
+					},
+				},
+			},
+			wantVendor: "static-vendor",
+			wantModel:  "static-model",
+		},
+		"final vnode labels remain authoritative": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Vendor: "static-vendor",
+				Model:  "static-model",
+				VnodeLabels: map[string]string{
+					"vendor": "vnode-vendor",
+					"model":  "vnode-model",
+				},
+			},
+			metrics: []*ddsnmp.ProfileMetrics{
+				{
+					DeviceMetadata: map[string]ddsnmp.MetaTag{
+						"vendor": {Value: "profile-vendor", IsExactMatch: true},
+						"model":  {Value: "profile-model", IsExactMatch: true},
+					},
+				},
+			},
+			wantVendor: "vnode-vendor",
+			wantModel:  "vnode-model",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := newTestTopologyCache(tc.device)
+			cache.updateTopologyProfileTags(tc.metrics)
+
+			assert.Equal(t, tc.wantVendor, cache.localDevice.Vendor)
+			assert.Equal(t, tc.wantModel, cache.localDevice.Model)
+		})
+	}
+}
+
 func TestTopologyCache_UpdateFdbEntry_DoesNotSetBridgeIdentityFromRowTags(t *testing.T) {
 	cache := newTopologyCache()
 	cache.localDevice = topologymodel.Device{

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_device.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
@@ -44,7 +45,7 @@ func normalizeTopologyDevice(dev topologymodel.Device) topologymodel.Device {
 	if dev.ChassisID != "" && dev.ChassisIDType == "" {
 		dev.ChassisIDType = "unknown"
 	}
-	dev.Vendor, dev.Model = resolveTopologyDeviceIdentity(dev.Vendor, dev.Model, nil, dev.Labels)
+	dev.Vendor, dev.Model = ddsnmp.ResolveDeviceIdentity(dev.Vendor, dev.Model, nil, dev.Labels)
 	metadata := newTopologyMetadataIndex(dev.Labels)
 	if value := metadata.value(topologyMetadataAliasSysDescr); value != "" && dev.SysDescr == "" {
 		dev.SysDescr = value

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_device.go
@@ -44,19 +44,21 @@ func normalizeTopologyDevice(dev topologymodel.Device) topologymodel.Device {
 	if dev.ChassisID != "" && dev.ChassisIDType == "" {
 		dev.ChassisIDType = "unknown"
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasSysDescr); value != "" && dev.SysDescr == "" {
+	dev.Vendor, dev.Model = resolveTopologyDeviceIdentity(dev.Vendor, dev.Model, nil, dev.Labels)
+	metadata := newTopologyMetadataIndex(dev.Labels)
+	if value := metadata.value(topologyMetadataAliasSysDescr); value != "" && dev.SysDescr == "" {
 		dev.SysDescr = value
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasSysContact); value != "" && dev.SysContact == "" {
+	if value := metadata.value(topologyMetadataAliasSysContact); value != "" && dev.SysContact == "" {
 		dev.SysContact = value
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasSysLocation); value != "" && dev.SysLocation == "" {
+	if value := metadata.value(topologyMetadataAliasSysLocation); value != "" && dev.SysLocation == "" {
 		dev.SysLocation = value
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasVendor); value != "" && dev.Vendor == "" {
+	if value := metadata.value(topologyMetadataAliasVendor); value != "" && dev.Vendor == "" {
 		dev.Vendor = value
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasModel); value != "" && dev.Model == "" {
+	if value := metadata.value(topologyMetadataAliasModel); value != "" && dev.Model == "" {
 		dev.Model = value
 	}
 	if value := topologyutil.NormalizeTopologyRouterID(dev.Labels[tagOSPFRouterID]); value != "" && dev.OSPFRouterID == "" {
@@ -67,23 +69,23 @@ func normalizeTopologyDevice(dev topologymodel.Device) topologymodel.Device {
 		setTopologyMetadataLabelIfMissing(dev.Labels, tagOSPFRouterID, value)
 	}
 	if dev.SysUptime <= 0 {
-		if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasSysUptime); value != "" {
+		if value := metadata.value(topologyMetadataAliasSysUptime); value != "" {
 			dev.SysUptime = topologyutil.ParsePositiveInt64(value)
 		}
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasSerial); value != "" && dev.SerialNumber == "" {
+	if value := metadata.value(topologyMetadataAliasSerial); value != "" && dev.SerialNumber == "" {
 		dev.SerialNumber = value
 		setTopologyMetadataLabelIfMissing(dev.Labels, "serial_number", value)
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasSoftware); value != "" && dev.SoftwareVersion == "" {
+	if value := metadata.value(topologyMetadataAliasSoftware); value != "" && dev.SoftwareVersion == "" {
 		dev.SoftwareVersion = value
 		setTopologyMetadataLabelIfMissing(dev.Labels, "software_version", value)
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasFirmware); value != "" && dev.FirmwareVersion == "" {
+	if value := metadata.value(topologyMetadataAliasFirmware); value != "" && dev.FirmwareVersion == "" {
 		dev.FirmwareVersion = value
 		setTopologyMetadataLabelIfMissing(dev.Labels, "firmware_version", value)
 	}
-	if value := topologyMetadataValue(dev.Labels, topologyMetadataAliasHardware); value != "" && dev.HardwareVersion == "" {
+	if value := metadata.value(topologyMetadataAliasHardware); value != "" && dev.HardwareVersion == "" {
 		dev.HardwareVersion = value
 		setTopologyMetadataLabelIfMissing(dev.Labels, "hardware_version", value)
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_metadata.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_metadata.go
@@ -5,8 +5,6 @@ package snmptopology
 import (
 	"sort"
 	"strings"
-
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
 var (
@@ -98,25 +96,6 @@ func (idx topologyMetadataIndex) value(aliases []string) string {
 		}
 	}
 	return ""
-}
-
-func resolveTopologyDeviceIdentity(
-	vendor string,
-	model string,
-	profile map[string]ddsnmp.MetaTag,
-	final map[string]string,
-) (string, string) {
-	finalIdentity := make(map[string]string, 2)
-	for _, key := range []string{"vendor", "model"} {
-		if value, ok := final[key]; ok {
-			finalIdentity[key] = value
-		}
-	}
-	resolved := ddsnmp.ResolveDeviceMetadata(map[string]string{
-		"vendor": vendor,
-		"model":  model,
-	}, profile, finalIdentity)
-	return resolved["vendor"], resolved["model"]
 }
 
 func setTopologyMetadataLabelIfMissing(labels map[string]string, key, value string) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_metadata.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_metadata.go
@@ -5,6 +5,8 @@ package snmptopology
 import (
 	"sort"
 	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
 var (
@@ -53,19 +55,21 @@ func topologyCanonicalMetadataKey(key string) string {
 	return strings.Trim(key, "_")
 }
 
-func topologyMetadataValue(labels map[string]string, aliases []string) string {
-	if len(labels) == 0 || len(aliases) == 0 {
-		return ""
+type topologyMetadataIndex map[string]string
+
+func newTopologyMetadataIndex(labels map[string]string) topologyMetadataIndex {
+	if len(labels) == 0 {
+		return nil
 	}
-	byKey := make(map[string]string, len(labels))
+
+	byKey := make(topologyMetadataIndex, len(labels))
 	keys := make([]string, 0, len(labels))
 	for key := range labels {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		value := labels[key]
-		value = strings.TrimSpace(value)
+		value := strings.TrimSpace(labels[key])
 		if value == "" {
 			continue
 		}
@@ -77,16 +81,42 @@ func topologyMetadataValue(labels map[string]string, aliases []string) string {
 			byKey[canonical] = value
 		}
 	}
+	return byKey
+}
+
+func (idx topologyMetadataIndex) value(aliases []string) string {
+	if len(idx) == 0 || len(aliases) == 0 {
+		return ""
+	}
 	for _, alias := range aliases {
 		alias = topologyCanonicalMetadataKey(alias)
 		if alias == "" {
 			continue
 		}
-		if value := strings.TrimSpace(byKey[alias]); value != "" {
+		if value := strings.TrimSpace(idx[alias]); value != "" {
 			return value
 		}
 	}
 	return ""
+}
+
+func resolveTopologyDeviceIdentity(
+	vendor string,
+	model string,
+	profile map[string]ddsnmp.MetaTag,
+	final map[string]string,
+) (string, string) {
+	finalIdentity := make(map[string]string, 2)
+	for _, key := range []string{"vendor", "model"} {
+		if value, ok := final[key]; ok {
+			finalIdentity[key] = value
+		}
+	}
+	resolved := ddsnmp.ResolveDeviceMetadata(map[string]string{
+		"vendor": vendor,
+		"model":  model,
+	}, profile, finalIdentity)
+	return resolved["vendor"], resolved["model"]
 }
 
 func setTopologyMetadataLabelIfMissing(labels map[string]string, key, value string) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_metadata_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTopologyMetadataValue_CanonicalizesAliasKeys(t *testing.T) {
+func TestTopologyMetadataIndex_CanonicalizesAliasKeys(t *testing.T) {
 	labels := map[string]string{
 		"Serial Number":    "SN-123",
 		"software.version": "17.9.4",
@@ -26,7 +26,7 @@ func TestTopologyMetadataValue_CanonicalizesAliasKeys(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tc.want, topologyMetadataValue(labels, tc.keys))
+			require.Equal(t, tc.want, newTopologyMetadataIndex(labels).value(tc.keys))
 		})
 	}
 }
@@ -41,7 +41,7 @@ func TestSetTopologyMetadataLabelIfMissing_PreservesExistingValue(t *testing.T) 
 	require.Equal(t, "1.2.3", labels["firmware_version"])
 }
 
-func TestTopologyMetadataValue_DeterministicAcrossCanonicalKeyCollisions(t *testing.T) {
+func TestTopologyMetadataIndex_DeterministicAcrossCanonicalKeyCollisions(t *testing.T) {
 	tests := map[string]struct {
 		labels map[string]string
 	}{
@@ -61,7 +61,7 @@ func TestTopologyMetadataValue_DeterministicAcrossCanonicalKeyCollisions(t *test
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, "SN-100", topologyMetadataValue(tc.labels, []string{"serial_number"}))
+			require.Equal(t, "SN-100", newTopologyMetadataIndex(tc.labels).value([]string{"serial_number"}))
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_builder.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_builder.go
@@ -30,7 +30,7 @@ func buildLocalTopologyDevice(dev ddsnmp.DeviceConnectionInfo) topologymodel.Dev
 	if len(dev.VnodeLabels) > 0 {
 		device.Labels = cloneTopologyLabels(dev.VnodeLabels)
 	}
-	device.Vendor, device.Model = resolveTopologyDeviceIdentity(device.Vendor, device.Model, nil, device.Labels)
+	device.Vendor, device.Model = ddsnmp.ResolveDeviceIdentity(device.Vendor, device.Model, nil, device.Labels)
 	metadata := newTopologyMetadataIndex(device.Labels)
 
 	if value := metadata.value(topologyMetadataAliasSysDescr); value != "" && device.SysDescr == "" {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_builder.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_builder.go
@@ -30,20 +30,22 @@ func buildLocalTopologyDevice(dev ddsnmp.DeviceConnectionInfo) topologymodel.Dev
 	if len(dev.VnodeLabels) > 0 {
 		device.Labels = cloneTopologyLabels(dev.VnodeLabels)
 	}
+	device.Vendor, device.Model = resolveTopologyDeviceIdentity(device.Vendor, device.Model, nil, device.Labels)
+	metadata := newTopologyMetadataIndex(device.Labels)
 
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasSysDescr); value != "" && device.SysDescr == "" {
+	if value := metadata.value(topologyMetadataAliasSysDescr); value != "" && device.SysDescr == "" {
 		device.SysDescr = value
 	}
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasSysContact); value != "" && device.SysContact == "" {
+	if value := metadata.value(topologyMetadataAliasSysContact); value != "" && device.SysContact == "" {
 		device.SysContact = value
 	}
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasSysLocation); value != "" && device.SysLocation == "" {
+	if value := metadata.value(topologyMetadataAliasSysLocation); value != "" && device.SysLocation == "" {
 		device.SysLocation = value
 	}
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasVendor); value != "" && device.Vendor == "" {
+	if value := metadata.value(topologyMetadataAliasVendor); value != "" && device.Vendor == "" {
 		device.Vendor = value
 	}
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasModel); value != "" && device.Model == "" {
+	if value := metadata.value(topologyMetadataAliasModel); value != "" && device.Model == "" {
 		device.Model = value
 	}
 	if value := topologyutil.NormalizeTopologyRouterID(device.Labels[tagOSPFRouterID]); value != "" {
@@ -51,24 +53,24 @@ func buildLocalTopologyDevice(dev ddsnmp.DeviceConnectionInfo) topologymodel.Dev
 		setTopologyMetadataLabelIfMissing(device.Labels, tagOSPFRouterID, value)
 	}
 
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasSysUptime); value != "" {
+	if value := metadata.value(topologyMetadataAliasSysUptime); value != "" {
 		if uptime := topologyutil.ParsePositiveInt64(value); uptime > 0 {
 			device.SysUptime = uptime
 		}
 	}
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasSerial); value != "" {
+	if value := metadata.value(topologyMetadataAliasSerial); value != "" {
 		device.SerialNumber = value
 		setTopologyMetadataLabelIfMissing(device.Labels, "serial_number", value)
 	}
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasSoftware); value != "" {
+	if value := metadata.value(topologyMetadataAliasSoftware); value != "" {
 		device.SoftwareVersion = value
 		setTopologyMetadataLabelIfMissing(device.Labels, "software_version", value)
 	}
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasFirmware); value != "" {
+	if value := metadata.value(topologyMetadataAliasFirmware); value != "" {
 		device.FirmwareVersion = value
 		setTopologyMetadataLabelIfMissing(device.Labels, "firmware_version", value)
 	}
-	if value := topologyMetadataValue(device.Labels, topologyMetadataAliasHardware); value != "" {
+	if value := metadata.value(topologyMetadataAliasHardware); value != "" {
 		device.HardwareVersion = value
 		setTopologyMetadataLabelIfMissing(device.Labels, "hardware_version", value)
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
@@ -119,6 +119,68 @@ func TestTopologyProductionPath_UniFiQBridgeRendersDefaultManagedFabric(t *testi
 	assert.GreaterOrEqual(t, testCountTopologyLinksByType(data.Links, "fdb"), 1)
 }
 
+func TestTopologyProductionPath_UniFiActorUsesSharedDynamicProfileMetadata(t *testing.T) {
+	device := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.20",
+		SysObjectID: "1.3.6.1.4.1.41112",
+		SysName:     "unifi-ap",
+		SysDescr:    "Ubiquiti UniFi U6 Mesh",
+		Vendor:      "Unknown",
+		Model:       "UniFi UAP-FlexHD",
+	}
+	mainMetrics := collectMainProfileMetrics(t, device, topologyUniFiAPPDUs())
+	metadata := make(map[string]ddsnmp.MetaTag)
+	for _, pm := range mainMetrics {
+		ddsnmp.MergeMetaTags(metadata, pm.DeviceMetadata)
+	}
+	require.Equal(t, ddsnmp.MetaTag{Value: "Ubiquiti", IsExactMatch: true}, metadata["vendor"])
+	require.Equal(t, ddsnmp.MetaTag{Value: "UniFi U6-Mesh", IsExactMatch: true}, metadata["model"])
+	identity := ddsnmp.ResolveDeviceMetadata(map[string]string{
+		"vendor": device.Vendor,
+		"model":  device.Model,
+	}, metadata, nil)
+	device.Vendor = identity["vendor"]
+	device.Model = identity["model"]
+
+	metrics := collectTopologyProfileMetrics(t, device, topologyUniFiAPPDUs())
+	cache := newTestTopologyCache(device)
+	cache.updateTopologyProfileTags(metrics)
+	cache.ingestTopologyProfileMetrics(metrics)
+	cache.finalizeTopologyCache()
+
+	registry := newTopologyRegistry()
+	registry.register(cache)
+	data, ok := snapshotTopologyRegistryForTest(registry)
+	require.True(t, ok)
+
+	actor := findDeviceActorBySysName(data, "unifi-ap")
+	require.NotNil(t, actor)
+	assert.Equal(t, "Ubiquiti", actor.Detail.SNMP.Vendor)
+	assert.Equal(t, "UniFi U6-Mesh", actor.Detail.SNMP.Model)
+}
+
+func collectMainProfileMetrics(
+	t *testing.T,
+	device ddsnmp.DeviceConnectionInfo,
+	pdus []gosnmp.SnmpPDU,
+) []*ddsnmp.ProfileMetrics {
+	t.Helper()
+
+	profiles := ddsnmp.DefaultCatalog().Resolve(ddsnmp.ResolveRequest{
+		SysObjectID: device.SysObjectID,
+		SysDescr:    device.SysDescr,
+	}).Project(ddsnmp.ConsumerMetrics, ddsnmp.ConsumerLicensing, ddsnmp.ConsumerBGP).Profiles()
+	require.NotEmpty(t, profiles)
+	metrics, err := ddsnmpcollector.New(ddsnmpcollector.Config{
+		SnmpClient:  newTopologySNMPHandler(pdus),
+		Profiles:    profiles,
+		Log:         newTestSNMPTopologyCollector().Logger,
+		SysObjectID: device.SysObjectID,
+	}).Collect()
+	require.NoError(t, err)
+	return metrics
+}
+
 func collectTopologyProfileMetrics(
 	t *testing.T,
 	device ddsnmp.DeviceConnectionInfo,
@@ -171,6 +233,7 @@ func topologyUniFiSwitchPDUs() []gosnmp.SnmpPDU {
 
 func topologyUniFiAPPDUs() []gosnmp.SnmpPDU {
 	return []gosnmp.SnmpPDU{
+		topologyOctetStringPDU("1.3.6.1.4.1.41112.1.6.3.3.0", "U6-Mesh"),
 		topologyOctetPDU("1.3.6.1.2.1.4.22.1.2.17.192.0.2.1", 0x02, 0, 0, 0, 0, 1),
 		topologyIntegerPDU("1.3.6.1.2.1.4.22.1.4.17.192.0.2.1", 3),
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
@@ -131,16 +131,11 @@ func TestTopologyProductionPath_UniFiActorUsesSharedDynamicProfileMetadata(t *te
 	mainMetrics := collectMainProfileMetrics(t, device, topologyUniFiAPPDUs())
 	metadata := make(map[string]ddsnmp.MetaTag)
 	for _, pm := range mainMetrics {
-		ddsnmp.MergeMetaTags(metadata, pm.DeviceMetadata)
+		ddsnmp.MergeDeviceIdentityMetadata(metadata, pm.DeviceMetadata)
 	}
 	require.Equal(t, ddsnmp.MetaTag{Value: "Ubiquiti", IsExactMatch: true}, metadata["vendor"])
 	require.Equal(t, ddsnmp.MetaTag{Value: "UniFi U6-Mesh", IsExactMatch: true}, metadata["model"])
-	identity := ddsnmp.ResolveDeviceMetadata(map[string]string{
-		"vendor": device.Vendor,
-		"model":  device.Model,
-	}, metadata, nil)
-	device.Vendor = identity["vendor"]
-	device.Model = identity["model"]
+	device.Vendor, device.Model = ddsnmp.ResolveDeviceIdentity(device.Vendor, device.Model, metadata, nil)
 
 	metrics := collectTopologyProfileMetrics(t, device, topologyUniFiAPPDUs())
 	cache := newTestTopologyCache(device)

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/metadata/other.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/metadata/other.yaml
@@ -8439,7 +8439,6 @@ sysobjectids:
       model: DB Engine
     1.3.6.1.4.1.41112:
       category: Access Point
-      model: UniFi UAP-FlexHD
     1.3.6.1.4.1.41112.1.3:
       category: Switch
       model: Ubiquiti Networks UniFi switch

--- a/src/go/plugin/go.d/pkg/snmputils/overrides_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/overrides_test.go
@@ -142,6 +142,70 @@ func TestLookupEnterpriseNumber(t *testing.T) {
 	}
 }
 
+func TestEnterpriseNumberFromSysObject(t *testing.T) {
+	tests := map[string]struct {
+		sysObjectID string
+		wantPEN     string
+		wantOK      bool
+	}{
+		"bare numeric PEN": {
+			sysObjectID: "1.3.6.1.4.1.41112",
+			wantPEN:     "41112",
+			wantOK:      true,
+		},
+		"descendant numeric PEN": {
+			sysObjectID: "1.3.6.1.4.1.14988.1",
+			wantPEN:     "14988",
+			wantOK:      true,
+		},
+		"enterprise prefix without PEN": {
+			sysObjectID: "1.3.6.1.4.1",
+		},
+		"empty trailing-dot remainder": {
+			sysObjectID: "1.3.6.1.4.1.",
+		},
+		"empty PEN before descendant": {
+			sysObjectID: "1.3.6.1.4.1..1",
+		},
+		"non-enterprise OID": {
+			sysObjectID: "1.3.6.1.2.1.1.2.0",
+		},
+		"bare non-numeric PEN": {
+			sysObjectID: "1.3.6.1.4.1.vendor",
+		},
+		"existing descendant validation remains unchanged": {
+			sysObjectID: "1.3.6.1.4.1.vendor.product",
+			wantPEN:     "vendor",
+			wantOK:      true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotPEN, gotOK := enterpriseNumberFromSysObject(tc.sysObjectID)
+			assert.Equal(t, tc.wantPEN, gotPEN)
+			assert.Equal(t, tc.wantOK, gotOK)
+		})
+	}
+}
+
+func TestStockUbiquitiBareRootMetadata(t *testing.T) {
+	dir := getSnmpMetadataDir()
+	require.NotEmpty(t, dir, "metadata dir must resolve in tests")
+
+	agg, err := loadOverridesFromDir(dir)
+	require.NoError(t, err)
+	defer withOverrides(t, agg)()
+	withEnterpriseNumbersFile(t, filepath.Join(t.TempDir(), "missing.txt"))
+
+	si := &SysInfo{SysObjectID: "1.3.6.1.4.1.41112"}
+	updateMetadata(si)
+
+	assert.Equal(t, "Ubiquiti", si.Vendor)
+	assert.Equal(t, "Access Point", si.Category)
+	assert.Empty(t, si.Model)
+}
+
 func TestLookupEnterpriseNumberLoadsRegistryFromDisk(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "iana-enterprise-numbers.txt")
 	require.NoError(t, os.WriteFile(path, []byte(`

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -178,11 +178,18 @@ func enterpriseNumberFromSysObject(sysObject string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	num, _, ok := strings.Cut(v, ".")
-	if !ok {
+	if num, _, ok := strings.Cut(v, "."); ok {
+		return num, num != ""
+	}
+	if v == "" {
 		return "", false
 	}
-	return num, true
+	for _, ch := range v {
+		if ch < '0' || ch > '9' {
+			return "", false
+		}
+	}
+	return v, true
 }
 
 func enterpriseNumbersMapping() (map[string]string, error) {


### PR DESCRIPTION
## Summary

Fixes: #23583.

Multiple UniFi access-point families report the same root device identifier. Treating that identifier as one specific product caused topology actors to display an incorrect model and an unknown vendor, even though the SNMP collector had already obtained the correct metadata.

The fix establishes one consistent metadata precedence across the SNMP collector, shared device state, and topology.

---

SNMP topology now reports the same effective device vendor and model as the SNMP collector.

This change:

- Removes the incorrect assumption that every device using Ubiquiti’s root identifier is a UniFi UAP-FlexHD.
- Correctly identifies the vendor for devices reporting a bare enterprise identifier.
- Uses live profile metadata when available.
- Keeps configured vnode labels authoritative.
- Works when vnode creation is disabled, without adding SNMP requests.
- Preserves all existing L2 and L3 topology links and behavior.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report correct SNMP device vendor and model in topology by centralizing device identity resolution. Previously, devices under Ubiquiti’s root OID appeared as UniFi UAP‑FlexHD with unknown vendor; now we resolve vendor/model from static sysInfo, live profile metadata (exact > wildcard), and final vnode labels (authoritative) without extra SNMP.

- Add `ddsnmp` identity helpers (`ResolveDeviceIdentity`, `ResolveDeviceMetadata`, `MergeMetaTag`, `MergeMetaTags`, `MergeDeviceIdentityMetadata`) and use them in `go.d/snmp` collector, shared `DeviceStore`, and `snmp_topology` cache/snapshot builders.
- Sync profile device metadata once when vnode creation is disabled; reuse it across actors; `registerDeviceState` now accepts profile metadata and stores the resolved identity.
- Remove the hardcoded model for `1.3.6.1.4.1.41112`; bare enterprise OIDs now set vendor only until profiles or labels provide a model; extend PEN parsing to handle numeric bare roots.
- Normalize label lookups via an indexed view and resolve sysDescr/contact/location/vendor/model deterministically from labels.
- Preserve all existing L2/L3 links; add unit and production-path tests for precedence, Ubiquiti AP families, and enterprise-number parsing.

<sup>Written for commit b6277a16fdffd153efa09f199428856a4ba53279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved SNMP device metadata resolution across device views and topology data.
  - Vendor and model information now consistently reflects profile data, discovered values, and final labels, with appropriate precedence.
  - Device metadata is synchronized reliably after collection and applied consistently to virtual nodes.

- **Bug Fixes**
  - Improved handling of enterprise identifiers without trailing OID components.
  - Removed an incorrect fixed model mapping for a Ubiquiti access point while retaining its device category.
  - Preserved accurate fallback information for hardware, software, serial number, and uptime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->