### PR TITLE
Align documentation checks with Learn runtime

### DIFF
--- a/.agents/skills/integrations-lifecycle/pipeline.md
+++ b/.agents/skills/integrations-lifecycle/pipeline.md
@@ -539,9 +539,11 @@ Repo path: `.github/workflows/check-markdown.yml`.
 1. Checkout the PR branch and the `netdata/learn` repo with
    `actions/checkout@v7`; the Agent checkout uses full history for
    the PR-diff taxonomy gate.
-2. Use `actions/setup-python@v7` with Python 3.10, create a virtual
-   environment, and install both Learn ingest requirements and
-   `./integrations/pip.sh` dependencies.
+2. Use `actions/setup-python@v7` with Python 3.13, create a virtual
+   environment, install Learn's compiled requirements with
+   `python -m pip install --require-hashes`, and install the
+   `./integrations/pip.sh` dependencies. Learn owns the ingestion runtime and
+   dependency lock; this downstream workflow must stay aligned with that contract.
 3. Set up Go from `netdata/src/go/go.mod`, then run the NPM and ibm.d
    source-metadata producers.
 4. Run `gen_integrations.py`.

--- a/.agents/skills/learn-pr-preview/SKILL.md
+++ b/.agents/skills/learn-pr-preview/SKILL.md
@@ -53,9 +53,9 @@ git -C "${LEARN_COPY}" rev-parse HEAD
 Install ingest dependencies in the isolated preview:
 
 ```bash
-python3 -m venv "${PREVIEW_ROOT}/venv"
-"${PREVIEW_ROOT}/venv/bin/python" -m pip install --upgrade pip
+python3.13 -m venv "${PREVIEW_ROOT}/venv"
 "${PREVIEW_ROOT}/venv/bin/python" -m pip install \
+  --require-hashes \
   -r "${LEARN_COPY}/.learn_environment/ingest-requirements.txt"
 ```
 

--- a/.agents/skills/learn-site-structure/how-tos/preview-documentation-pr-locally.md
+++ b/.agents/skills/learn-site-structure/how-tos/preview-documentation-pr-locally.md
@@ -15,7 +15,7 @@ checkout because ingest cleans and regenerates `docs/`.
 - `${NETDATA_REPOS_DIR}/learn/ingest/ingest.py:2808` copies a local source repo
   into the ingest temp folder when `--local-repo netdata:<path>` is used.
 - `${NETDATA_REPOS_DIR}/learn/.learn_environment/ingest-requirements.txt:1`
-  lists the Python dependencies for ingest.
+  records the Python 3.13 compilation target and hashes every ingest dependency.
 - `${NETDATA_REPOS_DIR}/learn/package.json:8` defines the Docusaurus build
   script.
 - `${NETDATA_REPOS_DIR}/learn/netlify.toml:5` pins the Netlify runtime to
@@ -56,9 +56,9 @@ checkout because ingest cleans and regenerates `docs/`.
 4. Install ingest dependencies:
 
    ```bash
-   python3 -m venv "${PREVIEW_ROOT}/venv"
-   "${PREVIEW_ROOT}/venv/bin/python" -m pip install --upgrade pip
+   python3.13 -m venv "${PREVIEW_ROOT}/venv"
    "${PREVIEW_ROOT}/venv/bin/python" -m pip install \
+     --require-hashes \
      -r "${LEARN_COPY}/.learn_environment/ingest-requirements.txt"
    ```
 

--- a/.agents/skills/learn-site-structure/pipeline.md
+++ b/.agents/skills/learn-site-structure/pipeline.md
@@ -188,11 +188,9 @@ Python pipeline.
    `secrets.GITHUB_TOKEN`.
 2. SSH agent for `secrets.NETDATABOT_SSH_PRIVATE_KEY` (used to
    clone private repos like `.github`).
-3. Python 3.10, install
+3. Python 3.13, install the hash-locked
    `${NETDATA_REPOS_DIR}/learn/.learn_environment/ingest-requirements.txt`
-   (`pip`, `requests==2.33.0`, `Pillow`, `PyGithub`, `gitpython`,
-   `mergedeep`, `pandas`, `numpy`, `retrypy`, `pyyaml`,
-   `jsonschema`).
+   with `python -m pip install --require-hashes`.
 4. **Run `python ingest/ingest.py --fail-links 2>&1`** --
    captures output for issue creation, propagates exit code 1
    (broken links) into a workflow output but does NOT fail
@@ -259,8 +257,8 @@ From within the learn repo:
 
 ```bash
 # Install deps once.
-python3 -m venv venv && . venv/bin/activate
-pip install -r .learn_environment/ingest-requirements.txt
+python3.13 -m venv venv && . venv/bin/activate
+python -m pip install --require-hashes -r .learn_environment/ingest-requirements.txt
 
 # Test against your local netdata clone.
 python3 ingest/ingest.py --local-repo netdata:<repo> --ignore-on-prem-repo --fail-links-netdata

--- a/.agents/skills/learn-site-structure/recipes/INDEX.md
+++ b/.agents/skills/learn-site-structure/recipes/INDEX.md
@@ -38,8 +38,8 @@ The cheapest way to verify your `map.yaml` change works:
 cd ${NETDATA_REPOS_DIR}/learn
 
 # Set up venv once.
-python3 -m venv venv && . venv/bin/activate
-pip install -r .learn_environment/ingest-requirements.txt
+python3.13 -m venv venv && . venv/bin/activate
+python -m pip install --require-hashes -r .learn_environment/ingest-requirements.txt
 
 # Test against your local netdata clone.
 python3 ingest/ingest.py --local-repo netdata:<repo> \

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Init python env
         uses: actions/setup-python@v7
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -55,7 +55,7 @@ jobs:
         run: |
           python3 -m venv ./venv
           source ./venv/bin/activate
-          pip install -r learn/.learn_environment/ingest-requirements.txt
+          python -m pip install --require-hashes -r learn/.learn_environment/ingest-requirements.txt
           cd netdata && ./integrations/pip.sh
 
       - name: Generate Source Metadata


### PR DESCRIPTION
## Summary

- run the Agent documentation link check with Python 3.13, matching the Learn ingestion runtime
- enforce the hashes in Learn's compiled dependency lock
- align the directly coupled integration and local-preview guidance

## Reason

The workflow consumes Learn's current ingestion program and dependency lock. Python 3.10 cannot install the lock because numpy 2.5.2 requires Python 3.12 or newer, so the job exits before checking any links.

## Validation

- actionlint
- fresh Python 3.13 hash-locked dependency installation
- Agent integration dependency installation
- NPM and IBM source generation plus generated runtime-output verification
- integration generation and collector taxonomy check
- taxonomy tests: 44 passed
- integration description tests: 44 passed
- integration, collector, secrets, and service-discovery documentation generation
- full Learn ingestion and Agent link validation: exit code 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run documentation link checks with Python 3.13 and enforce Learn’s hash-locked ingest dependencies to match the Learn runtime. Previously CI used Python 3.10 and non-locked installs, which failed early (e.g., `numpy` 2.5.2 requires Python ≥3.12) and skipped link verification.

- Updates the CI workflow to `python-version: "3.13"` and `pip --require-hashes`.
- Updates local preview and integration docs to use `python3.13` venvs and the same hash-locked install path.
- Keeps `./integrations/pip.sh` and source metadata generation unchanged; only the Python/runtime contract is aligned.

**Developer actions**

- Use Python 3.13 for Learn ingest and local previews; install ingest deps with `python -m pip install --require-hashes -r .learn_environment/ingest-requirements.txt`.
- Replace any generic `python3` venv setup with `python3.13` to avoid version drift.

<sup>Written for commit d72e12d218dfe66d681ce39a36845fa00fd4a13b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local setup and preview instructions to use Python 3.13.
  * Clarified dependency installation steps and ownership of the ingestion runtime.
* **Chores**
  * Updated automated checks and preview workflows to verify dependency hashes during installation.
  * Removed the separate package-manager upgrade step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->