### PR TITLE
perf(rrd): avoid redundant chart metadata re-interning

### DIFF
--- a/src/database/rrd.c
+++ b/src/database/rrd.c
@@ -29,14 +29,24 @@ STRING *rrd_string_strdupz(const char *s) {
 
     size_t len = strlen(s);
     size_t dst_size = (len * 2) + 1;
-    char *buf = mallocz(dst_size);
+
+    // The sanitized copy is scratch: it is interned and thrown away immediately.
+    // Keep it on the stack for the sizes chart metadata actually uses, so the hot path
+    // (re-registration of an already known chart, which on a parent is continuous)
+    // does not touch the allocator at all. Ids may be up to RRD_ID_LENGTH_MAX, so the
+    // heap fallback stays for the long ones.
+    char stack_buf[512];
+    char *buf = (dst_size <= sizeof(stack_buf)) ? stack_buf : mallocz(dst_size);
 
     // Sanitize the string, preserving valid UTF-8
     text_sanitize((unsigned char *)buf, (const unsigned char *)s, dst_size,
                   rrd_string_allowed_chars, true, "", NULL);
 
     STRING *result = string_strdupz(buf);
-    freez(buf);
+
+    if(buf != stack_buf)
+        freez(buf);
+
     return result;
 }
 

--- a/src/database/rrdset-index-id.c
+++ b/src/database/rrdset-index-id.c
@@ -191,6 +191,26 @@ static void rrdset_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     memset(st, 0, sizeof(RRDSET));
 }
 
+// Re-intern a chart metadata field only when the incoming raw value differs from the
+// already-stored one, and report whether it changed.
+//
+// *field holds the output of rrd_string_strdupz(), i.e. the sanitized form. So an exact
+// match against the raw incoming string means sanitizing it is a no-op and interning it
+// would hand back the very same STRING - the whole update is provably a no-op and can be
+// skipped. A mismatch (including one that only sanitizing would resolve) falls through to
+// the full path, so this is one-directional and cannot skip a real change.
+static inline bool rrdset_metadata_field_update(STRING **field, const char *value) {
+    if(!value || !*value || string_strcmp(*field, value) == 0)
+        return false;
+
+    STRING *old = *field;
+    *field = rrd_string_strdupz(value);
+    bool changed = (old != *field);
+    string_freez(old);
+
+    return changed;
+}
+
 // the item to be inserted, is already in the dictionary
 // this callback deals with the situation, migrating the existing object to the new values
 // the dictionary is write locked while this runs
@@ -212,53 +232,23 @@ static bool rrdset_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
         ctr->react_action |= RRDSET_REACT_UPDATED;
     }
 
-    if(ctr->plugin && *ctr->plugin) {
-        STRING *old_plugin = st->plugin_name;
-        st->plugin_name = rrd_string_strdupz(ctr->plugin);
-        if (old_plugin != st->plugin_name)
-            ctr->react_action |= RRDSET_REACT_PLUGIN_UPDATED;
-        string_freez(old_plugin);
-    }
+    if(rrdset_metadata_field_update(&st->plugin_name, ctr->plugin))
+        ctr->react_action |= RRDSET_REACT_PLUGIN_UPDATED;
 
-    if(ctr->module && *ctr->module) {
-        STRING *old_module = st->module_name;
-        st->module_name = rrd_string_strdupz(ctr->module);
-        if (old_module != st->module_name)
-            ctr->react_action |= RRDSET_REACT_MODULE_UPDATED;
-        string_freez(old_module);
-    }
+    if(rrdset_metadata_field_update(&st->module_name, ctr->module))
+        ctr->react_action |= RRDSET_REACT_MODULE_UPDATED;
 
-    if(ctr->title && *ctr->title) {
-        STRING *old_title = st->title;
-        st->title = rrd_string_strdupz(ctr->title);
-        if(old_title != st->title)
-            ctr->react_action |= RRDSET_REACT_UPDATED;
-        string_freez(old_title);
-    }
+    if(rrdset_metadata_field_update(&st->title, ctr->title))
+        ctr->react_action |= RRDSET_REACT_UPDATED;
 
-    if(ctr->units && *ctr->units) {
-        STRING *old_units = st->units;
-        st->units = rrd_string_strdupz(ctr->units);
-        if(old_units != st->units)
-            ctr->react_action |= RRDSET_REACT_UPDATED;
-        string_freez(old_units);
-    }
+    if(rrdset_metadata_field_update(&st->units, ctr->units))
+        ctr->react_action |= RRDSET_REACT_UPDATED;
 
-    if(ctr->family && *ctr->family) {
-        STRING *old_family = st->family;
-        st->family = rrd_string_strdupz(ctr->family);
-        if(old_family != st->family)
-            ctr->react_action |= RRDSET_REACT_UPDATED;
-        string_freez(old_family);
-    }
+    if(rrdset_metadata_field_update(&st->family, ctr->family))
+        ctr->react_action |= RRDSET_REACT_UPDATED;
 
-    if(ctr->context && *ctr->context) {
-        STRING *old_context = st->context;
-        st->context = rrd_string_strdupz(ctr->context);
-        if(old_context != st->context)
-            ctr->react_action |= RRDSET_REACT_UPDATED;
-        string_freez(old_context);
-    }
+    if(rrdset_metadata_field_update(&st->context, ctr->context))
+        ctr->react_action |= RRDSET_REACT_UPDATED;
 
     if(st->chart_type != ctr->chart_type) {
         st->chart_type = ctr->chart_type;

--- a/src/libnetdata/sanitizers/utf8-sanitizer-unittest.c
+++ b/src/libnetdata/sanitizers/utf8-sanitizer-unittest.c
@@ -1354,6 +1354,101 @@ static void test_rrd_string_allowed_chars(void) {
 }
 
 // ============================================================================
+// TEST: rrd_string_allowed_chars IDEMPOTENCY
+//
+// rrdset_metadata_field_update() (src/database/rrdset-index-id.c) skips
+// re-interning a chart metadata field when the RAW incoming string compares
+// equal to the STORED one - and the stored one is always the output of
+// rrd_string_strdupz(), i.e. already sanitized with rrd_string_allowed_chars.
+// That fast path is correct ONLY IF this sanitizer is idempotent over its own
+// image: sanitize(sanitize(x)) == sanitize(x). If a future change to the table
+// or to text_sanitize() broke that, an equal-compare would no longer prove
+// "interning is a no-op", and charts would silently keep stale metadata.
+//
+// Pin the invariant here, with the REAL table (the generic stress_idempotent
+// case below uses identity_char_map, which cannot catch a table regression).
+// ============================================================================
+
+static void test_rrd_string_allowed_chars_idempotency(void) {
+    fprintf(stderr, "\n=== RRD String Allowed Chars Idempotency ===\n");
+
+    extern unsigned char rrd_string_allowed_chars[256];
+
+    // one pass of exactly what rrd_string_strdupz() does: dst_size = 2*len+1
+    #define SANITIZE_ONCE(dst, dstcap, src) do {                                    \
+        size_t _len = strlen((const char *)(src));                                  \
+        size_t _cap = (_len * 2) + 1;                                               \
+        if(_cap > (dstcap)) _cap = (dstcap);                                        \
+        text_sanitize((unsigned char *)(dst), (const unsigned char *)(src), _cap,   \
+                      rrd_string_allowed_chars, true, "", NULL);                    \
+    } while(0)
+
+    static const char * const inputs[] = {
+        "cpu.user",                     // plain ascii
+        "\"value\"",                    // double quote -> single quote
+        "path\\file",                   // backslash -> slash
+        "requests/s\xC2\xB2",           // valid 2-byte utf8
+        "\xC2\xB5s",                    // micro sign
+        "\xF0\x9F\x98\x80",             // valid 4-byte utf8
+        "bad\xFF" "byte",                // invalid byte -> hex encoded
+        "trunc\xC2",                    // truncated 2-byte sequence
+        "trunc\xE2\x82",                // truncated 3-byte sequence
+        "\x80\x81lone",                 // lone continuation bytes
+        "___",                          // all-underscore -> collapses to empty
+        "  a   b  ",                    // leading/trailing/repeated spaces
+        "a\x01\x02" "b",                // control characters
+        "test\xC0\x80test",             // overlong NUL, structurally valid
+        "\xC2\xB0" "C \xFF A",          // mixed valid utf8 + invalid + ascii
+        "",                             // empty
+    };
+
+    bool all_ok = true;
+    for(size_t i = 0; i < sizeof(inputs) / sizeof(inputs[0]); i++) {
+        char once[512], twice[512];
+
+        SANITIZE_ONCE(once, sizeof(once), inputs[i]);
+        SANITIZE_ONCE(twice, sizeof(twice), once);
+
+        if(strcmp(once, twice) != 0) {
+            all_ok = false;
+            fprintf(stderr, "  input %zu: '%s' -> '%s' -> '%s'\n", i, inputs[i], once, twice);
+        }
+    }
+    TEST_ASSERT("rrd_idempotent_cases", all_ok,
+                "rrd_string_allowed_chars sanitization is not idempotent");
+
+    // deterministic randomized sweep over arbitrary byte strings
+    all_ok = true;
+    uint32_t seed = 0x5eed1234;
+    for(size_t iter = 0; iter < 100000 && all_ok; iter++) {
+        unsigned char src[25];
+        char once[512], twice[512];
+
+        seed = seed * 1103515245 + 12345;
+        size_t len = 1 + (seed >> 16) % (sizeof(src) - 1);
+        for(size_t i = 0; i < len; i++) {
+            seed = seed * 1103515245 + 12345;
+            src[i] = (unsigned char)((seed >> 16) & 0xFF);
+            if(!src[i]) src[i] = 1; // keep it a single NUL-terminated string
+        }
+        src[len] = '\0';
+
+        SANITIZE_ONCE(once, sizeof(once), src);
+        SANITIZE_ONCE(twice, sizeof(twice), once);
+
+        if(strcmp(once, twice) != 0) {
+            all_ok = false;
+            fprintf(stderr, "  iter %zu: '%s' -> '%s' (len %zu)\n", iter, once, twice, len);
+        }
+    }
+    TEST_ASSERT("rrd_idempotent_random", all_ok,
+                "rrd_string_allowed_chars sanitization is not idempotent on random input");
+
+    #undef SANITIZE_ONCE
+}
+
+
+// ============================================================================
 // TEST: SECURITY-FOCUSED CASES
 // ============================================================================
 
@@ -2063,6 +2158,7 @@ int utf8_sanitizer_unittest(void) {
     test_utf_parameter();
     test_multibyte_length();
     test_rrd_string_allowed_chars();
+    test_rrd_string_allowed_chars_idempotency();
     test_security_cases();
     test_regression_fixed_bugs();
     test_all_control_characters();

--- a/src/libnetdata/sanitizers/utf8-sanitizer-unittest.c
+++ b/src/libnetdata/sanitizers/utf8-sanitizer-unittest.c
@@ -1374,11 +1374,13 @@ static void test_rrd_string_allowed_chars_idempotency(void) {
 
     extern unsigned char rrd_string_allowed_chars[256];
 
-    // one pass of exactly what rrd_string_strdupz() does: dst_size = 2*len+1
+    // one pass of exactly what rrd_string_strdupz() does: dst_size = 2*len+1.
+    // The destination MUST be able to hold exactly that - clamping it instead
+    // would silently exercise a truncating sanitization production never does,
+    // so the invariant would stop being tested without anyone noticing.
     #define SANITIZE_ONCE(dst, dstcap, src) do {                                    \
-        size_t _len = strlen((const char *)(src));                                  \
-        size_t _cap = (_len * 2) + 1;                                               \
-        if(_cap > (dstcap)) _cap = (dstcap);                                        \
+        size_t _cap = (strlen((const char *)(src)) * 2) + 1;                        \
+        fatal_assert(_cap <= (dstcap));                                             \
         text_sanitize((unsigned char *)(dst), (const unsigned char *)(src), _cap,   \
                       rrd_string_allowed_chars, true, "", NULL);                    \
     } while(0)
@@ -1416,6 +1418,30 @@ static void test_rrd_string_allowed_chars_idempotency(void) {
     }
     TEST_ASSERT("rrd_idempotent_cases", all_ok,
                 "rrd_string_allowed_chars sanitization is not idempotent");
+
+    // exhaustive over every 1- and 2-byte string (NUL excluded, it terminates).
+    // This is the complete regression net for the table itself: all 255 single
+    // bytes, plus every start-byte/continuation pair - overlongs (c0, c1), the
+    // out-of-range start bytes (f5..ff), truncated sequences, and lone
+    // continuation bytes - none of which the random sweep below guarantees.
+    all_ok = true;
+    for(unsigned i = 1; i < 256 && all_ok; i++) {
+        for(unsigned j = 0; j < 256 && all_ok; j++) {
+            unsigned char src[3] = { (unsigned char)i, (unsigned char)j, '\0' };
+            char once[16], twice[64];
+
+            // j == 0 makes it the 1-byte string
+            SANITIZE_ONCE(once, sizeof(once), src);
+            SANITIZE_ONCE(twice, sizeof(twice), once);
+
+            if(strcmp(once, twice) != 0) {
+                all_ok = false;
+                fprintf(stderr, "  bytes %02x %02x: '%s' -> '%s'\n", i, j, once, twice);
+            }
+        }
+    }
+    TEST_ASSERT("rrd_idempotent_exhaustive_2bytes", all_ok,
+                "rrd_string_allowed_chars sanitization is not idempotent on all 1-2 byte strings");
 
     // deterministic randomized sweep over arbitrary byte strings
     all_ok = true;


### PR DESCRIPTION
##### Summary
- Skip sanitizing and re-interning unchanged chart metadata during repeated chart registration, while preserving updates for changed or sanitization-affected values.
- Use stack storage for typical sanitized metadata strings to avoid hot-path allocations; retain heap fallback for long inputs.
- Add exhaustive one- and two-byte plus randomized idempotency coverage for the RRD metadata sanitizer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart metadata updates to preserve accurate change detection across titles, units, contexts, families, modules, and plugins.
  - Improved handling of sanitized text to ensure consistent chart labels and metadata.

- **Performance**
  - Reduced unnecessary memory usage when processing shorter sanitized strings.

- **Quality Improvements**
  - Added extensive validation to ensure repeated text sanitization produces stable, predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->