### PR TITLE
Order Ceph profile charts by operator priority

### DIFF
--- a/.agents/skills/project-prometheus-profiles/SKILL.md
+++ b/.agents/skills/project-prometheus-profiles/SKILL.md
@@ -147,7 +147,7 @@ an explicit future input when the validator cannot derive it.
 
 Contributed stock profiles MUST keep authored YAML minimal and predictable:
 
-- omit chart `priority`; Netdata presents equal-priority charts predictably rather than preserving an author-only order;
+- set chart `priority` only when operator navigation requires deliberate section ordering; otherwise omit it so the chart uses the runtime default;
 - omit explicit chart `id` when the context-derived ID is sufficient;
 - avoid `instances.by_labels: ['*']`; use a source-backed explicit identity;
 - omit lifecycle caps; stock coverage must not depend on silently dropping observed or future entities;

--- a/.agents/skills/project-prometheus-profiles/chart-design.md
+++ b/.agents/skills/project-prometheus-profiles/chart-design.md
@@ -595,9 +595,9 @@ need unrelated scale manipulation, they probably do not belong on one axis.
 
 ## Order the operator journey
 
-Prometheus profiles MUST omit `priority`. Every chart receives the same runtime
-default, and the UI owns presentation sorting. YAML order is useful for human
-review but does not promise runtime or UI order.
+Set chart `priority` deliberately when section order is part of the operator journey.
+Omit it for unrelated charts; the runtime default remains `70000`. YAML position is
+still not an ordering contract.
 
 At the application level, order domain capabilities by the operator's causal
 journey. Within each capability, a useful local order is health/workload →
@@ -645,8 +645,9 @@ contexts, and dimensions. Unseen future values remain a review risk.
   legend.
 - **Broad deny list:** makes validation pass by deleting diagnostic surface
   instead of designing it.
-- **Authored chart priority:** claims UI ordering authority the Prometheus
-  profile does not own and creates unnecessary maintenance.
+- **Priority on every chart:** obscures which few navigation boundaries truly
+  require ordering and creates unnecessary maintenance. Set it only where it
+  supports the operator journey.
 - **Titles derived mechanically from metric names:** repeat exporter syntax
   instead of explaining operational meaning.
 - **Passing the validator as definition of quality:** proves runtime behavior for

--- a/.agents/skills/project-prometheus-profiles/profile-schema.md
+++ b/.agents/skills/project-prometheus-profiles/profile-schema.md
@@ -182,7 +182,7 @@ use a stricter minimal policy so intent is reviewable and defaults cannot drift:
 | Runtime field | Generic capability | Stock contribution policy |
 |---|---|---|
 | `id` | explicit stable base ID | omit when the context-derived ID is sufficient |
-| `priority` | numeric ordering hint | omit; every Prometheus chart uses the common default |
+| `priority` | numeric ordering hint | omit unless chart order is deliberately part of the operator journey |
 | `instances.by_labels: ['*']` | all current labels become identity | use explicit source-backed identity |
 | `lifecycle` | best-effort caps and expiry | omit; do not make coverage depend on silent caps |
 | `options.float` | force floating wire precision | omit when inherited runtime precision already does so |
@@ -233,7 +233,7 @@ make a stale or excluded family look intentionally covered.
 ## Charts control presentation and identity
 
 Required chart fields are `title`, `context`, `units`, and at least one
-`dimension`. Stock Prometheus profiles MUST omit `priority`.
+`dimension`. `priority` MAY be set deliberately to order charts in the operator journey.
 
 Optional fields include:
 
@@ -261,12 +261,11 @@ or semantics into one chart merely because a chart-wide algorithm compiles.
 Priority behavior:
 
 - omitted or non-positive priority becomes `70000`;
-- every Prometheus chart intentionally uses that same runtime value;
-- YAML position does not become runtime or UI presentation order;
-- UI sorting is outside the profile contract.
+- an explicit positive priority is preserved to the chart engine;
+- YAML position still does not become runtime or UI presentation order.
 
-Therefore omit `priority`. Keep source order coherent for review without
-claiming that it controls presentation.
+Omit `priority` for unrelated charts. Set it deliberately when a profile needs
+stable section ordering in the operator journey.
 
 Presentation rules checked by the profile-validation tool:
 

--- a/.agents/skills/project-prometheus-profiles/scripts/profile-toc.py
+++ b/.agents/skills/project-prometheus-profiles/scripts/profile-toc.py
@@ -74,11 +74,21 @@ def build_tree(profile: dict) -> Node:
     return root
 
 
+def node_priority(node: Node) -> int:
+    priorities = [chart.priority for chart in descendant_charts(node)]
+    return min(priorities, default=DEFAULT_PRIORITY)
+
+
+def descendant_charts(node: Node) -> list[Chart]:
+    charts = list(node.charts)
+    for child in node.children.values():
+        charts.extend(descendant_charts(child))
+    return charts
+
+
 def sort_key(item: tuple[str, Node]) -> tuple[int, int, str]:
     name, node = item
-    priorities = [chart.priority for chart in node.charts]
-    minimum = min(priorities, default=DEFAULT_PRIORITY)
-    return (minimum, -len(name), name)
+    return (node_priority(node), -len(name), name)
 
 
 def render(node: Node, depth: int = 0) -> list[str]:

--- a/.agents/skills/project-prometheus-profiles/scripts/profile-toc.py
+++ b/.agents/skills/project-prometheus-profiles/scripts/profile-toc.py
@@ -64,7 +64,10 @@ def build_tree(profile: dict) -> Node:
             context = ".".join(part for part in (*child_context_parts, normalize(chart.get("context"))) if part)
             if not context:
                 context = "(no context)"
-            node.charts.append(Chart(context, int(chart.get("priority") or DEFAULT_PRIORITY)))
+            priority = int(chart.get("priority") or DEFAULT_PRIORITY)
+            if priority <= 0:
+                priority = DEFAULT_PRIORITY
+            node.charts.append(Chart(context, priority))
 
         for child in group.get("groups") or []:
             add_group(child, node, child_context_parts)

--- a/.agents/skills/project-prometheus-profiles/scripts/test_profile_toc.py
+++ b/.agents/skills/project-prometheus-profiles/scripts/test_profile_toc.py
@@ -75,5 +75,22 @@ template:
         self.assertTrue(any("contains one context" in warning for warning in profile_toc.warnings(root)))
 
 
+class ProfileTocOrderingTest(unittest.TestCase):
+    def test_parent_sort_uses_descendant_chart_priority(self) -> None:
+        root = profile_toc.Node("App")
+        overview = profile_toc.Node("Overview")
+        overview_child = profile_toc.Node("Health")
+        detail = profile_toc.Node("Details")
+        overview_child.charts.append(profile_toc.Chart("health", 100))
+        overview.children["Health"] = overview_child
+        detail.charts.append(profile_toc.Chart("detail", 200))
+        root.children["Overview"] = overview
+        root.children["Details"] = detail
+
+        ordered = [name for name, _ in sorted(root.children.items(), key=profile_toc.sort_key)]
+
+        self.assertEqual(["Overview", "Details"], ordered)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/project-prometheus-profiles/scripts/test_profile_toc.py
+++ b/.agents/skills/project-prometheus-profiles/scripts/test_profile_toc.py
@@ -76,12 +76,13 @@ template:
 
 
 class ProfileTocOrderingTest(unittest.TestCase):
-    def test_parent_sort_uses_descendant_chart_priority(self) -> None:
+    def test_parent_sort_uses_minimum_descendant_priority(self) -> None:
         root = profile_toc.Node("App")
         overview = profile_toc.Node("Overview")
         overview_child = profile_toc.Node("Health")
         detail = profile_toc.Node("Details")
         overview_child.charts.append(profile_toc.Chart("health", 100))
+        overview_child.charts.append(profile_toc.Chart("status", 300))
         overview.children["Health"] = overview_child
         detail.charts.append(profile_toc.Chart("detail", 200))
         root.children["Overview"] = overview
@@ -90,6 +91,28 @@ class ProfileTocOrderingTest(unittest.TestCase):
         ordered = [name for name, _ in sorted(root.children.items(), key=profile_toc.sort_key)]
 
         self.assertEqual(["Overview", "Details"], ordered)
+
+    def test_profile_priority_uses_runtime_default_for_non_positive_values(self) -> None:
+        root = tree_from_yaml(
+            """
+template:
+  family: App
+  groups:
+  - family: Overview
+    charts:
+    - title: a
+      context: a
+      units: x
+      priority: -1
+      dimensions: []
+"""
+        )
+
+        self.assertEqual("App", root.name)
+        self.assertEqual(["Overview"], list(root.children))
+        overview = root.children["Overview"]
+        self.assertEqual(70000, profile_toc.node_priority(overview))
+        self.assertEqual(70000, overview.charts[0].priority)
 
 
 if __name__ == "__main__":

--- a/src/go/internal/promprofile/semantics/replay_policy.go
+++ b/src/go/internal/promprofile/semantics/replay_policy.go
@@ -203,10 +203,6 @@ func indexSemanticChartPolicies(
 				errs = append(errs, fmt.Errorf("production profile %q chart %s declares redundant explicit ID %q",
 					profile.Name, policy.RuntimePath, policy.ExplicitID))
 			}
-			if policy.Priority != 0 {
-				errs = append(errs, fmt.Errorf("production profile %q chart %s declares priority %d",
-					profile.Name, policy.RuntimePath, policy.Priority))
-			}
 			if policy.WildcardIdentity {
 				errs = append(errs, fmt.Errorf("production profile %q chart %s uses wildcard all-label identity",
 					profile.Name, policy.RuntimePath))

--- a/src/go/internal/promprofile/semantics/replay_policy_test.go
+++ b/src/go/internal/promprofile/semantics/replay_policy_test.go
@@ -53,6 +53,24 @@ func TestReconcileProductionChartPoliciesRequiresAlgorithmWhenWireKindDiffersFro
 	}
 }
 
+func TestReconcileProductionChartPoliciesAcceptsExplicitPriority(t *testing.T) {
+	program := compileTestSemanticContract(t, validProfileDesignV1, validSourceSemanticsV1)
+	semanticCase, err := program.EvaluateCaseEnvironment(context.Background(), map[string]map[string]AxisValue{"example": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := validProductionRouteSnapshot()
+	snapshot.Profiles[0].Charts[0].Priority = 100
+	reconciled := reconcileTestProductionCase(t, semanticCase, snapshot)
+	if err := semanticCase.ReconcileProductionRoutes(context.Background(), snapshot, reconciled); err != nil {
+		t.Fatal(err)
+	}
+	if err := semanticCase.ReconcileProductionChartPolicies(context.Background(), snapshot, reconciled); err != nil {
+		t.Fatalf("explicit chart priority must be accepted: %v", err)
+	}
+}
+
 func TestReconcileProductionChartPoliciesRejectsStaticDebt(t *testing.T) {
 	program := compileTestSemanticContract(t, validProfileDesignV1, validSourceSemanticsV1)
 	semanticCase, err := program.EvaluateCaseEnvironment(context.Background(), map[string]map[string]AxisValue{"example": {}})
@@ -66,10 +84,6 @@ func TestReconcileProductionChartPoliciesRejectsStaticDebt(t *testing.T) {
 		"explicit id": {
 			mutate: func(policy *promreplay.SemanticChartPolicy) { policy.ExplicitID = "requests" },
 			want:   "redundant explicit ID",
-		},
-		"priority": {
-			mutate: func(policy *promreplay.SemanticChartPolicy) { policy.Priority = 100 },
-			want:   "declares priority",
 		},
 		"wildcard identity": {
 			mutate: func(policy *promreplay.SemanticChartPolicy) { policy.WildcardIdentity = true },

--- a/src/go/internal/promprofile/validation/authored_profile.go
+++ b/src/go/internal/promprofile/validation/authored_profile.go
@@ -13,17 +13,8 @@ func inspectAuthoredCharts(root charttpl.Group, rootPath string, r *Report) int 
 	var charts int
 	var walk func(group charttpl.Group, path string)
 	walk = func(group charttpl.Group, path string) {
-		for i, chart := range group.Charts {
+		for range group.Charts {
 			charts++
-			if chart.Priority != 0 {
-				chartPath := fmt.Sprintf("%s.charts[%d]", path, i)
-				r.addError(
-					"priority_forbidden",
-					chartPath,
-					fmt.Sprintf("chart %q declares priority %d", chart.Title, chart.Priority),
-					"Prometheus profiles give every chart the same runtime priority; omit priority and let the UI own presentation sorting.",
-				)
-			}
 		}
 		for i, child := range group.Groups {
 			childPath := fmt.Sprintf("%s.groups[%d](%s)", path, i, filepath.Base(child.Family))

--- a/src/go/internal/promprofile/validation/policy_advisory_test.go
+++ b/src/go/internal/promprofile/validation/policy_advisory_test.go
@@ -8,10 +8,17 @@ import (
 	"testing"
 )
 
-func TestValidateProfileRejectsExplicitPriority(t *testing.T) {
+func TestValidateProfileAcceptsAndPropagatesExplicitPriority(t *testing.T) {
 	profile := strings.Replace(validProfile, "    - title: Temperature\n", "    - title: Temperature\n      priority: 100\n", 1)
 	result := runValidation(t, profile, validDump, "")
-	requireFinding(t, result, "priority_forbidden")
+	if result.exitCode != 0 {
+		t.Fatalf("explicit chart priority must pass\nreport:\n%s", result.stdout)
+	}
+	for _, chart := range result.report.Charts {
+		if chart.Title == "Temperature" && chart.Priority != 100 {
+			t.Fatalf("authored priority was not propagated: got %d, want 100: %#v", chart.Priority, chart)
+		}
+	}
 }
 
 func TestValidateProfileUsesOneRuntimePriorityWhenPrioritiesAreOmitted(t *testing.T) {

--- a/src/go/internal/promprofile/validation/policy_advisory_test.go
+++ b/src/go/internal/promprofile/validation/policy_advisory_test.go
@@ -14,10 +14,18 @@ func TestValidateProfileAcceptsAndPropagatesExplicitPriority(t *testing.T) {
 	if result.exitCode != 0 {
 		t.Fatalf("explicit chart priority must pass\nreport:\n%s", result.stdout)
 	}
+	found := false
 	for _, chart := range result.report.Charts {
-		if chart.Title == "Temperature" && chart.Priority != 100 {
+		if chart.Title != "Temperature" {
+			continue
+		}
+		found = true
+		if chart.Priority != 100 {
 			t.Fatalf("authored priority was not propagated: got %d, want 100: %#v", chart.Priority, chart)
 		}
+	}
+	if !found {
+		t.Fatal("Temperature chart was not reported")
 	}
 }
 

--- a/src/go/internal/promprofile/validation/profile_owner_diagnostics_test.go
+++ b/src/go/internal/promprofile/validation/profile_owner_diagnostics_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 )
 
-func TestValidateComposedProfilePriorityFindingIdentifiesSupportOwner(t *testing.T) {
+func TestValidateComposedProfilePropagatesSupportPriority(t *testing.T) {
 	candidate := simpleOwnedProfile("app", "app_value", "")
 	support := strings.Replace(
 		simpleOwnedProfile("runtime", "runtime_value", ""),
@@ -23,9 +23,17 @@ func TestValidateComposedProfilePriorityFindingIdentifiesSupportOwner(t *testing
 	)
 	report := validateComposedProfiles(t, candidate, support, simpleOwnedDump())
 
-	finding := findFinding(t, report, "priority_forbidden")
-	if finding.Path != "profiles[runtime].template.charts[0]" {
-		t.Fatalf("support priority path: got %q", finding.Path)
+	var found bool
+	for _, item := range report.AuthoredMapping {
+		if item.Path == "profiles[runtime].template.charts[0]" {
+			found = true
+			if item.Priority != 100 {
+				t.Fatalf("support priority was not propagated: %#v", item)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("support authored mapping was not found: %#v", report.AuthoredMapping)
 	}
 }
 

--- a/src/go/internal/promprofile/validation/profile_owner_diagnostics_test.go
+++ b/src/go/internal/promprofile/validation/profile_owner_diagnostics_test.go
@@ -22,6 +22,11 @@ func TestValidateComposedProfilePropagatesSupportPriority(t *testing.T) {
 		1,
 	)
 	report := validateComposedProfiles(t, candidate, support, simpleOwnedDump())
+	for _, item := range report.Findings {
+		if item.Code == "priority_forbidden" {
+			t.Fatalf("explicit support priority must not be rejected: %#v", item)
+		}
+	}
 
 	var found bool
 	for _, item := range report.AuthoredMapping {

--- a/src/go/internal/promprofile/validation/validation_core_test.go
+++ b/src/go/internal/promprofile/validation/validation_core_test.go
@@ -64,11 +64,6 @@ func TestValidateProfilePassesThroughRealPipeline(t *testing.T) {
 	if result.report.AuthoredMapping[2].Dimensions[0].NameFromLabel != "le" {
 		t.Fatalf("authored mapping lost dynamic naming mechanism: %#v", result.report.AuthoredMapping[2].Dimensions)
 	}
-	for _, chart := range result.report.AuthoredMapping {
-		if chart.Priority != 0 {
-			t.Fatalf("authored chart unexpectedly declares priority: %#v", chart)
-		}
-	}
 	if !hasFinding(result.report, "default_validation_job", "warning") {
 		t.Fatalf("missing warning that the deployable job policy was not validated: %#v", result.report.Findings)
 	}

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -9141,7 +9141,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.accumulated_reservation_latency:
-    family: Ceph/OSDs/Scrubbing/Ceph 19/Elapsed Time
+    family: Ceph/OSDs/Scrubbing Ceph 19/Elapsed Time
     question: What is the accumulated reservation elapsed time for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9182,7 +9182,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.accumulated_scrub_latency:
-    family: Ceph/OSDs/Scrubbing/Ceph 19/Elapsed Time
+    family: Ceph/OSDs/Scrubbing Ceph 19/Elapsed Time
     question: What is the accumulated scrub elapsed time for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9223,7 +9223,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.reservation_latency_measurements:
-    family: Ceph/OSDs/Scrubbing/Ceph 19/Elapsed Time
+    family: Ceph/OSDs/Scrubbing Ceph 19/Elapsed Time
     question: What is the reservation elapsed-time measurements for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9264,7 +9264,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.scrub_latency_measurements:
-    family: Ceph/OSDs/Scrubbing/Ceph 19/Elapsed Time
+    family: Ceph/OSDs/Scrubbing Ceph 19/Elapsed Time
     question: What is the scrub elapsed-time measurements for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9305,7 +9305,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.outcomes.scrub_work:
-    family: Ceph/OSDs/Scrubbing/Ceph 19/Outcomes
+    family: Ceph/OSDs/Scrubbing Ceph 19/Outcomes
     question: What is the scrub work for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9362,7 +9362,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.replicas_in_reservation:
-    family: Ceph/OSDs/Scrubbing/Ceph 19/Reservations
+    family: Ceph/OSDs/Scrubbing Ceph 19/Reservations
     question: What is the replicas in reservation for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9387,7 +9387,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.reservation_process_outcomes:
-    family: Ceph/OSDs/Scrubbing/Ceph 19/Reservations
+    family: Ceph/OSDs/Scrubbing Ceph 19/Reservations
     question: What is the reservation process outcomes for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9444,7 +9444,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.scrubs_past_reservation:
-    family: Ceph/OSDs/Scrubbing/Ceph 19/Reservations
+    family: Ceph/OSDs/Scrubbing Ceph 19/Reservations
     question: What is the scrubs past reservation for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9469,7 +9469,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.accumulated_reservation_latency:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Elapsed Time
+    family: Ceph/OSDs/Scrubbing Ceph 20/Elapsed Time
     question: What is the accumulated reservation elapsed time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9494,7 +9494,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.accumulated_scrub_latency:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Elapsed Time
+    family: Ceph/OSDs/Scrubbing Ceph 20/Elapsed Time
     question: What is the accumulated scrub elapsed time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9519,7 +9519,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.reservation_latency_measurements:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Elapsed Time
+    family: Ceph/OSDs/Scrubbing Ceph 20/Elapsed Time
     question: What is the reservation elapsed-time measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9544,7 +9544,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.scrub_latency_measurements:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Elapsed Time
+    family: Ceph/OSDs/Scrubbing Ceph 20/Elapsed Time
     question: What is the scrub elapsed-time measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9569,7 +9569,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.interference_and_scheduling.client_write_interference:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing Ceph 20/Interference and Scheduling
     question: What is the client write interference for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9594,7 +9594,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.outcomes.scrub_work:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Outcomes
+    family: Ceph/OSDs/Scrubbing Ceph 20/Outcomes
     question: What is the scrub work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9627,7 +9627,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.replicas_in_reservation:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Reservations
+    family: Ceph/OSDs/Scrubbing Ceph 20/Reservations
     question: What is the replicas in reservation for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9644,7 +9644,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.reservation_process_outcomes:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Reservations
+    family: Ceph/OSDs/Scrubbing Ceph 20/Reservations
     question: What is the reservation process outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9685,7 +9685,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.scrubs_past_reservation:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Reservations
+    family: Ceph/OSDs/Scrubbing Ceph 20/Reservations
     question: What is the scrubs past reservation for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9702,7 +9702,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.scrub_work.byte_throughput:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Scrub Work
+    family: Ceph/OSDs/Scrubbing Ceph 20/Scrub Work
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9719,7 +9719,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.scrub_work.scrub_calls:
-    family: Ceph/OSDs/Scrubbing/Ceph 20/Scrub Work
+    family: Ceph/OSDs/Scrubbing Ceph 20/Scrub Work
     question: What is the scrub calls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9752,7 +9752,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.blocked_client_writes:
-    family: Ceph/OSDs/Scrubbing/Common Work/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing Common Work/Interference and Scheduling
     question: What is the client writes blocked by scrub for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9777,7 +9777,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.chunk_selection_outcomes:
-    family: Ceph/OSDs/Scrubbing/Common Work/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing Common Work/Interference and Scheduling
     question: What is the chunk selection outcomes for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9818,7 +9818,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.object_lock_waits:
-    family: Ceph/OSDs/Scrubbing/Common Work/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing Common Work/Interference and Scheduling
     question: What is the object-lock waits for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9843,7 +9843,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.preemptions:
-    family: Ceph/OSDs/Scrubbing/Common Work/Interference and Scheduling
+    family: Ceph/OSDs/Scrubbing Common Work/Interference and Scheduling
     question: What is the scrub preemptions for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9868,7 +9868,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.reservations.completed_reservations:
-    family: Ceph/OSDs/Scrubbing/Common Work/Reservations
+    family: Ceph/OSDs/Scrubbing Common Work/Reservations
     question: What is the completed scrub reservations for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9893,7 +9893,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.scrub_work.byte_throughput:
-    family: Ceph/OSDs/Scrubbing/Common Work/Scrub Work
+    family: Ceph/OSDs/Scrubbing Common Work/Scrub Work
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9910,7 +9910,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.scrub_work.omap_calls:
-    family: Ceph/OSDs/Scrubbing/Common Work/Scrub Work
+    family: Ceph/OSDs/Scrubbing Common Work/Scrub Work
     question: What is the omap scrub calls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -292,6 +292,7 @@ template:
             - ceph_num_objects_unfound
           charts:
             - title: Objects
+              priority: 1200
               context: object_state
               units: objects
               label_promotion: []
@@ -310,6 +311,7 @@ template:
             - ceph_cluster_total_used_raw_bytes
           charts:
             - title: Space and Memory
+              priority: 1200
               context: space
               units: bytes
               label_promotion: []
@@ -328,6 +330,7 @@ template:
             - ceph_cluster_by_class_total_used_raw_bytes
           charts:
             - title: Space and Memory
+              priority: 1200
               context: space
               units: bytes
               label_promotion: []
@@ -351,6 +354,7 @@ template:
             - ceph_fs_metadata
           charts:
             - title: State and Metadata
+              priority: 1800
               context: state
               units: '{status}'
               label_promotion: []
@@ -370,6 +374,7 @@ template:
             - ceph_mds_metadata
           charts:
             - title: State and Metadata
+              priority: 1800
               context: state
               units: '{status}'
               label_promotion: []
@@ -395,6 +400,7 @@ template:
         - ceph_prometheus_collect_duration_seconds_sum
       charts:
         - title: Latency Measurements
+          priority: 1000
           context: latency_measurements
           units: operations/s
           label_promotion: []
@@ -406,6 +412,7 @@ template:
               - method
             optional_by_labels: []
         - title: Accumulated Latency
+          priority: 1000
           context: accumulated_latency
           units: seconds/s
           label_promotion: []
@@ -417,6 +424,7 @@ template:
               - method
             optional_by_labels: []
         - title: Current Work
+          priority: 1000
           context: current_work
           units: items
           label_promotion: []
@@ -424,6 +432,7 @@ template:
             - selector: ceph_cluster_osd_blocklist_count
               name: value
         - title: State and Metadata — Occupation
+          priority: 1000
           context: state_occupation
           units: '{status}'
           label_promotion: []
@@ -441,6 +450,7 @@ template:
               - db_device
               - wal_device
         - title: State and Metadata — Human
+          priority: 1000
           context: state_human
           units: '{status}'
           label_promotion: []
@@ -462,6 +472,7 @@ template:
             - ceph_cephadm_daemon_status
           charts:
             - title: State and Metadata
+              priority: 1300
               context: state
               units: '{status}'
               label_promotion: []
@@ -482,6 +493,7 @@ template:
             - ceph_mgr_status
           charts:
             - title: State and Metadata — Metadata
+              priority: 1300
               context: state_metadata
               units: '{status}'
               label_promotion: []
@@ -495,6 +507,7 @@ template:
                   - hostname
                 optional_by_labels: []
             - title: State and Metadata — Status
+              priority: 1300
               context: state_status
               units: '{status}'
               label_promotion: []
@@ -512,6 +525,7 @@ template:
             - ceph_mgr_module_status
           charts:
             - title: State and Metadata
+              priority: 1300
               context: state
               units: '{status}'
               label_promotion: []
@@ -531,6 +545,7 @@ template:
             - ceph_mon_quorum_status
           charts:
             - title: Cluster Summary
+              priority: 1300
               context: cluster_summary
               units: monitors
               label_promotion: []
@@ -541,6 +556,7 @@ template:
                   name: in_quorum
               aggregation: sum
             - title: State and Metadata — Metadata
+              priority: 1300
               context: state_metadata
               units: monitors
               label_promotion: []
@@ -556,6 +572,7 @@ template:
                   - rank
                 optional_by_labels: []
             - title: State and Metadata — Quorum Status
+              priority: 1300
               context: state_quorum_status
               units: monitors
               label_promotion: []
@@ -618,6 +635,7 @@ template:
             - ceph_paxos_store_state_latency_sum
           charts:
             - title: Byte Measurement Measurements
+              priority: 1300
               context: bytes_measurements
               units: measurements/s
               label_promotion: []
@@ -637,6 +655,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Byte Measurement
+              priority: 1300
               context: accumulated_bytes
               units: bytes/s
               label_promotion: []
@@ -657,6 +676,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Key Measurement Measurements
+              priority: 1300
               context: keys_measurements
               units: measurements/s
               label_promotion: []
@@ -676,6 +696,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Key Measurement
+              priority: 1300
               context: accumulated_keys
               units: keys/s
               label_promotion: []
@@ -696,6 +717,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Latency Measurements
+              priority: 1300
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -717,6 +739,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1300
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -739,6 +762,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Events
+              priority: 1300
               context: events
               units: events/s
               label_promotion: []
@@ -762,6 +786,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Failure and Delay Outcomes
+              priority: 1300
               context: failure_outcomes
               units: events/s
               label_promotion: []
@@ -779,6 +804,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Paxos Operations
+              priority: 1300
               context: operations
               units: operations/s
               label_promotion: []
@@ -794,6 +820,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Collected Uncommitted Values
+              priority: 1300
               context: collected_uncommitted_values
               units: values/s
               label_promotion: []
@@ -813,6 +840,7 @@ template:
             - ceph_health_status
           charts:
             - title: State and Metadata
+              priority: 1100
               context: state
               units: '{status}'
               label_promotion: []
@@ -825,6 +853,7 @@ template:
             - ceph_daemon_health_metrics
           charts:
             - title: Health Metric Count
+              priority: 1100
               context: item_count
               units: items
               label_promotion: []
@@ -842,6 +871,7 @@ template:
             - ceph_health_detail
           charts:
             - title: State and Metadata
+              priority: 1100
               context: state
               units: '{status}'
               label_promotion:
@@ -859,6 +889,7 @@ template:
             - ceph_healthcheck_slow_ops
           charts:
             - title: Slow Operations
+              priority: 1100
               context: current_operations
               units: operations
               label_promotion: []
@@ -880,6 +911,7 @@ template:
             - ceph_osd_flag_noup
           charts:
             - title: State and Metadata
+              priority: 1400
               context: state
               units: '{status}'
               label_promotion: []
@@ -905,6 +937,7 @@ template:
             - ceph_osd_nearfull_ratio
           charts:
             - title: Ratios
+              priority: 1400
               context: ratio
               units: ratio
               label_promotion: []
@@ -919,6 +952,7 @@ template:
             - ceph_osd_metadata
           charts:
             - title: State and Metadata
+              priority: 1400
               context: state
               units: OSDs
               label_promotion: []
@@ -946,6 +980,7 @@ template:
             - ceph_osd_weight
           charts:
             - title: Cluster Summary
+              priority: 1400
               context: cluster_summary
               units: OSDs
               label_promotion: []
@@ -956,6 +991,7 @@ template:
                   name: up
               aggregation: sum
             - title: OSD State
+              priority: 1400
               context: state
               units: OSDs
               label_promotion: []
@@ -969,6 +1005,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: OSD Weight
+              priority: 1400
               context: weight
               units: ratio
               label_promotion: []
@@ -988,6 +1025,7 @@ template:
             - ceph_hardware_cpu_cores
           charts:
             - title: CPU Cores
+              priority: 2400
               context: cpu_cores
               units: cpu cores
               label_promotion: []
@@ -1008,6 +1046,7 @@ template:
             - ceph_hardware_fan_rpm
           charts:
             - title: Fan Speed
+              priority: 2400
               context: fan_speed
               units: fan revolutions per minute
               label_promotion: []
@@ -1025,6 +1064,7 @@ template:
             - ceph_hardware_health
           charts:
             - title: Hardware Health
+              priority: 2400
               context: state
               units: '{status}'
               label_promotion: []
@@ -1043,6 +1083,7 @@ template:
             - ceph_hardware_memory_capacity_bytes
           charts:
             - title: Memory Module Capacity
+              priority: 2400
               context: capacity
               units: bytes
               label_promotion: []
@@ -1061,6 +1102,7 @@ template:
             - ceph_hardware_storage_capacity_bytes
           charts:
             - title: Storage Device Capacity
+              priority: 2400
               context: capacity
               units: bytes
               label_promotion: []
@@ -1083,6 +1125,7 @@ template:
             - ceph_hardware_temperature_celsius
           charts:
             - title: Sensor Temperature
+              priority: 2400
               context: temperature
               units: Celsius
               label_promotion: []
@@ -1101,6 +1144,7 @@ template:
         - ceph_osd_commit_latency_ms
       charts:
         - title: Latency
+          priority: 1400
           context: latency
           units: milliseconds
           label_promotion: []
@@ -1119,6 +1163,7 @@ template:
         - ceph_rgw_metadata
       charts:
         - title: State and Metadata
+          priority: 1700
           context: state
           units: '{status}'
           label_promotion: []
@@ -1146,6 +1191,7 @@ template:
             - ceph_pg_remapped
           charts:
             - title: Placement Groups
+              priority: 1500
               context: pg_state
               units: PGs
               label_promotion: []
@@ -1175,6 +1221,7 @@ template:
             - ceph_pg_total
           charts:
             - title: Placement Groups
+              priority: 1500
               context: pg_state
               units: PGs
               label_promotion: []
@@ -1207,6 +1254,7 @@ template:
             - ceph_pg_wait
           charts:
             - title: Placement Groups
+              priority: 1500
               context: pg_state
               units: PGs
               label_promotion: []
@@ -1244,6 +1292,7 @@ template:
             - ceph_osd_flag_norecover
           charts:
             - title: State and Metadata
+              priority: 1500
               context: state
               units: '{status}'
               label_promotion: []
@@ -1264,6 +1313,7 @@ template:
             - ceph_pg_undersized
           charts:
             - title: Placement Groups
+              priority: 1500
               context: pg_state
               units: PGs
               label_promotion: []
@@ -1298,6 +1348,7 @@ template:
             - ceph_pg_snaptrim_wait
           charts:
             - title: Placement Groups
+              priority: 1500
               context: pg_state
               units: PGs
               label_promotion: []
@@ -1338,6 +1389,7 @@ template:
             - ceph_pool_stored_raw
           charts:
             - title: Objects
+              priority: 1600
               context: object_state
               units: objects
               label_promotion: []
@@ -1349,6 +1401,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Logical Pool Capacity
+              priority: 1600
               context: logical_space
               units: bytes
               label_promotion: []
@@ -1364,6 +1417,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Raw Pool Capacity
+              priority: 1600
               context: raw_space
               units: bytes
               label_promotion: []
@@ -1379,6 +1433,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Compression Space
+              priority: 1600
               context: compression_space
               units: bytes
               label_promotion: []
@@ -1392,6 +1447,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Utilization
+              priority: 1600
               context: utilization
               units: percentage
               label_promotion: []
@@ -1411,6 +1467,7 @@ template:
             - ceph_pool_wr_bytes
           charts:
             - title: Byte Throughput
+              priority: 1600
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -1424,6 +1481,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Operations
+              priority: 1600
               context: operations
               units: operations/s
               label_promotion: []
@@ -1442,6 +1500,7 @@ template:
             - ceph_pool_metadata
           charts:
             - title: State and Metadata
+              priority: 1600
               context: state
               units: '{status}'
               label_promotion: []
@@ -1464,6 +1523,7 @@ template:
             - ceph_pool_objects
           charts:
             - title: Objects
+              priority: 1600
               context: object_state
               units: objects
               label_promotion: []
@@ -1487,6 +1547,7 @@ template:
             - ceph_pool_recovering_objects_per_sec
           charts:
             - title: Current Throughput
+              priority: 1600
               context: current_throughput_bytes_s
               units: bytes/s
               label_promotion: []
@@ -1498,6 +1559,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Current Throughput
+              priority: 1600
               context: current_throughput_keys_s
               units: keys/s
               label_promotion: []
@@ -1509,6 +1571,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Current Throughput
+              priority: 1600
               context: current_throughput_objects_s
               units: objects/s
               label_promotion: []
@@ -1520,6 +1583,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Objects
+              priority: 1600
               context: object_state
               units: objects
               label_promotion: []
@@ -1531,6 +1595,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Object Work
+              priority: 1600
               context: object_work
               units: objects/s
               label_promotion: []
@@ -1542,6 +1607,7 @@ template:
                   - pool_id
                 optional_by_labels: []
             - title: Pool Capacity and Data Volume
+              priority: 1600
               context: space
               units: bytes
               label_promotion: []
@@ -1564,6 +1630,7 @@ template:
             - ceph_rbd_write_ops
           charts:
             - title: Byte Throughput
+              priority: 1900
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -1579,6 +1646,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Operations
+              priority: 1900
               context: operations
               units: operations/s
               label_promotion: []
@@ -1599,6 +1667,7 @@ template:
             - ceph_rbd_image_metadata
           charts:
             - title: State and Metadata
+              priority: 1900
               context: state
               units: '{status}'
               label_promotion: []
@@ -1619,6 +1688,7 @@ template:
             - ceph_rbd_write_latency_sum
           charts:
             - title: Latency Measurements
+              priority: 1900
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -1634,6 +1704,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1900
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -1654,6 +1725,7 @@ template:
             - ceph_rbd_mirror_metadata
           charts:
             - title: State and Metadata
+              priority: 1900
               context: state
               units: '{status}'
               label_promotion: []
@@ -1674,6 +1746,7 @@ template:
         - ceph_smb_metadata
       charts:
         - title: State and Metadata
+          priority: 1830
           context: state
           units: '{status}'
           label_promotion: []
@@ -1711,6 +1784,7 @@ template:
             - ceph_bluefs_wal_alloc_lat_sum
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -1726,6 +1800,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -1742,6 +1817,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Allocation Sizes and High-Water Marks
+              priority: 2100
               context: allocation_high_water
               units: bytes
               label_promotion: []
@@ -1758,6 +1834,7 @@ template:
                 optional_by_labels: []
               algorithm: absolute
             - title: Duration and Time
+              priority: 2100
               context: duration
               units: seconds
               label_promotion: []
@@ -1773,6 +1850,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Failure and Delay Outcomes
+              priority: 2100
               context: failure_outcomes
               units: events/s
               label_promotion: []
@@ -1795,6 +1873,7 @@ template:
             - ceph_bluefs_log_compactions
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -1808,6 +1887,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -1822,6 +1902,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Events
+              priority: 2100
               context: events
               units: events/s
               label_promotion: []
@@ -1875,6 +1956,7 @@ template:
             - ceph_bluefs_write_disk_count
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -1896,6 +1978,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -1918,6 +2001,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Byte Throughput
+              priority: 2100
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -1953,6 +2037,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Operations
+              priority: 2100
               context: operations
               units: operations/s
               label_promotion: []
@@ -1984,6 +2069,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Zero-Read Outcomes
+              priority: 2100
               context: zero_read_outcomes
               units: reads/s
               label_promotion: []
@@ -2019,6 +2105,7 @@ template:
             - ceph_bluefs_wal_used_bytes
           charts:
             - title: Allocation Sizes and High-Water Marks
+              priority: 2100
               context: allocation_high_water
               units: bytes
               label_promotion: []
@@ -2035,6 +2122,7 @@ template:
                 optional_by_labels: []
               algorithm: absolute
             - title: Byte Throughput
+              priority: 2100
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -2052,6 +2140,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Files
+              priority: 2100
               context: file_state
               units: files
               label_promotion: []
@@ -2063,6 +2152,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: File Work
+              priority: 2100
               context: file_work
               units: files/s
               label_promotion: []
@@ -2076,6 +2166,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -2110,6 +2201,7 @@ template:
             - ceph_bluestore_allocator_lat_sum
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -2121,6 +2213,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -2133,6 +2226,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Allocation Unit
+              priority: 2100
               context: allocation_unit
               units: bytes
               label_promotion: []
@@ -2144,6 +2238,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Allocated Space
+              priority: 2100
               context: allocated_space
               units: bytes
               label_promotion: []
@@ -2171,6 +2266,7 @@ template:
             - ceph_bluestore_extent_compress
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -2186,6 +2282,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -2202,6 +2299,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Compression Operations
+              priority: 2100
               context: compression_operations
               units: operations/s
               label_promotion: []
@@ -2215,6 +2313,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Compressed Extents
+              priority: 2100
               context: compressed_extents
               units: extents/s
               label_promotion: []
@@ -2226,6 +2325,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -2281,6 +2381,7 @@ template:
             - ceph_bluestore_write_small_unused
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -2302,6 +2403,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -2324,6 +2426,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Byte Throughput
+              priority: 2100
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -2347,6 +2450,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Read Outcomes
+              priority: 2100
               context: read_outcomes
               units: reads/s
               label_promotion: []
@@ -2360,6 +2464,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Slow Reads
+              priority: 2100
               context: slow_reads
               units: reads/s
               label_promotion: []
@@ -2373,6 +2478,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Slow AIO Waits
+              priority: 2100
               context: slow_aio_waits
               units: waits/s
               label_promotion: []
@@ -2384,6 +2490,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Skipped Blobs
+              priority: 2100
               context: skipped_blobs
               units: blobs/s
               label_promotion: []
@@ -2395,6 +2502,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Skipped Writes
+              priority: 2100
               context: skipped_writes
               units: writes/s
               label_promotion: []
@@ -2406,6 +2514,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Write Operations
+              priority: 2100
               context: write_operations
               units: writes/s
               label_promotion: []
@@ -2431,6 +2540,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Written Blobs
+              priority: 2100
               context: written_blobs
               units: blobs/s
               label_promotion: []
@@ -2442,6 +2552,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Penalty Reads
+              priority: 2100
               context: penalty_reads
               units: reads/s
               label_promotion: []
@@ -2479,6 +2590,7 @@ template:
             - ceph_bluestore_omap_upper_bound_lat_sum
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -2502,6 +2614,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -2526,6 +2639,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Byte Throughput
+              priority: 2100
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -2539,6 +2653,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Open Iterators
+              priority: 2100
               context: open_iterators
               units: iterators
               label_promotion: []
@@ -2551,6 +2666,7 @@ template:
                 optional_by_labels: []
               algorithm: absolute
             - title: Mutation Calls
+              priority: 2100
               context: mutation_calls
               units: calls/s
               label_promotion: []
@@ -2564,6 +2680,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Removed Key Ranges
+              priority: 2100
               context: removed_key_ranges
               units: ranges/s
               label_promotion: []
@@ -2575,6 +2692,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Key Mutations
+              priority: 2100
               context: key_mutations
               units: keys/s
               label_promotion: []
@@ -2602,6 +2720,7 @@ template:
             - ceph_bluestore_onodes_pinned
           charts:
             - title: Onode Blobs
+              priority: 2100
               context: blob_state
               units: blobs
               label_promotion: []
@@ -2615,6 +2734,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Onode Extents
+              priority: 2100
               context: extent_state
               units: extents
               label_promotion: []
@@ -2626,6 +2746,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Onodes
+              priority: 2100
               context: onode_state
               units: onodes
               label_promotion: []
@@ -2639,6 +2760,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Events
+              priority: 2100
               context: events
               units: events/s
               label_promotion: []
@@ -2650,6 +2772,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Onode Lookup Outcomes
+              priority: 2100
               context: onode_lookup_outcomes
               units: lookups/s
               label_promotion: []
@@ -2663,6 +2786,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Onode Shard Lookup Outcomes
+              priority: 2100
               context: shard_lookup_outcomes
               units: lookups/s
               label_promotion: []
@@ -2694,6 +2818,7 @@ template:
             - ceph_bluestore_pricache:data_reserved_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -2749,6 +2874,7 @@ template:
             - ceph_bluestore_pricache:kv_reserved_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -2804,6 +2930,7 @@ template:
             - ceph_bluestore_pricache:kv_onode_reserved_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -2859,6 +2986,7 @@ template:
             - ceph_bluestore_pricache:meta_reserved_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -2905,6 +3033,7 @@ template:
             - ceph_bluestore_pricache_unmapped_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -2947,6 +3076,7 @@ template:
             - ceph_bluestore_stored
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -2966,6 +3096,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -2986,6 +3117,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Byte Throughput
+              priority: 2100
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -2999,6 +3131,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Current Work
+              priority: 2100
               context: current_work
               units: items
               label_promotion: []
@@ -3010,6 +3143,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Blob Splits
+              priority: 2100
               context: blob_splits
               units: blobs/s
               label_promotion: []
@@ -3021,6 +3155,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Garbage-Collection Merge Throughput
+              priority: 2100
               context: gc_merge_throughput
               units: bytes/s
               label_promotion: []
@@ -3032,6 +3167,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Failure and Delay Outcomes
+              priority: 2100
               context: failure_outcomes
               units: events/s
               label_promotion: []
@@ -3043,6 +3179,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Fragmentation
+              priority: 2100
               context: fragmentation
               units: per mille
               label_promotion: []
@@ -3054,6 +3191,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Buffer Cache Residency
+              priority: 2100
               context: buffer_cache_residency
               units: bytes
               label_promotion: []
@@ -3065,6 +3203,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Logical Stored Data
+              priority: 2100
               context: logical_stored_data
               units: bytes
               label_promotion: []
@@ -3109,6 +3248,7 @@ template:
             - ceph_bluestore_txc_throttle_lat_sum
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -3146,6 +3286,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -3184,6 +3325,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Operations
+              priority: 2100
               context: operations
               units: operations/s
               label_promotion: []
@@ -3214,6 +3356,7 @@ template:
             - ceph_mds_server_req_setxattr_latency_sum
           charts:
             - title: Latency Measurements
+              priority: 1810
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -3235,6 +3378,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1810
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -3275,6 +3419,7 @@ template:
             - ceph_mds_server_cap_revoke_eviction
           charts:
             - title: Capabilities
+              priority: 1810
               context: capability_state
               units: capabilities
               label_promotion: []
@@ -3286,6 +3431,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Capability Messages
+              priority: 1810
               context: capability_messages
               units: messages/s
               label_promotion: []
@@ -3301,6 +3447,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Capability-Throttled Requests
+              priority: 1810
               context: throttled_requests
               units: requests/s
               label_promotion: []
@@ -3312,6 +3459,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Capability-Revoke Evictions
+              priority: 1810
               context: evicted_clients
               units: clients/s
               label_promotion: []
@@ -3323,6 +3471,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Inodes
+              priority: 1810
               context: inode_state
               units: inodes
               label_promotion: []
@@ -3334,6 +3483,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Inode Work
+              priority: 1810
               context: inode_work
               units: inodes/s
               label_promotion: []
@@ -3345,6 +3495,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Operations
+              priority: 1810
               context: operations
               units: operations/s
               label_promotion: []
@@ -3390,6 +3541,7 @@ template:
             - ceph_mds_log_wrpos
           charts:
             - title: Latency Measurements
+              priority: 1810
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -3401,6 +3553,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1810
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -3413,6 +3566,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Current Journal Events
+              priority: 1810
               context: events_current
               units: events
               label_promotion: []
@@ -3428,6 +3582,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Large Journal Events
+              priority: 1810
               context: large_events
               units: events/s
               label_promotion: []
@@ -3440,6 +3595,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Journal Events
+              priority: 1810
               context: journal_events
               units: events/s
               label_promotion: []
@@ -3457,6 +3613,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Journal Positions
+              priority: 1810
               context: journal_positions
               units: position
               label_promotion: []
@@ -3472,6 +3629,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Journal Segments
+              priority: 1810
               context: journal_segments
               units: segments/s
               label_promotion: []
@@ -3487,6 +3645,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Journal Segments
+              priority: 1810
               context: segments_current
               units: segments
               label_promotion: []
@@ -3513,6 +3672,7 @@ template:
             - ceph_mds_cache_dir_update_receipt
           charts:
             - title: Discovery Messages
+              priority: 1810
               context: discovery_messages
               units: messages/s
               label_promotion: []
@@ -3526,6 +3686,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Discovery Attempts
+              priority: 1810
               context: discovery_attempts
               units: attempts/s
               label_promotion: []
@@ -3537,6 +3698,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Replication Directives
+              priority: 1810
               context: replication_directives
               units: directives/s
               label_promotion: []
@@ -3562,6 +3724,7 @@ template:
             - ceph_mds_cache_ireq_quiesce_path
           charts:
             - title: Inode Work
+              priority: 1810
               context: inode_work
               units: inodes/s
               label_promotion: []
@@ -3575,6 +3738,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Operations
+              priority: 1810
               context: operations
               units: operations/s
               label_promotion: []
@@ -3594,6 +3758,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Scrub Work
+              priority: 1810
               context: scrub_work
               units: scrubs/s
               label_promotion: []
@@ -3621,6 +3786,7 @@ template:
             - ceph_mds_cache_strays_reintegrated
           charts:
             - title: Current Work
+              priority: 1810
               context: current_work
               units: items
               label_promotion: []
@@ -3636,6 +3802,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Events
+              priority: 1810
               context: events
               units: events/s
               label_promotion: []
@@ -3653,6 +3820,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Files
+              priority: 1810
               context: file_state
               units: files
               label_promotion: []
@@ -3668,6 +3836,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: File Work
+              priority: 1810
               context: file_work
               units: files/s
               label_promotion: []
@@ -3688,6 +3857,7 @@ template:
             - ceph_mds_cache_uninline_write_failed
           charts:
             - title: Events
+              priority: 1810
               context: events
               units: events/s
               label_promotion: []
@@ -3701,6 +3871,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Failure and Delay Outcomes
+              priority: 1810
               context: failure_outcomes
               units: events/s
               label_promotion: []
@@ -3732,6 +3903,7 @@ template:
             - ceph_mds_server_req_unlink_latency_sum
           charts:
             - title: Latency Measurements
+              priority: 1810
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -3757,6 +3929,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1810
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -3802,6 +3975,7 @@ template:
             - ceph_mds_traverse_remote_ino
           charts:
             - title: Directory-Fragment Lifecycle
+              priority: 1810
               context: dirfrag_lifecycle
               units: dirfrags/s
               label_promotion: []
@@ -3817,6 +3991,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Namespace Traversals
+              priority: 1810
               context: traversals
               units: traversals/s
               label_promotion: []
@@ -3838,6 +4013,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Inode Work
+              priority: 1810
               context: inode_work
               units: inodes/s
               label_promotion: []
@@ -3849,6 +4025,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Key Work
+              priority: 1810
               context: key_work
               units: keys/s
               label_promotion: []
@@ -3860,6 +4037,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Lookup Outcomes
+              priority: 1810
               context: lookup_outcomes
               units: lookups/s
               label_promotion: []
@@ -3871,6 +4049,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Operations
+              priority: 1810
               context: operations
               units: operations/s
               label_promotion: []
@@ -3897,6 +4076,7 @@ template:
             - ceph_purge_queue_pq_item_in_journal
           charts:
             - title: Current Work
+              priority: 1810
               context: current_work
               units: items
               label_promotion: []
@@ -3908,6 +4088,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Executed Purge Operations
+              priority: 1810
               context: purge_operations
               units: operations/s
               label_promotion: []
@@ -3919,6 +4100,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Purge Operations in Flight
+              priority: 1810
               context: purge_operations_state
               units: operations
               label_promotion: []
@@ -3932,6 +4114,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Executed Purge Tasks
+              priority: 1810
               context: purge_tasks
               units: tasks/s
               label_promotion: []
@@ -3943,6 +4126,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Purge Tasks in Flight
+              priority: 1810
               context: purge_tasks_state
               units: tasks
               label_promotion: []
@@ -3964,6 +4148,7 @@ template:
             - ceph_mds_imported_inodes
           charts:
             - title: Events
+              priority: 1810
               context: events
               units: events/s
               label_promotion: []
@@ -3977,6 +4162,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Inode Work
+              priority: 1810
               context: inode_work
               units: inodes/s
               label_promotion: []
@@ -4018,6 +4204,7 @@ template:
             - ceph_mds_server_req_readdir_latency_sum
           charts:
             - title: Latency Measurements
+              priority: 1810
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -4051,6 +4238,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1810
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -4113,6 +4301,7 @@ template:
             - ceph_mds_subtrees
           charts:
             - title: Latency Measurements
+              priority: 1810
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -4124,6 +4313,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1810
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -4136,6 +4326,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Connected Clients
+              priority: 1810
               context: connected_clients
               units: clients
               label_promotion: []
@@ -4149,6 +4340,7 @@ template:
                   - id
                 optional_by_labels: []
             - title: Queued Requests
+              priority: 1810
               context: queued_requests
               units: requests
               label_promotion: []
@@ -4160,6 +4352,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Events
+              priority: 1810
               context: events
               units: events/s
               label_promotion: []
@@ -4173,6 +4366,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Failure and Delay Outcomes
+              priority: 1810
               context: failure_outcomes
               units: events/s
               label_promotion: []
@@ -4184,6 +4378,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Files
+              priority: 1810
               context: file_state
               units: files
               label_promotion: []
@@ -4195,6 +4390,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Inodes
+              priority: 1810
               context: inode_state
               units: inodes
               label_promotion: []
@@ -4214,6 +4410,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Expired Inodes
+              priority: 1810
               context: expired_inodes
               units: inodes/s
               label_promotion: []
@@ -4226,6 +4423,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Load
+              priority: 1810
               context: load
               units: load
               label_promotion: []
@@ -4237,6 +4435,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Operations
+              priority: 1810
               context: operations
               units: operations/s
               label_promotion: []
@@ -4258,6 +4457,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Snapshots
+              priority: 1810
               context: snapshot_state
               units: snapshots
               label_promotion: []
@@ -4269,6 +4469,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Space and Memory
+              priority: 1810
               context: space
               units: bytes
               label_promotion: []
@@ -4280,6 +4481,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Subtrees
+              priority: 1810
               context: subtrees
               units: subtrees
               label_promotion: []
@@ -4303,6 +4505,7 @@ template:
             - ceph_mds_scrub_set_tag
           charts:
             - title: Scrubbed Inodes
+              priority: 1810
               context: scrubbed_inodes
               units: inodes/s
               label_promotion: []
@@ -4319,6 +4522,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Backtrace Work
+              priority: 1810
               context: backtrace_work
               units: backtraces/s
               label_promotion: []
@@ -4333,6 +4537,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Repaired Inotables
+              priority: 1810
               context: repaired_inotables
               units: inotables/s
               label_promotion: []
@@ -4345,6 +4550,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Applied Scrub Tags
+              priority: 1810
               context: applied_tags
               units: tags/s
               label_promotion: []
@@ -4357,6 +4563,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Directory-Fragment Recursive-Stat Updates
+              priority: 1810
               context: dirfrag_rstat_updates
               units: dirfrags/s
               label_promotion: []
@@ -4383,6 +4590,7 @@ template:
             - ceph_mds_server_req_snapdiff_latency_sum
           charts:
             - title: Latency Measurements
+              priority: 1810
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -4402,6 +4610,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1810
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -4440,6 +4649,7 @@ template:
         - ceph_mds_mem_rss
       charts:
         - title: Capabilities
+          priority: 1810
           context: capability_state
           units: capabilities
           label_promotion: []
@@ -4451,6 +4661,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Capability Work
+          priority: 1810
           context: capability_work
           units: capabilities/s
           label_promotion: []
@@ -4464,6 +4675,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Dentries
+          priority: 1810
           context: dentry_state
           units: dentries
           label_promotion: []
@@ -4475,6 +4687,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Dentry Cache Churn
+          priority: 1810
           context: dentry_work
           units: dentries/s
           label_promotion: []
@@ -4488,6 +4701,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Directories
+          priority: 1810
           context: directory_state
           units: directories
           label_promotion: []
@@ -4499,6 +4713,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Directory Cache Churn
+          priority: 1810
           context: directory_work
           units: directories/s
           label_promotion: []
@@ -4512,6 +4727,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Inodes
+          priority: 1810
           context: inode_state
           units: inodes
           label_promotion: []
@@ -4523,6 +4739,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Inode Work
+          priority: 1810
           context: inode_work
           units: inodes/s
           label_promotion: []
@@ -4536,6 +4753,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Space and Memory
+          priority: 1810
           context: space
           units: bytes
           label_promotion: []
@@ -4562,6 +4780,7 @@ template:
         - ceph_mds_sessions_total_load
       charts:
         - title: Duration and Time
+          priority: 1810
           context: duration
           units: seconds
           label_promotion: []
@@ -4573,6 +4792,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Events
+          priority: 1810
           context: events
           units: events/s
           label_promotion: []
@@ -4586,6 +4806,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Average Session Load
+          priority: 1810
           context: average_load
           units: load
           label_promotion: []
@@ -4597,6 +4818,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Total Session Load
+          priority: 1810
           context: total_load
           units: load
           label_promotion: []
@@ -4608,6 +4830,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Metadata-Threshold Evictions
+          priority: 1810
           context: metadata_threshold_evictions
           units: sessions/s
           label_promotion: []
@@ -4620,6 +4843,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Sessions
+          priority: 1810
           context: session_state
           units: sessions
           label_promotion: []
@@ -4654,6 +4878,7 @@ template:
         - ceph_mds_per_client_total_write_size
       charts:
         - title: Capability Access Outcomes
+          priority: 1810
           context: capability_outcomes
           units: accesses/s
           label_promotion: []
@@ -4671,6 +4896,7 @@ template:
               - mds_filesystem_key
           algorithm: incremental
         - title: Dentry Lease Lookup Outcomes
+          priority: 1810
           context: dentry_lease_outcomes
           units: lookups/s
           label_promotion: []
@@ -4688,6 +4914,7 @@ template:
               - mds_filesystem_key
           algorithm: incremental
         - title: Average Operation Latency
+          priority: 1810
           context: average_operation_latency
           units: seconds
           label_promotion: []
@@ -4706,6 +4933,7 @@ template:
             optional_by_labels:
               - mds_filesystem_key
         - title: Open Files
+          priority: 1810
           context: open_files
           units: files
           label_promotion: []
@@ -4720,6 +4948,7 @@ template:
             optional_by_labels:
               - mds_filesystem_key
         - title: Inode State
+          priority: 1810
           context: inode_state
           units: inodes
           label_promotion: []
@@ -4736,6 +4965,7 @@ template:
             optional_by_labels:
               - mds_filesystem_key
         - title: Pinned Inode Capabilities
+          priority: 1810
           context: pinned_inode_capabilities
           units: capabilities
           label_promotion: []
@@ -4750,6 +4980,7 @@ template:
             optional_by_labels:
               - mds_filesystem_key
         - title: Reported I/O Operations
+          priority: 1810
           context: reported_io_operations
           units: operations/s
           label_promotion: []
@@ -4767,6 +4998,7 @@ template:
               - mds_filesystem_key
           algorithm: incremental
         - title: Reported I/O Volume
+          priority: 1810
           context: reported_io_volume
           units: bytes/s
           label_promotion: []
@@ -4792,6 +5024,7 @@ template:
             - ceph_exporter_scrape_time
           charts:
             - title: Collection Duration
+              priority: 2300
               context: duration
               units: seconds
               label_promotion: []
@@ -4809,6 +5042,7 @@ template:
             - ceph_daemon_socket_up
           charts:
             - title: Daemon Socket State
+              priority: 2300
               context: state
               units: '{status}'
               label_promotion: []
@@ -4832,6 +5066,7 @@ template:
             - ceph_exporter_vm_size
           charts:
             - title: Page Faults
+              priority: 2300
               context: page_faults
               units: faults/s
               label_promotion: []
@@ -4845,6 +5080,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Threads
+              priority: 2300
               context: threads
               units: threads
               label_promotion: []
@@ -4856,6 +5092,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: CPU Utilization
+              priority: 2300
               context: cpu_utilization
               units: percentage
               label_promotion: []
@@ -4867,6 +5104,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: CPU Time
+              priority: 2300
               context: cpu_time
               units: seconds/s
               label_promotion: []
@@ -4878,6 +5116,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Memory
+              priority: 2300
               context: memory
               units: bytes
               label_promotion: []
@@ -4897,6 +5136,7 @@ template:
         - ceph_mgr_cache_miss
       charts:
         - title: Lookup Outcomes
+          priority: 1300
           context: lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -4932,6 +5172,7 @@ template:
         - ceph_AsyncMessenger_Worker_msgr_connection_ready_timeouts
       charts:
         - title: RDMA Errors
+          priority: 2310
           context: rdma_errors
           units: errors/s
           label_promotion: []
@@ -4951,6 +5192,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Connection Timeouts
+          priority: 2310
           context: connection_timeouts
           units: connections/s
           label_promotion: []
@@ -4966,6 +5208,7 @@ template:
               - ceph_daemon
               - instance_id
         - title: Active Queue Pairs
+          priority: 2310
           context: active_queue_pairs
           units: queue pairs
           label_promotion: []
@@ -4978,6 +5221,7 @@ template:
             optional_by_labels: []
           algorithm: absolute
         - title: Created Queue Pairs
+          priority: 2310
           context: created_queue_pairs
           units: queue pairs/s
           label_promotion: []
@@ -4989,6 +5233,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: In-Flight Transmit Chunks
+          priority: 2310
           context: inflight_tx_chunks
           units: chunks
           label_promotion: []
@@ -5001,6 +5246,7 @@ template:
             optional_by_labels: []
           algorithm: absolute
         - title: Polling State
+          priority: 2310
           context: polling_state
           units: '{status}'
           label_promotion: []
@@ -5013,6 +5259,7 @@ template:
             optional_by_labels: []
           algorithm: absolute
         - title: Receive Buffers
+          priority: 2310
           context: receive_buffers
           units: buffers
           label_promotion: []
@@ -5027,6 +5274,7 @@ template:
             optional_by_labels: []
           algorithm: absolute
         - title: Asynchronous Events
+          priority: 2310
           context: async_events
           units: events/s
           label_promotion: []
@@ -5040,6 +5288,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Work Completions
+          priority: 2310
           context: work_completions
           units: completions/s
           label_promotion: []
@@ -5053,6 +5302,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Received FIN Messages
+          priority: 2310
           context: received_fin_messages
           units: messages/s
           label_promotion: []
@@ -5076,6 +5326,7 @@ template:
         - ceph_mon_session_trim
       charts:
         - title: Elections
+          priority: 1300
           context: elections
           units: elections/s
           label_promotion: []
@@ -5093,6 +5344,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Sessions
+          priority: 1300
           context: session_state
           units: sessions
           label_promotion: []
@@ -5104,6 +5356,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Session Churn
+          priority: 1300
           context: session_work
           units: sessions/s
           label_promotion: []
@@ -5186,6 +5439,7 @@ template:
         - ceph_osd_tier_proxy_write
       charts:
         - title: Latency Measurements
+          priority: 1410
           context: latency_measurements
           units: operations/s
           label_promotion: []
@@ -5231,6 +5485,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Accumulated Latency
+          priority: 1410
           context: accumulated_latency
           units: seconds/s
           label_promotion: []
@@ -5277,6 +5532,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Byte Throughput
+          priority: 1410
           context: byte_throughput
           units: bytes/s
           label_promotion: []
@@ -5304,6 +5560,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Operations in Progress
+          priority: 1410
           context: current_operations
           units: operations
           label_promotion: []
@@ -5315,6 +5572,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Events
+          priority: 1410
           context: events
           units: events/s
           label_promotion: []
@@ -5326,6 +5584,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Failure and Delay Outcomes
+          priority: 1410
           context: failure_outcomes
           units: events/s
           label_promotion: []
@@ -5337,6 +5596,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Lookup Outcomes
+          priority: 1410
           context: lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -5348,6 +5608,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Object Work
+          priority: 1410
           context: object_work
           units: objects/s
           label_promotion: []
@@ -5363,6 +5624,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Operations
+          priority: 1410
           context: operations
           units: operations/s
           label_promotion: []
@@ -5420,6 +5682,7 @@ template:
         - ceph_recoverystate_perf_pg_rebuild_min_secs
       charts:
         - title: Latency Measurements
+          priority: 1420
           context: latency_measurements
           units: operations/s
           label_promotion: []
@@ -5445,6 +5708,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Accumulated Latency
+          priority: 1420
           context: accumulated_latency
           units: seconds/s
           label_promotion: []
@@ -5471,6 +5735,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Byte Throughput
+          priority: 1420
           context: byte_throughput
           units: bytes/s
           label_promotion: []
@@ -5482,6 +5747,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Operations
+          priority: 1420
           context: operations
           units: operations/s
           label_promotion: []
@@ -5493,6 +5759,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: PG Rebuild Duration Measurements
+          priority: 1420
           context: pg_rebuild_duration_measurements
           units: duration measurements/s
           label_promotion: []
@@ -5504,6 +5771,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: PG Rebuild Accumulated Duration
+          priority: 1420
           context: pg_rebuild_accumulated_duration
           units: seconds/s
           label_promotion: []
@@ -5516,6 +5784,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: PG Rebuild Duration Range
+          priority: 1420
           context: pg_rebuild_duration_range
           units: seconds
           label_promotion: []
@@ -5588,6 +5857,7 @@ template:
         - ceph_osd_watch_timeouts
       charts:
         - title: Latency Measurements
+          priority: 1430
           context: latency_measurements
           units: operations/s
           label_promotion: []
@@ -5603,6 +5873,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Accumulated Latency
+          priority: 1430
           context: accumulated_latency
           units: seconds/s
           label_promotion: []
@@ -5619,6 +5890,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Value Measurement Measurements
+          priority: 1430
           context: value_measurements
           units: measurements/s
           label_promotion: []
@@ -5630,6 +5902,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Accumulated Value Measurement
+          priority: 1430
           context: accumulated_value
           units: value/s
           label_promotion: []
@@ -5642,6 +5915,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Byte Throughput
+          priority: 1430
           context: byte_throughput
           units: bytes/s
           label_promotion: []
@@ -5653,6 +5927,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: CRC Cache Lookup Outcomes
+          priority: 1430
           context: crc_lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -5669,6 +5944,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Tier-Agent Actions
+          priority: 1430
           context: tier_agent_actions
           units: actions/s
           label_promotion: []
@@ -5692,6 +5968,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Copy-From Operations
+          priority: 1430
           context: copyfrom_operations
           units: operations/s
           label_promotion: []
@@ -5703,6 +5980,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: OSD-Map Messages
+          priority: 1430
           context: map_messages
           units: messages/s
           label_promotion: []
@@ -5716,6 +5994,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: OSD-Map Epochs
+          priority: 1430
           context: map_epochs
           units: epochs/s
           label_promotion: []
@@ -5729,6 +6008,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Placement-Group Updates
+          priority: 1430
           context: pg_updates
           units: updates/s
           label_promotion: []
@@ -5742,6 +6022,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Total Placement-Group Updates
+          priority: 1430
           context: pg_updates_total
           units: placement group updates/s
           label_promotion: []
@@ -5753,6 +6034,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Pushes
+          priority: 1430
           context: pushes
           units: pushes/s
           label_promotion: []
@@ -5764,6 +6046,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Suboperations
+          priority: 1430
           context: suboperations
           units: suboperations/s
           label_promotion: []
@@ -5775,6 +6058,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Failed Tier Flush Attempts
+          priority: 1430
           context: failed_tier_flush_attempts
           units: attempts/s
           label_promotion: []
@@ -5788,6 +6072,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Watch Timeouts
+          priority: 1430
           context: watch_timeouts
           units: watches/s
           label_promotion: []
@@ -5799,6 +6084,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: OSD-Map Buffer-Cache Lookup Outcomes
+          priority: 1430
           context: map_buffer_cache_lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -5812,6 +6098,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Decoded OSD-Map Cache Lookup Outcomes
+          priority: 1430
           context: map_cache_lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -5827,6 +6114,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Tier Whiteouts
+          priority: 1430
           context: tier_whiteouts
           units: whiteouts/s
           label_promotion: []
@@ -5838,6 +6126,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Skipped Objects
+          priority: 1430
           context: skipped_objects
           units: objects/s
           label_promotion: []
@@ -5849,6 +6138,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Object-Context Cache Lookup Outcomes
+          priority: 1430
           context: object_context_cache_lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -5862,6 +6152,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Tier Flush Attempts
+          priority: 1430
           context: tier_flush_attempts
           units: attempts/s
           label_promotion: []
@@ -5877,6 +6168,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Pulls
+          priority: 1430
           context: pulls
           units: pulls/s
           label_promotion: []
@@ -5888,6 +6180,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Placement Groups
+          priority: 1430
           context: pg_state
           units: PGs
           label_promotion: []
@@ -5907,6 +6200,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Space and Memory
+          priority: 1430
           context: space
           units: bytes
           label_promotion: []
@@ -5922,6 +6216,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Heartbeat Peers
+          priority: 1430
           context: heartbeat_peers
           units: peers
           label_promotion: []
@@ -5933,6 +6228,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: OSD Load Average
+          priority: 1430
           context: load_average
           units: load
           label_promotion: []
@@ -5943,7 +6239,7 @@ template:
             by_labels:
               - ceph_daemon
             optional_by_labels: []
-    - family: OSDs/Scrubbing/Ceph 19
+    - family: OSDs/Scrubbing Ceph 19
       context_namespace: osd_scrubbing_ceph_19
       groups:
         - family: Elapsed Time
@@ -5983,6 +6279,7 @@ template:
             - ceph_osd_scrub_sh_repl_successful_scrubs_elapsed_sum
           charts:
             - title: Scrub Elapsed-Time Measurements
+              priority: 1440
               context: scrub_latency_measurements
               units: scrubs/s
               label_promotion: []
@@ -6010,6 +6307,7 @@ template:
                   - pooltype
                 optional_by_labels: []
             - title: Reservation Elapsed-Time Measurements
+              priority: 1440
               context: reservation_latency_measurements
               units: reservations/s
               label_promotion: []
@@ -6037,6 +6335,7 @@ template:
                   - pooltype
                 optional_by_labels: []
             - title: Accumulated Scrub Elapsed Time
+              priority: 1440
               context: accumulated_scrub_latency
               units: seconds/s
               label_promotion: []
@@ -6065,6 +6364,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Accumulated Reservation Elapsed Time
+              priority: 1440
               context: accumulated_reservation_latency
               units: seconds/s
               label_promotion: []
@@ -6109,6 +6409,7 @@ template:
             - ceph_osd_scrub_sh_repl_successful_scrubs
           charts:
             - title: Scrub Work
+              priority: 1440
               context: scrub_work
               units: scrubs/s
               label_promotion: []
@@ -6168,6 +6469,7 @@ template:
             - ceph_osd_scrub_sh_repl_reservation_process_skipped
           charts:
             - title: Replicas in Reservation
+              priority: 1440
               context: replicas_in_reservation
               units: replicas
               label_promotion: []
@@ -6187,6 +6489,7 @@ template:
                   - pooltype
                 optional_by_labels: []
             - title: Scrubs Past Reservation
+              priority: 1440
               context: scrubs_past_reservation
               units: scrubs/s
               label_promotion: []
@@ -6206,6 +6509,7 @@ template:
                   - pooltype
                 optional_by_labels: []
             - title: Reservation Process Outcomes
+              priority: 1440
               context: reservation_process_outcomes
               units: reservations/s
               label_promotion: []
@@ -6240,7 +6544,7 @@ template:
                   - level
                   - pooltype
                 optional_by_labels: []
-    - family: OSDs/Scrubbing/Ceph 20
+    - family: OSDs/Scrubbing Ceph 20
       context_namespace: osd_scrubbing_ceph_20
       groups:
         - family: Elapsed Time
@@ -6264,6 +6568,7 @@ template:
             - ceph_osd_successful_scrubs_replicated_elapsed_sum
           charts:
             - title: Scrub Elapsed-Time Measurements
+              priority: 1450
               context: scrub_latency_measurements
               units: scrubs/s
               label_promotion: []
@@ -6281,6 +6586,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Reservation Elapsed-Time Measurements
+              priority: 1450
               context: reservation_latency_measurements
               units: reservations/s
               label_promotion: []
@@ -6298,6 +6604,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Scrub Elapsed Time
+              priority: 1450
               context: accumulated_scrub_latency
               units: seconds/s
               label_promotion: []
@@ -6316,6 +6623,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Accumulated Reservation Elapsed Time
+              priority: 1450
               context: accumulated_reservation_latency
               units: seconds/s
               label_promotion: []
@@ -6342,6 +6650,7 @@ template:
             - ceph_osd_scrub_replicated_io_intersects
           charts:
             - title: Client Write Interference
+              priority: 1450
               context: client_write_interference
               units: writes/s
               label_promotion: []
@@ -6369,6 +6678,7 @@ template:
             - ceph_osd_successful_scrubs_replicated
           charts:
             - title: Scrub Work
+              priority: 1450
               context: scrub_work
               units: scrubs/s
               label_promotion: []
@@ -6406,6 +6716,7 @@ template:
             - ceph_osd_scrub_replicated_scrub_reservations_completed
           charts:
             - title: Replicas in Reservation
+              priority: 1450
               context: replicas_in_reservation
               units: replicas
               label_promotion: []
@@ -6419,6 +6730,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Scrubs Past Reservation
+              priority: 1450
               context: scrubs_past_reservation
               units: scrubs/s
               label_promotion: []
@@ -6432,6 +6744,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Reservation Process Outcomes
+              priority: 1450
               context: reservation_process_outcomes
               units: reservations/s
               label_promotion: []
@@ -6469,6 +6782,7 @@ template:
             - ceph_osd_scrub_replicated_stats_cnt
           charts:
             - title: Byte Throughput
+              priority: 1450
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -6482,6 +6796,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Scrub Calls
+              priority: 1450
               context: scrub_calls
               units: calls/s
               label_promotion: []
@@ -6502,7 +6817,7 @@ template:
                 by_labels:
                   - ceph_daemon
                 optional_by_labels: []
-    - family: OSDs/Scrubbing/Common Work
+    - family: OSDs/Scrubbing Common Work
       context_namespace: osd_scrubbing_common_work
       groups:
         - family: Interference and Scheduling
@@ -6530,6 +6845,7 @@ template:
             - ceph_osd_scrub_sh_repl_write_blocked_by_scrub
           charts:
             - title: Object-Lock Waits
+              priority: 1460
               context: object_lock_waits
               units: waits/s
               label_promotion: []
@@ -6549,6 +6865,7 @@ template:
                   - pooltype
                 optional_by_labels: []
             - title: Chunk Selection Outcomes
+              priority: 1460
               context: chunk_selection_outcomes
               units: chunks/s
               label_promotion: []
@@ -6576,6 +6893,7 @@ template:
                   - pooltype
                 optional_by_labels: []
             - title: Scrub Preemptions
+              priority: 1460
               context: preemptions
               units: preemptions/s
               label_promotion: []
@@ -6595,6 +6913,7 @@ template:
                   - pooltype
                 optional_by_labels: []
             - title: Client Writes Blocked by Scrub
+              priority: 1460
               context: blocked_client_writes
               units: writes/s
               label_promotion: []
@@ -6622,6 +6941,7 @@ template:
             - ceph_osd_scrub_sh_repl_scrub_reservations_completed
           charts:
             - title: Completed Scrub Reservations
+              priority: 1460
               context: completed_reservations
               units: reservations/s
               label_promotion: []
@@ -6649,6 +6969,7 @@ template:
             - ceph_osd_scrub_omapgetheader_cnt
           charts:
             - title: Byte Throughput
+              priority: 1460
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -6662,6 +6983,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: OMAP Scrub Calls
+              priority: 1460
               context: omap_calls
               units: calls/s
               label_promotion: []
@@ -6707,6 +7029,7 @@ template:
             - ceph_rgw_op_put_obj_ops
           charts:
             - title: Operations
+              priority: 1700
               context: operations
               units: operations/s
               label_promotion: []
@@ -6730,6 +7053,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Object Bytes
+              priority: 1700
               context: object_bytes
               units: bytes/s
               label_promotion: []
@@ -6747,6 +7071,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Latency Measurements
+              priority: 1700
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -6770,6 +7095,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1700
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -6823,6 +7149,7 @@ template:
             - ceph_rgw_op_per_user_put_obj_ops
           charts:
             - title: Operations
+              priority: 1700
               context: operations
               units: operations/s
               label_promotion: []
@@ -6848,6 +7175,7 @@ template:
                 optional_by_labels:
                   - tenant
             - title: Object Bytes
+              priority: 1700
               context: object_bytes
               units: bytes/s
               label_promotion: []
@@ -6867,6 +7195,7 @@ template:
                 optional_by_labels:
                   - tenant
             - title: Latency Measurements
+              priority: 1700
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -6892,6 +7221,7 @@ template:
                 optional_by_labels:
                   - tenant
             - title: Accumulated Latency
+              priority: 1700
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -6947,6 +7277,7 @@ template:
             - ceph_rgw_op_per_bucket_put_obj_ops
           charts:
             - title: Operations
+              priority: 1700
               context: operations
               units: operations/s
               label_promotion: []
@@ -6972,6 +7303,7 @@ template:
                 optional_by_labels:
                   - tenant
             - title: Object Bytes
+              priority: 1700
               context: object_bytes
               units: bytes/s
               label_promotion: []
@@ -6991,6 +7323,7 @@ template:
                 optional_by_labels:
                   - tenant
             - title: Latency Measurements
+              priority: 1700
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -7016,6 +7349,7 @@ template:
                 optional_by_labels:
                   - tenant
             - title: Accumulated Latency
+              priority: 1700
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -7052,6 +7386,7 @@ template:
             - ceph_rgw_lc_transition_noncurrent
           charts:
             - title: Lifecycle Actions
+              priority: 1700
               context: lifecycle_actions
               units: actions/s
               label_promotion: []
@@ -7071,6 +7406,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Aborted Multipart Uploads
+              priority: 1700
               context: aborted_multipart_uploads
               units: uploads/s
               label_promotion: []
@@ -7089,6 +7425,7 @@ template:
             - ceph_rgw_lua_script_ok
           charts:
             - title: Current Lua Virtual Machines
+              priority: 1700
               context: current_vms
               units: VMs
               label_promotion: []
@@ -7100,6 +7437,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Lua Script Executions
+              priority: 1700
               context: script_executions
               units: executions/s
               label_promotion: []
@@ -7126,6 +7464,7 @@ template:
             - ceph_rgw_pubsub_store_ok
           charts:
             - title: Pending Notification Events
+              priority: 1700
               context: pending_events
               units: events
               label_promotion: []
@@ -7137,6 +7476,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Stored Events
+              priority: 1700
               context: event_state
               units: events
               label_promotion: []
@@ -7148,6 +7488,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Events
+              priority: 1700
               context: events
               units: events/s
               label_promotion: []
@@ -7165,6 +7506,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Failure and Delay Outcomes
+              priority: 1700
               context: failure_outcomes
               units: events/s
               label_promotion: []
@@ -7178,6 +7520,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Missing Notification Configurations
+              priority: 1700
               context: missing_configurations
               units: events/s
               label_promotion: []
@@ -7195,6 +7538,7 @@ template:
             - ceph_rgw_topic_persistent_topic_size
           charts:
             - title: Persistent Topic Queue Length
+              priority: 1700
               context: queue_length
               units: entries
               label_promotion: []
@@ -7207,6 +7551,7 @@ template:
                 optional_by_labels:
                   - topic
             - title: Persistent Topic Queue Size
+              priority: 1700
               context: queue_size
               units: bytes
               label_promotion: []
@@ -7236,6 +7581,7 @@ template:
             - ceph_rgw_req
           charts:
             - title: Latency Measurements
+              priority: 1700
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -7249,6 +7595,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1700
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -7263,6 +7610,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Byte Throughput
+              priority: 1700
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -7276,6 +7624,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Queued and Active Requests
+              priority: 1700
               context: current_requests
               units: requests
               label_promotion: []
@@ -7289,6 +7638,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Failed Requests
+              priority: 1700
               context: failed_requests
               units: requests/s
               label_promotion: []
@@ -7300,6 +7650,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Object Work
+              priority: 1700
               context: object_work
               units: objects/s
               label_promotion: []
@@ -7311,6 +7662,7 @@ template:
                   - instance_id
                 optional_by_labels: []
             - title: Requests
+              priority: 1700
               context: requests
               units: requests/s
               label_promotion: []
@@ -7337,6 +7689,7 @@ template:
         - ceph_rgw_keystone_token_cache_miss
       charts:
         - title: Keystone Token Cache Lookup Outcomes
+          priority: 1710
           context: keystone_lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -7350,6 +7703,7 @@ template:
               - instance_id
             optional_by_labels: []
         - title: D4N Cache Lookup Outcomes
+          priority: 1710
           context: d4n_lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -7363,6 +7717,7 @@ template:
               - instance_id
             optional_by_labels: []
         - title: D4N Cache Evictions
+          priority: 1710
           context: d4n_cache_evictions
           units: evictions/s
           label_promotion: []
@@ -7374,6 +7729,7 @@ template:
               - instance_id
             optional_by_labels: []
         - title: Lookup Outcomes
+          priority: 1710
           context: lookup_outcomes
           units: lookups/s
           label_promotion: []
@@ -7401,6 +7757,7 @@ template:
         - ceph_data_sync_from_zone_poll_latency_sum
       charts:
         - title: Replicated Objects
+          priority: 1720
           context: replicated_objects
           units: objects/s
           label_promotion: []
@@ -7413,6 +7770,7 @@ template:
             optional_by_labels:
               - source_zone
         - title: Data Log Shard Delay
+          priority: 1720
           context: data_log_shard_delay
           units: seconds
           label_promotion: []
@@ -7428,6 +7786,7 @@ template:
             optional_by_labels:
               - sync_shard
         - title: Accumulated Byte Measurement
+          priority: 1720
           context: accumulated_bytes
           units: bytes/s
           label_promotion: []
@@ -7441,6 +7800,7 @@ template:
               - source_zone
           algorithm: incremental
         - title: Latency Measurements
+          priority: 1720
           context: latency_measurements
           units: operations/s
           label_promotion: []
@@ -7455,6 +7815,7 @@ template:
             optional_by_labels:
               - source_zone
         - title: Accumulated Latency
+          priority: 1720
           context: accumulated_latency
           units: seconds/s
           label_promotion: []
@@ -7470,6 +7831,7 @@ template:
               - source_zone
           algorithm: incremental
         - title: Replication-Log Request Errors
+          priority: 1720
           context: replication_log_request_errors
           units: requests/s
           label_promotion: []
@@ -7482,6 +7844,7 @@ template:
             optional_by_labels:
               - source_zone
         - title: Object Work
+          priority: 1720
           context: object_work
           units: objects/s
           label_promotion: []
@@ -7570,6 +7933,7 @@ template:
         - ceph_objecter_statfs_send
       charts:
         - title: Latency Measurements
+          priority: 2200
           context: latency_measurements
           units: operations/s
           label_promotion: []
@@ -7583,6 +7947,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Accumulated Latency
+          priority: 2200
           context: accumulated_latency
           units: seconds/s
           label_promotion: []
@@ -7597,6 +7962,7 @@ template:
           algorithm: incremental
           aggregation: sum
         - title: Submitted Top-Level Operations
+          priority: 2200
           context: submitted_operations
           units: operations/s
           label_promotion: []
@@ -7610,6 +7976,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Operation-Vector Entries
+          priority: 2200
           context: operation_vector_entries
           units: entries/s
           label_promotion: []
@@ -7624,6 +7991,7 @@ template:
           algorithm: incremental
           aggregation: sum
         - title: Byte Throughput
+          priority: 2200
           context: byte_throughput
           units: bytes/s
           label_promotion: []
@@ -7637,6 +8005,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Active Commands
+          priority: 2200
           context: active_commands
           units: commands
           label_promotion: []
@@ -7650,6 +8019,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Active Lingering Operations
+          priority: 2200
           context: active_lingering_operations
           units: operations
           label_promotion: []
@@ -7663,6 +8033,7 @@ template:
               - instance_id
           aggregation: sum
         - title: OSD-Map Epoch
+          priority: 2200
           context: map_epoch
           units: epoch
           label_promotion: []
@@ -7676,6 +8047,7 @@ template:
               - instance_id
           aggregation: min
         - title: Objecter Operations
+          priority: 2200
           context: active_operations
           units: operations
           label_promotion: []
@@ -7693,6 +8065,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Active Pool Operations
+          priority: 2200
           context: active_pool_operations
           units: operations
           label_promotion: []
@@ -7706,6 +8079,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Active Pool-Stat Requests
+          priority: 2200
           context: active_poolstat_requests
           units: requests
           label_promotion: []
@@ -7719,6 +8093,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Active StatFS Requests
+          priority: 2200
           context: active_statfs_requests
           units: requests
           label_promotion: []
@@ -7732,6 +8107,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Commands
+          priority: 2200
           context: commands
           units: commands/s
           label_promotion: []
@@ -7747,6 +8123,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Lingering Operations
+          priority: 2200
           context: lingering_operations
           units: operations/s
           label_promotion: []
@@ -7764,6 +8141,7 @@ template:
               - instance_id
           aggregation: sum
         - title: OSD Maps
+          priority: 2200
           context: maps
           units: maps/s
           label_promotion: []
@@ -7779,6 +8157,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Object Operations
+          priority: 2200
           context: operations
           units: operations/s
           label_promotion: []
@@ -7862,6 +8241,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Replica Reads
+          priority: 2200
           context: replica_reads
           units: reads/s
           label_promotion: []
@@ -7879,6 +8259,7 @@ template:
               - instance_id
           aggregation: sum
         - title: OSD Sessions
+          priority: 2200
           context: osd_sessions
           units: sessions/s
           label_promotion: []
@@ -7894,6 +8275,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Pool Operations
+          priority: 2200
           context: pool_operations
           units: operations/s
           label_promotion: []
@@ -7909,6 +8291,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Pool-Stat and StatFS Requests
+          priority: 2200
           context: stat_requests
           units: requests/s
           label_promotion: []
@@ -7928,6 +8311,7 @@ template:
               - instance_id
           aggregation: sum
         - title: Sessions
+          priority: 2200
           context: session_state
           units: sessions
           label_promotion: []
@@ -7981,6 +8365,7 @@ template:
         - ceph_rbd_librbd_image_ws_latency_sum
       charts:
         - title: I/O Operations
+          priority: 1910
           context: io_operations
           units: operations/s
           label_promotion: []
@@ -7995,6 +8380,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: I/O Byte Throughput
+          priority: 1910
           context: io_byte_throughput
           units: bytes/s
           label_promotion: []
@@ -8009,6 +8395,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: I/O Latency Measurements
+          priority: 1910
           context: io_latency_measurements
           units: operations/s
           label_promotion: []
@@ -8023,6 +8410,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Accumulated I/O Latency
+          priority: 1910
           context: accumulated_io_latency
           units: seconds/s
           label_promotion: []
@@ -8038,6 +8426,7 @@ template:
               - librbd_image_key
           algorithm: incremental
         - title: Lifecycle Timestamps
+          priority: 1910
           context: lifecycle_timestamps
           units: seconds since epoch
           label_promotion: []
@@ -8052,6 +8441,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Data Operations
+          priority: 1910
           context: data_operations
           units: operations/s
           label_promotion: []
@@ -8068,6 +8458,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Data Operation Byte Throughput
+          priority: 1910
           context: data_operation_byte_throughput
           units: bytes/s
           label_promotion: []
@@ -8084,6 +8475,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Data Operation Latency Measurements
+          priority: 1910
           context: data_operation_latency_measurements
           units: operations/s
           label_promotion: []
@@ -8100,6 +8492,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Accumulated Data Operation Latency
+          priority: 1910
           context: accumulated_data_operation_latency
           units: seconds/s
           label_promotion: []
@@ -8117,6 +8510,7 @@ template:
               - librbd_image_key
           algorithm: incremental
         - title: Flush Operations
+          priority: 1910
           context: flush_operations
           units: operations/s
           label_promotion: []
@@ -8129,6 +8523,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Flush Latency Measurements
+          priority: 1910
           context: flush_latency_measurements
           units: operations/s
           label_promotion: []
@@ -8141,6 +8536,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Accumulated Flush Latency
+          priority: 1910
           context: accumulated_flush_latency
           units: seconds/s
           label_promotion: []
@@ -8154,6 +8550,7 @@ template:
               - librbd_image_key
           algorithm: incremental
         - title: Snapshot Mutations
+          priority: 1910
           context: snapshot_mutations
           units: operations/s
           label_promotion: []
@@ -8172,6 +8569,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Maintenance Operations
+          priority: 1910
           context: maintenance_operations
           units: operations/s
           label_promotion: []
@@ -8190,6 +8588,7 @@ template:
             optional_by_labels:
               - librbd_image_key
         - title: Readahead Byte Throughput
+          priority: 1910
           context: readahead_byte_throughput
           units: bytes/s
           label_promotion: []
@@ -8217,6 +8616,7 @@ template:
             - ceph_rbd_mirror_journal_replay_latency_sum
           charts:
             - title: Journal Replay Latency Measurements
+              priority: 1920
               context: latency_measurements
               units: entries/s
               label_promotion: []
@@ -8231,6 +8631,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Image Journal Replay Latency Measurements
+              priority: 1920
               context: image_latency_measurements
               units: entries/s
               label_promotion: []
@@ -8245,6 +8646,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 1920
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -8260,6 +8662,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Accumulated Image Journal Replay Latency
+              priority: 1920
               context: image_accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -8275,6 +8678,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Byte Throughput
+              priority: 1920
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -8289,6 +8693,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Image Journal Replay Byte Throughput
+              priority: 1920
               context: image_byte_throughput
               units: bytes/s
               label_promotion: []
@@ -8303,6 +8708,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Journal Entries
+              priority: 1920
               context: journal_entries
               units: entries/s
               label_promotion: []
@@ -8317,6 +8723,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Journal Entries Queued for Replay
+              priority: 1920
               context: image_journal_entries
               units: entries/s
               label_promotion: []
@@ -8347,6 +8754,7 @@ template:
             - ceph_rbd_mirror_snapshot_sync_time_sum
           charts:
             - title: Snapshot Sync Latency Measurements — Image Sync Time
+              priority: 1920
               context: latency_measurements_image_sync_time
               units: snapshots/s
               label_promotion: []
@@ -8361,6 +8769,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Snapshot Sync Latency Measurements — Sync Time
+              priority: 1920
               context: latency_measurements_sync_time
               units: snapshots/s
               label_promotion: []
@@ -8372,6 +8781,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency — Image Sync Time
+              priority: 1920
               context: accumulated_latency_image_sync_time
               units: seconds/s
               label_promotion: []
@@ -8387,6 +8797,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Accumulated Latency — Sync Time
+              priority: 1920
               context: accumulated_latency_sync_time
               units: seconds/s
               label_promotion: []
@@ -8399,6 +8810,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Byte Throughput — Image Sync Bytes
+              priority: 1920
               context: byte_throughput_image_sync_bytes
               units: bytes/s
               label_promotion: []
@@ -8413,6 +8825,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Byte Throughput — Sync Bytes
+              priority: 1920
               context: byte_throughput_sync_bytes
               units: bytes/s
               label_promotion: []
@@ -8424,6 +8837,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Last Snapshot Sync Duration
+              priority: 1920
               context: last_sync_duration
               units: seconds
               label_promotion: []
@@ -8438,6 +8852,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Last Snapshot Sync Size
+              priority: 1920
               context: last_sync_size
               units: bytes
               label_promotion: []
@@ -8452,6 +8867,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Snapshot Work — Image Snapshots
+              priority: 1920
               context: snapshot_work_image_snapshots
               units: snapshots/s
               label_promotion: []
@@ -8466,6 +8882,7 @@ template:
                   - pool
                 optional_by_labels: []
             - title: Snapshot Work — Snapshots
+              priority: 1920
               context: snapshot_work_snapshots
               units: snapshots/s
               label_promotion: []
@@ -8477,6 +8894,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Timestamps
+              priority: 1920
               context: timestamp
               units: seconds since epoch
               label_promotion: []
@@ -8649,6 +9067,7 @@ template:
             - ceph_recoverystate_perf_waitupthru_latency_sum
           charts:
             - title: KStore Transaction Latency Measurements
+              priority: 2220
               context: kstore_latency_measurements
               units: transactions/s
               label_promotion: []
@@ -8668,6 +9087,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Client Request Latency Measurements
+              priority: 2220
               context: client_latency_measurements
               units: requests/s
               label_promotion: []
@@ -8679,6 +9099,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Recovery-State Transition Latency Measurements
+              priority: 2220
               context: recovery_state_latency_measurements
               units: state transitions/s
               label_promotion: []
@@ -8750,6 +9171,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated KStore Transaction Latency
+              priority: 2220
               context: accumulated_kstore_latency
               units: seconds/s
               label_promotion: []
@@ -8770,6 +9192,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Accumulated Client Request Latency
+              priority: 2220
               context: accumulated_client_latency
               units: seconds/s
               label_promotion: []
@@ -8782,6 +9205,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Accumulated Recovery-State Transition Latency
+              priority: 2220
               context: accumulated_recovery_state_latency
               units: seconds/s
               label_promotion: []
@@ -8854,6 +9278,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Client Operation Latency Measurements
+              priority: 2220
               context: client_operation_latency_measurements
               units: operations/s
               label_promotion: []
@@ -8871,6 +9296,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: SQLite VFS Operation Latency Measurements
+              priority: 2220
               context: sqlite_vfs_latency_measurements
               units: operations/s
               label_promotion: []
@@ -8914,6 +9340,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Client Operation Latency
+              priority: 2220
               context: accumulated_client_operation_latency
               units: seconds/s
               label_promotion: []
@@ -8932,6 +9359,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Accumulated SQLite VFS Operation Latency
+              priority: 2220
               context: accumulated_sqlite_vfs_latency
               units: seconds/s
               label_promotion: []
@@ -8976,6 +9404,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Monitors
+              priority: 2220
               context: monitor_state
               units: monitors
               label_promotion: []
@@ -8989,6 +9418,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: OSDs
+              priority: 2220
               context: osd_state
               units: OSDs
               label_promotion: []
@@ -9004,6 +9434,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Pools
+              priority: 2220
               context: pool_state
               units: pools
               label_promotion: []
@@ -9015,6 +9446,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: OSD-Map Epoch
+              priority: 2220
               context: osd_map_epoch
               units: epoch
               label_promotion: []
@@ -9026,6 +9458,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Duration and Time
+              priority: 2220
               context: duration
               units: seconds
               label_promotion: []
@@ -9041,6 +9474,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Invalidated Recovery Statistics
+              priority: 2220
               context: invalidations
               units: invalidations/s
               label_promotion: []
@@ -9052,6 +9486,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Objects
+              priority: 2220
               context: object_state
               units: objects
               label_promotion: []
@@ -9069,6 +9504,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Operations
+              priority: 2220
               context: operations
               units: operations/s
               label_promotion: []
@@ -9080,6 +9516,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Space and Memory
+              priority: 2220
               context: space
               units: bytes
               label_promotion: []
@@ -9097,6 +9534,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Placement Groups
+              priority: 2220
               context: pg_state
               units: PGs
               label_promotion: []
@@ -9114,6 +9552,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Client Latency Squared-Deviation Accumulators
+              priority: 2220
               context: client_latency_sqsum
               units: microseconds²/s
               label_promotion: []
@@ -9130,6 +9569,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: OpenFileTable OMAP Mutations
+              priority: 2220
               context: oft_omap_mutations
               units: operations/s
               label_promotion: []
@@ -9144,6 +9584,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Context Workers
+              priority: 2220
               context: worker_state
               units: workers
               label_promotion: []
@@ -9157,6 +9598,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: OpenFileTable Objects
+              priority: 2220
               context: oft_object_state
               units: objects
               label_promotion: []
@@ -9168,6 +9610,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: OpenFileTable Key-Value Pairs
+              priority: 2220
               context: oft_entry_state
               units: entries
               label_promotion: []
@@ -9184,6 +9627,7 @@ template:
             - ceph_trackedop_slow_ops_count
           charts:
             - title: Slow Operations
+              priority: 2220
               context: slow_operations
               units: operations/s
               label_promotion: []
@@ -9216,6 +9660,7 @@ template:
             - ceph_prioritycache:full_reserved_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -9271,6 +9716,7 @@ template:
             - ceph_prioritycache:inc_reserved_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -9326,6 +9772,7 @@ template:
             - ceph_prioritycache:kv_reserved_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -9372,6 +9819,7 @@ template:
             - ceph_prioritycache_unmapped_bytes
           charts:
             - title: Space and Memory
+              priority: 2100
               context: space
               units: bytes
               label_promotion: []
@@ -9401,6 +9849,7 @@ template:
             - ceph_rocksdb_compact_running
           charts:
             - title: Compaction Work
+              priority: 2100
               context: compaction_state
               units: compactions
               label_promotion: []
@@ -9415,6 +9864,7 @@ template:
                 optional_by_labels: []
               algorithm: absolute
             - title: Duration and Time
+              priority: 2100
               context: duration
               units: seconds
               label_promotion: []
@@ -9426,6 +9876,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Compactions
+              priority: 2100
               context: compactions
               units: compactions/s
               label_promotion: []
@@ -9439,6 +9890,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Compaction Queue Merges
+              priority: 2100
               context: queue_merges
               units: merges/s
               label_promotion: []
@@ -9460,6 +9912,7 @@ template:
             - ceph_rocksdb_submit_sync_latency_sum
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -9475,6 +9928,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -9503,6 +9957,7 @@ template:
             - ceph_rocksdb_rocksdb_write_wal_time_sum
           charts:
             - title: Latency Measurements
+              priority: 2100
               context: latency_measurements
               units: operations/s
               label_promotion: []
@@ -9520,6 +9975,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Accumulated Latency
+              priority: 2100
               context: accumulated_latency
               units: seconds/s
               label_promotion: []
@@ -9626,6 +10082,7 @@ template:
             - ceph_rbd_librbd_pwl_ws_lat_sum
           charts:
             - title: Reads
+              priority: 2210
               context: reads
               units: reads/s
               label_promotion: []
@@ -9642,6 +10099,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Writes
+              priority: 2210
               context: writes
               units: writes/s
               label_promotion: []
@@ -9666,6 +10124,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Log Appends
+              priority: 2210
               context: log_appends
               units: appends/s
               label_promotion: []
@@ -9678,6 +10137,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Cache and Image Operations
+              priority: 2210
               context: cache_image_operations
               units: operations/s
               label_promotion: []
@@ -9704,6 +10164,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Read Throughput
+              priority: 2210
               context: read_throughput
               units: bytes/s
               label_promotion: []
@@ -9718,6 +10179,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Write Throughput
+              priority: 2210
               context: write_throughput
               units: bytes/s
               label_promotion: []
@@ -9730,6 +10192,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Data-Operation Throughput
+              priority: 2210
               context: data_operation_throughput
               units: bytes/s
               label_promotion: []
@@ -9746,6 +10209,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Log-Append Throughput
+              priority: 2210
               context: log_append_throughput
               units: bytes/s
               label_promotion: []
@@ -9759,6 +10223,7 @@ template:
                   - librbd_pwl_key
               algorithm: incremental
             - title: Read Request Latency Measurements
+              priority: 2210
               context: read_latency_measurements
               units: requests/s
               label_promotion: []
@@ -9773,6 +10238,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Log-Append Size Measurements
+              priority: 2210
               context: log_append_size_measurements
               units: appends/s
               label_promotion: []
@@ -9785,6 +10251,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Write Request Latency Measurements
+              priority: 2210
               context: write_latency_measurements
               units: requests/s
               label_promotion: []
@@ -9815,6 +10282,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Log Operation Latency Measurements
+              priority: 2210
               context: log_operation_latency_measurements
               units: operations/s
               label_promotion: []
@@ -9841,6 +10309,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Data Operation Latency Measurements
+              priority: 2210
               context: data_operation_latency_measurements
               units: operations/s
               label_promotion: []
@@ -9861,6 +10330,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Transaction Latency Measurements
+              priority: 2210
               context: transaction_latency_measurements
               units: transactions/s
               label_promotion: []
@@ -9875,6 +10345,7 @@ template:
                 optional_by_labels:
                   - librbd_pwl_key
             - title: Accumulated Read Request Latency
+              priority: 2210
               context: accumulated_read_latency
               units: seconds/s
               label_promotion: []
@@ -9890,6 +10361,7 @@ template:
                   - librbd_pwl_key
               algorithm: incremental
             - title: Accumulated Write Request Latency
+              priority: 2210
               context: accumulated_write_latency
               units: seconds/s
               label_promotion: []
@@ -9921,6 +10393,7 @@ template:
                   - librbd_pwl_key
               algorithm: incremental
             - title: Accumulated Log Operation Latency
+              priority: 2210
               context: accumulated_log_operation_latency
               units: seconds/s
               label_promotion: []
@@ -9948,6 +10421,7 @@ template:
                   - librbd_pwl_key
               algorithm: incremental
             - title: Accumulated Data Operation Latency
+              priority: 2210
               context: accumulated_data_operation_latency
               units: seconds/s
               label_promotion: []
@@ -9969,6 +10443,7 @@ template:
                   - librbd_pwl_key
               algorithm: incremental
             - title: Accumulated Transaction Latency
+              priority: 2210
               context: accumulated_transaction_latency
               units: seconds/s
               label_promotion: []
@@ -9999,6 +10474,7 @@ template:
             - ceph_objectcacher_write_time_blocked
           charts:
             - title: Cache Outcomes
+              priority: 2210
               context: cache_outcomes
               units: operations/s
               label_promotion: []
@@ -10013,6 +10489,7 @@ template:
                 optional_by_labels:
                   - objectcacher_key
             - title: Cache Byte Outcomes
+              priority: 2210
               context: cache_byte_outcomes
               units: bytes/s
               label_promotion: []
@@ -10027,6 +10504,7 @@ template:
                 optional_by_labels:
                   - objectcacher_key
             - title: Data Throughput
+              priority: 2210
               context: data_throughput
               units: bytes/s
               label_promotion: []
@@ -10045,6 +10523,7 @@ template:
                 optional_by_labels:
                   - objectcacher_key
             - title: Blocked Writes
+              priority: 2210
               context: blocked_writes
               units: operations/s
               label_promotion: []
@@ -10057,6 +10536,7 @@ template:
                 optional_by_labels:
                   - objectcacher_key
             - title: Blocked Write Throughput
+              priority: 2210
               context: blocked_write_throughput
               units: bytes/s
               label_promotion: []
@@ -10069,6 +10549,7 @@ template:
                 optional_by_labels:
                   - objectcacher_key
             - title: Blocked Write Time
+              priority: 2210
               context: blocked_write_time
               units: seconds/s
               label_promotion: []
@@ -10089,6 +10570,7 @@ template:
             - ceph_finisher_queue_len
           charts:
             - title: Queued Callbacks
+              priority: 2210
               context: queue_depth
               units: callbacks
               label_promotion: []
@@ -10101,6 +10583,7 @@ template:
                 optional_by_labels:
                   - finisher_key
             - title: Drained Completion Batches
+              priority: 2210
               context: completions
               units: batches/s
               label_promotion: []
@@ -10113,6 +10596,7 @@ template:
                 optional_by_labels:
                   - finisher_key
             - title: Accumulated Completion Latency
+              priority: 2210
               context: accumulated_completion_latency
               units: seconds/s
               label_promotion: []
@@ -10143,6 +10627,7 @@ template:
             - ceph_throttle_wait_sum
           charts:
             - title: Utilization
+              priority: 2210
               context: utilization
               units: slots
               label_promotion: []
@@ -10157,6 +10642,7 @@ template:
                 optional_by_labels:
                   - throttle_key
             - title: Operations
+              priority: 2210
               context: operations
               units: operations/s
               label_promotion: []
@@ -10179,6 +10665,7 @@ template:
                 optional_by_labels:
                   - throttle_key
             - title: Slot Throughput
+              priority: 2210
               context: slot_throughput
               units: slots/s
               label_promotion: []
@@ -10194,6 +10681,7 @@ template:
                 optional_by_labels:
                   - throttle_key
             - title: Waits
+              priority: 2210
               context: wait_measurements
               units: waits/s
               label_promotion: []
@@ -10206,6 +10694,7 @@ template:
                 optional_by_labels:
                   - throttle_key
             - title: Accumulated Wait Time
+              priority: 2210
               context: accumulated_wait_time
               units: seconds/s
               label_promotion: []
@@ -10225,6 +10714,7 @@ template:
             - ceph_kernel_device_discard_threads
           charts:
             - title: Discard Operations
+              priority: 2210
               context: discard_operations
               units: operations/s
               label_promotion: []
@@ -10237,6 +10727,7 @@ template:
                 optional_by_labels:
                   - kernel_device_key
             - title: Discard Threads
+              priority: 2210
               context: discard_threads
               units: threads
               label_promotion: []
@@ -10259,6 +10750,7 @@ template:
             - ceph_mclock_shard_mclock_recovery_queue_len
           charts:
             - title: Queue Depth
+              priority: 2210
               context: queue_depth
               units: operations
               label_promotion: []
@@ -10300,6 +10792,7 @@ template:
             - ceph_async_messenger_worker_msgr_send_messages_queue_lat_sum
           charts:
             - title: Messages
+              priority: 2210
               context: messages
               units: messages/s
               label_promotion: []
@@ -10314,6 +10807,7 @@ template:
                 optional_by_labels:
                   - messenger_worker
             - title: Byte Throughput
+              priority: 2210
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -10332,6 +10826,7 @@ template:
                 optional_by_labels:
                   - messenger_worker
             - title: Connections
+              priority: 2210
               context: connections
               units: connections
               label_promotion: []
@@ -10345,6 +10840,7 @@ template:
                   - messenger_worker
               algorithm: absolute
             - title: Created Connections
+              priority: 2210
               context: created_connections
               units: connections/s
               label_promotion: []
@@ -10357,6 +10853,7 @@ template:
                 optional_by_labels:
                   - messenger_worker
             - title: Accumulated Worker Time
+              priority: 2210
               context: accumulated_worker_time
               units: seconds/s
               label_promotion: []
@@ -10376,6 +10873,7 @@ template:
                   - messenger_worker
               algorithm: incremental
             - title: Send-Queue Latency Measurements
+              priority: 2210
               context: send_queue_latency_measurements
               units: messages/s
               label_promotion: []
@@ -10388,6 +10886,7 @@ template:
                 optional_by_labels:
                   - messenger_worker
             - title: Acknowledgement Latency Measurements
+              priority: 2210
               context: ack_latency_measurements
               units: acknowledgements/s
               label_promotion: []
@@ -10400,6 +10899,7 @@ template:
                 optional_by_labels:
                   - messenger_worker
             - title: Accumulated Send-Queue Latency
+              priority: 2210
               context: accumulated_send_queue_latency
               units: seconds/s
               label_promotion: []
@@ -10413,6 +10913,7 @@ template:
                   - messenger_worker
               algorithm: incremental
             - title: Accumulated Acknowledgement Latency
+              priority: 2210
               context: accumulated_ack_latency
               units: seconds/s
               label_promotion: []
@@ -10438,6 +10939,7 @@ template:
             - ceph_async_messenger_rdma_worker_tx_parital_mem
           charts:
             - title: RDMA Transfer Errors
+              priority: 2210
               context: transfer_errors
               units: errors/s
               label_promotion: []
@@ -10454,6 +10956,7 @@ template:
                 optional_by_labels:
                   - rdma_worker
             - title: Chunk Throughput
+              priority: 2210
               context: chunk_throughput
               units: chunks/s
               label_promotion: []
@@ -10468,6 +10971,7 @@ template:
                 optional_by_labels:
                   - rdma_worker
             - title: Byte Throughput
+              priority: 2210
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -10482,6 +10986,7 @@ template:
                 optional_by_labels:
                   - rdma_worker
             - title: Pending Connections
+              priority: 2210
               context: pending_connections
               units: connections
               label_promotion: []
@@ -10516,6 +11021,7 @@ template:
             - ceph_dpdk_queue_dpdk_send_queue_length
           charts:
             - title: Packets
+              priority: 2210
               context: packets
               units: packets/s
               label_promotion: []
@@ -10530,6 +11036,7 @@ template:
                 optional_by_labels:
                   - dpdk_queue
             - title: Byte Throughput
+              priority: 2210
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -10548,6 +11055,7 @@ template:
                 optional_by_labels:
                   - dpdk_queue
             - title: Packet Fragments
+              priority: 2210
               context: packet_fragments
               units: fragments/s
               label_promotion: []
@@ -10562,6 +11070,7 @@ template:
                 optional_by_labels:
                   - dpdk_queue
             - title: Copy and Linearize Operations
+              priority: 2210
               context: copy_linearize_operations
               units: operations/s
               label_promotion: []
@@ -10580,6 +11089,7 @@ template:
                 optional_by_labels:
                   - dpdk_queue
             - title: Receive Errors
+              priority: 2210
               context: receive_errors
               units: errors/s
               label_promotion: []
@@ -10594,6 +11104,7 @@ template:
                 optional_by_labels:
                   - dpdk_queue
             - title: Last Batch Size
+              priority: 2210
               context: last_batch_size
               units: packets
               label_promotion: []
@@ -10609,6 +11120,7 @@ template:
                   - dpdk_queue
               algorithm: absolute
             - title: Send Queue Depth
+              priority: 2210
               context: send_queue_depth
               units: packets
               label_promotion: []
@@ -10632,6 +11144,7 @@ template:
             - ceph_dpdk_port_dpdk_device_send_total_errors
           charts:
             - title: Multicast Packets
+              priority: 2210
               context: multicast_packets
               units: packets/s
               label_promotion: []
@@ -10644,6 +11157,7 @@ template:
                 optional_by_labels:
                   - dpdk_port
             - title: Receive Errors
+              priority: 2210
               context: receive_errors
               units: errors/s
               label_promotion: []
@@ -10662,6 +11176,7 @@ template:
                 optional_by_labels:
                   - dpdk_port
             - title: Send Errors
+              priority: 2210
               context: send_errors
               units: errors/s
               label_promotion: []
@@ -10679,6 +11194,7 @@ template:
             - ceph_service_unique_id
           charts:
             - title: Service Identity Metadata Sentinel
+              priority: 2210
               context: identity_metadata
               units: identifier
               label_promotion: []
@@ -10703,6 +11219,7 @@ template:
             - ceph_libcephsqlite_striper_update_version
           charts:
             - title: Metadata and Lock Work
+              priority: 2210
               context: metadata_and_lock_work
               units: operations/s
               label_promotion: []
@@ -10726,6 +11243,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Shrink Throughput
+              priority: 2210
               context: shrink_throughput
               units: bytes/s
               label_promotion: []
@@ -10801,6 +11319,7 @@ template:
             - ceph_mempool_unittest_2_items
           charts:
             - title: Memory Use
+              priority: 2210
               context: memory_use
               units: bytes
               label_promotion: []
@@ -10870,6 +11389,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Item Count
+              priority: 2210
               context: item_count
               units: items
               label_promotion: []
@@ -10948,6 +11468,7 @@ template:
             - ceph_cephfs_mirror_mirrored_filesystems
           charts:
             - title: Mirrored Filesystems
+              priority: 1820
               context: filesystems
               units: filesystems
               label_promotion: []
@@ -10959,6 +11480,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Mirroring Enable Failures
+              priority: 1820
               context: enable_failures
               units: failures/s
               label_promotion: []
@@ -10976,6 +11498,7 @@ template:
             - ceph_cephfs_mirror_mirrored_filesystems_mirroring_peers
           charts:
             - title: Mirroring Peers
+              priority: 1820
               context: peers
               units: peers
               label_promotion: []
@@ -10988,6 +11511,7 @@ template:
                   - filesystem
                 optional_by_labels: []
             - title: Mirrored Directories
+              priority: 1820
               context: directories
               units: directories
               label_promotion: []
@@ -11015,6 +11539,7 @@ template:
             - ceph_cephfs_mirror_peers_sync_failures
           charts:
             - title: Snapshot Outcomes
+              priority: 1820
               context: snapshot_outcomes
               units: snapshots/s
               label_promotion: []
@@ -11036,6 +11561,7 @@ template:
                   - source_fscid
                 optional_by_labels: []
             - title: Sync-Time Measurements
+              priority: 1820
               context: sync_time_measurements
               units: snapshots/s
               label_promotion: []
@@ -11051,6 +11577,7 @@ template:
                   - source_fscid
                 optional_by_labels: []
             - title: Accumulated Sync Time
+              priority: 1820
               context: accumulated_sync_time
               units: seconds/s
               label_promotion: []
@@ -11067,6 +11594,7 @@ template:
                 optional_by_labels: []
               algorithm: incremental
             - title: Sync Throughput
+              priority: 1820
               context: sync_throughput
               units: bytes/s
               label_promotion: []
@@ -11082,6 +11610,7 @@ template:
                   - source_fscid
                 optional_by_labels: []
             - title: Last Sync Timestamps
+              priority: 1820
               context: last_sync_timestamps
               units: seconds since epoch
               label_promotion: []
@@ -11099,6 +11628,7 @@ template:
                   - source_fscid
                 optional_by_labels: []
             - title: Last Sync Duration
+              priority: 1820
               context: last_sync_duration
               units: seconds
               label_promotion: []
@@ -11114,6 +11644,7 @@ template:
                   - source_fscid
                 optional_by_labels: []
             - title: Last Sync Size
+              priority: 1820
               context: last_sync_size
               units: bytes
               label_promotion: []
@@ -11194,6 +11725,7 @@ template:
         - ceph_dmclock_scheduler_throttle
       charts:
         - title: Queue Depth
+          priority: 1730
           context: queue_depth
           units: requests
           label_promotion: []
@@ -11211,6 +11743,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Simple Throttler Outstanding Requests
+          priority: 1730
           context: simple_throttler_outstanding
           units: requests
           label_promotion: []
@@ -11222,6 +11755,7 @@ template:
               - instance_id
             optional_by_labels: []
         - title: Simple Throttler Rejections
+          priority: 1730
           context: simple_throttler_rejections
           units: requests/s
           label_promotion: []
@@ -11234,6 +11768,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Queued Request Cost
+          priority: 1730
           context: queue_cost
           units: cost
           label_promotion: []
@@ -11251,6 +11786,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Scheduled Requests
+          priority: 1730
           context: scheduled_requests
           units: requests/s
           label_promotion: []
@@ -11276,6 +11812,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Rejected and Cancelled Requests
+          priority: 1730
           context: rejected_and_cancelled_requests
           units: requests/s
           label_promotion: []
@@ -11301,6 +11838,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Scheduled and Rejected Cost
+          priority: 1730
           context: scheduled_and_rejected_cost
           units: cost/s
           label_promotion: []
@@ -11342,6 +11880,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Scheduling-Latency Measurements
+          priority: 1730
           context: latency_measurements
           units: requests/s
           label_promotion: []
@@ -11367,6 +11906,7 @@ template:
               - ceph_daemon
             optional_by_labels: []
         - title: Accumulated Scheduling Latency
+          priority: 1730
           context: accumulated_latency
           units: seconds/s
           label_promotion: []
@@ -11393,6 +11933,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Throttled Requests
+          priority: 1730
           context: throttled_requests
           units: requests/s
           label_promotion: []
@@ -11405,6 +11946,7 @@ template:
             optional_by_labels: []
           algorithm: incremental
         - title: Outstanding Requests
+          priority: 1730
           context: outstanding_requests
           units: requests
           label_promotion: []
@@ -11431,6 +11973,7 @@ template:
             - ceph_rocksdb_binned_cache_usage
           charts:
             - title: Cache Memory
+              priority: 2110
               context: memory
               units: bytes
               label_promotion: []
@@ -11447,6 +11990,7 @@ template:
                 optional_by_labels:
                   - rocksdb_cache_key
             - title: Cache Entries
+              priority: 2110
               context: entries
               units: entries
               label_promotion: []
@@ -11459,6 +12003,7 @@ template:
                 optional_by_labels:
                   - rocksdb_cache_key
             - title: Cache Insertions
+              priority: 2110
               context: insertions
               units: insertions/s
               label_promotion: []
@@ -11472,6 +12017,7 @@ template:
                   - rocksdb_cache_key
               algorithm: incremental
             - title: Cache Lookups
+              priority: 2110
               context: lookups
               units: lookups/s
               label_promotion: []
@@ -11485,6 +12031,7 @@ template:
                   - rocksdb_cache_key
               algorithm: incremental
             - title: Cache Lookup Outcomes
+              priority: 2110
               context: lookup_outcomes
               units: lookups/s
               label_promotion: []
@@ -11513,6 +12060,7 @@ template:
             - ceph_extblkdev_part_phy_size
           charts:
             - title: FCM Plugin State
+              priority: 2110
               context: plugin_state
               units: '{status}'
               label_promotion: []
@@ -11524,6 +12072,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Device Size
+              priority: 2110
               context: device_size
               units: bytes
               label_promotion: []
@@ -11537,6 +12086,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Device Utilization
+              priority: 2110
               context: device_utilization
               units: bytes
               label_promotion: []
@@ -11550,6 +12100,7 @@ template:
                   - ceph_daemon
                 optional_by_labels: []
             - title: Partition Space
+              priority: 2110
               context: partition_space
               units: bytes
               label_promotion: []
@@ -11574,6 +12125,7 @@ template:
         - ceph_client_wrops
       charts:
         - title: Client I/O Operations
+          priority: 2230
           context: io_operations
           units: operations/s
           label_promotion: []
@@ -11605,6 +12157,7 @@ template:
             - ceph_nvmeof_bdev_written_bytes_total
           charts:
             - title: Byte Throughput
+              priority: 2000
               context: byte_throughput
               units: bytes/s
               label_promotion: []
@@ -11618,6 +12171,7 @@ template:
                   - bdev_name
                 optional_by_labels: []
             - title: Operations
+              priority: 2000
               context: operations
               units: operations/s
               label_promotion: []
@@ -11631,6 +12185,7 @@ template:
                   - bdev_name
                 optional_by_labels: []
             - title: Space and Memory
+              priority: 2000
               context: space
               units: bytes
               label_promotion: []
@@ -11642,6 +12197,7 @@ template:
                   - bdev_name
                 optional_by_labels: []
             - title: State and Metadata
+              priority: 2000
               context: state
               units: '{status}'
               label_promotion: []
@@ -11657,6 +12213,7 @@ template:
                   - rbd_name
                 optional_by_labels: []
             - title: Accumulated Time
+              priority: 2000
               context: time_accumulation
               units: seconds/s
               label_promotion: []
@@ -11677,6 +12234,7 @@ template:
             - ceph_nvmeof_subsystem_namespace_count
           charts:
             - title: Collection Duration
+              priority: 2000
               context: duration
               units: seconds
               label_promotion: []
@@ -11688,6 +12246,7 @@ template:
                   - method
                 optional_by_labels: []
             - title: Accumulated Time
+              priority: 2000
               context: time_accumulation
               units: seconds/s
               label_promotion: []
@@ -11699,6 +12258,7 @@ template:
                   - name
                 optional_by_labels: []
             - title: Namespace Count
+              priority: 2000
               context: namespace_count
               units: namespaces
               label_promotion: []
@@ -11713,6 +12273,7 @@ template:
             - ceph_nvmeof_host_keepalive_timeout
           charts:
             - title: Host Connection State
+              priority: 2000
               context: connection_state
               units: '{status}'
               label_promotion: []
@@ -11727,6 +12288,7 @@ template:
                   - nqn
                 optional_by_labels: []
             - title: Keepalive Timeout State
+              priority: 2000
               context: keepalive_timeout_state
               units: '{status}'
               label_promotion: []
@@ -11751,6 +12313,7 @@ template:
             - ceph_nvmeof_subsystem_namespace_metadata
           charts:
             - title: Configured Hosts
+              priority: 2000
               context: host_state
               units: hosts
               label_promotion: []
@@ -11762,6 +12325,7 @@ template:
                   - nqn
                 optional_by_labels: []
             - title: Listener Interface Link Speed
+              priority: 2000
               context: link_speed
               units: Mbps
               label_promotion: []
@@ -11773,6 +12337,7 @@ template:
                   - device
                 optional_by_labels: []
             - title: Listener Addresses
+              priority: 2000
               context: listener_state
               units: listeners
               label_promotion: []
@@ -11784,6 +12349,7 @@ template:
                   - nqn
                 optional_by_labels: []
             - title: Namespaces
+              priority: 2000
               context: namespace_count
               units: namespaces
               label_promotion: []
@@ -11795,6 +12361,7 @@ template:
                   - nqn
                 optional_by_labels: []
             - title: Namespace Capacity
+              priority: 2000
               context: namespace_capacity
               units: namespaces
               label_promotion: []
@@ -11808,6 +12375,7 @@ template:
                   - nqn
                 optional_by_labels: []
             - title: State and Metadata — Metadata
+              priority: 2000
               context: state_metadata
               units: '{status}'
               label_promotion: []
@@ -11824,6 +12392,7 @@ template:
                   - serial_number
                 optional_by_labels: []
             - title: State and Metadata — Namespace Metadata
+              priority: 2000
               context: state_namespace_metadata
               units: '{status}'
               label_promotion: []

--- a/src/go/tools/prometheus-profile-validation/README.md
+++ b/src/go/tools/prometheus-profile-validation/README.md
@@ -200,7 +200,7 @@ For the supplied dump and job policy, a pass establishes that:
   and effective contexts do not normalize to empty;
 - observed dynamic dimension names do not collapse into duplicate emitted wire
   IDs or sanitize to an omitted empty ID;
-- every chart omits explicit priority so all use the common runtime default;
+- explicit chart priorities, when present, are preserved and verified; charts without priority use the common runtime default;
 - every chart has at least one visible dimension;
 - histogram bucket charts use observation-rate units and incremental semantics.
 


### PR DESCRIPTION
## Summary

- Allows explicit chart priorities in contributed Prometheus profiles and preserves them through profile validation and semantic reconciliation.
- Orders the Ceph profile by the operator journey: cluster overview and health first, then capacity/control plane/OSDs, storage services, and runtime details last.
- Flattens release-specific OSD scrubbing navigation from `OSDs/Scrubbing/Ceph 19/...` to `OSDs/Scrubbing Ceph 19/...`.
- Makes the profile ToC helper rank parent families by their minimum descendant chart priority and adds a regression test for that behavior.

## Validation

- `go test ./internal/promprofile/... ./plugin/go.d/collector/prometheus -count=1`
- `python3 -m unittest discover -s .agents/skills/project-prometheus-profiles/scripts -p 'test_*.py'`
- `git diff --check`
- Installed the candidate profile on the authorized Ceph lab and verified ordered live priorities, zero raw Ceph fallback contexts, and active Agents on all nine nodes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Orders Ceph Prometheus profile charts using operator-defined priorities to reflect the expected troubleshooting flow. Previously explicit priorities were rejected and ordering fell back to a uniform default; now positive priorities are preserved end-to-end, ToC sections sort by the minimum descendant priority, and non-positive values fall back to 70000.

- Validation and semantics accept and propagate authored chart `priority`; remove the `priority_forbidden` finding and add coverage in Go and Python tests.
- Profile ToC ranks parent families by the minimum descendant chart priority (not just direct children) and treats non-positive priorities as the runtime default.
- Ceph profile assigns priorities to put overview/health first, then capacity/control plane/OSDs, storage services, and runtime details last; flattens OSD scrubbing paths from Ceph/OSDs/Scrubbing/Ceph 19/... to Ceph/OSDs/Scrubbing Ceph 19/... (and Ceph 20/Common Work variants).
- Documentation clarifies to set `priority` only where navigation order matters; the validator README notes that explicit priorities are preserved.
- Migration: add `priority` only at boundaries that need stable ordering; omit elsewhere to use the `70000` default.

<sup>Written for commit 284d695b29bd3edb31ec17569ae00c86e1ea56d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chart priorities can be explicitly set to define meaningful operator navigation order.
  - Priority settings are preserved through profile validation and reconciliation.
  - Parent sections can follow the priority of nested charts.

- **Documentation**
  - Clarified when chart priorities should be used.
  - Charts without explicit priorities use the runtime default; YAML order does not determine presentation order.

- **Improvements**
  - Normalized Ceph scrubbing view family paths for more consistent profile presentation.
  - Non-positive priorities now use the runtime default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->