### PR TITLE
fix(dbengine): prevent negative tier retention reporting

### DIFF
--- a/src/database/contexts/api_v2_contexts_agents.c
+++ b/src/database/contexts/api_v2_contexts_agents.c
@@ -100,7 +100,11 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
                 buffer_json_member_add_double(wb, "disk_percent", rounded_percent);
             }
 
-            if(tier_info->first_time_s < tier_info->last_time_s) {
+            // rrdstats_retention_collect() sets retention only when the tier has a
+            // known retention start; do not re-derive the condition from
+            // first_time_s here, or a zero (unknown) first_time_s publishes
+            // "from" as the unix epoch.
+            if(tier_info->retention) {
                 buffer_json_member_add_time_t_formatted(wb, "from", tier_info->first_time_s, options & CONTEXTS_OPTION_RFC3339);
                 buffer_json_member_add_time_t_formatted(wb, "to", tier_info->last_time_s, options & CONTEXTS_OPTION_RFC3339);
                 buffer_json_member_add_time_t(wb, "retention", tier_info->retention);

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1336,11 +1336,18 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
         , ((double)(ended_ut - started_ut) / USEC_PER_MS)
         );
 
-    time_t old = __atomic_load_n(&ctx->atomic.first_time_s, __ATOMIC_RELAXED);;
-    do {
-        if(old <= global_first_time_s)
-            break;
-    } while(!__atomic_compare_exchange_n(&ctx->atomic.first_time_s, &old, global_first_time_s, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
+    // A zero header start time is the "this journal has no metrics" marker
+    // written by journalfile_migrate_to_v2_callback(); it is not a retention
+    // start. Letting it win the MIN below pins the whole tier's global first
+    // time to the epoch permanently, for every consumer of
+    // storage_engine_global_first_time_s().
+    if(global_first_time_s > 0) {
+        time_t old = __atomic_load_n(&ctx->atomic.first_time_s, __ATOMIC_RELAXED);
+        do {
+            if(old <= global_first_time_s)
+                break;
+        } while(!__atomic_compare_exchange_n(&ctx->atomic.first_time_s, &old, global_first_time_s, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
+    }
 }
 
 int journalfile_v2_load(struct rrdengine_instance *ctx, struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile)

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1336,11 +1336,11 @@ void journalfile_v2_populate_retention_to_mrg(struct rrdengine_instance *ctx, st
         , ((double)(ended_ut - started_ut) / USEC_PER_MS)
         );
 
-    // A zero header start time is the "this journal has no metrics" marker
-    // written by journalfile_migrate_to_v2_callback(); it is not a retention
-    // start. Letting it win the MIN below pins the whole tier's global first
-    // time to the epoch permanently, for every consumer of
-    // storage_engine_global_first_time_s().
+    // A zero header start time means this v2 file carries no usable retention
+    // start (a header written by an older agent, or one whose metrics had an
+    // unknown first time); it is not a retention start of the epoch. Letting it
+    // win the MIN below pins the whole tier's global first time to the epoch
+    // permanently, for every consumer of storage_engine_global_first_time_s().
     if(global_first_time_s > 0) {
         time_t old = __atomic_load_n(&ctx->atomic.first_time_s, __ATOMIC_RELAXED);
         do {

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1275,7 +1275,10 @@ static time_t find_uuid_first_time(
         if (no_signal_received) {
             time_t journal_start_time_s = (time_t)(j2_header->start_time_ut / USEC_PER_SEC);
 
-            if (journal_start_time_s < global_first_time_s)
+            // same as journalfile_v2_populate_retention_to_mrg(): a zero header
+            // start time means the journal has no metrics, not that its
+            // retention starts at the epoch
+            if (journal_start_time_s > 0 && journal_start_time_s < global_first_time_s)
                 global_first_time_s = journal_start_time_s;
 
             size_t metric_offset = j2_header->metric_offset;

--- a/src/database/rrd-retention.c
+++ b/src/database/rrd-retention.c
@@ -112,13 +112,17 @@ RRDSTATS_RETENTION rrdstats_retention_collect(void) {
                 // push the product past time_t's range, and an out-of-range
                 // floating-point to integer conversion is undefined - it can
                 // itself yield a negative value that a later clamp cannot fix.
+                // The clamp bound never goes below requested_retention, so a tier
+                // configured for a longer retention than MAX_EXPECTED_RETENTION_S never
+                // publishes an expected retention lower than the requested one.
+                time_t max_retention = MAX(MAX_EXPECTED_RETENTION_S, tier_info->requested_retention);
                 time_t space_retention = 0;
                 if(tier_info->disk_percent > 0) {
                     double extrapolated =
                         (double)(now_s - tier_info->first_time_s) * 100.0 / tier_info->disk_percent;
 
-                    space_retention = (extrapolated >= (double)MAX_EXPECTED_RETENTION_S)
-                                          ? MAX_EXPECTED_RETENTION_S
+                    space_retention = (extrapolated >= (double)max_retention)
+                                          ? max_retention
                                           : (time_t)extrapolated;
                 }
 

--- a/src/database/rrd-retention.c
+++ b/src/database/rrd-retention.c
@@ -8,8 +8,10 @@
 // The expected retention is an extrapolation of the current disk usage
 // (elapsed * 100 / disk_percent). On a mostly empty quota it grows without
 // bound: a 20 GiB tier with a few KiB used extrapolates to centuries. Cap it,
-// so the published value stays a plausible duration.
-#define MAX_EXPECTED_RETENTION_S (10 * 365 * 86400)
+// so the published value stays a plausible duration. The ceiling is set high
+// enough not to truncate realistic long estimates - a 20 GiB tier ingesting
+// ~1 GiB/year legitimately extrapolates to ~21 years.
+#define MAX_EXPECTED_RETENTION_S (25 * 365 * 86400)
 
 // Round retention time to more human-readable values (days/hours/minutes)
 static time_t round_retention(time_t retention_seconds) {

--- a/src/database/rrd-retention.c
+++ b/src/database/rrd-retention.c
@@ -5,6 +5,12 @@
 #include "rrd-retention.h"
 #include "libnetdata/parsers/duration.h"
 
+// The expected retention is an extrapolation of the current disk usage
+// (elapsed * 100 / disk_percent). On a mostly empty quota it grows without
+// bound: a 20 GiB tier with a few KiB used extrapolates to centuries. Cap it,
+// so the published value stays a plausible duration.
+#define MAX_EXPECTED_RETENTION_S (10 * 365 * 86400)
+
 // Round retention time to more human-readable values (days/hours/minutes)
 static time_t round_retention(time_t retention_seconds) {
     if(retention_seconds > 60 * 86400)
@@ -75,12 +81,16 @@ RRDSTATS_RETENTION rrdstats_retention_collect(void) {
         tier_info->first_time_s = storage_engine_global_first_time_s(eng->seb, localhost->db[tier].si);
         tier_info->last_time_s = now_s;
         
-        if(tier_info->first_time_s < tier_info->last_time_s) {
+        // first_time_s zero means the storage engine does not know the start of
+        // the retention - rrdeng_global_first_time_s() normalizes both LONG_MAX
+        // (nothing loaded yet) and negatives to zero. It is not 1970: treating
+        // it as a timestamp reports the whole unix epoch as retention.
+        if(tier_info->first_time_s > 0 && tier_info->first_time_s < tier_info->last_time_s) {
             tier_info->retention = tier_info->last_time_s - tier_info->first_time_s;
-            
+
             // Format human-readable retention
-            duration_snprintf(tier_info->retention_human, sizeof(tier_info->retention_human),
-                             round_retention(tier_info->retention), "s", false);
+            duration_snprintf_time_t(tier_info->retention_human, sizeof(tier_info->retention_human),
+                                     round_retention(tier_info->retention));
 
             if(tier_info->disk_used || tier_info->disk_max) {
                 // Get requested retention time
@@ -91,21 +101,32 @@ RRDSTATS_RETENTION rrdstats_retention_collect(void) {
 #endif
 
                 // Format human-readable requested retention
-                duration_snprintf(tier_info->requested_retention_human, sizeof(tier_info->requested_retention_human),
-                                 (int)tier_info->requested_retention, "s", false);
+                duration_snprintf_time_t(tier_info->requested_retention_human, sizeof(tier_info->requested_retention_human),
+                                         tier_info->requested_retention);
 
-                // Calculate expected retention based on current usage
+                // Calculate expected retention based on current usage.
+                // Clamp in double space, BEFORE converting: a very small
+                // disk_percent (a nearly empty database on a huge disk_max) can
+                // push the product past time_t's range, and an out-of-range
+                // floating-point to integer conversion is undefined - it can
+                // itself yield a negative value that a later clamp cannot fix.
                 time_t space_retention = 0;
-                if(tier_info->disk_percent > 0)
-                    space_retention = (time_t)((double)(now_s - tier_info->first_time_s) * 100.0 / tier_info->disk_percent);
-                
-                tier_info->expected_retention = (tier_info->requested_retention && tier_info->requested_retention < space_retention) 
-                                              ? tier_info->requested_retention 
+                if(tier_info->disk_percent > 0) {
+                    double extrapolated =
+                        (double)(now_s - tier_info->first_time_s) * 100.0 / tier_info->disk_percent;
+
+                    space_retention = (extrapolated >= (double)MAX_EXPECTED_RETENTION_S)
+                                          ? MAX_EXPECTED_RETENTION_S
+                                          : (time_t)extrapolated;
+                }
+
+                tier_info->expected_retention = (tier_info->requested_retention && tier_info->requested_retention < space_retention)
+                                              ? tier_info->requested_retention
                                               : space_retention;
 
                 // Format human-readable expected retention
-                duration_snprintf(tier_info->expected_retention_human, sizeof(tier_info->expected_retention_human),
-                                 (int)round_retention(tier_info->expected_retention), "s", false);
+                duration_snprintf_time_t(tier_info->expected_retention_human, sizeof(tier_info->expected_retention_human),
+                                         round_retention(tier_info->expected_retention));
             }
         }
         else {

--- a/src/libnetdata/inicfg/inicfg_api.c
+++ b/src/libnetdata/inicfg/inicfg_api.c
@@ -415,7 +415,7 @@ static STRING *reformat_duration_days_to_seconds(STRING *value) {
 
 time_t inicfg_get_duration_days_to_seconds(struct config *root, const char *section, const char *name, unsigned default_value_seconds) {
     char default_str[128];
-    duration_snprintf(default_str, sizeof(default_str), (int)default_value_seconds, "s", false);
+    duration_snprintf(default_str, sizeof(default_str), (int64_t)default_value_seconds, "s", false);
 
     struct config_option *opt = inicfg_get_raw_value(
         root, section, name, default_str,


### PR DESCRIPTION
##### Summary
- Avoid 32-bit truncation when formatting retention durations.
- Treat unknown/zero retention start times as unavailable instead of Unix epoch.
- Ignore zero-start journal headers when calculating global retention.
- Cap extrapolated expected retention and keep API fields internally consistent.
- Add a check to not emit wrong retention values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected retention ranges when the start time is unknown, preventing them from incorrectly displaying the Unix epoch.
  * Ignored empty journals when calculating retention start times.
  * Prevented invalid or excessively large retention values from being reported.
  * Improved formatting for human-readable retention durations.
  * Updated default duration handling for more accurate values.
  * Improved retention reporting consistency across database and journal data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->