### PR TITLE
fix(dictionary): defer destruction while dictionary APIs are active

### DIFF
--- a/src/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/src/collectors/diskspace.plugin/plugin_diskspace.c
@@ -662,9 +662,6 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
         }
     }
 
-    if(unlikely(!item))
-        goto cleanup;
-
     struct mount_point_metadata *m = dictionary_acquired_item_value(item);
     if (m->slow) {
         add_basic_mountinfo(&slow_mountinfo_tmp_root, mi);

--- a/src/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/src/collectors/diskspace.plugin/plugin_diskspace.c
@@ -652,6 +652,10 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
         item = dictionary_set_and_acquire_item(dict_mountpoints, mi->mount_point, &mp, sizeof(struct mount_point_metadata));
     }
 
+    // NULL when dict_mountpoints is being destroyed (shutdown)
+    if(unlikely(!item))
+        goto cleanup;
+
     struct mount_point_metadata *m = dictionary_acquired_item_value(item);
     if (m->slow) {
         add_basic_mountinfo(&slow_mountinfo_tmp_root, mi);

--- a/src/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/src/collectors/diskspace.plugin/plugin_diskspace.c
@@ -650,9 +650,18 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
         rrdlabels_add(mp.chart_labels, "mount_root", mi->root, RRDLABEL_SRC_AUTO);
 
         item = dictionary_set_and_acquire_item(dict_mountpoints, mi->mount_point, &mp, sizeof(struct mount_point_metadata));
+
+        if(unlikely(!item)) {
+            // dict_mountpoints is being destroyed (shutdown): the insert
+            // callback never ran, so mountpoint_delete_cb() will never free
+            // what this candidate owns - do it here (mirrors that callback)
+            string_freez(mp.filesystem);
+            string_freez(mp.mountroot);
+            rrdlabels_destroy(mp.chart_labels);
+            goto cleanup;
+        }
     }
 
-    // NULL when dict_mountpoints is being destroyed (shutdown)
     if(unlikely(!item))
         goto cleanup;
 

--- a/src/daemon/dyncfg/dyncfg-files.c
+++ b/src/daemon/dyncfg/dyncfg-files.c
@@ -252,7 +252,15 @@ void dyncfg_file_load(const char *d_name) {
     // it here too so the conflict_cb SWAP cannot reintroduce a stale mask.
     tmp.cmds = dyncfg_sanitize_cmds(tmp.type, tmp.current.source_type, tmp.cmds);
 
-    dictionary_set(dyncfg_globals.nodes, id, &tmp, sizeof(tmp));
+    if(!dictionary_set(dyncfg_globals.nodes, id, &tmp, sizeof(tmp))) {
+        // dyncfg_globals.nodes is being destroyed (dyncfg_shutdown_low_level()):
+        // the insert callback never ran, so we still own everything we
+        // allocated above - free it exactly as dyncfg_add_internal() does.
+        // NULL is unambiguous here only because value_len > 0 and the id is
+        // valid - see the set-family contract in dictionary.h
+        dyncfg_cleanup(&tmp);
+        return;
+    }
 
     // check if we need to rename the file
     CLEAN_CHAR_P *fixed_id = dyncfg_escape_id_for_filename(id);

--- a/src/database/contexts/rrdcontext-instance.c
+++ b/src/database/contexts/rrdcontext-instance.c
@@ -301,6 +301,16 @@ inline void rrdinstance_from_rrdset(RRDSET *st) {
     };
 
     RRDCONTEXT_ACQUIRED *rca = (RRDCONTEXT_ACQUIRED *)dictionary_set_and_acquire_item(st->rrdhost->rrdctx.contexts, string2str(trc.id), &trc, sizeof(trc));
+    if(unlikely(!rca)) {
+        // the contexts dictionary is being destroyed (host shutdown); the insert
+        // callback never ran, so we still own what we duplicated above
+        string_freez(trc.id);
+        string_freez(trc.title);
+        string_freez(trc.units);
+        string_freez(trc.family);
+        return;
+    }
+
     RRDCONTEXT *rc = rrdcontext_acquired_value(rca);
 
     RRDINSTANCE tri = {
@@ -318,6 +328,18 @@ inline void rrdinstance_from_rrdset(RRDSET *st) {
     };
 
     RRDINSTANCE_ACQUIRED *ria = (RRDINSTANCE_ACQUIRED *)dictionary_set_and_acquire_item(rc->rrdinstances, string2str(tri.id), &tri, sizeof(tri));
+    if(unlikely(!ria)) {
+        // the instances dictionary is being destroyed; free what we duplicated
+        // above (mirrors rrdinstance_free()) and drop the context reference
+        string_freez(tri.id);
+        string_freez(tri.name);
+        string_freez(tri.units);
+        string_freez(tri.family);
+        string_freez(tri.title);
+        uuidmap_free(tri.uuid);
+        rrdcontext_release(rca);
+        return;
+    }
 
     RRDCONTEXT_ACQUIRED *rca_old = st->rrdcontexts.rrdcontext;
     RRDINSTANCE_ACQUIRED *ria_old = st->rrdcontexts.rrdinstance;

--- a/src/database/contexts/rrdcontext-loading.c
+++ b/src/database/contexts/rrdcontext-loading.c
@@ -64,7 +64,14 @@ static void rrdinstance_load_dimension_callback(SQL_DIMENSION_DATA *sd, void *da
     };
     if(sd->hidden) trm.flags |= RRD_FLAG_HIDDEN;
 
-    dictionary_set(ri->rrdmetrics, string2str(trm.id), &trm, sizeof(trm));
+    if(!dictionary_set(ri->rrdmetrics, string2str(trm.id), &trm, sizeof(trm))) {
+        // the metrics dictionary is being destroyed; the insert callback never
+        // ran, so free what we duplicated above (mirrors rrdmetric_free())
+        th_ignored_metrics++;
+        string_freez(trm.id);
+        string_freez(trm.name);
+        uuidmap_free(trm.uuid);
+    }
 
     rrdinstance_release(ria);
     rrdcontext_release(rca);
@@ -150,7 +157,11 @@ static void rrdcontext_load_context_callback(VERSIONED_CONTEXT_DATA *ctx_data, v
 
         .hub = *ctx_data,
     };
-    dictionary_set(host->rrdctx.contexts, string2str(trc.id), &trc, sizeof(trc));
+    if(!dictionary_set(host->rrdctx.contexts, string2str(trc.id), &trc, sizeof(trc)))
+        // the contexts dictionary is being destroyed; the insert callback never
+        // ran, so it never took ownership of the hub strings - only the id we
+        // duplicated above is ours to free (mirrors rrdcontext_freez())
+        string_freez(trc.id);
 }
 
 void rrdhost_load_rrdcontext_data(RRDHOST *host) {

--- a/src/database/contexts/rrdcontext-loading.c
+++ b/src/database/contexts/rrdcontext-loading.c
@@ -66,7 +66,9 @@ static void rrdinstance_load_dimension_callback(SQL_DIMENSION_DATA *sd, void *da
 
     if(!dictionary_set(ri->rrdmetrics, string2str(trm.id), &trm, sizeof(trm))) {
         // the metrics dictionary is being destroyed; the insert callback never
-        // ran, so free what we duplicated above (mirrors rrdmetric_free())
+        // ran, so free what we duplicated above (mirrors rrdmetric_free()).
+        // NULL is unambiguous here only because value_len > 0 and the name is
+        // valid - see the set-family contract in dictionary.h
         th_ignored_metrics++;
         string_freez(trm.id);
         string_freez(trm.name);
@@ -160,7 +162,9 @@ static void rrdcontext_load_context_callback(VERSIONED_CONTEXT_DATA *ctx_data, v
     if(!dictionary_set(host->rrdctx.contexts, string2str(trc.id), &trc, sizeof(trc)))
         // the contexts dictionary is being destroyed; the insert callback never
         // ran, so it never took ownership of the hub strings - only the id we
-        // duplicated above is ours to free (mirrors rrdcontext_freez())
+        // duplicated above is ours to free (mirrors rrdcontext_freez()).
+        // NULL is unambiguous here only because value_len > 0 and the name is
+        // valid - see the set-family contract in dictionary.h
         string_freez(trc.id);
 }
 

--- a/src/database/contexts/rrdcontext-metric.c
+++ b/src/database/contexts/rrdcontext-metric.c
@@ -265,6 +265,15 @@ void rrdmetric_from_rrddim(RRDDIM *rd) {
     };
 
     RRDMETRIC_ACQUIRED *rma = (RRDMETRIC_ACQUIRED *)dictionary_set_and_acquire_item(ri->rrdmetrics, string2str(trm.id), &trm, sizeof(trm));
+    if(unlikely(!rma)) {
+        // the metrics dictionary is being destroyed; the insert callback never
+        // ran, so free what we duplicated above (mirrors rrdmetric_free()) and
+        // keep the existing link untouched
+        string_freez(trm.id);
+        string_freez(trm.name);
+        uuidmap_free(trm.uuid);
+        return;
+    }
 
     if(rd->rrdcontexts.rrdmetric)
         rrdmetric_release(rd->rrdcontexts.rrdmetric);

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -567,6 +567,20 @@ RRDDIM *rrddim_add_custom(RRDSET *st
         };
 
         rd = dictionary_set_advanced(st->rrddim_root_index, tmp.id, -1, NULL, rrddim_size(), &tmp);
+
+        if(unlikely(!rd))
+            // The index refused the insert, which only happens once
+            // rrddim_index_destroy() has destroyed it - and that runs from
+            // rrdset_free(), i.e. this chart is already being freed. Retrying
+            // can never succeed: the loop above would spin at 100% CPU forever
+            // on a dictionary that refuses every insert. Returning NULL is not
+            // an option either - rrddim_add() callers dereference the result
+            // unconditionally (the usual idiom is rrddim_set_by_pointer() on
+            // the very next line), so this mirrors rrdset_create_custom().
+            fatal("RRDDIM: dimension '%s' of chart '%s' on host '%s' cannot be created: "
+                  "the chart's dimension index is being destroyed. "
+                  "A collector is still adding dimensions to a chart that is being freed.",
+                  id, rrdset_id(st), rrdhost_hostname(st->rrdhost));
     }
 
     return(rd);

--- a/src/database/rrdset-index-id.c
+++ b/src/database/rrdset-index-id.c
@@ -535,6 +535,20 @@ RRDSET *rrdset_create_custom(
         };
 
         st_item = rrdset_index_add_and_acquire(host, chart_full_id, &ctr);
+
+        if(unlikely(!st_item))
+            // The index refused the insert, which only happens once
+            // rrdset_index_destroy() has destroyed it - and that runs in
+            // rrdhost_free_unlinked(), after collection on this host has been
+            // stopped and the host unlinked. So we are being called with a
+            // host that is already being freed: retrying can never succeed
+            // (it would spin at 100% CPU forever) and we cannot return NULL,
+            // because rrdset_create() callers dereference the result
+            // unconditionally. The archive path only flushes the index, which
+            // keeps accepting inserts, so this is never the benign case.
+            fatal("RRDSET: chart '%s' of host '%s' cannot be created: the host's chart index is being destroyed. "
+                  "A collector is still creating charts on a host that is being freed.",
+                  chart_full_id, rrdhost_hostname(host));
     }
 
     RRDSET *st = dictionary_acquired_item_value(st_item);

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -40,9 +40,28 @@ typedef enum __attribute__ ((__packed__)) {
 // protect a caller holding a stale DICTIONARY * that has not entered yet -
 // that window is unclosable from inside the dictionary and remains a
 // caller-ownership bug.
-#define dictionary_inflight_enter(dict) __atomic_add_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST)
-#define dictionary_inflight_exit(dict)  __atomic_sub_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST)
-#define dictionary_inflight(dict)       __atomic_load_n(&((dict)->inflight), __ATOMIC_SEQ_CST)
+//
+// EVERY public function that touches the dictionary object must be bracketed
+// by dictionary_api_enter() / dictionary_api_exit(). Taking one of the
+// dictionary's own locks without it is the exact race this closes: pass the
+// destroyed check, then block on a lock inside a struct that
+// dictionary_destroy() already freed because it saw inflight == 0.
+//
+// Single-threaded dictionaries are exempt: ll_recursive_lock() short-circuits
+// for them (dictionary-locks.h), so they pay nothing today, and by definition
+// they are not racing a destroy from another thread. Keeping them exempt
+// preserves their zero-overhead property.
+#define dictionary_api_enter(dict) do {                                             \
+        if(likely(!is_dictionary_single_threaded(dict)))                            \
+            __atomic_add_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST);            \
+    } while(0)
+
+#define dictionary_api_exit(dict) do {                                              \
+        if(likely(!is_dictionary_single_threaded(dict)))                            \
+            __atomic_sub_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST);            \
+    } while(0)
+
+#define dictionary_inflight(dict) __atomic_load_n(&((dict)->inflight), __ATOMIC_SEQ_CST)
 
 // configuration options macros
 #define is_dictionary_single_threaded(dict) ((dict)->options & DICT_OPTION_SINGLE_THREADED)

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -38,27 +38,54 @@ typedef enum __attribute__ ((__packed__)) {
 //
 // Limit: this protects a caller that has already entered the API. It cannot
 // protect a caller holding a stale DICTIONARY * that has not entered yet -
-// that window is unclosable from inside the dictionary and remains a
+// destroy may read inflight == 0 and free the object a moment before that
+// caller increments it. That window is unclosable from inside the dictionary
+// (it needs a reference held by whoever owns the DICTIONARY *) and remains a
 // caller-ownership bug.
 //
-// EVERY public function that touches the dictionary object must be bracketed
-// by dictionary_api_enter() / dictionary_api_exit(). Taking one of the
-// dictionary's own locks without it is the exact race this closes: pass the
-// destroyed check, then block on a lock inside a struct that
-// dictionary_destroy() already freed because it saw inflight == 0.
+// Contract: every public function that takes one of the dictionary's own locks,
+// or that holds the dictionary object across a blocking point, must be
+// bracketed by dictionary_api_enter() / dictionary_api_exit(). That is the
+// exact race this closes: pass the destroyed check, then block on a lock inside
+// a struct that dictionary_destroy() already freed because it saw
+// inflight == 0.
 //
-// Single-threaded dictionaries are exempt: ll_recursive_lock() short-circuits
-// for them (dictionary-locks.h), so they pay nothing today, and by definition
-// they are not racing a destroy from another thread. Keeping them exempt
-// preserves their zero-overhead property.
+// dictionary_destroy() is the one deliberate exception to that rule, and it
+// cannot be otherwise: bracketing it would count the destroying thread in
+// inflight, so its own recheck below would always observe a non-zero counter
+// and it could never take the immediate free path. It is instead SINGLE-OWNER
+// (dictionary.h) - exactly one thread ends a dictionary's life, externally
+// serialized against any other destroy of the same object. Two concurrent
+// destroys can both pass the destroyed-flag check, and one can free the object
+// while the other is blocked on ll_recursive_lock(); that is a
+// double-free-class caller error, in the same class as the stale-pointer case
+// above, and is likewise not detectable from inside the dictionary.
+//
+// Functions that only perform a single atomic load or add on the object
+// (dictionary_version(), dictionary_entries(), dictionary_referenced_items(),
+// dictionary_version_increment()) are deliberately not bracketed: they hold
+// nothing across a blocking point, so the bracket would close no window that
+// caller ownership does not already have to cover, and dictionary_api_enter()
+// itself is a plain atomic add of the same weight.
+//
+// The callback registration functions (dictionary_register_*_callback()) are
+// construction-time API; the rule is stated for callers in dictionary.h. They
+// write dict->hooks - and dict->options, with a non-atomic read-modify-write -
+// so they must be called before the dictionary is published to other threads.
+// enter/exit would not make them safe.
+//
+// The counter is incremented unconditionally, including for single-threaded
+// dictionaries. Testing DICT_OPTION_SINGLE_THREADED first would dereference the
+// dictionary before the caller is counted, widening the window above by the
+// length of that load, and would itself race the non-atomic dict->options
+// update in dictionary_register_conflict_callback(). One uncontended atomic RMW
+// is not worth either.
 #define dictionary_api_enter(dict) do {                                             \
-        if(likely(!is_dictionary_single_threaded(dict)))                            \
-            __atomic_add_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST);            \
+        __atomic_add_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST);               \
     } while(0)
 
 #define dictionary_api_exit(dict) do {                                              \
-        if(likely(!is_dictionary_single_threaded(dict)))                            \
-            __atomic_sub_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST);            \
+        __atomic_sub_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST);               \
     } while(0)
 
 #define dictionary_inflight(dict) __atomic_load_n(&((dict)->inflight), __ATOMIC_SEQ_CST)

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -20,6 +20,30 @@ typedef enum __attribute__ ((__packed__)) {
 // flags macros
 #define is_dictionary_destroyed(dict) dict_flag_check(dict, DICT_FLAG_DESTROYED)
 
+// ----------------------------------------------------------------------------
+// in-flight API callers
+//
+// referenced_items keeps ITEMS alive; this counter keeps the DICTIONARY OBJECT
+// alive. A thread inside the API - or blocked on one of the dictionary's own
+// locks - holds no item reference, so without this counter
+// dictionary_destroy() can free the DICTIONARY (and the locks inside it) from
+// under it. See dictionary_destroy() and dictionary_free_all_resources().
+//
+// Ordering: an entering caller increments this counter (a SEQ_CST read-modify-
+// write, i.e. a full barrier) and only then touches the dictionary;
+// dictionary_destroy() sets DICT_FLAG_DESTROYED, issues a SEQ_CST fence, and
+// only then reads this counter. Sequential consistency guarantees the two
+// cannot miss each other: either the caller is counted, or it sees the
+// destroyed flag and bails out.
+//
+// Limit: this protects a caller that has already entered the API. It cannot
+// protect a caller holding a stale DICTIONARY * that has not entered yet -
+// that window is unclosable from inside the dictionary and remains a
+// caller-ownership bug.
+#define dictionary_inflight_enter(dict) __atomic_add_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST)
+#define dictionary_inflight_exit(dict)  __atomic_sub_fetch(&((dict)->inflight), 1, __ATOMIC_SEQ_CST)
+#define dictionary_inflight(dict)       __atomic_load_n(&((dict)->inflight), __ATOMIC_SEQ_CST)
+
 // configuration options macros
 #define is_dictionary_single_threaded(dict) ((dict)->options & DICT_OPTION_SINGLE_THREADED)
 #define is_view_dictionary(dict) ((dict)->master)
@@ -174,6 +198,7 @@ struct dictionary {
     int32_t entries;                   // how many items are currently in the index (the linked list may have more)
     int32_t referenced_items;          // how many items of the dictionary are currently being used by 3rd parties
     int32_t pending_deletion_items;    // how many items of the dictionary have been deleted, but have not been removed yet
+    int32_t inflight;                  // how many threads are currently inside the dictionary API (see dictionary_inflight_enter)
 
 #ifdef NETDATA_DICTIONARY_VALIDATE_POINTERS
     netdata_mutex_t global_pointer_registry_mutex;

--- a/src/libnetdata/dictionary/dictionary-internals.h
+++ b/src/libnetdata/dictionary/dictionary-internals.h
@@ -13,9 +13,13 @@ typedef enum __attribute__ ((__packed__)) {
     DICT_FLAG_QUEUED_FOR_DESTRUCTION = (1 << 1), // this dictionary is queued for delayed destruction
 } DICT_FLAGS;
 
-#define dict_flag_check(dict, flag) (__atomic_load_n(&((dict)->flags), __ATOMIC_RELAXED) & (flag))
-#define dict_flag_set(dict, flag)   __atomic_or_fetch(&((dict)->flags), flag, __ATOMIC_RELAXED)
-#define dict_flag_clear(dict, flag) __atomic_and_fetch(&((dict)->flags), ~(flag), __ATOMIC_RELAXED)
+// These are __ATOMIC_SEQ_CST, not relaxed: DICT_FLAG_DESTROYED is one half of
+// the admission handshake with the in-flight counter below, and that handshake
+// is only provable if all four operations involved are sequentially consistent.
+// See the comment on dictionary_api_enter().
+#define dict_flag_check(dict, flag) (__atomic_load_n(&((dict)->flags), __ATOMIC_SEQ_CST) & (flag))
+#define dict_flag_set(dict, flag)   __atomic_or_fetch(&((dict)->flags), flag, __ATOMIC_SEQ_CST)
+#define dict_flag_clear(dict, flag) __atomic_and_fetch(&((dict)->flags), ~(flag), __ATOMIC_SEQ_CST)
 
 // flags macros
 #define is_dictionary_destroyed(dict) dict_flag_check(dict, DICT_FLAG_DESTROYED)
@@ -29,12 +33,28 @@ typedef enum __attribute__ ((__packed__)) {
 // dictionary_destroy() can free the DICTIONARY (and the locks inside it) from
 // under it. See dictionary_destroy() and dictionary_free_all_resources().
 //
-// Ordering: an entering caller increments this counter (a SEQ_CST read-modify-
-// write, i.e. a full barrier) and only then touches the dictionary;
-// dictionary_destroy() sets DICT_FLAG_DESTROYED, issues a SEQ_CST fence, and
-// only then reads this counter. Sequential consistency guarantees the two
-// cannot miss each other: either the caller is counted, or it sees the
-// destroyed flag and bails out.
+// Ordering: this is the store-buffer (Dekker) pattern over two objects, and it
+// is made safe by keeping ALL FOUR operations __ATOMIC_SEQ_CST, so that they
+// all appear in the single total order S the C memory model defines:
+//
+//   entering caller     destroy
+//   ---------------     -------
+//   1. RMW  inflight++  3. RMW  flags |= DESTROYED
+//   2. load flags       4. load inflight
+//
+// Proof that the two cannot miss each other: suppose the caller's load (2)
+// does not observe the flag, i.e. (2) precedes (3) in S. Sequentially
+// consistent operations respect program order in S, so
+// (1) < (2) < (3) < (4) in S. A SEQ_CST load reads the last preceding write in
+// S, so (4) observes the increment of (1) and destroy defers. Either the caller
+// is counted, or it sees the destroyed flag and bails out.
+//
+// This is why dict_flag_check() / dict_flag_set() are SEQ_CST and not relaxed:
+// with a relaxed flag access the argument above collapses. A SEQ_CST RMW is not
+// a fence in the C model - it does not order a later relaxed load of a
+// different object - so both sides could legally miss each other and destroy
+// would free the dictionary under an entering caller. No explicit
+// __atomic_thread_fence() is needed once every operation is SEQ_CST.
 //
 // Limit: this protects a caller that has already entered the API. It cannot
 // protect a caller holding a stale DICTIONARY * that has not entered yet -

--- a/src/libnetdata/dictionary/dictionary-traversal.c
+++ b/src/libnetdata/dictionary/dictionary-traversal.c
@@ -9,10 +9,16 @@
 void *dictionary_foreach_start_rw(DICTFE *dfe) {
     if(unlikely(!dfe || !dfe->dict)) return NULL;
 
+    // Keep the DICTIONARY object alive for the whole traversal: we are about to
+    // take its lock, and dictionary_destroy() would otherwise free the object
+    // (locks included) from under us. Released in dictionary_foreach_done().
+    dictionary_inflight_enter(dfe->dict);
+
     DICTIONARY_STATS_TRAVERSALS_PLUS1(dfe->dict);
 
     if(unlikely(is_dictionary_destroyed(dfe->dict))) {
         internal_error(true, "DICTIONARY: attempted to dictionary_foreach_start_rw() on a destroyed dictionary");
+        dictionary_inflight_exit(dfe->dict);
         dfe->dict = NULL;
         dfe->item = NULL;
         dfe->name = NULL;
@@ -30,6 +36,7 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
     if(unlikely(is_dictionary_destroyed(dfe->dict))) {
         ll_recursive_unlock(dfe->dict, dfe->rw);
         dfe->locked = false;
+        dictionary_inflight_exit(dfe->dict);
         dfe->dict = NULL;
         dfe->item = NULL;
         dfe->name = NULL;
@@ -146,6 +153,9 @@ void dictionary_foreach_done(DICTFE *dfe) {
         ll_recursive_unlock(dfe->dict, dfe->rw);
         dfe->locked = false;
     }
+
+    // matches dictionary_inflight_enter() in dictionary_foreach_start_rw()
+    dictionary_inflight_exit(dfe->dict);
 
     dfe->dict = NULL;
     dfe->item = NULL;

--- a/src/libnetdata/dictionary/dictionary-traversal.c
+++ b/src/libnetdata/dictionary/dictionary-traversal.c
@@ -12,13 +12,13 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
     // Keep the DICTIONARY object alive for the whole traversal: we are about to
     // take its lock, and dictionary_destroy() would otherwise free the object
     // (locks included) from under us. Released in dictionary_foreach_done().
-    dictionary_inflight_enter(dfe->dict);
+    dictionary_api_enter(dfe->dict);
 
     DICTIONARY_STATS_TRAVERSALS_PLUS1(dfe->dict);
 
     if(unlikely(is_dictionary_destroyed(dfe->dict))) {
         internal_error(true, "DICTIONARY: attempted to dictionary_foreach_start_rw() on a destroyed dictionary");
-        dictionary_inflight_exit(dfe->dict);
+        dictionary_api_exit(dfe->dict);
         dfe->dict = NULL;
         dfe->item = NULL;
         dfe->name = NULL;
@@ -36,7 +36,7 @@ void *dictionary_foreach_start_rw(DICTFE *dfe) {
     if(unlikely(is_dictionary_destroyed(dfe->dict))) {
         ll_recursive_unlock(dfe->dict, dfe->rw);
         dfe->locked = false;
-        dictionary_inflight_exit(dfe->dict);
+        dictionary_api_exit(dfe->dict);
         dfe->dict = NULL;
         dfe->item = NULL;
         dfe->name = NULL;
@@ -154,8 +154,8 @@ void dictionary_foreach_done(DICTFE *dfe) {
         dfe->locked = false;
     }
 
-    // matches dictionary_inflight_enter() in dictionary_foreach_start_rw()
-    dictionary_inflight_exit(dfe->dict);
+    // matches dictionary_api_enter() in dictionary_foreach_start_rw()
+    dictionary_api_exit(dfe->dict);
 
     dfe->dict = NULL;
     dfe->item = NULL;
@@ -169,7 +169,7 @@ void dictionary_foreach_done(DICTFE *dfe) {
 // The dictionary is locked for reading while this happens
 // do not use other dictionary calls while walking the dictionary - deadlock!
 
-int dictionary_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough_callback_t walkthrough_callback, void *data) {
+static int dictionary_walkthrough_rw_internal(DICTIONARY *dict, char rw, dict_walkthrough_callback_t walkthrough_callback, void *data) {
     if(unlikely(!dict || !walkthrough_callback)) return 0;
 
     if(unlikely(is_dictionary_destroyed(dict))) {
@@ -234,7 +234,7 @@ static int dictionary_sort_compar(const void *item1, const void *item2) {
     return strcmp(item_get_name((*(DICTIONARY_ITEM **)item1)), item_get_name((*(DICTIONARY_ITEM **)item2)));
 }
 
-int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough_callback_t walkthrough_callback, void *data, dict_item_comparator_t item_comparator) {
+static int dictionary_sorted_walkthrough_rw_internal(DICTIONARY *dict, char rw, dict_walkthrough_callback_t walkthrough_callback, void *data, dict_item_comparator_t item_comparator) {
     if(unlikely(!dict || !walkthrough_callback)) return 0;
 
     if(unlikely(is_dictionary_destroyed(dict))) {
@@ -298,3 +298,23 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough
     return ret;
 }
 
+
+int dictionary_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough_callback_t walkthrough_callback, void *data) {
+    if(unlikely(!dict)) return 0;
+
+    dictionary_api_enter(dict);
+    int ret = dictionary_walkthrough_rw_internal(dict, rw, walkthrough_callback, data);
+    dictionary_api_exit(dict);
+
+    return ret;
+}
+
+int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, dict_walkthrough_callback_t walkthrough_callback, void *data, dict_item_comparator_t item_comparator) {
+    if(unlikely(!dict)) return 0;
+
+    dictionary_api_enter(dict);
+    int ret = dictionary_sorted_walkthrough_rw_internal(dict, rw, walkthrough_callback, data, item_comparator);
+    dictionary_api_exit(dict);
+
+    return ret;
+}

--- a/src/libnetdata/dictionary/dictionary-traversal.c
+++ b/src/libnetdata/dictionary/dictionary-traversal.c
@@ -140,22 +140,27 @@ void dictionary_foreach_unlock(DICTFE *dfe) {
 void dictionary_foreach_done(DICTFE *dfe) {
     if(unlikely(!dfe || !dfe->dict)) return;
 
+    // work on a local copy: the dictionary of this traversal cannot change
+    // while we are tearing it down, and a single load keeps the null check
+    // above provably covering every use below
+    DICTIONARY *dict = dfe->dict;
+
     // the item we just did
     DICTIONARY_ITEM *item = dfe->item;
 
     // release it, so that it can possibly be deleted
     if(likely(item)) {
-        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dfe->dict, item, dfe->rw);
-        // item_release(dfe->dict, item);
+        dict_item_release_and_check_if_it_is_deleted_and_can_be_removed_under_this_lock_mode(dict, item, dfe->rw);
+        // item_release(dict, item);
     }
 
     if(likely(dfe->rw != DICTIONARY_LOCK_REENTRANT) && dfe->locked) {
-        ll_recursive_unlock(dfe->dict, dfe->rw);
+        ll_recursive_unlock(dict, dfe->rw);
         dfe->locked = false;
     }
 
     // matches dictionary_api_enter() in dictionary_foreach_start_rw()
-    dictionary_api_exit(dfe->dict);
+    dictionary_api_exit(dict);
 
     dfe->dict = NULL;
     dfe->item = NULL;

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -1177,6 +1177,7 @@ struct dict_destroy_race_data {
     DICTIONARY *dict;
     int ready;          // atomic: worker signals it is looping
     int stop;           // atomic: main tells worker to stop
+    int refused;        // atomic: inserts the destroy refused (race window hit)
 };
 
 // Worker that continuously acquires and releases an item.
@@ -1214,7 +1215,14 @@ static void dict_destroy_race_setter_thread(void *arg) {
         // destruction without racing on value replacement semantics.
         snprintfz(key, sizeof(key), "key-%d", counter);
         snprintfz(val, sizeof(val), "val-%d", counter);
-        dictionary_set(d->dict, key, val, strlen(val) + 1);
+
+        // value_len > 0 and the name is valid, so NULL here is unambiguously a
+        // refusal by a concurrent destroy (see the set-family contract in
+        // dictionary.h). Count it: it is the proof that this test actually
+        // reached the destroy-vs-insert window it exists to cover.
+        if(!dictionary_set(d->dict, key, val, strlen(val) + 1))
+            __atomic_add_fetch(&d->refused, 1, __ATOMIC_RELAXED);
+
         counter++;
     }
 }
@@ -1268,6 +1276,13 @@ static void dict_destroy_race_anchor_thread(void *arg) {
 // while the main thread destroys the dictionary. Without the fix this may
 // crash or trip internal consistency checks, depending on timing.
 static void dict_destroy_race_child(int iterations) {
+    // Drain whatever the parent process left queued, then take a baseline.
+    // Anything still queued after this is stuck for reasons outside this test
+    // and stays stuck, so the count is stable and each iteration below must
+    // return to it.
+    cleanup_destroyed_dictionaries(false);
+    size_t queued_baseline = dictionary_destroy_delayed_count();
+
     for(int i = 0; i < iterations; i++) {
         DICTIONARY *dict = dictionary_create(DICT_OPTION_NONE);
         dictionary_set(dict, "key", "value", 6);
@@ -1337,6 +1352,24 @@ static void dict_destroy_race_child(int iterations) {
         if(freed != 0)
             _exit(3);
 
+        // Let the workers actually operate on the now-DESTROYED dictionary.
+        // dictionary_destroy() has flagged it (via the deferred-destruction
+        // path), so from here every insert must be refused under the index
+        // lock. Waiting for the first refusal - rather than setting stop
+        // immediately - is what makes each iteration exercise the window this
+        // test exists to cover: otherwise the workers can leave their loops
+        // before ever calling in again, and the iteration proves nothing.
+        // Bounded by wall clock, not by a spin count: the workers loop tightly
+        // on a destroyed dictionary, so the first refusal lands in microseconds.
+        // The deadline is only ever paid once, because reaching it exits.
+        usec_t refuse_deadline = now_monotonic_usec() + 2 * USEC_PER_SEC;
+        while(!__atomic_load_n(&setter_data.refused, __ATOMIC_RELAXED) &&
+              now_monotonic_usec() < refuse_deadline)
+            tinysleep();
+
+        if(!__atomic_load_n(&setter_data.refused, __ATOMIC_RELAXED))
+            _exit(5);
+
         __atomic_store_n(&getter_data.stop, 1, __ATOMIC_RELEASE);
         __atomic_store_n(&setter_data.stop, 1, __ATOMIC_RELEASE);
         __atomic_store_n(&traverser_data.stop, 1, __ATOMIC_RELEASE);
@@ -1350,6 +1383,24 @@ static void dict_destroy_race_child(int iterations) {
         nd_thread_join(anchor);
 
         cleanup_destroyed_dictionaries(false);
+
+        // The deferred destruction MUST have completed: nothing holds an item
+        // reference and nothing is inside the API any more, so the dictionary
+        // queued above must be gone and the queue back to its baseline.
+        //
+        // This is what makes the whole test prove something about production
+        // bracketing rather than only about the anchor. Every
+        // dictionary_api_enter() the workers executed - in the getter, the
+        // setter and the traversal - had to be matched by its exit; a single
+        // leaked in-flight count, or a leaked item reference, pins the object
+        // in the queue forever and fails here.
+        //
+        // Known limit: removing a bracket PAIR outright keeps the counter
+        // balanced, so that reverts to the ASAN-plus-timing detection which
+        // originally found the use-after-free. What is caught deterministically
+        // here is an unbalanced bracket.
+        if(dictionary_destroy_delayed_count() != queued_baseline)
+            _exit(4);
     }
 }
 
@@ -1420,7 +1471,19 @@ static int dictionary_destroy_race_unittest(void) {
     if(WIFEXITED(status) && WEXITSTATUS(status) != 0) {
         int code = WEXITSTATUS(status);
 
-        if(code == 3)
+        if(code == 5)
+            fprintf(stderr,
+                    "dictionary_destroy() TOCTOU race test: FAILED — "
+                    "the setter was never refused after the dictionary was destroyed, "
+                    "so the race window this test exists to cover was never reached "
+                    "(the test, not the engine, needs fixing)\n");
+        else if(code == 4)
+            fprintf(stderr,
+                    "dictionary_destroy() TOCTOU race test: FAILED — "
+                    "the deferred destruction never drained: the dictionary is still "
+                    "queued after every worker left the API (unbalanced "
+                    "dictionary_api_enter()/exit(), or a leaked item reference)\n");
+        else if(code == 3)
             fprintf(stderr,
                     "dictionary_destroy() TOCTOU race test: FAILED — "
                     "dictionary_destroy() freed the dictionary while a thread was "

--- a/src/libnetdata/dictionary/dictionary-unittest.c
+++ b/src/libnetdata/dictionary/dictionary-unittest.c
@@ -1236,6 +1236,34 @@ static void dict_destroy_race_traverser_thread(void *arg) {
     }
 }
 
+// Anchor thread: enters the dictionary API and stays admitted - holding no
+// item reference and none of the dictionary's locks - until told to leave.
+//
+// This is what makes the rest of the test legal. The documented contract only
+// protects a caller that is ALREADY inside the API; a thread holding a
+// DICTIONARY * it has not entered with is explicitly unsupported
+// (dictionary-internals.h). Without this anchor, a worker below could be
+// descheduled between its stop check and its next dictionary call while
+// dictionary_destroy() observes inflight == 0 and force-frees the object. The
+// worker would then resume into freed memory - a stale-pointer use-after-free
+// of the test's own making, which would make this test both flaky and useless
+// as proof of the admitted-caller guarantee.
+//
+// With the anchor admitted, dictionary_destroy() must take one of its deferred
+// paths, so the object stays alive until cleanup_destroyed_dictionaries() runs
+// after every worker has been joined and the anchor has left.
+static void dict_destroy_race_anchor_thread(void *arg) {
+    struct dict_destroy_race_data *d = arg;
+
+    dictionary_api_enter(d->dict);
+    __atomic_store_n(&d->ready, 1, __ATOMIC_RELEASE);
+
+    while(!__atomic_load_n(&d->stop, __ATOMIC_RELAXED))
+        tinysleep();
+
+    dictionary_api_exit(d->dict);
+}
+
 // Run the racy workload in a child process: concurrent get/set/traverse
 // while the main thread destroys the dictionary. Without the fix this may
 // crash or trip internal consistency checks, depending on timing.
@@ -1247,6 +1275,11 @@ static void dict_destroy_race_child(int iterations) {
         struct dict_destroy_race_data getter_data = { .dict = dict, .ready = 0, .stop = 0 };
         struct dict_destroy_race_data setter_data = { .dict = dict, .ready = 0, .stop = 0 };
         struct dict_destroy_race_data traverser_data = { .dict = dict, .ready = 0, .stop = 0 };
+        struct dict_destroy_race_data anchor_data = { .dict = dict, .ready = 0, .stop = 0 };
+
+        ND_THREAD *anchor = nd_thread_create(
+            "race-anchor", NETDATA_THREAD_OPTION_DONT_LOG,
+            dict_destroy_race_anchor_thread, &anchor_data);
 
         ND_THREAD *getter = nd_thread_create(
             "race-getter", NETDATA_THREAD_OPTION_DONT_LOG,
@@ -1260,7 +1293,7 @@ static void dict_destroy_race_child(int iterations) {
             "race-trav", NETDATA_THREAD_OPTION_DONT_LOG,
             dict_destroy_race_traverser_thread, &traverser_data);
 
-        if(!getter || !setter || !traverser) {
+        if(!anchor || !getter || !setter || !traverser) {
             // Thread creation failed — stop any that did start and clean up.
             __atomic_store_n(&getter_data.stop, 1, __ATOMIC_RELEASE);
             __atomic_store_n(&setter_data.stop, 1, __ATOMIC_RELEASE);
@@ -1268,13 +1301,21 @@ static void dict_destroy_race_child(int iterations) {
             if(getter) nd_thread_join(getter);
             if(setter) nd_thread_join(setter);
             if(traverser) nd_thread_join(traverser);
+
+            // the anchor leaves last: it is what keeps the object alive
+            __atomic_store_n(&anchor_data.stop, 1, __ATOMIC_RELEASE);
+            if(anchor) nd_thread_join(anchor);
+
             dictionary_destroy(dict);
             cleanup_destroyed_dictionaries(false);
             _exit(2);
         }
 
         // wait for all workers to be running
-        while(!__atomic_load_n(&getter_data.ready, __ATOMIC_ACQUIRE) ||
+        // the anchor's ready flag also means "this thread is admitted", which
+        // is the precondition that makes the destroy below legal
+        while(!__atomic_load_n(&anchor_data.ready, __ATOMIC_ACQUIRE) ||
+              !__atomic_load_n(&getter_data.ready, __ATOMIC_ACQUIRE) ||
               !__atomic_load_n(&setter_data.ready, __ATOMIC_ACQUIRE) ||
               !__atomic_load_n(&traverser_data.ready, __ATOMIC_ACQUIRE))
             tinysleep();
@@ -1286,7 +1327,15 @@ static void dict_destroy_race_child(int iterations) {
         // the new destroyed-flag + index-teardown synchronization. Instead,
         // rely on the active workers to create transient in-flight accesses
         // while destroy() races with get/set/traversal.
-        dictionary_destroy(dict);
+        size_t freed = dictionary_destroy(dict);
+
+        // This is the admitted-caller guarantee, asserted: the anchor is inside
+        // the API, so dictionary_destroy() MUST refuse to free the object and
+        // return 0 (having queued it for deferred destruction). A non-zero
+        // return means it freed the dictionary out from under an admitted
+        // caller, which is the exact bug this test exists to catch.
+        if(freed != 0)
+            _exit(3);
 
         __atomic_store_n(&getter_data.stop, 1, __ATOMIC_RELEASE);
         __atomic_store_n(&setter_data.stop, 1, __ATOMIC_RELEASE);
@@ -1294,6 +1343,11 @@ static void dict_destroy_race_child(int iterations) {
         nd_thread_join(getter);
         nd_thread_join(setter);
         nd_thread_join(traverser);
+
+        // Only now can the object become freeable: every worker has left the
+        // API for good, so the anchor can drop the last in-flight count.
+        __atomic_store_n(&anchor_data.stop, 1, __ATOMIC_RELEASE);
+        nd_thread_join(anchor);
 
         cleanup_destroyed_dictionaries(false);
     }
@@ -1364,10 +1418,22 @@ static int dictionary_destroy_race_unittest(void) {
     }
 
     if(WIFEXITED(status) && WEXITSTATUS(status) != 0) {
-        fprintf(stderr,
-                "dictionary_destroy() TOCTOU race test: FAILED — "
-                "child exited with status %d\n",
-                WEXITSTATUS(status));
+        int code = WEXITSTATUS(status);
+
+        if(code == 3)
+            fprintf(stderr,
+                    "dictionary_destroy() TOCTOU race test: FAILED — "
+                    "dictionary_destroy() freed the dictionary while a thread was "
+                    "admitted inside the API (in-flight counter ignored)\n");
+        else if(code == 2)
+            fprintf(stderr,
+                    "dictionary_destroy() TOCTOU race test: FAILED — "
+                    "child could not create its worker threads\n");
+        else
+            fprintf(stderr,
+                    "dictionary_destroy() TOCTOU race test: FAILED — "
+                    "child exited with status %d\n", code);
+
         return 1;
     }
 

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -710,6 +710,13 @@ DICTIONARY *dictionary_create_advanced(DICT_OPTIONS options, struct dictionary_s
 }
 
 DICTIONARY *dictionary_create_view(DICTIONARY *master) {
+    // Keep the MASTER alive for the whole view construction: we dereference it
+    // and mutate its hooks across dictionary_create_internal(), which allocates
+    // and takes locks. Without this, a concurrent dictionary_destroy(master)
+    // could observe inflight == 0 and free the master (and its hooks) while we
+    // are still building the view on top of it.
+    dictionary_api_enter(master);
+
     DICTIONARY *dict = dictionary_create_internal(master->options, master->stats,
                                                   master->value_aral ? aral_requested_element_size(master->value_aral) : 0);
 
@@ -733,6 +740,11 @@ DICTIONARY *dictionary_create_view(DICTIONARY *master) {
 
     DICTIONARY_STATS_DICT_CREATIONS_PLUS1(dict);
     dictionary_debug_track_dict(dict);
+
+    // matches dictionary_api_enter(master) above; the view now holds a hooks
+    // link, and the master's lifetime past this point is the caller's
+    dictionary_api_exit(master);
+
     return dict;
 }
 
@@ -794,13 +806,12 @@ size_t dictionary_destroy(DICTIONARY *dict) {
         return 0;
     }
 
-    dict_flag_set(dict, DICT_FLAG_DESTROYED);
-
     // Publish the destroyed flag before reading the in-flight counter below.
-    // A thread entering the API increments that counter (a SEQ_CST RMW) before
-    // touching the dictionary, so this fence makes the two orderings meet:
-    // either we see its increment, or it sees our flag.
-    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    // Both are SEQ_CST, as is a caller's inflight++ / destroyed-flag check, so
+    // the four operations are totally ordered and the two sides cannot miss
+    // each other: either we observe the caller's increment and defer, or the
+    // caller observes this flag and bails out. See dictionary-internals.h.
+    dict_flag_set(dict, DICT_FLAG_DESTROYED);
 
     // Destroy the index while holding the items write lock.
     // This prevents a TOCTOU race: without this, a reader could pass the

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -331,7 +331,8 @@ static bool dictionary_free_all_resources(DICTIONARY *dict, size_t *mem, bool fo
     if(mem)
         *mem = 0;
 
-    if(!force && dictionary_referenced_items(dict))
+    // referenced_items keeps items alive; inflight keeps this object alive
+    if(!force && (dictionary_referenced_items(dict) || dictionary_inflight(dict)))
         return false;
 
     size_t dict_size = 0, counted_items = 0, item_size = 0, index_size = 0;
@@ -782,6 +783,12 @@ size_t dictionary_destroy(DICTIONARY *dict) {
 
     dict_flag_set(dict, DICT_FLAG_DESTROYED);
 
+    // Publish the destroyed flag before reading the in-flight counter below.
+    // A thread entering the API increments that counter (a SEQ_CST RMW) before
+    // touching the dictionary, so this fence makes the two orderings meet:
+    // either we see its increment, or it sees our flag.
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+
     // Destroy the index while holding the items write lock.
     // This prevents a TOCTOU race: without this, a reader could pass the
     // is_dictionary_destroyed() check, then acquire an item via the index,
@@ -797,8 +804,11 @@ size_t dictionary_destroy(DICTIONARY *dict) {
 
     // Re-check: a reader that held the index read lock during the destroy
     // above may have acquired an item before we got the index write lock.
-    // If so, fall back to the deferred destruction path.
-    if(dictionary_referenced_items(dict)) {
+    // Also refuse to free the object while any thread is inside the API - it
+    // holds no item reference, but it is about to touch this object and the
+    // locks that live in it. Both cases fall back to the deferred destruction
+    // path, and cleanup_destroyed_dictionaries() frees once they drain.
+    if(dictionary_referenced_items(dict) || dictionary_inflight(dict)) {
         dictionary_queue_for_destruction(dict);
 
         ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
@@ -816,7 +826,7 @@ size_t dictionary_destroy(DICTIONARY *dict) {
 // ----------------------------------------------------------------------------
 // SET an item to the dictionary
 
-DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data) {
+static DICTIONARY_ITEM *dictionary_set_and_acquire_item_internal(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data) {
     if(unlikely(!api_is_name_good(dict, name, name_len)))
         return NULL;
 
@@ -844,7 +854,21 @@ DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_set_and_acquire_item_advanced(DICTIO
 
     DICTIONARY_ITEM *item =
         dict_item_add_or_reset_value_and_acquire(dict, name, name_len, value, value_len, constructor_data, NULL);
-    api_internal_check(dict, item, false, false);
+
+    // NULL is a valid result: a concurrent dictionary_destroy() refuses the
+    // insert under the index write lock. See dictionary.h.
+    api_internal_check(dict, item, false, true);
+    return item;
+}
+
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data) {
+    if(unlikely(!dict)) return NULL;
+
+    dictionary_inflight_enter(dict);
+    DICTIONARY_ITEM *item =
+        dictionary_set_and_acquire_item_internal(dict, name, name_len, value, value_len, constructor_data);
+    dictionary_inflight_exit(dict);
+
     return item;
 }
 
@@ -860,7 +884,7 @@ void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
     return NULL;
 }
 
-DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, DICTIONARY_ITEM *master_item) {
+static DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_internal(DICTIONARY *dict, const char *name, ssize_t name_len, DICTIONARY_ITEM *master_item) {
     if(unlikely(!api_is_name_good(dict, name, name_len)))
         return NULL;
 
@@ -885,7 +909,18 @@ DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_advanced(D
     DICTIONARY_ITEM *item = dict_item_add_or_reset_value_and_acquire(dict, name, name_len, NULL, 0, NULL, master_item);
     dictionary_acquired_item_release(dict->master, master_item);
 
-    api_internal_check(dict, item, false, false);
+    // NULL is a valid result; see dictionary_set_and_acquire_item_internal().
+    api_internal_check(dict, item, false, true);
+    return item;
+}
+
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, DICTIONARY_ITEM *master_item) {
+    if(unlikely(!dict)) return NULL;
+
+    dictionary_inflight_enter(dict);
+    DICTIONARY_ITEM *item = dictionary_view_set_and_acquire_item_internal(dict, name, name_len, master_item);
+    dictionary_inflight_exit(dict);
+
     return item;
 }
 
@@ -904,13 +939,23 @@ void *dictionary_view_set_advanced(DICTIONARY *dict, const char *name, ssize_t n
 // ----------------------------------------------------------------------------
 // GET an item from the dictionary
 
-DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_get_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len) {
+static DICTIONARY_ITEM *dictionary_get_and_acquire_item_internal(DICTIONARY *dict, const char *name, ssize_t name_len) {
     if(unlikely(!api_is_name_good(dict, name, name_len)))
         return NULL;
 
     api_internal_check(dict, NULL, false, true);
     DICTIONARY_ITEM *item = dict_item_find_and_acquire(dict, name, name_len);
     api_internal_check(dict, item, false, true);
+    return item;
+}
+
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_get_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len) {
+    if(unlikely(!dict)) return NULL;
+
+    dictionary_inflight_enter(dict);
+    DICTIONARY_ITEM *item = dictionary_get_and_acquire_item_internal(dict, name, name_len);
+    dictionary_inflight_exit(dict);
+
     return item;
 }
 
@@ -992,7 +1037,7 @@ size_t dictionary_acquired_item_references(DICT_ITEM_CONST DICTIONARY_ITEM *item
 // ----------------------------------------------------------------------------
 // DEL an item
 
-bool dictionary_del_advanced(DICTIONARY *dict, const char *name, ssize_t name_len) {
+static bool dictionary_del_internal(DICTIONARY *dict, const char *name, ssize_t name_len) {
     if(unlikely(!api_is_name_good(dict, name, name_len)))
         return false;
 
@@ -1004,4 +1049,14 @@ bool dictionary_del_advanced(DICTIONARY *dict, const char *name, ssize_t name_le
     }
 
     return dict_item_del(dict, name, name_len);
+}
+
+bool dictionary_del_advanced(DICTIONARY *dict, const char *name, ssize_t name_len) {
+    if(unlikely(!dict)) return false;
+
+    dictionary_inflight_enter(dict);
+    bool ret = dictionary_del_internal(dict, name, name_len);
+    dictionary_inflight_exit(dict);
+
+    return ret;
 }

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -13,11 +13,15 @@ struct dictionary_stats dictionary_stats_category_other = {
 // public locks API
 
 inline void dictionary_write_lock(DICTIONARY *dict) {
+    // paired with dictionary_write_unlock(): the caller holds this
+    // dictionary's lock in between, so the object must stay alive
+    dictionary_api_enter(dict);
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 }
 
 inline void dictionary_write_unlock(DICTIONARY *dict) {
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
+    dictionary_api_exit(dict);
 }
 
 // ----------------------------------------------------------------------------
@@ -224,7 +228,10 @@ void garbage_collect_pending_deletes(DICTIONARY *dict) {
 
 void dictionary_garbage_collect(DICTIONARY *dict) {
     if(!dict) return;
+
+    dictionary_api_enter(dict);
     garbage_collect_pending_deletes(dict);
+    dictionary_api_exit(dict);
 }
 
 // Like dictionary_garbage_collect(), but the victims' delete callbacks run
@@ -729,10 +736,7 @@ DICTIONARY *dictionary_create_view(DICTIONARY *master) {
     return dict;
 }
 
-void dictionary_flush(DICTIONARY *dict) {
-    if(unlikely(!dict))
-        return;
-
+static void dictionary_flush_internal(DICTIONARY *dict) {
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE);
 
     DICTIONARY_ITEM *item = dict->items.list;
@@ -755,6 +759,15 @@ void dictionary_flush(DICTIONARY *dict) {
     DICTIONARY_STATS_DICT_FLUSHES_PLUS1(dict);
 
     dictionary_garbage_collect(dict);
+}
+
+void dictionary_flush(DICTIONARY *dict) {
+    if(unlikely(!dict))
+        return;
+
+    dictionary_api_enter(dict);
+    dictionary_flush_internal(dict);
+    dictionary_api_exit(dict);
 }
 
 size_t dictionary_destroy(DICTIONARY *dict) {
@@ -864,10 +877,10 @@ static DICTIONARY_ITEM *dictionary_set_and_acquire_item_internal(DICTIONARY *dic
 DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data) {
     if(unlikely(!dict)) return NULL;
 
-    dictionary_inflight_enter(dict);
+    dictionary_api_enter(dict);
     DICTIONARY_ITEM *item =
         dictionary_set_and_acquire_item_internal(dict, name, name_len, value, value_len, constructor_data);
-    dictionary_inflight_exit(dict);
+    dictionary_api_exit(dict);
 
     return item;
 }
@@ -917,9 +930,9 @@ static DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_internal(DICTIONARY
 DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, DICTIONARY_ITEM *master_item) {
     if(unlikely(!dict)) return NULL;
 
-    dictionary_inflight_enter(dict);
+    dictionary_api_enter(dict);
     DICTIONARY_ITEM *item = dictionary_view_set_and_acquire_item_internal(dict, name, name_len, master_item);
-    dictionary_inflight_exit(dict);
+    dictionary_api_exit(dict);
 
     return item;
 }
@@ -952,9 +965,9 @@ static DICTIONARY_ITEM *dictionary_get_and_acquire_item_internal(DICTIONARY *dic
 DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_get_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len) {
     if(unlikely(!dict)) return NULL;
 
-    dictionary_inflight_enter(dict);
+    dictionary_api_enter(dict);
     DICTIONARY_ITEM *item = dictionary_get_and_acquire_item_internal(dict, name, name_len);
-    dictionary_inflight_exit(dict);
+    dictionary_api_exit(dict);
 
     return item;
 }
@@ -978,7 +991,11 @@ DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_item_acquire_if_not_deleted(DICTIONA
     if(unlikely(!dict || !item))
         return NULL;
 
-    if(unlikely(!item_check_and_acquire(dict, item)))
+    dictionary_api_enter(dict);
+    bool acquired = item_check_and_acquire(dict, item);
+    dictionary_api_exit(dict);
+
+    if(unlikely(!acquired))
         return NULL;
 
     api_internal_check(dict, item, false, false);
@@ -991,7 +1008,10 @@ DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_acquired_item_dup(DICTIONARY *dict, 
     api_internal_check(dict, item, false, true);
 
     if(likely(item)) {
+        dictionary_api_enter(dict);
         item_acquire(dict, item);
+        dictionary_api_exit(dict);
+
         api_internal_check(dict, item, false, false);
     }
 
@@ -1007,8 +1027,13 @@ void dictionary_acquired_item_release(DICTIONARY *dict, DICT_ITEM_CONST DICTIONA
     // we pass the last parameter to reference_counter_release() as true
     // so that the release may get a write-lock if required to clean up
 
-    if(likely(item))
+    if(likely(item)) {
+        // the reference we are dropping is what kept this dictionary alive, so
+        // hold it across the release itself
+        dictionary_api_enter(dict);
         item_release(dict, item);
+        dictionary_api_exit(dict);
+    }
 }
 
 // ----------------------------------------------------------------------------
@@ -1054,9 +1079,9 @@ static bool dictionary_del_internal(DICTIONARY *dict, const char *name, ssize_t 
 bool dictionary_del_advanced(DICTIONARY *dict, const char *name, ssize_t name_len) {
     if(unlikely(!dict)) return false;
 
-    dictionary_inflight_enter(dict);
+    dictionary_api_enter(dict);
     bool ret = dictionary_del_internal(dict, name, name_len);
-    dictionary_inflight_exit(dict);
+    dictionary_api_exit(dict);
 
     return ret;
 }

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -907,7 +907,7 @@ void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
 
     if(likely(item)) {
         void *v = item->shared->value;
-        item_release(dict, item);
+        dictionary_acquired_item_release(dict, item);
         return v;
     }
 
@@ -959,7 +959,7 @@ void *dictionary_view_set_advanced(DICTIONARY *dict, const char *name, ssize_t n
 
     if(likely(item)) {
         void *v = item->shared->value;
-        item_release(dict, item);
+        dictionary_acquired_item_release(dict, item);
         return v;
     }
 
@@ -994,7 +994,7 @@ void *dictionary_get_advanced(DICTIONARY *dict, const char *name, ssize_t name_l
 
     if(likely(item)) {
         void *v = item->shared->value;
-        item_release(dict, item);
+        dictionary_acquired_item_release(dict, item);
         return v;
     }
 

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -250,6 +250,8 @@ void dictionary_garbage_collect(DICTIONARY *dict) {
 size_t dictionary_garbage_collect_and_deliver(DICTIONARY *dict) {
     if(!dict) return 0;
 
+    dictionary_api_enter(dict);
+
     // hard API misuse, same class (and same handling) as the view check in
     // dictionary_set_and_acquire_item_advanced(): a view here would scan
     // master items with is_view=false and skip the index wrlock the view GC
@@ -258,8 +260,10 @@ size_t dictionary_garbage_collect_and_deliver(DICTIONARY *dict) {
         fatal("DICTIONARY: dictionary_garbage_collect_and_deliver() does not support views.");
 
     // the happy path pays nothing
-    if(DICTIONARY_PENDING_DELETES_GET(dict) <= 0)
+    if(DICTIONARY_PENDING_DELETES_GET(dict) <= 0) {
+        dictionary_api_exit(dict);
         return 0;
+    }
 
     DICTIONARY_ITEM *detached = NULL;
 
@@ -309,6 +313,8 @@ size_t dictionary_garbage_collect_and_deliver(DICTIONARY *dict) {
         detached = next;
         delivered++;
     }
+
+    dictionary_api_exit(dict);
 
     return delivered;
 }

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -119,6 +119,19 @@ DICTIONARY *dictionary_create_advanced(DICT_OPTIONS options, struct dictionary_s
 // Create a view on a dictionary
 DICTIONARY *dictionary_create_view(DICTIONARY *master);
 
+// ----------------------------------------------------------------------------
+// Callback registration - CONSTRUCTION TIME ONLY
+//
+// All four dictionary_register_*_callback() functions below must be called on
+// the creating thread, before the DICTIONARY * is published to any other
+// thread. They are NOT thread-safe and are NOT protected against a concurrent
+// dictionary_destroy():
+//   - they write dict->hooks without holding any of the dictionary's locks;
+//   - dictionary_register_conflict_callback() additionally performs a
+//     non-atomic read-modify-write on dict->options.
+// Registering a callback on a dictionary that other threads can already reach
+// is a data race, regardless of what those threads are doing with it.
+
 // an insert callback to be called just after an item is added to the dictionary
 // this callback is called while the dictionary is write locked!
 typedef void (*dict_cb_insert_t)(const DICTIONARY_ITEM *item, void *value, void *data);
@@ -196,6 +209,13 @@ void dictionary_print_still_allocated_stacktraces(void);
 //   Unsafe - a thread holding a DICTIONARY * that has not entered the API yet.
 //            Nothing inside the dictionary can see such a thread, so the caller
 //            owns that lifetime.
+//   Unsafe - two threads calling dictionary_destroy() on the same dictionary.
+//            dictionary_destroy() is SINGLE-OWNER: exactly one thread may end a
+//            dictionary's life, and it must be externally serialized against any
+//            other destroy of the same object. Concurrent destroys are a
+//            double-free-class caller error, not something the dictionary
+//            detects: both can pass the destroyed-flag check and one can free
+//            the object while the other is blocked on its write lock.
 #define dictionary_set(dict, name, value, value_len) dictionary_set_advanced(dict, name, -1, value, value_len, NULL)
 void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data);
 

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -183,6 +183,19 @@ void dictionary_print_still_allocated_stacktraces(void);
 //
 // Passing NULL as value, the dictionary will callocz() the newly allocated value, otherwise it will copy it.
 // Passing 0 as value_len, the dictionary will set the value to NULL (no allocations for value will be made).
+//
+// The set family MAY RETURN NULL: if another thread is destroying the
+// dictionary, the insert is refused and NULL (or false) is returned. Callers
+// that can race a dictionary_destroy() must check the result.
+//
+// Concurrency contract for dictionary_destroy():
+//   Safe   - other threads already inside the dictionary API (a set/get/del
+//            call, or a traversal between dfe_start and dfe_done). They are
+//            counted, and destruction is deferred until they leave;
+//            cleanup_destroyed_dictionaries() frees the dictionary afterwards.
+//   Unsafe - a thread holding a DICTIONARY * that has not entered the API yet.
+//            Nothing inside the dictionary can see such a thread, so the caller
+//            owns that lifetime.
 #define dictionary_set(dict, name, value, value_len) dictionary_set_advanced(dict, name, -1, value, value_len, NULL)
 void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data);
 

--- a/src/libnetdata/dictionary/dictionary.h
+++ b/src/libnetdata/dictionary/dictionary.h
@@ -197,9 +197,19 @@ void dictionary_print_still_allocated_stacktraces(void);
 // Passing NULL as value, the dictionary will callocz() the newly allocated value, otherwise it will copy it.
 // Passing 0 as value_len, the dictionary will set the value to NULL (no allocations for value will be made).
 //
-// The set family MAY RETURN NULL: if another thread is destroying the
-// dictionary, the insert is refused and NULL (or false) is returned. Callers
-// that can race a dictionary_destroy() must check the result.
+// The set family MAY REFUSE THE INSERT: if another thread is destroying the
+// dictionary, nothing is inserted. How that is reported depends on the form:
+//
+//   dictionary_set_and_acquire_item*() - returns NULL. This is the ONLY
+//       unambiguous failure signal in the family: a successful insert always
+//       returns an acquired item. Callers that can race a dictionary_destroy()
+//       must check it.
+//   dictionary_set() / dictionary_set_advanced() / dictionary_view_set*() -
+//       return the item's value, so NULL is AMBIGUOUS. They also return NULL
+//       after a SUCCESSFUL insert with value_len == 0 (the value is NULL by
+//       design, see above), and on invalid input (bad or over-long name,
+//       over-long value). A caller that must distinguish refusal from either
+//       of those has to use the *_and_acquire_item*() form.
 //
 // Concurrency contract for dictionary_destroy():
 //   Safe   - other threads already inside the dictionary API (a set/get/del

--- a/src/web/api/http_auth.c
+++ b/src/web/api/http_auth.c
@@ -226,12 +226,20 @@ time_t bearer_create_token(nd_uuid_t *uuid, HTTP_USER_ROLE user_role, HTTP_ACCES
         *uuid, user_role, access, cloud_account_id, client_name,
         now_s, now_s + BEARER_TOKEN_EXPIRATION, true);
 
+    if(!expires_s)
+        // the token could not be registered - skip the cleanup, it needs the
+        // same dictionary
+        return 0;
+
     bearer_token_cleanup(false);
 
     return expires_s;
 }
 
-static bool bearer_token_parse_json(nd_uuid_t token, struct json_object *jobj, BUFFER *error) {
+// Returns false when the file is invalid (the caller deletes it).
+// *stored is set to false when the token was valid but could not be registered
+// (the bearer tokens dictionary is being destroyed) - the file must be kept.
+static bool bearer_token_parse_json(nd_uuid_t token, struct json_object *jobj, BUFFER *error, bool *stored) {
     int64_t version;
     nd_uuid_t token_in_file, cloud_account_id, host_uuid;
     CLEAN_STRING *client_name = NULL;
@@ -284,9 +292,9 @@ static bool bearer_token_parse_json(nd_uuid_t token, struct json_object *jobj, B
         return false;
     }
 
-    bearer_create_token_internal(token, user_role, access,
-                                 cloud_account_id, string2str(client_name),
-                                 created_s, expires_s, false);
+    *stored = bearer_create_token_internal(token, user_role, access,
+                                           cloud_account_id, string2str(client_name),
+                                           created_s, expires_s, false) != 0;
 
     return true;
 }
@@ -306,10 +314,19 @@ static bool bearer_token_load_token(nd_uuid_t token) {
     }
 
     CLEAN_BUFFER *error = buffer_create(0, NULL);
-    bool rc = bearer_token_parse_json(token, jobj, error);
+    bool stored = false;
+    bool rc = bearer_token_parse_json(token, jobj, error, &stored);
     if(!rc) {
         nd_log(NDLS_DAEMON, NDLP_ERR, "Failed to parse bearer token file '%s': %s", filename, buffer_tostring(error));
         unlink(filename);
+        return false;
+    }
+
+    if(!stored) {
+        // the token is valid but could not be registered - keep the file and
+        // do not run the cleanup, which needs the dictionary we just failed on
+        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+               "Could not register the bearer token of file '%s' - the bearer tokens dictionary is unavailable", filename);
         return false;
     }
 

--- a/src/web/api/http_auth.c
+++ b/src/web/api/http_auth.c
@@ -189,6 +189,10 @@ static time_t bearer_create_token_internal(nd_uuid_t token, HTTP_USER_ROLE user_
     const DICTIONARY_ITEM *item = bearer_token_set_and_acquire(
         token, user_role, access, cloud_account_id, client_name,
         created_s, expires_s, &inserted);
+    // NULL when netdata_authorized_bearers is being destroyed (shutdown)
+    if(unlikely(!item))
+        return 0;
+
     struct bearer_token *bt = dictionary_acquired_item_value(item);
 
     if(inserted && save)

--- a/src/web/api/v2/api_v2_bearer.c
+++ b/src/web/api/v2/api_v2_bearer.c
@@ -78,6 +78,10 @@ int bearer_get_token_json_response(BUFFER *wb, RRDHOST *host, const char *claim_
 
     nd_uuid_t uuid;
     time_t expires_s = bearer_create_token(&uuid, user_role, access, cloud_account_id, client_name);
+    if(!expires_s)
+        // the token could not be stored (the bearer tokens dictionary is being
+        // destroyed) - never hand out a token that was not registered
+        return nrpc_call_error(wb, "Failed to create a bearer token", HTTP_RESP_INTERNAL_SERVER_ERROR);
 
     buffer_reset(wb);
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_MINIFY);


### PR DESCRIPTION
##### Summary
- Track in-flight dictionary API calls and defer resource cleanup until they complete.
- Make set/get/delete and traversal paths safe against concurrent dictionary destruction.
- Return and handle NULL when shutdown-time dictionary inserts are refused, releasing caller-owned allocations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during shutdown and concurrent data updates.
  * Prevented resource leaks and incomplete cleanup when charts, metrics, configurations, or mount points are removed.
  * Improved handling of chart and dimension creation failures.
  * Fixed bearer-token validation and prevented invalid tokens from being returned.
  * Preserved valid authentication files while removing invalid ones.

* **Reliability**
  * Improved protection against data access conflicts during cleanup and background processing.
  * Added safer handling for metadata updates and configuration loading failures.
  * Improved behavior when resources are removed while operations are still in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->