### PR TITLE
fix(go.d/jobmgr): converge accepted job activation asynchronously

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -249,7 +249,8 @@ Which mechanism each command surface uses:
 | --- | --- | --- |
 | SecretStore DynCfg `add` / `update` / `test` / `remove` | Pre-claim stage | `composition/secret_adapter.go` |
 | Retained pending SecretStore retry | Pre-claim stage | `secrets/pending.go` |
-| Collector job DynCfg `add` / `update` / `enable` / `restart` / `disable` / `remove` | Claim yield on `dyncfg:jobs` | `composition/dyncfg.go` |
+| Collector job DynCfg `add` / `update` / `restart` / `disable` / `remove`, plus non-accepted `enable` | Claim yield on `dyncfg:jobs` | `composition/dyncfg.go` |
+| Applied accepted-job `enable` | Short transaction, then detached accepted-activation owner | `joboutput/accepted_activation.go` |
 | Discovered job reconciliation and autodetection retry | Claim yield on `dyncfg:jobs` | `joboutput/discovery.go` |
 | Dependent-restart children of a Store change | Claim yield on `dyncfg:jobs` | `joboutput/secret_restart.go` |
 
@@ -362,9 +363,10 @@ Who admits, and who does not:
 - **Persistent** file/discovery state keeps only its latest desired replacement and retries after identity release.
 - SecretStore add/update requests, including DynCfg, retain only their latest desired config after retryable
   contention and apply it after the identity releases.
-- Other **synchronous** DynCfg requests are not retained or retried after a busy/contained response. Cancellation
-  prevents queued service-discovery mutations from starting; it does not roll back work that already began while its
-  request context was live.
+- Other **synchronous** DynCfg requests are not retained or retried after a busy/contained response. An applied
+  accepted-job ENABLE is asynchronous instead: it returns `202`, and a run-owned activation worker retains authority
+  through the later terminal transaction. Cancellation prevents queued service-discovery mutations from starting; it
+  does not roll back work that already began while its request context was live.
 
 ### No process-wide slot limit
 
@@ -505,8 +507,9 @@ Two different guarantees apply during replacement:
   outcome.
 
 A proposal rejected before it establishes desired state, or an attempt that cannot start because its physical identity
-is still busy, leaves the incumbent unchanged. Persistent sources retain only their latest desired retry; a
-synchronous DynCfg command reports busy and is not applied later.
+is still busy, leaves the incumbent unchanged. Persistent sources retain only their latest desired retry; an ordinary
+synchronous DynCfg command reports busy and is not applied later. Applied accepted-job ENABLE follows the asynchronous
+ownership path described below.
 
 ```mermaid
 flowchart TD
@@ -608,6 +611,30 @@ flowchart TD
      terminal chart-obsoletion frames only after the managed loop and Function handlers physically quiesce.
    - The `job-runtime` identity stays occupied through cleanup, so a same-job successor cannot start before those
      terminal frames complete.
+
+### Accepted-job activation
+
+An applied graph record in `accepted` is already visible to the daemon but has no installed runtime. ENABLE therefore
+uses a dedicated run-owned activation index instead of keeping the Function request open during collector `Init` and
+`Check`:
+
+- The short ENABLE transaction rechecks the accepted record, arms `{run epoch, config UID, activation generation}` in
+  `AfterApply`, returns `202`, and emits `CONFIG ... status accepted`. Repeated ENABLE for that exact config coalesces.
+- The activation worker builds and probes the process-owned candidate outside the Function request, graph claim, and
+  same-resource command lane. A non-cooperative collector can therefore outlive the request without blocking a later
+  disable or removal.
+- Once staging settles, one response-free internal transaction reacquires the ordinary resource lane and graph claim.
+  It rechecks the exact token, config UID, accepted graph state, and absent runtime before consuming the candidate.
+- Success atomically installs the runtime and commits `running`. Probe or construction failure commits `failed`, or
+  removes a plain stock config, and uses the existing autodetection retry policy where applicable. The corresponding
+  STATUS or DELETE frame is emitted only after the terminal transaction applies.
+- Any applied disable, removal, replacement, different config UID, or run stop revokes publication authority. A late
+  physical result then becomes a silent no-op; it cannot overwrite the newer graph state or emit a stale STATUS.
+- An unexpected terminal preparation, application, cleanup, or submission failure fails the run closed. The owner does
+  not blindly resubmit because the transaction may already have committed.
+
+This owner is intentionally limited to `accepted -> running|failed/removed`. Running UPDATE/RESTART and non-accepted
+ENABLE retain their synchronous transaction semantics.
 
 ### Job generations and fencing
 
@@ -1002,8 +1029,8 @@ Job Manager separates two lifetimes:
   resolver, the process-attempt and Store epoch authorities, the vnode registry, and the runtime metrics service.
 - **The run generation is the current tenant.** A complete, self-contained occupant built by `composition/run.go`: the
   kernel and its loop, the task supervisor, the run supervisor, the DynCfg graph, the run-owned SecretStore
-  controller/dependency projections, Function catalog projections and publications, the job factory, the autodetection
-  scheduler, and the `jobmgr.runtime` metrics.
+  controller/dependency projections, Function catalog projections and publications, the job factory, the accepted-job
+  activation owner, the autodetection scheduler, and the `jobmgr.runtime` metrics.
 
 A **SIGHUP reload tries to evict the whole tenant and move a fresh one in without touching the building.** The host
 gives the complete rotation one 30-second budget. If it expires, or a quarantined agent-module identity makes an

--- a/src/go/plugin/agent/jobmgr/composition/run.go
+++ b/src/go/plugin/agent/jobmgr/composition/run.go
@@ -363,7 +363,7 @@ func (rg *runGeneration) startWithRunContext(
 	rg.mu.Lock()
 	rg.started = true
 	rg.mu.Unlock()
-	if err := rg.dyncfg.BindAutoDetectionRetries(
+	if err := rg.dyncfg.BindBackgroundWorkers(
 		rg.kernel,
 		rg.run.Generation(),
 		func(err error) {
@@ -432,7 +432,7 @@ func (rg *runGeneration) abortConstruction() error {
 
 func (rg *runGeneration) Stop() {
 	if rg != nil && rg.kernel != nil {
-		rg.scheduler.StopAutoDetectionRetries()
+		rg.scheduler.StopBackgroundWorkers()
 		rg.kernel.Stop()
 	}
 }
@@ -444,10 +444,10 @@ func (rg *runGeneration) Wait(ctx context.Context) error {
 	waitErr := rg.kernel.Wait(ctx)
 	select {
 	case <-rg.kernel.Done():
-		rg.scheduler.StopAutoDetectionRetries()
+		rg.scheduler.StopBackgroundWorkers()
 	default:
 	}
-	return errors.Join(waitErr, rg.scheduler.WaitAutoDetectionRetries(ctx))
+	return errors.Join(waitErr, rg.scheduler.WaitBackgroundWorkers(ctx))
 }
 
 type runMetricsRegistration struct {

--- a/src/go/plugin/agent/jobmgr/composition/run_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/run_test.go
@@ -5,6 +5,7 @@ package composition
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -366,7 +367,7 @@ func TestRunGenerationKeepsDynCfgRoutePrivateAndUsesSameNamePerJobProtocolID(t *
 	wire := output.String()
 	templateAt := strings.Index(wire, "CONFIG go.d:collector:module create accepted template")
 	createAt := strings.Index(wire, "CONFIG go.d:collector:module:module create accepted job")
-	resultAt := strings.Index(wire, "FUNCTION_RESULT_BEGIN enable 200 application/json")
+	resultAt := strings.Index(wire, "FUNCTION_RESULT_BEGIN enable 202 application/json")
 	statusAt := strings.Index(wire, "CONFIG go.d:collector:module:module status running")
 	require.NotContains(t, wire, `FUNCTION GLOBAL "config"`)
 	require.NotContains(t, wire, `FUNCTION_DEL GLOBAL "config"`)
@@ -383,6 +384,254 @@ func TestRunGenerationKeepsDynCfgRoutePrivateAndUsesSameNamePerJobProtocolID(t *
 	}, time.Second, time.Millisecond)
 
 	closeRunTestUIDs(t, uids)
+}
+
+func TestRunGenerationAcceptedEnableDoesNotBlockDisableBehindNonCooperativeCheck(t *testing.T) {
+	checkEntered := make(chan struct{})
+	checkRelease := make(chan struct{})
+	var cleanupCalls atomic.Int32
+	modules := collectorapi.Registry{
+		"module": {
+			Create: func() collectorapi.CollectorV1 {
+				return &collectorapi.MockCollectorV1{
+					CheckFunc: func(context.Context) error {
+						close(checkEntered)
+						<-checkRelease
+						return nil
+					},
+					CleanupFunc: func(context.Context) {
+						cleanupCalls.Add(1)
+					},
+				}
+			},
+			Config: func() any {
+				return &collectorapi.MockConfiguration{}
+			},
+			AgentFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "method"}}
+			},
+			MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+				return &runTestHandler{cleanup: func() {}}
+			},
+			JobConfigSchema: collectorapi.MockConfigSchema,
+		},
+	}
+	config := confgroup.Config{
+		"module":        "module",
+		"name":          "job",
+		"update_every":  1,
+		"function_only": true,
+	}
+	config.SetProvider(confgroup.TypeDyncfg)
+	config.SetSourceType(confgroup.TypeDyncfg)
+	config.SetSource("test")
+	jobs := testRunJobServices(t)
+	jobs.Defaults = confgroup.Registry{
+		"module": {UpdateEvery: 1},
+	}
+
+	output := newProcessSynchronizedBuffer()
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	uids := lifecycle.NewUIDLedger()
+	generation, err := newTestRunGeneration(t, runGenerationConfig{
+		Generation:      1,
+		ShutdownTimeout: time.Second,
+		UIDs:            uids,
+		Frames:          frames,
+		Modules:         modules,
+		Jobs:            jobs,
+		Discovery:       testRunDiscoveryServicesAccepted(t, config),
+	})
+	require.NoError(t, err)
+	require.NoError(t, generation.start(context.Background()))
+	t.Cleanup(func() {
+		select {
+		case <-checkRelease:
+		default:
+			close(checkRelease)
+		}
+		generation.Stop()
+		require.NoError(t, generation.Wait(context.Background()))
+		closeRunTestUIDs(t, uids)
+	})
+	require.Eventually(t, func() bool {
+		record, ok := generation.vnodes.graph.Lookup(config.FullName())
+		return ok && record.Status == dyncfg.StatusAccepted.String()
+	}, time.Second, time.Millisecond)
+
+	require.NoError(t, generation.kernel.Submit(
+		context.Background(),
+		jobmgr.Request{
+			UID:    "slow-enable",
+			Source: lifecycle.SourceFunction,
+			Route:  "config",
+			Args:   []string{"go.d:collector:module:job", string(dyncfg.CommandEnable)},
+		},
+	))
+	select {
+	case <-checkEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "managed check did not enter")
+	}
+	require.Eventually(t, func() bool {
+		wire := output.String()
+		return strings.Contains(wire, "FUNCTION_RESULT_BEGIN slow-enable 202 application/json") &&
+			strings.Contains(wire, "CONFIG go.d:collector:module:job status accepted")
+	}, time.Second, time.Millisecond)
+
+	require.NoError(t, generation.kernel.Submit(
+		context.Background(),
+		jobmgr.Request{
+			UID:    "disable-during-enable",
+			Source: lifecycle.SourceFunction,
+			Route:  "config",
+			Args:   []string{"go.d:collector:module:job", string(dyncfg.CommandDisable)},
+		},
+	))
+	require.Eventually(t, func() bool {
+		record, ok := generation.vnodes.graph.Lookup(config.FullName())
+		wire := output.String()
+		return ok && record.Status == dyncfg.StatusDisabled.String() &&
+			strings.Contains(wire, "FUNCTION_RESULT_BEGIN disable-during-enable 200 application/json") &&
+			strings.Contains(wire, "CONFIG go.d:collector:module:job status disabled")
+	}, time.Second, time.Millisecond)
+
+	close(checkRelease)
+	require.Eventually(t, func() bool {
+		return cleanupCalls.Load() == 1
+	}, time.Second, time.Millisecond)
+	require.NotContains(t, output.String(), "CONFIG go.d:collector:module:job status running")
+}
+
+func TestRunGenerationAcceptedEnablePublishesLateProbeFailure(t *testing.T) {
+	tests := map[string]struct {
+		sourceType string
+		wantStatus dyncfg.Status
+		wantFrame  string
+	}{
+		"dynamic config becomes failed": {
+			sourceType: confgroup.TypeDyncfg,
+			wantStatus: dyncfg.StatusFailed,
+			wantFrame:  "CONFIG go.d:collector:module:job status failed",
+		},
+		"file config becomes failed": {
+			sourceType: confgroup.TypeUser,
+			wantStatus: dyncfg.StatusFailed,
+			wantFrame:  "CONFIG go.d:collector:module:job status failed",
+		},
+		"plain stock config is removed": {
+			sourceType: confgroup.TypeStock,
+			wantFrame:  "CONFIG go.d:collector:module:job delete",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			checkEntered := make(chan struct{})
+			checkRelease := make(chan struct{})
+			var cleanupCalls atomic.Int32
+			modules := collectorapi.Registry{
+				"module": {
+					Create: func() collectorapi.CollectorV1 {
+						return &collectorapi.MockCollectorV1{
+							CheckFunc: func(context.Context) error {
+								close(checkEntered)
+								<-checkRelease
+								return errors.New("check failed")
+							},
+							CleanupFunc: func(context.Context) {
+								cleanupCalls.Add(1)
+							},
+						}
+					},
+					Config: func() any {
+						return &collectorapi.MockConfiguration{}
+					},
+					JobConfigSchema: collectorapi.MockConfigSchema,
+				},
+			}
+			config := confgroup.Config{
+				"module":       "module",
+				"name":         "job",
+				"update_every": 1,
+			}
+			config.SetProvider(test.sourceType)
+			config.SetSourceType(test.sourceType)
+			config.SetSource("test")
+			jobs := testRunJobServices(t)
+			jobs.Defaults = confgroup.Registry{
+				"module": {UpdateEvery: 1},
+			}
+
+			output := newProcessSynchronizedBuffer()
+			frames, err := lifecycle.NewFrameOwner(output)
+			require.NoError(t, err)
+			uids := lifecycle.NewUIDLedger()
+			generation, err := newTestRunGeneration(t, runGenerationConfig{
+				Generation:      1,
+				ShutdownTimeout: time.Second,
+				UIDs:            uids,
+				Frames:          frames,
+				Modules:         modules,
+				Jobs:            jobs,
+				Discovery:       testRunDiscoveryServicesAccepted(t, config),
+			})
+			require.NoError(t, err)
+			require.NoError(t, generation.start(context.Background()))
+			t.Cleanup(func() {
+				select {
+				case <-checkRelease:
+				default:
+					close(checkRelease)
+				}
+				generation.Stop()
+				require.NoError(t, generation.Wait(context.Background()))
+				closeRunTestUIDs(t, uids)
+			})
+			require.Eventually(t, func() bool {
+				record, ok := generation.vnodes.graph.Lookup(config.FullName())
+				return ok && record.Status == dyncfg.StatusAccepted.String()
+			}, time.Second, time.Millisecond)
+
+			require.NoError(t, generation.kernel.Submit(
+				context.Background(),
+				jobmgr.Request{
+					UID:    "late-failure",
+					Source: lifecycle.SourceFunction,
+					Route:  "config",
+					Args:   []string{"go.d:collector:module:job", string(dyncfg.CommandEnable)},
+				},
+			))
+			select {
+			case <-checkEntered:
+			case <-time.After(time.Second):
+				require.FailNow(t, "test failed", "managed check did not enter")
+			}
+			require.Eventually(t, func() bool {
+				wire := output.String()
+				return strings.Contains(wire, "FUNCTION_RESULT_BEGIN late-failure 202 application/json") &&
+					strings.Contains(wire, "CONFIG go.d:collector:module:job status accepted")
+			}, time.Second, time.Millisecond)
+
+			close(checkRelease)
+			require.Eventually(t, func() bool {
+				record, exists := generation.vnodes.graph.Lookup(config.FullName())
+				if test.sourceType == confgroup.TypeStock {
+					return !exists
+				}
+				return exists && record.Status == test.wantStatus.String()
+			}, time.Second, time.Millisecond)
+			require.Eventually(t, func() bool {
+				wire := output.String()
+				resultAt := strings.Index(wire, "FUNCTION_RESULT_BEGIN late-failure 202 application/json")
+				terminalAt := strings.Index(wire, test.wantFrame)
+				return resultAt >= 0 && terminalAt > resultAt
+			}, time.Second, time.Millisecond)
+			require.Eventually(t, func() bool {
+				return cleanupCalls.Load() == 1
+			}, time.Second, time.Millisecond)
+		})
+	}
 }
 
 func TestRunGenerationShutdownRejectsInFlightJobProbeBeforePublication(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/functions/bundle_containment_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/bundle_containment_test.go
@@ -222,10 +222,19 @@ func (*failedRollbackBundleTestHandler) Cleanup(context.Context) {
 func TestFunctionBundleQuarantineWaitsForEveryActiveInvocation(t *testing.T) {
 	delegate, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
+	firstIdentity := jobmgr.ProcessAttemptIdentity{
+		Namespace: jobmgr.ProcessAttemptFunctionInvocation,
+		Key:       "1/module/agent/invocation/1",
+		Resource:  "module",
+	}
+	secondIdentity := jobmgr.ProcessAttemptIdentity{
+		Namespace: jobmgr.ProcessAttemptFunctionInvocation,
+		Key:       "1/module/agent/invocation/2",
+		Resource:  "module",
+	}
 	attempts := &gatedAwaitAuthority{
 		delegate:    delegate,
-		namespace:   jobmgr.ProcessAttemptFunctionInvocation,
-		ordinal:     2,
+		identity:    secondIdentity,
 		settled:     make(chan struct{}),
 		allowReturn: make(chan struct{}),
 	}
@@ -294,11 +303,6 @@ func TestFunctionBundleQuarantineWaitsForEveryActiveInvocation(t *testing.T) {
 	require.NoError(t, <-firstDone)
 	require.True(t, functionBundleQuarantined(bundle))
 
-	firstIdentity := jobmgr.ProcessAttemptIdentity{
-		Namespace: jobmgr.ProcessAttemptFunctionInvocation,
-		Key:       "1/module/agent/invocation/1",
-		Resource:  "module",
-	}
 	firstReleased, ok := attempts.ProcessAttemptReleased(firstIdentity)
 	require.True(t, ok)
 	close(firstRelease)
@@ -314,11 +318,6 @@ func TestFunctionBundleQuarantineWaitsForEveryActiveInvocation(t *testing.T) {
 
 	close(attempts.allowReturn)
 	require.NoError(t, <-secondDone)
-	secondIdentity := jobmgr.ProcessAttemptIdentity{
-		Namespace: jobmgr.ProcessAttemptFunctionInvocation,
-		Key:       "1/module/agent/invocation/2",
-		Resource:  "module",
-	}
 	secondReleased, ok := attempts.ProcessAttemptReleased(secondIdentity)
 	require.True(t, ok)
 	close(secondRelease)
@@ -503,9 +502,12 @@ func TestContainedAvailabilityPollFencesInvocationBeforeAwaitReturns(t *testing.
 	delegate, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
 	attempts := &gatedAwaitAuthority{
-		delegate:    delegate,
-		namespace:   jobmgr.ProcessAttemptFunctionPoll,
-		ordinal:     1,
+		delegate: delegate,
+		identity: jobmgr.ProcessAttemptIdentity{
+			Namespace: jobmgr.ProcessAttemptFunctionPoll,
+			Key:       "1/module/agent",
+			Resource:  "module",
+		},
 		settled:     make(chan struct{}),
 		allowReturn: make(chan struct{}),
 	}
@@ -580,9 +582,12 @@ func TestContainedInvocationFencesSiblingBeforeAwaitReturns(t *testing.T) {
 	delegate, err := containment.NewAuthority(nil)
 	require.NoError(t, err)
 	attempts := &gatedAwaitAuthority{
-		delegate:    delegate,
-		namespace:   jobmgr.ProcessAttemptFunctionInvocation,
-		ordinal:     1,
+		delegate: delegate,
+		identity: jobmgr.ProcessAttemptIdentity{
+			Namespace: jobmgr.ProcessAttemptFunctionInvocation,
+			Key:       "1/module/agent/invocation/1",
+			Resource:  "module",
+		},
 		settled:     make(chan struct{}),
 		allowReturn: make(chan struct{}),
 	}
@@ -870,11 +875,95 @@ type availabilityPublicationPort struct {
 	published chan PublicationRecord
 }
 
+func TestGatedAwaitAuthorityTargetsPlannedAttemptWhenDelegateReturnsOutOfOrder(t *testing.T) {
+	delegate, err := containment.NewAuthority(nil)
+	require.NoError(t, err)
+	firstIdentity := jobmgr.ProcessAttemptIdentity{
+		Namespace: jobmgr.ProcessAttemptFunctionInvocation,
+		Key:       "1/module/agent/invocation/1",
+		Resource:  "module",
+	}
+	secondIdentity := jobmgr.ProcessAttemptIdentity{
+		Namespace: jobmgr.ProcessAttemptFunctionInvocation,
+		Key:       "1/module/agent/invocation/2",
+		Resource:  "module",
+	}
+	delayed := &delayedAttemptStartAuthority{
+		ProcessAttemptAuthority: delegate,
+		identity:                firstIdentity,
+		entered:                 make(chan struct{}),
+		release:                 make(chan struct{}),
+	}
+	attempts := &gatedAwaitAuthority{
+		delegate:    delayed,
+		identity:    secondIdentity,
+		settled:     make(chan struct{}),
+		allowReturn: make(chan struct{}),
+	}
+	t.Cleanup(func() {
+		select {
+		case <-delayed.release:
+		default:
+			close(delayed.release)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = delegate.Shutdown(ctx)
+	})
+
+	type startResult struct {
+		attempt jobmgr.ProcessAttempt
+		err     error
+	}
+	firstResult := make(chan startResult, 1)
+	go func() {
+		attempt, startErr := attempts.StartProcessAttempt(context.Background(), jobmgr.ProcessAttemptPlan{
+			Identity: firstIdentity,
+			Target:   1,
+			Work:     func(context.Context, jobmgr.ProcessAttemptAdmission) error { return nil },
+		})
+		firstResult <- startResult{attempt: attempt, err: startErr}
+	}()
+	waitBundleContainmentTestValue(t, delayed.entered, "delayed first attempt start")
+
+	secondAttempt, err := attempts.StartProcessAttempt(context.Background(), jobmgr.ProcessAttemptPlan{
+		Identity: secondIdentity,
+		Target:   1,
+		Work:     func(context.Context, jobmgr.ProcessAttemptAdmission) error { return nil },
+	})
+	require.NoError(t, err)
+	close(delayed.release)
+	first := waitBundleContainmentTestValue(t, firstResult, "delayed first attempt return")
+	require.NoError(t, first.err)
+
+	_, firstGated := first.attempt.(*gatedAwaitAttempt)
+	_, secondGated := secondAttempt.(*gatedAwaitAttempt)
+	require.False(t, firstGated)
+	require.True(t, secondGated)
+}
+
+type delayedAttemptStartAuthority struct {
+	jobmgr.ProcessAttemptAuthority
+	identity jobmgr.ProcessAttemptIdentity
+	entered  chan struct{}
+	release  chan struct{}
+}
+
+func (dasa *delayedAttemptStartAuthority) StartProcessAttempt(
+	ctx context.Context,
+	plan jobmgr.ProcessAttemptPlan,
+) (jobmgr.ProcessAttempt, error) {
+	attempt, err := dasa.ProcessAttemptAuthority.StartProcessAttempt(ctx, plan)
+	if err == nil && plan.Identity == dasa.identity {
+		close(dasa.entered)
+		<-dasa.release
+	}
+	return attempt, err
+}
+
 type gatedAwaitAuthority struct {
 	delegate    jobmgr.ProcessAttemptAuthority
-	namespace   jobmgr.ProcessAttemptNamespace
-	ordinal     int32
-	started     atomic.Int32
+	identity    jobmgr.ProcessAttemptIdentity
 	settled     chan struct{}
 	allowReturn chan struct{}
 }
@@ -883,10 +972,9 @@ func (gaa *gatedAwaitAuthority) StartProcessAttempt(
 	ctx context.Context,
 	plan jobmgr.ProcessAttemptPlan,
 ) (jobmgr.ProcessAttempt, error) {
+	gate := plan.Identity == gaa.identity
 	attempt, err := gaa.delegate.StartProcessAttempt(ctx, plan)
-	if err != nil ||
-		plan.Identity.Namespace != gaa.namespace ||
-		gaa.started.Add(1) != gaa.ordinal {
+	if err != nil || !gate {
 		return attempt, err
 	}
 	return &gatedAwaitAttempt{

--- a/src/go/plugin/agent/jobmgr/joboutput/accepted_activation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/accepted_activation.go
@@ -1,0 +1,617 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package joboutput
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"gopkg.in/yaml.v2"
+)
+
+type acceptedActivationToken struct {
+	run        uint64
+	generation uint64
+	uid        string
+}
+
+type acceptedActivationSpec struct {
+	config confgroup.Config
+}
+
+func newAcceptedActivationSpec(config confgroup.Config) (acceptedActivationSpec, error) {
+	if config == nil || config.FullName() == "" || config.UID() == "" {
+		return acceptedActivationSpec{}, errors.New("job output: invalid accepted activation config")
+	}
+	cloned, err := config.Clone()
+	if err != nil {
+		return acceptedActivationSpec{}, err
+	}
+	return acceptedActivationSpec{config: cloned}, nil
+}
+
+type acceptedActivationAttempt struct {
+	spec    acceptedActivationSpec
+	token   acceptedActivationToken
+	stage   *preparedJobCandidate
+	err     error
+	applied *atomic.Bool
+}
+
+func (attempt acceptedActivationAttempt) valid() bool {
+	return attempt.spec.config != nil &&
+		attempt.spec.config.FullName() != "" &&
+		attempt.token.run != 0 &&
+		attempt.token.generation != 0 &&
+		attempt.token.uid != "" &&
+		attempt.applied != nil &&
+		(attempt.stage != nil) != (attempt.err != nil)
+}
+
+func (attempt acceptedActivationAttempt) markApplied() func() {
+	return func() {
+		attempt.applied.Store(true)
+	}
+}
+
+type acceptedActivationPlanner func(acceptedActivationAttempt) (jobmgr.WorkPlan, error)
+
+type acceptedActivationState uint8
+
+const (
+	acceptedActivationStaging acceptedActivationState = iota + 1
+	acceptedActivationTerminal
+)
+
+type acceptedActivationEntry struct {
+	spec   acceptedActivationSpec
+	token  acceptedActivationToken
+	state  acceptedActivationState
+	stage  *preparedJobCandidate
+	cancel chan struct{}
+}
+
+type acceptedActivationIndex struct {
+	mu sync.Mutex
+	wg sync.WaitGroup
+
+	entries     map[string]*acceptedActivationEntry
+	factory     *Factory
+	commands    jobmgr.PreparedCommandPort
+	plan        acceptedActivationPlanner
+	failure     func(error)
+	run         uint64
+	generation  uint64
+	bound       bool
+	closed      bool
+	failed      bool
+	terminalErr error
+	stop        chan struct{}
+	done        chan struct{}
+}
+
+func newAcceptedActivationIndex() *acceptedActivationIndex {
+	return &acceptedActivationIndex{
+		entries: make(map[string]*acceptedActivationEntry),
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+func (aai *acceptedActivationIndex) bind(
+	factory *Factory,
+	commands jobmgr.PreparedCommandPort,
+	plan acceptedActivationPlanner,
+	run uint64,
+	failure func(error),
+) error {
+	if aai == nil || factory == nil || commands == nil || plan == nil || run == 0 || failure == nil {
+		return errors.New("job output: invalid accepted activation binding")
+	}
+	aai.mu.Lock()
+	if aai.bound || aai.closed {
+		aai.mu.Unlock()
+		return errors.New("job output: accepted activations already bound")
+	}
+	aai.factory = factory
+	aai.commands = commands
+	aai.plan = plan
+	aai.failure = failure
+	aai.run = run
+	aai.bound = true
+	aai.mu.Unlock()
+	go aai.join()
+	return nil
+}
+
+func (aai *acceptedActivationIndex) arm(spec acceptedActivationSpec) {
+	if aai == nil || spec.config == nil || spec.config.FullName() == "" || spec.config.UID() == "" {
+		return
+	}
+	id := spec.config.FullName()
+	aai.mu.Lock()
+	if !aai.bound || aai.closed || aai.failed {
+		aai.mu.Unlock()
+		return
+	}
+	if current := aai.entries[id]; current != nil && current.token.uid == spec.config.UID() {
+		aai.mu.Unlock()
+		return
+	}
+	aai.generation++
+	if aai.generation == 0 {
+		aai.mu.Unlock()
+		aai.fail(errors.New("job output: accepted activation generation wrapped"))
+		return
+	}
+	entry := &acceptedActivationEntry{
+		spec: spec,
+		token: acceptedActivationToken{
+			run:        aai.run,
+			generation: aai.generation,
+			uid:        spec.config.UID(),
+		},
+		state:  acceptedActivationStaging,
+		cancel: make(chan struct{}),
+	}
+	previous := aai.detachLocked(id)
+	aai.entries[id] = entry
+	aai.wg.Add(1)
+	aai.mu.Unlock()
+	releaseAcceptedActivationStage(previous, jobmgr.ErrProcessAttemptSuperseded)
+	go aai.runEntry(id, entry)
+}
+
+func (aai *acceptedActivationIndex) runEntry(id string, entry *acceptedActivationEntry) {
+	defer aai.wg.Done()
+	stage, stageErr := aai.factory.newCandidate(entry.spec.config)
+
+	aai.mu.Lock()
+	if aai.closed || aai.failed || aai.entries[id] != entry || entry.state != acceptedActivationStaging {
+		aai.mu.Unlock()
+		releaseAcceptedActivationStage(stage, jobmgr.ErrProcessAttemptSuperseded)
+		return
+	}
+	entry.stage = stage
+	aai.mu.Unlock()
+
+	if stage != nil {
+		stage.Start()
+		select {
+		case <-stage.Ready():
+		case <-entry.cancel:
+			releaseAcceptedActivationStage(stage, jobmgr.ErrProcessAttemptSuperseded)
+			return
+		case <-aai.stop:
+			releaseAcceptedActivationStage(stage, context.Canceled)
+			return
+		}
+	}
+
+	aai.mu.Lock()
+	if aai.closed || aai.failed || aai.entries[id] != entry || entry.state != acceptedActivationStaging {
+		aai.mu.Unlock()
+		releaseAcceptedActivationStage(stage, jobmgr.ErrProcessAttemptSuperseded)
+		return
+	}
+	entry.state = acceptedActivationTerminal
+	plan := aai.plan
+	commands := aai.commands
+	attempt := acceptedActivationAttempt{
+		spec:    entry.spec,
+		token:   entry.token,
+		stage:   stage,
+		err:     stageErr,
+		applied: &atomic.Bool{},
+	}
+	aai.mu.Unlock()
+
+	if stage != nil {
+		defer stage.Release()
+	}
+	work, err := plan(attempt)
+	if err == nil {
+		err = commands.SubmitPreparedAndWait(context.Background(), jobmgr.Request{
+			UID: fmt.Sprintf(
+				"jobmgr-accepted-activation-%d-%d",
+				entry.token.run,
+				entry.token.generation,
+			),
+			LaneKey: id,
+			Source:  lifecycle.SourceJobManager,
+			Route:   "internal/jobs/accepted-activation",
+		}, work)
+	}
+	if err == nil {
+		aai.settle(id, entry.token)
+		return
+	}
+	if lifecycle.ContainsOnlyCurrentStoppingRejections(err, entry.token.run) {
+		aai.settle(id, entry.token)
+		return
+	}
+	aai.failAttempt(id, entry.token, attempt.applied.Load(), err)
+}
+
+func (aai *acceptedActivationIndex) isCurrent(id string, token acceptedActivationToken) bool {
+	if aai == nil || id == "" || token.run == 0 || token.generation == 0 || token.uid == "" {
+		return false
+	}
+	aai.mu.Lock()
+	defer aai.mu.Unlock()
+	entry := aai.entries[id]
+	return entry != nil && entry.token == token && entry.state == acceptedActivationTerminal
+}
+
+func (aai *acceptedActivationIndex) settle(id string, token acceptedActivationToken) {
+	if aai == nil || id == "" || token.generation == 0 {
+		return
+	}
+	aai.mu.Lock()
+	entry := aai.entries[id]
+	if entry == nil || entry.token != token {
+		aai.mu.Unlock()
+		return
+	}
+	stage := aai.detachLocked(id)
+	aai.mu.Unlock()
+	releaseAcceptedActivationStage(stage, nil)
+}
+
+func (aai *acceptedActivationIndex) cancelUnless(id, keepUID string) {
+	if aai == nil || id == "" {
+		return
+	}
+	aai.mu.Lock()
+	entry := aai.entries[id]
+	if entry == nil || keepUID != "" && entry.token.uid == keepUID {
+		aai.mu.Unlock()
+		return
+	}
+	stage := aai.detachLocked(id)
+	aai.mu.Unlock()
+	releaseAcceptedActivationStage(stage, jobmgr.ErrProcessAttemptSuperseded)
+}
+
+func (aai *acceptedActivationIndex) detachLocked(id string) *preparedJobCandidate {
+	entry := aai.entries[id]
+	if entry == nil {
+		return nil
+	}
+	delete(aai.entries, id)
+	close(entry.cancel)
+	if entry.state == acceptedActivationTerminal {
+		// The terminal worker exclusively owns the stage while its transaction
+		// may consume it. Revocation only removes authority; the worker releases
+		// the stage after that transaction settles.
+		return nil
+	}
+	stage := entry.stage
+	entry.stage = nil
+	return stage
+}
+
+func releaseAcceptedActivationStage(stage *preparedJobCandidate, cause error) {
+	if stage == nil {
+		return
+	}
+	stage.Cancel(cause)
+	stage.Release()
+}
+
+func (aai *acceptedActivationIndex) stopWorker() {
+	if aai == nil {
+		return
+	}
+	aai.mu.Lock()
+	if aai.closed {
+		aai.mu.Unlock()
+		return
+	}
+	aai.closed = true
+	stages := make([]*preparedJobCandidate, 0, len(aai.entries))
+	for id := range aai.entries {
+		stages = append(stages, aai.detachLocked(id))
+	}
+	close(aai.stop)
+	aai.mu.Unlock()
+	for _, stage := range stages {
+		releaseAcceptedActivationStage(stage, context.Canceled)
+	}
+}
+
+func (aai *acceptedActivationIndex) wait(ctx context.Context) error {
+	if aai == nil || ctx == nil {
+		return errors.New("job output: invalid accepted activation wait")
+	}
+	aai.mu.Lock()
+	bound := aai.bound
+	done := aai.done
+	aai.mu.Unlock()
+	if !bound {
+		return nil
+	}
+	select {
+	case <-done:
+		return aai.terminalError()
+	case <-ctx.Done():
+		return errors.Join(ctx.Err(), aai.terminalError())
+	}
+}
+
+func (aai *acceptedActivationIndex) terminalError() error {
+	aai.mu.Lock()
+	defer aai.mu.Unlock()
+	return aai.terminalErr
+}
+
+func (aai *acceptedActivationIndex) join() {
+	<-aai.stop
+	aai.wg.Wait()
+	close(aai.done)
+}
+
+func (aai *acceptedActivationIndex) fail(err error) {
+	aai.failAttempt("", acceptedActivationToken{}, true, err)
+}
+
+func (aai *acceptedActivationIndex) failAttempt(
+	id string,
+	token acceptedActivationToken,
+	applied bool,
+	err error,
+) {
+	if aai == nil || err == nil {
+		return
+	}
+	aai.mu.Lock()
+	if aai.failed {
+		aai.mu.Unlock()
+		return
+	}
+	entry := aai.entries[id]
+	if !applied && (entry == nil || entry.token != token) {
+		aai.mu.Unlock()
+		return
+	}
+	aai.failed = true
+	aai.terminalErr = errors.Join(aai.terminalErr, err)
+	failure := aai.failure
+	stages := make([]*preparedJobCandidate, 0, len(aai.entries))
+	if !aai.closed {
+		aai.closed = true
+		for currentID := range aai.entries {
+			stages = append(stages, aai.detachLocked(currentID))
+		}
+		close(aai.stop)
+	}
+	aai.mu.Unlock()
+	for _, stage := range stages {
+		releaseAcceptedActivationStage(stage, err)
+	}
+	if failure != nil {
+		failure(err)
+	}
+}
+
+func (dcjc *DynCfgJobController) planAcceptedActivation(
+	attempt acceptedActivationAttempt,
+) (jobmgr.WorkPlan, error) {
+	if dcjc == nil || !attempt.valid() || attempt.spec.config.FullName() == "" {
+		return jobmgr.WorkPlan{}, errors.New("job output: invalid accepted activation plan")
+	}
+	return jobmgr.WorkPlan{
+		Claims:     []string{DynCfgJobGraphClaim},
+		NoResponse: true,
+		Transaction: &jobmgr.ResourceTransactionPlan{
+			ID:                attempt.spec.config.FullName(),
+			AllocateSuccessor: true,
+			Permit:            lifecycle.NewJobLongLivedPlan(),
+			Prepare: func(
+				ctx context.Context,
+				current lifecycle.ReadyResource,
+				scope lifecycle.ResourceTransactionScope,
+				permit lifecycle.LongLivedPermit,
+			) (lifecycle.PreparedResourceTransaction, error) {
+				return dcjc.prepareAcceptedActivation(ctx, attempt, current, scope, permit)
+			},
+		},
+	}, nil
+}
+
+func (dcjc *DynCfgJobController) prepareAcceptedActivation(
+	ctx context.Context,
+	attempt acceptedActivationAttempt,
+	current lifecycle.ReadyResource,
+	scope lifecycle.ResourceTransactionScope,
+	permit lifecycle.LongLivedPermit,
+) (lifecycle.PreparedResourceTransaction, error) {
+	if dcjc == nil || ctx == nil || !attempt.valid() || !scope.Valid() || scope.ID != attempt.spec.config.FullName() {
+		return nil, errors.New("job output: invalid accepted activation preparation")
+	}
+	record, exists := dcjc.graph.Lookup(scope.ID)
+	if err := validateGraphResourcePair(record, exists, current, scope); err != nil {
+		return nil, err
+	}
+	result := mustDynCfgMessage(204, "")
+	if !dcjc.scheduler.accepted.isCurrent(scope.ID, attempt.token) ||
+		!exists || record.Status != dyncfg.StatusAccepted.String() {
+		return dcjc.noop(scope, current, permit, result)
+	}
+	config, err := graphRecordConfig(record)
+	if err != nil {
+		return nil, err
+	}
+	if config.UID() != attempt.token.uid || config.UID() != attempt.spec.config.UID() {
+		return dcjc.noop(scope, current, permit, result)
+	}
+	if attempt.stage == nil {
+		return dcjc.prepareAcceptedActivationError(attempt, current, scope, permit, attempt.err)
+	}
+	successor, probeFailure, err := dcjc.factory.prepareCandidate(scope.Successor, permit, attempt.stage)
+	if err != nil {
+		return dcjc.prepareAcceptedActivationError(attempt, current, scope, permit, err)
+	}
+	failedPostimage := graphConfig(record, dyncfg.StatusFailed)
+	if probeFailure != nil {
+		return dcjc.prepareProbeFailure(
+			scope,
+			current,
+			permit,
+			autoDetectionRetryToken{},
+			probeFailure,
+			probeFailurePlan{
+				postimage:        failedPostimage,
+				failedCleanup:    dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
+				removedCleanup:   dcjc.configDeleteCleanup(dcjc.externalID(scope.ID)),
+				result:           func(*autoDetectionFailure) lifecycle.SealedResult { return result },
+				afterApply:       composeProbeFailureAfterApply(dcjc.scheduleRetryAfterApply(config), attempt.markApplied()),
+				removePlainStock: config.SourceType() == confgroup.TypeStock,
+			},
+		)
+	}
+	runningPostimage := graphConfig(record, dyncfg.StatusRunning)
+	busyFailure := transientActivationFailure(config, jobmgr.ErrProcessAttemptBusy)
+	return dcjc.prepareMutationWithActivationFallbacks(
+		scope,
+		current,
+		successor,
+		lifecycle.ResourceTransactionInstalled,
+		&runningPostimage,
+		result,
+		dcjc.configStatusCleanup(scope.ID, dyncfg.StatusRunning),
+		autoDetectionRetryToken{},
+		attempt.markApplied(),
+		activationFallbackPlan{
+			postimage:  &failedPostimage,
+			result:     result,
+			cleanup:    dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
+			afterApply: composeAfterApply(func() { dcjc.scheduleAutoDetectionRetry(config, busyFailure) }, attempt.markApplied()),
+		},
+		activationFallbackPlan{
+			postimage:  &failedPostimage,
+			result:     result,
+			cleanup:    dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
+			afterApply: attempt.markApplied(),
+		},
+	)
+}
+
+func (dcjc *DynCfgJobController) prepareAcceptedActivationError(
+	attempt acceptedActivationAttempt,
+	current lifecycle.ReadyResource,
+	scope lifecycle.ResourceTransactionScope,
+	permit lifecycle.LongLivedPermit,
+	err error,
+) (lifecycle.PreparedResourceTransaction, error) {
+	if err == nil {
+		return nil, errors.New("job output: accepted activation has no candidate outcome")
+	}
+	result := mustDynCfgMessage(204, "")
+	if errors.Is(err, jobmgr.ErrProcessAttemptRetired) ||
+		errors.Is(err, jobmgr.ErrProcessAttemptStopped) ||
+		errors.Is(err, context.Canceled) {
+		return dcjc.noop(scope, current, permit, result)
+	}
+	record, exists := dcjc.graph.Lookup(scope.ID)
+	if !exists || record.Status != dyncfg.StatusAccepted.String() {
+		return dcjc.noop(scope, current, permit, result)
+	}
+	failedPostimage := graphConfig(record, dyncfg.StatusFailed)
+	config := attempt.spec.config
+	if errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+		return dcjc.prepareMutationWithRetryAfterApply(
+			scope,
+			current,
+			nil,
+			permit,
+			resourceRemovalDisposition(current),
+			&failedPostimage,
+			result,
+			dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
+			autoDetectionRetryToken{},
+			attempt.markApplied(),
+		)
+	}
+	if errors.Is(err, jobmgr.ErrProcessAttemptBusy) ||
+		errors.Is(err, jobmgr.ErrProcessAttemptSuperseded) ||
+		errors.Is(err, jobmgr.ErrProcessAttemptDeadline) ||
+		errors.Is(err, ErrStaleStoreGeneration) ||
+		classifyConstructionError(err) == constructionErrorTransient {
+		failure := transientActivationFailure(config, err)
+		return dcjc.prepareMutationWithRetryAfterApply(
+			scope,
+			current,
+			nil,
+			permit,
+			resourceRemovalDisposition(current),
+			&failedPostimage,
+			result,
+			dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
+			autoDetectionRetryToken{},
+			composeAfterApply(func() { dcjc.scheduleAutoDetectionRetry(config, failure) }, attempt.markApplied()),
+		)
+	}
+	if classifyConstructionError(err) == constructionErrorProposal {
+		return dcjc.prepareMutationWithRetryAfterApply(
+			scope,
+			current,
+			nil,
+			permit,
+			resourceRemovalDisposition(current),
+			&failedPostimage,
+			result,
+			dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
+			autoDetectionRetryToken{},
+			attempt.markApplied(),
+		)
+	}
+	return nil, err
+}
+
+func composeProbeFailureAfterApply(
+	first func(*autoDetectionFailure),
+	second func(),
+) func(*autoDetectionFailure) {
+	return func(failure *autoDetectionFailure) {
+		if first != nil {
+			first(failure)
+		}
+		if second != nil {
+			second()
+		}
+	}
+}
+
+func (dcjc *DynCfgJobController) acceptedActivationAfterApply(
+	id string,
+	postimage *dyncfg.GraphConfig,
+) (func(), error) {
+	if dcjc == nil || dcjc.scheduler == nil || dcjc.scheduler.accepted == nil || id == "" {
+		return nil, errors.New("job output: invalid accepted activation graph reconciliation")
+	}
+	keepUID := ""
+	if postimage != nil && postimage.Status == dyncfg.StatusAccepted.String() {
+		var config confgroup.Config
+		if err := yaml.Unmarshal(postimage.Payload, &config); err != nil {
+			return nil, fmt.Errorf("job output: invalid accepted graph payload: %w", err)
+		}
+		if config == nil || config.Module() != postimage.Module || config.Name() != postimage.Name {
+			return nil, errors.New("job output: accepted graph payload identity differs")
+		}
+		keepUID = config.UID()
+		if keepUID == "" {
+			return nil, errors.New("job output: accepted graph payload has no UID")
+		}
+	}
+	return func() {
+		dcjc.scheduler.accepted.cancelUnless(id, keepUID)
+	}, nil
+}

--- a/src/go/plugin/agent/jobmgr/joboutput/accepted_activation_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/accepted_activation_test.go
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package joboutput
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcceptedActivationInstallsV1AndV2Collectors(t *testing.T) {
+	tests := map[string]func(*factoryTestState) collectorapi.Creator{
+		"V1": func(state *factoryTestState) collectorapi.Creator {
+			return collectorapi.Creator{
+				Create: func() collectorapi.CollectorV1 {
+					module := state.module(nil, false)
+					charts := collectorapi.Charts{
+						&collectorapi.Chart{
+							ID:    "work",
+							Title: "Work",
+							Units: "units",
+							Dims:  collectorapi.Dims{{ID: "value"}},
+						},
+					}
+					module.ChartsFunc = func() *collectorapi.Charts { return &charts }
+					module.CollectFunc = func(context.Context) map[string]int64 {
+						return map[string]int64{"value": 1}
+					}
+					return module
+				},
+			}
+		},
+		"V2": func(state *factoryTestState) collectorapi.Creator {
+			return collectorapi.Creator{
+				CreateV2: func() collectorapi.CollectorV2 {
+					return &factoryTestV2{
+						state:    state,
+						store:    metrix.NewCollectorStore(),
+						template: factoryTestChartTemplate,
+					}
+				},
+			}
+		},
+	}
+	for name, newCreator := range tests {
+		t.Run(name, func(t *testing.T) {
+			controller, graph, _, _, state := newDynCfgJobTestHarness(t)
+			creator := newCreator(state)
+			controller.modules["module"] = creator
+
+			releaseSubmission := make(chan struct{})
+			var releaseOnce sync.Once
+			commands := &autoDetectionRetryTestCommands{block: releaseSubmission}
+			require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(error) {}))
+			var active lifecycle.ReadyResource
+			t.Cleanup(func() {
+				releaseOnce.Do(func() { close(releaseSubmission) })
+				controller.scheduler.StopBackgroundWorkers()
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				require.NoError(t, controller.scheduler.WaitBackgroundWorkers(ctx))
+				if active != nil {
+					require.NoError(t, active.Stop(context.Background()))
+					require.NoError(t, active.Finalize())
+				}
+			})
+
+			config := acceptedActivationTestConfig(confgroup.TypeUser)
+			seedDynCfgJobGraphRecord(t, graph, config, dyncfg.StatusAccepted)
+			applyAcceptedEnableForTest(t, controller, graph, config, 1)
+
+			commands.waitForSubmissions(t, 1)
+			submitted, plans, waited := commands.snapshot()
+			require.Len(t, submitted, 1)
+			require.Len(t, plans, 1)
+			require.True(t, waited)
+			require.Equal(t, "internal/jobs/accepted-activation", submitted[0].Route)
+
+			permit, tasks := issueTestJobPermit(t, config.FullName(), 2)
+			terminal, err := plans[0].Transaction.Prepare(
+				context.Background(),
+				nil,
+				lifecycle.ResourceTransactionScope{
+					ID: config.FullName(),
+					Successor: lifecycle.ResourceIdentity{
+						ID: config.FullName(), Generation: 2,
+					},
+				},
+				permit,
+			)
+			require.NoError(t, err)
+			applied, err := terminal.Apply(context.Background())
+			require.NoError(t, err)
+			var disposition lifecycle.ResourceTransactionDisposition
+			_, disposition, active = applied.Ownership()
+			require.Equal(t, lifecycle.ResourceTransactionInstalled, disposition)
+			require.NotNil(t, active)
+			record, exists := graph.Lookup(config.FullName())
+			require.True(t, exists)
+			require.Equal(t, dyncfg.StatusRunning.String(), record.Status)
+
+			releaseOnce.Do(func() { close(releaseSubmission) })
+			controller.scheduler.StopBackgroundWorkers()
+			require.NoError(t, controller.scheduler.WaitBackgroundWorkers(context.Background()))
+			require.NoError(t, active.Stop(context.Background()))
+			require.NoError(t, active.Finalize())
+			active = nil
+			require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+			requireFactoryAttemptsIdle(t, controller.factory)
+			require.EqualValues(t, 1, state.collectorCleanup)
+		})
+	}
+}
+
+func TestAcceptedActivationCoalescesRepeatedEnableForSameConfig(t *testing.T) {
+	controller, graph, _, _, state := newDynCfgJobTestHarness(t)
+	checkRelease := make(chan struct{})
+	var checkCalls atomic.Int32
+	creator := controller.modules["module"]
+	creator.Create = func() collectorapi.CollectorV1 {
+		return state.module(func(context.Context) error {
+			checkCalls.Add(1)
+			<-checkRelease
+			return nil
+		}, false)
+	}
+	controller.modules["module"] = creator
+
+	releaseSubmission := make(chan struct{})
+	var checkReleaseOnce sync.Once
+	var submissionReleaseOnce sync.Once
+	commands := &autoDetectionRetryTestCommands{block: releaseSubmission}
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(error) {}))
+	t.Cleanup(func() {
+		checkReleaseOnce.Do(func() { close(checkRelease) })
+		submissionReleaseOnce.Do(func() { close(releaseSubmission) })
+		controller.scheduler.StopBackgroundWorkers()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, controller.scheduler.WaitBackgroundWorkers(ctx))
+	})
+
+	config := acceptedActivationTestConfig(confgroup.TypeUser)
+	seedDynCfgJobGraphRecord(t, graph, config, dyncfg.StatusAccepted)
+	applyAcceptedEnableForTest(t, controller, graph, config, 1)
+	require.Eventually(t, func() bool {
+		return checkCalls.Load() == 1
+	}, time.Second, time.Millisecond)
+	applyAcceptedEnableForTest(t, controller, graph, config, 2)
+	require.EqualValues(t, 1, checkCalls.Load())
+
+	checkReleaseOnce.Do(func() { close(checkRelease) })
+	commands.waitForSubmissions(t, 1)
+	time.Sleep(20 * time.Millisecond)
+	submitted, _, waited := commands.snapshot()
+	require.Len(t, submitted, 1)
+	require.True(t, waited)
+}
+
+func TestAcceptedActivationArmsOnlyAfterEnableApplies(t *testing.T) {
+	controller, graph, _, _, state := newDynCfgJobTestHarness(t)
+	var checkCalls atomic.Int32
+	creator := controller.modules["module"]
+	creator.Create = func() collectorapi.CollectorV1 {
+		return state.module(func(context.Context) error {
+			checkCalls.Add(1)
+			return nil
+		}, false)
+	}
+	controller.modules["module"] = creator
+	commands := &autoDetectionRetryTestCommands{}
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(error) {}))
+	t.Cleanup(func() {
+		controller.scheduler.StopBackgroundWorkers()
+		require.NoError(t, controller.scheduler.WaitBackgroundWorkers(context.Background()))
+	})
+
+	config := acceptedActivationTestConfig(confgroup.TypeUser)
+	seedDynCfgJobGraphRecord(t, graph, config, dyncfg.StatusAccepted)
+	record, exists := graph.Lookup(config.FullName())
+	require.True(t, exists)
+	permit, tasks := issueTestJobPermit(t, config.FullName(), 1)
+	transaction, err := controller.prepareEnable(
+		context.Background(),
+		dynCfgTarget{
+			module:     config.Module(),
+			name:       config.Name(),
+			resourceID: config.FullName(),
+			creator:    creator,
+		},
+		record,
+		true,
+		nil,
+		lifecycle.ResourceTransactionScope{
+			ID: config.FullName(),
+			Successor: lifecycle.ResourceIdentity{
+				ID: config.FullName(), Generation: 1,
+			},
+		},
+		permit,
+	)
+	require.NoError(t, err)
+	current, err := transaction.Dispose(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, current)
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+	commands.waitForSubmissions(t, 0)
+	require.Zero(t, checkCalls.Load())
+	controller.scheduler.accepted.mu.Lock()
+	entries := len(controller.scheduler.accepted.entries)
+	controller.scheduler.accepted.mu.Unlock()
+	require.Zero(t, entries)
+}
+
+func TestAcceptedActivationFailsRunWhenTerminalSubmissionFails(t *testing.T) {
+	controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
+	sentinel := errors.New("terminal submission failed")
+	commands := &autoDetectionRetryTestCommands{submitErr: sentinel}
+	failed := make(chan error, 1)
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(err error) {
+		failed <- err
+	}))
+	t.Cleanup(func() {
+		controller.scheduler.StopBackgroundWorkers()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.ErrorIs(t, controller.scheduler.WaitBackgroundWorkers(ctx), sentinel)
+	})
+
+	config := acceptedActivationTestConfig(confgroup.TypeUser)
+	seedDynCfgJobGraphRecord(t, graph, config, dyncfg.StatusAccepted)
+	applyAcceptedEnableForTest(t, controller, graph, config, 1)
+
+	select {
+	case err := <-failed:
+		require.ErrorIs(t, err, sentinel)
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "terminal submission failure did not fail the run")
+	}
+	_, plans, waited := commands.snapshot()
+	require.Len(t, plans, 1)
+	require.True(t, waited)
+}
+
+func TestAcceptedActivationCurrentContentionConvergesToFailed(t *testing.T) {
+	tests := map[string]func(*DynCfgJobController, *factoryTestState, confgroup.Config){
+		"busy candidate identity": func(controller *DynCfgJobController, _ *factoryTestState, _ confgroup.Config) {
+			controller.factory.config.Attempts = busySupersessionAuthority{
+				ProcessAttemptAuthority: controller.factory.config.Attempts,
+			}
+		},
+		"stale secret-store snapshot": func(
+			controller *DynCfgJobController,
+			state *factoryTestState,
+			config confgroup.Config,
+		) {
+			scopeState := &factoryTestAtomicScope{value: "resolved"}
+			creator := controller.modules["module"]
+			creator.Create = func() collectorapi.CollectorV1 {
+				module := state.module(func(context.Context) error {
+					scopeState.current.Store(false)
+					return nil
+				}, false)
+				charts := collectorapi.Charts{}
+				module.ChartsFunc = func() *collectorapi.Charts { return &charts }
+				return module
+			}
+			controller.modules["module"] = creator
+			controller.factory.config.ConfigModules.config.StoreScope =
+				func([]string) (secretresolver.AtomicScope, error) {
+					scopeState.current.Store(true)
+					return scopeState, nil
+				}
+			config["option_str"] = "${store:vault:test:key}"
+		},
+	}
+	for name, arrange := range tests {
+		t.Run(name, func(t *testing.T) {
+			controller, graph, _, _, state := newDynCfgJobTestHarness(t)
+			config := acceptedActivationTestConfig(confgroup.TypeUser)
+			config.Set("autodetection_retry", 1)
+			arrange(controller, state, config)
+
+			releaseSubmission := make(chan struct{})
+			var releaseOnce sync.Once
+			commands := &autoDetectionRetryTestCommands{block: releaseSubmission}
+			require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(error) {}))
+			t.Cleanup(func() {
+				releaseOnce.Do(func() { close(releaseSubmission) })
+				controller.scheduler.StopBackgroundWorkers()
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				require.NoError(t, controller.scheduler.WaitBackgroundWorkers(ctx))
+			})
+
+			seedDynCfgJobGraphRecord(t, graph, config, dyncfg.StatusAccepted)
+			applyAcceptedEnableForTest(t, controller, graph, config, 1)
+			commands.waitForSubmissions(t, 1)
+			_, plans, waited := commands.snapshot()
+			require.Len(t, plans, 1)
+			require.True(t, waited)
+
+			permit, tasks := issueTestJobPermit(t, config.FullName(), 2)
+			terminal, err := plans[0].Transaction.Prepare(
+				context.Background(),
+				nil,
+				lifecycle.ResourceTransactionScope{
+					ID: config.FullName(),
+					Successor: lifecycle.ResourceIdentity{
+						ID: config.FullName(), Generation: 2,
+					},
+				},
+				permit,
+			)
+			require.NoError(t, err)
+			applied, err := terminal.Apply(context.Background())
+			require.NoError(t, err)
+			_, disposition, current := applied.Ownership()
+			require.Equal(t, lifecycle.ResourceTransactionUnchanged, disposition)
+			require.Nil(t, current)
+			record, exists := graph.Lookup(config.FullName())
+			require.True(t, exists)
+			require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
+			require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+
+			controller.scheduler.retries.mu.Lock()
+			_, retryScheduled := controller.scheduler.retries.entries[config.FullName()]
+			controller.scheduler.retries.mu.Unlock()
+			require.True(t, retryScheduled)
+			releaseOnce.Do(func() { close(releaseSubmission) })
+		})
+	}
+}
+
+func acceptedActivationTestConfig(sourceType string) confgroup.Config {
+	config := factoryTestConfig(false)
+	config.SetProvider(sourceType)
+	config.SetSourceType(sourceType)
+	config.SetSource("test")
+	return config
+}
+
+func applyAcceptedEnableForTest(
+	t *testing.T,
+	controller *DynCfgJobController,
+	graph *dyncfg.Graph,
+	config confgroup.Config,
+	generation uint64,
+) {
+	t.Helper()
+	record, exists := graph.Lookup(config.FullName())
+	require.True(t, exists)
+	permit, tasks := issueTestJobPermit(t, config.FullName(), generation)
+	transaction, err := controller.prepareEnable(
+		context.Background(),
+		dynCfgTarget{
+			module:     config.Module(),
+			name:       config.Name(),
+			resourceID: config.FullName(),
+			creator:    controller.modules[config.Module()],
+		},
+		record,
+		true,
+		nil,
+		lifecycle.ResourceTransactionScope{
+			ID: config.FullName(),
+			Successor: lifecycle.ResourceIdentity{
+				ID: config.FullName(), Generation: generation,
+			},
+		},
+		permit,
+	)
+	require.NoError(t, err)
+	applied, err := transaction.Apply(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 202, applied.ResultStatus())
+	require.EqualValues(t, lifecycle.LongLivedCensus{}, tasks.LongLivedCensus())
+}

--- a/src/go/plugin/agent/jobmgr/joboutput/autodetection_retry_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/autodetection_retry_test.go
@@ -212,7 +212,7 @@ func TestSchedulerTickDoesNotBlockOnRetryAdmission(t *testing.T) {
 	}
 	scheduler, err := NewScheduler(testModuleReconciler{})
 	require.NoError(t, err)
-	require.NoError(t, scheduler.bindAutoDetectionRetries(
+	require.NoError(t, scheduler.bindBackgroundWorkers(
 		commands,
 		func(confgroup.Config, autoDetectionRetryToken) (jobmgr.WorkPlan, error) {
 			return jobmgr.WorkPlan{}, nil
@@ -240,8 +240,8 @@ func TestSchedulerTickDoesNotBlockOnRetryAdmission(t *testing.T) {
 	}
 	commands.waitForSubmissions(t, 1)
 	close(release)
-	scheduler.StopAutoDetectionRetries()
-	require.NoError(t, scheduler.WaitAutoDetectionRetries(context.Background()))
+	scheduler.StopBackgroundWorkers()
+	require.NoError(t, scheduler.WaitBackgroundWorkers(context.Background()))
 	require.True(t, scheduler.retries.joined() && scheduler.pending.joined())
 }
 
@@ -421,9 +421,26 @@ func (adrtc *autoDetectionRetryTestCommands) SubmitPrepared(
 	request jobmgr.Request,
 	plan jobmgr.WorkPlan,
 ) error {
+	return adrtc.submit(request, plan, false)
+}
+
+func (adrtc *autoDetectionRetryTestCommands) SubmitPreparedAndWait(
+	_ context.Context,
+	request jobmgr.Request,
+	plan jobmgr.WorkPlan,
+) error {
+	return adrtc.submit(request, plan, true)
+}
+
+func (adrtc *autoDetectionRetryTestCommands) submit(
+	request jobmgr.Request,
+	plan jobmgr.WorkPlan,
+	waited bool,
+) error {
 	adrtc.mu.Lock()
 	adrtc.submitted = append(adrtc.submitted, request)
 	adrtc.plans = append(adrtc.plans, plan)
+	adrtc.waited = adrtc.waited || waited
 	if adrtc.notify == nil {
 		adrtc.notify = make(chan struct{}, 1)
 	}
@@ -439,17 +456,6 @@ func (adrtc *autoDetectionRetryTestCommands) SubmitPrepared(
 		<-block
 	}
 	return err
-}
-
-func (adrtc *autoDetectionRetryTestCommands) SubmitPreparedAndWait(
-	context.Context,
-	jobmgr.Request,
-	jobmgr.WorkPlan,
-) error {
-	adrtc.mu.Lock()
-	adrtc.waited = true
-	adrtc.mu.Unlock()
-	return nil
 }
 
 func (adrtc *autoDetectionRetryTestCommands) snapshot() ([]jobmgr.Request, []jobmgr.WorkPlan, bool) {

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs.go
@@ -93,21 +93,34 @@ func NewDynCfgJobController(config DynCfgJobControllerConfig) (*DynCfgJobControl
 	}, nil
 }
 
-func (dcjc *DynCfgJobController) BindAutoDetectionRetries(
+func (dcjc *DynCfgJobController) BindBackgroundWorkers(
 	commands jobmgr.PreparedCommandPort,
 	run uint64,
 	failure func(error),
 ) error {
 	if dcjc == nil || dcjc.scheduler == nil {
-		return errors.New("job output: invalid autodetection retry controller")
+		return errors.New("job output: invalid background worker controller")
 	}
-	return dcjc.scheduler.bindAutoDetectionRetries(
+	if err := dcjc.scheduler.accepted.bind(
+		dcjc.factory,
+		commands,
+		dcjc.planAcceptedActivation,
+		run,
+		failure,
+	); err != nil {
+		return err
+	}
+	if err := dcjc.scheduler.bindBackgroundWorkers(
 		commands,
 		dcjc.planAutoDetectionRetry,
 		dcjc.planPendingJob,
 		run,
 		failure,
-	)
+	); err != nil {
+		dcjc.scheduler.accepted.stopWorker()
+		return err
+	}
+	return nil
 }
 
 func DynCfgJobPrefix(pluginName string) string {

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
@@ -841,7 +841,7 @@ func TestFailedAutoDetectionCommitsFailedStateAndSchedulesRetry(t *testing.T) {
 	}
 	controller.modules["module"] = creator
 	commands := &autoDetectionRetryTestCommands{}
-	require.NoError(t, controller.BindAutoDetectionRetries(
+	require.NoError(t, controller.BindBackgroundWorkers(
 		commands,
 		1,
 		func(error) {},
@@ -948,8 +948,8 @@ func TestFailedAutoDetectionCommitsFailedStateAndSchedulesRetry(t *testing.T) {
 	require.Equal(t, []string{"autodetection", "current-stop", "current-finalize"}, events)
 	require.EqualValues(t, lifecycle.LongLivedCensus{}, retryTasks.LongLivedCensus())
 
-	controller.scheduler.StopAutoDetectionRetries()
-	require.NoError(t, controller.scheduler.WaitAutoDetectionRetries(context.Background()))
+	controller.scheduler.StopBackgroundWorkers()
+	require.NoError(t, controller.scheduler.WaitBackgroundWorkers(context.Background()))
 }
 
 func TestNonRetryableAutoDetectionFailureSettlesExistingRetry(t *testing.T) {
@@ -1029,7 +1029,7 @@ func TestDiscoveredTransientConstructionFailureCommitsFailedAndSchedulesRetry(t 
 	controller, graph, _, _, state := newDynCfgJobTestHarness(t)
 	installFailingFixtureResolver(t, controller)
 	commands := &autoDetectionRetryTestCommands{}
-	require.NoError(t, controller.BindAutoDetectionRetries(commands, 1, func(error) {}))
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 1, func(error) {}))
 
 	config := factoryTestConfig(false)
 	config.Set("option", "${fixture:value}")
@@ -1107,7 +1107,7 @@ func TestManualEnableTransientConstructionFailureCommitsFailedAndSchedulesRetry(
 	controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
 	installFailingFixtureResolver(t, controller)
 	commands := &autoDetectionRetryTestCommands{}
-	require.NoError(t, controller.BindAutoDetectionRetries(commands, 1, func(error) {}))
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 1, func(error) {}))
 
 	config := factoryTestConfig(false)
 	config.Set("option", "${fixture:value}")
@@ -1165,7 +1165,7 @@ func TestRunningUpdateTransientConstructionFailureCommitsFailedAndSchedulesRetry
 	controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
 	installFailingFixtureResolver(t, controller)
 	commands := &autoDetectionRetryTestCommands{}
-	require.NoError(t, controller.BindAutoDetectionRetries(commands, 1, func(error) {}))
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 1, func(error) {}))
 
 	config := factoryTestConfig(false)
 	config.Set("autodetection_retry", 1)

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
@@ -103,6 +103,14 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApplyAndFallback(
 	quarantinedFallback *ResourceActivationFallback,
 ) (lifecycle.PreparedResourceTransaction, error) {
 	afterApply = composeAfterApply(dcjc.retrySettlement(scope.ID, retry), afterApply)
+	acceptedAfterApply, err := dcjc.acceptedActivationAfterApply(scope.ID, postimage)
+	if err != nil {
+		if successor != nil {
+			err = rollbackSuccessorMutation(successor, err)
+		}
+		return nil, err
+	}
+	afterApply = composeAfterApply(afterApply, acceptedAfterApply)
 	var dependencyCommit func()
 	if dcjc.dependencies != nil {
 		var err error
@@ -178,6 +186,11 @@ func (dcjc *DynCfgJobController) newActivationFallback(
 	if dcjc == nil || id == "" || cleanup == nil {
 		return nil, errors.New("job output: invalid activation fallback")
 	}
+	acceptedAfterApply, err := dcjc.acceptedActivationAfterApply(id, postimage)
+	if err != nil {
+		return nil, err
+	}
+	afterApply = composeAfterApply(afterApply, acceptedAfterApply)
 	var dependencyCommit func()
 	if dcjc.dependencies != nil {
 		var err error

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_prepare.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_prepare.go
@@ -351,6 +351,26 @@ func (dcjc *DynCfgJobController) prepareEnable(
 			dcjc.configStatusCleanup(target.resourceID, dyncfg.StatusRunning),
 		)
 	}
+	if record.Status == dyncfg.StatusAccepted.String() {
+		config, err := graphRecordConfig(record)
+		if err != nil {
+			return nil, err
+		}
+		spec, err := newAcceptedActivationSpec(config)
+		if err != nil {
+			return nil, err
+		}
+		return dcjc.noopWithAfterApply(
+			scope,
+			current,
+			permit,
+			mustDynCfgMessage(202, ""),
+			func() {
+				dcjc.scheduler.accepted.arm(spec)
+			},
+			dcjc.configStatusCleanup(target.resourceID, dyncfg.StatusAccepted),
+		)
+	}
 	return dcjc.prepareRunningTransition(
 		ctx,
 		target,

--- a/src/go/plugin/agent/jobmgr/joboutput/pending_job_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/pending_job_test.go
@@ -90,10 +90,10 @@ func TestDiscoveredBusyRetainsPendingDesiredAndRetriesOnRelease(t *testing.T) {
 	release := make(chan struct{})
 	controller.factory.config.Attempts = busyPendingJobAuthority{release: release}
 	commands := &autoDetectionRetryTestCommands{}
-	require.NoError(t, controller.BindAutoDetectionRetries(commands, 9, func(error) {}))
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(error) {}))
 	t.Cleanup(func() {
-		controller.scheduler.StopAutoDetectionRetries()
-		require.NoError(t, controller.scheduler.WaitAutoDetectionRetries(context.Background()))
+		controller.scheduler.StopBackgroundWorkers()
+		require.NoError(t, controller.scheduler.WaitBackgroundWorkers(context.Background()))
 	})
 
 	config := autoDetectionRetryTestConfig("job")
@@ -161,10 +161,10 @@ func TestDiscoveredStaleStoreCandidateRetainsPendingDesired(t *testing.T) {
 			return scopeState, nil
 		}
 	commands := &autoDetectionRetryTestCommands{}
-	require.NoError(t, controller.BindAutoDetectionRetries(commands, 9, func(error) {}))
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(error) {}))
 	t.Cleanup(func() {
-		controller.scheduler.StopAutoDetectionRetries()
-		require.NoError(t, controller.scheduler.WaitAutoDetectionRetries(context.Background()))
+		controller.scheduler.StopBackgroundWorkers()
+		require.NoError(t, controller.scheduler.WaitBackgroundWorkers(context.Background()))
 	})
 
 	config := autoDetectionRetryTestConfig("job")

--- a/src/go/plugin/agent/jobmgr/joboutput/scheduler.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/scheduler.go
@@ -22,6 +22,7 @@ type Scheduler struct {
 	reconciler ModuleReconciler                          // per-module reconciliation callback
 	retries    *autoDetectionRetryIndex                  // auto-detection retry worker
 	pending    *pendingJobIndex                          // release-triggered latest desired jobs
+	accepted   *acceptedActivationIndex                  // detached accepted-job activation owner
 	jobs       map[lifecycle.ResourceIdentity]RuntimeJob // scheduled job by identity
 	modules    map[string]int                            // scheduled job count by module
 }
@@ -34,12 +35,13 @@ func NewScheduler(reconciler ModuleReconciler) (*Scheduler, error) {
 		reconciler: reconciler,
 		retries:    newAutoDetectionRetryIndex(),
 		pending:    newPendingJobIndex(),
+		accepted:   newAcceptedActivationIndex(),
 		jobs:       make(map[lifecycle.ResourceIdentity]RuntimeJob),
 		modules:    make(map[string]int),
 	}, nil
 }
 
-func (s *Scheduler) bindAutoDetectionRetries(
+func (s *Scheduler) bindBackgroundWorkers(
 	commands jobmgr.PreparedCommandPort,
 	plan autoDetectionRetryPlanner,
 	pendingPlan pendingJobPlanner,
@@ -47,7 +49,7 @@ func (s *Scheduler) bindAutoDetectionRetries(
 	failure func(error),
 ) error {
 	if s == nil {
-		return errors.New("job output: nil autodetection retry scheduler")
+		return errors.New("job output: nil background scheduler")
 	}
 	if err := s.pending.bind(commands, pendingPlan, run, failure); err != nil {
 		return err
@@ -59,18 +61,20 @@ func (s *Scheduler) bindAutoDetectionRetries(
 	return nil
 }
 
-func (s *Scheduler) StopAutoDetectionRetries() {
+func (s *Scheduler) StopBackgroundWorkers() {
 	if s != nil {
+		s.accepted.stopWorker()
 		s.retries.stopWorker()
 		s.pending.stopWorker()
 	}
 }
 
-func (s *Scheduler) WaitAutoDetectionRetries(ctx context.Context) error {
+func (s *Scheduler) WaitBackgroundWorkers(ctx context.Context) error {
 	if s == nil {
-		return errors.New("job output: nil autodetection retry scheduler")
+		return errors.New("job output: nil background scheduler")
 	}
 	return errors.Join(
+		s.accepted.wait(ctx),
 		s.retries.wait(ctx),
 		s.pending.wait(ctx),
 	)

--- a/src/go/plugin/agent/jobmgr/joboutput/secret_restart_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/secret_restart_test.go
@@ -36,10 +36,10 @@ func TestSecretDependentStartCommitsFailedAndWaitsForBusyRuntimeRelease(t *testi
 	controller.configModules.config.Modules = controller.modules
 
 	commands := &autoDetectionRetryTestCommands{}
-	require.NoError(t, controller.BindAutoDetectionRetries(commands, 9, func(error) {}))
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(error) {}))
 	t.Cleanup(func() {
-		controller.scheduler.StopAutoDetectionRetries()
-		require.NoError(t, controller.scheduler.WaitAutoDetectionRetries(context.Background()))
+		controller.scheduler.StopBackgroundWorkers()
+		require.NoError(t, controller.scheduler.WaitBackgroundWorkers(context.Background()))
 	})
 
 	config := factoryTestConfig(false)
@@ -197,10 +197,10 @@ func TestSecretDependentStartRetainsAbsentPendingAfterExternalDeadline(t *testin
 	release := make(chan struct{})
 	controller.factory.config.Attempts = busyPendingJobAuthority{release: release}
 	commands := &autoDetectionRetryTestCommands{}
-	require.NoError(t, controller.BindAutoDetectionRetries(commands, 9, func(error) {}))
+	require.NoError(t, controller.BindBackgroundWorkers(commands, 9, func(error) {}))
 	t.Cleanup(func() {
-		controller.scheduler.StopAutoDetectionRetries()
-		require.NoError(t, controller.scheduler.WaitAutoDetectionRetries(context.Background()))
+		controller.scheduler.StopBackgroundWorkers()
+		require.NoError(t, controller.scheduler.WaitBackgroundWorkers(context.Background()))
 	})
 
 	config := factoryTestConfig(false)


### PR DESCRIPTION
## Problem

go.d jobs can remain indefinitely in the `accepted` state when their initial collector activation takes longer than the DynCfg request deadline.

The DynCfg request is cancelled after its deadline, but some collector operations—such as SNMP walks—cannot stop cooperatively. Their eventual result therefore had no active owner capable of safely updating the Job Manager graph to `running` or `failed`.

## Solution

Move activation of applied `accepted` jobs out of the DynCfg request lifecycle.

ENABLE now completes promptly with `202 accepted`. A run-owned activation worker performs the potentially slow collector initialization and check, then conditionally applies the result through a new Job Manager transaction.

Each activation is fenced by its run, generation, and configuration identity. Results from disabled, replaced, superseded, or stopped jobs cannot update current state.

## Changes

- Add a dedicated owner for asynchronous `accepted` job activation.
- Return `202 accepted` without waiting for collector initialization or its initial check.
- Converge successful activation to `running`.
- Converge activation failures to `failed`, or remove failed plain stock jobs according to the existing policy.
- Preserve the existing configured retry behavior.
- Coalesce repeated ENABLE requests for the same accepted configuration.
- Revoke stale activation authority on disable, replacement, removal, and shutdown.
- Publish terminal DynCfg status only after the corresponding graph transaction is applied.
- Generalize scheduler worker lifecycle naming for the additional background worker.
- Document the accepted-activation ownership and lifecycle invariants.
- Add production-path, lifecycle, concurrency, shutdown, V1/V2, and race-enabled tests.

## Scope

This change is limited to activation of jobs already applied as `accepted`.

Existing synchronous behavior for disabled-job ENABLE, running UPDATE/RESTART, discovery replacement, and secret restart remains unchanged. No daemon DynCfg or nRPC changes are included.

## Validation

- Full Job Manager test suite
- Race-enabled Job Manager test suite
- Go vet
- Representative framework runtime tests
- Diff and scope checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Accepted job enables now activate asynchronously and return HTTP 202.
  - Added activation validation, cancellation, supersession handling, retries, and terminal failure reporting.
  - Late probe failures now update configuration status appropriately.
  - Background worker lifecycle now includes accepted activations.

- **Bug Fixes**
  - Disable operations no longer remain blocked by stalled enable checks.
  - Improved containment handling for delayed process attempts.
  - Prevented stale or canceled activations from applying results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->