### PR TITLE
Adjust eBPF in static buidling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,10 @@ netdata_fixup_system_processor()
 
 option(STATIC_BUILD "Use static linking instead of dynamic linking for the build." FALSE)
 mark_as_advanced(STATIC_BUILD)
-set(BUILD_SHARED_LIBS "${STATIC_BUILD}")
+# Every bundled sub-project is linked into our own binaries and deliberately
+# not installed, so they must always be static. Build intent lives in
+# STATIC_BUILD; this knob only governs bundled libraries.
+set(BUILD_SHARED_LIBS OFF)
 
 if(STATIC_BUILD)
   set(CMAKE_FIND_LIBRARY_PREFIXES "${CMAKE_STATIC_LIBRARY_PREFIX}")

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -773,11 +773,6 @@ if [ -n "${NETDATA_PREPARE_ONLY}" ]; then
     exit 0
 fi
 
-# Let cmake know we don't want to link shared libs
-if [ "${IS_NETDATA_STATIC_BINARY}" = "yes" ]; then
-    NETDATA_CMAKE_OPTIONS="${NETDATA_CMAKE_OPTIONS} -DBUILD_SHARED_LIBS=Off"
-fi
-
 # shellcheck disable=SC2086
 if ! run_cmake_configure; then
   fatal "Failed to configure Netdata sources." I000A

--- a/packaging/cmake/Modules/NetdataEBPFLegacy.cmake
+++ b/packaging/cmake/Modules/NetdataEBPFLegacy.cmake
@@ -11,10 +11,10 @@ set(ebpf-legacy_BUILD_DIR "${CMAKE_BINARY_DIR}/ebpf-legacy-build")
 function(netdata_fetch_legacy_ebpf_code)
     netdata_identify_libc(_libc)
 
-    if(DEFINED BUILD_SHARED_LIBS)
-        if(NOT BUILD_SHARED_LIBS)
-            set(need_static TRUE)
-        endif()
+    # Static builds ship the flavor-neutral object set; keep this test aligned
+    # with netdata_bundle_libbpf() in NetdataLibBPF.cmake.
+    if(STATIC_BUILD)
+        set(need_static TRUE)
     endif()
 
     if(need_static)

--- a/packaging/cmake/Modules/NetdataProtobuf.cmake
+++ b/packaging/cmake/Modules/NetdataProtobuf.cmake
@@ -101,7 +101,7 @@ macro(netdata_detect_protobuf)
                 set(HAVE_PROTOBUF True)
         else()
                 if(NOT ENABLE_BUNDLED_PROTOBUF)
-                        if (NOT BUILD_SHARED_LIBS)
+                        if(STATIC_BUILD)
                                 set(Protobuf_USE_STATIC_LIBS On)
                         endif()
 


### PR DESCRIPTION
##### Summary
Fix https://github.com/netdata/netdata/issues/23604

##### Test Plan
1. Check CI

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make bundled libraries always build as static and use `STATIC_BUILD` to control whether Netdata links statically, fixing static eBPF/protobuf selection. Previously `BUILD_SHARED_LIBS` mirrored `STATIC_BUILD`; now `BUILD_SHARED_LIBS` is forced OFF and only bundled deps are affected, while `STATIC_BUILD` governs final linking.

- `CMakeLists.txt`: unconditionally sets `BUILD_SHARED_LIBS=OFF`; intent remains in `STATIC_BUILD`.
- `NetdataEBPFLegacy.cmake` and `NetdataProtobuf.cmake`: switch checks from `BUILD_SHARED_LIBS` to `STATIC_BUILD` to choose static artifacts, resolving incorrect behavior in static builds (issue #23604).
- `netdata-installer.sh`: removes `-DBUILD_SHARED_LIBS=Off` since CMake enforces it.
- Migration: use `-DSTATIC_BUILD=On` to request fully static binaries; stop setting `-DBUILD_SHARED_LIBS`. Dynamic builds continue to link against system libs; bundled deps are static-only.

<sup>Written for commit 823e8193ef7500c361a426ab96cf95f6845ad145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

