### PR TITLE
Drop retries on artifact downloads.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -612,15 +612,11 @@ jobs:
       - name: Retrieve Windows Artifacts
         id: fetch-windows
         if: needs.file-check.outputs.run == 'true'
-        uses: Wandalen/wretry.action@v3
+        uses: actions/download-artifact@v4
         with:
-          action: actions/download-artifact@v4
-          with: |
-            pattern: windows-*-installer
-            path: dist-artifacts
-            merge-multiple: true
-          attempt_limit: 3
-          attempt_delay: 2000
+          pattern: windows-*-installer
+          path: dist-artifacts
+          merge-multiple: true
       - name: Install Netdata
         id: install-netdata
         if: needs.file-check.outputs.run == 'true'
@@ -684,27 +680,19 @@ jobs:
       - name: Retrieve Build Artifacts
         id: fetch-dist
         if: needs.file-check.outputs.run == 'true'
-        uses: Wandalen/wretry.action@v3
+        uses: actions/download-artifact@v4
         with:
-          action: actions/download-artifact@v4
-          with: |
-            pattern: dist-*
-            path: dist-artifacts
-            merge-multiple: true
-          attempt_limit: 3
-          attempt_delay: 2000
+          pattern: dist-*
+          path: dist-artifacts
+          merge-multiple: true
       - name: Retrieve Windows Artifacts
         id: fetch-windows
         if: needs.file-check.outputs.run == 'true'
-        uses: Wandalen/wretry.action@v3
+        uses: actions/download-artifact@v4
         with:
-          action: actions/download-artifact@v4
-          with: |
-            pattern: windows-*-installer
-            path: dist-artifacts
-            merge-multiple: true
-          attempt_limit: 3
-          attempt_delay: 2000
+          pattern: windows-*-installer
+          path: dist-artifacts
+          merge-multiple: true
       - name: Prepare Artifacts
         id: consolidate
         if: needs.file-check.outputs.run == 'true'
@@ -775,14 +763,10 @@ jobs:
       - name: Fetch artifacts
         id: fetch
         if: needs.file-check.outputs.run == 'true'
-        uses: Wandalen/wretry.action@v3
+        uses: actions/download-artifact@v4
         with:
-          action: actions/download-artifact@v4
-          with: |
-            name: final-artifacts
-            path: artifacts
-          attempt_limit: 3
-          attempt_delay: 2000
+          name: final-artifacts
+          path: artifacts
       - name: Prepare artifacts directory
         id: prepare
         if: needs.file-check.outputs.run == 'true'
@@ -846,14 +830,10 @@ jobs:
       - name: Fetch artifacts
         id: fetch-artifacts
         if: needs.file-check.outputs.run == 'true'
-        uses: Wandalen/wretry.action@v3
+        uses: actions/download-artifact@v4
         with:
-          action: actions/download-artifact@v4
-          with: |
-            name: final-artifacts
-            path: artifacts
-          attempt_limit: 3
-          attempt_delay: 2000
+          name: final-artifacts
+          path: artifacts
       - name: Prepare artifacts directory
         id: prepare
         if: needs.file-check.outputs.run == 'true'
@@ -917,14 +897,10 @@ jobs:
       - name: Fetch artifacts
         id: fetch-artifacts
         if: needs.file-check.outputs.run == 'true'
-        uses: Wandalen/wretry.action@v3
+        uses: actions/download-artifact@v4
         with:
-          action: actions/download-artifact@v4
-          with: |
-            name: final-artifacts
-            path: artifacts
-          attempt_limit: 3
-          attempt_delay: 2000
+          name: final-artifacts
+          path: artifacts
       - name: Prepare artifacts directory
         id: prepare
         if: needs.file-check.outputs.run == 'true'
@@ -989,14 +965,10 @@ jobs:
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
       - name: Retrieve Artifacts
         id: fetch
-        uses: Wandalen/wretry.action@v3
+        uses: actions/download-artifact@v4
         with:
-          action: actions/download-artifact@v4
-          with: |
-            name: final-artifacts
-            path: final-artifacts
-          attempt_limit: 3
-          attempt_delay: 2000
+          name: final-artifacts
+          path: final-artifacts
       - name: Prepare version info
         id: version
         run: |
@@ -1115,14 +1087,10 @@ jobs:
         uses: actions/checkout@v7
       - name: Retrieve Artifacts
         id: fetch
-        uses: Wandalen/wretry.action@v3
+        uses: actions/download-artifact@v4
         with:
-          action: actions/download-artifact@v4
-          with: |
-            name: final-artifacts
-            path: final-artifacts
-          attempt_limit: 3
-          attempt_delay: 2000
+          name: final-artifacts
+          path: final-artifacts
       - name: Create Release
         id: create-release
         uses: ncipollo/release-action@v1
@@ -1240,20 +1208,16 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Build test environment
         id: build
-        uses: Wandalen/wretry.action@v3
+        uses: docker/build-push-action@v6
         with:
-          action: docker/build-push-action@v6
-          with: |
-            push: false
-            load: true
-            file: .github/dockerfiles/Dockerfile.build_test
-            build-args: |
-              BASE=${{ matrix.distro }}
-              PRE=${{ matrix.env_prep }}
-              RMJSONC=${{ matrix.jsonc_removal }}
-            tags: test:${{ matrix.artifact_key }}
-          attempt_limit: 3
-          attempt_delay: 15000
+          push: false
+          load: true
+          file: .github/dockerfiles/Dockerfile.build_test
+          build-args: |
+            BASE=${{ matrix.distro }}
+            PRE=${{ matrix.env_prep }}
+            RMJSONC=${{ matrix.jsonc_removal }}
+          tags: test:${{ matrix.artifact_key }}
       - name: netdata-installer on ${{ matrix.distro }}
         id: build-cloud
         if: needs.file-check.outputs.run == 'true'


### PR DESCRIPTION
##### Summary

The reason we originally added the retries seems to be a non-issue now, and the action we’re using for the retries hasn’t been updated to handle the Node.JS 20 deprecation, so just get rid of them.

##### Test Plan

CI works on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the retry wrapper from artifact downloads and Docker build steps in CI to eliminate Node.js 20 deprecation issues. Old behavior: up to 3 retries with delays via `Wandalen/wretry.action@v3`; new behavior: direct calls to `actions/download-artifact@v4` and `docker/build-push-action@v6`. This speeds up jobs and removes deprecation warnings, but transient network failures may need a manual re-run.

**Refactors**
- Replace `Wandalen/wretry.action@v3` with direct `actions/download-artifact@v4` calls for dist and Windows artifacts.
- Invoke `docker/build-push-action@v6` directly in the build test job.
- Remove retry limits and delays from all affected steps.

<sup>Written for commit f28a72be572386b69818f27064fe5ca41f9339a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release workflows to use current artifact download and container build actions directly.
  * Simplified Windows testing, artifact consolidation, verification, and release automation.
  * Removed custom retry-wrapper configuration from CI workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->