### PR TITLE
docs(prometheus): emit MDX-safe profile details

### DIFF
--- a/integrations/gen_docs_integrations.py
+++ b/integrations/gen_docs_integrations.py
@@ -97,7 +97,7 @@ def clean_and_write(md: str, path: Path):
 
         def _profile_details(match, attribute=attribute):
             opened = ' open' if match.group(1) else ''
-            return f'<details{opened} {attribute}><summary>{match.group(2)}</summary>\n'
+            return f'<details{opened} {attribute}>\n<summary>{match.group(2)}</summary>\n'
 
         md = re.sub(pattern, _profile_details, md)
 

--- a/integrations/tests/test_prometheus_profile_docs.py
+++ b/integrations/tests/test_prometheus_profile_docs.py
@@ -149,8 +149,19 @@ class PrometheusProfileCatalogTest(unittest.TestCase):
             path = Path(directory) / 'integration.md'
             clean_and_write(markdown, path)
             rendered = path.read_text(encoding='utf-8')
-        self.assertIn('<details open data-prometheus-profile-catalog>', rendered)
-        self.assertIn('<details data-prometheus-profile-chart>', rendered)
+        self.assertIn(
+            '<details open data-prometheus-profile-catalog>\n<summary>Coverage</summary>\n',
+            rendered,
+        )
+        self.assertIn(
+            '<details data-prometheus-profile-chart>\n<summary>Requests</summary>\n',
+            rendered,
+        )
+        self.assertNotIn(
+            '<details open data-prometheus-profile-catalog><summary>',
+            rendered,
+        )
+        self.assertNotIn('<details data-prometheus-profile-chart><summary>', rendered)
         self.assertNotIn('prometheus-profile-catalog -->', rendered)
 
     def test_view_chart_mismatch_fails_closed(self):


### PR DESCRIPTION
## Result

Prometheus profile catalogue disclosures are emitted as block-safe HTML in generated integration Markdown. The opening `<details>` element and its `<summary>` now occupy separate lines, preserving the catalogue data hooks while allowing downstream MDX compilers to parse nested catalogue content.

Only profile-marked disclosures change. Existing generic integration details keep their established output, avoiding unrelated generated-document churn. Runtime collection and profile selection are unaffected.

## Validation

- `python3 -m unittest discover -s integrations/tests -p "test_*.py"` — 99 passed
- `python3 integrations/gen_docs_integrations.py --check` — 1,620 pages validated
- Prometheus documentation regeneration changed exactly the five profile-enabled integration documents
- Full local Learn ingest — 1,948 files, success
- Learn Docusaurus production build against regenerated documents — success
- Generated Ceph page — 569 profile chart hooks
- `git diff --check` — passed

Generated integration documents remain owned by the post-merge integration-generation workflow and are not included in this source PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit MDX-safe Prometheus profile disclosures by moving the <summary> onto a new line. Previously we wrote <details ...><summary>…</summary>; now we write <details ...>\n<summary>…</summary>, preserving profile data hooks while leaving non-profile disclosures and runtime behavior unchanged.

- Review notes: One-line change in `clean_and_write`’s `_profile_details` replacement inserts the newline and only applies to profile-marked blocks. Tests assert the new sequences and reject the old inline pattern. Generated docs are produced post-merge; none are committed here.

<sup>Written for commit 7adb7185120be2cf4e67b0642119847a808b9ffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated documentation formatting by placing expandable section headings on separate lines for clearer readability.

* **Tests**
  * Strengthened documentation checks to verify the expected multi-line layout and prevent compact, single-line rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->