### PR TITLE
fix(go.d/mssql): exclude disabled SQL Agent jobs by default

### DIFF
--- a/src/go/plugin/go.d/collector/mssql/charts.go
+++ b/src/go/plugin/go.d/collector/mssql/charts.go
@@ -978,42 +978,41 @@ func (c *Collector) addLockStatsCharts(resourceType string) {
 	}
 }
 
-func (c *Collector) addJobCharts(job sqlAgentJob) {
-	c.removeObsoleteJobCharts(job.chartID)
-
-	charts := &collectorapi.Charts{
-		jobStatusChartTmpl.Copy(),
-		jobLastExecutionStatusChartTmpl.Copy(),
-		jobLastExecutionDurationChartTmpl.Copy(),
-		jobLastExecutionAgeChartTmpl.Copy(),
-		jobCurrentExecutionTimeChartTmpl.Copy(),
-	}
-
-	labels := []collectorapi.Label{
-		{Key: "job_name", Value: job.name},
-	}
-	for _, chart := range *charts {
-		chart.ID = fmt.Sprintf(chart.ID, job.chartID)
-		chart.Labels = labels
-		for _, dim := range chart.Dims {
-			dim.ID = fmt.Sprintf(dim.ID, job.chartID)
-		}
-	}
-
-	if err := c.Charts().Add(*charts...); err != nil {
-		c.Warning(err)
-	}
+func (c *Collector) ensureJobStatusChart(job sqlAgentJob) {
+	c.ensureJobChart(job, jobStatusChartTmpl)
 }
 
-func (c *Collector) removeObsoleteJobCharts(chartID string) {
-	for _, id := range jobChartIDs(chartID) {
-		chart := c.Charts().Get(id)
-		if chart == nil || !chart.IsRemoved() {
-			continue
+func (c *Collector) ensureJobExecutionCharts(job sqlAgentJob) {
+	c.ensureJobChart(job, jobLastExecutionStatusChartTmpl)
+	c.ensureJobChart(job, jobLastExecutionDurationChartTmpl)
+	c.ensureJobChart(job, jobLastExecutionAgeChartTmpl)
+	c.ensureJobChart(job, jobCurrentExecutionTimeChartTmpl)
+}
+
+func (c *Collector) ensureJobChart(job sqlAgentJob, template collectorapi.Chart) {
+	id := fmt.Sprintf(template.ID, job.chartID)
+	if chart := c.Charts().Get(id); chart != nil {
+		if !chart.IsRemoved() {
+			return
 		}
 		if err := c.Charts().Remove(id); err != nil {
 			c.Warningf("remove obsolete job chart '%s': %v", id, err)
+			return
 		}
+	}
+
+	chart := template.Copy()
+	labels := []collectorapi.Label{
+		{Key: "job_name", Value: job.name},
+	}
+	chart.ID = fmt.Sprintf(chart.ID, job.chartID)
+	chart.Labels = labels
+	for _, dim := range chart.Dims {
+		dim.ID = fmt.Sprintf(dim.ID, job.chartID)
+	}
+
+	if err := c.Charts().Add(chart); err != nil {
+		c.Warning(err)
 	}
 }
 
@@ -1045,9 +1044,25 @@ func (c *Collector) removeJobCharts(chartID string) {
 	}
 }
 
+func (c *Collector) removeJobExecutionCharts(chartID string) {
+	for _, id := range jobExecutionChartIDs(chartID) {
+		chart := c.Charts().Get(id)
+		if chart == nil {
+			continue
+		}
+		chart.MarkRemove()
+		chart.MarkNotCreated()
+	}
+}
+
 func jobChartIDs(chartID string) []string {
-	return []string{
+	return append([]string{
 		fmt.Sprintf(jobStatusChartTmpl.ID, chartID),
+	}, jobExecutionChartIDs(chartID)...)
+}
+
+func jobExecutionChartIDs(chartID string) []string {
+	return []string{
 		fmt.Sprintf(jobLastExecutionStatusChartTmpl.ID, chartID),
 		fmt.Sprintf(jobLastExecutionDurationChartTmpl.ID, chartID),
 		fmt.Sprintf(jobLastExecutionAgeChartTmpl.ID, chartID),

--- a/src/go/plugin/go.d/collector/mssql/collect.go
+++ b/src/go/plugin/go.d/collector/mssql/collect.go
@@ -703,19 +703,19 @@ func (c *Collector) collectJobStatus(mx map[string]int64) {
 	}
 
 	assignJobChartIDs(jobs, c.jobChartIDs)
-	jobs = c.updateJobCharts(jobs, complete)
-
 	for _, job := range jobs {
 		px := fmt.Sprintf("job_%s_", job.chartID)
 		mx[px+"enabled"] = boolToInt64(job.enabled)
 		mx[px+"disabled"] = boolToInt64(!job.enabled)
 	}
-	if len(jobs) == 0 {
+
+	selectedJobs := c.updateJobCharts(jobs, complete)
+	if len(selectedJobs) == 0 {
 		return
 	}
 
 	if lastExecutions, ok := c.querySQLAgentJobLastExecutions(); ok {
-		for _, job := range jobs {
+		for _, job := range selectedJobs {
 			if lastExec, ok := lastExecutions[job.id]; ok {
 				collectJobLastExecution(mx, job, &lastExec)
 			} else {
@@ -725,7 +725,7 @@ func (c *Collector) collectJobStatus(mx map[string]int64) {
 	}
 
 	if currentExecutions, ok := c.querySQLAgentJobCurrentExecutions(); ok {
-		for _, job := range jobs {
+		for _, job := range selectedJobs {
 			mx[fmt.Sprintf("job_%s_current_execution_time", job.chartID)] = currentExecutions[job.id]
 		}
 	}
@@ -821,36 +821,27 @@ func (c *Collector) updateJobCharts(jobs []sqlAgentJob, inventoryComplete bool) 
 	for _, job := range jobs {
 		seen[job.id] = true
 		c.jobChartIDs[job.id] = job.chartID
-		if job.enabled || c.CollectDisabledJobs {
-			currentChartIDs[job.chartID] = true
-		}
+		currentChartIDs[job.chartID] = true
 	}
 
 	selected := jobs[:0]
 	for _, job := range jobs {
-		if !job.enabled && !c.CollectDisabledJobs {
-			if chartID, ok := c.activeJobs[job.id]; ok {
-				if !currentChartIDs[chartID] {
-					c.removeJobCharts(chartID)
-				}
-				delete(c.activeJobs, job.id)
-			}
-			continue
-		}
-		selected = append(selected, job)
-
 		if chartID, ok := c.activeJobs[job.id]; ok {
 			if chartID != job.chartID {
 				if !currentChartIDs[chartID] {
 					c.removeJobCharts(chartID)
 				}
-				c.addJobCharts(job)
-			} else {
-				c.updateJobChartsLabels(job)
 			}
-		} else {
-			c.addJobCharts(job)
 		}
+
+		c.ensureJobStatusChart(job)
+		if job.enabled || c.CollectDisabledJobs {
+			c.ensureJobExecutionCharts(job)
+			selected = append(selected, job)
+		} else {
+			c.removeJobExecutionCharts(job.chartID)
+		}
+		c.updateJobChartsLabels(job)
 		c.activeJobs[job.id] = job.chartID
 	}
 

--- a/src/go/plugin/go.d/collector/mssql/collect.go
+++ b/src/go/plugin/go.d/collector/mssql/collect.go
@@ -702,13 +702,16 @@ func (c *Collector) collectJobStatus(mx map[string]int64) {
 		return
 	}
 
-	assignJobChartIDs(jobs, c.seenJobs)
-	c.updateJobCharts(jobs, complete)
+	assignJobChartIDs(jobs, c.jobChartIDs)
+	jobs = c.updateJobCharts(jobs, complete)
 
 	for _, job := range jobs {
 		px := fmt.Sprintf("job_%s_", job.chartID)
 		mx[px+"enabled"] = boolToInt64(job.enabled)
 		mx[px+"disabled"] = boolToInt64(!job.enabled)
+	}
+	if len(jobs) == 0 {
+		return
 	}
 
 	if lastExecutions, ok := c.querySQLAgentJobLastExecutions(); ok {
@@ -776,7 +779,17 @@ func assignJobChartIDs(jobs []sqlAgentJob, previous map[string]string) {
 		return jobs[i].id < jobs[j].id
 	})
 
-	used := make(map[string]bool, len(jobs))
+	current := make(map[string]bool, len(jobs))
+	for _, job := range jobs {
+		current[job.id] = true
+	}
+
+	used := make(map[string]bool, len(previous)+len(jobs))
+	for jobID, chartID := range previous {
+		if !current[jobID] {
+			used[chartID] = true
+		}
+	}
 	for i := range jobs {
 		if chartID := previous[jobs[i].id]; chartID != "" && !used[chartID] {
 			jobs[i].chartID = chartID
@@ -802,17 +815,31 @@ func assignJobChartIDs(jobs []sqlAgentJob, previous map[string]string) {
 	}
 }
 
-func (c *Collector) updateJobCharts(jobs []sqlAgentJob, removeMissing bool) {
+func (c *Collector) updateJobCharts(jobs []sqlAgentJob, inventoryComplete bool) []sqlAgentJob {
 	seen := make(map[string]bool, len(jobs))
 	currentChartIDs := make(map[string]bool, len(jobs))
 	for _, job := range jobs {
-		currentChartIDs[job.chartID] = true
+		seen[job.id] = true
+		c.jobChartIDs[job.id] = job.chartID
+		if job.enabled || c.CollectDisabledJobs {
+			currentChartIDs[job.chartID] = true
+		}
 	}
 
+	selected := jobs[:0]
 	for _, job := range jobs {
-		seen[job.id] = true
+		if !job.enabled && !c.CollectDisabledJobs {
+			if chartID, ok := c.activeJobs[job.id]; ok {
+				if !currentChartIDs[chartID] {
+					c.removeJobCharts(chartID)
+				}
+				delete(c.activeJobs, job.id)
+			}
+			continue
+		}
+		selected = append(selected, job)
 
-		if chartID, ok := c.seenJobs[job.id]; ok {
+		if chartID, ok := c.activeJobs[job.id]; ok {
 			if chartID != job.chartID {
 				if !currentChartIDs[chartID] {
 					c.removeJobCharts(chartID)
@@ -824,26 +851,36 @@ func (c *Collector) updateJobCharts(jobs []sqlAgentJob, removeMissing bool) {
 		} else {
 			c.addJobCharts(job)
 		}
-		c.seenJobs[job.id] = job.chartID
+		c.activeJobs[job.id] = job.chartID
 	}
 
-	if !removeMissing {
-		return
+	if !inventoryComplete {
+		return selected
 	}
-	for jobID, chartID := range c.seenJobs {
+	for jobID, chartID := range c.activeJobs {
 		if seen[jobID] {
 			continue
 		}
 		c.removeJobCharts(chartID)
-		delete(c.seenJobs, jobID)
+		delete(c.activeJobs, jobID)
 	}
+	for jobID := range c.jobChartIDs {
+		if !seen[jobID] {
+			delete(c.jobChartIDs, jobID)
+		}
+	}
+	return selected
 }
 
 func (c *Collector) querySQLAgentJobLastExecutions() (map[string]sqlAgentJobLastExecution, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout.Duration())
 	defer cancel()
 
-	rows, err := c.db.QueryContext(ctx, queryJobLastExecutions)
+	query := queryJobLastExecutions
+	if c.CollectDisabledJobs {
+		query = queryJobLastExecutionsAll
+	}
+	rows, err := c.db.QueryContext(ctx, query)
 	if err != nil {
 		c.Debugf("job last executions query failed: %v", err)
 		return nil, false
@@ -916,7 +953,11 @@ func (c *Collector) querySQLAgentJobCurrentExecutions() (map[string]int64, bool)
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout.Duration())
 	defer cancel()
 
-	rows, err := c.db.QueryContext(ctx, queryJobCurrentExecutions)
+	query := queryJobCurrentExecutions
+	if c.CollectDisabledJobs {
+		query = queryJobCurrentExecutionsAll
+	}
+	rows, err := c.db.QueryContext(ctx, query)
 	if err != nil {
 		c.Debugf("job current executions query failed: %v", err)
 		return nil, false

--- a/src/go/plugin/go.d/collector/mssql/collector.go
+++ b/src/go/plugin/go.d/collector/mssql/collector.go
@@ -38,8 +38,9 @@ func init() {
 func New() *Collector {
 	return &Collector{
 		Config: Config{
-			DSN:     "sqlserver://localhost:1433",
-			Timeout: confopt.Duration(time.Second * 5),
+			DSN:                 "sqlserver://localhost:1433",
+			Timeout:             confopt.Duration(time.Second * 5),
+			CollectDisabledJobs: false,
 			Functions: FunctionsConfig{
 				TopQueries: TopQueriesConfig{
 					Limit:          500,
@@ -55,7 +56,8 @@ func New() *Collector {
 		seenWaitTypes:        make(map[string]bool),
 		seenLockTypes:        make(map[string]bool),
 		seenLockStatsTypes:   make(map[string]bool),
-		seenJobs:             make(map[string]string),
+		jobChartIDs:          make(map[string]string),
+		activeJobs:           make(map[string]string),
 		seenReplications:     make(map[string]bool),
 
 		seenAGs:                make(map[string]bool),
@@ -67,12 +69,13 @@ func New() *Collector {
 }
 
 type Config struct {
-	Vnode       string           `yaml:"vnode,omitempty" json:"vnode"`
-	UpdateEvery int              `yaml:"update_every,omitempty" json:"update_every"`
-	DSN         string           `yaml:"dsn" json:"dsn"`
-	Timeout     confopt.Duration `yaml:"timeout,omitempty" json:"timeout"`
-	CloudAuth   cloudauth.Config `yaml:"cloud_auth" json:"cloud_auth"`
-	Functions   FunctionsConfig  `yaml:"functions,omitempty" json:"functions"`
+	Vnode               string           `yaml:"vnode,omitempty" json:"vnode"`
+	UpdateEvery         int              `yaml:"update_every,omitempty" json:"update_every"`
+	DSN                 string           `yaml:"dsn" json:"dsn"`
+	Timeout             confopt.Duration `yaml:"timeout,omitempty" json:"timeout"`
+	CollectDisabledJobs bool             `yaml:"collect_disabled_jobs" json:"collect_disabled_jobs"`
+	CloudAuth           cloudauth.Config `yaml:"cloud_auth" json:"cloud_auth"`
+	Functions           FunctionsConfig  `yaml:"functions,omitempty" json:"functions"`
 }
 
 type FunctionsConfig struct {
@@ -165,7 +168,8 @@ type Collector struct {
 	seenWaitTypes        map[string]bool
 	seenLockTypes        map[string]bool
 	seenLockStatsTypes   map[string]bool
-	seenJobs             map[string]string
+	jobChartIDs          map[string]string
+	activeJobs           map[string]string
 	seenReplications     map[string]bool
 
 	hadrEnabled bool // true if Always On AG is enabled on this instance

--- a/src/go/plugin/go.d/collector/mssql/config_schema.json
+++ b/src/go/plugin/go.d/collector/mssql/config_schema.json
@@ -162,8 +162,8 @@
         "default": 5
       },
       "collect_disabled_jobs": {
-        "title": "Collect disabled SQL Agent jobs",
-        "description": "Collect charts and execution metrics for disabled SQL Server Agent jobs. Disabled jobs are excluded by default. Enabling this option adds five charts and ten dimensions per disabled job; stock execution alerts remain gated by the job's enabled state.",
+        "title": "Collect disabled SQL Agent job executions",
+        "description": "Collect execution-result, execution-age, execution-duration, and current-runtime charts for disabled SQL Server Agent jobs. Their administrative enabled/disabled status is always collected. Enabling this option adds four charts and eight dimensions per disabled job; stock execution alerts remain gated by the job's enabled state.",
         "type": "boolean",
         "default": false
       },

--- a/src/go/plugin/go.d/collector/mssql/config_schema.json
+++ b/src/go/plugin/go.d/collector/mssql/config_schema.json
@@ -161,6 +161,12 @@
         "minimum": 0.5,
         "default": 5
       },
+      "collect_disabled_jobs": {
+        "title": "Collect disabled SQL Agent jobs",
+        "description": "Collect charts and execution metrics for disabled SQL Server Agent jobs. Disabled jobs are excluded by default. Enabling this option adds five charts and ten dimensions per disabled job; stock execution alerts remain gated by the job's enabled state.",
+        "type": "boolean",
+        "default": false
+      },
       "functions": {
         "title": "Functions",
         "description": "Configuration for Netdata functions exposed by this collector.",
@@ -341,6 +347,12 @@
             "dsn",
             "timeout",
             "vnode"
+          ]
+        },
+        {
+          "title": "SQL Agent",
+          "fields": [
+            "collect_disabled_jobs"
           ]
         },
         {

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -45,6 +45,8 @@ modules:
           On editions that lack certain features, the collector omits the unavailable metrics and continues
           collecting the rest:
           - SQL Server Express and other editions without SQL Server Agent: job metrics are not collected.
+          - Disabled SQL Server Agent jobs are excluded by default. Set `collect_disabled_jobs: true` to retain their
+            state and execution-history charts; stock execution alerts still apply only while a job is enabled.
           - Editions without Always On Availability Groups (e.g., Express): AG metrics are not collected.
           - Editions without replication configured: replication metrics are not collected.
 
@@ -83,6 +85,8 @@ modules:
           description: |
             The collector executes lightweight queries against system views.
             Most queries complete in milliseconds and have minimal impact on server performance.
+            Enabling `collect_disabled_jobs` expands SQL Agent history/activity queries and adds five charts with ten
+            dimensions for every disabled job.
       additional_permissions:
         description: |
           The monitoring user requires the VIEW SERVER STATE permission to access DMVs.
@@ -260,6 +264,15 @@ modules:
               default_value: 5
               required: false
               group: Target
+
+            - name: collect_disabled_jobs
+              description: |
+                Collect status, last-execution, and current-execution charts for disabled SQL Server Agent jobs.
+                Disabled jobs are excluded by default. Enabling this option adds five charts and ten dimensions per
+                disabled job. Stock last-execution alerts remain gated by the job's enabled state.
+              default_value: false
+              required: false
+              group: SQL Agent
 
             - name: functions.top_queries.disabled
               description: Disable the [top-queries](#top-queries) function.
@@ -443,11 +456,11 @@ modules:
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf
       - name: mssql_sql_agent_job_last_execution_warning
         metric: mssql.job_last_execution_status
-        info: SQL Server Agent job succeeded but at least one step failed in the last completed execution
+        info: Enabled SQL Server Agent job succeeded but at least one step failed in the last completed execution
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf
       - name: mssql_sql_agent_job_last_execution_failed
         metric: mssql.job_last_execution_status
-        info: SQL Server Agent job failed in the last completed execution
+        info: Enabled SQL Server Agent job failed in the last completed execution
         link: https://github.com/netdata/netdata/blob/master/src/health/health.d/mssql.conf
     functions:
       description: |

--- a/src/go/plugin/go.d/collector/mssql/metadata.yaml
+++ b/src/go/plugin/go.d/collector/mssql/metadata.yaml
@@ -45,8 +45,9 @@ modules:
           On editions that lack certain features, the collector omits the unavailable metrics and continues
           collecting the rest:
           - SQL Server Express and other editions without SQL Server Agent: job metrics are not collected.
-          - Disabled SQL Server Agent jobs are excluded by default. Set `collect_disabled_jobs: true` to retain their
-            state and execution-history charts; stock execution alerts still apply only while a job is enabled.
+          - Disabled SQL Server Agent jobs retain their administrative enabled/disabled status by default, while their
+            execution charts are excluded. Set `collect_disabled_jobs: true` to retain their execution charts; stock
+            execution alerts still apply only while a job is enabled.
           - Editions without Always On Availability Groups (e.g., Express): AG metrics are not collected.
           - Editions without replication configured: replication metrics are not collected.
 
@@ -85,8 +86,8 @@ modules:
           description: |
             The collector executes lightweight queries against system views.
             Most queries complete in milliseconds and have minimal impact on server performance.
-            Enabling `collect_disabled_jobs` expands SQL Agent history/activity queries and adds five charts with ten
-            dimensions for every disabled job.
+            Enabling `collect_disabled_jobs` expands SQL Agent history/activity queries and adds four charts with eight
+            dimensions for every disabled job. The administrative job-status chart is always collected.
       additional_permissions:
         description: |
           The monitoring user requires the VIEW SERVER STATE permission to access DMVs.
@@ -267,9 +268,10 @@ modules:
 
             - name: collect_disabled_jobs
               description: |
-                Collect status, last-execution, and current-execution charts for disabled SQL Server Agent jobs.
-                Disabled jobs are excluded by default. Enabling this option adds five charts and ten dimensions per
-                disabled job. Stock last-execution alerts remain gated by the job's enabled state.
+                Collect execution-result, execution-age, execution-duration, and current-runtime charts for disabled SQL
+                Server Agent jobs. Their administrative enabled/disabled status is always collected. Enabling this option
+                adds four charts and eight dimensions per disabled job. Stock last-execution alerts remain gated by the
+                job's enabled state.
               default_value: false
               required: false
               group: SQL Agent

--- a/src/go/plugin/go.d/collector/mssql/mssql_test.go
+++ b/src/go/plugin/go.d/collector/mssql/mssql_test.go
@@ -239,33 +239,6 @@ func TestSQLAgentExecutionQuerySelection(t *testing.T) {
 	assert.NotContains(t, queryJobCurrentExecutionsAll, "AND j.enabled = 1")
 }
 
-func TestSQLAgentExecutionAlertContract(t *testing.T) {
-	for _, name := range []string{
-		"mssql_sql_agent_job_last_execution_warning",
-		"mssql_sql_agent_job_last_execution_failed",
-	} {
-		block := mssqlHealthAlertBlock(t, name)
-		assert.Contains(t, block, "calc: $this * ${mssql.job_status.enabled}")
-		assert.Contains(t, block, "($this == nan or $this == inf) ? (nan) : ($this > 0)")
-		assert.NotContains(t, block, "delay:")
-		assert.Contains(t, block, "info: Enabled SQL Server Agent job")
-	}
-}
-
-func mssqlHealthAlertBlock(t *testing.T, template string) string {
-	t.Helper()
-	content, err := os.ReadFile("../../../../../health/health.d/mssql.conf")
-	require.NoError(t, err)
-
-	start := strings.Index(string(content), "template: "+template)
-	require.NotEqual(t, -1, start)
-	block := string(content)[start:]
-	if end := strings.Index(block, "\n template:"); end >= 0 {
-		block = block[:end]
-	}
-	return block
-}
-
 func TestCollectJobLastExecution(t *testing.T) {
 	job := sqlAgentJob{id: "job-id", name: "Job", chartID: "job"}
 
@@ -406,15 +379,18 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 		notWantMetrics     []string
 		checkCollector     func(t *testing.T, c *Collector)
 	}{
-		"disabled job is excluded by default": {
+		"disabled job keeps only administrative status by default": {
 			prepareMock: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery(queryJobs).WillReturnRows(
 					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
 						AddRow(jobID2, "Disabled Job", int64(0)),
 				)
 			},
+			wantMetrics: map[string]int64{
+				"job_disabled_job_enabled":  0,
+				"job_disabled_job_disabled": 1,
+			},
 			notWantMetrics: []string{
-				"job_disabled_job_disabled",
 				"job_disabled_job_last_execution_status_error",
 				"job_disabled_job_last_execution_duration",
 				"job_disabled_job_last_execution_age",
@@ -422,7 +398,18 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 			},
 			checkCollector: func(t *testing.T, c *Collector) {
 				chart := c.Charts().Get("job_disabled_job_status")
-				assert.True(t, chart == nil || chart.IsRemoved())
+				require.NotNil(t, chart)
+				assert.False(t, chart.IsRemoved())
+
+				for _, chartID := range []string{
+					"job_disabled_job_last_execution_status",
+					"job_disabled_job_last_execution_duration",
+					"job_disabled_job_last_execution_age",
+					"job_disabled_job_current_execution_time",
+				} {
+					chart := c.Charts().Get(chartID)
+					assert.Truef(t, chart == nil || chart.IsRemoved(), "execution chart %s should not be active", chartID)
+				}
 			},
 		},
 		"disabled job is collected when enabled": {
@@ -462,7 +449,7 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				mock.ExpectQuery(queryJobs).WillReturnRows(
 					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
 						AddRow(jobID1, "Clean Job", int64(1)).
-						AddRow(jobID2, "Warning.Job", int64(0)).
+						AddRow(jobID2, "Middle.Job", int64(0)).
 						AddRow("33333333-3333-3333-3333-333333333333", "Never Job", int64(1)),
 				)
 				mock.ExpectQuery(queryJobLastExecutions).WillReturnRows(
@@ -486,14 +473,14 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				"job_clean_job_current_execution_time":        0,
 				"job_never_job_last_execution_status_unknown": 1,
 				"job_never_job_current_execution_time":        0,
+				"job_middle_job_enabled":                      0,
+				"job_middle_job_disabled":                     1,
 			},
 			notWantMetrics: []string{
-				"job_warning_job_enabled",
-				"job_warning_job_disabled",
-				"job_warning_job_last_execution_status_warning",
-				"job_warning_job_last_execution_duration",
-				"job_warning_job_last_execution_age",
-				"job_warning_job_current_execution_time",
+				"job_middle_job_last_execution_status_warning",
+				"job_middle_job_last_execution_duration",
+				"job_middle_job_last_execution_age",
+				"job_middle_job_current_execution_time",
 				"job_never_job_last_execution_duration",
 				"job_never_job_last_execution_age",
 			},
@@ -647,10 +634,14 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				c.collectJobStatus(mx)
 				chart := c.Charts().Get("job_job_status")
 				require.NotNil(t, chart)
-				assert.True(t, chart.IsRemoved())
-				assert.NotContains(t, mx, "job_job_disabled")
+				assert.False(t, chart.IsRemoved())
+				assert.Equal(t, int64(1), mx["job_job_disabled"])
 				assert.Equal(t, "job", c.jobChartIDs[jobID1])
-				assert.NotContains(t, c.activeJobs, jobID1)
+				assert.Equal(t, "job", c.activeJobs[jobID1])
+
+				execution := c.Charts().Get("job_job_last_execution_status")
+				require.NotNil(t, execution)
+				assert.True(t, execution.IsRemoved())
 
 				mx = make(map[string]int64)
 				c.collectJobStatus(mx)
@@ -659,6 +650,10 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				assert.False(t, chart.IsRemoved())
 				assert.Equal(t, int64(1), mx["job_job_enabled"])
 				assert.Equal(t, "job", c.activeJobs[jobID1])
+
+				execution = c.Charts().Get("job_job_last_execution_status")
+				require.NotNil(t, execution)
+				assert.False(t, execution.IsRemoved())
 			},
 		},
 		"configuration can exclude and restore a disabled job": {
@@ -690,8 +685,11 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				c.collectJobStatus(make(map[string]int64))
 				chart := c.Charts().Get("job_job_status")
 				require.NotNil(t, chart)
-				assert.True(t, chart.IsRemoved())
+				assert.False(t, chart.IsRemoved())
 				assert.Equal(t, "job", c.jobChartIDs[jobID1])
+				execution := c.Charts().Get("job_job_last_execution_status")
+				require.NotNil(t, execution)
+				assert.True(t, execution.IsRemoved())
 
 				c.CollectDisabledJobs = true
 				c.collectJobStatus(make(map[string]int64))
@@ -700,6 +698,10 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				assert.False(t, chart.IsRemoved())
 				assert.Equal(t, "job", c.activeJobs[jobID1])
 				assert.Equal(t, 1, countCollectorChartsByID(c, "job_job_status"))
+				execution = c.Charts().Get("job_job_last_execution_status")
+				require.NotNil(t, execution)
+				assert.False(t, execution.IsRemoved())
+				assert.Equal(t, 1, countCollectorChartsByID(c, "job_job_last_execution_status"))
 			},
 		},
 		"inventory failure preserves active job charts": {
@@ -736,11 +738,14 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				suffix := "a_b_" + cleanJobID(jobID2)
 				assert.Equal(t, "a_b", c.jobChartIDs[jobID1])
 				assert.Equal(t, suffix, c.jobChartIDs[jobID2])
-				assert.NotContains(t, c.activeJobs, jobID1)
+				assert.Equal(t, "a_b", c.activeJobs[jobID1])
 				assert.Equal(t, suffix, c.activeJobs[jobID2])
 
 				base := c.Charts().Get("job_a_b_status")
-				assert.True(t, base == nil || base.IsRemoved())
+				require.NotNil(t, base)
+				assert.False(t, base.IsRemoved())
+				baseExecution := c.Charts().Get("job_a_b_last_execution_status")
+				assert.True(t, baseExecution == nil || baseExecution.IsRemoved())
 				active := c.Charts().Get("job_" + suffix + "_status")
 				require.NotNil(t, active)
 				assert.False(t, active.IsRemoved())
@@ -768,11 +773,18 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 
 				observedDisabled := c.Charts().Get("job_job_one_status")
 				require.NotNil(t, observedDisabled)
-				assert.True(t, observedDisabled.IsRemoved())
+				assert.False(t, observedDisabled.IsRemoved())
+				assert.Equal(t, int64(1), mx["job_job_one_disabled"])
+				observedExecution := c.Charts().Get("job_job_one_last_execution_status")
+				require.NotNil(t, observedExecution)
+				assert.True(t, observedExecution.IsRemoved())
 
 				unobserved := c.Charts().Get("job_job_two_status")
 				require.NotNil(t, unobserved)
 				assert.False(t, unobserved.IsRemoved())
+				unobservedExecution := c.Charts().Get("job_job_two_last_execution_status")
+				require.NotNil(t, unobservedExecution)
+				assert.False(t, unobservedExecution.IsRemoved())
 				assert.Equal(t, "job_two", c.activeJobs[jobID2])
 			},
 		},

--- a/src/go/plugin/go.d/collector/mssql/mssql_test.go
+++ b/src/go/plugin/go.d/collector/mssql/mssql_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -13,9 +14,21 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/cloudauth"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/cloudauth/sqladapter"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var (
+	dataConfigJSON, _ = os.ReadFile("testdata/config.json")
+	dataConfigYAML, _ = os.ReadFile("testdata/config.yaml")
+)
+
+func TestCollector_ConfigurationSerialize(t *testing.T) {
+	require.NotNil(t, dataConfigJSON)
+	require.NotNil(t, dataConfigYAML)
+	collecttest.TestConfigurationSerialize(t, &Collector{}, dataConfigJSON, dataConfigYAML)
+}
 
 func TestCollector_Init(t *testing.T) {
 	c := New()
@@ -75,6 +88,7 @@ func TestCollector_Configuration(t *testing.T) {
 
 	// Verify defaults
 	assert.Equal(t, "sqlserver://localhost:1433", c.DSN)
+	assert.False(t, c.CollectDisabledJobs)
 }
 
 func TestCollector_Charts(t *testing.T) {
@@ -211,10 +225,45 @@ func TestAGDatabaseReplicaQuery(t *testing.T) {
 }
 
 func TestQueryJobLastExecutionsAvoidsSQLServer2012OnlyFunctions(t *testing.T) {
-	query := strings.ToUpper(queryJobLastExecutions)
+	for _, query := range []string{queryJobLastExecutions, queryJobLastExecutionsAll} {
+		query = strings.ToUpper(query)
+		assert.NotContains(t, query, "TRY_CONVERT")
+		assert.NotContains(t, query, "LEAD(")
+	}
+}
 
-	assert.NotContains(t, query, "TRY_CONVERT")
-	assert.NotContains(t, query, "LEAD(")
+func TestSQLAgentExecutionQuerySelection(t *testing.T) {
+	assert.Contains(t, queryJobLastExecutions, "AND j.enabled = 1")
+	assert.NotContains(t, queryJobLastExecutionsAll, "AND j.enabled = 1")
+	assert.Contains(t, queryJobCurrentExecutions, "AND j.enabled = 1")
+	assert.NotContains(t, queryJobCurrentExecutionsAll, "AND j.enabled = 1")
+}
+
+func TestSQLAgentExecutionAlertContract(t *testing.T) {
+	for _, name := range []string{
+		"mssql_sql_agent_job_last_execution_warning",
+		"mssql_sql_agent_job_last_execution_failed",
+	} {
+		block := mssqlHealthAlertBlock(t, name)
+		assert.Contains(t, block, "calc: $this * ${mssql.job_status.enabled}")
+		assert.Contains(t, block, "($this == nan or $this == inf) ? (nan) : ($this > 0)")
+		assert.NotContains(t, block, "delay:")
+		assert.Contains(t, block, "info: Enabled SQL Server Agent job")
+	}
+}
+
+func mssqlHealthAlertBlock(t *testing.T, template string) string {
+	t.Helper()
+	content, err := os.ReadFile("../../../../../health/health.d/mssql.conf")
+	require.NoError(t, err)
+
+	start := strings.Index(string(content), "template: "+template)
+	require.NotEqual(t, -1, start)
+	block := string(content)[start:]
+	if end := strings.Index(block, "\n template:"); end >= 0 {
+		block = block[:end]
+	}
+	return block
 }
 
 func TestCollectJobLastExecution(t *testing.T) {
@@ -351,11 +400,63 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 	)
 
 	tests := map[string]struct {
-		prepareMock    func(mock sqlmock.Sqlmock)
-		wantMetrics    map[string]int64
-		notWantMetrics []string
-		checkCollector func(t *testing.T, c *Collector)
+		prepareMock        func(mock sqlmock.Sqlmock)
+		configureCollector func(c *Collector)
+		wantMetrics        map[string]int64
+		notWantMetrics     []string
+		checkCollector     func(t *testing.T, c *Collector)
 	}{
+		"disabled job is excluded by default": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID2, "Disabled Job", int64(0)),
+				)
+			},
+			notWantMetrics: []string{
+				"job_disabled_job_disabled",
+				"job_disabled_job_last_execution_status_error",
+				"job_disabled_job_last_execution_duration",
+				"job_disabled_job_last_execution_age",
+				"job_disabled_job_current_execution_time",
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				chart := c.Charts().Get("job_disabled_job_status")
+				assert.True(t, chart == nil || chart.IsRemoved())
+			},
+		},
+		"disabled job is collected when enabled": {
+			configureCollector: func(c *Collector) {
+				c.CollectDisabledJobs = true
+			},
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID2, "Disabled Job", int64(0)),
+				)
+				mock.ExpectQuery(queryJobLastExecutionsAll).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "run_status", "duration_seconds", "age_seconds", "has_failed_step"}).
+						AddRow(jobID2, int64(sqlAgentJobRunStatusFailed), int64(30), int64(60), int64(0)),
+				)
+				mock.ExpectQuery(queryJobCurrentExecutionsAll).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "current_execution_time_seconds"}).
+						AddRow(jobID2, int64(15)),
+				)
+			},
+			wantMetrics: map[string]int64{
+				"job_disabled_job_enabled":                     0,
+				"job_disabled_job_disabled":                    1,
+				"job_disabled_job_last_execution_status_error": 1,
+				"job_disabled_job_last_execution_duration":     30,
+				"job_disabled_job_last_execution_age":          60,
+				"job_disabled_job_current_execution_time":      15,
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				chart := c.Charts().Get("job_disabled_job_status")
+				require.NotNil(t, chart)
+				assert.False(t, chart.IsRemoved())
+			},
+		},
 		"complete collection": {
 			prepareMock: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery(queryJobs).WillReturnRows(
@@ -376,24 +477,23 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				)
 			},
 			wantMetrics: map[string]int64{
-				"job_clean_job_enabled":                         1,
-				"job_clean_job_disabled":                        0,
-				"job_clean_job_last_execution_status_ok":        1,
-				"job_clean_job_last_execution_status_warning":   0,
-				"job_clean_job_last_execution_duration":         90,
-				"job_clean_job_last_execution_age":              30,
-				"job_clean_job_current_execution_time":          0,
-				"job_warning_job_enabled":                       0,
-				"job_warning_job_disabled":                      1,
-				"job_warning_job_last_execution_status_ok":      0,
-				"job_warning_job_last_execution_status_warning": 1,
-				"job_warning_job_last_execution_duration":       3723,
-				"job_warning_job_current_execution_time":        3600,
-				"job_never_job_last_execution_status_unknown":   1,
-				"job_never_job_current_execution_time":          0,
+				"job_clean_job_enabled":                       1,
+				"job_clean_job_disabled":                      0,
+				"job_clean_job_last_execution_status_ok":      1,
+				"job_clean_job_last_execution_status_warning": 0,
+				"job_clean_job_last_execution_duration":       90,
+				"job_clean_job_last_execution_age":            30,
+				"job_clean_job_current_execution_time":        0,
+				"job_never_job_last_execution_status_unknown": 1,
+				"job_never_job_current_execution_time":        0,
 			},
 			notWantMetrics: []string{
+				"job_warning_job_enabled",
+				"job_warning_job_disabled",
+				"job_warning_job_last_execution_status_warning",
+				"job_warning_job_last_execution_duration",
 				"job_warning_job_last_execution_age",
+				"job_warning_job_current_execution_time",
 				"job_never_job_last_execution_duration",
 				"job_never_job_last_execution_age",
 			},
@@ -485,8 +585,6 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
 
 				mock.ExpectQuery(queryJobs).WillReturnRows(sqlmock.NewRows([]string{"job_id", "name", "enabled"}))
-				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
-				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
 
 				mock.ExpectQuery(queryJobs).WillReturnRows(
 					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
@@ -496,8 +594,6 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
 
 				mock.ExpectQuery(queryJobs).WillReturnRows(sqlmock.NewRows([]string{"job_id", "name", "enabled"}))
-				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
-				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
 			},
 			checkCollector: func(t *testing.T, c *Collector) {
 				mx := make(map[string]int64)
@@ -525,6 +621,161 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				assert.Equal(t, 1, countCollectorChartsByID(c, "job_abc_status"))
 			},
 		},
+		"enabled job can be disabled and re-enabled": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job", int64(0)),
+				)
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				mx := make(map[string]int64)
+				c.collectJobStatus(mx)
+				chart := c.Charts().Get("job_job_status")
+				require.NotNil(t, chart)
+				assert.True(t, chart.IsRemoved())
+				assert.NotContains(t, mx, "job_job_disabled")
+				assert.Equal(t, "job", c.jobChartIDs[jobID1])
+				assert.NotContains(t, c.activeJobs, jobID1)
+
+				mx = make(map[string]int64)
+				c.collectJobStatus(mx)
+				chart = c.Charts().Get("job_job_status")
+				require.NotNil(t, chart)
+				assert.False(t, chart.IsRemoved())
+				assert.Equal(t, int64(1), mx["job_job_enabled"])
+				assert.Equal(t, "job", c.activeJobs[jobID1])
+			},
+		},
+		"configuration can exclude and restore a disabled job": {
+			configureCollector: func(c *Collector) {
+				c.CollectDisabledJobs = true
+			},
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job", int64(0)),
+				)
+				mock.ExpectQuery(queryJobLastExecutionsAll).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutionsAll).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job", int64(0)),
+				)
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job", int64(0)),
+				)
+				mock.ExpectQuery(queryJobLastExecutionsAll).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutionsAll).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				c.CollectDisabledJobs = false
+				c.collectJobStatus(make(map[string]int64))
+				chart := c.Charts().Get("job_job_status")
+				require.NotNil(t, chart)
+				assert.True(t, chart.IsRemoved())
+				assert.Equal(t, "job", c.jobChartIDs[jobID1])
+
+				c.CollectDisabledJobs = true
+				c.collectJobStatus(make(map[string]int64))
+				chart = c.Charts().Get("job_job_status")
+				require.NotNil(t, chart)
+				assert.False(t, chart.IsRemoved())
+				assert.Equal(t, "job", c.activeJobs[jobID1])
+				assert.Equal(t, 1, countCollectorChartsByID(c, "job_job_status"))
+			},
+		},
+		"inventory failure preserves active job charts": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnError(fmt.Errorf("temporary failure"))
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				c.collectJobStatus(make(map[string]int64))
+				chart := c.Charts().Get("job_job_status")
+				require.NotNil(t, chart)
+				assert.False(t, chart.IsRemoved())
+				assert.Equal(t, "job", c.jobChartIDs[jobID1])
+				assert.Equal(t, "job", c.activeJobs[jobID1])
+			},
+		},
+		"disabled collision owner reserves the base chart ID": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "A-B", int64(0)).
+						AddRow(jobID2, "A.B", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				suffix := "a_b_" + cleanJobID(jobID2)
+				assert.Equal(t, "a_b", c.jobChartIDs[jobID1])
+				assert.Equal(t, suffix, c.jobChartIDs[jobID2])
+				assert.NotContains(t, c.activeJobs, jobID1)
+				assert.Equal(t, suffix, c.activeJobs[jobID2])
+
+				base := c.Charts().Get("job_a_b_status")
+				assert.True(t, base == nil || base.IsRemoved())
+				active := c.Charts().Get("job_" + suffix + "_status")
+				require.NotNil(t, active)
+				assert.False(t, active.IsRemoved())
+			},
+		},
+		"partial inventory applies observed disablement and retains unobserved jobs": {
+			prepareMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job One", int64(1)).
+						AddRow(jobID2, "Job Two", int64(1)),
+				)
+				mock.ExpectQuery(queryJobLastExecutions).WillReturnError(fmt.Errorf("permission denied"))
+				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
+
+				mock.ExpectQuery(queryJobs).WillReturnRows(
+					sqlmock.NewRows([]string{"job_id", "name", "enabled"}).
+						AddRow(jobID1, "Job One", int64(0)).
+						AddRow(jobID2, nil, int64(1)),
+				)
+			},
+			checkCollector: func(t *testing.T, c *Collector) {
+				mx := make(map[string]int64)
+				c.collectJobStatus(mx)
+
+				observedDisabled := c.Charts().Get("job_job_one_status")
+				require.NotNil(t, observedDisabled)
+				assert.True(t, observedDisabled.IsRemoved())
+
+				unobserved := c.Charts().Get("job_job_two_status")
+				require.NotNil(t, unobserved)
+				assert.False(t, unobserved.IsRemoved())
+				assert.Equal(t, "job_two", c.activeJobs[jobID2])
+			},
+		},
 		"new colliding job keeps existing owner charts": {
 			prepareMock: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery(queryJobs).WillReturnRows(
@@ -543,14 +794,14 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 				mock.ExpectQuery(queryJobCurrentExecutions).WillReturnError(fmt.Errorf("permission denied"))
 			},
 			checkCollector: func(t *testing.T, c *Collector) {
-				require.Equal(t, "a_b", c.seenJobs[jobID2])
+				require.Equal(t, "a_b", c.jobChartIDs[jobID2])
 
 				mx := make(map[string]int64)
 				c.collectJobStatus(mx)
 
 				suffix := "a_b_" + cleanJobID(jobID1)
-				assert.Equal(t, "a_b", c.seenJobs[jobID2])
-				assert.Equal(t, suffix, c.seenJobs[jobID1])
+				assert.Equal(t, "a_b", c.jobChartIDs[jobID2])
+				assert.Equal(t, suffix, c.jobChartIDs[jobID1])
 				assert.Equal(t, int64(1), mx["job_a_b_enabled"])
 				assert.Equal(t, int64(1), mx["job_"+suffix+"_enabled"])
 
@@ -584,14 +835,14 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 			},
 			checkCollector: func(t *testing.T, c *Collector) {
 				suffix := "a_b_" + cleanJobID(jobID2)
-				require.Equal(t, "a_b", c.seenJobs[jobID1])
-				require.Equal(t, suffix, c.seenJobs[jobID2])
+				require.Equal(t, "a_b", c.jobChartIDs[jobID1])
+				require.Equal(t, suffix, c.jobChartIDs[jobID2])
 
 				mx := make(map[string]int64)
 				c.collectJobStatus(mx)
 
-				assert.Equal(t, suffix, c.seenJobs[jobID2])
-				assert.NotContains(t, c.seenJobs, jobID1)
+				assert.Equal(t, suffix, c.jobChartIDs[jobID2])
+				assert.NotContains(t, c.jobChartIDs, jobID1)
 				assert.Equal(t, int64(1), mx["job_"+suffix+"_enabled"])
 
 				removedBase := c.Charts().Get("job_a_b_status")
@@ -614,6 +865,9 @@ func TestCollector_CollectJobStatus(t *testing.T) {
 
 			c := New()
 			c.db = db
+			if tc.configureCollector != nil {
+				tc.configureCollector(c)
+			}
 			tc.prepareMock(mock)
 
 			mx := make(map[string]int64)

--- a/src/go/plugin/go.d/collector/mssql/queries.go
+++ b/src/go/plugin/go.d/collector/mssql/queries.go
@@ -219,22 +219,27 @@ ORDER BY name, job_id;
 `
 
 // queryJobLastExecutions gets the latest completed SQL Agent job execution.
-const queryJobLastExecutions = `
+const queryJobLastExecutionsHead = `
 WITH final_summary_rows AS (
   SELECT
-    job_id,
-    instance_id,
-    run_status,
-    run_date,
-    run_time,
-    run_duration,
+    sh.job_id,
+    sh.instance_id,
+    sh.run_status,
+    sh.run_date,
+    sh.run_time,
+    sh.run_duration,
     ROW_NUMBER() OVER (
-      PARTITION BY job_id
-      ORDER BY instance_id DESC
+      PARTITION BY sh.job_id
+      ORDER BY sh.instance_id DESC
     ) AS row_num
-  FROM msdb.dbo.sysjobhistory
-  WHERE step_id = 0
-    AND run_status IN (0, 1, 3)
+  FROM msdb.dbo.sysjobhistory AS sh
+  JOIN msdb.dbo.sysjobs AS j
+    ON j.job_id = sh.job_id
+  WHERE sh.step_id = 0
+    AND sh.run_status IN (0, 1, 3)
+`
+
+const queryJobLastExecutionsTail = `
 ),
 latest_final_summary AS (
   SELECT
@@ -307,24 +312,39 @@ LEFT JOIN failed_steps AS fs
   ON fs.job_id = ls.job_id;
 `
 
+const queryJobLastExecutions = queryJobLastExecutionsHead + `  AND j.enabled = 1
+` + queryJobLastExecutionsTail
+
+const queryJobLastExecutionsAll = queryJobLastExecutionsHead + queryJobLastExecutionsTail
+
 // queryJobCurrentExecutions gets current SQL Agent job execution runtime.
-const queryJobCurrentExecutions = `
+const queryJobCurrentExecutionsHead = `
 WITH latest_session AS (
   SELECT MAX(session_id) AS session_id
   FROM msdb.dbo.sysjobactivity
 )
 SELECT
-  CONVERT(varchar(36), job_id) AS job_id,
+  CONVERT(varchar(36), ja.job_id) AS job_id,
   CASE
-    WHEN start_execution_date IS NOT NULL
-     AND stop_execution_date IS NULL
-     AND DATEDIFF(second, start_execution_date, GETDATE()) > 0
-      THEN DATEDIFF(second, start_execution_date, GETDATE())
+    WHEN ja.start_execution_date IS NOT NULL
+     AND ja.stop_execution_date IS NULL
+     AND DATEDIFF(second, ja.start_execution_date, GETDATE()) > 0
+      THEN DATEDIFF(second, ja.start_execution_date, GETDATE())
     ELSE 0
   END AS current_execution_time_seconds
-FROM msdb.dbo.sysjobactivity
-WHERE session_id = (SELECT session_id FROM latest_session);
+FROM msdb.dbo.sysjobactivity AS ja
+JOIN msdb.dbo.sysjobs AS j
+  ON j.job_id = ja.job_id
+WHERE ja.session_id = (SELECT session_id FROM latest_session)
 `
+
+const queryJobCurrentExecutionsTail = `;
+`
+
+const queryJobCurrentExecutions = queryJobCurrentExecutionsHead + `  AND j.enabled = 1
+` + queryJobCurrentExecutionsTail
+
+const queryJobCurrentExecutionsAll = queryJobCurrentExecutionsHead + queryJobCurrentExecutionsTail
 
 // querySQLErrors gets SQL error counts from performance counters
 const querySQLErrors = `

--- a/src/go/plugin/go.d/collector/mssql/testdata/config.json
+++ b/src/go/plugin/go.d/collector/mssql/testdata/config.json
@@ -1,0 +1,29 @@
+{
+  "vnode": "test-vnode",
+  "update_every": 15,
+  "dsn": "sqlserver://localhost:1433",
+  "timeout": 5,
+  "collect_disabled_jobs": true,
+  "cloud_auth": {
+    "provider": "none"
+  },
+  "functions": {
+    "top_queries": {
+      "disabled": false,
+      "timeout": 0,
+      "limit": 500,
+      "time_window_days": 7
+    },
+    "deadlock_info": {
+      "disabled": false,
+      "timeout": 0,
+      "use_ring_buffer": false
+    },
+    "error_info": {
+      "disabled": false,
+      "timeout": 0,
+      "session_name": "netdata_errors",
+      "use_ring_buffer": false
+    }
+  }
+}

--- a/src/go/plugin/go.d/collector/mssql/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/mssql/testdata/config.yaml
@@ -1,0 +1,16 @@
+vnode: "test-vnode"
+update_every: 15
+dsn: "sqlserver://localhost:1433"
+timeout: 5
+collect_disabled_jobs: yes
+cloud_auth:
+  provider: none
+functions:
+  top_queries:
+    disabled: no
+    limit: 500
+    time_window_days: 7
+  error_info:
+    disabled: no
+    session_name: "netdata_errors"
+    use_ring_buffer: no

--- a/src/go/plugin/go.d/config/go.d/mssql.conf
+++ b/src/go/plugin/go.d/config/go.d/mssql.conf
@@ -14,6 +14,7 @@
 #  - name: full_example
 #    dsn: "sqlserver://netdata_user:password@localhost:1433"
 #    timeout: 5
+#    collect_disabled_jobs: false
 #    functions:
 #      top_queries:
 #        disabled: false

--- a/src/health/health.d/mssql.conf
+++ b/src/health/health.d/mssql.conf
@@ -22,8 +22,7 @@ component: Microsoft SQL Server
     class: Errors
      type: Database
 component: Microsoft SQL Server
-   lookup: average -1m unaligned of warning
-     calc: $this * ${mssql.job_status.enabled}
+     calc: $warning * ${mssql.job_status.enabled}
     units: status
     every: 1m
      warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
@@ -36,8 +35,7 @@ component: Microsoft SQL Server
     class: Errors
      type: Database
 component: Microsoft SQL Server
-   lookup: average -1m unaligned of error
-     calc: $this * ${mssql.job_status.enabled}
+     calc: $error * ${mssql.job_status.enabled}
     units: status
     every: 1m
      crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)

--- a/src/health/health.d/mssql.conf
+++ b/src/health/health.d/mssql.conf
@@ -23,12 +23,12 @@ component: Microsoft SQL Server
      type: Database
 component: Microsoft SQL Server
    lookup: average -1m unaligned of warning
+     calc: $this * ${mssql.job_status.enabled}
     units: status
     every: 1m
-     warn: $this > 0
-    delay: down 5m multiplier 1.5 max 1h
+     warn: ($this == nan or $this == inf) ? (nan) : ($this > 0)
   summary: SQL Server Agent job ${label:job_name} completed with failed steps
-     info: SQL Server Agent job succeeded, but at least one step failed in the last completed execution
+     info: Enabled SQL Server Agent job succeeded, but at least one step failed in the last completed execution
        to: dba
 
  template: mssql_sql_agent_job_last_execution_failed
@@ -37,10 +37,10 @@ component: Microsoft SQL Server
      type: Database
 component: Microsoft SQL Server
    lookup: average -1m unaligned of error
+     calc: $this * ${mssql.job_status.enabled}
     units: status
     every: 1m
-     crit: $this > 0
-    delay: down 5m multiplier 1.5 max 1h
+     crit: ($this == nan or $this == inf) ? (nan) : ($this > 0)
   summary: SQL Server Agent job ${label:job_name} failed
-     info: SQL Server Agent job failed in the last completed execution
+     info: Enabled SQL Server Agent job failed in the last completed execution
        to: dba


### PR DESCRIPTION
##### Summary

Disabled SQL Agent jobs now retain only their administrative status metrics by default, preventing stale execution results and timings from polluting charts. Add `collect_disabled_jobs` to restore execution metrics when needed, while stock execution alerts always ignore disabled jobs.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled SQL Server Agent jobs are now excluded from execution metrics by default in `go.d/mssql`; only their enabled/disabled status is reported. Previously they still produced last/current execution data and could trigger alerts; enable `collect_disabled_jobs` to restore these metrics, and stock execution alerts now fire only when a job is enabled.

- Refactors
  - Job status charts are always present; execution charts are added or removed as a job’s enabled state changes.
  - Execution queries now filter to enabled jobs; “All” query variants are used when collecting disabled jobs.

- Migration
  - To keep execution charts for disabled jobs, set `collect_disabled_jobs: true` in `go.d/mssql.conf`.
  - Enabling this adds four charts and eight dimensions per disabled job.

<sup>Written for commit 79b136f54b638e69d47ad315299703ec42a0486a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to collect execution metrics for disabled SQL Server Agent jobs.
  - Added SQL Agent configuration settings to the MSSQL collector UI and example configuration.
  - Improved chart handling as jobs are added, removed, or enabled/disabled.

- **Bug Fixes**
  - Health alerts now apply only to enabled jobs and handle unavailable metric values safely.
  - Improved cleanup and reassignment of job execution charts.

- **Documentation**
  - Documented disabled-job collection behavior, defaults, and related metric considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->