### PR TITLE
docs: document Netdata Cloud outbound IP addresses endpoint

### DIFF
--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -411,6 +411,17 @@ sidebar:
             - unseen
             - transitions
       - meta:
+          label: Netdata Cloud Outbound IP Addresses
+          edit_url: https://github.com/netdata/netdata/edit/master/docs/netdata-cloud/netdata-cloud-outbound-ips.md
+          description: The public endpoint listing the source IP addresses Netdata Cloud connects from, for firewall and IP allowlist hardening
+          keywords:
+            - outbound ips
+            - source ip
+            - firewall
+            - allowlist
+            - webhook
+            - mcp
+      - meta:
           label: Unclaim and Reclaim a Node
           edit_url: https://github.com/netdata/netdata/edit/master/docs/learn/unclaim-reclaim-node.md
       - meta:

--- a/docs/netdata-ai/mcp/mcp-connections.md
+++ b/docs/netdata-ai/mcp/mcp-connections.md
@@ -155,4 +155,6 @@ Reports do not yet include a tool-call trace.
 
 ### Which IP addresses does Netdata connect from?
 
-If your MCP endpoint is behind an IP allowlist, contact support for Netdata Cloud's current outbound addresses.
+If your MCP endpoint is behind an IP allowlist, see
+[Netdata Cloud Outbound IP Addresses](/docs/netdata-cloud/netdata-cloud-outbound-ips.md) for the published list and how
+to consume it.

--- a/docs/netdata-cloud/netdata-cloud-outbound-ips.md
+++ b/docs/netdata-cloud/netdata-cloud-outbound-ips.md
@@ -1,0 +1,65 @@
+# Netdata Cloud Outbound IP Addresses
+
+Some Netdata Cloud features require Netdata Cloud to open a connection **to your infrastructure** — for example delivering
+alert notifications to a webhook you host, or reading context from an MCP server you run.
+
+If those endpoints sit behind a firewall, a WAF, or an IP allowlist, you need to know which source addresses Netdata Cloud
+connects from. Netdata publishes that list at a public endpoint so you can allowlist it and refresh it automatically.
+
+## The endpoint
+
+```bash
+curl https://app.netdata.cloud/ips-v4
+```
+
+- **Authentication:** none required.
+- **Response:** `text/plain`, one IPv4 CIDR block per line, newline-separated.
+- **Scope:** IPv4 only. There is no IPv6 equivalent today, so an allowlist built from this endpoint must not assume
+  Netdata Cloud will reach you over IPv6.
+
+Example response:
+
+```text
+3.224.66.12/32
+52.21.70.201/32
+35.169.216.169/32
+```
+
+:::important
+
+The values above are an illustration of the response format, not a reference list. **Always read the live endpoint.**
+Anything you copy from this page will eventually be wrong.
+
+:::
+
+## Which traffic these addresses cover
+
+These are the source addresses for connections Netdata Cloud initiates **outbound to your systems**, including:
+
+- [Webhook notifications](/integrations/cloud-notifications/integrations/webhook.md) — alert and reachability payloads
+  POSTed to your webhook URL.
+- [MCP Connections](/docs/netdata-ai/mcp/mcp-connections.md) — requests to a Custom MCP Server or a self-hosted MCP
+  endpoint.
+
+This is the **opposite direction** from your Agents connecting to Netdata Cloud. For the outbound access your Agents need
+(ACLK, telemetry, updates), see
+[Required endpoints and ports](/docs/netdata-agent/configure-netdata-for-cybersecurity-platforms.md#required-endpoints-and-ports).
+
+## Using the list in a firewall rule
+
+Fetch the list and rebuild your rule rather than pasting addresses into a config once:
+
+```bash
+curl -fsS https://app.netdata.cloud/ips-v4
+```
+
+Guidance:
+
+- **Refresh on a schedule.** Re-fetch periodically and reconcile your allowlist, so a change to the published list does
+  not silently break notification delivery.
+- **Fail closed on a bad fetch.** If the request fails or returns an empty body, keep the previous list. Do not replace a
+  working allowlist with an empty one.
+- **Parse defensively.** Skip blank lines and trim whitespace. Treat each entry as a CIDR block, not a bare address.
+- **Combine with authentication.** An IP allowlist is a network control, not an identity control. Keep the
+  [webhook authentication mechanism](/integrations/cloud-notifications/integrations/webhook.md#authentication-mechanisms)
+  — mutual TLS, Basic, or Bearer — in place as well.

--- a/integrations/cloud-notifications/metadata.yaml
+++ b/integrations/cloud-notifications/metadata.yaml
@@ -567,7 +567,8 @@
 
       #### Source IP addresses
 
-      Netdata Cloud connects to your webhook URL from a fixed set of IP addresses. If your endpoint sits behind a firewall,
+      Netdata Cloud connects to your webhook URL from the currently published set of IP addresses. The set can change, so
+      refresh your allowlist periodically. If your endpoint sits behind a firewall,
       a WAF, or an IP allowlist, see
       [Netdata Cloud Outbound IP Addresses](/docs/netdata-cloud/netdata-cloud-outbound-ips.md) for the published list and
       how to consume it.

--- a/integrations/cloud-notifications/metadata.yaml
+++ b/integrations/cloud-notifications/metadata.yaml
@@ -565,6 +565,16 @@
       | status.reachable | boolean | `true` if host is reachable, `false` otherwise                                                                                |
       | status.text      | string  | Can be `reachable` or `unreachable`                                                                                           |
 
+      #### Source IP addresses
+
+      Netdata Cloud connects to your webhook URL from a fixed set of IP addresses. If your endpoint sits behind a firewall,
+      a WAF, or an IP allowlist, see
+      [Netdata Cloud Outbound IP Addresses](/docs/netdata-cloud/netdata-cloud-outbound-ips.md) for the published list and
+      how to consume it.
+
+      An IP allowlist is a network control, not an identity control — keep one of the authentication mechanisms below in
+      place as well.
+
       #### Extra headers
 
       When setting up a webhook service, the user can specify a set of headers to be included in the HTTP requests sent to the webhook URL.


### PR DESCRIPTION
##### Summary

Update the docs by adding information about a new endpoint to get the Netdata Cloud outgoing IPs.

##### Test Plan

n/a

##### Additional Information

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for finding and consuming Netdata Cloud’s published outbound IPv4 address list.
  - Documented firewall allowlisting recommendations, including scheduled refreshes, fail-closed handling, and defensive parsing.
  - Clarified which outbound traffic is covered and distinguished it from Agent-to-Cloud connectivity.
  - Updated MCP connection and webhook documentation with source IP details and authentication guidance.
  - Noted that published source IPs may change and should be refreshed periodically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->