### PR TITLE
fix(pulse): prevent redundant chart metadata version bumps

### DIFF
--- a/src/daemon/pulse/pulse-parents.c
+++ b/src/daemon/pulse/pulse-parents.c
@@ -371,7 +371,7 @@ static void pulse_child_chart_labels(RRDSET *st, RRDHOST *host) {
 // dictionary write (conflict callback, destroy_lock trylock, collection reinitialise) and is only
 // needed the first time each dimension appears, so look it up first and fall back to creating it.
 static inline RRDDIM *pulse_child_dim(RRDSET *st, const char *id, collected_number multiplier, RRD_ALGORITHM algorithm) {
-    // rrdddim_find_active() only hides an obsolete dimension when its chart is ALSO undiscoverable
+    // rrddim_find_active() only hides an obsolete dimension when its chart is ALSO undiscoverable
     // (rrdset_is_discoverable()), and these pulse charts are never obsolete - so it can hand back an
     // obsolete dimension. Returning it unrevived would defer revival to rrdset_done(), which logs
     // "has the OBSOLETE flag set, but it is collected" as an error. Fall through to rrddim_add(),

--- a/src/daemon/pulse/pulse-parents.c
+++ b/src/daemon/pulse/pulse-parents.c
@@ -367,6 +367,22 @@ static void pulse_child_chart_labels(RRDSET *st, RRDHOST *host) {
     rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
 }
 
+// The per-child charts are refreshed on every pulse step, for every streamed host. rrddim_add() is a
+// dictionary write (conflict callback, destroy_lock trylock, collection reinitialise) and is only
+// needed the first time each dimension appears, so look it up first and fall back to creating it.
+static inline RRDDIM *pulse_child_dim(RRDSET *st, const char *id, collected_number multiplier, RRD_ALGORITHM algorithm) {
+    // rrdddim_find_active() only hides an obsolete dimension when its chart is ALSO undiscoverable
+    // (rrdset_is_discoverable()), and these pulse charts are never obsolete - so it can hand back an
+    // obsolete dimension. Returning it unrevived would defer revival to rrdset_done(), which logs
+    // "has the OBSOLETE flag set, but it is collected" as an error. Fall through to rrddim_add(),
+    // whose pre-lookup revives it properly.
+    RRDDIM *rd = rrddim_find_active(st, id);
+    if(likely(rd && !rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)))
+        return rd;
+
+    return rrddim_add(st, id, NULL, multiplier, 1, algorithm);
+}
+
 static void pulse_child_charts_update(RRDHOST *host, PULSE_INBOUND_STATE state) {
     char id[RRD_ID_LENGTH_MAX + 1];
     const char *guid = host->machine_guid;
@@ -386,9 +402,9 @@ static void pulse_child_charts_update(RRDHOST *host, PULSE_INBOUND_STATE state) 
         130160, localhost->rrd_update_every, RRDSET_TYPE_AREA);
     if(unlikely(refresh_labels || !rrdlabels_exist(st_traffic->rrdlabels, "machine_guid")))
         pulse_child_chart_labels(st_traffic, host);
-    rrddim_set_by_pointer(st_traffic, rrddim_add(st_traffic, "in", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL),
+    rrddim_set_by_pointer(st_traffic, pulse_child_dim(st_traffic, "in", 1, RRD_ALGORITHM_INCREMENTAL),
         (collected_number)single_writer_atomic_read(&host->stream.rcv.status.bytes_in));
-    rrddim_set_by_pointer(st_traffic, rrddim_add(st_traffic, "out", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL),
+    rrddim_set_by_pointer(st_traffic, pulse_child_dim(st_traffic, "out", -1, RRD_ALGORITHM_INCREMENTAL),
         (collected_number)single_writer_atomic_read(&host->stream.rcv.status.bytes_out));
     rrdset_done(st_traffic);
 
@@ -410,7 +426,7 @@ static void pulse_child_charts_update(RRDHOST *host, PULSE_INBOUND_STATE state) 
         pulse_child_chart_labels(st_state, host);
     for(size_t i = 0; i < PULSE_INBOUND_MAX ; i++) {
         if(!state_dim[i]) continue;
-        rrddim_set_by_pointer(st_state, rrddim_add(st_state, state_dim[i], NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE),
+        rrddim_set_by_pointer(st_state, pulse_child_dim(st_state, state_dim[i], 1, RRD_ALGORITHM_ABSOLUTE),
             (collected_number)(state == i ? 1 : 0));
     }
     rrdset_done(st_state);
@@ -423,7 +439,7 @@ static void pulse_child_charts_update(RRDHOST *host, PULSE_INBOUND_STATE state) 
         130162, localhost->rrd_update_every, RRDSET_TYPE_LINE);
     if(unlikely(refresh_labels || !rrdlabels_exist(st_reconnects->rrdlabels, "machine_guid")))
         pulse_child_chart_labels(st_reconnects, host);
-    rrddim_set_by_pointer(st_reconnects, rrddim_add(st_reconnects, "connections", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL),
+    rrddim_set_by_pointer(st_reconnects, pulse_child_dim(st_reconnects, "connections", 1, RRD_ALGORITHM_INCREMENTAL),
         (collected_number)__atomic_load_n(&host->stream.rcv.status.connections, __ATOMIC_RELAXED));
     rrdset_done(st_reconnects);
 
@@ -437,7 +453,7 @@ static void pulse_child_charts_update(RRDHOST *host, PULSE_INBOUND_STATE state) 
         pulse_child_chart_labels(st_age, host);
     time_t changed = __atomic_load_n(&host->stream.rcv.status.state_changed_s, __ATOMIC_RELAXED);
     time_t now_s = now_realtime_sec();
-    rrddim_set_by_pointer(st_age, rrddim_add(st_age, "age", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE),
+    rrddim_set_by_pointer(st_age, pulse_child_dim(st_age, "age", 1, RRD_ALGORITHM_ABSOLUTE),
         (collected_number)((changed && now_s > changed) ? now_s - changed : 0));
     rrdset_done(st_age);
 }

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1619,6 +1619,74 @@ static int test_rrdmetric_algorithm_follows_rrddim(void) {
     return rc;
 }
 
+static int test_rrddim_add_does_not_bump_metadata_version(void) {
+    fprintf(stderr, "%s() running...\n", __FUNCTION__);
+
+    RRD_DB_MODE old_default_rrd_memory_mode = default_rrd_memory_mode;
+    default_rrd_memory_mode = RRD_DB_MODE_ALLOC;
+
+    int rc = 0;
+
+    RRDSET *st = rrdset_create_localhost(
+        "netdata", "unittest-metadata-version", "unittest-metadata-version", "netdata", NULL,
+        "Unit Testing", "x", "unittest", NULL, 1,
+        nd_profile.update_every, RRDSET_TYPE_LINE);
+
+    RRDDIM *rd = rrddim_add(st, "dim1", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    // An unchanged rrddim_add() must not bump the chart metadata version: the streaming sender
+    // treats a bump as "re-send the whole chart definition upstream" (rrdset_check_upstream_exposed()).
+    uint32_t before = rrdset_metadata_version(st);
+    for(int i = 0; i < 5 ;i++)
+        rrddim_add(st, "dim1", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    if(rrdset_metadata_version(st) != before) {
+        fprintf(stderr, "%s: repeated rrddim_add() bumped the chart metadata version (%u -> %u)\n",
+                __FUNCTION__, before, rrdset_metadata_version(st));
+        rc = 1;
+    }
+
+    // A genuinely obsolete dimension must still be revived, and that revival must bump the version
+    // exactly once so the parent learns the chart is collected again.
+    rrddim_is_obsolete___safe_from_collector_thread(st, rd);
+
+    // ...and repeating the obsolete declaration must not bump it again either.
+    before = rrdset_metadata_version(st);
+    for(int i = 0; i < 5 ;i++)
+        rrddim_is_obsolete___safe_from_collector_thread(st, rd);
+    if(rrdset_metadata_version(st) != before) {
+        fprintf(stderr, "%s: repeated rrddim_is_obsolete() bumped the chart metadata version\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    before = rrdset_metadata_version(st);
+
+    rrddim_add(st, "dim1", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    if(rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
+        fprintf(stderr, "%s: obsolete dimension was not revived by rrddim_add()\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    if(rrdset_metadata_version(st) == before) {
+        fprintf(stderr, "%s: reviving an obsolete dimension did not bump the chart metadata version\n",
+                __FUNCTION__);
+        rc = 1;
+    }
+
+    // ...and once revived, further identical adds must go quiet again.
+    before = rrdset_metadata_version(st);
+    rrddim_add(st, "dim1", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    if(rrdset_metadata_version(st) != before) {
+        fprintf(stderr, "%s: rrddim_add() on a revived dimension bumped the version again\n", __FUNCTION__);
+        rc = 1;
+    }
+
+    rrdset_is_obsolete___safe_from_collector_thread(st);
+    default_rrd_memory_mode = old_default_rrd_memory_mode;
+    return rc;
+}
+
 static int test_rrddim_scale_minimum_magnitude(void) {
     fprintf(stderr, "%s() running...\n", __FUNCTION__);
 
@@ -2322,6 +2390,9 @@ int run_all_mockup_tests(void)
         return 1;
 
     if(test_rrdmetric_algorithm_follows_rrddim())
+        return 1;
+
+    if(test_rrddim_add_does_not_bump_metadata_version())
         return 1;
 
     if(test_rrddim_scale_minimum_magnitude())

--- a/src/daemon/unit_test.c
+++ b/src/daemon/unit_test.c
@@ -1646,9 +1646,16 @@ static int test_rrddim_add_does_not_bump_metadata_version(void) {
         rc = 1;
     }
 
-    // A genuinely obsolete dimension must still be revived, and that revival must bump the version
-    // exactly once so the parent learns the chart is collected again.
+    // Marking a live dimension obsolete is a real state transition, so it MUST bump - exactly once.
+    // Asserting the exact delta (not just "it changed") is what pins the contract: a path that
+    // bumped twice would still re-send the chart definition twice.
+    before = rrdset_metadata_version(st);
     rrddim_is_obsolete___safe_from_collector_thread(st, rd);
+    if(rrdset_metadata_version(st) != before + 1) {
+        fprintf(stderr, "%s: marking a dimension obsolete bumped the version by %u, expected exactly 1\n",
+                __FUNCTION__, rrdset_metadata_version(st) - before);
+        rc = 1;
+    }
 
     // ...and repeating the obsolete declaration must not bump it again either.
     before = rrdset_metadata_version(st);
@@ -1668,9 +1675,9 @@ static int test_rrddim_add_does_not_bump_metadata_version(void) {
         rc = 1;
     }
 
-    if(rrdset_metadata_version(st) == before) {
-        fprintf(stderr, "%s: reviving an obsolete dimension did not bump the chart metadata version\n",
-                __FUNCTION__);
+    if(rrdset_metadata_version(st) != before + 1) {
+        fprintf(stderr, "%s: reviving an obsolete dimension bumped the version by %u, expected exactly 1\n",
+                __FUNCTION__, rrdset_metadata_version(st) - before);
         rc = 1;
     }
 

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -626,6 +626,17 @@ int rrddim_unhide(RRDSET *st, const char *id) {
 }
 
 inline void rrddim_is_obsolete___safe_from_collector_thread(RRDSET *st, RRDDIM *rd) {
+    // Already obsolete - there is no transition to make, and bumping RRDSET.version again would
+    // re-send the whole chart definition upstream. pluginsd_dimension() calls this on every
+    // DIMENSION line carrying the "obsolete" option, so a child that keeps declaring a dimension
+    // obsolete would otherwise re-announce its chart forever.
+    // Skipping the housekeeping flag re-raise is safe: svc_rrdset_archive_obsolete_dimensions()
+    // (daemon/service.c) re-sets RRDSET_FLAG_OBSOLETE_DIMENSIONS itself whenever a candidate could
+    // not be archived in a pass, so cleanup does not depend on the collector re-raising it.
+    // Mirrors rrdset_is_obsolete___safe_from_collector_thread(), which has always been guarded.
+    if(unlikely(rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)))
+        return;
+
     netdata_log_debug(D_RRD_CALLS, "rrddim_is_obsolete___safe_from_collector_thread() for chart %s, dimension %s", rrdset_name(st), rrddim_name(rd));
 
     rrddim_flag_set(rd, RRDDIM_FLAG_OBSOLETE);
@@ -636,6 +647,18 @@ inline void rrddim_is_obsolete___safe_from_collector_thread(RRDSET *st, RRDDIM *
 }
 
 inline void rrddim_isnot_obsolete___safe_from_collector_thread(RRDSET *st __maybe_unused, RRDDIM *rd) {
+    // Nothing to clear when the dimension is not obsolete - and doing the work anyway is not free:
+    // rrdset_metadata_updated() bumps RRDSET.version, which makes rrdset_check_upstream_exposed()
+    // false and re-sends the entire chart definition (incl. every chart label) to the parent. The
+    // hot callers (rrddim_add_custom(), pluginsd_dimension()) reach this on every collection step,
+    // so without this guard every collected dimension re-announces its chart, forever.
+    // This mirrors rrdset_isnot_obsolete___safe_from_collector_thread(), which has always been guarded.
+    // Skipping rrddim_reinitialize_collection() here is safe: it is idempotent (it only fills
+    // rd->tiers[].sch when NULL) and rrddim_conflict_callback() already runs it on every one of
+    // these paths, via the rrddim_add() that precedes them.
+    if(likely(!rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)))
+        return;
+
     netdata_log_debug(D_RRD_CALLS, "rrddim_isnot_obsolete___safe_from_collector_thread() for chart %s, dimension %s", rrdset_name(st), rrddim_name(rd));
 
     rrddim_flag_clear(rd, RRDDIM_FLAG_OBSOLETE);

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -653,9 +653,12 @@ inline void rrddim_isnot_obsolete___safe_from_collector_thread(RRDSET *st __mayb
     // hot callers (rrddim_add_custom(), pluginsd_dimension()) reach this on every collection step,
     // so without this guard every collected dimension re-announces its chart, forever.
     // This mirrors rrdset_isnot_obsolete___safe_from_collector_thread(), which has always been guarded.
-    // Skipping rrddim_reinitialize_collection() here is safe: it is idempotent (it only fills
-    // rd->tiers[].sch when NULL) and rrddim_conflict_callback() already runs it on every one of
-    // these paths, via the rrddim_add() that precedes them.
+    // Skipping rrddim_reinitialize_collection() here is safe: the hot callers that pass a
+    // non-obsolete dimension (rrddim_add_custom(), pluginsd_dimension()) have just run it via
+    // rrddim_conflict_callback() in the rrddim_add() that precedes them, and it is idempotent
+    // anyway (it only fills rd->tiers[].sch when NULL). The callers that revive a genuinely
+    // obsolete dimension (pluginsd_set_v2(), rrdset_done()) already test RRDDIM_FLAG_OBSOLETE
+    // themselves, so this guard never fires for them and the full body below runs.
     if(likely(!rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)))
         return;
 

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -284,8 +284,13 @@ static bool labels_add_already_sanitized(RRDLABELS *labels, const char *key, con
         // observable downstream: stream_send_clabels_callback() serializes it on the wire and
         // exporters filter on its bits. So report a source-only change as a change, otherwise
         // consumers keep a stale source forever.
-        changed = (old_ls & ~(RRDLABEL_FLAG_NEW | RRDLABEL_FLAG_OLD)) !=
-                  (new_ls & ~(RRDLABEL_FLAG_NEW | RRDLABEL_FLAG_OLD));
+        //
+        // Compare with RRDLABEL_FLAG_INTERNAL masked off - the SAME mask
+        // stream_send_clabels_callback() applies before putting the source on the wire. That
+        // matters for RRDLABEL_FLAG_DONT_DELETE: a receiver stores the stripped wire value while
+        // the local copy may carry the flag, so masking only NEW|OLD would report every single
+        // CLABEL_COMMIT as a change and re-announce the chart upstream forever.
+        changed = (old_ls & ~RRDLABEL_FLAG_INTERNAL) != (new_ls & ~RRDLABEL_FLAG_INTERNAL);
     }
     else {
         new_ls |= RRDLABEL_FLAG_NEW;
@@ -1697,6 +1702,14 @@ static int rrdlabels_unittest_change_detection(void) {
               "same key+value with a DIFFERENT source should return true");
     UT_EXPECT(rrdlabels_add_changed(l, "k1", "v1", RRDLABEL_SRC_ACLK) == false,
               "re-add with the same source again should return false");
+    // RRDLABEL_FLAG_DONT_DELETE is part of RRDLABEL_FLAG_INTERNAL and is stripped by
+    // stream_send_clabels_callback() before the source goes on the wire. A receiver therefore
+    // stores the flag-free value while a local copy may carry it; if the comparison did not mask
+    // it, every CLABEL_COMMIT would look like a change and re-announce the chart forever.
+    UT_EXPECT(rrdlabels_add_changed(l, "k1", "v1", RRDLABEL_SRC_ACLK | RRDLABEL_FLAG_DONT_DELETE) == false,
+              "DONT_DELETE differing from the stored value must NOT count as a source change");
+    UT_EXPECT(rrdlabels_add_changed(l, "k1", "v1", RRDLABEL_SRC_ACLK) == false,
+              "...and dropping DONT_DELETE again must NOT count as a change either");
     UT_EXPECT(rrdlabels_add_changed(l, "k1", "v2", RRDLABEL_SRC_CONFIG) == true,
               "value change for an existing key should return true");
     UT_EXPECT(rrdlabels_add_changed(l, "k2", "v2", RRDLABEL_SRC_CONFIG) == true,

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -273,11 +273,19 @@ static bool labels_add_already_sanitized(RRDLABELS *labels, const char *key, con
 
     bool changed;
     if(*PValue) {
+        const RRDLABEL_SRC old_ls = *((RRDLABEL_SRC *)PValue);
+
         new_ls |= RRDLABEL_FLAG_OLD;
         *((RRDLABEL_SRC *)PValue) = new_ls;
 
         delete_label(new_label);
-        changed = false;
+
+        // The key=value pair is unchanged, but the SOURCE may not be - and the source is
+        // observable downstream: stream_send_clabels_callback() serializes it on the wire and
+        // exporters filter on its bits. So report a source-only change as a change, otherwise
+        // consumers keep a stale source forever.
+        changed = (old_ls & ~(RRDLABEL_FLAG_NEW | RRDLABEL_FLAG_OLD)) !=
+                  (new_ls & ~(RRDLABEL_FLAG_NEW | RRDLABEL_FLAG_OLD));
     }
     else {
         new_ls |= RRDLABEL_FLAG_NEW;
@@ -1681,6 +1689,14 @@ static int rrdlabels_unittest_change_detection(void) {
               "add of new label should return true");
     UT_EXPECT(rrdlabels_add_changed(l, "k1", "v1", RRDLABEL_SRC_CONFIG) == false,
               "re-add of identical key+value should return false");
+    // A source-only change must be reported: the source is serialized on the streaming wire
+    // (stream_send_clabels_callback) and exporters filter on its bits, so a missed change
+    // leaves downstream consumers with a stale source. k1=v1 must still exist at this point
+    // for this to exercise the existing-slot branch rather than a fresh insert.
+    UT_EXPECT(rrdlabels_add_changed(l, "k1", "v1", RRDLABEL_SRC_ACLK) == true,
+              "same key+value with a DIFFERENT source should return true");
+    UT_EXPECT(rrdlabels_add_changed(l, "k1", "v1", RRDLABEL_SRC_ACLK) == false,
+              "re-add with the same source again should return false");
     UT_EXPECT(rrdlabels_add_changed(l, "k1", "v2", RRDLABEL_SRC_CONFIG) == true,
               "value change for an existing key should return true");
     UT_EXPECT(rrdlabels_add_changed(l, "k2", "v2", RRDLABEL_SRC_CONFIG) == true,

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -120,6 +120,7 @@ static inline void pluginsd_clear_scope_chart(PARSER *parser, const char *keywor
     parser->user.st = NULL;
     parser->user.cleanup_slots = false;
     parser->user.clabel_count = 0;
+    parser->user.clabel_changed = false;
 }
 
 static ALWAYS_INLINE bool pluginsd_set_scope_chart(PARSER *parser, RRDSET *st, const char *keyword) {
@@ -152,6 +153,7 @@ static ALWAYS_INLINE bool pluginsd_set_scope_chart(PARSER *parser, RRDSET *st, c
     parser->user.st = st;
     parser->user.cleanup_slots = false;
     parser->user.clabel_count = 0;
+    parser->user.clabel_changed = false;
 
     return true;
 }

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -851,7 +851,8 @@ static inline PARSER_RC pluginsd_clabel(char **words, size_t num_words, PARSER *
     if(unlikely(parser->user.clabel_count++ == 0))
         rrdlabels_unmark_all(st->rrdlabels);
 
-    rrdlabels_add(st->rrdlabels, name, value, str2l(label_source));
+    if(rrdlabels_add_changed(st->rrdlabels, name, value, str2l(label_source)))
+        parser->user.clabel_changed = true;
 
     return PARSER_RC_OK;
 }
@@ -870,18 +871,26 @@ static inline PARSER_RC pluginsd_clabel_commit(char **words __maybe_unused, size
         return PLUGINSD_DISABLE_PLUGIN(parser, NULL, NULL);
     }
 
-    bool labels_changed = rrdlabels_remove_all_unmarked_and_changed(st->rrdlabels);
+    // rrdlabels_remove_all_unmarked_and_changed() only sees added/removed pairs; a source-only
+    // change lands on an existing slot, so pick that up from the per-CLABEL results.
+    bool labels_changed = rrdlabels_remove_all_unmarked_and_changed(st->rrdlabels) ||
+                          parser->user.clabel_changed;
 
-    rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
-    rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_METADATA_UPDATE);
-    rrdset_metadata_updated(st);
-
+    // CLABEL_COMMIT arrives on every chart definition the child sends, but the labels are usually
+    // identical to what we already hold. Only flag metadata dirty and bump RRDSET.version when they
+    // actually changed - an unconditional bump re-sends the whole chart definition upstream and
+    // re-queues the chart for context post-processing on every commit.
     if(labels_changed) {
+        rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
+        rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_METADATA_UPDATE);
+        rrdset_metadata_updated(st);
+
         rrdset_flag_set(st, RRDSET_FLAG_PENDING_LABEL_RECHECK);
         rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
     }
 
     parser->user.clabel_count = 0;
+    parser->user.clabel_changed = false;
 
     return PARSER_RC_OK;
 }

--- a/src/plugins.d/pluginsd_parser.h
+++ b/src/plugins.d/pluginsd_parser.h
@@ -58,6 +58,7 @@ typedef struct parser_user_object {
     int trust_durations;
     RRDLABELS *new_host_labels;
     size_t clabel_count;
+    bool clabel_changed;                     // any CLABEL in this commit changed a key, value or source
     size_t data_collections_count;
     int enabled;
     bool retry;


### PR DESCRIPTION
##### Summary
- Avoid repeated rrddim_add() metadata churn for unchanged dimensions.
- Cache pulse chart dimensions and correctly revive obsolete dimensions.
- Only resend chart metadata when chart labels or label sources actually change.
- Add regression coverage for metadata-version and label-source changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary chart and label metadata updates when values remain unchanged.
  * Correctly detects label changes, including updates from different sources.
  * Ensured obsolete chart dimensions are restored and refreshed only when needed.
  * Improved chart label processing so health and metadata updates occur only after actual changes.
  * Improved consistency when charts and dimensions are refreshed repeatedly.

* **Tests**
  * Added coverage for repeated dimension declarations, obsolete-dimension transitions, and label source updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->