### PR TITLE
fix(go.d/snmp): count all managed topology devices as discovered

### DIFF
--- a/src/go/pkg/l2topology/internal/projector/device_actor.go
+++ b/src/go/pkg/l2topology/internal/projector/device_actor.go
@@ -85,10 +85,11 @@ func buildDeviceActorDetail(
 	match graph.Match,
 	addresses []string,
 ) model.ProjectionDeviceActorDetail {
-	discovered := strings.TrimSpace(localDeviceID) == "" || dev.ID != localDeviceID
+	deviceID := strings.TrimSpace(dev.ID)
+	discovered := deviceID != "" && deviceID != strings.TrimSpace(localDeviceID)
 
 	detail := model.ProjectionDeviceActorDetail{
-		DeviceID:              strings.TrimSpace(dev.ID),
+		DeviceID:              deviceID,
 		Discovered:            discovered,
 		Inferred:              topologyDeviceInferred(dev),
 		ManagementIP:          selectedDeviceManagementIP(dev),

--- a/src/go/pkg/l2topology/internal/projector/endpoints.go
+++ b/src/go/pkg/l2topology/internal/projector/endpoints.go
@@ -228,31 +228,17 @@ func addEndpointIDIdentity(acc *endpointActorAccumulator, endpointID string) {
 }
 
 func discoveredDeviceCount(devices []model.Device, localDeviceID string) int {
-	if len(devices) == 0 {
-		return 0
-	}
-
 	localDeviceID = strings.TrimSpace(localDeviceID)
-	if localDeviceID == "" {
-		return maxIntValue(len(devices)-1, 0)
-	}
-
 	count := 0
 	for _, dev := range devices {
-		if strings.TrimSpace(dev.ID) == "" {
+		deviceID := strings.TrimSpace(dev.ID)
+		if deviceID == "" {
 			continue
 		}
-		if dev.ID == localDeviceID {
+		if deviceID == localDeviceID {
 			continue
 		}
 		count++
 	}
 	return count
-}
-
-func maxIntValue(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/src/go/pkg/l2topology/internal/projector/projector_test.go
+++ b/src/go/pkg/l2topology/internal/projector/projector_test.go
@@ -738,17 +738,92 @@ func TestDeviceToTopologyActor_DoesNotOverrideExplicitVendor(t *testing.T) {
 	require.NotEmpty(t, actor.Detail.Device.VendorDerivedMatchPrefix)
 }
 
-func TestToGraph_DefaultDiscoveredCountWithoutLocalID(t *testing.T) {
-	result := model.Result{
-		Devices: []model.Device{
-			{ID: "a", Hostname: "a"},
-			{ID: "b", Hostname: "b"},
-			{ID: "c", Hostname: "c"},
+func TestDiscoveredDeviceCount(t *testing.T) {
+	tests := map[string]struct {
+		devices       []model.Device
+		localDeviceID string
+		want          int
+	}{
+		"no devices": {
+			want: 0,
+		},
+		"no local device": {
+			devices: []model.Device{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+			want:    3,
+		},
+		"matching local device": {
+			devices:       []model.Device{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+			localDeviceID: "b",
+			want:          2,
+		},
+		"normalized matching local device": {
+			devices:       []model.Device{{ID: " a "}, {ID: "b"}},
+			localDeviceID: " a ",
+			want:          1,
+		},
+		"unmatched local device": {
+			devices:       []model.Device{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+			localDeviceID: "other",
+			want:          3,
+		},
+		"whitespace local device": {
+			devices:       []model.Device{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+			localDeviceID: " \t ",
+			want:          3,
+		},
+		"blank device IDs": {
+			devices: []model.Device{{ID: ""}, {ID: " \t "}, {ID: "a"}},
+			want:    1,
 		},
 	}
 
-	_, stats := toGraphForTest(result, model.GraphOptions{})
-	require.Equal(t, 2, stats.DevicesDiscovered)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, discoveredDeviceCount(test.devices, test.localDeviceID))
+		})
+	}
+}
+
+func TestBuildDeviceActorDetail_ClassifiesDiscoveredByNormalizedDeviceID(t *testing.T) {
+	tests := map[string]struct {
+		deviceID      string
+		localDeviceID string
+		want          bool
+	}{
+		"no local device": {
+			deviceID: "remote",
+			want:     true,
+		},
+		"matching local device": {
+			deviceID:      "local",
+			localDeviceID: "local",
+		},
+		"normalized matching local device": {
+			deviceID:      " local ",
+			localDeviceID: "\tlocal\t",
+		},
+		"unmatched local device": {
+			deviceID:      "remote",
+			localDeviceID: "local",
+			want:          true,
+		},
+		"blank device ID": {
+			deviceID: " \t ",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			detail := buildDeviceActorDetail(
+				model.Device{ID: test.deviceID},
+				test.localDeviceID,
+				topologyDeviceInterfaceSummary{},
+				graph.Match{},
+				nil,
+			)
+			require.Equal(t, test.want, detail.Discovered)
+		})
+	}
 }
 
 func TestToGraph_AssignsDeterministicActorIDsAndLinkActorIDs(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/observations.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/observations.go
@@ -28,7 +28,6 @@ type ObservationAggregate struct {
 	L3Interfaces    []L3Interface
 	OSPFNeighbors   []OSPFNeighbor
 	BGPPeers        []BGPPeer
-	LocalDeviceID   string
 	AgentID         string
 	ProducerScopeID string
 	CollectedAt     time.Time

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_build.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_build.go
@@ -36,7 +36,6 @@ func buildSingleMapTopologySnapshot(aggregate topologymodel.ObservationAggregate
 	data, err := projectSNMPL2TopologyData(
 		result,
 		aggregate.AgentID,
-		aggregate.LocalDeviceID,
 		aggregate.CollectedAt,
 		options,
 	)
@@ -64,7 +63,6 @@ func buildProbableTopologySnapshot(aggregate topologymodel.ObservationAggregate,
 	strictData, err := projectSNMPL2TopologyData(
 		result,
 		aggregate.AgentID,
-		aggregate.LocalDeviceID,
 		aggregate.CollectedAt,
 		strictOptions,
 	)
@@ -79,7 +77,6 @@ func buildProbableTopologySnapshot(aggregate topologymodel.ObservationAggregate,
 	probableData, err := projectSNMPL2TopologyData(
 		result,
 		aggregate.AgentID,
-		aggregate.LocalDeviceID,
 		aggregate.CollectedAt,
 		probableOptions,
 	)
@@ -147,7 +144,6 @@ func buildSNMPL2TopologyResult(observations []topologyengine.L2Observation) (top
 func projectSNMPL2TopologyData(
 	result topologyengine.Result,
 	agentID string,
-	localDeviceID string,
 	collectedAt time.Time,
 	options topologyoptions.QueryOptions,
 ) (topologymodel.Data, error) {
@@ -157,7 +153,6 @@ func projectSNMPL2TopologyData(
 		Layer:                     "2",
 		View:                      "summary",
 		AgentID:                   agentID,
-		LocalDeviceID:             localDeviceID,
 		CollectedAt:               collectedAt,
 		ResolveDNSName:            options.ResolveDNSName,
 		CollapseActorsByIP:        options.CollapseActorsByIP,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_observations.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_observations.go
@@ -98,9 +98,6 @@ func aggregateTopologyObservationSnapshots(snapshots []topologymodel.Observation
 		aggregate.L3Interfaces = append(aggregate.L3Interfaces, snapshot.L3Interfaces...)
 		aggregate.OSPFNeighbors = append(aggregate.OSPFNeighbors, snapshot.OSPFNeighbors...)
 		aggregate.BGPPeers = append(aggregate.BGPPeers, snapshot.BGPPeers...)
-		if aggregate.LocalDeviceID == "" {
-			aggregate.LocalDeviceID = snapshot.LocalDeviceID
-		}
 		if aggregate.AgentID == "" && snapshot.AgentID != "" {
 			aggregate.AgentID = snapshot.AgentID
 		}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -169,9 +169,8 @@ func TestBuildProbableTopologySnapshotMatchesIndependentLegacyPath(t *testing.T)
 				},
 			},
 		},
-		LocalDeviceID: "switch-a",
-		AgentID:       "agent-1",
-		CollectedAt:   collectedAt,
+		AgentID:     "agent-1",
+		CollectedAt: collectedAt,
 	}
 	options := topologyoptions.DefaultQueryOptions()
 	options.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
@@ -204,7 +203,7 @@ func buildProbableTopologySnapshotIndependentLegacyForTest(
 	strictOptions := options
 	strictOptions.MapType = topologyoptions.MapTypeHighConfidenceInferred
 	strictData, err := projectSNMPL2TopologyData(
-		strictResult, aggregate.AgentID, aggregate.LocalDeviceID, aggregate.CollectedAt, strictOptions,
+		strictResult, aggregate.AgentID, aggregate.CollectedAt, strictOptions,
 	)
 	require.NoError(t, err)
 	augmentTopologySnapshotLocals(&strictData, aggregate.Snapshots)
@@ -216,7 +215,7 @@ func buildProbableTopologySnapshotIndependentLegacyForTest(
 	probableOptions := options
 	probableOptions.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
 	probableData, err := projectSNMPL2TopologyData(
-		probableResult, aggregate.AgentID, aggregate.LocalDeviceID, aggregate.CollectedAt, probableOptions,
+		probableResult, aggregate.AgentID, aggregate.CollectedAt, probableOptions,
 	)
 	require.NoError(t, err)
 	augmentTopologySnapshotLocals(&probableData, aggregate.Snapshots)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
@@ -144,6 +144,14 @@ func TestSNMPTopologyScenarioSemantics(t *testing.T) {
 	}
 }
 
+func TestSNMPTopologyScenarioCountsAllManagedDevicesAsDiscovered(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	data := topologyv1test.NormalizeData(t, scenario.render(t))
+
+	assertScenarioStatEquals(t, data, "devices_total", len(scenario.devs))
+	assertScenarioStatEquals(t, data, "devices_discovered", len(scenario.devs))
+}
+
 func TestSNMPTopologyScenarioGoldens(t *testing.T) {
 	dir, ok := topologyScenarioGoldenDir(t)
 	if !ok {


### PR DESCRIPTION
##### Summary

Fixes: #23584

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counts all managed SNMP topology devices as discovered, normalizing IDs and ignoring blank device IDs. This fixes undercounting when the local device is unknown and prevents overcounting from empty IDs.

- Discovered device count: previously subtracted one device when no local device ID was provided and could include blank IDs; now counts every device with a non-empty ID except the normalized local device ID. Expect `devices_discovered` to match `devices_total` in `snmp_topology` scenarios without a known local device.
- Device actor detail: previously marked all devices as discovered if the local device ID was empty; now marks as discovered only when the device ID is non-empty and not equal (after trimming) to the local device ID.
- `snmp_topology` registry: removes `LocalDeviceID` from `topologymodel.ObservationAggregate` and from projection calls; tests updated to reflect the new counting and normalization rules.

<sup>Written for commit 4e39e4ec8171179cdcbf9c2d7c1460bef9f15448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topology discovery counts by consistently ignoring surrounding whitespace in device IDs.
  * Correctly classifies non-empty devices as discovered, including scenarios without a configured local device ID.
  * Ensured managed devices are accurately represented as discovered in topology views.

* **Tests**
  * Added coverage for blank, whitespace-only, matching, normalized, and unmatched device IDs.
  * Added regression coverage for managed-device discovery counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->