### PR TITLE
fix(go.d/snmp): identify qualified UniFi devices as Ubiquiti

### DIFF
--- a/integrations/gen_npm_catalog.py
+++ b/integrations/gen_npm_catalog.py
@@ -604,6 +604,7 @@ GENERIC_NAMES = {
     'net-snmp.yaml': 'Net-SNMP Host',
     'generic-ups.yaml': 'Generic UPS (UPS-MIB)',
     'meraki-cloud-controller.yaml': 'Cisco Meraki (Cloud Controller)',
+    'ubiquiti-net-snmp.yaml': 'Ubiquiti Net-SNMP Devices',
 }
 
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
@@ -119,39 +119,102 @@ func TestTopologyProductionPath_UniFiQBridgeRendersDefaultManagedFabric(t *testi
 	assert.GreaterOrEqual(t, testCountTopologyLinksByType(data.Links, "fdb"), 1)
 }
 
-func TestTopologyProductionPath_UniFiActorUsesSharedDynamicProfileMetadata(t *testing.T) {
-	device := ddsnmp.DeviceConnectionInfo{
-		Hostname:    "192.0.2.20",
-		SysObjectID: "1.3.6.1.4.1.41112",
-		SysName:     "unifi-ap",
-		SysDescr:    "Ubiquiti UniFi U6 Mesh",
-		Vendor:      "Unknown",
-		Model:       "UniFi UAP-FlexHD",
+func TestTopologyProductionPath_UniFiActorsUseProfileIdentity(t *testing.T) {
+	tests := map[string]struct {
+		device            ddsnmp.DeviceConnectionInfo
+		pdus              []gosnmp.SnmpPDU
+		wantProfileVendor bool
+		wantVendor        string
+		wantModel         string
+	}{
+		"access point uses dynamic Ubiquiti identity": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Hostname:    "192.0.2.20",
+				SysObjectID: "1.3.6.1.4.1.41112",
+				SysName:     "unifi-ap",
+				SysDescr:    "Ubiquiti UniFi U6 Mesh",
+				Vendor:      "Unknown",
+				Model:       "UniFi UAP-FlexHD",
+			},
+			pdus:              topologyUniFiAPPDUs(),
+			wantProfileVendor: true,
+			wantVendor:        "Ubiquiti",
+			wantModel:         "UniFi U6-Mesh",
+		},
+		"switch overrides generic Net-SNMP vendor": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Hostname:    "192.0.2.10",
+				SysObjectID: "1.3.6.1.4.1.8072.3.2.10",
+				SysName:     "unifi-switch",
+				SysDescr:    "Linux UBNT 4.4.153 mips",
+				Vendor:      "net-snmp",
+				Model:       "Linux",
+			},
+			pdus:              topologyUniFiSwitchPDUs(),
+			wantProfileVendor: true,
+			wantVendor:        "Ubiquiti",
+			wantModel:         "Linux",
+		},
+		"gateway overrides generic Net-SNMP vendor": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Hostname:    "192.0.2.1",
+				SysObjectID: "1.3.6.1.4.1.8072.3.2.10",
+				SysName:     "unifi-gateway",
+				SysDescr:    "Linux Router 6.6.43-ui-ipq9574 aarch64",
+				Vendor:      "net-snmp",
+				Model:       "Linux",
+			},
+			pdus:              topologyUniFiGatewayPDUs(),
+			wantProfileVendor: true,
+			wantVendor:        "Ubiquiti",
+			wantModel:         "Linux",
+		},
+		"unrelated generic Net-SNMP host keeps fallback identity": {
+			device: ddsnmp.DeviceConnectionInfo{
+				Hostname:    "192.0.2.30",
+				SysObjectID: "1.3.6.1.4.1.8072.3.2.10",
+				SysName:     "linux-host",
+				SysDescr:    "Linux generic Net-SNMP agent",
+				Vendor:      "net-snmp",
+				Model:       "Linux",
+			},
+			wantVendor: "net-snmp",
+			wantModel:  "Linux",
+		},
 	}
-	mainMetrics := collectMainProfileMetrics(t, device, topologyUniFiAPPDUs())
-	metadata := make(map[string]ddsnmp.MetaTag)
-	for _, pm := range mainMetrics {
-		ddsnmp.MergeDeviceIdentityMetadata(metadata, pm.DeviceMetadata)
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			device := tc.device
+			mainMetrics := collectMainProfileMetrics(t, device, tc.pdus)
+			metadata := make(map[string]ddsnmp.MetaTag)
+			for _, pm := range mainMetrics {
+				ddsnmp.MergeDeviceIdentityMetadata(metadata, pm.DeviceMetadata)
+			}
+			if tc.wantProfileVendor {
+				assert.Equal(t, ddsnmp.MetaTag{Value: "Ubiquiti", IsExactMatch: true}, metadata["vendor"])
+			} else {
+				assert.NotContains(t, metadata, "vendor")
+			}
+			device.Vendor, device.Model = ddsnmp.ResolveDeviceIdentity(device.Vendor, device.Model, metadata, nil)
+
+			metrics := collectTopologyProfileMetrics(t, device, tc.pdus)
+			cache := newTestTopologyCache(device)
+			cache.updateTopologyProfileTags(metrics)
+			cache.ingestTopologyProfileMetrics(metrics)
+			cache.finalizeTopologyCache()
+
+			registry := newTopologyRegistry()
+			registry.register(cache)
+			data, ok := snapshotTopologyRegistryForTest(registry)
+			require.True(t, ok)
+
+			actor := findDeviceActorBySysName(data, device.SysName)
+			require.NotNil(t, actor)
+			assert.Equal(t, tc.wantVendor, actor.Detail.SNMP.Vendor)
+			assert.Equal(t, tc.wantModel, actor.Detail.SNMP.Model)
+		})
 	}
-	require.Equal(t, ddsnmp.MetaTag{Value: "Ubiquiti", IsExactMatch: true}, metadata["vendor"])
-	require.Equal(t, ddsnmp.MetaTag{Value: "UniFi U6-Mesh", IsExactMatch: true}, metadata["model"])
-	device.Vendor, device.Model = ddsnmp.ResolveDeviceIdentity(device.Vendor, device.Model, metadata, nil)
-
-	metrics := collectTopologyProfileMetrics(t, device, topologyUniFiAPPDUs())
-	cache := newTestTopologyCache(device)
-	cache.updateTopologyProfileTags(metrics)
-	cache.ingestTopologyProfileMetrics(metrics)
-	cache.finalizeTopologyCache()
-
-	registry := newTopologyRegistry()
-	registry.register(cache)
-	data, ok := snapshotTopologyRegistryForTest(registry)
-	require.True(t, ok)
-
-	actor := findDeviceActorBySysName(data, "unifi-ap")
-	require.NotNil(t, actor)
-	assert.Equal(t, "Ubiquiti", actor.Detail.SNMP.Vendor)
-	assert.Equal(t, "UniFi U6-Mesh", actor.Detail.SNMP.Model)
 }
 
 func collectMainProfileMetrics(

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/ubiquiti-net-snmp.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/ubiquiti-net-snmp.yaml
@@ -1,0 +1,13 @@
+extends:
+  - _ubiquiti.yaml
+
+selector:
+  # Some UniFi switches and gateways expose Net-SNMP's generic Linux identity.
+  # Require a Ubiquiti firmware marker so ordinary Net-SNMP hosts do not match.
+  - sysobjectid:
+      include:
+        - 1.3.6.1.4.1.8072.3.2.10
+    sysdescr:
+      include:
+        - Linux UBNT
+        - ui-ipq9574


### PR DESCRIPTION
##### Summary

Fixes https://github.com/netdata/netdata/issues/23584#issuecomment-5380193237

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Identify qualified UniFi switches and gateways running Net-SNMP as Ubiquiti. Previously these devices resolved to vendor "net-snmp"; now they resolve to vendor "Ubiquiti" when firmware markers are present, while unrelated Net-SNMP hosts remain unchanged.

- Add SNMP profile `ubiquiti-net-snmp.yaml` extending `_ubiquiti.yaml` that matches `sysObjectID` 1.3.6.1.4.1.8072.3.2.10 and `sysDescr` containing "Linux UBNT" or "ui-ipq9574".
- Resolve device identity to vendor "Ubiquiti" for matched hosts; keep model as appropriate (e.g., "Linux" for switches/gateways).
- Expand topology tests to cover UniFi APs, switches, gateways, and a generic Net-SNMP host to confirm correct overrides and non-matches.
- Register the new profile in `integrations/gen_npm_catalog.py` for catalog visibility.

<sup>Written for commit 78cf15bf3a27869f5b9928cad39330e8e1c46e13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying Ubiquiti devices that use generic Net-SNMP signatures.
  * Ubiquiti access points, switches, and gateways now receive more accurate vendor and model information in topology views.
  * Added safeguards to avoid incorrectly identifying unrelated Net-SNMP hosts as Ubiquiti devices.
  * Updated the integration catalog to display the name “Ubiquiti Net-SNMP Devices.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->