### PR TITLE
chore(go.d/prometheus): flatten application profile families

### DIFF
--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/ceph/PROFILE-DESIGN.yaml
@@ -1392,7 +1392,7 @@ limitations:
     effect: aggregate_drop_may_create_one_reset_interpreted_rate_gap
 views:
   bluefs.allocation.accumulated_latency:
-    family: Ceph/BlueFS/Allocation
+    family: BlueFS/Allocation
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1413,7 +1413,7 @@ views:
       promote: []
       omit: {}
   bluefs.allocation.allocation_high_water:
-    family: Ceph/BlueFS/Allocation
+    family: BlueFS/Allocation
     question: What is the allocation sizes and high-water marks for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1434,7 +1434,7 @@ views:
       promote: []
       omit: {}
   bluefs.allocation.duration:
-    family: Ceph/BlueFS/Allocation
+    family: BlueFS/Allocation
     question: What is the duration and time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1455,7 +1455,7 @@ views:
       promote: []
       omit: {}
   bluefs.allocation.failure_outcomes:
-    family: Ceph/BlueFS/Allocation
+    family: BlueFS/Allocation
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1472,7 +1472,7 @@ views:
       promote: []
       omit: {}
   bluefs.allocation.latency_measurements:
-    family: Ceph/BlueFS/Allocation
+    family: BlueFS/Allocation
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1493,7 +1493,7 @@ views:
       promote: []
       omit: {}
   bluefs.compaction.accumulated_latency:
-    family: Ceph/BlueFS/Compaction
+    family: BlueFS/Compaction
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1510,7 +1510,7 @@ views:
       promote: []
       omit: {}
   bluefs.compaction.events:
-    family: Ceph/BlueFS/Compaction
+    family: BlueFS/Compaction
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1523,7 +1523,7 @@ views:
       promote: []
       omit: {}
   bluefs.compaction.latency_measurements:
-    family: Ceph/BlueFS/Compaction
+    family: BlueFS/Compaction
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1540,7 +1540,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.accumulated_latency:
-    family: Ceph/BlueFS/IO and Files
+    family: BlueFS/IO and Files
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1573,7 +1573,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.byte_throughput:
-    family: Ceph/BlueFS/IO and Files
+    family: BlueFS/IO and Files
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1634,7 +1634,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.latency_measurements:
-    family: Ceph/BlueFS/IO and Files
+    family: BlueFS/IO and Files
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1667,7 +1667,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.operations:
-    family: Ceph/BlueFS/IO and Files
+    family: BlueFS/IO and Files
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1720,7 +1720,7 @@ views:
       promote: []
       omit: {}
   bluefs.i_o_and_files.zero_read_outcomes:
-    family: Ceph/BlueFS/IO and Files
+    family: BlueFS/IO and Files
     question: What is the zero-read outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1737,7 +1737,7 @@ views:
       promote: []
       omit: {}
   bluefs.space_and_files.allocation_high_water:
-    family: Ceph/BlueFS/Space and Files
+    family: BlueFS/Space and Files
     question: What is the allocation sizes and high-water marks for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1758,7 +1758,7 @@ views:
       promote: []
       omit: {}
   bluefs.space_and_files.byte_throughput:
-    family: Ceph/BlueFS/Space and Files
+    family: BlueFS/Space and Files
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1783,7 +1783,7 @@ views:
       promote: []
       omit: {}
   bluefs.space_and_files.file_state:
-    family: Ceph/BlueFS/Space and Files
+    family: BlueFS/Space and Files
     question: What is the files for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1796,7 +1796,7 @@ views:
       promote: []
       omit: {}
   bluefs.space_and_files.file_work:
-    family: Ceph/BlueFS/Space and Files
+    family: BlueFS/Space and Files
     question: What is the file work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1813,7 +1813,7 @@ views:
       promote: []
       omit: {}
   bluefs.space_and_files.space:
-    family: Ceph/BlueFS/Space and Files
+    family: BlueFS/Space and Files
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1850,7 +1850,7 @@ views:
       promote: []
       omit: {}
   bluestore.allocation.accumulated_latency:
-    family: Ceph/BlueStore/Allocation
+    family: BlueStore/Allocation
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1863,7 +1863,7 @@ views:
       promote: []
       omit: {}
   bluestore.allocation.allocated_space:
-    family: Ceph/BlueStore/Allocation
+    family: BlueStore/Allocation
     question: What is the allocated space for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1876,7 +1876,7 @@ views:
       promote: []
       omit: {}
   bluestore.allocation.allocation_unit:
-    family: Ceph/BlueStore/Allocation
+    family: BlueStore/Allocation
     question: What is the allocation unit for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1889,7 +1889,7 @@ views:
       promote: []
       omit: {}
   bluestore.allocation.latency_measurements:
-    family: Ceph/BlueStore/Allocation
+    family: BlueStore/Allocation
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1902,7 +1902,7 @@ views:
       promote: []
       omit: {}
   bluestore.compression_and_checksums.accumulated_latency:
-    family: Ceph/BlueStore/Compression and Checksums
+    family: BlueStore/Compression and Checksums
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1923,7 +1923,7 @@ views:
       promote: []
       omit: {}
   bluestore.compression_and_checksums.compressed_extents:
-    family: Ceph/BlueStore/Compression and Checksums
+    family: BlueStore/Compression and Checksums
     question: What is the compressed extents for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1936,7 +1936,7 @@ views:
       promote: []
       omit: {}
   bluestore.compression_and_checksums.compression_operations:
-    family: Ceph/BlueStore/Compression and Checksums
+    family: BlueStore/Compression and Checksums
     question: What is the compression operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1953,7 +1953,7 @@ views:
       promote: []
       omit: {}
   bluestore.compression_and_checksums.latency_measurements:
-    family: Ceph/BlueStore/Compression and Checksums
+    family: BlueStore/Compression and Checksums
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1974,7 +1974,7 @@ views:
       promote: []
       omit: {}
   bluestore.compression_and_checksums.space:
-    family: Ceph/BlueStore/Compression and Checksums
+    family: BlueStore/Compression and Checksums
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -1995,7 +1995,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.accumulated_latency:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2028,7 +2028,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.byte_throughput:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2065,7 +2065,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.latency_measurements:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2098,7 +2098,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.penalty_reads:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the penalty reads for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2111,7 +2111,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.read_outcomes:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the read outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2128,7 +2128,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.skipped_blobs:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the skipped blobs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2141,7 +2141,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.skipped_writes:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the skipped writes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2154,7 +2154,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.slow_aio_waits:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the slow aio waits for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2167,7 +2167,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.slow_reads:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the slow reads for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2184,7 +2184,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.write_operations:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the write operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2225,7 +2225,7 @@ views:
       promote: []
       omit: {}
   bluestore.i_o.written_blobs:
-    family: Ceph/BlueStore/IO
+    family: BlueStore/IO
     question: What is the written blobs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2238,7 +2238,7 @@ views:
       promote: []
       omit: {}
   bluestore.omap.accumulated_latency:
-    family: Ceph/BlueStore/OMAP
+    family: BlueStore/OMAP
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2275,7 +2275,7 @@ views:
       promote: []
       omit: {}
   bluestore.omap.byte_throughput:
-    family: Ceph/BlueStore/OMAP
+    family: BlueStore/OMAP
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2292,7 +2292,7 @@ views:
       promote: []
       omit: {}
   bluestore.omap.key_mutations:
-    family: Ceph/BlueStore/OMAP
+    family: BlueStore/OMAP
     question: What is the key mutations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2309,7 +2309,7 @@ views:
       promote: []
       omit: {}
   bluestore.omap.latency_measurements:
-    family: Ceph/BlueStore/OMAP
+    family: BlueStore/OMAP
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2346,7 +2346,7 @@ views:
       promote: []
       omit: {}
   bluestore.omap.mutation_calls:
-    family: Ceph/BlueStore/OMAP
+    family: BlueStore/OMAP
     question: What is the mutation calls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2363,7 +2363,7 @@ views:
       promote: []
       omit: {}
   bluestore.omap.open_iterators:
-    family: Ceph/BlueStore/OMAP
+    family: BlueStore/OMAP
     question: What is the open iterators for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2376,7 +2376,7 @@ views:
       promote: []
       omit: {}
   bluestore.omap.removed_key_ranges:
-    family: Ceph/BlueStore/OMAP
+    family: BlueStore/OMAP
     question: What is the removed key ranges for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2389,7 +2389,7 @@ views:
       promote: []
       omit: {}
   bluestore.onode_cache.blob_state:
-    family: Ceph/BlueStore/Onode Cache
+    family: BlueStore/Onode Cache
     question: What is the onode blobs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2406,7 +2406,7 @@ views:
       promote: []
       omit: {}
   bluestore.onode_cache.events:
-    family: Ceph/BlueStore/Onode Cache
+    family: BlueStore/Onode Cache
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2419,7 +2419,7 @@ views:
       promote: []
       omit: {}
   bluestore.onode_cache.extent_state:
-    family: Ceph/BlueStore/Onode Cache
+    family: BlueStore/Onode Cache
     question: What is the onode extents for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2432,7 +2432,7 @@ views:
       promote: []
       omit: {}
   bluestore.onode_cache.onode_lookup_outcomes:
-    family: Ceph/BlueStore/Onode Cache
+    family: BlueStore/Onode Cache
     question: What is the onode lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2449,7 +2449,7 @@ views:
       promote: []
       omit: {}
   bluestore.onode_cache.onode_state:
-    family: Ceph/BlueStore/Onode Cache
+    family: BlueStore/Onode Cache
     question: What is the onodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2466,7 +2466,7 @@ views:
       promote: []
       omit: {}
   bluestore.onode_cache.shard_lookup_outcomes:
-    family: Ceph/BlueStore/Onode Cache
+    family: BlueStore/Onode Cache
     question: What is the onode shard lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2483,7 +2483,7 @@ views:
       promote: []
       omit: {}
   bluestore.priority_cache_data.space:
-    family: Ceph/BlueStore/Priority Cache Data
+    family: BlueStore/Priority Cache Data
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2548,7 +2548,7 @@ views:
       promote: []
       omit: {}
   bluestore.priority_cache_kv.space:
-    family: Ceph/BlueStore/Priority Cache KV
+    family: BlueStore/Priority Cache KV
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2613,7 +2613,7 @@ views:
       promote: []
       omit: {}
   bluestore.priority_cache_kv_onode.space:
-    family: Ceph/BlueStore/Priority Cache KV Onode
+    family: BlueStore/Priority Cache KV Onode
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2678,7 +2678,7 @@ views:
       promote: []
       omit: {}
   bluestore.priority_cache_metadata.space:
-    family: Ceph/BlueStore/Priority Cache Metadata
+    family: BlueStore/Priority Cache Metadata
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2743,7 +2743,7 @@ views:
       promote: []
       omit: {}
   bluestore.priority_cache_runtime.space:
-    family: Ceph/BlueStore/Priority Cache Runtime
+    family: BlueStore/Priority Cache Runtime
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2772,7 +2772,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.accumulated_latency:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2801,7 +2801,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.blob_splits:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the blob splits for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2814,7 +2814,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.buffer_cache_residency:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the buffer cache residency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2827,7 +2827,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.byte_throughput:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2844,7 +2844,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.current_work:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the current work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2857,7 +2857,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.failure_outcomes:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2870,7 +2870,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.fragmentation:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the fragmentation for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2888,7 +2888,7 @@ views:
       evidence:
         - ceph_display_conventions
   bluestore.space_and_core_state.gc_merge_throughput:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the garbage-collection merge throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2901,7 +2901,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.latency_measurements:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2930,7 +2930,7 @@ views:
       promote: []
       omit: {}
   bluestore.space_and_core_state.logical_stored_data:
-    family: Ceph/BlueStore/Space and Core State
+    family: BlueStore/Space and Core State
     question: What is the logical stored data for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -2943,7 +2943,7 @@ views:
       promote: []
       omit: {}
   bluestore.transaction_pipeline.accumulated_latency:
-    family: Ceph/BlueStore/Transaction Pipeline
+    family: BlueStore/Transaction Pipeline
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3008,7 +3008,7 @@ views:
       promote: []
       omit: {}
   bluestore.transaction_pipeline.latency_measurements:
-    family: Ceph/BlueStore/Transaction Pipeline
+    family: BlueStore/Transaction Pipeline
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3073,7 +3073,7 @@ views:
       promote: []
       omit: {}
   bluestore.transaction_pipeline.operations:
-    family: Ceph/BlueStore/Transaction Pipeline
+    family: BlueStore/Transaction Pipeline
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3086,7 +3086,7 @@ views:
       promote: []
       omit: {}
   capacity.object_health.object_state:
-    family: Ceph/Capacity/Object Health
+    family: Capacity/Object Health
     question: What is the objects?
     entity: cluster
     inputs:
@@ -3107,7 +3107,7 @@ views:
       promote: []
       omit: {}
   capacity.overall_cluster_space.space:
-    family: Ceph/Capacity/Overall Cluster Space
+    family: Capacity/Overall Cluster Space
     question: What is the space and memory?
     entity: cluster
     inputs:
@@ -3128,7 +3128,7 @@ views:
       promote: []
       omit: {}
   capacity.space_by_device_class.space:
-    family: Ceph/Capacity/Space by Device Class
+    family: Capacity/Space by Device Class
     question: What is the space and memory for each device class?
     entity: by_device_class
     inputs:
@@ -3149,7 +3149,7 @@ views:
       promote: []
       omit: {}
   ceph_clients.io_operations:
-    family: Ceph/Clients
+    family: Clients
     question: What is the client i/o operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3170,7 +3170,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.attribute_and_layout_mutation_latency.accumulated_latency:
-    family: Ceph/CephFS/MDS/Attribute and Layout Mutation Latency
+    family: CephFS/MDS/Attribute and Layout Mutation Latency
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3203,7 +3203,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.attribute_and_layout_mutation_latency.latency_measurements:
-    family: Ceph/CephFS/MDS/Attribute and Layout Mutation Latency
+    family: CephFS/MDS/Attribute and Layout Mutation Latency
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3236,7 +3236,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.capability_messages:
-    family: Ceph/CephFS/MDS/Capabilities
+    family: CephFS/MDS/Capabilities
     question: What is the capability messages for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3257,7 +3257,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.capability_state:
-    family: Ceph/CephFS/MDS/Capabilities
+    family: CephFS/MDS/Capabilities
     question: What is the capabilities for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3270,7 +3270,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.evicted_clients:
-    family: Ceph/CephFS/MDS/Capabilities
+    family: CephFS/MDS/Capabilities
     question: What is the capability-revoke evictions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3283,7 +3283,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.inode_state:
-    family: Ceph/CephFS/MDS/Capabilities
+    family: CephFS/MDS/Capabilities
     question: What is the inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3296,7 +3296,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.inode_work:
-    family: Ceph/CephFS/MDS/Capabilities
+    family: CephFS/MDS/Capabilities
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3309,7 +3309,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.operations:
-    family: Ceph/CephFS/MDS/Capabilities
+    family: CephFS/MDS/Capabilities
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3342,7 +3342,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.capabilities.throttled_requests:
-    family: Ceph/CephFS/MDS/Capabilities
+    family: CephFS/MDS/Capabilities
     question: What is the capability-throttled requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3355,7 +3355,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.accumulated_latency:
-    family: Ceph/CephFS/MDS/Journal
+    family: CephFS/MDS/Journal
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3368,7 +3368,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.events_current:
-    family: Ceph/CephFS/MDS/Journal
+    family: CephFS/MDS/Journal
     question: What is the current journal events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3389,7 +3389,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.journal_events:
-    family: Ceph/CephFS/MDS/Journal
+    family: CephFS/MDS/Journal
     question: What is the journal events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3414,7 +3414,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.journal_positions:
-    family: Ceph/CephFS/MDS/Journal
+    family: CephFS/MDS/Journal
     question: What is the journal positions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3435,7 +3435,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.journal_segments:
-    family: Ceph/CephFS/MDS/Journal
+    family: CephFS/MDS/Journal
     question: What is the journal segments for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3456,7 +3456,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.large_events:
-    family: Ceph/CephFS/MDS/Journal
+    family: CephFS/MDS/Journal
     question: What is the large journal events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3469,7 +3469,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.latency_measurements:
-    family: Ceph/CephFS/MDS/Journal
+    family: CephFS/MDS/Journal
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3482,7 +3482,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.journal.segments_current:
-    family: Ceph/CephFS/MDS/Journal
+    family: CephFS/MDS/Journal
     question: What is the journal segments for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3507,7 +3507,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_directory.discovery_attempts:
-    family: Ceph/CephFS/MDS/Metadata Cache Directory
+    family: CephFS/MDS/Metadata Cache Directory
     question: What is the discovery attempts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3520,7 +3520,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_directory.discovery_messages:
-    family: Ceph/CephFS/MDS/Metadata Cache Directory
+    family: CephFS/MDS/Metadata Cache Directory
     question: What is the discovery messages for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3537,7 +3537,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_directory.replication_directives:
-    family: Ceph/CephFS/MDS/Metadata Cache Directory
+    family: CephFS/MDS/Metadata Cache Directory
     question: What is the replication directives for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3554,7 +3554,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_internal_requests.inode_work:
-    family: Ceph/CephFS/MDS/Metadata Cache Internal Requests
+    family: CephFS/MDS/Metadata Cache Internal Requests
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3571,7 +3571,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_internal_requests.operations:
-    family: Ceph/CephFS/MDS/Metadata Cache Internal Requests
+    family: CephFS/MDS/Metadata Cache Internal Requests
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3600,7 +3600,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_internal_requests.scrub_work:
-    family: Ceph/CephFS/MDS/Metadata Cache Internal Requests
+    family: CephFS/MDS/Metadata Cache Internal Requests
     question: What is the scrub work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3613,7 +3613,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_recovery.current_work:
-    family: Ceph/CephFS/MDS/Metadata Cache Recovery
+    family: CephFS/MDS/Metadata Cache Recovery
     question: What is the current work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3634,7 +3634,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_recovery.events:
-    family: Ceph/CephFS/MDS/Metadata Cache Recovery
+    family: CephFS/MDS/Metadata Cache Recovery
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3659,7 +3659,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_recovery.file_state:
-    family: Ceph/CephFS/MDS/Metadata Cache Recovery
+    family: CephFS/MDS/Metadata Cache Recovery
     question: What is the files for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3680,7 +3680,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_recovery.file_work:
-    family: Ceph/CephFS/MDS/Metadata Cache Recovery
+    family: CephFS/MDS/Metadata Cache Recovery
     question: What is the file work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3697,7 +3697,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_uninline.events:
-    family: Ceph/CephFS/MDS/Metadata Cache Uninline
+    family: CephFS/MDS/Metadata Cache Uninline
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3714,7 +3714,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.metadata_cache_uninline.failure_outcomes:
-    family: Ceph/CephFS/MDS/Metadata Cache Uninline
+    family: CephFS/MDS/Metadata Cache Uninline
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3727,7 +3727,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_mutation_latency.accumulated_latency:
-    family: Ceph/CephFS/MDS/Namespace Mutation Latency
+    family: CephFS/MDS/Namespace Mutation Latency
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3768,7 +3768,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_mutation_latency.latency_measurements:
-    family: Ceph/CephFS/MDS/Namespace Mutation Latency
+    family: CephFS/MDS/Namespace Mutation Latency
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3809,7 +3809,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.dirfrag_lifecycle:
-    family: Ceph/CephFS/MDS/Namespace Traversal
+    family: CephFS/MDS/Namespace Traversal
     question: What is the directory-fragment lifecycle for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3830,7 +3830,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.inode_work:
-    family: Ceph/CephFS/MDS/Namespace Traversal
+    family: CephFS/MDS/Namespace Traversal
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3843,7 +3843,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.key_work:
-    family: Ceph/CephFS/MDS/Namespace Traversal
+    family: CephFS/MDS/Namespace Traversal
     question: What is the key work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3856,7 +3856,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.lookup_outcomes:
-    family: Ceph/CephFS/MDS/Namespace Traversal
+    family: CephFS/MDS/Namespace Traversal
     question: What is the lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3869,7 +3869,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.operations:
-    family: Ceph/CephFS/MDS/Namespace Traversal
+    family: CephFS/MDS/Namespace Traversal
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3890,7 +3890,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.namespace_traversal.traversals:
-    family: Ceph/CephFS/MDS/Namespace Traversal
+    family: CephFS/MDS/Namespace Traversal
     question: What is the namespace traversals for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3923,7 +3923,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.current_work:
-    family: Ceph/CephFS/MDS/Purge Queue
+    family: CephFS/MDS/Purge Queue
     question: What is the current work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3936,7 +3936,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.purge_operations:
-    family: Ceph/CephFS/MDS/Purge Queue
+    family: CephFS/MDS/Purge Queue
     question: What is the executed purge operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3949,7 +3949,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.purge_operations_state:
-    family: Ceph/CephFS/MDS/Purge Queue
+    family: CephFS/MDS/Purge Queue
     question: What is the purge operations in flight for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3966,7 +3966,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.purge_tasks:
-    family: Ceph/CephFS/MDS/Purge Queue
+    family: CephFS/MDS/Purge Queue
     question: What is the executed purge tasks for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3979,7 +3979,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.purge_queue.purge_tasks_state:
-    family: Ceph/CephFS/MDS/Purge Queue
+    family: CephFS/MDS/Purge Queue
     question: What is the purge tasks in flight for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -3996,7 +3996,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.rank_migration.events:
-    family: Ceph/CephFS/MDS/Rank Migration
+    family: CephFS/MDS/Rank Migration
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4013,7 +4013,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.rank_migration.inode_work:
-    family: Ceph/CephFS/MDS/Rank Migration
+    family: CephFS/MDS/Rank Migration
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4030,7 +4030,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.read_request_latency.accumulated_latency:
-    family: Ceph/CephFS/MDS/Read Request Latency
+    family: CephFS/MDS/Read Request Latency
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4087,7 +4087,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.read_request_latency.latency_measurements:
-    family: Ceph/CephFS/MDS/Read Request Latency
+    family: CephFS/MDS/Read Request Latency
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4144,7 +4144,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.accumulated_latency:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4157,7 +4157,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.connected_clients:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the connected clients for each ceph daemon and fs name and id?
     entity: by_ceph_daemon_and_fs_name_and_id
     inputs:
@@ -4170,7 +4170,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.events:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4187,7 +4187,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.expired_inodes:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the expired inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4200,7 +4200,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.failure_outcomes:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4213,7 +4213,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.file_state:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the files for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4226,7 +4226,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.inode_state:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4255,7 +4255,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.latency_measurements:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4268,7 +4268,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.load:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the load for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4281,7 +4281,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.operations:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4314,7 +4314,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.queued_requests:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the queued requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4327,7 +4327,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.snapshot_state:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the snapshots for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4340,7 +4340,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.space:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4353,7 +4353,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.request_handling_and_state.subtrees:
-    family: Ceph/CephFS/MDS/Request Handling and State
+    family: CephFS/MDS/Request Handling and State
     question: What is the subtrees for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4366,7 +4366,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.applied_tags:
-    family: Ceph/CephFS/MDS/Scrubbing
+    family: CephFS/MDS/Scrubbing
     question: What is the applied scrub tags for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4379,7 +4379,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.backtrace_work:
-    family: Ceph/CephFS/MDS/Scrubbing
+    family: CephFS/MDS/Scrubbing
     question: What is the backtrace work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4396,7 +4396,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.dirfrag_rstat_updates:
-    family: Ceph/CephFS/MDS/Scrubbing
+    family: CephFS/MDS/Scrubbing
     question: What is the directory-fragment recursive-stat updates for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4409,7 +4409,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.repaired_inotables:
-    family: Ceph/CephFS/MDS/Scrubbing
+    family: CephFS/MDS/Scrubbing
     question: What is the repaired inotables for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4422,7 +4422,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.scrubbing.scrubbed_inodes:
-    family: Ceph/CephFS/MDS/Scrubbing
+    family: CephFS/MDS/Scrubbing
     question: What is the scrubbed inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4443,7 +4443,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.snapshot_mutation_latency.accumulated_latency:
-    family: Ceph/CephFS/MDS/Snapshot Mutation Latency
+    family: CephFS/MDS/Snapshot Mutation Latency
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4472,7 +4472,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds.snapshot_mutation_latency.latency_measurements:
-    family: Ceph/CephFS/MDS/Snapshot Mutation Latency
+    family: CephFS/MDS/Snapshot Mutation Latency
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4501,7 +4501,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.average_operation_latency:
-    family: Ceph/CephFS/MDS/Clients
+    family: CephFS/MDS/Clients
     question: What is the average operation latency for each ceph daemon and client and rank and mds filesystem
       key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
@@ -4523,7 +4523,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.capability_outcomes:
-    family: Ceph/CephFS/MDS/Clients
+    family: CephFS/MDS/Clients
     question: What is the capability access outcomes for each ceph daemon and client and rank and mds filesystem
       key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
@@ -4541,7 +4541,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.dentry_lease_outcomes:
-    family: Ceph/CephFS/MDS/Clients
+    family: CephFS/MDS/Clients
     question: What is the dentry lease lookup outcomes for each ceph daemon and client and rank and mds filesystem
       key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
@@ -4559,7 +4559,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.inode_state:
-    family: Ceph/CephFS/MDS/Clients
+    family: CephFS/MDS/Clients
     question: What is the inode state for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4576,7 +4576,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.open_files:
-    family: Ceph/CephFS/MDS/Clients
+    family: CephFS/MDS/Clients
     question: What is the open files for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4589,7 +4589,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.pinned_inode_capabilities:
-    family: Ceph/CephFS/MDS/Clients
+    family: CephFS/MDS/Clients
     question: What is the pinned inode capabilities for each ceph daemon and client and rank and mds filesystem
       key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
@@ -4603,7 +4603,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.reported_io_operations:
-    family: Ceph/CephFS/MDS/Clients
+    family: CephFS/MDS/Clients
     question: What is the reported i/o operations for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4620,7 +4620,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_clients.reported_io_volume:
-    family: Ceph/CephFS/MDS/Clients
+    family: CephFS/MDS/Clients
     question: What is the reported i/o volume for each ceph daemon and client and rank and mds filesystem key?
     entity: by_ceph_daemon_and_client_and_rank_and_mds_filesystem_key
     inputs:
@@ -4637,7 +4637,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.capability_state:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the capabilities for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4650,7 +4650,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.capability_work:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the capability work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4667,7 +4667,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.dentry_state:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the dentries for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4680,7 +4680,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.dentry_work:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the dentry cache churn for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4697,7 +4697,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.directory_state:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the directories for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4710,7 +4710,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.directory_work:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the directory cache churn for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4727,7 +4727,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.inode_state:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the inodes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4740,7 +4740,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.inode_work:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the inode work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4757,7 +4757,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_memory.space:
-    family: Ceph/CephFS/MDS/Memory
+    family: CephFS/MDS/Memory
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4774,7 +4774,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.average_load:
-    family: Ceph/CephFS/MDS/Sessions
+    family: CephFS/MDS/Sessions
     question: What is the average session load for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4787,7 +4787,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.duration:
-    family: Ceph/CephFS/MDS/Sessions
+    family: CephFS/MDS/Sessions
     question: What is the duration and time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4800,7 +4800,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.events:
-    family: Ceph/CephFS/MDS/Sessions
+    family: CephFS/MDS/Sessions
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4817,7 +4817,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.metadata_threshold_evictions:
-    family: Ceph/CephFS/MDS/Sessions
+    family: CephFS/MDS/Sessions
     question: What is the metadata-threshold evictions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4830,7 +4830,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.session_state:
-    family: Ceph/CephFS/MDS/Sessions
+    family: CephFS/MDS/Sessions
     question: What is the sessions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4851,7 +4851,7 @@ views:
       promote: []
       omit: {}
   cephfs_mds_sessions.total_load:
-    family: Ceph/CephFS/MDS/Sessions
+    family: CephFS/MDS/Sessions
     question: What is the total session load for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -4864,7 +4864,7 @@ views:
       promote: []
       omit: {}
   cephfs_metadata.filesystem_metadata.state:
-    family: Ceph/CephFS/Metadata/Filesystem Metadata
+    family: CephFS/Metadata/Filesystem Metadata
     question: What is the state and metadata for each data pools and fs id and metadata pool and name?
     entity: by_data_pools_and_fs_id_and_metadata_pool_and_name
     inputs:
@@ -4877,7 +4877,7 @@ views:
       promote: []
       omit: {}
   cephfs_metadata.mds_metadata.state:
-    family: Ceph/CephFS/Metadata/MDS Metadata
+    family: CephFS/Metadata/MDS Metadata
     question: What is the state and metadata for each ceph daemon and ceph version and fs id and hostname and public
       addr and rank?
     entity: by_ceph_daemon_and_ceph_version_and_fs_id_and_hostname_and_public_addr_and_rank
@@ -4891,7 +4891,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.filesystems.directories:
-    family: Ceph/CephFS/Mirror/Filesystems
+    family: CephFS/Mirror/Filesystems
     question: What is the mirrored directories for each ceph daemon and filesystem?
     entity: by_ceph_daemon_and_filesystem
     inputs:
@@ -4904,7 +4904,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.filesystems.peers:
-    family: Ceph/CephFS/Mirror/Filesystems
+    family: CephFS/Mirror/Filesystems
     question: What is the mirroring peers for each ceph daemon and filesystem?
     entity: by_ceph_daemon_and_filesystem
     inputs:
@@ -4917,7 +4917,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.accumulated_sync_time:
-    family: Ceph/CephFS/Mirror/Peers
+    family: CephFS/Mirror/Peers
     question: What is the accumulated sync time for each ceph daemon and peer cluster filesystem and peer cluster
       name and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4931,7 +4931,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_duration:
-    family: Ceph/CephFS/Mirror/Peers
+    family: CephFS/Mirror/Peers
     question: What is the last sync duration for each ceph daemon and peer cluster filesystem and peer cluster name
       and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4945,7 +4945,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_size:
-    family: Ceph/CephFS/Mirror/Peers
+    family: CephFS/Mirror/Peers
     question: What is the last sync size for each ceph daemon and peer cluster filesystem and peer cluster name
       and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4959,7 +4959,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.last_sync_timestamps:
-    family: Ceph/CephFS/Mirror/Peers
+    family: CephFS/Mirror/Peers
     question: What is the last sync timestamps for each ceph daemon and peer cluster filesystem and peer cluster
       name and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -4977,7 +4977,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.snapshot_outcomes:
-    family: Ceph/CephFS/Mirror/Peers
+    family: CephFS/Mirror/Peers
     question: What is the snapshot outcomes for each ceph daemon and peer cluster filesystem and peer cluster name
       and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -5003,7 +5003,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.sync_throughput:
-    family: Ceph/CephFS/Mirror/Peers
+    family: CephFS/Mirror/Peers
     question: What is the sync throughput for each ceph daemon and peer cluster filesystem and peer cluster name
       and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -5017,7 +5017,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.peers.sync_time_measurements:
-    family: Ceph/CephFS/Mirror/Peers
+    family: CephFS/Mirror/Peers
     question: What is the sync-time measurements for each ceph daemon and peer cluster filesystem and peer cluster
       name and source filesystem and source fscid?
     entity: by_ceph_daemon_and_peer_cluster_filesystem_and_peer_cluster_name_and_source_filesystem_and_source_fscid
@@ -5031,7 +5031,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.service.enable_failures:
-    family: Ceph/CephFS/Mirror/Service
+    family: CephFS/Mirror/Service
     question: What is the mirroring enable failures for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5044,7 +5044,7 @@ views:
       promote: []
       omit: {}
   cephfs_mirror.service.filesystems:
-    family: Ceph/CephFS/Mirror/Service
+    family: CephFS/Mirror/Service
     question: What is the mirrored filesystems for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5057,7 +5057,7 @@ views:
       promote: []
       omit: {}
   cluster_overview.accumulated_latency:
-    family: Ceph/Cluster Overview
+    family: Cluster Overview
     question: What is the accumulated latency for each method?
     entity: by_method
     inputs:
@@ -5070,7 +5070,7 @@ views:
       promote: []
       omit: {}
   cluster_overview.current_work:
-    family: Ceph/Cluster Overview
+    family: Cluster Overview
     question: What is the current work?
     entity: cluster
     inputs:
@@ -5083,7 +5083,7 @@ views:
       promote: []
       omit: {}
   cluster_overview.latency_measurements:
-    family: Ceph/Cluster Overview
+    family: Cluster Overview
     question: What is the latency measurements for each method?
     entity: by_method
     inputs:
@@ -5096,7 +5096,7 @@ views:
       promote: []
       omit: {}
   cluster_overview.state_human:
-    family: Ceph/Cluster Overview
+    family: Cluster Overview
     question: What is the state and metadata — human for each ceph daemon and ceph instance and device?
     entity: by_ceph_daemon_and_ceph_instance_and_device
     inputs:
@@ -5109,7 +5109,7 @@ views:
       promote: []
       omit: {}
   cluster_overview.state_occupation:
-    family: Ceph/Cluster Overview
+    family: Cluster Overview
     question: What is the state and metadata — occupation for each ceph daemon and ceph instance and db device and
       device and device ids and devices and wal device?
     entity: by_ceph_daemon_and_ceph_instance_and_db_device_and_device_and_device_ids_and_devices_and_wal_device
@@ -5123,7 +5123,7 @@ views:
       promote: []
       omit: {}
   control_plane.cephadm.state:
-    family: Ceph/Control Plane/Cephadm
+    family: Control Plane/Cephadm
     question: What is the state and metadata for each daemon name and hostname and service name and service type?
     entity: by_daemon_name_and_hostname_and_service_name_and_service_type
     inputs:
@@ -5136,7 +5136,7 @@ views:
       promote: []
       omit: {}
   control_plane.manager.state_metadata:
-    family: Ceph/Control Plane/Manager
+    family: Control Plane/Manager
     question: What is the state and metadata — metadata for each ceph daemon and ceph version and hostname?
     entity: by_ceph_daemon_and_ceph_version_and_hostname
     inputs:
@@ -5149,7 +5149,7 @@ views:
       promote: []
       omit: {}
   control_plane.manager.state_status:
-    family: Ceph/Control Plane/Manager
+    family: Control Plane/Manager
     question: What is the state and metadata — status for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5162,7 +5162,7 @@ views:
       promote: []
       omit: {}
   control_plane.manager_modules.state:
-    family: Ceph/Control Plane/Manager Modules
+    family: Control Plane/Manager Modules
     question: What is the state and metadata for each name?
     entity: by_name
     inputs:
@@ -5179,7 +5179,7 @@ views:
       promote: []
       omit: {}
   control_plane.monitor.state_metadata:
-    family: Ceph/Control Plane/Monitor
+    family: Control Plane/Monitor
     question: What is the state and metadata — metadata for each ceph daemon and ceph version and hostname and public
       addr and rank?
     entity: by_ceph_daemon_and_ceph_version_and_hostname_and_public_addr_and_rank
@@ -5193,7 +5193,7 @@ views:
       promote: []
       omit: {}
   control_plane.monitor.cluster_summary:
-    family: Ceph/Control Plane/Monitor
+    family: Control Plane/Monitor
     question: How many monitors exist and are currently in quorum for this cluster endpoint?
     entity: cluster
     inputs:
@@ -5219,7 +5219,7 @@ views:
       lost_comparison: Individual monitor rows remain available in the member charts; this view is the additive
         population for one MGR job.
   control_plane.monitor.state_quorum_status:
-    family: Ceph/Control Plane/Monitor
+    family: Control Plane/Monitor
     question: What is the state and metadata — quorum status for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5232,7 +5232,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.accumulated_bytes:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the accumulated byte measurement for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5261,7 +5261,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.accumulated_keys:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the accumulated key measurement for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5290,7 +5290,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.accumulated_latency:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5323,7 +5323,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.bytes_measurements:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the byte measurement measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5352,7 +5352,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.collected_uncommitted_values:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the collected uncommitted values for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5365,7 +5365,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.events:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5402,7 +5402,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.failure_outcomes:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5427,7 +5427,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.keys_measurements:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the key measurement measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5456,7 +5456,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.latency_measurements:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5489,7 +5489,7 @@ views:
       promote: []
       omit: {}
   control_plane.paxos.operations:
-    family: Ceph/Control Plane/Paxos
+    family: Control Plane/Paxos
     question: What is the paxos operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5510,7 +5510,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.collection.duration:
-    family: Ceph/Exporter and Process/Collection
+    family: Exporter and Process/Collection
     question: What is the collection duration for each function and host?
     entity: by_function_and_host
     inputs:
@@ -5523,7 +5523,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_availability.state:
-    family: Ceph/Exporter and Process/Daemon Availability
+    family: Exporter and Process/Daemon Availability
     question: What is the daemon socket state for each ceph daemon and hostname?
     entity: by_ceph_daemon_and_hostname
     inputs:
@@ -5536,7 +5536,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_processes.cpu_time:
-    family: Ceph/Exporter and Process/Daemon Processes
+    family: Exporter and Process/Daemon Processes
     question: What is the cpu time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5551,7 +5551,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_processes.cpu_utilization:
-    family: Ceph/Exporter and Process/Daemon Processes
+    family: Exporter and Process/Daemon Processes
     question: What is the cpu utilization for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5569,7 +5569,7 @@ views:
       evidence:
         - ceph_display_conventions
   exporter_and_process_runtime.daemon_processes.memory:
-    family: Ceph/Exporter and Process/Daemon Processes
+    family: Exporter and Process/Daemon Processes
     question: What is the memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5586,7 +5586,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_processes.page_faults:
-    family: Ceph/Exporter and Process/Daemon Processes
+    family: Exporter and Process/Daemon Processes
     question: What is the page faults for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5603,7 +5603,7 @@ views:
       promote: []
       omit: {}
   exporter_and_process_runtime.daemon_processes.threads:
-    family: Ceph/Exporter and Process/Daemon Processes
+    family: Exporter and Process/Daemon Processes
     question: What is the threads for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5616,7 +5616,7 @@ views:
       promote: []
       omit: {}
   health.cluster_status.state:
-    family: Ceph/Health/Cluster Status
+    family: Health/Cluster Status
     question: What is the state and metadata?
     entity: cluster
     inputs:
@@ -5629,7 +5629,7 @@ views:
       promote: []
       omit: {}
   health.daemon_health.item_count:
-    family: Ceph/Health/Daemon Health
+    family: Health/Daemon Health
     question: How many items does each Ceph daemon health metric currently report?
     entity: by_ceph_daemon_and_type
     inputs:
@@ -5642,7 +5642,7 @@ views:
       promote: []
       omit: {}
   health.health_checks.state:
-    family: Ceph/Health/Health Checks
+    family: Health/Health Checks
     question: What are the state and source-recorded severity of each health check?
     entity: by_name
     inputs:
@@ -5656,7 +5656,7 @@ views:
         - severity
       omit: {}
   health.slow_operations.current_operations:
-    family: Ceph/Health/Slow Operations
+    family: Health/Slow Operations
     question: How many slow operations does the cluster currently report?
     entity: cluster
     inputs:
@@ -5669,7 +5669,7 @@ views:
       promote: []
       omit: {}
   manager_daemons.lookup_outcomes:
-    family: Ceph/Managers/Daemons
+    family: Managers/Daemons
     question: What is the lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5686,7 +5686,7 @@ views:
       promote: []
       omit: {}
   messenger.active_queue_pairs:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the active queue pairs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5699,7 +5699,7 @@ views:
       promote: []
       omit: {}
   messenger.async_events:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the asynchronous events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5716,7 +5716,7 @@ views:
       promote: []
       omit: {}
   messenger.connection_timeouts:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the connection timeout rate for each worker and its daemon-owner alternative?
     entity: by_id_and_daemon_owner_alternative
     inputs:
@@ -5733,7 +5733,7 @@ views:
       promote: []
       omit: {}
   messenger.created_queue_pairs:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the created queue pairs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5746,7 +5746,7 @@ views:
       promote: []
       omit: {}
   messenger.inflight_tx_chunks:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the in-flight transmit chunks for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5759,7 +5759,7 @@ views:
       promote: []
       omit: {}
   messenger.polling_state:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the polling state for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5772,7 +5772,7 @@ views:
       promote: []
       omit: {}
   messenger.rdma_errors:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the rdma errors for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5801,7 +5801,7 @@ views:
       promote: []
       omit: {}
   messenger.receive_buffers:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the receive buffers for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5818,7 +5818,7 @@ views:
       promote: []
       omit: {}
   messenger.received_fin_messages:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the received fin messages for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5831,7 +5831,7 @@ views:
       promote: []
       omit: {}
   messenger.work_completions:
-    family: Ceph/Messenger
+    family: Messenger
     question: What is the work completions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5848,7 +5848,7 @@ views:
       promote: []
       omit: {}
   monitor_daemons.elections:
-    family: Ceph/Monitors/Daemons
+    family: Monitors/Daemons
     question: What is the elections for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5873,7 +5873,7 @@ views:
       promote: []
       omit: {}
   monitor_daemons.session_state:
-    family: Ceph/Monitors/Daemons
+    family: Monitors/Daemons
     question: What is the sessions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5886,7 +5886,7 @@ views:
       promote: []
       omit: {}
   monitor_daemons.session_work:
-    family: Ceph/Monitors/Daemons
+    family: Monitors/Daemons
     question: What is the session churn for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -5907,7 +5907,7 @@ views:
       promote: []
       omit: {}
   node_hardware.health.state:
-    family: Ceph/Hardware/Health
+    family: Hardware/Health
     question: What is the current health state of each reported hardware component?
     entity: node_hardware_component
     inputs:
@@ -5920,7 +5920,7 @@ views:
       promote: []
       omit: {}
   node_hardware.temperature.temperature:
-    family: Ceph/Hardware/Temperature
+    family: Hardware/Temperature
     question: What temperature does each reported hardware sensor observe?
     entity: node_hardware_temperature_sensor
     inputs:
@@ -5939,7 +5939,7 @@ views:
         per second.
       evidence:
         - ceph_display_conventions
-    family: Ceph/Hardware/Cooling
+    family: Hardware/Cooling
     question: What is the current speed of each reported fan?
     entity: node_hardware_fan
     inputs:
@@ -5952,7 +5952,7 @@ views:
       promote: []
       omit: {}
   node_hardware.memory.capacity:
-    family: Ceph/Hardware/Memory
+    family: Hardware/Memory
     question: What capacity does each reported memory module provide?
     entity: node_hardware_memory_module
     inputs:
@@ -5965,7 +5965,7 @@ views:
       promote: []
       omit: {}
   node_hardware.processors.cpu_cores:
-    family: Ceph/Hardware/Processors
+    family: Hardware/Processors
     question: How many cores does each reported CPU provide?
     entity: node_hardware_cpu
     inputs:
@@ -5978,7 +5978,7 @@ views:
       promote: []
       omit: {}
   node_hardware.storage.capacity:
-    family: Ceph/Hardware/Storage
+    family: Hardware/Storage
     question: What capacity does each reported storage device provide?
     entity: node_hardware_storage_device
     inputs:
@@ -5991,7 +5991,7 @@ views:
       promote: []
       omit: {}
   nvme_of.block_devices.byte_throughput:
-    family: Ceph/NVMe-oF/Block Devices
+    family: NVMe-oF/Block Devices
     question: What is the byte throughput for each bdev name?
     entity: by_bdev_name
     inputs:
@@ -6008,7 +6008,7 @@ views:
       promote: []
       omit: {}
   nvme_of.block_devices.operations:
-    family: Ceph/NVMe-oF/Block Devices
+    family: NVMe-oF/Block Devices
     question: What is the operations for each bdev name?
     entity: by_bdev_name
     inputs:
@@ -6025,7 +6025,7 @@ views:
       promote: []
       omit: {}
   nvme_of.block_devices.space:
-    family: Ceph/NVMe-oF/Block Devices
+    family: NVMe-oF/Block Devices
     question: What is the space and memory for each bdev name?
     entity: by_bdev_name
     inputs:
@@ -6038,7 +6038,7 @@ views:
       promote: []
       omit: {}
   nvme_of.block_devices.state:
-    family: Ceph/NVMe-oF/Block Devices
+    family: NVMe-oF/Block Devices
     question: What is the state and metadata for each bdev name and block size and namespace and pool name and rbd
       name?
     entity: by_bdev_name_and_block_size_and_namespace_and_pool_name_and_rbd_name
@@ -6052,7 +6052,7 @@ views:
       promote: []
       omit: {}
   nvme_of.block_devices.time_accumulation:
-    family: Ceph/NVMe-oF/Block Devices
+    family: NVMe-oF/Block Devices
     question: What is the accumulated time for each bdev name?
     entity: by_bdev_name
     inputs:
@@ -6069,7 +6069,7 @@ views:
       promote: []
       omit: {}
   nvme_of.gateways.duration:
-    family: Ceph/NVMe-oF/Gateways
+    family: NVMe-oF/Gateways
     question: What is the collection duration for each method?
     entity: by_method
     inputs:
@@ -6082,7 +6082,7 @@ views:
       promote: []
       omit: {}
   nvme_of.gateways.time_accumulation:
-    family: Ceph/NVMe-oF/Gateways
+    family: NVMe-oF/Gateways
     question: What is the accumulated busy and idle reactor time for each local gateway reactor thread?
     entity: by_name
     inputs:
@@ -6096,7 +6096,7 @@ views:
       promote: []
       omit: {}
   nvme_of.hosts.connection_state:
-    family: Ceph/NVMe-oF/Hosts
+    family: NVMe-oF/Hosts
     question: What is the host connection state for each gw name and host addr and host nqn and nqn?
     entity: by_gw_name_and_host_addr_and_host_nqn_and_nqn
     inputs:
@@ -6109,7 +6109,7 @@ views:
       promote: []
       omit: {}
   nvme_of.hosts.keepalive_timeout_state:
-    family: Ceph/NVMe-oF/Hosts
+    family: NVMe-oF/Hosts
     question: What is the keepalive timeout state for each gw name and host nqn and nqn?
     entity: by_gw_name_and_host_nqn_and_nqn
     inputs:
@@ -6122,7 +6122,7 @@ views:
       promote: []
       omit: {}
   nvme_of.subsystems.host_state:
-    family: Ceph/NVMe-oF/Subsystems
+    family: NVMe-oF/Subsystems
     question: What is the configured hosts for each nqn?
     entity: by_nqn
     inputs:
@@ -6135,7 +6135,7 @@ views:
       promote: []
       omit: {}
   nvme_of.subsystems.link_speed:
-    family: Ceph/NVMe-oF/Subsystems
+    family: NVMe-oF/Subsystems
     question: What is the listener interface link speed for each device?
     entity: by_device
     inputs:
@@ -6153,7 +6153,7 @@ views:
       evidence:
         - nvmeof_display_conventions
   nvme_of.subsystems.listener_state:
-    family: Ceph/NVMe-oF/Subsystems
+    family: NVMe-oF/Subsystems
     question: What is the listener addresses for each nqn?
     entity: by_nqn
     inputs:
@@ -6166,7 +6166,7 @@ views:
       promote: []
       omit: {}
   nvme_of.subsystems.namespace_count:
-    family: Ceph/NVMe-oF/Subsystems
+    family: NVMe-oF/Subsystems
     question: What is the namespaces for each nqn?
     entity: by_nqn
     inputs:
@@ -6179,7 +6179,7 @@ views:
       promote: []
       omit: {}
   nvme_of.gateways.namespace_count:
-    family: Ceph/NVMe-oF/Gateways
+    family: NVMe-oF/Gateways
     question: How many namespaces does this local exporter endpoint serve?
     entity: local_gateway_endpoint
     inputs:
@@ -6196,7 +6196,7 @@ views:
       reducer: sum
       lost_comparison: Individual subsystem namespace counts remain available in the Subsystems/Namespaces chart.
   nvme_of.subsystems.namespace_capacity:
-    family: Ceph/NVMe-oF/Subsystems
+    family: NVMe-oF/Subsystems
     question: How does each subsystem namespace population compare with its configured limit?
     entity: by_nqn
     inputs:
@@ -6213,7 +6213,7 @@ views:
       promote: []
       omit: {}
   nvme_of.subsystems.state_metadata:
-    family: Ceph/NVMe-oF/Subsystems
+    family: NVMe-oF/Subsystems
     question: What is the state and metadata — metadata for each allow any host and group and ha enabled and model
       number and nqn and serial number?
     entity: by_allow_any_host_and_group_and_ha_enabled_and_model_number_and_nqn_and_serial_number
@@ -6227,7 +6227,7 @@ views:
       promote: []
       omit: {}
   nvme_of.subsystems.state_namespace_metadata:
-    family: Ceph/NVMe-oF/Subsystems
+    family: NVMe-oF/Subsystems
     question: What is the state and metadata — namespace metadata for each anagrpid and bdev name and nqn and nsid
       and rados namespace name?
     entity: by_anagrpid_and_bdev_name_and_nqn_and_nsid_and_rados_namespace_name
@@ -6241,7 +6241,7 @@ views:
       promote: []
       omit: {}
   object_gateway.lifecycle.aborted_multipart_uploads:
-    family: Ceph/Object Gateway/Lifecycle
+    family: Object Gateway/Lifecycle
     question: What is the aborted multipart uploads for each instance id?
     entity: by_instance_id
     inputs:
@@ -6254,7 +6254,7 @@ views:
       promote: []
       omit: {}
   object_gateway.lifecycle.lifecycle_actions:
-    family: Ceph/Object Gateway/Lifecycle
+    family: Object Gateway/Lifecycle
     question: What is the lifecycle actions for each instance id?
     entity: by_instance_id
     inputs:
@@ -6283,7 +6283,7 @@ views:
       promote: []
       omit: {}
   object_gateway.lua.current_vms:
-    family: Ceph/Object Gateway/Lua
+    family: Object Gateway/Lua
     question: What is the current lua virtual machines for each instance id?
     entity: by_instance_id
     inputs:
@@ -6301,7 +6301,7 @@ views:
       evidence:
         - ceph_display_conventions
   object_gateway.lua.script_executions:
-    family: Ceph/Object Gateway/Lua
+    family: Object Gateway/Lua
     question: What is the lua script executions for each instance id?
     entity: by_instance_id
     inputs:
@@ -6318,7 +6318,7 @@ views:
       promote: []
       omit: {}
   object_gateway.notifications.event_state:
-    family: Ceph/Object Gateway/Notifications
+    family: Object Gateway/Notifications
     question: What is the stored events for each instance id?
     entity: by_instance_id
     inputs:
@@ -6331,7 +6331,7 @@ views:
       promote: []
       omit: {}
   object_gateway.notifications.events:
-    family: Ceph/Object Gateway/Notifications
+    family: Object Gateway/Notifications
     question: What is the events for each instance id?
     entity: by_instance_id
     inputs:
@@ -6356,7 +6356,7 @@ views:
       promote: []
       omit: {}
   object_gateway.notifications.failure_outcomes:
-    family: Ceph/Object Gateway/Notifications
+    family: Object Gateway/Notifications
     question: What is the failure and delay outcomes for each instance id?
     entity: by_instance_id
     inputs:
@@ -6373,7 +6373,7 @@ views:
       promote: []
       omit: {}
   object_gateway.notifications.missing_configurations:
-    family: Ceph/Object Gateway/Notifications
+    family: Object Gateway/Notifications
     question: What is the missing notification configurations for each instance id?
     entity: by_instance_id
     inputs:
@@ -6386,7 +6386,7 @@ views:
       promote: []
       omit: {}
   object_gateway.notifications.pending_events:
-    family: Ceph/Object Gateway/Notifications
+    family: Object Gateway/Notifications
     question: What is the pending notification events for each instance id?
     entity: by_instance_id
     inputs:
@@ -6399,7 +6399,7 @@ views:
       promote: []
       omit: {}
   object_gateway.requests_and_queue.accumulated_latency:
-    family: Ceph/Object Gateway/Requests and Queue
+    family: Object Gateway/Requests and Queue
     question: What is the accumulated latency for each instance id?
     entity: by_instance_id
     inputs:
@@ -6416,7 +6416,7 @@ views:
       promote: []
       omit: {}
   object_gateway.requests_and_queue.byte_throughput:
-    family: Ceph/Object Gateway/Requests and Queue
+    family: Object Gateway/Requests and Queue
     question: What is the byte throughput for each instance id?
     entity: by_instance_id
     inputs:
@@ -6433,7 +6433,7 @@ views:
       promote: []
       omit: {}
   object_gateway.requests_and_queue.current_requests:
-    family: Ceph/Object Gateway/Requests and Queue
+    family: Object Gateway/Requests and Queue
     question: What is the queued and active requests for each instance id?
     entity: by_instance_id
     inputs:
@@ -6450,7 +6450,7 @@ views:
       promote: []
       omit: {}
   object_gateway.requests_and_queue.failed_requests:
-    family: Ceph/Object Gateway/Requests and Queue
+    family: Object Gateway/Requests and Queue
     question: What is the failed requests for each instance id?
     entity: by_instance_id
     inputs:
@@ -6463,7 +6463,7 @@ views:
       promote: []
       omit: {}
   object_gateway.requests_and_queue.latency_measurements:
-    family: Ceph/Object Gateway/Requests and Queue
+    family: Object Gateway/Requests and Queue
     question: What is the latency measurements for each instance id?
     entity: by_instance_id
     inputs:
@@ -6480,7 +6480,7 @@ views:
       promote: []
       omit: {}
   object_gateway.requests_and_queue.object_work:
-    family: Ceph/Object Gateway/Requests and Queue
+    family: Object Gateway/Requests and Queue
     question: What is the object work for each instance id?
     entity: by_instance_id
     inputs:
@@ -6493,7 +6493,7 @@ views:
       promote: []
       omit: {}
   object_gateway.requests_and_queue.requests:
-    family: Ceph/Object Gateway/Requests and Queue
+    family: Object Gateway/Requests and Queue
     question: What is the requests for each instance id?
     entity: by_instance_id
     inputs:
@@ -6514,7 +6514,7 @@ views:
       promote: []
       omit: {}
   object_gateway_cache.keystone_lookup_outcomes:
-    family: Ceph/Object Gateway/Cache
+    family: Object Gateway/Cache
     question: What is the keystone token cache lookup outcomes for each instance id?
     entity: by_instance_id
     inputs:
@@ -6531,7 +6531,7 @@ views:
       promote: []
       omit: {}
   object_gateway_cache.lookup_outcomes:
-    family: Ceph/Object Gateway/Cache
+    family: Object Gateway/Cache
     question: What is the lookup outcomes for each instance id?
     entity: by_instance_id
     inputs:
@@ -6548,7 +6548,7 @@ views:
       promote: []
       omit: {}
   object_gateway_metadata.state:
-    family: Ceph/Object Gateway/Metadata
+    family: Object Gateway/Metadata
     question: What is the state and metadata for each ceph daemon and ceph version and hostname and instance id?
     entity: by_ceph_daemon_and_ceph_version_and_hostname_and_instance_id
     inputs:
@@ -6561,7 +6561,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.accumulated_bytes:
-    family: Ceph/Object Gateway/Multisite
+    family: Object Gateway/Multisite
     question: What is the accumulated byte measurement for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6574,7 +6574,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.accumulated_latency:
-    family: Ceph/Object Gateway/Multisite
+    family: Object Gateway/Multisite
     question: What is the accumulated latency for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6591,7 +6591,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.latency_measurements:
-    family: Ceph/Object Gateway/Multisite
+    family: Object Gateway/Multisite
     question: What is the latency measurements for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6608,7 +6608,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.object_work:
-    family: Ceph/Object Gateway/Multisite
+    family: Object Gateway/Multisite
     question: What is the object work for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6625,7 +6625,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.replicated_objects:
-    family: Ceph/Object Gateway/Multisite
+    family: Object Gateway/Multisite
     question: What is the replicated objects for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6638,7 +6638,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.replication_log_request_errors:
-    family: Ceph/Object Gateway/Multisite
+    family: Object Gateway/Multisite
     question: What is the replication-log request errors for each instance id and source zone?
     entity: by_instance_id_and_source_zone
     inputs:
@@ -6651,7 +6651,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.accumulated_latency:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the accumulated scheduling latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6692,7 +6692,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.latency_measurements:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the scheduling-latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6733,7 +6733,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.outstanding_requests:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the outstanding requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6746,7 +6746,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.queue_cost:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the queued request cost for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6771,7 +6771,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.queue_depth:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the queue depth for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6796,7 +6796,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.rejected_and_cancelled_requests:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the rejected and cancelled requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6837,7 +6837,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.scheduled_and_rejected_cost:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the scheduled and rejected cost for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6910,7 +6910,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.scheduled_requests:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the scheduled requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6951,7 +6951,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.throttled_requests:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the throttled requests for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -6964,7 +6964,7 @@ views:
       promote: []
       omit: {}
   object_gateway.global_operations.operations:
-    family: Ceph/Object Gateway/Global Operations
+    family: Object Gateway/Global Operations
     question: What is the operations for each instance id?
     entity: by_instance_id
     inputs:
@@ -7001,7 +7001,7 @@ views:
       promote: []
       omit: {}
   object_gateway.global_operations.object_bytes:
-    family: Ceph/Object Gateway/Global Operations
+    family: Object Gateway/Global Operations
     question: What is the object bytes for each instance id?
     entity: by_instance_id
     inputs:
@@ -7026,7 +7026,7 @@ views:
       promote: []
       omit: {}
   object_gateway.global_operations.latency_measurements:
-    family: Ceph/Object Gateway/Global Operations
+    family: Object Gateway/Global Operations
     question: What is the latency measurements for each instance id?
     entity: by_instance_id
     inputs:
@@ -7063,7 +7063,7 @@ views:
       promote: []
       omit: {}
   object_gateway.global_operations.accumulated_latency:
-    family: Ceph/Object Gateway/Global Operations
+    family: Object Gateway/Global Operations
     question: What is the accumulated latency for each instance id?
     entity: by_instance_id
     inputs:
@@ -7100,7 +7100,7 @@ views:
       promote: []
       omit: {}
   object_gateway.user_operations.operations:
-    family: Ceph/Object Gateway/User Operations
+    family: Object Gateway/User Operations
     question: What is the operations for each instance id and user and tenant?
     entity: by_instance_id_and_user_and_tenant
     inputs:
@@ -7137,7 +7137,7 @@ views:
       promote: []
       omit: {}
   object_gateway.user_operations.object_bytes:
-    family: Ceph/Object Gateway/User Operations
+    family: Object Gateway/User Operations
     question: What is the object bytes for each instance id and user and tenant?
     entity: by_instance_id_and_user_and_tenant
     inputs:
@@ -7162,7 +7162,7 @@ views:
       promote: []
       omit: {}
   object_gateway.user_operations.latency_measurements:
-    family: Ceph/Object Gateway/User Operations
+    family: Object Gateway/User Operations
     question: What is the latency measurements for each instance id and user and tenant?
     entity: by_instance_id_and_user_and_tenant
     inputs:
@@ -7199,7 +7199,7 @@ views:
       promote: []
       omit: {}
   object_gateway.user_operations.accumulated_latency:
-    family: Ceph/Object Gateway/User Operations
+    family: Object Gateway/User Operations
     question: What is the accumulated latency for each instance id and user and tenant?
     entity: by_instance_id_and_user_and_tenant
     inputs:
@@ -7236,7 +7236,7 @@ views:
       promote: []
       omit: {}
   object_gateway.bucket_operations.operations:
-    family: Ceph/Object Gateway/Bucket Operations
+    family: Object Gateway/Bucket Operations
     question: What is the operations for each instance id and bucket and tenant?
     entity: by_instance_id_and_bucket_and_tenant
     inputs:
@@ -7273,7 +7273,7 @@ views:
       promote: []
       omit: {}
   object_gateway.bucket_operations.object_bytes:
-    family: Ceph/Object Gateway/Bucket Operations
+    family: Object Gateway/Bucket Operations
     question: What is the object bytes for each instance id and bucket and tenant?
     entity: by_instance_id_and_bucket_and_tenant
     inputs:
@@ -7298,7 +7298,7 @@ views:
       promote: []
       omit: {}
   object_gateway.bucket_operations.latency_measurements:
-    family: Ceph/Object Gateway/Bucket Operations
+    family: Object Gateway/Bucket Operations
     question: What is the latency measurements for each instance id and bucket and tenant?
     entity: by_instance_id_and_bucket_and_tenant
     inputs:
@@ -7335,7 +7335,7 @@ views:
       promote: []
       omit: {}
   object_gateway.bucket_operations.accumulated_latency:
-    family: Ceph/Object Gateway/Bucket Operations
+    family: Object Gateway/Bucket Operations
     question: What is the accumulated latency for each instance id and bucket and tenant?
     entity: by_instance_id_and_bucket_and_tenant
     inputs:
@@ -7372,7 +7372,7 @@ views:
       promote: []
       omit: {}
   object_gateway_multisite.data_log_shard_delay:
-    family: Ceph/Object Gateway/Multisite
+    family: Object Gateway/Multisite
     question: What is the current data-log shard delay for each instance id and dynamic sync shard?
     entity: by_instance_id_and_local_zone_id_and_source_zone_id_and_shard_id_and_sync_shard
     inputs:
@@ -7386,7 +7386,7 @@ views:
       omit: {}
 
   object_gateway.persistent_topics.queue_length:
-    family: Ceph/Object Gateway/Persistent Topics
+    family: Object Gateway/Persistent Topics
     question: What is the persistent topic queue length for each instance id and topic?
     entity: by_instance_id_and_topic
     inputs:
@@ -7399,7 +7399,7 @@ views:
       promote: []
       omit: {}
   object_gateway.persistent_topics.queue_size:
-    family: Ceph/Object Gateway/Persistent Topics
+    family: Object Gateway/Persistent Topics
     question: What is the persistent topic queue size for each instance id and topic?
     entity: by_instance_id_and_topic
     inputs:
@@ -7413,7 +7413,7 @@ views:
       omit: {}
 
   object_gateway_cache.d4n_lookup_outcomes:
-    family: Ceph/Object Gateway/Cache
+    family: Object Gateway/Cache
     question: What are the D4N cache lookup outcomes for each instance id?
     entity: by_instance_id
     inputs:
@@ -7430,7 +7430,7 @@ views:
       promote: []
       omit: {}
   object_gateway_cache.d4n_cache_evictions:
-    family: Ceph/Object Gateway/Cache
+    family: Object Gateway/Cache
     question: What is the D4N cache eviction rate for each instance id?
     entity: by_instance_id
     inputs:
@@ -7444,7 +7444,7 @@ views:
       omit: {}
 
   object_gateway_scheduling.simple_throttler_outstanding:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the current simple throttler outstanding requests for each instance id?
     entity: by_instance_id
     inputs:
@@ -7457,7 +7457,7 @@ views:
       promote: []
       omit: {}
   object_gateway_scheduling.simple_throttler_rejections:
-    family: Ceph/Object Gateway/Scheduling
+    family: Object Gateway/Scheduling
     question: What is the cumulative simple throttler request rejections for each instance id?
     entity: by_instance_id
     inputs:
@@ -7471,7 +7471,7 @@ views:
       omit: {}
 
   objecter.accumulated_latency:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the accumulated latency for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7488,7 +7488,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_commands:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the active commands for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7505,7 +7505,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_lingering_operations:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the active lingering operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7522,7 +7522,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_operations:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the objecter operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7547,7 +7547,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_pool_operations:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the active pool operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7564,7 +7564,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_poolstat_requests:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the active pool-stat requests for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7581,7 +7581,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.active_statfs_requests:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the active statfs requests for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7598,7 +7598,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.byte_throughput:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the byte throughput for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7615,7 +7615,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.commands:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the commands for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7636,7 +7636,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.latency_measurements:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the latency measurements for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7653,7 +7653,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.lingering_operations:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the lingering operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7678,7 +7678,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.map_epoch:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the osd-map epoch for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7695,7 +7695,7 @@ views:
       reducer: min
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.maps:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the osd maps for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7716,7 +7716,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.operation_vector_entries:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the operation-vector entries for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7733,7 +7733,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.operations:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the object operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7890,7 +7890,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.osd_sessions:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the osd sessions for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7911,7 +7911,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.pool_operations:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the pool operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7932,7 +7932,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.replica_reads:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the replica reads for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7957,7 +7957,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.session_state:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the sessions for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -7978,7 +7978,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.stat_requests:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the pool-stat and statfs requests for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -8007,7 +8007,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   objecter.submitted_operations:
-    family: Ceph/Runtime and Clients/Objecter
+    family: Runtime and Clients/Objecter
     question: What is the submitted top-level operations for each ceph daemon and instance id?
     entity: by_ceph_daemon_and_instance_id
     inputs:
@@ -8024,7 +8024,7 @@ views:
       reducer: sum
       lost_comparison: Individual internal Objecter handles are intentionally not comparable in this view.
   osd_capacity_and_state.cluster_flags.state:
-    family: Ceph/OSDs/Capacity and State/Cluster Flags
+    family: OSDs/Capacity and State/Cluster Flags
     question: What is the state and metadata?
     entity: cluster
     inputs:
@@ -8061,7 +8061,7 @@ views:
       promote: []
       omit: {}
   osd_capacity_and_state.fullness_thresholds.ratio:
-    family: Ceph/OSDs/Capacity and State/Fullness Thresholds
+    family: OSDs/Capacity and State/Fullness Thresholds
     question: What is the ratios?
     entity: cluster
     inputs:
@@ -8083,7 +8083,7 @@ views:
       reason: Render the additive OSD population with the established operator-facing unit.
       evidence:
         - ceph_display_conventions
-    family: Ceph/OSDs/Capacity and State/Metadata
+    family: OSDs/Capacity and State/Metadata
     question: What is the state and metadata for each back iface and ceph daemon and ceph version and cluster addr
       and device class and front iface and hostname and objectstore and public addr?
     entity: by_back_iface_and_ceph_daemon_and_ceph_version_and_cluster_addr_and_device_class_and_front_iface_and_hostname_and_objectstore_and_public_addr
@@ -8102,7 +8102,7 @@ views:
       reason: Render the additive OSD population with the established operator-facing unit.
       evidence:
         - ceph_display_conventions
-    family: Ceph/OSDs/Capacity and State/OSD State
+    family: OSDs/Capacity and State/OSD State
     question: What is the osd state for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8124,7 +8124,7 @@ views:
       reason: Render the additive OSD population with the established operator-facing unit.
       evidence:
         - ceph_display_conventions
-    family: Ceph/OSDs/Capacity and State/OSD State
+    family: OSDs/Capacity and State/OSD State
     question: How many OSDs exist and are currently up for this cluster endpoint?
     entity: cluster
     inputs:
@@ -8154,7 +8154,7 @@ views:
       lost_comparison: Individual OSD rows remain available in the member charts; this view is the additive population
         for one MGR job.
   osd_capacity_and_state.osd_state.weight:
-    family: Ceph/OSDs/Capacity and State/OSD State
+    family: OSDs/Capacity and State/OSD State
     question: What is the osd weight for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8167,7 +8167,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.accumulated_latency:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8248,7 +8248,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.byte_throughput:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8293,7 +8293,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.current_operations:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the operations in progress for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8306,7 +8306,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.events:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the events for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8319,7 +8319,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.failure_outcomes:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the failure and delay outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8332,7 +8332,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.latency_measurements:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8413,7 +8413,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.lookup_outcomes:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8426,7 +8426,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.object_work:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the object work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8447,7 +8447,7 @@ views:
       promote: []
       omit: {}
   osd_client_i_o.operations:
-    family: Ceph/OSDs/Client IO
+    family: OSDs/Client IO
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8500,7 +8500,7 @@ views:
       promote: []
       omit: {}
   osd_overview.latency:
-    family: Ceph/OSDs/Overview
+    family: OSDs/Overview
     question: What is the latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8522,7 +8522,7 @@ views:
       evidence:
         - ceph_display_conventions
   osd_recovery.accumulated_latency:
-    family: Ceph/OSDs/Recovery
+    family: OSDs/Recovery
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8563,7 +8563,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.byte_throughput:
-    family: Ceph/OSDs/Recovery
+    family: OSDs/Recovery
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8576,7 +8576,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.latency_measurements:
-    family: Ceph/OSDs/Recovery
+    family: OSDs/Recovery
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8617,7 +8617,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.operations:
-    family: Ceph/OSDs/Recovery
+    family: OSDs/Recovery
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8630,7 +8630,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.pg_rebuild_accumulated_duration:
-    family: Ceph/OSDs/Recovery
+    family: OSDs/Recovery
     question: At what rate is primary-OSD PG-rebuild duration accumulating for each Ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8643,7 +8643,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.pg_rebuild_duration_measurements:
-    family: Ceph/OSDs/Recovery
+    family: OSDs/Recovery
     question: At what rate are primary-OSD PG-rebuild duration measurements recorded for each Ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8656,7 +8656,7 @@ views:
       promote: []
       omit: {}
   osd_recovery.pg_rebuild_duration_range:
-    family: Ceph/OSDs/Recovery
+    family: OSDs/Recovery
     question: What minimum and maximum PG-rebuild durations does each primary OSD currently report?
     entity: by_ceph_daemon
     inputs:
@@ -8673,7 +8673,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.accumulated_latency:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8694,7 +8694,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.accumulated_value:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the accumulated value measurement for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8707,7 +8707,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.byte_throughput:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8720,7 +8720,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.copyfrom_operations:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the copy-from operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8733,7 +8733,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.crc_lookup_outcomes:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the crc cache lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8754,7 +8754,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.failed_tier_flush_attempts:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the failed tier flush attempts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8771,7 +8771,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.heartbeat_peers:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the heartbeat peers for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8784,7 +8784,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.latency_measurements:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8805,7 +8805,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.load_average:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the osd load average for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8818,7 +8818,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.map_buffer_cache_lookup_outcomes:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the osd-map buffer-cache lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8835,7 +8835,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.map_cache_lookup_outcomes:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the decoded osd-map cache lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8856,7 +8856,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.map_epochs:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the osd-map epochs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8873,7 +8873,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.map_messages:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the osd-map messages for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8890,7 +8890,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.object_context_cache_lookup_outcomes:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the object-context cache lookup outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8907,7 +8907,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.pg_state:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the placement groups for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8941,7 +8941,7 @@ views:
       evidence:
         - ceph_display_conventions
   osd_runtime.pg_updates:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the placement-group updates for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8958,7 +8958,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.pg_updates_total:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the total placement-group updates for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8971,7 +8971,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.pulls:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the pulls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8984,7 +8984,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.pushes:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the pushes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -8997,7 +8997,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.skipped_objects:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the skipped objects for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9010,7 +9010,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.space:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9031,7 +9031,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.suboperations:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the suboperations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9044,7 +9044,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.tier_agent_actions:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the tier-agent actions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9081,7 +9081,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.tier_flush_attempts:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the tier flush attempts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9102,7 +9102,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.tier_whiteouts:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the tier whiteouts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9115,7 +9115,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.value_measurements:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the value measurement measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9128,7 +9128,7 @@ views:
       promote: []
       omit: {}
   osd_runtime.watch_timeouts:
-    family: Ceph/OSDs/Runtime
+    family: OSDs/Runtime
     question: What is the watch timeouts for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9141,7 +9141,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.accumulated_reservation_latency:
-    family: Ceph/OSDs/Scrubbing Ceph 19/Elapsed Time
+    family: OSDs/Scrubbing Ceph 19/Elapsed Time
     question: What is the accumulated reservation elapsed time for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9182,7 +9182,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.accumulated_scrub_latency:
-    family: Ceph/OSDs/Scrubbing Ceph 19/Elapsed Time
+    family: OSDs/Scrubbing Ceph 19/Elapsed Time
     question: What is the accumulated scrub elapsed time for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9223,7 +9223,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.reservation_latency_measurements:
-    family: Ceph/OSDs/Scrubbing Ceph 19/Elapsed Time
+    family: OSDs/Scrubbing Ceph 19/Elapsed Time
     question: What is the reservation elapsed-time measurements for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9264,7 +9264,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.elapsed_time.scrub_latency_measurements:
-    family: Ceph/OSDs/Scrubbing Ceph 19/Elapsed Time
+    family: OSDs/Scrubbing Ceph 19/Elapsed Time
     question: What is the scrub elapsed-time measurements for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9305,7 +9305,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.outcomes.scrub_work:
-    family: Ceph/OSDs/Scrubbing Ceph 19/Outcomes
+    family: OSDs/Scrubbing Ceph 19/Outcomes
     question: What is the scrub work for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9362,7 +9362,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.replicas_in_reservation:
-    family: Ceph/OSDs/Scrubbing Ceph 19/Reservations
+    family: OSDs/Scrubbing Ceph 19/Reservations
     question: What is the replicas in reservation for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9387,7 +9387,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.reservation_process_outcomes:
-    family: Ceph/OSDs/Scrubbing Ceph 19/Reservations
+    family: OSDs/Scrubbing Ceph 19/Reservations
     question: What is the reservation process outcomes for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9444,7 +9444,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_19.reservations.scrubs_past_reservation:
-    family: Ceph/OSDs/Scrubbing Ceph 19/Reservations
+    family: OSDs/Scrubbing Ceph 19/Reservations
     question: What is the scrubs past reservation for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9469,7 +9469,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.accumulated_reservation_latency:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Elapsed Time
+    family: OSDs/Scrubbing Ceph 20/Elapsed Time
     question: What is the accumulated reservation elapsed time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9494,7 +9494,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.accumulated_scrub_latency:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Elapsed Time
+    family: OSDs/Scrubbing Ceph 20/Elapsed Time
     question: What is the accumulated scrub elapsed time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9519,7 +9519,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.reservation_latency_measurements:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Elapsed Time
+    family: OSDs/Scrubbing Ceph 20/Elapsed Time
     question: What is the reservation elapsed-time measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9544,7 +9544,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.elapsed_time.scrub_latency_measurements:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Elapsed Time
+    family: OSDs/Scrubbing Ceph 20/Elapsed Time
     question: What is the scrub elapsed-time measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9569,7 +9569,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.interference_and_scheduling.client_write_interference:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Interference and Scheduling
+    family: OSDs/Scrubbing Ceph 20/Interference and Scheduling
     question: What is the client write interference for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9594,7 +9594,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.outcomes.scrub_work:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Outcomes
+    family: OSDs/Scrubbing Ceph 20/Outcomes
     question: What is the scrub work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9627,7 +9627,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.replicas_in_reservation:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Reservations
+    family: OSDs/Scrubbing Ceph 20/Reservations
     question: What is the replicas in reservation for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9644,7 +9644,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.reservation_process_outcomes:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Reservations
+    family: OSDs/Scrubbing Ceph 20/Reservations
     question: What is the reservation process outcomes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9685,7 +9685,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.reservations.scrubs_past_reservation:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Reservations
+    family: OSDs/Scrubbing Ceph 20/Reservations
     question: What is the scrubs past reservation for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9702,7 +9702,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.scrub_work.byte_throughput:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Scrub Work
+    family: OSDs/Scrubbing Ceph 20/Scrub Work
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9719,7 +9719,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_ceph_20.scrub_work.scrub_calls:
-    family: Ceph/OSDs/Scrubbing Ceph 20/Scrub Work
+    family: OSDs/Scrubbing Ceph 20/Scrub Work
     question: What is the scrub calls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9752,7 +9752,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.blocked_client_writes:
-    family: Ceph/OSDs/Scrubbing Common Work/Interference and Scheduling
+    family: OSDs/Scrubbing Common Work/Interference and Scheduling
     question: What is the client writes blocked by scrub for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9777,7 +9777,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.chunk_selection_outcomes:
-    family: Ceph/OSDs/Scrubbing Common Work/Interference and Scheduling
+    family: OSDs/Scrubbing Common Work/Interference and Scheduling
     question: What is the chunk selection outcomes for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9818,7 +9818,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.object_lock_waits:
-    family: Ceph/OSDs/Scrubbing Common Work/Interference and Scheduling
+    family: OSDs/Scrubbing Common Work/Interference and Scheduling
     question: What is the object-lock waits for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9843,7 +9843,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.interference_and_scheduling.preemptions:
-    family: Ceph/OSDs/Scrubbing Common Work/Interference and Scheduling
+    family: OSDs/Scrubbing Common Work/Interference and Scheduling
     question: What is the scrub preemptions for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9868,7 +9868,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.reservations.completed_reservations:
-    family: Ceph/OSDs/Scrubbing Common Work/Reservations
+    family: OSDs/Scrubbing Common Work/Reservations
     question: What is the completed scrub reservations for each ceph daemon and level and pooltype?
     entity: by_ceph_daemon_and_level_and_pooltype
     inputs:
@@ -9893,7 +9893,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.scrub_work.byte_throughput:
-    family: Ceph/OSDs/Scrubbing Common Work/Scrub Work
+    family: OSDs/Scrubbing Common Work/Scrub Work
     question: What is the byte throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9910,7 +9910,7 @@ views:
       promote: []
       omit: {}
   osd_scrubbing_common_work.scrub_work.omap_calls:
-    family: Ceph/OSDs/Scrubbing Common Work/Scrub Work
+    family: OSDs/Scrubbing Common Work/Scrub Work
     question: What is the omap scrub calls for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -9927,7 +9927,7 @@ views:
       promote: []
       omit: {}
   placement_groups_and_recovery.backfill.pg_state:
-    family: Ceph/Placement Groups/Backfill
+    family: Placement Groups/Backfill
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -9965,7 +9965,7 @@ views:
       evidence:
         - ceph_display_conventions
   placement_groups_and_recovery.healthy_state.pg_state:
-    family: Ceph/Placement Groups/Healthy State
+    family: Placement Groups/Healthy State
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -9995,7 +9995,7 @@ views:
       evidence:
         - ceph_display_conventions
   placement_groups_and_recovery.peering_and_availability.pg_state:
-    family: Ceph/Placement Groups/Peering and Availability
+    family: Placement Groups/Peering and Availability
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -10053,7 +10053,7 @@ views:
       evidence:
         - ceph_display_conventions
   placement_groups_and_recovery.recovery_and_degradation.pg_state:
-    family: Ceph/Placement Groups/Recovery and Degradation
+    family: Placement Groups/Recovery and Degradation
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -10095,7 +10095,7 @@ views:
       evidence:
         - ceph_display_conventions
   placement_groups_and_recovery.recovery_flags.state:
-    family: Ceph/Placement Groups/Recovery Flags
+    family: Placement Groups/Recovery Flags
     question: What is the state and metadata?
     entity: cluster
     inputs:
@@ -10112,7 +10112,7 @@ views:
       promote: []
       omit: {}
   placement_groups_and_recovery.scrub_and_repair_state.pg_state:
-    family: Ceph/Placement Groups/Scrub and Repair State
+    family: Placement Groups/Scrub and Repair State
     question: What is the placement groups for each pool id?
     entity: by_pool_id
     inputs:
@@ -10154,7 +10154,7 @@ views:
       evidence:
         - ceph_display_conventions
   pools.capacity_and_quotas.compression_space:
-    family: Ceph/Pools/Capacity and Quotas
+    family: Pools/Capacity and Quotas
     question: What is the compression space for each pool id?
     entity: by_pool_id
     inputs:
@@ -10171,7 +10171,7 @@ views:
       promote: []
       omit: {}
   pools.capacity_and_quotas.logical_space:
-    family: Ceph/Pools/Capacity and Quotas
+    family: Pools/Capacity and Quotas
     question: What is the logical pool capacity for each pool id?
     entity: by_pool_id
     inputs:
@@ -10192,7 +10192,7 @@ views:
       promote: []
       omit: {}
   pools.capacity_and_quotas.object_state:
-    family: Ceph/Pools/Capacity and Quotas
+    family: Pools/Capacity and Quotas
     question: What is the objects for each pool id?
     entity: by_pool_id
     inputs:
@@ -10205,7 +10205,7 @@ views:
       promote: []
       omit: {}
   pools.capacity_and_quotas.raw_space:
-    family: Ceph/Pools/Capacity and Quotas
+    family: Pools/Capacity and Quotas
     question: What is the raw pool capacity for each pool id?
     entity: by_pool_id
     inputs:
@@ -10226,7 +10226,7 @@ views:
       promote: []
       omit: {}
   pools.capacity_and_quotas.utilization:
-    family: Ceph/Pools/Capacity and Quotas
+    family: Pools/Capacity and Quotas
     question: What is the utilization for each pool id?
     entity: by_pool_id
     inputs:
@@ -10244,7 +10244,7 @@ views:
       evidence:
         - ceph_display_conventions
   pools.client_i_o.byte_throughput:
-    family: Ceph/Pools/Client IO
+    family: Pools/Client IO
     question: What is the byte throughput for each pool id?
     entity: by_pool_id
     inputs:
@@ -10261,7 +10261,7 @@ views:
       promote: []
       omit: {}
   pools.client_i_o.operations:
-    family: Ceph/Pools/Client IO
+    family: Pools/Client IO
     question: What is the operations for each pool id?
     entity: by_pool_id
     inputs:
@@ -10278,7 +10278,7 @@ views:
       promote: []
       omit: {}
   pools.metadata.state:
-    family: Ceph/Pools/Metadata
+    family: Pools/Metadata
     question: What is the state and metadata for each application and compression mode and description and name
       and pool id and type?
     entity: by_application_and_compression_mode_and_description_and_name_and_pool_id_and_type
@@ -10292,7 +10292,7 @@ views:
       promote: []
       omit: {}
   pools.objects.object_state:
-    family: Ceph/Pools/Objects
+    family: Pools/Objects
     question: What is the objects for each pool id?
     entity: by_pool_id
     inputs:
@@ -10309,7 +10309,7 @@ views:
       promote: []
       omit: {}
   pools.recovery.current_throughput_bytes_s:
-    family: Ceph/Pools/Recovery
+    family: Pools/Recovery
     question: What is the current throughput for each pool id?
     entity: by_pool_id
     inputs:
@@ -10322,7 +10322,7 @@ views:
       promote: []
       omit: {}
   pools.recovery.current_throughput_keys_s:
-    family: Ceph/Pools/Recovery
+    family: Pools/Recovery
     question: What is the current throughput for each pool id?
     entity: by_pool_id
     inputs:
@@ -10335,7 +10335,7 @@ views:
       promote: []
       omit: {}
   pools.recovery.current_throughput_objects_s:
-    family: Ceph/Pools/Recovery
+    family: Pools/Recovery
     question: What is the current throughput for each pool id?
     entity: by_pool_id
     inputs:
@@ -10348,7 +10348,7 @@ views:
       promote: []
       omit: {}
   pools.recovery.object_state:
-    family: Ceph/Pools/Recovery
+    family: Pools/Recovery
     question: What is the objects for each pool id?
     entity: by_pool_id
     inputs:
@@ -10361,7 +10361,7 @@ views:
       promote: []
       omit: {}
   pools.recovery.object_work:
-    family: Ceph/Pools/Recovery
+    family: Pools/Recovery
     question: What is the object work for each pool id?
     entity: by_pool_id
     inputs:
@@ -10374,7 +10374,7 @@ views:
       promote: []
       omit: {}
   pools.recovery.space:
-    family: Ceph/Pools/Recovery
+    family: Pools/Recovery
     question: What is the pool capacity and data volume for each pool id?
     entity: by_pool_id
     inputs:
@@ -10387,7 +10387,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.accumulated_data_operation_latency:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the accumulated data operation latency for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10408,7 +10408,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.accumulated_flush_latency:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the accumulated flush latency for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10421,7 +10421,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.accumulated_io_latency:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the accumulated i/o latency for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10438,7 +10438,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.data_operation_byte_throughput:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the data operation byte throughput for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10459,7 +10459,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.data_operation_latency_measurements:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the data operation latency measurements for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10480,7 +10480,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.data_operations:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the data operations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10501,7 +10501,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.flush_latency_measurements:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the flush latency measurements for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10514,7 +10514,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.flush_operations:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the flush operations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10527,7 +10527,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.io_byte_throughput:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the i/o byte throughput for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10544,7 +10544,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.io_latency_measurements:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the i/o latency measurements for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10561,7 +10561,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.io_operations:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the i/o operations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10578,7 +10578,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.lifecycle_timestamps:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the lifecycle timestamps for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10595,7 +10595,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.maintenance_operations:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the maintenance operations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10620,7 +10620,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.readahead_byte_throughput:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the readahead byte throughput for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10633,7 +10633,7 @@ views:
       promote: []
       omit: {}
   rbd_client_images.snapshot_mutations:
-    family: Ceph/RBD Images/Client Images
+    family: RBD Images/Client Images
     question: What is the snapshot mutations for each ceph daemon and librbd image key?
     entity: by_ceph_daemon_and_librbd_image_key
     inputs:
@@ -10658,7 +10658,7 @@ views:
       promote: []
       omit: {}
   rbd_images.i_o.byte_throughput:
-    family: Ceph/RBD Images/IO
+    family: RBD Images/IO
     question: What is the byte throughput for each image and namespace and pool?
     entity: by_image_and_namespace_and_pool
     inputs:
@@ -10675,7 +10675,7 @@ views:
       promote: []
       omit: {}
   rbd_images.i_o.operations:
-    family: Ceph/RBD Images/IO
+    family: RBD Images/IO
     question: What is the operations for each image and namespace and pool?
     entity: by_image_and_namespace_and_pool
     inputs:
@@ -10692,7 +10692,7 @@ views:
       promote: []
       omit: {}
   rbd_images.image_metadata.state:
-    family: Ceph/RBD Images/Image Metadata
+    family: RBD Images/Image Metadata
     question: What is the state and metadata for each image name and pool id?
     entity: by_image_name_and_pool_id
     inputs:
@@ -10705,7 +10705,7 @@ views:
       promote: []
       omit: {}
   rbd_images.latency.accumulated_latency:
-    family: Ceph/RBD Images/Latency
+    family: RBD Images/Latency
     question: What is the accumulated latency for each image and namespace and pool?
     entity: by_image_and_namespace_and_pool
     inputs:
@@ -10722,7 +10722,7 @@ views:
       promote: []
       omit: {}
   rbd_images.latency.latency_measurements:
-    family: Ceph/RBD Images/Latency
+    family: RBD Images/Latency
     question: What is the latency measurements for each image and namespace and pool?
     entity: by_image_and_namespace_and_pool
     inputs:
@@ -10739,7 +10739,7 @@ views:
       promote: []
       omit: {}
   rbd_images.mirror_metadata.state:
-    family: Ceph/RBD Images/Mirror Metadata
+    family: RBD Images/Mirror Metadata
     question: What is the state and metadata for each ceph daemon and ceph version and hostname and id and instance
       id?
     entity: by_ceph_daemon_and_ceph_version_and_hostname_and_id_and_instance_id
@@ -10753,7 +10753,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.accumulated_latency:
-    family: Ceph/RBD Images/Mirror/Journal
+    family: RBD Images/Mirror/Journal
     question: What is the accumulated latency for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10766,7 +10766,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.byte_throughput:
-    family: Ceph/RBD Images/Mirror/Journal
+    family: RBD Images/Mirror/Journal
     question: What is the byte throughput for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10779,7 +10779,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.image_accumulated_latency:
-    family: Ceph/RBD Images/Mirror/Journal
+    family: RBD Images/Mirror/Journal
     question: What is the accumulated image journal replay latency for each ceph daemon and image and namespace
       and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
@@ -10793,7 +10793,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.image_byte_throughput:
-    family: Ceph/RBD Images/Mirror/Journal
+    family: RBD Images/Mirror/Journal
     question: What is the image journal replay byte throughput for each ceph daemon and image and namespace and
       pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
@@ -10807,7 +10807,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.image_journal_entries:
-    family: Ceph/RBD Images/Mirror/Journal
+    family: RBD Images/Mirror/Journal
     question: What is the journal entries queued for replay for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10820,7 +10820,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.image_latency_measurements:
-    family: Ceph/RBD Images/Mirror/Journal
+    family: RBD Images/Mirror/Journal
     question: What is the image journal replay latency measurements for each ceph daemon and image and namespace
       and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
@@ -10834,7 +10834,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.journal_entries:
-    family: Ceph/RBD Images/Mirror/Journal
+    family: RBD Images/Mirror/Journal
     question: What is the journal entries for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10847,7 +10847,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.journal.latency_measurements:
-    family: Ceph/RBD Images/Mirror/Journal
+    family: RBD Images/Mirror/Journal
     question: What is the journal replay latency measurements for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10860,7 +10860,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.accumulated_latency_image_sync_time:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the accumulated latency — image sync time for each ceph daemon and image and namespace and
       pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
@@ -10874,7 +10874,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.accumulated_latency_sync_time:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the accumulated latency — sync time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -10887,7 +10887,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.byte_throughput_image_sync_bytes:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the byte throughput — image sync bytes for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10900,7 +10900,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.byte_throughput_sync_bytes:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the byte throughput — sync bytes for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -10913,7 +10913,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.last_sync_duration:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the last snapshot sync duration for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10926,7 +10926,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.last_sync_size:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the last snapshot sync size for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10939,7 +10939,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.latency_measurements_image_sync_time:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the snapshot sync latency measurements — image sync time for each ceph daemon and image and
       namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
@@ -10953,7 +10953,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.latency_measurements_sync_time:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the snapshot sync latency measurements — sync time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -10966,7 +10966,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.snapshot_work_image_snapshots:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the snapshot work — image snapshots for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -10979,7 +10979,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.snapshot_work_snapshots:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the snapshot work — snapshots for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -10992,7 +10992,7 @@ views:
       promote: []
       omit: {}
   rbd_mirror.snapshot_replication.timestamp:
-    family: Ceph/RBD Images/Mirror/Snapshot Replication
+    family: RBD Images/Mirror/Snapshot Replication
     question: What is the timestamps for each ceph daemon and image and namespace and pool?
     entity: by_ceph_daemon_and_image_and_namespace_and_pool
     inputs:
@@ -11009,7 +11009,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.accumulated_client_latency:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the accumulated client request latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11022,7 +11022,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.accumulated_client_operation_latency:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the accumulated client operation latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11047,7 +11047,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.accumulated_kstore_latency:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the accumulated kstore transaction latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11076,7 +11076,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.accumulated_recovery_state_latency:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the accumulated recovery-state transition latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11209,7 +11209,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.accumulated_sqlite_vfs_latency:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the accumulated sqlite vfs operation latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11286,7 +11286,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.client_latency_measurements:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the client request latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11299,7 +11299,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.client_latency_sqsum:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the client latency squared-deviation accumulators for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11325,7 +11325,7 @@ views:
       evidence:
         - ceph_display_conventions
   runtime.shared_daemon.client_operation_latency_measurements:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the client operation latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11350,7 +11350,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.duration:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the duration and time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11371,7 +11371,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.invalidations:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the invalidated recovery statistics for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11384,7 +11384,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.kstore_latency_measurements:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the kstore transaction latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11413,7 +11413,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.monitor_state:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the monitors for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11430,7 +11430,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.object_state:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the objects for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11455,7 +11455,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.oft_entry_state:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the openfiletable key-value pairs for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11468,7 +11468,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.oft_object_state:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the openfiletable objects for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11481,7 +11481,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.oft_omap_mutations:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the openfiletable omap mutations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11498,7 +11498,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.operations:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11511,7 +11511,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.osd_map_epoch:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the osd-map epoch for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11524,7 +11524,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.osd_state:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the osds for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11550,7 +11550,7 @@ views:
       evidence:
         - ceph_display_conventions
   runtime.shared_daemon.pg_state:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the placement groups for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11580,7 +11580,7 @@ views:
       evidence:
         - ceph_display_conventions
   runtime.shared_daemon.pool_state:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the pools for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11593,7 +11593,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.recovery_state_latency_measurements:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the recovery-state transition latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11726,7 +11726,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.space:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11751,7 +11751,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.sqlite_vfs_latency_measurements:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the sqlite vfs operation latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11828,7 +11828,7 @@ views:
       promote: []
       omit: {}
   runtime.shared_daemon.worker_state:
-    family: Ceph/Runtime/Shared Daemon
+    family: Runtime/Shared Daemon
     question: What is the context workers for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11845,7 +11845,7 @@ views:
       promote: []
       omit: {}
   runtime.slow_operations.slow_operations:
-    family: Ceph/Runtime/Slow Operations
+    family: Runtime/Slow Operations
     question: What is the slow operations for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -11858,7 +11858,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_ports.multicast_packets:
-    family: Ceph/Runtime and Clients/DPDK Ports
+    family: Runtime and Clients/DPDK Ports
     question: What is the multicast packets for each ceph daemon and dpdk port?
     entity: by_ceph_daemon_and_dpdk_port
     inputs:
@@ -11871,7 +11871,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_ports.receive_errors:
-    family: Ceph/Runtime and Clients/DPDK Ports
+    family: Runtime and Clients/DPDK Ports
     question: What is the receive errors for each ceph daemon and dpdk port?
     entity: by_ceph_daemon_and_dpdk_port
     inputs:
@@ -11896,7 +11896,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_ports.send_errors:
-    family: Ceph/Runtime and Clients/DPDK Ports
+    family: Runtime and Clients/DPDK Ports
     question: What is the send errors for each ceph daemon and dpdk port?
     entity: by_ceph_daemon_and_dpdk_port
     inputs:
@@ -11909,7 +11909,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.byte_throughput:
-    family: Ceph/Runtime and Clients/DPDK Queues
+    family: Runtime and Clients/DPDK Queues
     question: What is the byte throughput for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11934,7 +11934,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.copy_linearize_operations:
-    family: Ceph/Runtime and Clients/DPDK Queues
+    family: Runtime and Clients/DPDK Queues
     question: What is the copy and linearize operations for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11959,7 +11959,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.last_batch_size:
-    family: Ceph/Runtime and Clients/DPDK Queues
+    family: Runtime and Clients/DPDK Queues
     question: What is the last batch size for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11976,7 +11976,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.packet_fragments:
-    family: Ceph/Runtime and Clients/DPDK Queues
+    family: Runtime and Clients/DPDK Queues
     question: What is the packet fragments for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -11993,7 +11993,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.packets:
-    family: Ceph/Runtime and Clients/DPDK Queues
+    family: Runtime and Clients/DPDK Queues
     question: What is the packets for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -12010,7 +12010,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.receive_errors:
-    family: Ceph/Runtime and Clients/DPDK Queues
+    family: Runtime and Clients/DPDK Queues
     question: What is the receive errors for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -12027,7 +12027,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.dpdk_queues.send_queue_depth:
-    family: Ceph/Runtime and Clients/DPDK Queues
+    family: Runtime and Clients/DPDK Queues
     question: What is the send queue depth for each ceph daemon and dpdk queue?
     entity: by_ceph_daemon_and_dpdk_queue
     inputs:
@@ -12040,7 +12040,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.finishers.accumulated_completion_latency:
-    family: Ceph/Runtime and Clients/Finishers
+    family: Runtime and Clients/Finishers
     question: What is the accumulated completion latency for each ceph daemon and finisher key?
     entity: by_ceph_daemon_and_finisher_key
     inputs:
@@ -12053,7 +12053,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.finishers.completions:
-    family: Ceph/Runtime and Clients/Finishers
+    family: Runtime and Clients/Finishers
     question: What is the drained completion batches for each ceph daemon and finisher key?
     entity: by_ceph_daemon_and_finisher_key
     inputs:
@@ -12066,7 +12066,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.finishers.queue_depth:
-    family: Ceph/Runtime and Clients/Finishers
+    family: Runtime and Clients/Finishers
     question: What is the queued callbacks for each ceph daemon and finisher key?
     entity: by_ceph_daemon_and_finisher_key
     inputs:
@@ -12079,7 +12079,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.kernel_devices.discard_operations:
-    family: Ceph/Runtime and Clients/Kernel Devices
+    family: Runtime and Clients/Kernel Devices
     question: What is the discard operations for each ceph daemon and kernel device key?
     entity: by_ceph_daemon_and_kernel_device_key
     inputs:
@@ -12092,7 +12092,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.kernel_devices.discard_threads:
-    family: Ceph/Runtime and Clients/Kernel Devices
+    family: Runtime and Clients/Kernel Devices
     question: What is the discard threads for each ceph daemon and kernel device key?
     entity: by_ceph_daemon_and_kernel_device_key
     inputs:
@@ -12105,7 +12105,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.mclock_shards.queue_depth:
-    family: Ceph/Runtime and Clients/mClock Shards
+    family: Runtime and Clients/mClock Shards
     question: What is the queue depth for each ceph daemon and mclock shard?
     entity: by_ceph_daemon_and_mclock_shard
     inputs:
@@ -12134,7 +12134,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.memory_pools.item_count:
-    family: Ceph/Runtime and Clients/Memory Pools
+    family: Runtime and Clients/Memory Pools
     question: What is the item count for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -12263,7 +12263,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.memory_pools.memory_use:
-    family: Ceph/Runtime and Clients/Memory Pools
+    family: Runtime and Clients/Memory Pools
     question: What is the memory use for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -12392,7 +12392,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.accumulated_ack_latency:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the accumulated acknowledgement latency for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12405,7 +12405,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.accumulated_send_queue_latency:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the accumulated send-queue latency for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12418,7 +12418,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.accumulated_worker_time:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the accumulated worker time for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12443,7 +12443,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.ack_latency_measurements:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the acknowledgement latency measurements for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12456,7 +12456,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.byte_throughput:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the byte throughput for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12481,7 +12481,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.connections:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the connections for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12494,7 +12494,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.created_connections:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the created connections for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12507,7 +12507,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.messages:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the messages for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12524,7 +12524,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.messenger_workers.send_queue_latency_measurements:
-    family: Ceph/Runtime and Clients/Messenger Workers
+    family: Runtime and Clients/Messenger Workers
     question: What is the send-queue latency measurements for each ceph daemon and messenger worker?
     entity: by_ceph_daemon_and_messenger_worker
     inputs:
@@ -12537,7 +12537,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.blocked_write_throughput:
-    family: Ceph/Runtime and Clients/Object Caches
+    family: Runtime and Clients/Object Caches
     question: What is the blocked write throughput for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -12550,7 +12550,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.blocked_write_time:
-    family: Ceph/Runtime and Clients/Object Caches
+    family: Runtime and Clients/Object Caches
     question: What is the blocked write time for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -12563,7 +12563,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.blocked_writes:
-    family: Ceph/Runtime and Clients/Object Caches
+    family: Runtime and Clients/Object Caches
     question: What is the blocked writes for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -12576,7 +12576,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.cache_byte_outcomes:
-    family: Ceph/Runtime and Clients/Object Caches
+    family: Runtime and Clients/Object Caches
     question: What is the cache byte outcomes for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -12593,7 +12593,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.cache_outcomes:
-    family: Ceph/Runtime and Clients/Object Caches
+    family: Runtime and Clients/Object Caches
     question: What is the cache outcomes for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -12610,7 +12610,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.object_caches.data_throughput:
-    family: Ceph/Runtime and Clients/Object Caches
+    family: Runtime and Clients/Object Caches
     question: What is the data throughput for each ceph daemon and objectcacher key?
     entity: by_ceph_daemon_and_objectcacher_key
     inputs:
@@ -12635,7 +12635,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rados_striper.metadata_and_lock_work:
-    family: Ceph/Runtime and Clients/RADOS Striper
+    family: Runtime and Clients/RADOS Striper
     question: What is the metadata and lock work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -12672,7 +12672,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rados_striper.shrink_throughput:
-    family: Ceph/Runtime and Clients/RADOS Striper
+    family: Runtime and Clients/RADOS Striper
     question: What is the shrink throughput for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -12685,7 +12685,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_data_operation_latency:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated data operation latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12714,7 +12714,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_log_operation_latency:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated log operation latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12755,7 +12755,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_read_latency:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated read request latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12772,7 +12772,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_transaction_latency:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated transaction latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12789,7 +12789,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.accumulated_write_latency:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the accumulated write request latency for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12838,7 +12838,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.cache_image_operations:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the cache and image operations for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12879,7 +12879,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.data_operation_latency_measurements:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the data operation latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12908,7 +12908,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.data_operation_throughput:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the data-operation throughput for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12929,7 +12929,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.log_append_size_measurements:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the log-append size measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12942,7 +12942,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.log_append_throughput:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the log-append throughput for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12955,7 +12955,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.log_appends:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the log appends for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -12968,7 +12968,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.log_operation_latency_measurements:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the log operation latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -13009,7 +13009,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.read_latency_measurements:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the read request latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -13026,7 +13026,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.read_throughput:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the read throughput for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -13043,7 +13043,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.reads:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the reads for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -13064,7 +13064,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.transaction_latency_measurements:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the transaction latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -13081,7 +13081,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.write_latency_measurements:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the write request latency measurements for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -13130,7 +13130,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.write_throughput:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the write throughput for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -13143,7 +13143,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rbd_persistent_write_log.writes:
-    family: Ceph/Runtime and Clients/RBD Persistent Write Log
+    family: Runtime and Clients/RBD Persistent Write Log
     question: What is the writes for each ceph daemon and librbd pwl key?
     entity: by_ceph_daemon_and_librbd_pwl_key
     inputs:
@@ -13180,7 +13180,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rdma_workers.byte_throughput:
-    family: Ceph/Runtime and Clients/RDMA Workers
+    family: Runtime and Clients/RDMA Workers
     question: What is the byte throughput for each ceph daemon and rdma worker?
     entity: by_ceph_daemon_and_rdma_worker
     inputs:
@@ -13197,7 +13197,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rdma_workers.chunk_throughput:
-    family: Ceph/Runtime and Clients/RDMA Workers
+    family: Runtime and Clients/RDMA Workers
     question: What is the chunk throughput for each ceph daemon and rdma worker?
     entity: by_ceph_daemon_and_rdma_worker
     inputs:
@@ -13214,7 +13214,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rdma_workers.pending_connections:
-    family: Ceph/Runtime and Clients/RDMA Workers
+    family: Runtime and Clients/RDMA Workers
     question: What is the pending connections for each ceph daemon and rdma worker?
     entity: by_ceph_daemon_and_rdma_worker
     inputs:
@@ -13227,7 +13227,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.rdma_workers.transfer_errors:
-    family: Ceph/Runtime and Clients/RDMA Workers
+    family: Runtime and Clients/RDMA Workers
     question: What is the rdma transfer errors for each ceph daemon and rdma worker?
     entity: by_ceph_daemon_and_rdma_worker
     inputs:
@@ -13248,7 +13248,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.service_identity.identity_metadata:
-    family: Ceph/Runtime and Clients/Service Identity
+    family: Runtime and Clients/Service Identity
     question: What is the service identity metadata sentinel for each ceph daemon and service unique id?
     entity: by_ceph_daemon_and_service_unique_id
     inputs:
@@ -13261,7 +13261,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.accumulated_wait_time:
-    family: Ceph/Runtime and Clients/Throttles
+    family: Runtime and Clients/Throttles
     question: What is the accumulated wait time for each ceph daemon and throttle key?
     entity: by_ceph_daemon_and_throttle_key
     inputs:
@@ -13274,7 +13274,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.operations:
-    family: Ceph/Runtime and Clients/Throttles
+    family: Runtime and Clients/Throttles
     question: What is the operations for each ceph daemon and throttle key?
     entity: by_ceph_daemon_and_throttle_key
     inputs:
@@ -13307,7 +13307,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.slot_throughput:
-    family: Ceph/Runtime and Clients/Throttles
+    family: Runtime and Clients/Throttles
     question: What is the slot throughput for each throttle key?
     entity: by_throttle_key
     inputs:
@@ -13328,7 +13328,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.utilization:
-    family: Ceph/Runtime and Clients/Throttles
+    family: Runtime and Clients/Throttles
     question: What is the utilization for each ceph daemon and throttle key?
     entity: by_ceph_daemon_and_throttle_key
     inputs:
@@ -13345,7 +13345,7 @@ views:
       promote: []
       omit: {}
   runtime_and_client_components.throttles.wait_measurements:
-    family: Ceph/Runtime and Clients/Throttles
+    family: Runtime and Clients/Throttles
     question: What is the waits for each ceph daemon and throttle key?
     entity: by_ceph_daemon_and_throttle_key
     inputs:
@@ -13358,7 +13358,7 @@ views:
       promote: []
       omit: {}
   smb_metadata.state:
-    family: Ceph/CephFS/SMB/Metadata
+    family: CephFS/SMB/Metadata
     question: What is the state and metadata for each netbiosname and share and smb version and subvolume and subvolume
       group and volume?
     entity: by_netbiosname_and_share_and_smb_version_and_subvolume_and_subvolume_group_and_volume
@@ -13372,7 +13372,7 @@ views:
       promote: []
       omit: {}
   storage_engine.priority_cache_full.space:
-    family: Ceph/Storage Engine/Priority Cache Full
+    family: Storage Engine/Priority Cache Full
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13437,7 +13437,7 @@ views:
       promote: []
       omit: {}
   storage_engine.priority_cache_incremental.space:
-    family: Ceph/Storage Engine/Priority Cache Incremental
+    family: Storage Engine/Priority Cache Incremental
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13502,7 +13502,7 @@ views:
       promote: []
       omit: {}
   storage_engine.priority_cache_kv.space:
-    family: Ceph/Storage Engine/Priority Cache KV
+    family: Storage Engine/Priority Cache KV
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13567,7 +13567,7 @@ views:
       promote: []
       omit: {}
   storage_engine.priority_cache_runtime.space:
-    family: Ceph/Storage Engine/Priority Cache Runtime
+    family: Storage Engine/Priority Cache Runtime
     question: What is the space and memory for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13596,7 +13596,7 @@ views:
       promote: []
       omit: {}
   storage_engine.rocksdb_compaction.compaction_state:
-    family: Ceph/Storage Engine/RocksDB Compaction
+    family: Storage Engine/RocksDB Compaction
     question: What is the compaction work for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13613,7 +13613,7 @@ views:
       promote: []
       omit: {}
   storage_engine.rocksdb_compaction.compactions:
-    family: Ceph/Storage Engine/RocksDB Compaction
+    family: Storage Engine/RocksDB Compaction
     question: What is the compactions for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13630,7 +13630,7 @@ views:
       promote: []
       omit: {}
   storage_engine.rocksdb_compaction.duration:
-    family: Ceph/Storage Engine/RocksDB Compaction
+    family: Storage Engine/RocksDB Compaction
     question: What is the duration and time for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13643,7 +13643,7 @@ views:
       promote: []
       omit: {}
   storage_engine.rocksdb_compaction.queue_merges:
-    family: Ceph/Storage Engine/RocksDB Compaction
+    family: Storage Engine/RocksDB Compaction
     question: What is the compaction queue merges for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13656,7 +13656,7 @@ views:
       promote: []
       omit: {}
   storage_engine.rocksdb_requests.accumulated_latency:
-    family: Ceph/Storage Engine/RocksDB Requests
+    family: Storage Engine/RocksDB Requests
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13677,7 +13677,7 @@ views:
       promote: []
       omit: {}
   storage_engine.rocksdb_requests.latency_measurements:
-    family: Ceph/Storage Engine/RocksDB Requests
+    family: Storage Engine/RocksDB Requests
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13698,7 +13698,7 @@ views:
       promote: []
       omit: {}
   storage_engine.rocksdb_write_path.accumulated_latency:
-    family: Ceph/Storage Engine/RocksDB Write Path
+    family: Storage Engine/RocksDB Write Path
     question: What is the accumulated latency for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13723,7 +13723,7 @@ views:
       promote: []
       omit: {}
   storage_engine.rocksdb_write_path.latency_measurements:
-    family: Ceph/Storage Engine/RocksDB Write Path
+    family: Storage Engine/RocksDB Write Path
     question: What is the latency measurements for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13748,7 +13748,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.external_block_devices.device_size:
-    family: Ceph/Storage Engine/Extensions/External Block Devices
+    family: Storage Engine/Extensions/External Block Devices
     question: What is the device size for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13765,7 +13765,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.external_block_devices.device_utilization:
-    family: Ceph/Storage Engine/Extensions/External Block Devices
+    family: Storage Engine/Extensions/External Block Devices
     question: What is the device utilization for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13782,7 +13782,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.external_block_devices.partition_space:
-    family: Ceph/Storage Engine/Extensions/External Block Devices
+    family: Storage Engine/Extensions/External Block Devices
     question: What is the partition space for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13807,7 +13807,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.external_block_devices.plugin_state:
-    family: Ceph/Storage Engine/Extensions/External Block Devices
+    family: Storage Engine/Extensions/External Block Devices
     question: What is the fcm plugin state for each ceph daemon?
     entity: by_ceph_daemon
     inputs:
@@ -13820,7 +13820,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.entries:
-    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
+    family: Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache entries for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:
@@ -13833,7 +13833,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.insertions:
-    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
+    family: Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache insertions for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:
@@ -13846,7 +13846,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.lookup_outcomes:
-    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
+    family: Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache lookup outcomes for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:
@@ -13863,7 +13863,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.lookups:
-    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
+    family: Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache lookups for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:
@@ -13876,7 +13876,7 @@ views:
       promote: []
       omit: {}
   storage_engine_extensions.rocksdb_binned_cache.memory:
-    family: Ceph/Storage Engine/Extensions/RocksDB Binned Cache
+    family: Storage Engine/Extensions/RocksDB Binned Cache
     question: What is the cache memory for each ceph daemon and rocksdb cache key?
     entity: by_ceph_daemon_and_rocksdb_cache_key
     inputs:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/haproxy/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/haproxy/PROFILE-DESIGN.yaml
@@ -104,7 +104,7 @@ exclusions:
 limitations: {}
 views:
   process_recv_logs_total:
-    family: HAProxy/Process/Activity
+    family: Process/Activity
     question: What per-second rate does HAProxy report for received logs?
     entity: process
     inputs:
@@ -117,7 +117,7 @@ views:
       promote: []
       omit: {}
   process_relative_process_id:
-    family: HAProxy/Process/Activity
+    family: Process/Activity
     question: What value does HAProxy currently report for relative process id?
     entity: process
     inputs:
@@ -130,7 +130,7 @@ views:
       promote: []
       omit: {}
   process_requests_total:
-    family: HAProxy/Process/Activity
+    family: Process/Activity
     question: What per-second rate does HAProxy report for requests?
     entity: process
     inputs:
@@ -143,7 +143,7 @@ views:
       promote: []
       omit: {}
   process_nbthread:
-    family: HAProxy/Process/Activity
+    family: Process/Activity
     question: What value does HAProxy currently report for threads?
     entity: process
     inputs:
@@ -156,7 +156,7 @@ views:
       promote: []
       omit: {}
   process_nbproc:
-    family: HAProxy/Process/Activity
+    family: Process/Activity
     question: What value does HAProxy currently report for worker processes?
     entity: process
     inputs:
@@ -169,7 +169,7 @@ views:
       promote: []
       omit: {}
   process_current_zlib_memory:
-    family: HAProxy/Process/Compression
+    family: Process/Compression
     question: What value does HAProxy currently report for zlib memory?
     entity: process
     inputs:
@@ -182,7 +182,7 @@ views:
       promote: []
       omit: {}
   process_limit_http_comp:
-    family: HAProxy/Process/Compression
+    family: Process/Compression
     question: What value does HAProxy currently report for http compression limit?
     entity: process
     inputs:
@@ -195,7 +195,7 @@ views:
       promote: []
       omit: {}
   process_max_zlib_memory:
-    family: HAProxy/Process/Compression
+    family: Process/Compression
     question: What value does HAProxy currently report for max zlib memory?
     entity: process
     inputs:
@@ -208,7 +208,7 @@ views:
       promote: []
       omit: {}
   process_connections_total:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What per-second rate does HAProxy report for connections?
     entity: process
     inputs:
@@ -221,7 +221,7 @@ views:
       promote: []
       omit: {}
   process_current_connection_rate:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for connection rate?
     entity: process
     inputs:
@@ -234,7 +234,7 @@ views:
       promote: []
       omit: {}
   process_current_connections:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for connections?
     entity: process
     inputs:
@@ -247,7 +247,7 @@ views:
       promote: []
       omit: {}
   process_hard_max_connections:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for hard max connections?
     entity: process
     inputs:
@@ -260,7 +260,7 @@ views:
       promote: []
       omit: {}
   process_limit_connection_rate:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for limit connection rate?
     entity: process
     inputs:
@@ -273,7 +273,7 @@ views:
       promote: []
       omit: {}
   process_max_connection_rate:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for max connection rate?
     entity: process
     inputs:
@@ -286,7 +286,7 @@ views:
       promote: []
       omit: {}
   process_max_connections:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for max connections?
     entity: process
     inputs:
@@ -299,7 +299,7 @@ views:
       promote: []
       omit: {}
   process_max_fds:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for max fds?
     entity: process
     inputs:
@@ -312,7 +312,7 @@ views:
       promote: []
       omit: {}
   process_max_pipes:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for max pipes?
     entity: process
     inputs:
@@ -325,7 +325,7 @@ views:
       promote: []
       omit: {}
   process_max_sockets:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for max sockets?
     entity: process
     inputs:
@@ -338,7 +338,7 @@ views:
       promote: []
       omit: {}
   process_pipes:
-    family: HAProxy/Process/Connections
+    family: Process/Connections
     question: What value does HAProxy currently report for pipes?
     entity: process
     inputs:
@@ -355,7 +355,7 @@ views:
       promote: []
       omit: {}
   process_dropped_logs_total:
-    family: HAProxy/Process/Errors
+    family: Process/Errors
     question: What per-second rate does HAProxy report for dropped logs?
     entity: process
     inputs:
@@ -368,7 +368,7 @@ views:
       promote: []
       omit: {}
   process_failed_resolutions:
-    family: HAProxy/Process/Errors
+    family: Process/Errors
     question: What per-second rate does HAProxy report for failed resolutions?
     entity: process
     inputs:
@@ -381,7 +381,7 @@ views:
       promote: []
       omit: {}
   process_total_warnings:
-    family: HAProxy/Process/Errors
+    family: Process/Errors
     question: What per-second rate does HAProxy report for warnings?
     entity: process
     inputs:
@@ -394,7 +394,7 @@ views:
       promote: []
       omit: {}
   process_active_peers:
-    family: HAProxy/Process/Health
+    family: Process/Health
     question: What value does HAProxy currently report for active peers?
     entity: process
     inputs:
@@ -407,7 +407,7 @@ views:
       promote: []
       omit: {}
   process_max_memory_bytes:
-    family: HAProxy/Process/Memory
+    family: Process/Memory
     question: What value does HAProxy currently report for max memory bytes?
     entity: process
     inputs:
@@ -420,7 +420,7 @@ views:
       promote: []
       omit: {}
   process_pool_allocated_bytes:
-    family: HAProxy/Process/Memory
+    family: Process/Memory
     question: What value does HAProxy currently report for pool allocated bytes?
     entity: process
     inputs:
@@ -433,7 +433,7 @@ views:
       promote: []
       omit: {}
   process_pool_failures_total:
-    family: HAProxy/Process/Memory
+    family: Process/Memory
     question: What per-second rate does HAProxy report for pool failures?
     entity: process
     inputs:
@@ -446,7 +446,7 @@ views:
       promote: []
       omit: {}
   process_pool_used_bytes:
-    family: HAProxy/Process/Memory
+    family: Process/Memory
     question: What value does HAProxy currently report for pool used bytes?
     entity: process
     inputs:
@@ -459,7 +459,7 @@ views:
       promote: []
       omit: {}
   process_current_run_queue:
-    family: HAProxy/Process/Queue
+    family: Process/Queue
     question: What value does HAProxy currently report for run queue?
     entity: process
     inputs:
@@ -472,7 +472,7 @@ views:
       promote: []
       omit: {}
   process_current_backend_ssl_key_rate:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for backend ssl key rate?
     entity: process
     inputs:
@@ -485,7 +485,7 @@ views:
       promote: []
       omit: {}
   process_current_frontend_ssl_key_rate:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for frontend ssl key rate?
     entity: process
     inputs:
@@ -498,7 +498,7 @@ views:
       promote: []
       omit: {}
   process_current_ssl_connections:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for ssl connections?
     entity: process
     inputs:
@@ -511,7 +511,7 @@ views:
       promote: []
       omit: {}
   process_current_ssl_rate:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for ssl rate?
     entity: process
     inputs:
@@ -524,7 +524,7 @@ views:
       promote: []
       omit: {}
   process_frontend_ssl_reuse:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for frontend ssl reuse?
     entity: process
     inputs:
@@ -542,7 +542,7 @@ views:
       evidence:
       - percentage_display
   process_limit_ssl_rate:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for limit ssl rate?
     entity: process
     inputs:
@@ -555,7 +555,7 @@ views:
       promote: []
       omit: {}
   process_max_backend_ssl_key_rate:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for max backend ssl key rate?
     entity: process
     inputs:
@@ -568,7 +568,7 @@ views:
       promote: []
       omit: {}
   process_max_frontend_ssl_key_rate:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for max frontend ssl key rate?
     entity: process
     inputs:
@@ -581,7 +581,7 @@ views:
       promote: []
       omit: {}
   process_max_ssl_connections:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for max ssl connections?
     entity: process
     inputs:
@@ -594,7 +594,7 @@ views:
       promote: []
       omit: {}
   process_max_ssl_rate:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What value does HAProxy currently report for max ssl rate?
     entity: process
     inputs:
@@ -607,7 +607,7 @@ views:
       promote: []
       omit: {}
   process_ssl_cache_lookups_total:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What per-second rate does HAProxy report for ssl cache lookups?
     entity: process
     inputs:
@@ -620,7 +620,7 @@ views:
       promote: []
       omit: {}
   process_ssl_cache_misses_total:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What per-second rate does HAProxy report for ssl cache misses?
     entity: process
     inputs:
@@ -633,7 +633,7 @@ views:
       promote: []
       omit: {}
   process_ssl_connections_total:
-    family: HAProxy/Process/SSL
+    family: Process/SSL
     question: What per-second rate does HAProxy report for ssl connections?
     entity: process
     inputs:
@@ -646,7 +646,7 @@ views:
       promote: []
       omit: {}
   process_connected_peers:
-    family: HAProxy/Process/Scheduler
+    family: Process/Scheduler
     question: What value does HAProxy currently report for connected peers?
     entity: process
     inputs:
@@ -659,7 +659,7 @@ views:
       promote: []
       omit: {}
   process_current_tasks:
-    family: HAProxy/Process/Scheduler
+    family: Process/Scheduler
     question: What value does HAProxy currently report for tasks?
     entity: process
     inputs:
@@ -672,7 +672,7 @@ views:
       promote: []
       omit: {}
   process_jobs:
-    family: HAProxy/Process/Scheduler
+    family: Process/Scheduler
     question: What value does HAProxy currently report for jobs?
     entity: process
     inputs:
@@ -685,7 +685,7 @@ views:
       promote: []
       omit: {}
   process_listeners:
-    family: HAProxy/Process/Scheduler
+    family: Process/Scheduler
     question: What value does HAProxy currently report for listeners?
     entity: process
     inputs:
@@ -698,7 +698,7 @@ views:
       promote: []
       omit: {}
   process_unstoppable_jobs:
-    family: HAProxy/Process/Scheduler
+    family: Process/Scheduler
     question: What value does HAProxy currently report for unstoppable jobs?
     entity: process
     inputs:
@@ -711,7 +711,7 @@ views:
       promote: []
       omit: {}
   process_current_session_rate:
-    family: HAProxy/Process/Sessions
+    family: Process/Sessions
     question: What value does HAProxy currently report for session rate?
     entity: process
     inputs:
@@ -724,7 +724,7 @@ views:
       promote: []
       omit: {}
   process_limit_session_rate:
-    family: HAProxy/Process/Sessions
+    family: Process/Sessions
     question: What value does HAProxy currently report for limit session rate?
     entity: process
     inputs:
@@ -737,7 +737,7 @@ views:
       promote: []
       omit: {}
   process_max_session_rate:
-    family: HAProxy/Process/Sessions
+    family: Process/Sessions
     question: What value does HAProxy currently report for max session rate?
     entity: process
     inputs:
@@ -750,7 +750,7 @@ views:
       promote: []
       omit: {}
   process_busy_polling_enabled:
-    family: HAProxy/Process/Status
+    family: Process/Status
     question: What value does HAProxy currently report for busy polling enabled?
     entity: process
     inputs:
@@ -763,7 +763,7 @@ views:
       promote: []
       omit: {}
   process_stopping:
-    family: HAProxy/Process/Status
+    family: Process/Status
     question: What value does HAProxy currently report for stopping?
     entity: process
     inputs:
@@ -776,7 +776,7 @@ views:
       promote: []
       omit: {}
   process_idle_time_percent:
-    family: HAProxy/Process/Timing
+    family: Process/Timing
     question: What value does HAProxy currently report for idle time percent?
     entity: process
     inputs:
@@ -794,7 +794,7 @@ views:
       evidence:
       - percentage_display
   process_uptime_seconds:
-    family: HAProxy/Process/Timing
+    family: Process/Timing
     question: What value does HAProxy currently report for uptime seconds?
     entity: process
     inputs:
@@ -807,7 +807,7 @@ views:
       promote: []
       omit: {}
   process_bytes_out_total:
-    family: HAProxy/Process/Traffic
+    family: Process/Traffic
     question: What per-second rate does HAProxy report for bytes out?
     entity: process
     inputs:
@@ -820,7 +820,7 @@ views:
       promote: []
       omit: {}
   process_bytes_out_rate:
-    family: HAProxy/Process/Traffic
+    family: Process/Traffic
     question: What value does HAProxy currently report for bytes out rate?
     entity: process
     inputs:
@@ -833,7 +833,7 @@ views:
       promote: []
       omit: {}
   process_http_comp_bytes_in_total:
-    family: HAProxy/Process/Traffic
+    family: Process/Traffic
     question: What value does HAProxy currently report for http compression bytes in?
     entity: process
     inputs:
@@ -846,7 +846,7 @@ views:
       promote: []
       omit: {}
   process_http_comp_bytes_out_total:
-    family: HAProxy/Process/Traffic
+    family: Process/Traffic
     question: What value does HAProxy currently report for http compression bytes out?
     entity: process
     inputs:
@@ -859,7 +859,7 @@ views:
       promote: []
       omit: {}
   process_spliced_bytes_out_total:
-    family: HAProxy/Process/Traffic
+    family: Process/Traffic
     question: What per-second rate does HAProxy report for spliced bytes out?
     entity: process
     inputs:
@@ -872,7 +872,7 @@ views:
       promote: []
       omit: {}
   frontend_http_comp_responses_total:
-    family: HAProxy/Frontends/Compression
+    family: Frontends/Compression
     question: What per-second rate does HAProxy report for http compression responses?
     entity: frontend
     inputs:
@@ -885,7 +885,7 @@ views:
       promote: []
       omit: {}
   frontend_connections_total:
-    family: HAProxy/Frontends/Connections
+    family: Frontends/Connections
     question: What per-second rate does HAProxy report for connections?
     entity: frontend
     inputs:
@@ -898,7 +898,7 @@ views:
       promote: []
       omit: {}
   frontend_connections_rate_max:
-    family: HAProxy/Frontends/Connections
+    family: Frontends/Connections
     question: What value does HAProxy currently report for connections rate max?
     entity: frontend
     inputs:
@@ -911,7 +911,7 @@ views:
       promote: []
       omit: {}
   frontend_denied_connections_total:
-    family: HAProxy/Frontends/Connections
+    family: Frontends/Connections
     question: What per-second rate does HAProxy report for denied connections?
     entity: frontend
     inputs:
@@ -924,7 +924,7 @@ views:
       promote: []
       omit: {}
   frontend_errors:
-    family: HAProxy/Frontends/Errors
+    family: Frontends/Errors
     question: What per-second rate does HAProxy report for errors?
     entity: frontend
     inputs:
@@ -945,7 +945,7 @@ views:
       promote: []
       omit: {}
   frontend_requests_denied_total:
-    family: HAProxy/Frontends/Errors
+    family: Frontends/Errors
     question: What per-second rate does HAProxy report for requests denied?
     entity: frontend
     inputs:
@@ -958,7 +958,7 @@ views:
       promote: []
       omit: {}
   frontend_responses_denied_total:
-    family: HAProxy/Frontends/Errors
+    family: Frontends/Errors
     question: What per-second rate does HAProxy report for responses denied?
     entity: frontend
     inputs:
@@ -971,7 +971,7 @@ views:
       promote: []
       omit: {}
   frontend_http_cache_hits_total:
-    family: HAProxy/Frontends/HTTP
+    family: Frontends/HTTP
     question: What per-second rate does HAProxy report for http cache hits?
     entity: frontend
     inputs:
@@ -984,7 +984,7 @@ views:
       promote: []
       omit: {}
   frontend_http_cache_lookups_total:
-    family: HAProxy/Frontends/HTTP
+    family: Frontends/HTTP
     question: What per-second rate does HAProxy report for http cache lookups?
     entity: frontend
     inputs:
@@ -997,7 +997,7 @@ views:
       promote: []
       omit: {}
   frontend_http_requests_total:
-    family: HAProxy/Frontends/HTTP
+    family: Frontends/HTTP
     question: What per-second rate does HAProxy report for http requests?
     entity: frontend
     inputs:
@@ -1010,7 +1010,7 @@ views:
       promote: []
       omit: {}
   frontend_http_requests_rate_max:
-    family: HAProxy/Frontends/HTTP
+    family: Frontends/HTTP
     question: What value does HAProxy currently report for http requests rate max?
     entity: frontend
     inputs:
@@ -1023,7 +1023,7 @@ views:
       promote: []
       omit: {}
   frontend_http_responses_total:
-    family: HAProxy/Frontends/HTTP
+    family: Frontends/HTTP
     question: What per-second rate does HAProxy report for http responses?
     entity: frontend
     inputs:
@@ -1038,7 +1038,7 @@ views:
       promote: []
       omit: {}
   frontend_intercepted_requests_total:
-    family: HAProxy/Frontends/HTTP
+    family: Frontends/HTTP
     question: What per-second rate does HAProxy report for intercepted requests?
     entity: frontend
     inputs:
@@ -1051,7 +1051,7 @@ views:
       promote: []
       omit: {}
   frontend_current_session_rate:
-    family: HAProxy/Frontends/Sessions
+    family: Frontends/Sessions
     question: What value does HAProxy currently report for session rate?
     entity: frontend
     inputs:
@@ -1064,7 +1064,7 @@ views:
       promote: []
       omit: {}
   frontend_current_sessions:
-    family: HAProxy/Frontends/Sessions
+    family: Frontends/Sessions
     question: What value does HAProxy currently report for sessions?
     entity: frontend
     inputs:
@@ -1077,7 +1077,7 @@ views:
       promote: []
       omit: {}
   frontend_denied_sessions_total:
-    family: HAProxy/Frontends/Sessions
+    family: Frontends/Sessions
     question: What per-second rate does HAProxy report for denied sessions?
     entity: frontend
     inputs:
@@ -1090,7 +1090,7 @@ views:
       promote: []
       omit: {}
   frontend_limit_session_rate:
-    family: HAProxy/Frontends/Sessions
+    family: Frontends/Sessions
     question: What value does HAProxy currently report for limit session rate?
     entity: frontend
     inputs:
@@ -1103,7 +1103,7 @@ views:
       promote: []
       omit: {}
   frontend_limit_sessions:
-    family: HAProxy/Frontends/Sessions
+    family: Frontends/Sessions
     question: What value does HAProxy currently report for limit sessions?
     entity: frontend
     inputs:
@@ -1116,7 +1116,7 @@ views:
       promote: []
       omit: {}
   frontend_max_session_rate:
-    family: HAProxy/Frontends/Sessions
+    family: Frontends/Sessions
     question: What value does HAProxy currently report for max session rate?
     entity: frontend
     inputs:
@@ -1129,7 +1129,7 @@ views:
       promote: []
       omit: {}
   frontend_max_sessions:
-    family: HAProxy/Frontends/Sessions
+    family: Frontends/Sessions
     question: What value does HAProxy currently report for max sessions?
     entity: frontend
     inputs:
@@ -1142,7 +1142,7 @@ views:
       promote: []
       omit: {}
   frontend_sessions_total:
-    family: HAProxy/Frontends/Sessions
+    family: Frontends/Sessions
     question: What per-second rate does HAProxy report for sessions?
     entity: frontend
     inputs:
@@ -1155,7 +1155,7 @@ views:
       promote: []
       omit: {}
   frontend_status:
-    family: HAProxy/Frontends/Status
+    family: Frontends/Status
     question: What values does HAProxy report across the source-defined status states?
     entity: frontend
     inputs:
@@ -1170,7 +1170,7 @@ views:
       promote: []
       omit: {}
   frontend_http_comp_bytes_bypassed_total:
-    family: HAProxy/Frontends/Traffic
+    family: Frontends/Traffic
     question: What per-second rate does HAProxy report for http compression bytes bypassed?
     entity: frontend
     inputs:
@@ -1183,7 +1183,7 @@ views:
       promote: []
       omit: {}
   frontend_http_comp_bytes_in_total:
-    family: HAProxy/Frontends/Traffic
+    family: Frontends/Traffic
     question: What per-second rate does HAProxy report for http compression bytes in?
     entity: frontend
     inputs:
@@ -1196,7 +1196,7 @@ views:
       promote: []
       omit: {}
   frontend_http_comp_bytes_out_total:
-    family: HAProxy/Frontends/Traffic
+    family: Frontends/Traffic
     question: What per-second rate does HAProxy report for http compression bytes out?
     entity: frontend
     inputs:
@@ -1209,7 +1209,7 @@ views:
       promote: []
       omit: {}
   frontend_traffic:
-    family: HAProxy/Frontends/Traffic
+    family: Frontends/Traffic
     question: What per-second rate does HAProxy report for traffic?
     entity: frontend
     inputs:
@@ -1226,7 +1226,7 @@ views:
       promote: []
       omit: {}
   listener_connections_total:
-    family: HAProxy/Listeners/Connections
+    family: Listeners/Connections
     question: What per-second rate does HAProxy report for connections?
     entity: listener
     inputs:
@@ -1239,7 +1239,7 @@ views:
       promote: []
       omit: {}
   listener_denied_connections_total:
-    family: HAProxy/Listeners/Connections
+    family: Listeners/Connections
     question: What per-second rate does HAProxy report for denied connections?
     entity: listener
     inputs:
@@ -1252,7 +1252,7 @@ views:
       promote: []
       omit: {}
   listener_errors:
-    family: HAProxy/Listeners/Errors
+    family: Listeners/Errors
     question: What per-second rate does HAProxy report for errors?
     entity: listener
     inputs:
@@ -1273,7 +1273,7 @@ views:
       promote: []
       omit: {}
   listener_requests_denied_total:
-    family: HAProxy/Listeners/Errors
+    family: Listeners/Errors
     question: What per-second rate does HAProxy report for requests denied?
     entity: listener
     inputs:
@@ -1286,7 +1286,7 @@ views:
       promote: []
       omit: {}
   listener_responses_denied_total:
-    family: HAProxy/Listeners/Errors
+    family: Listeners/Errors
     question: What per-second rate does HAProxy report for responses denied?
     entity: listener
     inputs:
@@ -1299,7 +1299,7 @@ views:
       promote: []
       omit: {}
   listener_current_sessions:
-    family: HAProxy/Listeners/Sessions
+    family: Listeners/Sessions
     question: What value does HAProxy currently report for sessions?
     entity: listener
     inputs:
@@ -1312,7 +1312,7 @@ views:
       promote: []
       omit: {}
   listener_denied_sessions_total:
-    family: HAProxy/Listeners/Sessions
+    family: Listeners/Sessions
     question: What per-second rate does HAProxy report for denied sessions?
     entity: listener
     inputs:
@@ -1325,7 +1325,7 @@ views:
       promote: []
       omit: {}
   listener_limit_sessions:
-    family: HAProxy/Listeners/Sessions
+    family: Listeners/Sessions
     question: What value does HAProxy currently report for limit sessions?
     entity: listener
     inputs:
@@ -1338,7 +1338,7 @@ views:
       promote: []
       omit: {}
   listener_max_sessions:
-    family: HAProxy/Listeners/Sessions
+    family: Listeners/Sessions
     question: What value does HAProxy currently report for max sessions?
     entity: listener
     inputs:
@@ -1351,7 +1351,7 @@ views:
       promote: []
       omit: {}
   listener_sessions_total:
-    family: HAProxy/Listeners/Sessions
+    family: Listeners/Sessions
     question: What per-second rate does HAProxy report for sessions?
     entity: listener
     inputs:
@@ -1364,7 +1364,7 @@ views:
       promote: []
       omit: {}
   listener_status:
-    family: HAProxy/Listeners/Status
+    family: Listeners/Status
     question: What values does HAProxy report across the source-defined status states?
     entity: listener
     inputs:
@@ -1379,7 +1379,7 @@ views:
       promote: []
       omit: {}
   listener_traffic:
-    family: HAProxy/Listeners/Traffic
+    family: Listeners/Traffic
     question: What per-second rate does HAProxy report for traffic?
     entity: listener
     inputs:
@@ -1396,7 +1396,7 @@ views:
       promote: []
       omit: {}
   backend_http_comp_responses_total:
-    family: HAProxy/Backends/Compression
+    family: Backends/Compression
     question: What per-second rate does HAProxy report for http compression responses?
     entity: backend
     inputs:
@@ -1409,7 +1409,7 @@ views:
       promote: []
       omit: {}
   backend_connection_attempts_total:
-    family: HAProxy/Backends/Connections
+    family: Backends/Connections
     question: What per-second rate does HAProxy report for connection attempts?
     entity: backend
     inputs:
@@ -1422,7 +1422,7 @@ views:
       promote: []
       omit: {}
   backend_connection_reuses_total:
-    family: HAProxy/Backends/Connections
+    family: Backends/Connections
     question: What per-second rate does HAProxy report for connection reuses?
     entity: backend
     inputs:
@@ -1435,7 +1435,7 @@ views:
       promote: []
       omit: {}
   backend_aborts:
-    family: HAProxy/Backends/Errors
+    family: Backends/Errors
     question: What per-second rate does HAProxy report for aborts?
     entity: backend
     inputs:
@@ -1452,7 +1452,7 @@ views:
       promote: []
       omit: {}
   backend_errors:
-    family: HAProxy/Backends/Errors
+    family: Backends/Errors
     question: What per-second rate does HAProxy report for errors?
     entity: backend
     inputs:
@@ -1477,7 +1477,7 @@ views:
       promote: []
       omit: {}
   backend_requests_denied_total:
-    family: HAProxy/Backends/Errors
+    family: Backends/Errors
     question: What per-second rate does HAProxy report for requests denied?
     entity: backend
     inputs:
@@ -1490,7 +1490,7 @@ views:
       promote: []
       omit: {}
   backend_responses_denied_total:
-    family: HAProxy/Backends/Errors
+    family: Backends/Errors
     question: What per-second rate does HAProxy report for responses denied?
     entity: backend
     inputs:
@@ -1503,7 +1503,7 @@ views:
       promote: []
       omit: {}
   backend_warnings:
-    family: HAProxy/Backends/Errors
+    family: Backends/Errors
     question: What per-second rate does HAProxy report for warnings?
     entity: backend
     inputs:
@@ -1520,7 +1520,7 @@ views:
       promote: []
       omit: {}
   backend_http_cache_hits_total:
-    family: HAProxy/Backends/HTTP
+    family: Backends/HTTP
     question: What per-second rate does HAProxy report for http cache hits?
     entity: backend
     inputs:
@@ -1533,7 +1533,7 @@ views:
       promote: []
       omit: {}
   backend_http_cache_lookups_total:
-    family: HAProxy/Backends/HTTP
+    family: Backends/HTTP
     question: What per-second rate does HAProxy report for http cache lookups?
     entity: backend
     inputs:
@@ -1546,7 +1546,7 @@ views:
       promote: []
       omit: {}
   backend_http_requests_total:
-    family: HAProxy/Backends/HTTP
+    family: Backends/HTTP
     question: What per-second rate does HAProxy report for http requests?
     entity: backend
     inputs:
@@ -1559,7 +1559,7 @@ views:
       promote: []
       omit: {}
   backend_http_responses_total:
-    family: HAProxy/Backends/HTTP
+    family: Backends/HTTP
     question: What per-second rate does HAProxy report for http responses?
     entity: backend
     inputs:
@@ -1574,7 +1574,7 @@ views:
       promote: []
       omit: {}
   backend_servers:
-    family: HAProxy/Backends/Health
+    family: Backends/Health
     question: What value does HAProxy currently report for available servers?
     entity: backend
     inputs:
@@ -1591,7 +1591,7 @@ views:
       promote: []
       omit: {}
   backend_check_last_change_seconds:
-    family: HAProxy/Backends/Health
+    family: Backends/Health
     question: What value does HAProxy currently report for check last change seconds?
     entity: backend
     inputs:
@@ -1604,7 +1604,7 @@ views:
       promote: []
       omit: {}
   backend_downtime_seconds_total:
-    family: HAProxy/Backends/Health
+    family: Backends/Health
     question: What per-second rate does HAProxy report for downtime seconds?
     entity: backend
     inputs:
@@ -1617,7 +1617,7 @@ views:
       promote: []
       omit: {}
   backend_check_up_down_total:
-    family: HAProxy/Backends/Health
+    family: Backends/Health
     question: What per-second rate does HAProxy report for failed check state transitions?
     entity: backend
     inputs:
@@ -1630,7 +1630,7 @@ views:
       promote: []
       omit: {}
   backend_loadbalanced_total:
-    family: HAProxy/Backends/Health
+    family: Backends/Health
     question: What per-second rate does HAProxy report for load-balanced requests?
     entity: backend
     inputs:
@@ -1643,7 +1643,7 @@ views:
       promote: []
       omit: {}
   backend_uweight:
-    family: HAProxy/Backends/Health
+    family: Backends/Health
     question: What value does HAProxy currently report for user weight?
     entity: backend
     inputs:
@@ -1656,7 +1656,7 @@ views:
       promote: []
       omit: {}
   backend_weight:
-    family: HAProxy/Backends/Health
+    family: Backends/Health
     question: What value does HAProxy currently report for weight?
     entity: backend
     inputs:
@@ -1669,7 +1669,7 @@ views:
       promote: []
       omit: {}
   backend_current_queue:
-    family: HAProxy/Backends/Queue
+    family: Backends/Queue
     question: What value does HAProxy currently report for queue?
     entity: backend
     inputs:
@@ -1682,7 +1682,7 @@ views:
       promote: []
       omit: {}
   backend_max_queue:
-    family: HAProxy/Backends/Queue
+    family: Backends/Queue
     question: What value does HAProxy currently report for max queue?
     entity: backend
     inputs:
@@ -1695,7 +1695,7 @@ views:
       promote: []
       omit: {}
   backend_max_queue_time_seconds:
-    family: HAProxy/Backends/Queue
+    family: Backends/Queue
     question: What value does HAProxy currently report for max queue time seconds?
     entity: backend
     inputs:
@@ -1708,7 +1708,7 @@ views:
       promote: []
       omit: {}
   backend_queue_time_average_seconds:
-    family: HAProxy/Backends/Queue
+    family: Backends/Queue
     question: What value does HAProxy currently report for queue time average seconds?
     entity: backend
     inputs:
@@ -1721,7 +1721,7 @@ views:
       promote: []
       omit: {}
   backend_current_session_rate:
-    family: HAProxy/Backends/Sessions
+    family: Backends/Sessions
     question: What value does HAProxy currently report for session rate?
     entity: backend
     inputs:
@@ -1734,7 +1734,7 @@ views:
       promote: []
       omit: {}
   backend_current_sessions:
-    family: HAProxy/Backends/Sessions
+    family: Backends/Sessions
     question: What value does HAProxy currently report for sessions?
     entity: backend
     inputs:
@@ -1747,7 +1747,7 @@ views:
       promote: []
       omit: {}
   backend_last_session_seconds:
-    family: HAProxy/Backends/Sessions
+    family: Backends/Sessions
     question: What value does HAProxy currently report for last session seconds?
     entity: backend
     inputs:
@@ -1760,7 +1760,7 @@ views:
       promote: []
       omit: {}
   backend_limit_sessions:
-    family: HAProxy/Backends/Sessions
+    family: Backends/Sessions
     question: What value does HAProxy currently report for limit sessions?
     entity: backend
     inputs:
@@ -1773,7 +1773,7 @@ views:
       promote: []
       omit: {}
   backend_max_session_rate:
-    family: HAProxy/Backends/Sessions
+    family: Backends/Sessions
     question: What value does HAProxy currently report for max session rate?
     entity: backend
     inputs:
@@ -1786,7 +1786,7 @@ views:
       promote: []
       omit: {}
   backend_max_sessions:
-    family: HAProxy/Backends/Sessions
+    family: Backends/Sessions
     question: What value does HAProxy currently report for max sessions?
     entity: backend
     inputs:
@@ -1799,7 +1799,7 @@ views:
       promote: []
       omit: {}
   backend_sessions_total:
-    family: HAProxy/Backends/Sessions
+    family: Backends/Sessions
     question: What per-second rate does HAProxy report for sessions?
     entity: backend
     inputs:
@@ -1812,7 +1812,7 @@ views:
       promote: []
       omit: {}
   backend_agg_check_status:
-    family: HAProxy/Backends/Status
+    family: Backends/Status
     question: What values does HAProxy report across the source-defined aggregated check status states?
     entity: backend
     inputs:
@@ -1827,7 +1827,7 @@ views:
       promote: []
       omit: {}
   backend_agg_server_status:
-    family: HAProxy/Backends/Status
+    family: Backends/Status
     question: What values does HAProxy report across the source-defined aggregated server status states?
     entity: backend
     inputs:
@@ -1842,7 +1842,7 @@ views:
       promote: []
       omit: {}
   backend_status:
-    family: HAProxy/Backends/Status
+    family: Backends/Status
     question: What values does HAProxy report across the source-defined status states?
     entity: backend
     inputs:
@@ -1857,7 +1857,7 @@ views:
       promote: []
       omit: {}
   backend_total_time_average_seconds:
-    family: HAProxy/Backends/Timing
+    family: Backends/Timing
     question: What value does HAProxy currently report for average total time?
     entity: backend
     inputs:
@@ -1870,7 +1870,7 @@ views:
       promote: []
       omit: {}
   backend_connect_time_average_seconds:
-    family: HAProxy/Backends/Timing
+    family: Backends/Timing
     question: What value does HAProxy currently report for connect time average seconds?
     entity: backend
     inputs:
@@ -1883,7 +1883,7 @@ views:
       promote: []
       omit: {}
   backend_max_connect_time_seconds:
-    family: HAProxy/Backends/Timing
+    family: Backends/Timing
     question: What value does HAProxy currently report for max connect time seconds?
     entity: backend
     inputs:
@@ -1896,7 +1896,7 @@ views:
       promote: []
       omit: {}
   backend_max_response_time_seconds:
-    family: HAProxy/Backends/Timing
+    family: Backends/Timing
     question: What value does HAProxy currently report for max response time seconds?
     entity: backend
     inputs:
@@ -1909,7 +1909,7 @@ views:
       promote: []
       omit: {}
   backend_max_total_time_seconds:
-    family: HAProxy/Backends/Timing
+    family: Backends/Timing
     question: What value does HAProxy currently report for maximum total time?
     entity: backend
     inputs:
@@ -1922,7 +1922,7 @@ views:
       promote: []
       omit: {}
   backend_response_time_average_seconds:
-    family: HAProxy/Backends/Timing
+    family: Backends/Timing
     question: What value does HAProxy currently report for response time average seconds?
     entity: backend
     inputs:
@@ -1935,7 +1935,7 @@ views:
       promote: []
       omit: {}
   backend_http_comp_bytes_bypassed_total:
-    family: HAProxy/Backends/Traffic
+    family: Backends/Traffic
     question: What per-second rate does HAProxy report for http compression bytes bypassed?
     entity: backend
     inputs:
@@ -1948,7 +1948,7 @@ views:
       promote: []
       omit: {}
   backend_http_comp_bytes_in_total:
-    family: HAProxy/Backends/Traffic
+    family: Backends/Traffic
     question: What per-second rate does HAProxy report for http compression bytes in?
     entity: backend
     inputs:
@@ -1961,7 +1961,7 @@ views:
       promote: []
       omit: {}
   backend_http_comp_bytes_out_total:
-    family: HAProxy/Backends/Traffic
+    family: Backends/Traffic
     question: What per-second rate does HAProxy report for http compression bytes out?
     entity: backend
     inputs:
@@ -1974,7 +1974,7 @@ views:
       promote: []
       omit: {}
   backend_traffic:
-    family: HAProxy/Backends/Traffic
+    family: Backends/Traffic
     question: What per-second rate does HAProxy report for traffic?
     entity: backend
     inputs:
@@ -1991,7 +1991,7 @@ views:
       promote: []
       omit: {}
   server_connection_attempts_total:
-    family: HAProxy/Servers/Connections
+    family: Servers/Connections
     question: What per-second rate does HAProxy report for connection attempts?
     entity: server
     inputs:
@@ -2004,7 +2004,7 @@ views:
       promote: []
       omit: {}
   server_connection_reuses_total:
-    family: HAProxy/Servers/Connections
+    family: Servers/Connections
     question: What per-second rate does HAProxy report for connection reuses?
     entity: server
     inputs:
@@ -2017,7 +2017,7 @@ views:
       promote: []
       omit: {}
   server_idle_connections_current:
-    family: HAProxy/Servers/Connections
+    family: Servers/Connections
     question: What value does HAProxy currently report for idle connections?
     entity: server
     inputs:
@@ -2030,7 +2030,7 @@ views:
       promote: []
       omit: {}
   server_used_connections_current:
-    family: HAProxy/Servers/Connections
+    family: Servers/Connections
     question: What value does HAProxy currently report for used connections?
     entity: server
     inputs:
@@ -2043,7 +2043,7 @@ views:
       promote: []
       omit: {}
   server_idle_connections_limit:
-    family: HAProxy/Servers/Connections
+    family: Servers/Connections
     question: What value does HAProxy currently report for idle connection limit?
     entity: server
     inputs:
@@ -2056,7 +2056,7 @@ views:
       promote: []
       omit: {}
   server_idle_connection_safety:
-    family: HAProxy/Servers/Connections
+    family: Servers/Connections
     question: What value does HAProxy currently report for idle connection safety?
     entity: server
     inputs:
@@ -2073,7 +2073,7 @@ views:
       promote: []
       omit: {}
   server_need_connections_current:
-    family: HAProxy/Servers/Connections
+    family: Servers/Connections
     question: What value does HAProxy currently report for needed connections?
     entity: server
     inputs:
@@ -2086,7 +2086,7 @@ views:
       promote: []
       omit: {}
   server_aborts:
-    family: HAProxy/Servers/Errors
+    family: Servers/Errors
     question: What per-second rate does HAProxy report for aborts?
     entity: server
     inputs:
@@ -2103,7 +2103,7 @@ views:
       promote: []
       omit: {}
   server_check_failures_total:
-    family: HAProxy/Servers/Errors
+    family: Servers/Errors
     question: What per-second rate does HAProxy report for check failures?
     entity: server
     inputs:
@@ -2116,7 +2116,7 @@ views:
       promote: []
       omit: {}
   server_errors:
-    family: HAProxy/Servers/Errors
+    family: Servers/Errors
     question: What per-second rate does HAProxy report for errors?
     entity: server
     inputs:
@@ -2141,7 +2141,7 @@ views:
       promote: []
       omit: {}
   server_responses_denied_total:
-    family: HAProxy/Servers/Errors
+    family: Servers/Errors
     question: What per-second rate does HAProxy report for responses denied?
     entity: server
     inputs:
@@ -2154,7 +2154,7 @@ views:
       promote: []
       omit: {}
   server_warnings:
-    family: HAProxy/Servers/Errors
+    family: Servers/Errors
     question: What per-second rate does HAProxy report for warnings?
     entity: server
     inputs:
@@ -2171,7 +2171,7 @@ views:
       promote: []
       omit: {}
   server_http_requests_total:
-    family: HAProxy/Servers/HTTP
+    family: Servers/HTTP
     question: What per-second rate does HAProxy report for http requests?
     entity: server
     inputs:
@@ -2184,7 +2184,7 @@ views:
       promote: []
       omit: {}
   server_http_responses_total:
-    family: HAProxy/Servers/HTTP
+    family: Servers/HTTP
     question: What per-second rate does HAProxy report for http responses?
     entity: server
     inputs:
@@ -2199,7 +2199,7 @@ views:
       promote: []
       omit: {}
   server_agent_code:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for agent code?
     entity: server
     inputs:
@@ -2212,7 +2212,7 @@ views:
       promote: []
       omit: {}
   server_agent_duration_seconds:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for agent duration seconds?
     entity: server
     inputs:
@@ -2225,7 +2225,7 @@ views:
       promote: []
       omit: {}
   server_check_code:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for check code?
     entity: server
     inputs:
@@ -2238,7 +2238,7 @@ views:
       promote: []
       omit: {}
   server_check_duration_seconds:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for check duration seconds?
     entity: server
     inputs:
@@ -2251,7 +2251,7 @@ views:
       promote: []
       omit: {}
   server_check_last_change_seconds:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for check last change seconds?
     entity: server
     inputs:
@@ -2264,7 +2264,7 @@ views:
       promote: []
       omit: {}
   server_current_throttle:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for throttle?
     entity: server
     inputs:
@@ -2282,7 +2282,7 @@ views:
       evidence:
       - percentage_display
   server_downtime_seconds_total:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What per-second rate does HAProxy report for downtime seconds?
     entity: server
     inputs:
@@ -2295,7 +2295,7 @@ views:
       promote: []
       omit: {}
   server_check_up_down_total:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What per-second rate does HAProxy report for failed check state transitions?
     entity: server
     inputs:
@@ -2308,7 +2308,7 @@ views:
       promote: []
       omit: {}
   server_loadbalanced_total:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What per-second rate does HAProxy report for load-balanced requests?
     entity: server
     inputs:
@@ -2321,7 +2321,7 @@ views:
       promote: []
       omit: {}
   server_role:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for server role?
     entity: server
     inputs:
@@ -2338,7 +2338,7 @@ views:
       promote: []
       omit: {}
   server_uweight:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for user weight?
     entity: server
     inputs:
@@ -2351,7 +2351,7 @@ views:
       promote: []
       omit: {}
   server_weight:
-    family: HAProxy/Servers/Health
+    family: Servers/Health
     question: What value does HAProxy currently report for weight?
     entity: server
     inputs:
@@ -2364,7 +2364,7 @@ views:
       promote: []
       omit: {}
   server_current_queue:
-    family: HAProxy/Servers/Queue
+    family: Servers/Queue
     question: What value does HAProxy currently report for queue?
     entity: server
     inputs:
@@ -2377,7 +2377,7 @@ views:
       promote: []
       omit: {}
   server_max_queue:
-    family: HAProxy/Servers/Queue
+    family: Servers/Queue
     question: What value does HAProxy currently report for max queue?
     entity: server
     inputs:
@@ -2390,7 +2390,7 @@ views:
       promote: []
       omit: {}
   server_max_queue_time_seconds:
-    family: HAProxy/Servers/Queue
+    family: Servers/Queue
     question: What value does HAProxy currently report for max queue time seconds?
     entity: server
     inputs:
@@ -2403,7 +2403,7 @@ views:
       promote: []
       omit: {}
   server_queue_limit:
-    family: HAProxy/Servers/Queue
+    family: Servers/Queue
     question: What value does HAProxy currently report for queue limit?
     entity: server
     inputs:
@@ -2416,7 +2416,7 @@ views:
       promote: []
       omit: {}
   server_queue_time_average_seconds:
-    family: HAProxy/Servers/Queue
+    family: Servers/Queue
     question: What value does HAProxy currently report for queue time average seconds?
     entity: server
     inputs:
@@ -2429,7 +2429,7 @@ views:
       promote: []
       omit: {}
   server_current_session_rate:
-    family: HAProxy/Servers/Sessions
+    family: Servers/Sessions
     question: What value does HAProxy currently report for session rate?
     entity: server
     inputs:
@@ -2442,7 +2442,7 @@ views:
       promote: []
       omit: {}
   server_current_sessions:
-    family: HAProxy/Servers/Sessions
+    family: Servers/Sessions
     question: What value does HAProxy currently report for sessions?
     entity: server
     inputs:
@@ -2455,7 +2455,7 @@ views:
       promote: []
       omit: {}
   server_last_session_seconds:
-    family: HAProxy/Servers/Sessions
+    family: Servers/Sessions
     question: What value does HAProxy currently report for last session seconds?
     entity: server
     inputs:
@@ -2468,7 +2468,7 @@ views:
       promote: []
       omit: {}
   server_limit_sessions:
-    family: HAProxy/Servers/Sessions
+    family: Servers/Sessions
     question: What value does HAProxy currently report for limit sessions?
     entity: server
     inputs:
@@ -2481,7 +2481,7 @@ views:
       promote: []
       omit: {}
   server_max_session_rate:
-    family: HAProxy/Servers/Sessions
+    family: Servers/Sessions
     question: What value does HAProxy currently report for max session rate?
     entity: server
     inputs:
@@ -2494,7 +2494,7 @@ views:
       promote: []
       omit: {}
   server_max_sessions:
-    family: HAProxy/Servers/Sessions
+    family: Servers/Sessions
     question: What value does HAProxy currently report for max sessions?
     entity: server
     inputs:
@@ -2507,7 +2507,7 @@ views:
       promote: []
       omit: {}
   server_sessions_total:
-    family: HAProxy/Servers/Sessions
+    family: Servers/Sessions
     question: What per-second rate does HAProxy report for sessions?
     entity: server
     inputs:
@@ -2520,7 +2520,7 @@ views:
       promote: []
       omit: {}
   server_agent_status:
-    family: HAProxy/Servers/Status
+    family: Servers/Status
     question: What values does HAProxy report across the source-defined agent status states?
     entity: server
     inputs:
@@ -2535,7 +2535,7 @@ views:
       promote: []
       omit: {}
   server_check_status:
-    family: HAProxy/Servers/Status
+    family: Servers/Status
     question: What values does HAProxy report across the source-defined check status states?
     entity: server
     inputs:
@@ -2550,7 +2550,7 @@ views:
       promote: []
       omit: {}
   server_status:
-    family: HAProxy/Servers/Status
+    family: Servers/Status
     question: What values does HAProxy report across the source-defined status states?
     entity: server
     inputs:
@@ -2565,7 +2565,7 @@ views:
       promote: []
       omit: {}
   server_total_time_average_seconds:
-    family: HAProxy/Servers/Timing
+    family: Servers/Timing
     question: What value does HAProxy currently report for average total time?
     entity: server
     inputs:
@@ -2578,7 +2578,7 @@ views:
       promote: []
       omit: {}
   server_connect_time_average_seconds:
-    family: HAProxy/Servers/Timing
+    family: Servers/Timing
     question: What value does HAProxy currently report for connect time average seconds?
     entity: server
     inputs:
@@ -2591,7 +2591,7 @@ views:
       promote: []
       omit: {}
   server_max_connect_time_seconds:
-    family: HAProxy/Servers/Timing
+    family: Servers/Timing
     question: What value does HAProxy currently report for max connect time seconds?
     entity: server
     inputs:
@@ -2604,7 +2604,7 @@ views:
       promote: []
       omit: {}
   server_max_response_time_seconds:
-    family: HAProxy/Servers/Timing
+    family: Servers/Timing
     question: What value does HAProxy currently report for max response time seconds?
     entity: server
     inputs:
@@ -2617,7 +2617,7 @@ views:
       promote: []
       omit: {}
   server_max_total_time_seconds:
-    family: HAProxy/Servers/Timing
+    family: Servers/Timing
     question: What value does HAProxy currently report for maximum total time?
     entity: server
     inputs:
@@ -2630,7 +2630,7 @@ views:
       promote: []
       omit: {}
   server_response_time_average_seconds:
-    family: HAProxy/Servers/Timing
+    family: Servers/Timing
     question: What value does HAProxy currently report for response time average seconds?
     entity: server
     inputs:
@@ -2643,7 +2643,7 @@ views:
       promote: []
       omit: {}
   server_traffic:
-    family: HAProxy/Servers/Traffic
+    family: Servers/Traffic
     question: What per-second rate does HAProxy report for traffic?
     entity: server
     inputs:
@@ -2660,7 +2660,7 @@ views:
       promote: []
       omit: {}
   resolver_any_err:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for any errors?
     entity: resolver
     inputs:
@@ -2673,7 +2673,7 @@ views:
       promote: []
       omit: {}
   resolver_cname:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for cname?
     entity: resolver
     inputs:
@@ -2686,7 +2686,7 @@ views:
       promote: []
       omit: {}
   resolver_cname_error:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for cname error?
     entity: resolver
     inputs:
@@ -2699,7 +2699,7 @@ views:
       promote: []
       omit: {}
   resolver_invalid:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for invalid?
     entity: resolver
     inputs:
@@ -2712,7 +2712,7 @@ views:
       promote: []
       omit: {}
   resolver_nx:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for nx?
     entity: resolver
     inputs:
@@ -2725,7 +2725,7 @@ views:
       promote: []
       omit: {}
   resolver_other:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for other?
     entity: resolver
     inputs:
@@ -2738,7 +2738,7 @@ views:
       promote: []
       omit: {}
   resolver_outdated:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for outdated?
     entity: resolver
     inputs:
@@ -2751,7 +2751,7 @@ views:
       promote: []
       omit: {}
   resolver_refused:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for refused?
     entity: resolver
     inputs:
@@ -2764,7 +2764,7 @@ views:
       promote: []
       omit: {}
   resolver_send_error:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for send error?
     entity: resolver
     inputs:
@@ -2777,7 +2777,7 @@ views:
       promote: []
       omit: {}
   resolver_sent:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for sent?
     entity: resolver
     inputs:
@@ -2790,7 +2790,7 @@ views:
       promote: []
       omit: {}
   resolver_timeout:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for timeout?
     entity: resolver
     inputs:
@@ -2803,7 +2803,7 @@ views:
       promote: []
       omit: {}
   resolver_too_big:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for too big?
     entity: resolver
     inputs:
@@ -2816,7 +2816,7 @@ views:
       promote: []
       omit: {}
   resolver_truncated:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for truncated?
     entity: resolver
     inputs:
@@ -2829,7 +2829,7 @@ views:
       promote: []
       omit: {}
   resolver_update:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for update?
     entity: resolver
     inputs:
@@ -2842,7 +2842,7 @@ views:
       promote: []
       omit: {}
   resolver_valid:
-    family: HAProxy/Resolvers/DNS
+    family: Resolvers/DNS
     question: What per-second rate does HAProxy report for valid?
     entity: resolver
     inputs:
@@ -2855,7 +2855,7 @@ views:
       promote: []
       omit: {}
   sticktable_size:
-    family: HAProxy/Stick Tables/Entries
+    family: Stick Tables/Entries
     question: What value does HAProxy currently report for size?
     entity: sticktable
     inputs:
@@ -2868,7 +2868,7 @@ views:
       promote: []
       omit: {}
   sticktable_used:
-    family: HAProxy/Stick Tables/Entries
+    family: Stick Tables/Entries
     question: What value does HAProxy currently report for used?
     entity: sticktable
     inputs:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/litellm/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/litellm/PROFILE-DESIGN.yaml
@@ -835,7 +835,7 @@ exclusions:
 limitations: {}
 views:
   gateway.client_traffic.request_outcomes:
-    family: LiteLLM/Gateway/Client Traffic
+    family: Gateway/Client Traffic
     question: What does client request outcomes report for each route, status_class?
     entity: route_status_class
     inputs:
@@ -870,7 +870,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.client_traffic.failure_causes:
-    family: LiteLLM/Gateway/Client Traffic
+    family: Gateway/Client Traffic
     question: What does client failure causes report for each status_class, exception_class?
     entity: status_class_exception_class
     inputs:
@@ -905,7 +905,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.client_traffic.rate_limit_attribution:
-    family: LiteLLM/Gateway/Client Traffic
+    family: Gateway/Client Traffic
     question: What does client rate-limit attribution report for each rate_limit_category, rate_limit_type?
     entity: rate_limit_category_rate_limit_type
     inputs:
@@ -947,7 +947,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.client_traffic.in_flight_requests:
-    family: LiteLLM/Gateway/Client Traffic
+    family: Gateway/Client Traffic
     question: What does in-flight requests report for each collector job?
     entity: collector_job
     inputs:
@@ -960,7 +960,7 @@ views:
       promote: []
       omit: {}
   gateway.admission_queue.queue_time_distribution:
-    family: LiteLLM/Gateway/Admission Queue
+    family: Gateway/Admission Queue
     question: What does request queue-time distribution report for each model_id?
     entity: model_id
     inputs:
@@ -988,7 +988,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.admission_queue.queued_request_measurements:
-    family: LiteLLM/Gateway/Admission Queue
+    family: Gateway/Admission Queue
     question: What does queued request measurements report for each model_id?
     entity: model_id
     inputs:
@@ -1016,7 +1016,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.admission_queue.accumulated_queue_time:
-    family: LiteLLM/Gateway/Admission Queue
+    family: Gateway/Admission Queue
     question: What does accumulated request queue time report for each model_id?
     entity: model_id
     inputs:
@@ -1044,7 +1044,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.request_latency.distribution:
-    family: LiteLLM/Gateway/Request Latency
+    family: Gateway/Request Latency
     question: What does end-to-end request-latency distribution report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1072,7 +1072,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.request_latency.measurements:
-    family: LiteLLM/Gateway/Request Latency
+    family: Gateway/Request Latency
     question: What does end-to-end request measurements report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1100,7 +1100,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.request_latency.accumulated_time:
-    family: LiteLLM/Gateway/Request Latency
+    family: Gateway/Request Latency
     question: What does accumulated end-to-end request time report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1128,7 +1128,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.processing_overhead.distribution:
-    family: LiteLLM/Gateway/Processing Overhead
+    family: Gateway/Processing Overhead
     question: What does litellm overhead-latency distribution report for each model_id?
     entity: model_id
     inputs:
@@ -1151,7 +1151,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.processing_overhead.measurements:
-    family: LiteLLM/Gateway/Processing Overhead
+    family: Gateway/Processing Overhead
     question: What does litellm overhead measurements report for each model_id?
     entity: model_id
     inputs:
@@ -1174,7 +1174,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.processing_overhead.accumulated_time:
-    family: LiteLLM/Gateway/Processing Overhead
+    family: Gateway/Processing Overhead
     question: What does accumulated litellm overhead report for each model_id?
     entity: model_id
     inputs:
@@ -1197,7 +1197,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.processing_overhead.guardrail_inclusive_distribution:
-    family: LiteLLM/Gateway/Processing Overhead
+    family: Gateway/Processing Overhead
     question: What does guardrail-inclusive overhead distribution report for each model_id?
     entity: model_id
     inputs:
@@ -1220,7 +1220,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.processing_overhead.guardrail_inclusive_measurements:
-    family: LiteLLM/Gateway/Processing Overhead
+    family: Gateway/Processing Overhead
     question: What does guardrail-inclusive overhead measurements report for each model_id?
     entity: model_id
     inputs:
@@ -1243,7 +1243,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   gateway.processing_overhead.accumulated_guardrail_inclusive_time:
-    family: LiteLLM/Gateway/Processing Overhead
+    family: Gateway/Processing Overhead
     question: What does accumulated guardrail-inclusive overhead report for each model_id?
     entity: model_id
     inputs:
@@ -1266,7 +1266,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.deployment_requests.workload:
-    family: LiteLLM/Routing and Deployments/Deployment Requests
+    family: Routing and Deployments/Deployment Requests
     question: What does deployment request workload report for each model_id?
     entity: model_id
     inputs:
@@ -1293,7 +1293,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.deployment_requests.outcomes:
-    family: LiteLLM/Routing and Deployments/Deployment Requests
+    family: Routing and Deployments/Deployment Requests
     question: What does classified deployment outcomes report for each model_id?
     entity: model_id
     inputs:
@@ -1327,7 +1327,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.deployment_requests.failure_causes:
-    family: LiteLLM/Routing and Deployments/Deployment Requests
+    family: Routing and Deployments/Deployment Requests
     question: What does deployment failure causes report for each model_id, status_class, exception_class?
     entity: model_id_status_class_exception_class
     inputs:
@@ -1360,7 +1360,7 @@ views:
       evidence:
       - display_conventions
   routing.deployment_health.cooldowns:
-    family: LiteLLM/Routing and Deployments/Deployment Health
+    family: Routing and Deployments/Deployment Health
     question: What does deployment cooldowns report for each model_id, status_class?
     entity: model_id_status_class
     inputs:
@@ -1381,7 +1381,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.deployment_health.state:
-    family: LiteLLM/Routing and Deployments/Deployment Health
+    family: Routing and Deployments/Deployment Health
     question: What does deployment state report for each model_id?
     entity: model_id_with_pid
     inputs:
@@ -1401,7 +1401,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.deployment_capacity.request_limit:
-    family: LiteLLM/Routing and Deployments/Deployment Capacity
+    family: Routing and Deployments/Deployment Capacity
     question: What does deployment request limit report for each model_id?
     entity: model_id_with_pid
     inputs:
@@ -1426,7 +1426,7 @@ views:
       evidence:
       - display_conventions
   routing.deployment_capacity.token_limit:
-    family: LiteLLM/Routing and Deployments/Deployment Capacity
+    family: Routing and Deployments/Deployment Capacity
     question: What does deployment token limit report for each model_id?
     entity: model_id_with_pid
     inputs:
@@ -1451,7 +1451,7 @@ views:
       evidence:
       - display_conventions
   routing.deployment_capacity.remaining_requests:
-    family: LiteLLM/Routing and Deployments/Deployment Capacity
+    family: Routing and Deployments/Deployment Capacity
     question: What does provider remaining requests report for each model_id?
     entity: model_id_with_pid
     inputs:
@@ -1476,7 +1476,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.deployment_capacity.remaining_tokens:
-    family: LiteLLM/Routing and Deployments/Deployment Capacity
+    family: Routing and Deployments/Deployment Capacity
     question: What does provider remaining tokens report for each model_id?
     entity: model_id_with_pid
     inputs:
@@ -1501,7 +1501,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.output_token_latency.distribution:
-    family: LiteLLM/Routing and Deployments/Output-Token Latency
+    family: Routing and Deployments/Output-Token Latency
     question: What does deployment output-token latency distribution report for each model_id?
     entity: model_id
     inputs:
@@ -1527,7 +1527,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.output_token_latency.measurements:
-    family: LiteLLM/Routing and Deployments/Output-Token Latency
+    family: Routing and Deployments/Output-Token Latency
     question: What does deployment output-token latency measurements report for each model_id?
     entity: model_id
     inputs:
@@ -1553,7 +1553,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.output_token_latency.accumulated_time:
-    family: LiteLLM/Routing and Deployments/Output-Token Latency
+    family: Routing and Deployments/Output-Token Latency
     question: What does accumulated deployment output-token latency report for each model_id?
     entity: model_id
     inputs:
@@ -1579,7 +1579,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   routing.fallbacks.outcomes:
-    family: LiteLLM/Routing and Deployments/Fallbacks
+    family: Routing and Deployments/Fallbacks
     question: What does fallback outcomes report for each requested_model, fallback_model?
     entity: requested_model_fallback_model
     inputs:
@@ -1607,7 +1607,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   provider_api.latency_distribution:
-    family: LiteLLM/Provider API
+    family: Provider API
     question: What does provider api latency distribution report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1635,7 +1635,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   provider_api.latency_measurements:
-    family: LiteLLM/Provider API
+    family: Provider API
     question: What does provider api latency measurements report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1663,7 +1663,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   provider_api.accumulated_latency:
-    family: LiteLLM/Provider API
+    family: Provider API
     question: What does accumulated provider api latency report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1691,7 +1691,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   provider_api.time_to_first_token_distribution:
-    family: LiteLLM/Provider API
+    family: Provider API
     question: What does provider time-to-first-token distribution report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1719,7 +1719,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   provider_api.time_to_first_token_measurements:
-    family: LiteLLM/Provider API
+    family: Provider API
     question: What does provider time-to-first-token measurements report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1747,7 +1747,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   provider_api.accumulated_time_to_first_token:
-    family: LiteLLM/Provider API
+    family: Provider API
     question: What does accumulated provider time-to-first-token report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1775,7 +1775,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.deployment.request_token_throughput:
-    family: LiteLLM/Usage and Cost/By Deployment
+    family: Usage and Cost/By Deployment
     question: What does request token throughput report for each model_id?
     entity: model_id
     inputs:
@@ -1808,7 +1808,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.deployment.total_token_throughput:
-    family: LiteLLM/Usage and Cost/By Deployment
+    family: Usage and Cost/By Deployment
     question: What does reported total token throughput report for each model_id?
     entity: model_id
     inputs:
@@ -1837,7 +1837,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.deployment.spend:
-    family: LiteLLM/Usage and Cost/By Deployment
+    family: Usage and Cost/By Deployment
     question: What does llm spend report for each model_id, service_tier?
     entity: model_id_service_tier
     inputs:
@@ -1870,7 +1870,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.deployment.specialized_token_throughput:
-    family: LiteLLM/Usage and Cost/By Deployment
+    family: Usage and Cost/By Deployment
     question: What does audio and reasoning token throughput report for each model_id?
     entity: model_id
     inputs:
@@ -1905,7 +1905,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.deployment.generated_images:
-    family: LiteLLM/Usage and Cost/By Deployment
+    family: Usage and Cost/By Deployment
     question: What does generated images report for each model_id?
     entity: model_id
     inputs:
@@ -1934,7 +1934,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.deployment.generated_video_duration:
-    family: LiteLLM/Usage and Cost/By Deployment
+    family: Usage and Cost/By Deployment
     question: What does generated video duration report for each model_id?
     entity: model_id
     inputs:
@@ -1963,7 +1963,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.api_key.request_token_throughput:
-    family: LiteLLM/Usage and Cost/By API Key
+    family: Usage and Cost/By API Key
     question: What does request token throughput by api key report for each hashed_api_key?
     entity: hashed_api_key
     inputs:
@@ -1996,7 +1996,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.api_key.total_token_throughput:
-    family: LiteLLM/Usage and Cost/By API Key
+    family: Usage and Cost/By API Key
     question: What does reported total token throughput by api key report for each hashed_api_key?
     entity: hashed_api_key
     inputs:
@@ -2025,7 +2025,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.api_key.spend:
-    family: LiteLLM/Usage and Cost/By API Key
+    family: Usage and Cost/By API Key
     question: What does llm spend by api key report for each hashed_api_key?
     entity: hashed_api_key
     inputs:
@@ -2059,7 +2059,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.team.request_token_throughput:
-    family: LiteLLM/Usage and Cost/By Team
+    family: Usage and Cost/By Team
     question: What does request token throughput by team report for each team?
     entity: team
     inputs:
@@ -2092,7 +2092,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.team.total_token_throughput:
-    family: LiteLLM/Usage and Cost/By Team
+    family: Usage and Cost/By Team
     question: What does reported total token throughput by team report for each team?
     entity: team
     inputs:
@@ -2121,7 +2121,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.team.spend:
-    family: LiteLLM/Usage and Cost/By Team
+    family: Usage and Cost/By Team
     question: What does llm spend by team report for each team?
     entity: team
     inputs:
@@ -2155,7 +2155,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.user.request_token_throughput:
-    family: LiteLLM/Usage and Cost/By User
+    family: Usage and Cost/By User
     question: What does request token throughput by user report for each user?
     entity: user
     inputs:
@@ -2188,7 +2188,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.user.total_token_throughput:
-    family: LiteLLM/Usage and Cost/By User
+    family: Usage and Cost/By User
     question: What does reported total token throughput by user report for each user?
     entity: user
     inputs:
@@ -2217,7 +2217,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.user.spend:
-    family: LiteLLM/Usage and Cost/By User
+    family: Usage and Cost/By User
     question: What does llm spend by user report for each user?
     entity: user
     inputs:
@@ -2251,7 +2251,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.organization.request_token_throughput:
-    family: LiteLLM/Usage and Cost/By Organization
+    family: Usage and Cost/By Organization
     question: What does request token throughput by organization report for each org_id?
     entity: org_id
     inputs:
@@ -2284,7 +2284,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.organization.total_token_throughput:
-    family: LiteLLM/Usage and Cost/By Organization
+    family: Usage and Cost/By Organization
     question: What does reported total token throughput by organization report for each org_id?
     entity: org_id
     inputs:
@@ -2313,7 +2313,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.organization.spend:
-    family: LiteLLM/Usage and Cost/By Organization
+    family: Usage and Cost/By Organization
     question: What does llm spend by organization report for each org_id?
     entity: org_id
     inputs:
@@ -2347,7 +2347,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.end_user.request_token_throughput:
-    family: LiteLLM/Usage and Cost/By End User
+    family: Usage and Cost/By End User
     question: What does request token throughput by end user report for each end_user?
     entity: end_user
     inputs:
@@ -2380,7 +2380,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.end_user.total_token_throughput:
-    family: LiteLLM/Usage and Cost/By End User
+    family: Usage and Cost/By End User
     question: What does reported total token throughput by end user report for each end_user?
     entity: end_user
     inputs:
@@ -2409,7 +2409,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.end_user.spend:
-    family: LiteLLM/Usage and Cost/By End User
+    family: Usage and Cost/By End User
     question: What does llm spend by end user report for each end_user?
     entity: end_user
     inputs:
@@ -2443,7 +2443,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.requested_model.request_token_throughput:
-    family: LiteLLM/Usage and Cost/By Requested Model
+    family: Usage and Cost/By Requested Model
     question: What does request token throughput by requested model report for each requested_model?
     entity: requested_model
     inputs:
@@ -2476,7 +2476,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.requested_model.total_token_throughput:
-    family: LiteLLM/Usage and Cost/By Requested Model
+    family: Usage and Cost/By Requested Model
     question: What does reported total token throughput by requested model report for each requested_model?
     entity: requested_model
     inputs:
@@ -2505,7 +2505,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   usage.requested_model.spend:
-    family: LiteLLM/Usage and Cost/By Requested Model
+    family: Usage and Cost/By Requested Model
     question: What does llm spend by requested model report for each requested_model?
     entity: requested_model
     inputs:
@@ -2539,7 +2539,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   caching.outcomes:
-    family: LiteLLM/Caching
+    family: Caching
     question: What does cache outcomes report for each model_id?
     entity: model_id
     inputs:
@@ -2568,7 +2568,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   caching.cached_token_throughput:
-    family: LiteLLM/Caching
+    family: Caching
     question: What does litellm cached token throughput report for each model_id?
     entity: model_id
     inputs:
@@ -2593,7 +2593,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   caching.request_cache_token_throughput:
-    family: LiteLLM/Caching
+    family: Caching
     question: What does request input-cache token throughput report for each model_id?
     entity: model_id
     inputs:
@@ -2624,7 +2624,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   caching.provider_cache_token_throughput:
-    family: LiteLLM/Caching
+    family: Caching
     question: What does provider cache token throughput report for each model_id?
     entity: model_id
     inputs:
@@ -2653,7 +2653,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   governance.api_keys.remaining_budget:
-    family: LiteLLM/Governance/API Keys
+    family: Governance/API Keys
     question: What does api-key remaining budget report for each hashed_api_key?
     entity: hashed_api_key_with_pid
     inputs:
@@ -2667,7 +2667,7 @@ views:
       - api_key_alias
       omit: {}
   governance.api_keys.budget_limit:
-    family: LiteLLM/Governance/API Keys
+    family: Governance/API Keys
     question: What does api-key budget limit report for each hashed_api_key?
     entity: hashed_api_key_with_pid
     inputs:
@@ -2681,7 +2681,7 @@ views:
       - api_key_alias
       omit: {}
   governance.api_keys.budget_reset_window:
-    family: LiteLLM/Governance/API Keys
+    family: Governance/API Keys
     question: What does api-key budget reset window report for each hashed_api_key?
     entity: hashed_api_key_with_pid
     inputs:
@@ -2700,7 +2700,7 @@ views:
       evidence:
       - display_conventions
   governance.api_keys.model_request_headroom:
-    family: LiteLLM/Governance/API Keys
+    family: Governance/API Keys
     question: What does api-key model request headroom report for each hashed_api_key, model?
     entity: hashed_api_key_model_with_pid
     inputs:
@@ -2721,7 +2721,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   governance.api_keys.model_token_headroom:
-    family: LiteLLM/Governance/API Keys
+    family: Governance/API Keys
     question: What does api-key model token headroom report for each hashed_api_key, model?
     entity: hashed_api_key_model_with_pid
     inputs:
@@ -2742,7 +2742,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   governance.organizations.remaining_budget:
-    family: LiteLLM/Governance/Organizations
+    family: Governance/Organizations
     question: What does organization remaining budget report for each org_id?
     entity: org_id_with_pid
     inputs:
@@ -2756,7 +2756,7 @@ views:
       - org_alias
       omit: {}
   governance.organizations.budget_limit:
-    family: LiteLLM/Governance/Organizations
+    family: Governance/Organizations
     question: What does organization budget limit report for each org_id?
     entity: org_id_with_pid
     inputs:
@@ -2770,7 +2770,7 @@ views:
       - org_alias
       omit: {}
   governance.organizations.budget_reset_window:
-    family: LiteLLM/Governance/Organizations
+    family: Governance/Organizations
     question: What does organization budget reset window report for each org_id?
     entity: org_id_with_pid
     inputs:
@@ -2789,7 +2789,7 @@ views:
       evidence:
       - display_conventions
   governance.teams.remaining_budget:
-    family: LiteLLM/Governance/Teams
+    family: Governance/Teams
     question: What does team remaining budget report for each team?
     entity: team_with_pid
     inputs:
@@ -2803,7 +2803,7 @@ views:
       - team_alias
       omit: {}
   governance.teams.budget_limit:
-    family: LiteLLM/Governance/Teams
+    family: Governance/Teams
     question: What does team budget limit report for each team?
     entity: team_with_pid
     inputs:
@@ -2817,7 +2817,7 @@ views:
       - team_alias
       omit: {}
   governance.teams.budget_reset_window:
-    family: LiteLLM/Governance/Teams
+    family: Governance/Teams
     question: What does team budget reset window report for each team?
     entity: team_with_pid
     inputs:
@@ -2836,7 +2836,7 @@ views:
       evidence:
       - display_conventions
   governance.teams.membership:
-    family: LiteLLM/Governance/Teams
+    family: Governance/Teams
     question: What does team membership report for each team?
     entity: team_with_pid
     inputs:
@@ -2850,7 +2850,7 @@ views:
       - team_alias
       omit: {}
   governance.users.remaining_budget:
-    family: LiteLLM/Governance/Users
+    family: Governance/Users
     question: What does user remaining budget report for each user?
     entity: user_with_pid
     inputs:
@@ -2869,7 +2869,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   governance.users.budget_limit:
-    family: LiteLLM/Governance/Users
+    family: Governance/Users
     question: What does user budget limit report for each user?
     entity: user_with_pid
     inputs:
@@ -2888,7 +2888,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   governance.users.budget_reset_window:
-    family: LiteLLM/Governance/Users
+    family: Governance/Users
     question: What does user budget reset window report for each user?
     entity: user_with_pid
     inputs:
@@ -2912,7 +2912,7 @@ views:
       evidence:
       - display_conventions
   governance.providers.remaining_budget:
-    family: LiteLLM/Governance/Providers
+    family: Governance/Providers
     question: What does provider remaining budget report for each api_provider?
     entity: api_provider_with_pid
     inputs:
@@ -2925,7 +2925,7 @@ views:
       promote: []
       omit: {}
   guardrails.invocations:
-    family: LiteLLM/Guardrails
+    family: Guardrails
     question: What does guardrail invocations report for each guardrail_name, hook_type, status?
     entity: guardrail_name_hook_type_status
     inputs:
@@ -2942,7 +2942,7 @@ views:
       reducer: sum
       lost_comparison: Per-error-type invocation comparison remains available in the guardrail error view.
   guardrails.errors:
-    family: LiteLLM/Guardrails
+    family: Guardrails
     question: What does guardrail errors report for each guardrail_name, hook_type, error_type?
     entity: guardrail_name_hook_type_error_type
     inputs:
@@ -2955,7 +2955,7 @@ views:
       promote: []
       omit: {}
   guardrails.latency_distribution:
-    family: LiteLLM/Guardrails
+    family: Guardrails
     question: What does guardrail latency distribution report for each guardrail_name, hook_type?
     entity: guardrail_name_hook_type
     inputs:
@@ -2974,7 +2974,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   guardrails.accumulated_latency:
-    family: LiteLLM/Guardrails
+    family: Guardrails
     question: What does accumulated guardrail latency report for each guardrail_name, hook_type?
     entity: guardrail_name_hook_type
     inputs:
@@ -2993,7 +2993,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   mcp.tool_calls:
-    family: LiteLLM/MCP Gateway
+    family: MCP Gateway
     question: What does mcp tool calls report for each mcp_server_name, mcp_tool_name?
     entity: mcp_server_name_mcp_tool_name
     inputs:
@@ -3016,7 +3016,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   mcp.tool_call_spend:
-    family: LiteLLM/MCP Gateway
+    family: MCP Gateway
     question: What does mcp tool-call spend report for each mcp_server_name, mcp_tool_name?
     entity: mcp_server_name_mcp_tool_name
     inputs:
@@ -3039,7 +3039,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   managed.batches_created:
-    family: LiteLLM/Managed Batches and Files
+    family: Managed Batches and Files
     question: What does managed batches created report for each api_provider, model?
     entity: api_provider_model
     inputs:
@@ -3059,7 +3059,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   managed.batches_cost_tracked:
-    family: LiteLLM/Managed Batches and Files
+    family: Managed Batches and Files
     question: What does successfully cost-tracked batches report for each api_provider, model?
     entity: api_provider_model
     inputs:
@@ -3072,7 +3072,7 @@ views:
       promote: []
       omit: {}
   managed.batch_cost_errors:
-    family: LiteLLM/Managed Batches and Files
+    family: Managed Batches and Files
     question: What does batch-cost processing errors report for each collector job?
     entity: collector_job
     inputs:
@@ -3090,7 +3090,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   managed.files_created:
-    family: LiteLLM/Managed Batches and Files
+    family: Managed Batches and Files
     question: What does managed files created report for each api_provider, model?
     entity: api_provider_model
     inputs:
@@ -3110,7 +3110,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   managed.file_deletions:
-    family: LiteLLM/Managed Batches and Files
+    family: Managed Batches and Files
     question: What does managed file deletions report for each result?
     entity: result
     inputs:
@@ -3123,7 +3123,7 @@ views:
       promote: []
       omit: {}
   managed.batch_duration_distribution:
-    family: LiteLLM/Managed Batches and Files
+    family: Managed Batches and Files
     question: What does managed batch duration distribution report for each api_provider, model?
     entity: api_provider_model
     inputs:
@@ -3136,7 +3136,7 @@ views:
       promote: []
       omit: {}
   managed.batches_completed:
-    family: LiteLLM/Managed Batches and Files
+    family: Managed Batches and Files
     question: What does completed managed batches report for each api_provider, model?
     entity: api_provider_model
     inputs:
@@ -3149,7 +3149,7 @@ views:
       promote: []
       omit: {}
   managed.accumulated_batch_duration:
-    family: LiteLLM/Managed Batches and Files
+    family: Managed Batches and Files
     question: What does accumulated managed batch duration report for each api_provider, model?
     entity: api_provider_model
     inputs:
@@ -3162,7 +3162,7 @@ views:
       promote: []
       omit: {}
   inventory.total_users:
-    family: LiteLLM/Inventory and Callbacks
+    family: Inventory and Callbacks
     question: What does total users report for each collector job?
     entity: worker_with_pid
     inputs:
@@ -3175,7 +3175,7 @@ views:
       promote: []
       omit: {}
   inventory.billable_users:
-    family: LiteLLM/Inventory and Callbacks
+    family: Inventory and Callbacks
     question: What does billable users report for each collector job?
     entity: worker_with_pid
     inputs:
@@ -3188,7 +3188,7 @@ views:
       promote: []
       omit: {}
   inventory.teams:
-    family: LiteLLM/Inventory and Callbacks
+    family: Inventory and Callbacks
     question: What does teams report for each collector job?
     entity: worker_with_pid
     inputs:
@@ -3201,7 +3201,7 @@ views:
       promote: []
       omit: {}
   inventory.callback_logging_failures:
-    family: LiteLLM/Inventory and Callbacks
+    family: Inventory and Callbacks
     question: What does callback logging failures report for each callback_name?
     entity: callback_name
     inputs:
@@ -3214,7 +3214,7 @@ views:
       promote: []
       omit: {}
   internal_services.request_outcomes:
-    family: LiteLLM/Internal Services
+    family: Internal Services
     question: What does internal service request outcomes report for each service?
     entity: service
     inputs:
@@ -3254,7 +3254,7 @@ views:
       lost_comparison: Per-worker, per-request, caller-accounting, and custom-label comparisons are intentionally omitted
         from this view.
   internal_services.failure_causes:
-    family: LiteLLM/Internal Services
+    family: Internal Services
     question: What does internal service failure causes report for each function_name, error_class?
     entity: function_name_error_class
     inputs:
@@ -3289,7 +3289,7 @@ views:
       evidence:
       - display_conventions
   internal_services.latency_distribution:
-    family: LiteLLM/Internal Services
+    family: Internal Services
     question: What does internal service latency distribution report for each service?
     entity: service
     inputs:
@@ -3318,7 +3318,7 @@ views:
         router: This source label does not define the selected operator entity or a useful chart dimension/label.
         self: This source label does not define the selected operator entity or a useful chart dimension/label.
   internal_services.accumulated_latency:
-    family: LiteLLM/Internal Services
+    family: Internal Services
     question: What does accumulated internal service latency report for each service?
     entity: service
     inputs:

--- a/src/go/plugin/go.d/collector/prometheus/profile-proofs/vllm/PROFILE-DESIGN.yaml
+++ b/src/go/plugin/go.d/collector/prometheus/profile-proofs/vllm/PROFILE-DESIGN.yaml
@@ -785,7 +785,7 @@ exclusions:
 limitations: {}
 views:
   request_lifecycle.corrupted_requests:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate does corrupted requests change?
     entity: model_engine_ray
     inputs:
@@ -801,7 +801,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.time_to_first_token:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: How is time to first token distributed?
     entity: model_engine_ray
     inputs:
@@ -817,7 +817,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.end_to_end_latency:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: How is end-to-end request latency distributed?
     entity: model_engine_ray
     inputs:
@@ -833,7 +833,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.first_token_requests:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate does requests reaching first token change?
     entity: model_engine_ray
     inputs:
@@ -849,7 +849,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.completed_pre_response_time:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate is pre-response time attributed when requests reach their first token?
     entity: model_engine_ray
     inputs:
@@ -865,7 +865,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.completed_end_to_end_time:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate is end-to-end time attributed when requests complete?
     entity: model_engine_ray
     inputs:
@@ -881,7 +881,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.requested_sequences:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: How is requested sequences distributed?
     entity: model_engine_ray
     inputs:
@@ -897,7 +897,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.requested_sequence_volume:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate does requested sequence volume change?
     entity: model_engine_ray
     inputs:
@@ -913,7 +913,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.requested_token_limit:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: How is requested token limit distributed?
     entity: model_engine_ray
     inputs:
@@ -929,7 +929,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.requested_token_limits_sum:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate does requested token limits sum change?
     entity: model_engine_ray
     inputs:
@@ -945,7 +945,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.requests_with_explicit_token_limit:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate does requests with explicit token limit change?
     entity: model_engine_ray
     inputs:
@@ -961,7 +961,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.maximum_generated_tokens:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: How is maximum generated tokens distributed?
     entity: model_engine_ray
     inputs:
@@ -977,7 +977,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.maximum_generated_tokens_sum:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate does maximum generated tokens sum change?
     entity: model_engine_ray
     inputs:
@@ -993,7 +993,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.parent_requests:
-    family: vLLM/Request Lifecycle
+    family: Request Lifecycle
     question: At what rate does parent requests change?
     entity: model_engine_ray
     inputs:
@@ -1009,7 +1009,7 @@ views:
       - Version
       omit: {}
   request_lifecycle.outcomes:
-    family: vLLM/Request Lifecycle/Outcomes
+    family: Request Lifecycle/Outcomes
     question: At what rate does request outcomes change?
     entity: finished_request_ray
     inputs:
@@ -1025,7 +1025,7 @@ views:
       - Version
       omit: {}
   scheduler.request_state:
-    family: vLLM/Scheduler
+    family: Scheduler
     question: What is the current request state?
     entity: model_engine_ray
     inputs:
@@ -1063,7 +1063,7 @@ views:
       - Version
       omit: {}
   scheduler.preemptions:
-    family: vLLM/Scheduler
+    family: Scheduler
     question: At what rate does request preemptions change?
     entity: model_engine_ray
     inputs:
@@ -1079,7 +1079,7 @@ views:
       - Version
       omit: {}
   scheduler.sleep_state:
-    family: vLLM/Scheduler
+    family: Scheduler
     question: What is the current engine sleep state?
     entity: model_engine_ray
     inputs:
@@ -1097,7 +1097,7 @@ views:
       - Version
       omit: {}
   scheduler.queue_time:
-    family: vLLM/Scheduler
+    family: Scheduler
     question: How is request queue time distributed?
     entity: model_engine_ray
     inputs:
@@ -1113,7 +1113,7 @@ views:
       - Version
       omit: {}
   scheduler.completed_queue_time:
-    family: vLLM/Scheduler
+    family: Scheduler
     question: At what rate is queue time attributed when whole requests complete?
     entity: model_engine_ray
     inputs:
@@ -1129,7 +1129,7 @@ views:
       - Version
       omit: {}
   prefill.prompt_tokens_by_source:
-    family: vLLM/Prefill
+    family: Prefill
     question: At what rate does prompt tokens by source change?
     entity: model_engine_ray
     inputs:
@@ -1147,7 +1147,7 @@ views:
       - Version
       omit: {}
   prefill.prompt_size:
-    family: vLLM/Prefill
+    family: Prefill
     question: How is prompt size distributed?
     entity: model_engine_ray
     inputs:
@@ -1163,7 +1163,7 @@ views:
       - Version
       omit: {}
   prefill.prefill_time:
-    family: vLLM/Prefill
+    family: Prefill
     question: How is prefill time distributed?
     entity: model_engine_ray
     inputs:
@@ -1179,7 +1179,7 @@ views:
       - Version
       omit: {}
   prefill.computed_kv_tokens:
-    family: vLLM/Prefill
+    family: Prefill
     question: How is computed kv tokens distributed?
     entity: model_engine_ray
     inputs:
@@ -1195,7 +1195,7 @@ views:
       - Version
       omit: {}
   prefill.completed_request_prompt_volume:
-    family: vLLM/Prefill
+    family: Prefill
     question: At what rate does completed request prompt volume change?
     entity: model_engine_ray
     inputs:
@@ -1211,7 +1211,7 @@ views:
       - Version
       omit: {}
   prefill.computed_kv_token_volume:
-    family: vLLM/Prefill
+    family: Prefill
     question: At what rate does computed kv token volume change?
     entity: model_engine_ray
     inputs:
@@ -1227,7 +1227,7 @@ views:
       - Version
       omit: {}
   prefill.completed_time:
-    family: vLLM/Prefill
+    family: Prefill
     question: At what rate is prefill time attributed when whole requests complete?
     entity: model_engine_ray
     inputs:
@@ -1243,7 +1243,7 @@ views:
       - Version
       omit: {}
   decode.generation_throughput:
-    family: vLLM/Decode
+    family: Decode
     question: At what rate does generated tokens change?
     entity: model_engine_ray
     inputs:
@@ -1259,7 +1259,7 @@ views:
       - Version
       omit: {}
   decode.output_size:
-    family: vLLM/Decode
+    family: Decode
     question: How is output size distributed?
     entity: model_engine_ray
     inputs:
@@ -1275,7 +1275,7 @@ views:
       - Version
       omit: {}
   decode.decode_time:
-    family: vLLM/Decode
+    family: Decode
     question: How is decode time distributed?
     entity: model_engine_ray
     inputs:
@@ -1291,7 +1291,7 @@ views:
       - Version
       omit: {}
   decode.inter_token_latency:
-    family: vLLM/Decode
+    family: Decode
     question: How is inter-token latency distributed?
     entity: model_engine_ray
     inputs:
@@ -1307,7 +1307,7 @@ views:
       - Version
       omit: {}
   decode.mean_output_token_time:
-    family: vLLM/Decode
+    family: Decode
     question: How is mean output-token time distributed?
     entity: model_engine_ray
     inputs:
@@ -1323,7 +1323,7 @@ views:
       - Version
       omit: {}
   decode.output_token_volume:
-    family: vLLM/Decode
+    family: Decode
     question: At what rate does output token volume change?
     entity: model_engine_ray
     inputs:
@@ -1339,7 +1339,7 @@ views:
       - Version
       omit: {}
   decode.completed_time:
-    family: vLLM/Decode
+    family: Decode
     question: At what rate is decode time attributed when whole requests complete?
     entity: model_engine_ray
     inputs:
@@ -1355,7 +1355,7 @@ views:
       - Version
       omit: {}
   decode.inter_token_intervals:
-    family: vLLM/Decode
+    family: Decode
     question: At what rate does inter-token intervals change?
     entity: model_engine_ray
     inputs:
@@ -1371,7 +1371,7 @@ views:
       - Version
       omit: {}
   decode.inter_token_interval_time:
-    family: vLLM/Decode
+    family: Decode
     question: At what rate does inter-token interval time change?
     entity: model_engine_ray
     inputs:
@@ -1387,7 +1387,7 @@ views:
       - Version
       omit: {}
   decode.accumulated_mean_output_token_time:
-    family: vLLM/Decode
+    family: Decode
     question: At what rate does accumulated mean output-token time change?
     entity: model_engine_ray
     inputs:
@@ -1403,7 +1403,7 @@ views:
       - Version
       omit: {}
   engine_execution.inference_time:
-    family: vLLM/Engine Execution
+    family: Engine Execution
     question: How is inference time distributed?
     entity: model_engine_ray
     inputs:
@@ -1419,7 +1419,7 @@ views:
       - Version
       omit: {}
   engine_execution.completed_time:
-    family: vLLM/Engine Execution
+    family: Engine Execution
     question: At what rate is inference time attributed when whole requests complete?
     entity: model_engine_ray
     inputs:
@@ -1435,7 +1435,7 @@ views:
       - Version
       omit: {}
   engine_execution.tokens_per_step:
-    family: vLLM/Engine Execution
+    family: Engine Execution
     question: How is tokens per engine step distributed?
     entity: model_engine_ray
     inputs:
@@ -1451,7 +1451,7 @@ views:
       - Version
       omit: {}
   engine_execution.engine_steps:
-    family: vLLM/Engine Execution
+    family: Engine Execution
     question: At what rate does engine steps change?
     entity: model_engine_ray
     inputs:
@@ -1467,7 +1467,7 @@ views:
       - Version
       omit: {}
   engine_execution.step_token_volume:
-    family: vLLM/Engine Execution
+    family: Engine Execution
     question: At what rate does engine step token volume change?
     entity: model_engine_ray
     inputs:
@@ -1483,7 +1483,7 @@ views:
       - Version
       omit: {}
   engine_execution.estimated_compute:
-    family: vLLM/Engine Execution
+    family: Engine Execution
     question: At what rate does estimated compute per gpu change?
     entity: model_engine_ray
     inputs:
@@ -1504,7 +1504,7 @@ views:
       evidence:
       - display_conventions
   engine_execution.estimated_memory_bandwidth:
-    family: vLLM/Engine Execution
+    family: Engine Execution
     question: At what rate does estimated memory bandwidth per gpu change?
     entity: model_engine_ray
     inputs:
@@ -1529,7 +1529,7 @@ views:
       evidence:
       - display_conventions
   kv_cache.usage:
-    family: vLLM/KV Cache
+    family: KV Cache
     question: What is the current kv cache usage?
     entity: model_engine_ray
     inputs:
@@ -1550,7 +1550,7 @@ views:
       evidence:
       - display_conventions
   kv_cache.local_prefix:
-    family: vLLM/KV Cache
+    family: KV Cache
     question: At what rate does local prefix cache change?
     entity: model_engine_ray
     inputs:
@@ -1570,7 +1570,7 @@ views:
       - Version
       omit: {}
   kv_cache.external_prefix:
-    family: vLLM/KV Cache
+    family: KV Cache
     question: At what rate does external prefix cache change?
     entity: model_engine_ray
     inputs:
@@ -1590,7 +1590,7 @@ views:
       - Version
       omit: {}
   kv_cache.multimodal:
-    family: vLLM/KV Cache
+    family: KV Cache
     question: At what rate does multimodal cache change?
     entity: model_engine_ray
     inputs:
@@ -1610,7 +1610,7 @@ views:
       - Version
       omit: {}
   kv_cache_residency.block_lifetime:
-    family: vLLM/KV Cache Residency
+    family: KV Cache Residency
     question: How is kv block lifetime distributed?
     entity: model_engine_ray
     inputs:
@@ -1626,7 +1626,7 @@ views:
       - Version
       omit: {}
   kv_cache_residency.idle_before_eviction:
-    family: vLLM/KV Cache Residency
+    family: KV Cache Residency
     question: How is kv block idle time before eviction distributed?
     entity: model_engine_ray
     inputs:
@@ -1642,7 +1642,7 @@ views:
       - Version
       omit: {}
   kv_cache_residency.reuse_gap:
-    family: vLLM/KV Cache Residency
+    family: KV Cache Residency
     question: How is kv block reuse gap distributed?
     entity: model_engine_ray
     inputs:
@@ -1658,7 +1658,7 @@ views:
       - Version
       omit: {}
   kv_cache_residency.events:
-    family: vLLM/KV Cache Residency
+    family: KV Cache Residency
     question: At what rate does kv cache events change?
     entity: model_engine_ray
     inputs:
@@ -1678,7 +1678,7 @@ views:
       - Version
       omit: {}
   kv_cache_residency.accumulated_time:
-    family: vLLM/KV Cache Residency
+    family: KV Cache Residency
     question: At what rate does accumulated kv residency time change?
     entity: model_engine_ray
     inputs:
@@ -1702,7 +1702,7 @@ views:
       - Version
       omit: {}
   kv_offloading.load_size:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: How is kv offload load size distributed?
     entity: model_engine_ray
     inputs:
@@ -1718,7 +1718,7 @@ views:
       - Version
       omit: {}
   kv_offloading.store_size:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: How is kv offload store size distributed?
     entity: model_engine_ray
     inputs:
@@ -1734,7 +1734,7 @@ views:
       - Version
       omit: {}
   kv_offloading.transfer_operations:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does kv offload transfer operations change?
     entity: model_engine_ray
     inputs:
@@ -1754,7 +1754,7 @@ views:
       - Version
       omit: {}
   kv_offloading.transfer_bytes:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does kv offload transfer throughput change?
     entity: model_engine_ray
     inputs:
@@ -1774,7 +1774,7 @@ views:
       - Version
       omit: {}
   kv_offloading.completed_transfer_time:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate is completed kv offload transfer time attributed by direction?
     entity: model_engine_ray
     inputs:
@@ -1794,7 +1794,7 @@ views:
       - Version
       omit: {}
   kv_offloading.lookup_sync_delay:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: How is kv offload synchronous lookup delay distributed?
     entity: model_engine_ray
     inputs:
@@ -1810,7 +1810,7 @@ views:
       - Version
       omit: {}
   kv_offloading.lookup_async_delay:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: How is kv offload asynchronous lookup delay distributed?
     entity: model_engine_ray
     inputs:
@@ -1826,7 +1826,7 @@ views:
       - Version
       omit: {}
   kv_offloading.lookup_measurements:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does kv offload lookup measurements change?
     entity: model_engine_ray
     inputs:
@@ -1846,7 +1846,7 @@ views:
       - Version
       omit: {}
   kv_offloading.lookup_delay_accumulation:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does kv offload lookup delay accumulation change?
     entity: model_engine_ray
     inputs:
@@ -1866,7 +1866,7 @@ views:
       - Version
       omit: {}
   kv_offloading.cpu_cache_usage:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: What is the current cpu kv cache usage?
     entity: model_engine_ray
     inputs:
@@ -1895,7 +1895,7 @@ views:
       evidence:
       - display_conventions
   kv_offloading.cpu_allocation_size:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: How is cpu kv allocation size distributed?
     entity: model_engine_ray
     inputs:
@@ -1911,7 +1911,7 @@ views:
       - Version
       omit: {}
   kv_offloading.cpu_allocation_measurements:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does cpu kv allocation measurements change?
     entity: model_engine_ray
     inputs:
@@ -1927,7 +1927,7 @@ views:
       - Version
       omit: {}
   kv_offloading.cpu_allocation_volume:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does cpu kv allocation volume change?
     entity: model_engine_ray
     inputs:
@@ -1943,7 +1943,7 @@ views:
       - Version
       omit: {}
   kv_offloading.admission_outcomes:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does kv offload admission outcomes change?
     entity: model_engine_ray
     inputs:
@@ -1963,7 +1963,7 @@ views:
       - Version
       omit: {}
   kv_offloading.tiering_lookup_sync_delay:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: How is tiered kv offload synchronous lookup delay distributed?
     entity: model_engine_ray
     inputs:
@@ -1979,7 +1979,7 @@ views:
       - Version
       omit: {}
   kv_offloading.tiering_lookup_async_delay:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: How is tiered kv offload asynchronous lookup delay distributed?
     entity: model_engine_ray
     inputs:
@@ -1995,7 +1995,7 @@ views:
       - Version
       omit: {}
   kv_offloading.tiering_lookup_measurements:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does tiered kv offload lookup measurements change?
     entity: model_engine_ray
     inputs:
@@ -2015,7 +2015,7 @@ views:
       - Version
       omit: {}
   kv_offloading.tiering_lookup_delay_accumulation:
-    family: vLLM/KV Offloading
+    family: KV Offloading
     question: At what rate does tiered kv offload lookup delay accumulation change?
     entity: model_engine_ray
     inputs:
@@ -2035,7 +2035,7 @@ views:
       - Version
       omit: {}
   nixl_connector.transfer_duration:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: How is nixl transfer duration distributed?
     entity: model_engine_ray
     inputs:
@@ -2051,7 +2051,7 @@ views:
       - Version
       omit: {}
   nixl_connector.post_time:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: How is nixl transfer post time distributed?
     entity: model_engine_ray
     inputs:
@@ -2067,7 +2067,7 @@ views:
       - Version
       omit: {}
   nixl_connector.transfer_size:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: How is nixl transfer size distributed?
     entity: model_engine_ray
     inputs:
@@ -2083,7 +2083,7 @@ views:
       - Version
       omit: {}
   nixl_connector.transfer_descriptors:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: How is nixl transfer descriptors distributed?
     entity: model_engine_ray
     inputs:
@@ -2099,7 +2099,7 @@ views:
       - Version
       omit: {}
   nixl_connector.successful_transfers:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: At what rate does successful nixl transfers change?
     entity: model_engine_ray
     inputs:
@@ -2115,7 +2115,7 @@ views:
       - Version
       omit: {}
   nixl_connector.completed_transfer_time:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: At what rate is completed nixl transfer and post-processing time attributed?
     entity: model_engine_ray
     inputs:
@@ -2135,7 +2135,7 @@ views:
       - Version
       omit: {}
   nixl_connector.transfer_throughput:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: At what rate does nixl transfer throughput change?
     entity: model_engine_ray
     inputs:
@@ -2151,7 +2151,7 @@ views:
       - Version
       omit: {}
   nixl_connector.descriptor_throughput:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: At what rate does nixl descriptor throughput change?
     entity: model_engine_ray
     inputs:
@@ -2167,7 +2167,7 @@ views:
       - Version
       omit: {}
   nixl_connector.failures:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: At what rate does nixl failures change?
     entity: model_engine_ray
     inputs:
@@ -2187,7 +2187,7 @@ views:
       - Version
       omit: {}
   nixl_connector.expired_requests:
-    family: vLLM/NIXL Connector
+    family: NIXL Connector
     question: At what rate does nixl requests with expired kv change?
     entity: model_engine_ray
     inputs:
@@ -2203,7 +2203,7 @@ views:
       - Version
       omit: {}
   hf3fs_connector.save_duration:
-    family: vLLM/HF3FS Connector
+    family: HF3FS Connector
     question: How is hf3fs save duration distributed?
     entity: model_engine_ray
     inputs:
@@ -2219,7 +2219,7 @@ views:
       - Version
       omit: {}
   hf3fs_connector.load_duration:
-    family: vLLM/HF3FS Connector
+    family: HF3FS Connector
     question: How is hf3fs load duration distributed?
     entity: model_engine_ray
     inputs:
@@ -2235,7 +2235,7 @@ views:
       - Version
       omit: {}
   hf3fs_connector.transfer_measurements:
-    family: vLLM/HF3FS Connector
+    family: HF3FS Connector
     question: At what rate does hf3fs transfer measurements change?
     entity: model_engine_ray
     inputs:
@@ -2255,7 +2255,7 @@ views:
       - Version
       omit: {}
   hf3fs_connector.completed_transfer_time:
-    family: vLLM/HF3FS Connector
+    family: HF3FS Connector
     question: At what rate is completed hf3fs transfer time attributed by direction?
     entity: model_engine_ray
     inputs:
@@ -2275,7 +2275,7 @@ views:
       - Version
       omit: {}
   hf3fs_connector.failures:
-    family: vLLM/HF3FS Connector
+    family: HF3FS Connector
     question: At what rate does hf3fs transfer failures change?
     entity: model_engine_ray
     inputs:
@@ -2295,7 +2295,7 @@ views:
       - Version
       omit: {}
   mooncake_connector.timing.duration:
-    family: vLLM/Mooncake Connector/Operation Timing
+    family: Mooncake Connector/Operation Timing
     question: How is mooncake store operation time distributed?
     entity: connector_operation_status_ray
     inputs:
@@ -2311,7 +2311,7 @@ views:
       - Version
       omit: {}
   mooncake_connector.timing.operations:
-    family: vLLM/Mooncake Connector/Operation Timing
+    family: Mooncake Connector/Operation Timing
     question: At what rate does mooncake store operations change?
     entity: connector_operation_status_ray
     inputs:
@@ -2327,7 +2327,7 @@ views:
       - Version
       omit: {}
   mooncake_connector.timing.completed_time:
-    family: vLLM/Mooncake Connector/Operation Timing
+    family: Mooncake Connector/Operation Timing
     question: At what rate is completed mooncake store operation time attributed?
     entity: connector_operation_status_ray
     inputs:
@@ -2343,7 +2343,7 @@ views:
       - Version
       omit: {}
   mooncake_connector.volume.keys:
-    family: vLLM/Mooncake Connector/Operation Volume
+    family: Mooncake Connector/Operation Volume
     question: At what rate does mooncake store key throughput change?
     entity: connector_operation_status_ray
     inputs:
@@ -2359,7 +2359,7 @@ views:
       - Version
       omit: {}
   mooncake_connector.volume.bytes:
-    family: vLLM/Mooncake Connector/Operation Volume
+    family: Mooncake Connector/Operation Volume
     question: At what rate does mooncake store byte throughput change?
     entity: connector_operation_status_ray
     inputs:
@@ -2375,7 +2375,7 @@ views:
       - Version
       omit: {}
   mooncake_connector.volume.failed_keys:
-    family: vLLM/Mooncake Connector/Operation Volume
+    family: Mooncake Connector/Operation Volume
     question: At what rate does mooncake store failed keys change?
     entity: connector_operation_status_ray
     inputs:
@@ -2391,7 +2391,7 @@ views:
       - Version
       omit: {}
   speculative_decoding.drafts:
-    family: vLLM/Speculative Decoding
+    family: Speculative Decoding
     question: At what rate does drafts change?
     entity: model_engine_ray
     inputs:
@@ -2407,7 +2407,7 @@ views:
       - Version
       omit: {}
   speculative_decoding.token_outcomes:
-    family: vLLM/Speculative Decoding
+    family: Speculative Decoding
     question: At what rate does draft token outcomes change?
     entity: model_engine_ray
     inputs:
@@ -2427,7 +2427,7 @@ views:
       - Version
       omit: {}
   speculative_decoding.accepted_by_position:
-    family: vLLM/Speculative Decoding
+    family: Speculative Decoding
     question: At what rate does accepted tokens by position change?
     entity: model_engine_ray
     inputs:
@@ -2445,7 +2445,7 @@ views:
       - Version
       omit: {}
   diffusion_decoding.denoising_steps:
-    family: vLLM/Diffusion Decoding
+    family: Diffusion Decoding
     question: At what rate does diffusion denoising steps change?
     entity: model_engine_ray
     inputs:
@@ -2461,7 +2461,7 @@ views:
       - Version
       omit: {}
   diffusion_decoding.canvas_positions:
-    family: vLLM/Diffusion Decoding
+    family: Diffusion Decoding
     question: At what rate does diffusion canvas positions change?
     entity: model_engine_ray
     inputs:
@@ -2477,7 +2477,7 @@ views:
       - Version
       omit: {}
   diffusion_decoding.committed_tokens:
-    family: vLLM/Diffusion Decoding
+    family: Diffusion Decoding
     question: At what rate does diffusion committed tokens change?
     entity: model_engine_ray
     inputs:
@@ -2493,7 +2493,7 @@ views:
       - Version
       omit: {}
   websocket_service.active_connections:
-    family: vLLM/WebSocket Service
+    family: WebSocket Service
     question: What is the current active websocket connections?
     entity: service
     inputs:
@@ -2506,7 +2506,7 @@ views:
       promote: []
       omit: {}
   websocket_service.connection_lifecycle:
-    family: vLLM/WebSocket Service
+    family: WebSocket Service
     question: At what rate does websocket connection lifecycle change?
     entity: service
     inputs:
@@ -2523,7 +2523,7 @@ views:
       promote: []
       omit: {}
   websocket_service.connection_duration:
-    family: vLLM/WebSocket Service
+    family: WebSocket Service
     question: How is websocket connection duration distributed?
     entity: service
     inputs:
@@ -2536,7 +2536,7 @@ views:
       promote: []
       omit: {}
   websocket_service.completed_connection_time:
-    family: vLLM/WebSocket Service
+    family: WebSocket Service
     question: At what rate is connection time attributed when websocket connections close?
     entity: service
     inputs:
@@ -2549,7 +2549,7 @@ views:
       promote: []
       omit: {}
   tool_parsing.invocations:
-    family: vLLM/Tool Parsing
+    family: Tool Parsing
     question: At what rate does tool parser invocations change?
     entity: parser_request
     inputs:

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/ceph.yaml
@@ -278,7 +278,6 @@ relabeling:
         target_label: __name__
         replacement: ceph_throttle_${2}
 template:
-  family: Ceph
   context_namespace: ceph
   groups:
     - family: Capacity

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/haproxy.yaml
@@ -9,7 +9,6 @@ autogen:
     - haproxy_process_node
     - haproxy_process_start_time_seconds
 template:
-  family: HAProxy
   context_namespace: haproxy
   groups:
   - family: Process

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/litellm.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/litellm.yaml
@@ -175,7 +175,6 @@ relabeling:
         target_label: measurement
         replacement: time
 template:
-  family: LiteLLM
   context_namespace: litellm
   groups:
     - family: Gateway

--- a/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/vllm.yaml
+++ b/src/go/plugin/go.d/config/go.d/prometheus.profiles/default/vllm.yaml
@@ -172,7 +172,6 @@ relabeling:
     metric_relabel_configs:
       - action: drop
 template:
-  family: vLLM
   context_namespace: vllm
   chart_defaults:
     label_promotion: [Version, SessionName, Component]


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattens Prometheus application profile families by removing app-level prefixes in Ceph, HAProxy, LiteLLM, and vLLM profiles. Previously families were namespaced (e.g., "HAProxy/Process/Activity"); now they are shared ("Process/Activity"). Template-level "family" keys are removed; `context_namespace` continues to separate apps. No metric ingestion or relabeling logic changes.

- Reviewer focus
  - Profile proofs: replace family paths to drop app prefixes; verify all views moved to the correct shared families without losing grouping.
  - Templates: remove top-level `family` while keeping `context_namespace`; confirm autogen and relabeling blocks remain unchanged.
  - Expect only family path string changes; charts and contexts still segregate by `context_namespace`.

- Rollout/Migration
  - Update any overrides or dashboards that reference old family paths (e.g., "HAProxy/...") to the new paths ("...").
  - No agent config changes required; reload/restart to pick up profiles.

<sup>Written for commit 76bdaec62da3db788e4266614f0dc61c056d817d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Simplified dashboard category names for HAProxy, LiteLLM, and vLLM by removing redundant product-name prefixes.
  - Updated categories to use clearer groupings such as Process, Frontends, Servers, Gateway, Usage and Cost, and Request Lifecycle.
  - Removed redundant top-level family labels from the Ceph, HAProxy, LiteLLM, and vLLM profiles.
  - Existing metrics, charts, labels, and monitoring behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->