### PR TITLE
Fix Kavenegar notification documentation link

### DIFF
--- a/src/health/notifications/kavenegar/metadata.yaml
+++ b/src/health/notifications/kavenegar/metadata.yaml
@@ -19,7 +19,7 @@
       list:
         - title: ''
           description: |
-            - The APIKEY and Sender from http://panel.kavenegar.com/client/setting/account
+            - Obtain your API key and sender information from [Kavenegar's REST API documentation](https://kavenegar.com/rest.html).
             - Access to the terminal where Netdata Agent is running
     configuration:
       file:


### PR DESCRIPTION
## Summary

- replace the retired Kavenegar panel prerequisite with the maintained official REST documentation
- clarify that operators obtain both the API key and sender information from that documentation
- keep generated integration documentation in the existing post-merge regeneration workflow

## Validation

- `python3 integrations/gen_integrations.py`
- `python3 integrations/gen_docs_integrations.py --check`
- `python3 -m unittest integrations.tests.test_descriptions` (44 tests)
- full integration documentation generation produced only the expected Kavenegar README update
- replacement documentation returned HTTP 200 and documents API-key acquisition and the sender parameter

## Generated artifacts

The source PR intentionally changes only `metadata.yaml`. The existing post-merge workflow will open the derived integration-documentation PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the outdated Kavenegar panel link with the official REST API documentation so operators know where to get their API key and sender details from a live source.

No runtime behavior changes; only the integration’s prerequisite text is updated and the downstream docs will regenerate via the existing post-merge workflow.

<sup>Written for commit 5cd4dd2abad060acc4e61d91f6645130d80edd4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kavenegar setup instructions to link to the official REST API documentation for obtaining API key and sender information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->