### PR TITLE
fix(build): bound eBPF Go dependency discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3306,19 +3306,23 @@ if(ENABLE_PLUGIN_EBPF)
 
     # GLOB_RECURSE descends into subdirectories, so netipc/*.go covers
     # protocol/, service/, and transport/ even though no .go files exist at
-    # netipc/'s root level.  go.mod and go.sum are listed explicitly so a
-    # Go-version bump or new transitive dep in go/plugins triggers a rebuild.
+    # netipc/'s root level. Keep fixed workspace and module files out of the
+    # recursive glob so CMake does not scan their parent trees on every build.
     file(GLOB_RECURSE EBPF_GO_PLUGIN_FILES CONFIGURE_DEPENDS
             "${CMAKE_SOURCE_DIR}/src/collectors/ebpf.plugin/ebpfgo.plugin/*.go"
             "${CMAKE_SOURCE_DIR}/src/collectors/ebpf.plugin/ebpfgo.plugin/*.c"
             "${CMAKE_SOURCE_DIR}/src/collectors/ebpf.plugin/ebpfgo.plugin/*.h"
-            "${CMAKE_SOURCE_DIR}/src/collectors/ebpf.plugin/ebpfgo.plugin/go.mod"
-            "${CMAKE_SOURCE_DIR}/src/collectors/ebpf.plugin/ebpfgo.plugin/go.sum"
-            "${CMAKE_SOURCE_DIR}/go.work"
-            "${CMAKE_SOURCE_DIR}/src/go/go.mod"
-            "${CMAKE_SOURCE_DIR}/src/go/go.sum"
             "${CMAKE_SOURCE_DIR}/src/go/pkg/netipc/*.go"
             "${CMAKE_SOURCE_DIR}/src/go/pkg/netdataapi/*.go")
+    # go.work is optional; watch its exact path so appearance or removal regenerates the graph.
+    file(GLOB EBPF_GO_WORKSPACE_FILE CONFIGURE_DEPENDS LIST_DIRECTORIES false
+            "${CMAKE_SOURCE_DIR}/go.work")
+    list(APPEND EBPF_GO_PLUGIN_FILES
+            ${EBPF_GO_WORKSPACE_FILE}
+            "${CMAKE_SOURCE_DIR}/src/collectors/ebpf.plugin/ebpfgo.plugin/go.mod"
+            "${CMAKE_SOURCE_DIR}/src/collectors/ebpf.plugin/ebpfgo.plugin/go.sum"
+            "${CMAKE_SOURCE_DIR}/src/go/go.mod"
+            "${CMAKE_SOURCE_DIR}/src/go/go.sum")
 
     set(EBPF_GO_LIBBPF_LIB_DIR lib)
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(amd64)")


### PR DESCRIPTION
## Summary

- keep recursive CMake glob verification limited to the eBPF Go source trees
- track fixed module files as ordinary build dependencies
- preserve optional `go.work` appearance/removal detection with an exact, non-recursive check

## Root cause

The eBPF Go dependency list passed exact workspace and module filenames to `file(GLOB_RECURSE ... CONFIGURE_DEPENDS)`. CMake therefore repeated recursive scans from those files' parent directories during every build-system check, including from the repository root for optional `go.work`.

## Validation

- fresh CMake 3.28.3/Ninja configuration with the eBPF plugin enabled
- production `ebpf-go-plugin` target built successfully
- generated `VerifyGlobs.cmake` contains only five bounded recursive source patterns and one exact optional `go.work` check
- added and removed matching Go sources trigger regeneration
- optional `go.work` appearance and removal trigger regeneration without becoming a missing hard dependency
- each of the four tracked module files independently triggers an eBPF Go plugin rebuild
- repeated direct glob-verifier runs complete in 0.01 seconds and do not traverse ignored local trees


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds eBPF Go dependency discovery in CMake to stop unnecessary recursive scans and speed up configure checks. Previously, recursive globs included fixed files like go.mod and optional go.work, causing CMake to rescan parent trees (including the repo root) on every build-system check.

- Limit `GLOB_RECURSE` to eBPF plugin sources and `src/go/pkg/{netipc,netdataapi}`.
- Track `go.mod`/`go.sum` as explicit build dependencies so each change triggers a rebuild without widening scans.
- Watch `go.work` via a non-recursive exact glob; its appearance/removal still regenerates the graph without becoming a hard dependency.
- Validated with CMake 3.28.3/Ninja: plugin builds, source changes trigger regeneration, repeated glob verification is fast and avoids ignored trees.

<sup>Written for commit 40d90c05a0b2d5473b3cccf53c160405e4bdef5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated build tracking so changes to shared networking and data packages are detected automatically.
  * Added support for tracking optional workspace configuration changes.
  * Improved dependency monitoring for Go, C, and header files used by the eBPF plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->