### PR TITLE
fix(mcp): drop dead NULL check in mcp_function_get_info

### DIFF
--- a/src/web/mcp/mcp-tools-execute-function-registry.c
+++ b/src/web/mcp/mcp-tools-execute-function-registry.c
@@ -329,7 +329,7 @@ static MCP_FUNCTION_REGISTRY_ENTRY *mcp_function_get_info(RRDHOST *host, const c
     // Call the function with info parameter
     BUFFER *response = buffer_create(0, NULL);
     int code = nrpc_call(&(struct nrpc_call_spec) {
-        .owner = host ? rrdhost_nrpc_owner(host) : NRPC_OWNER_NONE,
+        .owner = rrdhost_nrpc_owner(host),
         .result_wb = response,
         .cmd = info_function,
         .source = buffer_tostring(source),


### PR DESCRIPTION
##### Summary
- Host is already validated non-NULL by the early return, so the ternary's NRPC_OWNER_NONE branch is unreachable. Coverity CID 505673.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NRPC info requests now consistently derive ownership from the host, improving request metadata accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->