### PR TITLE
feat(go/charttpl): allow root groups without a family

### DIFF
--- a/.agents/skills/project-prometheus-profiles/SKILL.md
+++ b/.agents/skills/project-prometheus-profiles/SKILL.md
@@ -134,6 +134,10 @@ an explicit future input when the validator cannot derive it.
 
 - Use nested groups to express hierarchy. Child `context_namespace` segments join with `.` and child `family` segments
   join with `/`.
+- Omit the template root `family` when it would only repeat the resolved application; its named child groups then become
+  top-level families. Retain a meaningful root for reusable instrumentation profiles that compose into other
+  applications. Nested groups still require `family`, and a chart directly under a transparent root needs its own
+  chart-level `family`.
 - Use base units. Convert bytes to bits only when the operator convention is bandwidth in bits/s; otherwise multiplier and
   divisor are usually unnecessary.
 - Omit `algorithm` normally. Runtime counter kind resolves to `incremental`; gauges and other kinds resolve to `absolute`.

--- a/.agents/skills/project-prometheus-profiles/profile-schema.md
+++ b/.agents/skills/project-prometheus-profiles/profile-schema.md
@@ -213,6 +213,11 @@ Each field affects a different part of the dashboard:
 
 - `family` composes with ancestor families using `/`. This is navigation, so use
   application functions and entity levels rather than metric types.
+- The profile template root MAY omit `family` when it is only a transparent
+  container and the application already provides that navigation level. Keep a
+  meaningful root for reusable instrumentation profiles. Nested groups MUST
+  provide `family`; a chart directly under a transparent root MUST provide its
+  own chart-level `family`.
 - `context_namespace` composes with `.` into chart contexts. It is identity, not
   merely display text.
 - `metrics` authorizes exact metric names for dimension selectors in the group

--- a/src/go/plugin/framework/chartengine/compiler_test.go
+++ b/src/go/plugin/framework/chartengine/compiler_test.go
@@ -383,6 +383,32 @@ func TestCompileScenarios(t *testing.T) {
 				assert.False(t, charts[0].Dimensions[0].Selector.Matcher.Matches("mysql_queries", mapLabelView{}))
 			},
 		},
+		"transparent root does not shift nested family": {
+			spec: charttpl.Spec{
+				Version: charttpl.VersionV1,
+				Groups: []charttpl.Group{{
+					Metrics: []string{"service_requests_total"},
+					Groups: []charttpl.Group{{
+						Family: "Requests",
+						Charts: []charttpl.Chart{{
+							Title:   "Requests",
+							Context: "requests",
+							Units:   "requests/s",
+							Dimensions: []charttpl.Dimension{{
+								Selector: "service_requests_total",
+								Name:     "requests",
+							}},
+						}},
+					}},
+				}},
+			},
+			assert: func(t *testing.T, p *program.Program) {
+				t.Helper()
+				charts := p.Charts()
+				require.Len(t, charts, 1)
+				assert.Equal(t, "Requests", charts[0].Meta.Family)
+			},
+		},
 		"infer histogram dimension name_from_label and parse instance selectors": {
 			rev: 7,
 			spec: charttpl.Spec{

--- a/src/go/plugin/framework/charttpl/README.md
+++ b/src/go/plugin/framework/charttpl/README.md
@@ -385,7 +385,9 @@ Explicitly defined charts (like `execution_state`) use the template. Any _other_
 
 ### 4. groups
 
-Groups organize charts into a hierarchy that can be nested to **any depth**. Each group defines a **family** segment, can declare **metrics** in scope, and contains **charts** and/or nested **groups**.
+Groups organize charts into a hierarchy that can be nested to **any depth**. A root group may be a transparent container
+without its own `family`; every nested group defines a **family** segment. Groups can also declare **metrics** in scope
+and contain **charts** and/or nested **groups**.
 
 Nesting serves three purposes:
 
@@ -412,7 +414,7 @@ groups:
 
 | Field               | Type          | Required | Description                                                                         |
 |---------------------|---------------|----------|-------------------------------------------------------------------------------------|
-| `family`            | string        | **yes**  | Family segment. Groups compose the chart family hierarchy.                          |
+| `family`            | string        | root: no; nested: **yes** | Family segment. An omitted root is transparent; nested groups compose the hierarchy. |
 | `context_namespace` | string        | no       | Context segment appended to inherited context namespace.                            |
 | `metrics`           | array[string] | no       | Metrics visible to dimension selectors in this group and descendants.               |
 | `chart_defaults`    | object        | no       | Inheritable defaults for descendant charts (see [chart_defaults](#chart_defaults)). |
@@ -427,6 +429,10 @@ groups:
 | Nested group         | `InnoDB`                                |
 | Nested group         | `Buffer Pool`                           |
 | **Resulting family** | **`Storage Engine/InnoDB/Buffer Pool`** |
+
+A root group may omit `family` when it exists only to share metric scope, context namespace, or chart defaults. Its
+children then become the top-level family sections. Nested groups must always provide a nonblank family. A chart directly
+under a transparent root must provide `chart.family`, so every emitted chart still has a nonblank effective family.
 
 Here is a real-world nesting example showing how family and context compose at each level:
 
@@ -1154,7 +1160,8 @@ All rules below produce semantic validation errors unless noted:
 |-----------------------------------------------------------------------------------------|---------------------------------|
 | `version` must be `v1`                                                                  | semantic                        |
 | `groups[]` must be non-empty                                                            | semantic                        |
-| `group.family` must not be empty or whitespace-only                                     | semantic                        |
+| Root `group.family` may be omitted; nested `group.family` must be nonblank               | semantic                        |
+| A chart directly under a transparent root must provide a nonblank `chart.family`         | semantic                        |
 | `group.metrics[]` entries must not be empty; no duplicates within same group            | semantic                        |
 | `chart.title`, `chart.context`, `chart.units` must be non-empty                         | semantic                        |
 | `chart.algorithm` must be `absolute` or `incremental` (when specified)                  | semantic                        |
@@ -1189,7 +1196,7 @@ All rules below produce semantic validation errors unless noted:
 | Missing `chart.id`                      | `id` derived from `context` (`.` replaced with `_`).                                     |
 | Missing `chart.algorithm`               | Resolved per rendered dimension from runtime series kind: counter = `incremental`; every other kind = `absolute`. |
 | `chart.priority = 0`                    | Treated as `70000` (engine default).                                                     |
-| Group family hierarchy + `chart.family` | Composed into `/`-separated chart family.                                                |
+| Root/nested family hierarchy + `chart.family` | Nonblank segments compose into a `/`-separated chart family.                         |
 | `options.multiplier = 0`                | Treated as `1`.                                                                          |
 | `options.divisor = 0`                   | Treated as `1`.                                                                          |
 

--- a/src/go/plugin/framework/charttpl/config_schema.json
+++ b/src/go/plugin/framework/charttpl/config_schema.json
@@ -22,7 +22,7 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "#/$defs/group"
+        "$ref": "#/$defs/root_group"
       }
     }
   },
@@ -147,16 +147,13 @@
         }
       }
     },
-    "group": {
+    "root_group": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "family"
-      ],
       "properties": {
         "family": {
           "type": "string",
-          "minLength": 1
+          "pattern": "^$|\\S"
         },
         "context_namespace": {
           "type": "string"
@@ -181,6 +178,37 @@
           "items": {
             "$ref": "#/$defs/chart"
           }
+        }
+      },
+      "if": {
+        "required": [
+          "family"
+        ],
+        "properties": {
+          "family": {
+            "pattern": "\\S"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "charts": {
+            "items": {
+              "$ref": "#/$defs/chart_with_family"
+            }
+          }
+        }
+      }
+    },
+    "group": {
+      "$ref": "#/$defs/root_group",
+      "required": [
+        "family"
+      ],
+      "properties": {
+        "family": {
+          "type": "string",
+          "pattern": "\\S"
         }
       }
     },
@@ -259,6 +287,18 @@
           "items": {
             "$ref": "#/$defs/dimension"
           }
+        }
+      }
+    },
+    "chart_with_family": {
+      "$ref": "#/$defs/chart",
+      "required": [
+        "family"
+      ],
+      "properties": {
+        "family": {
+          "type": "string",
+          "pattern": "\\S"
         }
       }
     },

--- a/src/go/plugin/framework/charttpl/marshal_test.go
+++ b/src/go/plugin/framework/charttpl/marshal_test.go
@@ -94,6 +94,30 @@ func TestSpecMarshalTemplate(t *testing.T) {
 				assert.Empty(t, promotion)
 			},
 		},
+		"omits transparent root family and round trips": {
+			spec: Spec{
+				Version: VersionV1,
+				Groups: []Group{{
+					Metrics: []string{"m"},
+					Groups: []Group{{
+						Family: "Service",
+						Charts: []Chart{{
+							Title:      "C",
+							Context:    "c",
+							Units:      "u",
+							Dimensions: []Dimension{{Selector: "m", Name: "d"}},
+						}},
+					}},
+				}},
+			},
+			check: func(t *testing.T, out string) {
+				assert.NotContains(t, out, "family: \"\"")
+				reDecoded, err := DecodeYAML([]byte(out))
+				require.NoError(t, err)
+				require.Len(t, reDecoded.Groups, 1)
+				assert.Empty(t, reDecoded.Groups[0].Family)
+			},
+		},
 		"errors when groups missing": {
 			spec:    Spec{Version: VersionV1},
 			wantErr: true,

--- a/src/go/plugin/framework/charttpl/spec.go
+++ b/src/go/plugin/framework/charttpl/spec.go
@@ -57,7 +57,7 @@ type EngineAutogenRule struct {
 
 // Group is a recursive chart-group container.
 type Group struct {
-	Family           string         `yaml:"family" json:"family"`
+	Family           string         `yaml:"family,omitempty" json:"family,omitempty"`
 	ContextNamespace string         `yaml:"context_namespace,omitempty" json:"context_namespace,omitempty"`
 	Metrics          []string       `yaml:"metrics,omitempty" json:"metrics,omitempty"`
 	ChartDefaults    *ChartDefaults `yaml:"chart_defaults,omitempty" json:"chart_defaults,omitempty"`

--- a/src/go/plugin/framework/charttpl/spec_test.go
+++ b/src/go/plugin/framework/charttpl/spec_test.go
@@ -611,8 +611,9 @@ func TestConfigSchemaRootGroupFamily(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		"nested group without family": {
+		"nested group without family under transparent root": {
 			mutate: func(root map[string]any) {
+				delete(root, "family")
 				child := map[string]any{"charts": root["charts"]}
 				delete(root, "charts")
 				root["groups"] = []any{child}

--- a/src/go/plugin/framework/charttpl/spec_test.go
+++ b/src/go/plugin/framework/charttpl/spec_test.go
@@ -563,6 +563,86 @@ func TestConfigSchemaOptionalInstanceLabels(t *testing.T) {
 	}
 }
 
+func TestConfigSchemaRootGroupFamily(t *testing.T) {
+	var schemaDoc any
+	require.NoError(t, json.Unmarshal([]byte(ConfigSchemaJSON), &schemaDoc))
+	compiler := jsonschema.NewCompiler()
+	require.NoError(t, compiler.AddResource("charttpl.schema.json", schemaDoc))
+	schema, err := compiler.Compile("charttpl.schema.json")
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		mutate  func(root map[string]any)
+		wantErr bool
+	}{
+		"transparent root with named child": {
+			mutate: func(root map[string]any) {
+				delete(root, "family")
+				child := map[string]any{
+					"family": rootFamilyTestName,
+					"charts": root["charts"],
+				}
+				delete(root, "charts")
+				root["groups"] = []any{child}
+			},
+		},
+		"transparent root with chart family": {
+			mutate: func(root map[string]any) {
+				delete(root, "family")
+				charts := root["charts"].([]any)
+				charts[0].(map[string]any)["family"] = rootFamilyTestName
+			},
+		},
+		"transparent root rejects whitespace family": {
+			mutate: func(root map[string]any) {
+				root["family"] = " "
+				child := map[string]any{
+					"family": rootFamilyTestName,
+					"charts": root["charts"],
+				}
+				delete(root, "charts")
+				root["groups"] = []any{child}
+			},
+			wantErr: true,
+		},
+		"transparent root without effective chart family": {
+			mutate: func(root map[string]any) {
+				delete(root, "family")
+			},
+			wantErr: true,
+		},
+		"nested group without family": {
+			mutate: func(root map[string]any) {
+				child := map[string]any{"charts": root["charts"]}
+				delete(root, "charts")
+				root["groups"] = []any{child}
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			raw, err := json.Marshal(validationSpec())
+			require.NoError(t, err)
+			var instance map[string]any
+			require.NoError(t, json.Unmarshal(raw, &instance))
+			groups := instance["groups"].([]any)
+			root := groups[0].(map[string]any)
+			tc.mutate(root)
+
+			err = schema.Validate(instance)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+const rootFamilyTestName = "Service"
+
 func TestDecodeYAMLFileScenarios(t *testing.T) {
 	tests := map[string]struct {
 		prepare func(t *testing.T) string

--- a/src/go/plugin/framework/charttpl/validate.go
+++ b/src/go/plugin/framework/charttpl/validate.go
@@ -68,16 +68,28 @@ func Validate(s *Spec) (Validation, error) {
 	errs = append(errs, err)
 
 	for i := range s.Groups {
-		errs = append(errs, validateGroup(s.Groups[i], fmt.Sprintf("groups[%d]", i), nil))
+		errs = append(errs, validateGroup(s.Groups[i], fmt.Sprintf("groups[%d]", i), nil, false, false))
 	}
 	return Validation{autogenRules: rules}, errors.Join(errs...)
 }
 
-func validateGroup(group Group, path string, inheritedMetrics map[string]struct{}) error {
+func validateGroup(
+	group Group,
+	path string,
+	inheritedMetrics map[string]struct{},
+	inheritedFamily bool,
+	requireFamily bool,
+) error {
 	var errs []error
-	if strings.TrimSpace(group.Family) == "" {
-		errs = append(errs, semErr(path+".family", "must not be empty"))
+	family := strings.TrimSpace(group.Family)
+	if family == "" {
+		if requireFamily {
+			errs = append(errs, semErr(path+".family", "must not be empty"))
+		} else if group.Family != "" {
+			errs = append(errs, semErr(path+".family", "must not be whitespace-only"))
+		}
 	}
+	effectiveFamily := inheritedFamily || family != ""
 	errs = append(errs, validateChartDefaults(group.ChartDefaults, path))
 
 	ownMetrics := make(map[string]struct{}, len(group.Metrics))
@@ -102,10 +114,20 @@ func validateGroup(group Group, path string, inheritedMetrics map[string]struct{
 	}
 
 	for i := range group.Charts {
+		if !effectiveFamily && strings.TrimSpace(group.Charts[i].Family) == "" {
+			errs = append(errs, semErr(fmt.Sprintf("%s.charts[%d].family", path, i),
+				"must not be empty when no group family is set"))
+		}
 		errs = append(errs, validateChart(group.Charts[i], fmt.Sprintf("%s.charts[%d]", path, i), effective))
 	}
 	for i := range group.Groups {
-		errs = append(errs, validateGroup(group.Groups[i], fmt.Sprintf("%s.groups[%d]", path, i), effective))
+		errs = append(errs, validateGroup(
+			group.Groups[i],
+			fmt.Sprintf("%s.groups[%d]", path, i),
+			effective,
+			effectiveFamily,
+			true,
+		))
 	}
 	return errors.Join(errs...)
 }

--- a/src/go/plugin/framework/charttpl/validate_test.go
+++ b/src/go/plugin/framework/charttpl/validate_test.go
@@ -869,11 +869,12 @@ func TestSpecValidateRootGroupFamily(t *testing.T) {
 			},
 			wantErr: "groups[0].charts[0].family",
 		},
-		"nested group without family": {
+		"nested group without family under transparent root": {
 			mutate: func(spec *Spec) {
 				root := &spec.Groups[0]
 				child := root.Clone()
 				child.Family = ""
+				root.Family = ""
 				root.Charts = nil
 				root.Groups = []Group{child}
 			},

--- a/src/go/plugin/framework/charttpl/validate_test.go
+++ b/src/go/plugin/framework/charttpl/validate_test.go
@@ -831,6 +831,71 @@ func TestSpecValidateNilAndVersion(t *testing.T) {
 	assert.ErrorContains(t, err, "expected \"v1\"")
 }
 
+func TestSpecValidateRootGroupFamily(t *testing.T) {
+	tests := map[string]struct {
+		mutate  func(spec *Spec)
+		wantErr string
+	}{
+		"transparent root with named child": {
+			mutate: func(spec *Spec) {
+				root := &spec.Groups[0]
+				child := root.Clone()
+				child.Family = "Service"
+				root.Family = ""
+				root.Charts = nil
+				root.Groups = []Group{child}
+			},
+		},
+		"transparent root with chart family": {
+			mutate: func(spec *Spec) {
+				spec.Groups[0].Family = ""
+				spec.Groups[0].Charts[0].Family = "Service"
+			},
+		},
+		"transparent root rejects whitespace family": {
+			mutate: func(spec *Spec) {
+				root := &spec.Groups[0]
+				child := root.Clone()
+				child.Family = "Service"
+				root.Family = " "
+				root.Charts = nil
+				root.Groups = []Group{child}
+			},
+			wantErr: "groups[0].family",
+		},
+		"transparent root without effective chart family": {
+			mutate: func(spec *Spec) {
+				spec.Groups[0].Family = ""
+			},
+			wantErr: "groups[0].charts[0].family",
+		},
+		"nested group without family": {
+			mutate: func(spec *Spec) {
+				root := &spec.Groups[0]
+				child := root.Clone()
+				child.Family = ""
+				root.Charts = nil
+				root.Groups = []Group{child}
+			},
+			wantErr: "groups[0].groups[0].family",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			spec := validationSpec()
+			tc.mutate(&spec)
+			err := spec.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
 func TestSpecValidateReportsAllSemanticErrors(t *testing.T) {
 	spec := Spec{
 		Version: VersionV1,

--- a/src/go/plugin/go.d/collector/prometheus/chart_template_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/chart_template_test.go
@@ -102,6 +102,41 @@ func TestBuildMergedChartTemplateAutogenRulesPreserveProfileScopes(t *testing.T)
 	}, spec.Engine.Autogen.Rules)
 }
 
+func TestBuildMergedChartTemplateAllowsTransparentProfileRoot(t *testing.T) {
+	catalog := loadTestCatalog(t, map[string]string{
+		"app": `
+match: "app_*"
+template:
+  context_namespace: app
+  metrics:
+    - app_requests_total
+  groups:
+    - family: Requests
+      charts:
+        - title: Requests
+          context: requests
+          units: requests/s
+          dimensions:
+            - selector: app_requests_total
+              name: requests
+`,
+	})
+	profiles, err := catalog.Resolve([]string{"app"})
+	require.NoError(t, err)
+
+	out, err := buildMergedChartTemplate("app", profiles)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "family: \"\"")
+
+	spec, err := charttpl.DecodeYAML([]byte(out))
+	require.NoError(t, err)
+	compiled, err := chartengine.Compile(spec, 1)
+	require.NoError(t, err)
+	charts := compiled.Charts()
+	require.Len(t, charts, 1)
+	assert.Equal(t, "Requests", charts[0].Meta.Family)
+}
+
 func TestBuildMergedChartTemplateHistogramProfileSuppressesFallbackComponents(t *testing.T) {
 	catalog := loadTestCatalog(t, map[string]string{
 		"latency": `

--- a/src/go/plugin/go.d/collector/prometheus/profile-format.md
+++ b/src/go/plugin/go.d/collector/prometheus/profile-format.md
@@ -65,7 +65,7 @@ autogen:                    # optional. Controls fallback charts inside this
       - example_http_request_duration_seconds
 
 template:                   # REQUIRED. One chart-template group; at least one chart.
-  family: Example           # top-level dashboard menu section
+  family: Example           # optional root dashboard section; nested families remain required
   context_namespace: example  # context prefix; by convention the profile name
   groups:
     - family: Requests      # nested menu section: Example -> Requests
@@ -402,6 +402,11 @@ dimension, presentation, and selector field. Prometheus profiles add these rules
   `version` and `engine` fields are rejected. The collector wraps your group into its per-job spec, where autogeneration
   for uncovered metrics stays enabled. Configure conditional fallback through the profile-root `autogen.selector`, not
   a nested `engine`.
+- **Root `family` is optional.** Omit `template.family` when the template root is only a container and the resolved
+  application already provides the same navigation level. Its named child groups then become the top-level families.
+  Keep a meaningful root on reusable instrumentation profiles so their charts remain identifiable when composed into
+  another application. Nested groups still require `family`; a chart directly under a family-less root must set its own
+  `family`, so every emitted chart has a nonblank effective family.
 - **Set `context_namespace` at the template root to the profile name.** This is the group-level `context_namespace`
   field -- a profile has no separate top-level one; the collector supplies the `prometheus.<app>` prefix. The emitted
   context is `prometheus.<app>.<context_namespace>.<chart context>`, with the namespace segment dropped when it equals

--- a/src/go/plugin/go.d/collector/prometheus/promprofiles/profile_test.go
+++ b/src/go/plugin/go.d/collector/prometheus/promprofiles/profile_test.go
@@ -49,6 +49,22 @@ template:
           name: d0
 `,
 		},
+		"valid with transparent template root": {
+			yaml: `match: "a_*"
+template:
+  metrics:
+    - a_total
+  groups:
+    - family: Requests
+      charts:
+        - title: Title
+          context: ctx
+          units: count
+          dimensions:
+            - selector: a_total
+              name: d0
+`,
+		},
 		"valid chart aggregation": {
 			yaml: `match: "a_*"
 template:


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `charttpl` templates to omit the root group family so profile roots can be transparent containers. Previously the root family was required; now only nested groups must set `family`, and charts directly under a transparent root must set `chart.family` to keep a nonblank effective family.

- Schema: `config_schema.json` adds `root_group` with conditional validation. Root `family` may be omitted (not whitespace); nested `group.family` remains required; charts under a family-less root must use `chart.family`. Introduces `chart_with_family` for this case.
- Validation: Mirrors schema, tracking inherited family and erroring on whitespace roots, missing nested `group.family`, and missing `chart.family` under a transparent root.
- Encoding: `Group.Family` uses `omitempty` so transparent roots do not serialize a blank family; round-trip and unnamed-root nesting tests added.
- Behavior: Family composition is unchanged; a transparent root does not shift nested family segments. Verified in `chartengine` compile tests and added coverage for unnamed root nesting.
- Docs: Updated `charttpl` README, Prometheus profile format, and schema guidance to document optional root families; examples adjusted.
- Prometheus profiles: `go.d` profile builder accepts transparent template roots; tests ensure merged templates compile and produce expected families.

- Migration
  - No action for existing specs. To adopt the new form: omit only the root `family`; keep `family` on all nested groups, and add `chart.family` for any chart directly under a family-less root. Avoid whitespace-only `family` values.

<sup>Written for commit 551f94f7f94f8ca121b276f8a337223f0e15318e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template roots may omit redundant family names when they transparently contain reusable charts or groups.
  * Charts and nested groups continue to require explicit family names when no family is inherited.
* **Bug Fixes**
  * Prevented transparent template roots from incorrectly changing the family assigned to nested charts.
  * Improved serialization and profile merging to avoid empty family values.
* **Documentation**
  * Updated profile format, schema, and validation guidance for transparent roots and family inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->