### PR TITLE
refactor(go.d/snmp_topology): publish immutable topology generations

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -209,7 +209,7 @@ func (c *Collector) Cleanup(ctx context.Context) {
 		c.funcRouter.Cleanup(ctx)
 	}
 	if c.deviceStore != nil {
-		c.deviceStore.Unregister(c.deviceStoreKey())
+		c.deviceStore.Unregister(c.deviceStoreOwnerKey())
 	}
 	if c.snmpClient != nil {
 		_ = c.snmpClient.Close()

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -212,7 +212,7 @@ func TestCollector_CollectRegistersAndCleanupUnregistersDevice(t *testing.T) {
 
 	entries := deviceStore.Entries()
 	require.Len(t, entries, 1)
-	assert.Equal(t, collr.deviceStoreKey(), entries[0].Key)
+	assert.NotZero(t, entries[0].RegistrationID)
 	assert.Equal(t, "192.0.2.1", entries[0].Info.Hostname)
 	assert.Equal(t, 161, entries[0].Info.Port)
 	assert.Equal(t, gosnmp.Version2c.String(), entries[0].Info.SNMPVersion)

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -206,22 +206,23 @@ func TestCollector_CollectRegistersAndCleanupUnregistersDevice(t *testing.T) {
 
 	require.NoError(t, collr.Init(context.Background()))
 	require.NoError(t, collr.Check(context.Background()))
-	require.Empty(t, deviceStore.Devices())
+	require.Empty(t, deviceStore.Entries())
 
 	_ = collr.Collect(context.Background())
 
-	devices := deviceStore.Devices()
-	require.Len(t, devices, 1)
-	assert.Equal(t, "192.0.2.1", devices[0].Hostname)
-	assert.Equal(t, 161, devices[0].Port)
-	assert.Equal(t, gosnmp.Version2c.String(), devices[0].SNMPVersion)
-	assert.Equal(t, "mock sysName", devices[0].SysName)
-	assert.Equal(t, "mock sysDescr", devices[0].SysDescr)
-	assert.Equal(t, "mock sysContact", devices[0].SysContact)
-	assert.Equal(t, "mock sysLocation", devices[0].SysLocation)
+	entries := deviceStore.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, collr.deviceStoreKey(), entries[0].Key)
+	assert.Equal(t, "192.0.2.1", entries[0].Info.Hostname)
+	assert.Equal(t, 161, entries[0].Info.Port)
+	assert.Equal(t, gosnmp.Version2c.String(), entries[0].Info.SNMPVersion)
+	assert.Equal(t, "mock sysName", entries[0].Info.SysName)
+	assert.Equal(t, "mock sysDescr", entries[0].Info.SysDescr)
+	assert.Equal(t, "mock sysContact", entries[0].Info.SysContact)
+	assert.Equal(t, "mock sysLocation", entries[0].Info.SysLocation)
 
 	collr.Cleanup(context.Background())
-	require.Empty(t, deviceStore.Devices())
+	require.Empty(t, deviceStore.Entries())
 }
 
 func TestCollector_CollectSynchronizesDeviceMetadataOnceWithoutVnode(t *testing.T) {
@@ -254,20 +255,20 @@ func TestCollector_CollectSynchronizesDeviceMetadataOnceWithoutVnode(t *testing.
 	require.NoError(t, collr.Check(context.Background()))
 	require.NotNil(t, collr.Collect(context.Background()))
 
-	devices := deviceStore.Devices()
-	require.Len(t, devices, 1)
-	assert.Equal(t, "profile-vendor", devices[0].Vendor)
-	assert.Equal(t, "profile-model", devices[0].Model)
+	entries := deviceStore.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "profile-vendor", entries[0].Info.Vendor)
+	assert.Equal(t, "profile-model", entries[0].Info.Model)
 	assert.Zero(t, mockCollector.metadataCalls, "normal collection metadata must be reused without a separate request")
 
 	profileMetrics.DeviceMetadata["vendor"] = ddsnmp.MetaTag{Value: "later-vendor", IsExactMatch: true}
 	profileMetrics.DeviceMetadata["model"] = ddsnmp.MetaTag{Value: "later-model", IsExactMatch: true}
 	require.NotNil(t, collr.Collect(context.Background()))
 
-	devices = deviceStore.Devices()
-	require.Len(t, devices, 1)
-	assert.Equal(t, "profile-vendor", devices[0].Vendor)
-	assert.Equal(t, "profile-model", devices[0].Model)
+	entries = deviceStore.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "profile-vendor", entries[0].Info.Vendor)
+	assert.Equal(t, "profile-model", entries[0].Info.Model)
 	assert.Equal(t, 2, mockCollector.collectCalls)
 	assert.Zero(t, mockCollector.metadataCalls)
 }
@@ -294,12 +295,12 @@ func TestCollector_SetupVnodeAndRegisterDeviceStateShareResolvedMetadata(t *test
 	collr.vnode = collr.setupVnode(si, profileMetadata)
 	collr.registerDeviceState(si, nil)
 
-	devices := deviceStore.Devices()
-	require.Len(t, devices, 1)
-	assert.Equal(t, "profile-vendor", devices[0].VnodeLabels["vendor"])
-	assert.Equal(t, "operator-model", devices[0].VnodeLabels["model"])
-	assert.Equal(t, "profile-vendor", devices[0].Vendor)
-	assert.Equal(t, "operator-model", devices[0].Model)
+	entries := deviceStore.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "profile-vendor", entries[0].Info.VnodeLabels["vendor"])
+	assert.Equal(t, "operator-model", entries[0].Info.VnodeLabels["model"])
+	assert.Equal(t, "profile-vendor", entries[0].Info.Vendor)
+	assert.Equal(t, "operator-model", entries[0].Info.Model)
 }
 
 func TestCollector_Check(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -5,7 +5,8 @@ package ddsnmp
 import (
 	"maps"
 	"net/netip"
-	"sort"
+	"slices"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -45,48 +46,64 @@ type DeviceConnectionInfo struct {
 	VnodeLabels   map[string]string
 }
 
+// DeviceRegistrationID identifies one uninterrupted registration lifetime.
+// IDs are unique within one DeviceStore and never reused.
+type DeviceRegistrationID uint64
+
+func (id DeviceRegistrationID) String() string {
+	return strconv.FormatUint(uint64(id), 10)
+}
+
 // DeviceEntry is one registered SNMP job and its connection state.
-// Key is the opaque registration identity supplied by the owning job.
 type DeviceEntry struct {
-	Key  string
-	Info DeviceConnectionInfo
+	RegistrationID DeviceRegistrationID
+	Info           DeviceConnectionInfo
 }
 
 // NewDeviceStore returns an empty SNMP device connection-state store.
 func NewDeviceStore() *DeviceStore {
 	return &DeviceStore{
-		devices:    make(map[string]DeviceConnectionInfo),
-		byHostname: make(map[string]map[string]struct{}),
+		ownerRegistrations: make(map[string]DeviceRegistrationID),
+		devices:            make(map[DeviceRegistrationID]DeviceConnectionInfo),
+		byHostname:         make(map[string]map[string]struct{}),
 	}
 }
 
 // DeviceStore holds SNMP device connection state shared between SNMP-family modules.
 type DeviceStore struct {
-	mu         sync.RWMutex
-	devices    map[string]DeviceConnectionInfo
-	byHostname map[string]map[string]struct{}
+	mu                 sync.RWMutex
+	ownerRegistrations map[string]DeviceRegistrationID
+	devices            map[DeviceRegistrationID]DeviceConnectionInfo
+	byHostname         map[string]map[string]struct{}
+	lastRegistrationID DeviceRegistrationID
 }
 
-// Register adds or updates a device in the store.
+// Register adds or updates a device by its caller-owned lookup key. An update
+// retains the current registration ID; a new registration receives a new ID.
 // Reference types are deep-copied to prevent data races with the caller.
-func (s *DeviceStore) Register(key string, info DeviceConnectionInfo) {
+func (s *DeviceStore) Register(ownerKey string, info DeviceConnectionInfo) {
 	s.mu.Lock()
 	s.ensureMapsLocked()
-	if old, ok := s.devices[key]; ok {
-		s.removeHostnameIndexLocked(key, old.Hostname)
+	registrationID, exists := s.ownerRegistrations[ownerKey]
+	if exists {
+		s.removeHostnameIndexLocked(ownerKey, s.devices[registrationID].Hostname)
+	} else {
+		registrationID = s.nextRegistrationIDLocked()
+		s.ownerRegistrations[ownerKey] = registrationID
 	}
-	s.devices[key] = cloneDeviceConnectionInfo(info)
-	s.addHostnameIndexLocked(key, info.Hostname)
+	s.devices[registrationID] = cloneDeviceConnectionInfo(info)
+	s.addHostnameIndexLocked(ownerKey, info.Hostname)
 	s.mu.Unlock()
 }
 
 // Unregister removes a device from the store.
-func (s *DeviceStore) Unregister(key string) {
+func (s *DeviceStore) Unregister(ownerKey string) {
 	s.mu.Lock()
-	if old, ok := s.devices[key]; ok {
-		s.removeHostnameIndexLocked(key, old.Hostname)
+	if registrationID, ok := s.ownerRegistrations[ownerKey]; ok {
+		s.removeHostnameIndexLocked(ownerKey, s.devices[registrationID].Hostname)
+		delete(s.devices, registrationID)
+		delete(s.ownerRegistrations, ownerKey)
 	}
-	delete(s.devices, key)
 	s.mu.Unlock()
 }
 
@@ -95,17 +112,17 @@ func (s *DeviceStore) Entries() []DeviceEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	keys := make([]string, 0, len(s.devices))
-	for key := range s.devices {
-		keys = append(keys, key)
+	registrationIDs := make([]DeviceRegistrationID, 0, len(s.devices))
+	for registrationID := range s.devices {
+		registrationIDs = append(registrationIDs, registrationID)
 	}
-	sort.Strings(keys)
+	slices.Sort(registrationIDs)
 
-	entries := make([]DeviceEntry, 0, len(keys))
-	for _, key := range keys {
+	entries := make([]DeviceEntry, 0, len(registrationIDs))
+	for _, registrationID := range registrationIDs {
 		entries = append(entries, DeviceEntry{
-			Key:  key,
-			Info: cloneDeviceConnectionInfo(s.devices[key]),
+			RegistrationID: registrationID,
+			Info:           cloneDeviceConnectionInfo(s.devices[registrationID]),
 		})
 	}
 	return entries
@@ -132,13 +149,13 @@ func (s *DeviceStore) DevicesByHostname(hostname string) []DeviceConnectionInfo 
 		for key := range keySet {
 			keys = append(keys, key)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 
 		devices := make([]DeviceConnectionInfo, 0, len(keys))
-		for _, key := range keys {
-			info, ok := s.devices[key]
+		for _, ownerKey := range keys {
+			registrationID, ok := s.ownerRegistrations[ownerKey]
 			if ok {
-				devices = append(devices, cloneDeviceConnectionInfo(info))
+				devices = append(devices, cloneDeviceConnectionInfo(s.devices[registrationID]))
 			}
 		}
 		return devices
@@ -167,15 +184,26 @@ func cloneDeviceConnectionInfo(info DeviceConnectionInfo) DeviceConnectionInfo {
 }
 
 func (s *DeviceStore) ensureMapsLocked() {
+	if s.ownerRegistrations == nil {
+		s.ownerRegistrations = make(map[string]DeviceRegistrationID)
+	}
 	if s.devices == nil {
-		s.devices = make(map[string]DeviceConnectionInfo)
+		s.devices = make(map[DeviceRegistrationID]DeviceConnectionInfo)
 	}
 	if s.byHostname == nil {
 		s.byHostname = make(map[string]map[string]struct{})
-		for key, info := range s.devices {
-			s.addHostnameIndexLocked(key, info.Hostname)
+		for ownerKey, registrationID := range s.ownerRegistrations {
+			s.addHostnameIndexLocked(ownerKey, s.devices[registrationID].Hostname)
 		}
 	}
+}
+
+func (s *DeviceStore) nextRegistrationIDLocked() DeviceRegistrationID {
+	if s.lastRegistrationID == ^DeviceRegistrationID(0) {
+		panic("SNMP DeviceStore registration ID space exhausted")
+	}
+	s.lastRegistrationID++
+	return s.lastRegistrationID
 }
 
 func (s *DeviceStore) addHostnameIndexLocked(key, hostname string) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -45,6 +45,13 @@ type DeviceConnectionInfo struct {
 	VnodeLabels   map[string]string
 }
 
+// DeviceEntry is one registered SNMP job and its connection state.
+// Key is the opaque registration identity supplied by the owning job.
+type DeviceEntry struct {
+	Key  string
+	Info DeviceConnectionInfo
+}
+
 // NewDeviceStore returns an empty SNMP device connection-state store.
 func NewDeviceStore() *DeviceStore {
 	return &DeviceStore{
@@ -83,16 +90,25 @@ func (s *DeviceStore) Unregister(key string) {
 	s.mu.Unlock()
 }
 
-// Devices returns a deep-copied snapshot of all registered devices.
-func (s *DeviceStore) Devices() []DeviceConnectionInfo {
+// Entries returns a deterministic, deep-copied snapshot of all registered jobs.
+func (s *DeviceStore) Entries() []DeviceEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	devices := make([]DeviceConnectionInfo, 0, len(s.devices))
-	for _, info := range s.devices {
-		devices = append(devices, cloneDeviceConnectionInfo(info))
+	keys := make([]string, 0, len(s.devices))
+	for key := range s.devices {
+		keys = append(keys, key)
 	}
-	return devices
+	sort.Strings(keys)
+
+	entries := make([]DeviceEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, DeviceEntry{
+			Key:  key,
+			Info: cloneDeviceConnectionInfo(s.devices[key]),
+		})
+	}
+	return entries
 }
 
 // DevicesByHostname returns all deep-copied registered devices whose configured

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
@@ -95,18 +95,39 @@ func TestDeviceStoreRegisterClonesReferenceFields(t *testing.T) {
 
 	entries := store.Entries()
 	require.Len(t, entries, 1)
-	require.Equal(t, "switch-a", entries[0].Key)
+	require.NotZero(t, entries[0].RegistrationID)
 	require.Equal(t, []string{"profile-a"}, entries[0].Info.ManualProfiles)
 	require.Equal(t, "lab", entries[0].Info.VnodeLabels["site"])
 }
 
-func TestDeviceStoreEntriesAreSortedByRegistrationKey(t *testing.T) {
+func TestDeviceStoreEntriesAreSortedByRegistrationID(t *testing.T) {
 	store := NewDeviceStore()
-	store.Register("job-b", DeviceConnectionInfo{Hostname: "192.0.2.10"})
-	store.Register("job-a", DeviceConnectionInfo{Hostname: "192.0.2.10"})
+	store.Register("job-b", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "switch-b"})
+	store.Register("job-a", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "switch-a"})
 
 	entries := store.Entries()
 	require.Len(t, entries, 2)
-	require.Equal(t, "job-a", entries[0].Key)
-	require.Equal(t, "job-b", entries[1].Key)
+	require.Less(t, entries[0].RegistrationID, entries[1].RegistrationID)
+	require.Equal(t, "switch-b", entries[0].Info.SysName)
+	require.Equal(t, "switch-a", entries[1].Info.SysName)
+}
+
+func TestDeviceStoreRegistrationIdentityChangesOnlyAfterUnregister(t *testing.T) {
+	store := NewDeviceStore()
+	store.Register("owner-a", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "initial"})
+
+	entries := store.Entries()
+	require.Len(t, entries, 1)
+	initialIdentity := entries[0].RegistrationID
+
+	store.Register("owner-a", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "updated"})
+	entries = store.Entries()
+	require.Len(t, entries, 1)
+	require.Equal(t, initialIdentity, entries[0].RegistrationID, "live metadata updates must retain the registration identity")
+
+	store.Unregister("owner-a")
+	store.Register("owner-a", DeviceConnectionInfo{Hostname: "192.0.2.10", SysName: "replacement"})
+	entries = store.Entries()
+	require.Len(t, entries, 1)
+	require.Greater(t, entries[0].RegistrationID, initialIdentity, "replacement registrations must receive a new identity")
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
@@ -93,8 +93,20 @@ func TestDeviceStoreRegisterClonesReferenceFields(t *testing.T) {
 	info.ManualProfiles[0] = "changed"
 	info.VnodeLabels["site"] = "changed"
 
-	devices := store.Devices()
-	require.Len(t, devices, 1)
-	require.Equal(t, []string{"profile-a"}, devices[0].ManualProfiles)
-	require.Equal(t, "lab", devices[0].VnodeLabels["site"])
+	entries := store.Entries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "switch-a", entries[0].Key)
+	require.Equal(t, []string{"profile-a"}, entries[0].Info.ManualProfiles)
+	require.Equal(t, "lab", entries[0].Info.VnodeLabels["site"])
+}
+
+func TestDeviceStoreEntriesAreSortedByRegistrationKey(t *testing.T) {
+	store := NewDeviceStore()
+	store.Register("job-b", DeviceConnectionInfo{Hostname: "192.0.2.10"})
+	store.Register("job-a", DeviceConnectionInfo{Hostname: "192.0.2.10"})
+
+	entries := store.Entries()
+	require.Len(t, entries, 2)
+	require.Equal(t, "job-a", entries[0].Key)
+	require.Equal(t, "job-b", entries[1].Key)
 }

--- a/src/go/plugin/go.d/collector/snmp/device_state.go
+++ b/src/go/plugin/go.d/collector/snmp/device_state.go
@@ -42,7 +42,7 @@ func (c *Collector) vnodeLabels() map[string]string {
 	return nil
 }
 
-func (c *Collector) deviceStoreKey() string {
+func (c *Collector) deviceStoreOwnerKey() string {
 	return fmt.Sprintf("%p:%s:%d", c, c.Hostname, c.Options.Port)
 }
 
@@ -60,7 +60,7 @@ func (c *Collector) registerDeviceState(si *snmputils.SysInfo, profileMetadata m
 		vnodeLabels,
 	)
 
-	c.deviceStore.Register(c.deviceStoreKey(), ddsnmp.DeviceConnectionInfo{
+	c.deviceStore.Register(c.deviceStoreOwnerKey(), ddsnmp.DeviceConnectionInfo{
 		Hostname:        c.Hostname,
 		Port:            c.Options.Port,
 		SNMPVersion:     c.Options.Version,

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -6,8 +6,8 @@ per-protocol details; those live in the profile definitions and focused tests.
 
 ## Short Version
 
-`snmp_topology` is a single-instance go.d collector that periodically builds a
-cached topology view from SNMP devices registered by the SNMP collector.
+`snmp_topology` is a single-instance go.d collector that periodically builds an
+immutable topology generation from SNMP jobs registered by the SNMP collector.
 
 It has three independent entry points:
 
@@ -15,7 +15,7 @@ It has three independent entry points:
 - `Collect(ctx)` only publishes internal collector metrics.
 - `snmp:topology:snmp` serves the latest cached topology through a Function.
 
-Function calls do not walk SNMP. They snapshot already-collected cache state,
+Function calls do not walk SNMP. They acquire one already-published generation,
 build a graph, shape/enrich it, and render `netdata.topology.v1`.
 
 ## Runtime Order
@@ -67,20 +67,21 @@ collector instance for the whole agent.
 ```mermaid
 flowchart TD
     Run["Run(ctx)"]
-    Publish["publish trap enrichment"]
+    TrapPublish["publish trap enrichment"]
     Tick["initial refresh, then every update_every"]
-    Devices["read devices from DeviceStore"]
-    Fresh{"new or refresh_every elapsed?"}
+    Devices["read keyed jobs from DeviceStore"]
+    Fresh{"next retry/refresh due?"}
     Resolve["resolve DNS targets<br/>up to 8 workers, shared 5s budget"]
     Walk["SNMP walk topology profiles"]
-    Next["build fresh topologyCache off-registry"]
-    Swap["swap fresh cache into registered cache"]
-    Prune["prune removed devices"]
+    Next["build mutable device state off-registry"]
+    Freeze["freeze immutable DeviceGeneration"]
+    GenPublish["publish one TopologyGeneration"]
+    Prune["prune unregistered job state"]
     Collect["Collect(ctx)"]
     Metrics["write internal metrics only"]
 
-    Run --> Publish --> Tick --> Devices --> Fresh
-    Fresh -->|"yes"| Resolve --> Walk --> Next --> Swap --> Prune --> Tick
+    Run --> TrapPublish --> Tick --> Devices --> Fresh
+    Fresh -->|"yes"| Resolve --> Walk --> Next --> Freeze --> Prune --> GenPublish --> Tick
     Fresh -->|"no"| Prune
     Collect --> Metrics
 ```
@@ -93,27 +94,38 @@ Run(ctx)
     refreshTopologyRecovering(ctx)
 
 refreshTopology(ctx)
-  read registered SNMP devices from ddsnmp.DeviceStore
-  build a plan of new or stale devices
+  read keyed SNMP job entries from ddsnmp.DeviceStore
+  clone the current per-job refresh state for this sweep
+  build a plan of jobs whose next retry/refresh is due
   resolve planned DNS targets with up to eight workers under one shared 5s budget
-  for each planned device, in DeviceStore snapshot order:
+  for each planned job, in registration-key order:
     refreshDeviceTopology(ctx, key, device, targetManagementIPs)
-  prune caches for devices no longer registered
+    update lastAttempt, lastSuccess, nextRetry, outcome, and failure count
+  prune state for jobs no longer registered
+  atomically publish one immutable TopologyGeneration for the complete sweep
 
 refreshDeviceTopology(ctx, key, device, targetManagementIPs)
   connect to the device with gosnmp
   select topology profiles
   collect topology ProfileMetrics with ddsnmpcollector
   query sysUpTime
-  build a fresh per-device topologyCache off-registry with private target candidates
-  ingest topology metrics into the fresh cache
+  build a fresh mutable per-device builder with private target candidates
+  ingest topology metrics into the builder
   collect VTP VLAN contexts when needed
   filter target and observed addresses with collected masks, select one management IP, and finalize diagnostics
-  swap the fresh cache into the registered cache
+  freeze one immutable DeviceGeneration
 ```
 
 The refresh loop checks devices every `update_every` seconds, but a device is
-fully refreshed only when it is new or older than `refresh_every`.
+fully refreshed only when its normal refresh or failure retry is due. A failed
+attempt retries after `update_every`, doubles the delay after each consecutive
+failure, and caps at `refresh_every`. Success resets the failure count and
+restores the normal interval. Retry timing is internal and has no public tuning
+option.
+
+Refresh ownership uses the opaque DeviceStore registration key, not a rebuilt
+`hostname:port` key. Two SNMP jobs targeting the same endpoint therefore keep
+independent refresh state and independent device generations.
 
 Only due DNS targets enter the lookup phase; IP literals bypass the resolver.
 The workers are joined before SNMP collection begins, stop with the refresh
@@ -125,10 +137,13 @@ addresses, then uses one selector across the surviving targets, LLDP/CDP
 addresses, and IP-MIB addresses. Only the selected target enters public identity
 or trap matching; alternate DNS answers are never published as aliases.
 
-The important safety property is that a device refresh builds the next cache
-off-registry and only swaps it into the registered cache after ingestion
-finishes. Function readers keep seeing the previous complete snapshot while a
-new SNMP walk is in progress.
+The important safety property is two-level immutability. A device refresh builds
+and freezes its next generation off-registry. The collector then publishes the
+complete device vector with one atomic pointer update only after the sweep
+finishes. Function, focus-option, availability, reverse-DNS warming, and trap
+readers each acquire one generation and cannot combine devices from different
+sweeps. A failed attempt retains the last successful device generation; a
+canceled or panicking sweep does not publish a partial vector.
 
 ## Topology Profile Composition
 
@@ -167,11 +182,12 @@ anchor. An existing PDU emits the tagged observation with an internal value of
 zero, including when the PDU is an OctetString. Cache ingestion consumes the
 tags; scalar topology values retain normal value semantics.
 
-## Per-Device Cache
+## Per-Device Builder And Generation
 
-`topology_cache.go` defines one mutable cache per SNMP device.
+`topology_cache.go` defines the mutable, collection-only builder for one SNMP
+job. It is never published to runtime readers and needs no synchronization.
 
-The cache stores normalized intermediate facts collected from topology profile
+The builder stores normalized intermediate facts collected from topology profile
 metrics:
 
 - local device identity and metadata;
@@ -195,22 +211,37 @@ Ingestion is split by source area:
 - `topology_vlan_context_*.go`
 
 `topology_cache_metric_dispatch.go` maps `ddsnmp.TopologyKind` values to the
-right cache ingester. Profile tags and device metadata are applied separately
+right builder ingester. Profile tags and device metadata are applied separately
 because they describe the device itself rather than one topology row.
+
+Finalization converts the builder into an immutable `topologyDeviceGeneration`:
+
+- a prepared `ObservationSnapshot` for Function, focus, availability, and
+  reverse-DNS readers;
+- immutable trap-match, interface-name, and neighbor indexes;
+- collection and expiry timestamps;
+- the opaque DeviceStore registration key.
+
+The collector separately owns `deviceRefreshState` per registration key. It
+tracks `lastAttempt`, `lastSuccess`, `nextRetry`, the latest outcome,
+consecutive failures, and the last successful device generation.
 
 ## Registry And Snapshot
 
-`topology_registry.go` owns the set of active per-device caches.
+`topology_registry.go` owns one atomic pointer to the latest immutable
+`topologyGeneration`. The generation contains the complete, registration-key
+ordered vector produced by one refresh sweep.
 
 ```text
 topologyRegistry.snapshotWithOptions(options)
   normalize query options
-  take active cache snapshots
+  acquire one topology generation
+  select fresh device observation snapshots
   aggregate per-device observations
   build a topology graph
 ```
 
-Each cache snapshot is converted into:
+Each device generation contributes:
 
 - an `l2topology.L2Observation`, used by the generic L2 engine;
 - typed SNMP-side observation rows for L3 interfaces, OSPF neighbors, and BGP
@@ -279,8 +310,11 @@ subnets observed by different Agents do not collide after Cloud aggregation.
 If the registry id is unavailable, L3 subnet segment actors are omitted; direct
 L3 subnet links, OSPF, and BGP enrichment still run.
 
-Only fresh caches contribute snapshots. Stale caches are ignored until refreshed
-or pruned.
+Only fresh device generations contribute Function, focus, availability, and
+reverse-DNS snapshots. Trap enrichment preserves the prior behavior of using
+the last successfully published device generation even after topology display
+freshness expires; unregistering the SNMP job removes it on the next completed
+sweep.
 
 ## Graph Build Order
 
@@ -293,7 +327,7 @@ aggregate observations
   -> l2topology.BuildL2ResultFromObservations
   -> l2topology.ToGraph
   -> convert generic graph to topologymodel.Data
-  -> augment local actors with SNMP device/cache detail
+  -> augment local actors with SNMP device-generation detail
   -> topologyshape.ApplyPolicies
   -> topologyenrich.ApplyLayer3 (L3 subnet, OSPF, BGP)
   -> topologyshape.ApplyDepthFocusFilter
@@ -327,7 +361,7 @@ resolver from copied managed-actor references and shares it across L3 subnet,
 OSPF, and BGP enrichment. BGP runs last because it extends the resolver with
 BGP-local identifiers and interface addresses. This keeps actor-alias work
 linear in the indexed identities instead of repeating the complete alias scan
-for every cache snapshot and logical L3 enricher.
+for every device snapshot and logical L3 enricher.
 
 L3 subnet enrichment has two grains:
 
@@ -350,7 +384,7 @@ context and segment identity includes it.
 
 ## Internal Packages
 
-The root package owns collector lifecycle, cache ingestion, registry snapshots,
+The root package owns collector lifecycle, builder ingestion, immutable generations, registry snapshots,
 and adapters to shared SNMP-family state.
 
 The internal packages are deliberately narrower:
@@ -413,7 +447,7 @@ flowchart TD
     Handler["snmptopologyfunc.Handle"]
     Options["resolve QueryOptions"]
     Registry["topologyRegistry.snapshotWithOptions"]
-    Snapshot["fresh cache snapshots"]
+    Snapshot["fresh device-generation snapshots"]
     Aggregate["aggregate observations"]
     L2["l2topology BuildL2Result -> ToGraph"]
     Shape["topologyshape policies and focus"]
@@ -460,7 +494,7 @@ payload; it is a cross-collector lookup path for trap log rows.
 ## Metrics And Charts
 
 The collector emits internal metrics only. These metrics describe refresh health
-and cache state; they are not the topology payload.
+and retained device-generation state; they are not the topology payload.
 
 - `Collect(ctx)` writes current internal metric values.
 - `Run(ctx)` performs SNMP topology refresh.
@@ -469,25 +503,31 @@ and cache state; they are not the topology payload.
 ## Concurrency Rules
 
 - `Collector.refreshMu` serializes topology refreshes and cleanup.
-- Each `topologyCache` has its own `mu`.
-- The registry has its own `mu` for the set of active cache pointers.
-- Function requests snapshot caches under read locks; they do not mutate caches.
-- Device refresh swaps a completed per-device cache into the already-registered
-  cache instead of mutating the published cache step by step.
+- Each due device is collected into a private `topologyBuilder`; builders have no
+  locks because runtime readers never receive them.
+- Finalization freezes the builder into one immutable
+  `topologyDeviceGeneration`. A failed collection retains the prior successful
+  device generation.
+- A completed sweep publishes one immutable `topologyGeneration` through an
+  atomic pointer. Cancellation or panic leaves the previous generation visible.
+- Function, focus, availability, reverse-DNS, and trap readers each load that
+  pointer once and never block on collection or builder locks.
+- The registry mutex only protects producer-scope discovery and the reverse-DNS
+  warmer context; it does not protect topology generations.
 
-When adding new cache state, add it to:
+When adding new collected state, add it to:
 
-- `topologyCache`;
-- `newTopologyCache`;
-- `replaceWith`;
-- the relevant snapshot builder;
-- tests that prove stale/partial data is not exposed.
+- `topologyBuilder` and `newTopologyBuilder`;
+- the relevant ingestion and finalization path;
+- the immutable observation or trap projection that owns the published value;
+- tests proving the value is complete before publication and that a failed or
+  canceled refresh cannot expose partial state.
 
 ## Where To Change Things
 
 - Add or adjust SNMP topology profile rows:
   - profile YAML and `ddsnmp.TopologyKind`;
-  - cache ingester in the root package;
+  - builder ingester in the root package;
   - snapshot conversion if the row contributes to graph facts.
 - Add graph shaping policy:
   - `internal/topologyshape`.
@@ -501,7 +541,7 @@ When adding new cache state, add it to:
   - `internal/topologyv1`;
   - normalized golden test;
   - topology schema validation tests.
-- Add collector refresh or cache lifecycle behavior:
+- Add collector refresh or generation lifecycle behavior:
   - root package only.
 
 ## Validation Checklist
@@ -522,4 +562,4 @@ If topology output may have changed, also inspect:
 git diff -- src/go/plugin/go.d/collector/snmp_topology/testdata/topology_v1_normalized_golden.json
 ```
 
-An unchanged golden is expected for internal refactors and cache-only cleanup.
+An unchanged golden is expected for internal ownership and generation refactors.

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -69,7 +69,7 @@ flowchart TD
     Run["Run(ctx)"]
     TrapPublish["publish trap enrichment"]
     Tick["initial refresh, then every update_every"]
-    Devices["read keyed jobs from DeviceStore"]
+    Devices["read registered jobs from DeviceStore"]
     Fresh{"next retry/refresh due?"}
     Resolve["resolve DNS targets<br/>up to 8 workers, shared 5s budget"]
     Walk["SNMP walk topology profiles"]
@@ -95,18 +95,18 @@ Run(ctx)
     refreshTopologyRecovering(ctx)
 
 refreshTopology(ctx)
-  read keyed SNMP job entries from ddsnmp.DeviceStore
+  read SNMP job entries and store-owned registration IDs from ddsnmp.DeviceStore
   clone the current per-job refresh state for this sweep
   build a plan of jobs whose next retry/refresh is due
   resolve planned DNS targets with up to eight workers under one shared 5s budget
-  for each planned job, in registration-key order:
-    refreshDeviceTopology(ctx, key, device, targetManagementIPs)
+  for each planned job, in registration-ID order:
+    refreshDeviceTopology(ctx, registrationID, device, targetManagementIPs)
     update lastAttempt, lastSuccess, nextRetry, outcome, and failure count
   prune state for jobs no longer registered
   activate successful snapshots with one publication-based freshness deadline
   atomically publish one immutable TopologyGeneration for the complete sweep
 
-refreshDeviceTopology(ctx, key, device, targetManagementIPs)
+refreshDeviceTopology(ctx, registrationID, device, targetManagementIPs)
   connect to the device with gosnmp
   select topology profiles
   collect topology ProfileMetrics with ddsnmpcollector
@@ -124,12 +124,16 @@ attempt retries after `update_every`, doubles the delay after each consecutive
 failure, and caps at `refresh_every`. Success resets the failure count and
 restores the normal interval. Retry timing is internal and has no public tuning
 option. Retryable client-construction, connection, and collection warnings use
-the logger's built-in hourly limiter keyed by opaque registration identity and
+the logger's built-in hourly limiter keyed by registration ID and
 bounded failure class; warning suppression does not change retry timing.
 
-Refresh ownership uses the opaque DeviceStore registration key, not a rebuilt
-`hostname:port` key. Two SNMP jobs targeting the same endpoint therefore keep
-independent refresh state and independent device generations.
+`DeviceStore` keeps each caller-owned key private and assigns a typed, monotonic
+registration ID to each uninterrupted registration lifetime. Updating a live
+registration retains its ID; unregistering and registering the same owner key
+again receives a new ID. Refresh ownership uses that ID, not the owner key or a
+rebuilt `hostname:port` key. Two SNMP jobs targeting the same endpoint therefore
+keep independent refresh state and device generations, and a replacement job
+cannot inherit the removed job's retry or warning-limiter state.
 
 Only due DNS targets enter the lookup phase; IP literals bypass the resolver.
 The workers are joined before SNMP collection begins, stop with the refresh
@@ -226,16 +230,16 @@ Finalization converts the builder into an immutable `topologyDeviceGeneration`:
   reverse-DNS readers;
 - immutable trap-match, interface-name, and neighbor indexes;
 - collection and expiry timestamps;
-- the opaque DeviceStore registration key.
+- the typed DeviceStore registration ID.
 
-The collector separately owns `deviceRefreshState` per registration key. It
+The collector separately owns `deviceRefreshState` per registration ID. It
 tracks `lastAttempt`, `lastSuccess`, `nextRetry`, the latest outcome,
 consecutive failures, and the last successful device generation.
 
 ## Registry And Snapshot
 
 `topology_registry.go` owns one atomic pointer to the latest immutable
-`topologyGeneration`. The generation contains the complete, registration-key
+`topologyGeneration`. The generation contains the complete, registration-ID
 ordered vector produced by one refresh sweep.
 
 ```text

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -74,14 +74,15 @@ flowchart TD
     Resolve["resolve DNS targets<br/>up to 8 workers, shared 5s budget"]
     Walk["SNMP walk topology profiles"]
     Next["build mutable device state off-registry"]
-    Freeze["freeze immutable DeviceGeneration"]
+    Freeze["freeze immutable DeviceSnapshot"]
+    Activate["activate snapshots at publication"]
     GenPublish["publish one TopologyGeneration"]
     Prune["prune unregistered job state"]
     Collect["Collect(ctx)"]
     Metrics["write internal metrics only"]
 
     Run --> TrapPublish --> Tick --> Devices --> Fresh
-    Fresh -->|"yes"| Resolve --> Walk --> Next --> Freeze --> Prune --> GenPublish --> Tick
+    Fresh -->|"yes"| Resolve --> Walk --> Next --> Freeze --> Prune --> Activate --> GenPublish --> Tick
     Fresh -->|"no"| Prune
     Collect --> Metrics
 ```
@@ -102,6 +103,7 @@ refreshTopology(ctx)
     refreshDeviceTopology(ctx, key, device, targetManagementIPs)
     update lastAttempt, lastSuccess, nextRetry, outcome, and failure count
   prune state for jobs no longer registered
+  activate successful snapshots with one publication-based freshness deadline
   atomically publish one immutable TopologyGeneration for the complete sweep
 
 refreshDeviceTopology(ctx, key, device, targetManagementIPs)
@@ -113,7 +115,7 @@ refreshDeviceTopology(ctx, key, device, targetManagementIPs)
   ingest topology metrics into the builder
   collect VTP VLAN contexts when needed
   filter target and observed addresses with collected masks, select one management IP, and finalize diagnostics
-  freeze one immutable DeviceGeneration
+  freeze one immutable DeviceSnapshot with its exact acquisition time
 ```
 
 The refresh loop checks devices every `update_every` seconds, but a device is
@@ -121,7 +123,9 @@ fully refreshed only when its normal refresh or failure retry is due. A failed
 attempt retries after `update_every`, doubles the delay after each consecutive
 failure, and caps at `refresh_every`. Success resets the failure count and
 restores the normal interval. Retry timing is internal and has no public tuning
-option.
+option. Retryable client-construction, connection, and collection warnings use
+the logger's built-in hourly limiter keyed by opaque registration identity and
+bounded failure class; warning suppression does not change retry timing.
 
 Refresh ownership uses the opaque DeviceStore registration key, not a rebuilt
 `hostname:port` key. Two SNMP jobs targeting the same endpoint therefore keep
@@ -138,12 +142,14 @@ addresses, and IP-MIB addresses. Only the selected target enters public identity
 or trap matching; alternate DNS answers are never published as aliases.
 
 The important safety property is two-level immutability. A device refresh builds
-and freezes its next generation off-registry. The collector then publishes the
-complete device vector with one atomic pointer update only after the sweep
-finishes. Function, focus-option, availability, reverse-DNS warming, and trap
+and freezes its next collected snapshot off-registry. At the completed sweep
+boundary, successful snapshots are activated with one shared publication time,
+then the collector publishes the complete device vector with one atomic pointer
+update. Function, focus-option, availability, reverse-DNS warming, and trap
 readers each acquire one generation and cannot combine devices from different
-sweeps. A failed attempt retains the last successful device generation; a
-canceled or panicking sweep does not publish a partial vector.
+sweeps. A failed attempt retains the last successful device generation and its
+original freshness deadline; a canceled or panicking sweep does not publish a
+partial vector.
 
 ## Topology Profile Composition
 
@@ -236,7 +242,7 @@ ordered vector produced by one refresh sweep.
 topologyRegistry.snapshotWithOptions(options)
   normalize query options
   acquire one topology generation
-  select fresh device observation snapshots
+  read the generation's fixed renderable device membership
   aggregate per-device observations
   build a topology graph
 ```
@@ -310,13 +316,16 @@ subnets observed by different Agents do not collide after Cloud aggregation.
 If the registry id is unavailable, L3 subnet segment actors are omitted; direct
 L3 subnet links, OSPF, and BGP enrichment still run.
 
-Only fresh device generations contribute Function, focus, availability, and
-reverse-DNS snapshots. Trap enrichment preserves the prior behavior of using
-the last successfully published device generation even after topology display
-freshness expires; unregistering the SNMP job removes it on the next completed
-sweep. Failed refreshes retain the last successful generation but do not extend
-its original collection time or display-freshness deadline, so sustained
-failures do not present indefinitely stale topology as current.
+Renderable membership is fixed when a complete topology generation publishes;
+Function, focus, availability, and reverse-DNS readers therefore see one stable
+view until the next completed sweep. Newly successful device snapshots start
+their display-freshness window at that publication boundary while preserving
+their exact acquisition timestamp. A retained generation from a failed refresh
+keeps its original deadline and is removed from renderable membership when a
+later completed sweep observes it expired. Trap enrichment preserves the prior
+behavior of using the last successfully published device generation even after
+topology display freshness expires; unregistering the SNMP job removes it on the
+next completed sweep.
 
 ## Graph Build Order
 
@@ -508,10 +517,12 @@ and retained device-generation state; they are not the topology payload.
 - Each due device is collected into a private `topologyBuilder`; builders have no
   locks because runtime readers never receive them.
 - Finalization freezes the builder into one immutable
-  `topologyDeviceGeneration`. A failed collection retains the prior successful
-  device generation.
-- A completed sweep publishes one immutable `topologyGeneration` through an
-  atomic pointer. Cancellation or panic leaves the previous generation visible.
+  `topologyDeviceSnapshot`. A completed sweep activates successful snapshots as
+  `topologyDeviceGeneration` values at one shared publication time. A failed
+  collection retains the prior successful device generation and deadline.
+- A completed sweep fixes renderable membership and publishes one immutable
+  `topologyGeneration` through an atomic pointer. Cancellation or panic leaves
+  the previous generation visible.
 - Function, focus, availability, reverse-DNS, and trap readers each load that
   pointer once and never block on collection or builder locks.
 - The registry mutex only protects producer-scope discovery and the reverse-DNS

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -314,7 +314,9 @@ Only fresh device generations contribute Function, focus, availability, and
 reverse-DNS snapshots. Trap enrichment preserves the prior behavior of using
 the last successfully published device generation even after topology display
 freshness expires; unregistering the SNMP job removes it on the next completed
-sweep.
+sweep. Failed refreshes retain the last successful generation but do not extend
+its original collection time or display-freshness deadline, so sustained
+failures do not present indefinitely stale topology as current.
 
 ## Graph Build Order
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -173,6 +173,13 @@ const (
 	defaultRefreshEvery            = 30 * time.Minute
 	topologyTargetLookupMaxTimeout = 5 * time.Second
 	topologyTargetLookupMaxWorkers = 8
+	topologyRefreshWarningEvery    = time.Hour
+)
+
+const (
+	topologyRefreshFailureClient     = "client"
+	topologyRefreshFailureConnect    = "connect"
+	topologyRefreshFailureCollection = "collection"
 )
 
 type topologyRefreshDevicePlan struct {
@@ -238,6 +245,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 		registeredDevices: len(entries),
 	}
 	nextStates := cloneDeviceRefreshStates(c.deviceStates)
+	successfulSnapshots := make(map[string]*topologyDeviceSnapshot)
 
 	plans := make([]topologyRefreshDevicePlan, 0, len(entries))
 	for _, entry := range entries {
@@ -265,7 +273,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 		attemptedAt := c.currentTime()
 		state := nextStates[plan.key]
 		state.lastAttempt = attemptedAt
-		generation, outcome := c.refreshDeviceTopology(ctx, plan.key, plan.device, plan.targetManagementIPs)
+		snapshot, outcome := c.refreshDeviceTopology(ctx, plan.key, plan.device, plan.targetManagementIPs)
 		if ctx.Err() != nil {
 			break
 		}
@@ -274,7 +282,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 		state.outcome = outcome
 		switch outcome {
 		case deviceRefreshOutcomeSuccess:
-			state.generation = generation
+			successfulSnapshots[plan.key] = snapshot
 			state.lastSuccess = completedAt
 			state.consecutiveFailures = 0
 			state.nextRetry = completedAt.Add(refreshEvery)
@@ -304,9 +312,15 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	}
 
 	pruneUnregisteredDeviceStates(nextStates, seen)
+	publishedAt := c.currentTime()
+	for key, snapshot := range successfulSnapshots {
+		state := nextStates[key]
+		state.generation = activateTopologyDeviceSnapshot(key, publishedAt, snapshot)
+		nextStates[key] = state
+	}
 	c.deviceStates = nextStates
 	c.generationSequence++
-	generation := newTopologyGeneration(c.generationSequence, c.currentTime(), nextStates)
+	generation := newTopologyGeneration(c.generationSequence, publishedAt, nextStates)
 	c.topologyRegistry.publishGeneration(generation)
 	stats.cachedDevices = generation.deviceCount()
 	stats.completedAt = c.currentTime()
@@ -340,21 +354,22 @@ func (c *Collector) refreshTopologyRecovering(ctx context.Context) {
 	c.recordRefreshStats(c.refreshTopology(ctx))
 }
 
-// refreshDeviceTopology builds one immutable generation without changing the
-// generation currently visible to readers.
+// refreshDeviceTopology builds one immutable collected snapshot without
+// changing the generation currently visible to readers.
 func (c *Collector) refreshDeviceTopology(
 	ctx context.Context,
 	key string,
 	dev ddsnmp.DeviceConnectionInfo,
 	targetManagementIPs []netip.Addr,
-) (*topologyDeviceGeneration, deviceRefreshOutcome) {
+) (*topologyDeviceSnapshot, deviceRefreshOutcome) {
 	if ctx.Err() != nil {
 		return nil, deviceRefreshOutcomeFailed
 	}
 
 	snmpClient, err := newSNMPClientFromDeviceInfo(c.newSnmpClient, dev)
 	if err != nil {
-		c.Warningf("device '%s': failed to create SNMP client: %v", dev.Hostname, err)
+		c.warnTopologyRefreshFailure(key, topologyRefreshFailureClient,
+			"device '%s': failed to create SNMP client: %v", dev.Hostname, err)
 		return nil, deviceRefreshOutcomeFailed
 	}
 	if dev.MaxRepetitions != 0 {
@@ -364,7 +379,8 @@ func (c *Collector) refreshDeviceTopology(
 		if ctx.Err() != nil {
 			return nil, deviceRefreshOutcomeFailed
 		}
-		c.Warningf("device '%s': failed to connect: %v", dev.Hostname, err)
+		c.warnTopologyRefreshFailure(key, topologyRefreshFailureConnect,
+			"device '%s': failed to connect: %v", dev.Hostname, err)
 		return nil, deviceRefreshOutcomeFailed
 	}
 	stopContextClose := closeSNMPClientOnContextCancel(ctx, snmpClient)
@@ -397,7 +413,8 @@ func (c *Collector) refreshDeviceTopology(
 		if ctx.Err() != nil {
 			return nil, deviceRefreshOutcomeFailed
 		}
-		c.Warningf("device '%s': topology collection failed: %v", dev.Hostname, err)
+		c.warnTopologyRefreshFailure(key, topologyRefreshFailureCollection,
+			"device '%s': topology collection failed: %v", dev.Hostname, err)
 		return nil, deviceRefreshOutcomeFailed
 	}
 
@@ -427,7 +444,11 @@ func (c *Collector) refreshDeviceTopology(
 	if ctx.Err() != nil {
 		return nil, deviceRefreshOutcomeFailed
 	}
-	return c.freezeTopologyBuilder(key, next), deviceRefreshOutcomeSuccess
+	return c.freezeTopologyBuilder(next), deviceRefreshOutcomeSuccess
+}
+
+func (c *Collector) warnTopologyRefreshFailure(key, class, format string, args ...any) {
+	c.Limit("snmp_topology:refresh:"+key+":"+class, 1, topologyRefreshWarningEvery).Warningf(format, args...)
 }
 
 func (c *Collector) resolveTopologyTargetManagementIPs(

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -75,18 +75,18 @@ func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmen
 	}
 	metricStore := metrix.NewCollectorStore()
 	return &Collector{
-		deviceCaches:        make(map[string]*topologyCache),
-		deviceLastCollected: make(map[string]time.Time),
-		topologyRegistry:    newTopologyRegistryWithResolver(reverseDNS),
-		deviceSource:        deviceStore,
-		trapEnrichment:      trapEnrichment,
-		newSnmpClient:       gosnmp.NewHandler,
+		deviceStates:     make(map[string]deviceRefreshState),
+		topologyRegistry: newTopologyRegistryWithResolver(reverseDNS),
+		deviceSource:     deviceStore,
+		trapEnrichment:   trapEnrichment,
+		newSnmpClient:    gosnmp.NewHandler,
 		newDdSnmpColl: func(cfg ddsnmpcollector.Config) ddCollector {
 			return ddsnmpcollector.New(cfg)
 		},
 		resolveTargetIPs: func(ctx context.Context, host string) ([]netip.Addr, error) {
 			return net.DefaultResolver.LookupNetIP(ctx, "ip", host)
 		},
+		now:     time.Now,
 		store:   metricStore,
 		metrics: newCollectorMetrics(metricStore),
 	}
@@ -97,8 +97,8 @@ type (
 		collectorapi.Base `yaml:",inline"`
 		Config            `yaml:",inline"`
 
-		deviceCaches         map[string]*topologyCache // one cache per SNMP device
-		deviceLastCollected  map[string]time.Time      // last collection time per device
+		deviceStates         map[string]deviceRefreshState
+		generationSequence   uint64
 		topologyRegistry     *topologyRegistry
 		functionAvailability atomic.Bool
 		deviceSource         deviceSource
@@ -115,9 +115,10 @@ type (
 		newSnmpClient    func() gosnmp.Handler
 		newDdSnmpColl    func(ddsnmpcollector.Config) ddCollector
 		resolveTargetIPs func(context.Context, string) ([]netip.Addr, error)
+		now              func() time.Time
 	}
 	deviceSource interface {
-		Devices() []ddsnmp.DeviceConnectionInfo
+		Entries() []ddsnmp.DeviceEntry
 	}
 	ddCollector interface {
 		Collect() ([]*ddsnmp.ProfileMetrics, error)
@@ -183,6 +184,24 @@ type topologyRefreshDevicePlan struct {
 	targetManagementIPs []netip.Addr
 }
 
+type deviceRefreshOutcome uint8
+
+const (
+	deviceRefreshOutcomeUnknown deviceRefreshOutcome = iota
+	deviceRefreshOutcomeSuccess
+	deviceRefreshOutcomeNoProfiles
+	deviceRefreshOutcomeFailed
+)
+
+type deviceRefreshState struct {
+	generation          *topologyDeviceGeneration
+	lastAttempt         time.Time
+	lastSuccess         time.Time
+	nextRetry           time.Time
+	outcome             deviceRefreshOutcome
+	consecutiveFailures uint32
+}
+
 func (c *Collector) deviceCheckEvery() time.Duration {
 	if c.UpdateEvery > 0 {
 		return time.Duration(c.UpdateEvery) * time.Second
@@ -203,38 +222,35 @@ func (c *Collector) Cleanup(context.Context) {
 	c.refreshMu.Lock()
 	defer c.refreshMu.Unlock()
 
-	for key, cache := range c.deviceCaches {
-		c.topologyRegistry.unregister(cache)
-		delete(c.deviceCaches, key)
-		delete(c.deviceLastCollected, key)
-	}
+	c.deviceStates = make(map[string]deviceRefreshState)
+	c.topologyRegistry.publishGeneration(nil)
+	c.functionAvailability.Store(false)
 	c.recordCleanupStats()
 }
 
 func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
-	start := time.Now()
+	start := c.currentTime()
 	c.refreshMu.Lock()
 	defer c.refreshMu.Unlock()
 
-	devices := c.getRegisteredDevices()
+	entries := c.getRegisteredDevices()
 	refreshEvery := c.refreshEvery()
-	now := time.Now()
-	seen := make(map[string]bool, len(devices))
+	now := c.currentTime()
+	seen := make(map[string]bool, len(entries))
 	stats := refreshStats{
 		hasDeviceCounts:   true,
-		registeredDevices: len(devices),
+		registeredDevices: len(entries),
 	}
+	nextStates := cloneDeviceRefreshStates(c.deviceStates)
 
-	plans := make([]topologyRefreshDevicePlan, 0, len(devices))
-	for _, dev := range devices {
-		key := fmt.Sprintf("%s:%d", dev.Hostname, dev.Port)
+	plans := make([]topologyRefreshDevicePlan, 0, len(entries))
+	for _, entry := range entries {
+		key := entry.Key
+		dev := entry.Info
 		seen[key] = true
 
-		lastCollected, exists := c.deviceLastCollected[key]
-		isNew := !exists
-		isStale := exists && now.Sub(lastCollected) >= refreshEvery
-
-		if isNew || isStale {
+		state, exists := nextStates[key]
+		if !exists || state.nextRetry.IsZero() || !now.Before(state.nextRetry) {
 			plans = append(plans, topologyRefreshDevicePlan{key: key, device: dev})
 		}
 	}
@@ -250,29 +266,63 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 		if ctx.Err() != nil {
 			break
 		}
-		if !c.refreshDeviceTopology(ctx, plan.key, plan.device, plan.targetManagementIPs) {
+		attemptedAt := c.currentTime()
+		state := nextStates[plan.key]
+		state.lastAttempt = attemptedAt
+		generation, outcome := c.refreshDeviceTopology(ctx, plan.key, plan.device, plan.targetManagementIPs)
+		if ctx.Err() != nil {
+			break
+		}
+		completedAt := c.currentTime()
+
+		state.outcome = outcome
+		switch outcome {
+		case deviceRefreshOutcomeSuccess:
+			state.generation = generation
+			state.lastSuccess = completedAt
+			state.consecutiveFailures = 0
+			state.nextRetry = completedAt.Add(refreshEvery)
+		case deviceRefreshOutcomeNoProfiles:
+			state.consecutiveFailures = 0
+			state.nextRetry = completedAt.Add(refreshEvery)
+		default:
 			if ctx.Err() != nil {
 				break
 			}
 			stats.errors++
+			state.consecutiveFailures++
+			state.nextRetry = completedAt.Add(failedRefreshRetryDelay(
+				c.deviceCheckEvery(),
+				refreshEvery,
+				state.consecutiveFailures,
+			))
 		}
-		c.deviceLastCollected[plan.key] = now
+		nextStates[plan.key] = state
 	}
 
-	if ctx.Err() == nil {
-		c.pruneStaleDeviceCaches(seen)
+	if ctx.Err() != nil {
+		stats.cachedDevices = c.topologyRegistry.acquireGeneration().deviceCount()
+		stats.completedAt = c.currentTime()
+		stats.duration = stats.completedAt.Sub(start)
+		return stats
 	}
-	stats.cachedDevices = len(c.deviceCaches)
-	stats.completedAt = time.Now()
+
+	pruneUnregisteredDeviceStates(nextStates, seen)
+	c.deviceStates = nextStates
+	c.generationSequence++
+	generation := newTopologyGeneration(c.generationSequence, c.currentTime(), nextStates)
+	c.topologyRegistry.publishGeneration(generation)
+	stats.cachedDevices = generation.deviceCount()
+	stats.completedAt = c.currentTime()
 	stats.duration = stats.completedAt.Sub(start)
 	return stats
 }
 
-func (c *Collector) getRegisteredDevices() []ddsnmp.DeviceConnectionInfo {
+func (c *Collector) getRegisteredDevices() []ddsnmp.DeviceEntry {
 	if c.deviceSource == nil {
 		return nil
 	}
-	return c.deviceSource.Devices()
+	return c.deviceSource.Entries()
 }
 
 func (c *Collector) refreshTopologyRecovering(ctx context.Context) {
@@ -296,55 +346,51 @@ func (c *Collector) refreshTopologyRecovering(ctx context.Context) {
 }
 
 func (c *Collector) updateFunctionAvailability() {
-	if c.functionAvailability.Load() {
-		return
-	}
-	if c.topologyRegistry.hasRenderableObservations() {
-		c.functionAvailability.Store(true)
-	}
+	c.functionAvailability.Store(c.topologyRegistry.hasRenderableObservations())
 }
 
-// refreshDeviceTopology collects topology data for a single device into its own cache.
+// refreshDeviceTopology builds one immutable generation without changing the
+// generation currently visible to readers.
 func (c *Collector) refreshDeviceTopology(
 	ctx context.Context,
 	key string,
 	dev ddsnmp.DeviceConnectionInfo,
 	targetManagementIPs []netip.Addr,
-) bool {
+) (*topologyDeviceGeneration, deviceRefreshOutcome) {
 	if ctx.Err() != nil {
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
 
 	snmpClient, err := newSNMPClientFromDeviceInfo(c.newSnmpClient, dev)
 	if err != nil {
 		c.Warningf("device '%s': failed to create SNMP client: %v", dev.Hostname, err)
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
 	if dev.MaxRepetitions != 0 {
 		snmpClient.SetMaxRepetitions(dev.MaxRepetitions)
 	}
 	if err := snmpClient.Connect(); err != nil {
 		if ctx.Err() != nil {
-			return false
+			return nil, deviceRefreshOutcomeFailed
 		}
 		c.Warningf("device '%s': failed to connect: %v", dev.Hostname, err)
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
 	stopContextClose := closeSNMPClientOnContextCancel(ctx, snmpClient)
 	defer stopContextClose()
 	defer func() { _ = snmpClient.Close() }()
 
 	if ctx.Err() != nil {
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
 
 	profiles := c.getTopologyProfiles(dev)
 	if len(profiles) == 0 {
-		return true
+		return nil, deviceRefreshOutcomeNoProfiles
 	}
 
 	if ctx.Err() != nil {
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
 
 	coll := c.newDdSnmpColl(ddsnmpcollector.Config{
@@ -358,14 +404,14 @@ func (c *Collector) refreshDeviceTopology(
 	pms, err := coll.Collect()
 	if err != nil {
 		if ctx.Err() != nil {
-			return false
+			return nil, deviceRefreshOutcomeFailed
 		}
 		c.Warningf("device '%s': topology collection failed: %v", dev.Hostname, err)
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
 
 	if ctx.Err() != nil {
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
 
 	sysUptime, err := snmputils.GetSysUptime(snmpClient)
@@ -374,12 +420,12 @@ func (c *Collector) refreshDeviceTopology(
 	}
 
 	if ctx.Err() != nil {
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
 
-	// Build the next snapshot off-registry. Function readers keep seeing the
-	// previous complete snapshot until this collection is fully ingested.
-	next := c.newDeviceCollectionCache(dev)
+	// Build the next device generation off-registry. Function readers keep
+	// seeing the previous global generation until collection is fully ingested.
+	next := c.newDeviceTopologyBuilder(dev)
 	next.targetManagementIPs = append([]netip.Addr(nil), targetManagementIPs...)
 
 	next.updateTopologySysUptime(sysUptime)
@@ -388,15 +434,9 @@ func (c *Collector) refreshDeviceTopology(
 	next.ingestTopologyBGPPeers(pms)
 	c.collectTopologyVTPVLANContexts(ctx, next, dev)
 	if ctx.Err() != nil {
-		return false
+		return nil, deviceRefreshOutcomeFailed
 	}
-	c.finalizeTopologyCache(next)
-
-	cache := c.getOrCreateDeviceCache(key)
-	cache.mu.Lock()
-	cache.replaceWith(next)
-	cache.mu.Unlock()
-	return true
+	return c.freezeTopologyBuilder(key, next), deviceRefreshOutcomeSuccess
 }
 
 func (c *Collector) resolveTopologyTargetManagementIPs(
@@ -473,23 +513,20 @@ func closeSNMPClientOnContextCancel(ctx context.Context, client gosnmp.Handler) 
 	return func() { close(done) }
 }
 
-func (c *Collector) getOrCreateDeviceCache(key string) *topologyCache {
-	cache, ok := c.deviceCaches[key]
-	if !ok {
-		cache = newTopologyCache()
-		c.deviceCaches[key] = cache
-		c.topologyRegistry.register(cache)
-	}
-	return cache
-}
-
-func (c *Collector) newDeviceCollectionCache(dev ddsnmp.DeviceConnectionInfo) *topologyCache {
-	cache := newTopologyCache()
-	cache.updateTime = time.Now()
+func (c *Collector) newDeviceTopologyBuilder(dev ddsnmp.DeviceConnectionInfo) *topologyBuilder {
+	cache := newTopologyBuilder()
+	cache.updateTime = c.currentTime()
 	cache.staleAfter = c.refreshEvery() + 2*c.deviceCheckEvery()
 	cache.agentID = dev.Hostname
 	cache.localDevice = buildLocalTopologyDevice(dev)
 	return cache
+}
+
+func (c *Collector) currentTime() time.Time {
+	if c != nil && c.now != nil {
+		return c.now()
+	}
+	return time.Now()
 }
 
 func (c *Collector) resolveDeviceTargetManagementIPs(ctx context.Context, dev ddsnmp.DeviceConnectionInfo) []netip.Addr {
@@ -521,14 +558,41 @@ func (c *Collector) resolveDeviceTargetManagementIPs(ctx context.Context, dev dd
 	return normalizeTargetManagementIPs(addrs)
 }
 
-func (c *Collector) pruneStaleDeviceCaches(seen map[string]bool) {
-	for key, cache := range c.deviceCaches {
+func cloneDeviceRefreshStates(states map[string]deviceRefreshState) map[string]deviceRefreshState {
+	cloned := make(map[string]deviceRefreshState, len(states))
+	for key, state := range states {
+		cloned[key] = state
+	}
+	return cloned
+}
+
+func pruneUnregisteredDeviceStates(states map[string]deviceRefreshState, seen map[string]bool) {
+	for key := range states {
 		if !seen[key] {
-			c.topologyRegistry.unregister(cache)
-			delete(c.deviceCaches, key)
-			delete(c.deviceLastCollected, key)
+			delete(states, key)
 		}
 	}
+}
+
+func failedRefreshRetryDelay(checkEvery, refreshEvery time.Duration, consecutiveFailures uint32) time.Duration {
+	if checkEvery <= 0 {
+		checkEvery = defaultDeviceCheckEvery
+	}
+	if refreshEvery <= 0 {
+		refreshEvery = defaultRefreshEvery
+	}
+	if checkEvery >= refreshEvery {
+		return refreshEvery
+	}
+
+	delay := checkEvery
+	for failure := uint32(1); failure < consecutiveFailures; failure++ {
+		if delay >= refreshEvery/2 {
+			return refreshEvery
+		}
+		delay *= 2
+	}
+	return min(delay, refreshEvery)
 }
 
 func (c *Collector) findTopologyProfiles(dev ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -74,7 +74,7 @@ func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmen
 	}
 	metricStore := metrix.NewCollectorStore()
 	return &Collector{
-		deviceStates:     make(map[string]deviceRefreshState),
+		deviceStates:     make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState),
 		topologyRegistry: newTopologyRegistryWithResolver(reverseDNS),
 		deviceSource:     deviceStore,
 		trapEnrichment:   trapEnrichment,
@@ -96,7 +96,7 @@ type (
 		collectorapi.Base `yaml:",inline"`
 		Config            `yaml:",inline"`
 
-		deviceStates       map[string]deviceRefreshState
+		deviceStates       map[ddsnmp.DeviceRegistrationID]deviceRefreshState
 		generationSequence uint64
 		topologyRegistry   *topologyRegistry
 		deviceSource       deviceSource
@@ -183,7 +183,7 @@ const (
 )
 
 type topologyRefreshDevicePlan struct {
-	key                 string
+	registrationID      ddsnmp.DeviceRegistrationID
 	device              ddsnmp.DeviceConnectionInfo
 	targetManagementIPs []netip.Addr
 }
@@ -226,7 +226,7 @@ func (c *Collector) Cleanup(context.Context) {
 	c.refreshMu.Lock()
 	defer c.refreshMu.Unlock()
 
-	c.deviceStates = make(map[string]deviceRefreshState)
+	c.deviceStates = make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState)
 	c.topologyRegistry.publishGeneration(nil)
 	c.recordCleanupStats()
 }
@@ -239,23 +239,23 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	entries := c.getRegisteredDevices()
 	refreshEvery := c.refreshEvery()
 	now := c.currentTime()
-	seen := make(map[string]bool, len(entries))
+	seen := make(map[ddsnmp.DeviceRegistrationID]bool, len(entries))
 	stats := refreshStats{
 		hasDeviceCounts:   true,
 		registeredDevices: len(entries),
 	}
 	nextStates := cloneDeviceRefreshStates(c.deviceStates)
-	successfulSnapshots := make(map[string]*topologyDeviceSnapshot)
+	successfulSnapshots := make(map[ddsnmp.DeviceRegistrationID]*topologyDeviceSnapshot)
 
 	plans := make([]topologyRefreshDevicePlan, 0, len(entries))
 	for _, entry := range entries {
-		key := entry.Key
+		registrationID := entry.RegistrationID
 		dev := entry.Info
-		seen[key] = true
+		seen[registrationID] = true
 
-		state, exists := nextStates[key]
+		state, exists := nextStates[registrationID]
 		if !exists || state.nextRetry.IsZero() || !now.Before(state.nextRetry) {
-			plans = append(plans, topologyRefreshDevicePlan{key: key, device: dev})
+			plans = append(plans, topologyRefreshDevicePlan{registrationID: registrationID, device: dev})
 		}
 	}
 
@@ -271,9 +271,9 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 			break
 		}
 		attemptedAt := c.currentTime()
-		state := nextStates[plan.key]
+		state := nextStates[plan.registrationID]
 		state.lastAttempt = attemptedAt
-		snapshot, outcome := c.refreshDeviceTopology(ctx, plan.key, plan.device, plan.targetManagementIPs)
+		snapshot, outcome := c.refreshDeviceTopology(ctx, plan.registrationID, plan.device, plan.targetManagementIPs)
 		if ctx.Err() != nil {
 			break
 		}
@@ -282,7 +282,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 		state.outcome = outcome
 		switch outcome {
 		case deviceRefreshOutcomeSuccess:
-			successfulSnapshots[plan.key] = snapshot
+			successfulSnapshots[plan.registrationID] = snapshot
 			state.lastSuccess = completedAt
 			state.consecutiveFailures = 0
 			state.nextRetry = completedAt.Add(refreshEvery)
@@ -301,7 +301,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 				state.consecutiveFailures,
 			))
 		}
-		nextStates[plan.key] = state
+		nextStates[plan.registrationID] = state
 	}
 
 	if ctx.Err() != nil {
@@ -313,10 +313,10 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 
 	pruneUnregisteredDeviceStates(nextStates, seen)
 	publishedAt := c.currentTime()
-	for key, snapshot := range successfulSnapshots {
-		state := nextStates[key]
-		state.generation = activateTopologyDeviceSnapshot(key, publishedAt, snapshot)
-		nextStates[key] = state
+	for registrationID, snapshot := range successfulSnapshots {
+		state := nextStates[registrationID]
+		state.generation = activateTopologyDeviceSnapshot(registrationID, publishedAt, snapshot)
+		nextStates[registrationID] = state
 	}
 	c.deviceStates = nextStates
 	c.generationSequence++
@@ -358,7 +358,7 @@ func (c *Collector) refreshTopologyRecovering(ctx context.Context) {
 // changing the generation currently visible to readers.
 func (c *Collector) refreshDeviceTopology(
 	ctx context.Context,
-	key string,
+	registrationID ddsnmp.DeviceRegistrationID,
 	dev ddsnmp.DeviceConnectionInfo,
 	targetManagementIPs []netip.Addr,
 ) (*topologyDeviceSnapshot, deviceRefreshOutcome) {
@@ -368,7 +368,7 @@ func (c *Collector) refreshDeviceTopology(
 
 	snmpClient, err := newSNMPClientFromDeviceInfo(c.newSnmpClient, dev)
 	if err != nil {
-		c.warnTopologyRefreshFailure(key, topologyRefreshFailureClient,
+		c.warnTopologyRefreshFailure(registrationID, topologyRefreshFailureClient,
 			"device '%s': failed to create SNMP client: %v", dev.Hostname, err)
 		return nil, deviceRefreshOutcomeFailed
 	}
@@ -379,7 +379,7 @@ func (c *Collector) refreshDeviceTopology(
 		if ctx.Err() != nil {
 			return nil, deviceRefreshOutcomeFailed
 		}
-		c.warnTopologyRefreshFailure(key, topologyRefreshFailureConnect,
+		c.warnTopologyRefreshFailure(registrationID, topologyRefreshFailureConnect,
 			"device '%s': failed to connect: %v", dev.Hostname, err)
 		return nil, deviceRefreshOutcomeFailed
 	}
@@ -413,7 +413,7 @@ func (c *Collector) refreshDeviceTopology(
 		if ctx.Err() != nil {
 			return nil, deviceRefreshOutcomeFailed
 		}
-		c.warnTopologyRefreshFailure(key, topologyRefreshFailureCollection,
+		c.warnTopologyRefreshFailure(registrationID, topologyRefreshFailureCollection,
 			"device '%s': topology collection failed: %v", dev.Hostname, err)
 		return nil, deviceRefreshOutcomeFailed
 	}
@@ -447,8 +447,8 @@ func (c *Collector) refreshDeviceTopology(
 	return c.freezeTopologyBuilder(next), deviceRefreshOutcomeSuccess
 }
 
-func (c *Collector) warnTopologyRefreshFailure(key, class, format string, args ...any) {
-	c.Limit("snmp_topology:refresh:"+key+":"+class, 1, topologyRefreshWarningEvery).Warningf(format, args...)
+func (c *Collector) warnTopologyRefreshFailure(registrationID ddsnmp.DeviceRegistrationID, class, format string, args ...any) {
+	c.Limit("snmp_topology:refresh:"+registrationID.String()+":"+class, 1, topologyRefreshWarningEvery).Warningf(format, args...)
 }
 
 func (c *Collector) resolveTopologyTargetManagementIPs(
@@ -458,8 +458,8 @@ func (c *Collector) resolveTopologyTargetManagementIPs(
 	maxWorkers int,
 ) {
 	type lookupJob struct {
-		planIndex int
-		key       string
+		planIndex      int
+		registrationID ddsnmp.DeviceRegistrationID
 	}
 
 	jobs := make([]lookupJob, 0, len(plans))
@@ -473,7 +473,7 @@ func (c *Collector) resolveTopologyTargetManagementIPs(
 			continue
 		}
 		if c.resolveTargetIPs != nil {
-			jobs = append(jobs, lookupJob{planIndex: i, key: plans[i].key})
+			jobs = append(jobs, lookupJob{planIndex: i, registrationID: plans[i].registrationID})
 		}
 	}
 	if len(jobs) == 0 || budget <= 0 || maxWorkers <= 0 || ctx.Err() != nil {
@@ -481,8 +481,8 @@ func (c *Collector) resolveTopologyTargetManagementIPs(
 	}
 
 	sort.SliceStable(jobs, func(i, j int) bool {
-		if jobs[i].key != jobs[j].key {
-			return jobs[i].key < jobs[j].key
+		if jobs[i].registrationID != jobs[j].registrationID {
+			return jobs[i].registrationID < jobs[j].registrationID
 		}
 		return jobs[i].planIndex < jobs[j].planIndex
 	})
@@ -570,18 +570,18 @@ func (c *Collector) resolveDeviceTargetManagementIPs(ctx context.Context, dev dd
 	return normalizeTargetManagementIPs(addrs)
 }
 
-func cloneDeviceRefreshStates(states map[string]deviceRefreshState) map[string]deviceRefreshState {
-	cloned := make(map[string]deviceRefreshState, len(states))
-	for key, state := range states {
-		cloned[key] = state
+func cloneDeviceRefreshStates(states map[ddsnmp.DeviceRegistrationID]deviceRefreshState) map[ddsnmp.DeviceRegistrationID]deviceRefreshState {
+	cloned := make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState, len(states))
+	for registrationID, state := range states {
+		cloned[registrationID] = state
 	}
 	return cloned
 }
 
-func pruneUnregisteredDeviceStates(states map[string]deviceRefreshState, seen map[string]bool) {
-	for key := range states {
-		if !seen[key] {
-			delete(states, key)
+func pruneUnregisteredDeviceStates(states map[ddsnmp.DeviceRegistrationID]deviceRefreshState, seen map[ddsnmp.DeviceRegistrationID]bool) {
+	for registrationID := range states {
+		if !seen[registrationID] {
+			delete(states, registrationID)
 		}
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/netip"
 	"runtime/debug"
@@ -572,9 +573,7 @@ func (c *Collector) resolveDeviceTargetManagementIPs(ctx context.Context, dev dd
 
 func cloneDeviceRefreshStates(states map[ddsnmp.DeviceRegistrationID]deviceRefreshState) map[ddsnmp.DeviceRegistrationID]deviceRefreshState {
 	cloned := make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState, len(states))
-	for registrationID, state := range states {
-		cloned[registrationID] = state
-	}
+	maps.Copy(cloned, states)
 	return cloned
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -97,12 +96,11 @@ type (
 		collectorapi.Base `yaml:",inline"`
 		Config            `yaml:",inline"`
 
-		deviceStates         map[string]deviceRefreshState
-		generationSequence   uint64
-		topologyRegistry     *topologyRegistry
-		functionAvailability atomic.Bool
-		deviceSource         deviceSource
-		trapEnrichment       *TrapEnrichmentHandle
+		deviceStates       map[string]deviceRefreshState
+		generationSequence uint64
+		topologyRegistry   *topologyRegistry
+		deviceSource       deviceSource
+		trapEnrichment     *TrapEnrichmentHandle
 
 		refreshMu sync.Mutex
 		statsMu   sync.RWMutex
@@ -148,7 +146,6 @@ func (c *Collector) Run(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return nil
 	}
-	c.functionAvailability.Store(false)
 	c.publishTrapTopologyEnrichment()
 	defer c.unpublishTrapTopologyEnrichment()
 	c.topologyRegistry.setReverseDNSWarmContext(ctx)
@@ -224,7 +221,6 @@ func (c *Collector) Cleanup(context.Context) {
 
 	c.deviceStates = make(map[string]deviceRefreshState)
 	c.topologyRegistry.publishGeneration(nil)
-	c.functionAvailability.Store(false)
 	c.recordCleanupStats()
 }
 
@@ -342,11 +338,6 @@ func (c *Collector) refreshTopologyRecovering(ctx context.Context) {
 	}()
 
 	c.recordRefreshStats(c.refreshTopology(ctx))
-	c.updateFunctionAvailability()
-}
-
-func (c *Collector) updateFunctionAvailability() {
-	c.functionAvailability.Store(c.topologyRegistry.hasRenderableObservations())
 }
 
 // refreshDeviceTopology builds one immutable generation without changing the

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net/netip"
 	"sort"
 	"sync"
@@ -34,17 +33,17 @@ func TestCollectorGetRegisteredDevicesUsesInjectedDeviceStore(t *testing.T) {
 		VnodeLabels:    map[string]string{"site": "lab"},
 	})
 
-	devices := coll.getRegisteredDevices()
-	require.Len(t, devices, 1)
-	require.Equal(t, "192.0.2.10", devices[0].Hostname)
+	entries := coll.getRegisteredDevices()
+	require.Len(t, entries, 1)
+	require.Equal(t, "192.0.2.10", entries[0].Info.Hostname)
 
-	devices[0].ManualProfiles[0] = "changed"
-	devices[0].VnodeLabels["site"] = "changed"
+	entries[0].Info.ManualProfiles[0] = "changed"
+	entries[0].Info.VnodeLabels["site"] = "changed"
 
 	again := coll.getRegisteredDevices()
 	require.Len(t, again, 1)
-	require.Equal(t, []string{"profile-a"}, again[0].ManualProfiles)
-	require.Equal(t, "lab", again[0].VnodeLabels["site"])
+	require.Equal(t, []string{"profile-a"}, again[0].Info.ManualProfiles)
+	require.Equal(t, "lab", again[0].Info.VnodeLabels["site"])
 }
 
 func TestCollectorValidationLifecycleDoesNotStartPolling(t *testing.T) {
@@ -147,18 +146,183 @@ func TestCollectorRunDoesNotPollWhenContextAlreadyCanceled(t *testing.T) {
 	require.NoError(t, coll.Run(ctx))
 }
 
-func TestCollectorPruneStaleDeviceCachesRemovesLastDeviceCache(t *testing.T) {
+func TestCollectorRefreshPrunesUnregisteredDeviceStateFromPublishedGeneration(t *testing.T) {
 	coll := newTestSNMPTopologyCollector()
-	cache := newTopologyCache()
-	coll.deviceCaches["gone:161"] = cache
-	coll.deviceLastCollected["gone:161"] = time.Now()
-	coll.topologyRegistry.register(cache)
+	cache := newTopologyBuilder()
+	seedPublishedEndpointSnapshot(cache)
+	generation := newTopologyDeviceGeneration("gone", cache)
+	coll.deviceStates["gone"] = deviceRefreshState{generation: generation}
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 
 	coll.refreshTopology(context.Background())
 
-	require.Empty(t, coll.deviceCaches)
-	require.Empty(t, coll.deviceLastCollected)
-	require.False(t, topologyRegistryHasCache(coll.topologyRegistry, cache))
+	require.Empty(t, coll.deviceStates)
+	require.Zero(t, coll.topologyRegistry.acquireGeneration().deviceCount())
+}
+
+func TestCollectorRefreshKeepsDistinctRegistrationKeysForSharedEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: gosnmp.Version2c.String(),
+	}
+	first := snmpmock.NewMockHandler(ctrl)
+	second := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(first, dev)
+	expectTopologyRefreshSNMPClient(second, dev)
+
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.Register("job-a", dev)
+	store.Register("job-b", dev)
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
+	}
+	clients := []gosnmp.Handler{first, second}
+	coll.newSnmpClient = func() gosnmp.Handler {
+		client := clients[0]
+		clients = clients[1:]
+		return client
+	}
+
+	stats := coll.refreshTopology(context.Background())
+
+	require.Zero(t, stats.errors)
+	require.Equal(t, 2, stats.registeredDevices)
+	require.Equal(t, 2, stats.cachedDevices)
+	require.Contains(t, coll.deviceStates, "job-a")
+	require.Contains(t, coll.deviceStates, "job-b")
+	require.NotSame(t, coll.deviceStates["job-a"].generation, coll.deviceStates["job-b"].generation)
+	require.Equal(t, 2, coll.topologyRegistry.acquireGeneration().deviceCount())
+}
+
+func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: gosnmp.Version2c.String(),
+	}
+	firstFailure := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClientConnectError(firstFailure, dev, errors.New("unreachable"))
+	success := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(success, dev)
+	secondFailure := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClientConnectError(secondFailure, dev, errors.New("unreachable again"))
+
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.Register("job-a", dev)
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
+	}
+	clients := []gosnmp.Handler{firstFailure, success, secondFailure}
+	coll.newSnmpClient = func() gosnmp.Handler {
+		client := clients[0]
+		clients = clients[1:]
+		return client
+	}
+
+	base := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	now := base
+	coll.now = func() time.Time { return now }
+
+	firstStats := coll.refreshTopology(context.Background())
+	firstState := coll.deviceStates["job-a"]
+	require.Equal(t, 1, firstStats.errors)
+	require.Equal(t, deviceRefreshOutcomeFailed, firstState.outcome)
+	require.Equal(t, base, firstState.lastAttempt)
+	require.True(t, firstState.lastSuccess.IsZero())
+	require.Equal(t, base.Add(defaultDeviceCheckEvery), firstState.nextRetry)
+	require.EqualValues(t, 1, firstState.consecutiveFailures)
+	require.Nil(t, firstState.generation)
+
+	now = base.Add(30 * time.Second)
+	skippedStats := coll.refreshTopology(context.Background())
+	require.Zero(t, skippedStats.errors)
+	require.Len(t, clients, 2, "refresh before nextRetry must not create a client")
+
+	now = base.Add(defaultDeviceCheckEvery)
+	successStats := coll.refreshTopology(context.Background())
+	successState := coll.deviceStates["job-a"]
+	require.Zero(t, successStats.errors)
+	require.Equal(t, deviceRefreshOutcomeSuccess, successState.outcome)
+	require.Equal(t, now, successState.lastSuccess)
+	require.Equal(t, now.Add(defaultRefreshEvery), successState.nextRetry)
+	require.Zero(t, successState.consecutiveFailures)
+	require.NotNil(t, successState.generation)
+	lastSuccessGeneration := successState.generation
+
+	now = successState.nextRetry
+	failedStats := coll.refreshTopology(context.Background())
+	failedState := coll.deviceStates["job-a"]
+	require.Equal(t, 1, failedStats.errors)
+	require.Equal(t, deviceRefreshOutcomeFailed, failedState.outcome)
+	require.Equal(t, successState.lastSuccess, failedState.lastSuccess)
+	require.Same(t, lastSuccessGeneration, failedState.generation)
+	require.Equal(t, now.Add(defaultDeviceCheckEvery), failedState.nextRetry)
+	require.EqualValues(t, 1, failedState.consecutiveFailures)
+}
+
+func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: gosnmp.Version2c.String(),
+	}
+	mockHandler := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClientConnect(mockHandler, dev)
+	mockHandler.EXPECT().Close().Return(nil)
+
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.Register("job-a", dev)
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return nil }
+	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		t.Fatal("a device without topology profiles must not create a collector")
+		return nil
+	}
+
+	base := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	previousSuccess := base.Add(-time.Hour)
+	builder := newTopologyBuilder()
+	seedPublishedEndpointSnapshot(builder)
+	previous := newTopologyDeviceGeneration("job-a", builder)
+	coll.deviceStates["job-a"] = deviceRefreshState{
+		generation:          previous,
+		lastSuccess:         previousSuccess,
+		consecutiveFailures: 3,
+	}
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, base, coll.deviceStates))
+	coll.now = func() time.Time { return base }
+
+	stats := coll.refreshTopology(context.Background())
+	state := coll.deviceStates["job-a"]
+
+	require.Zero(t, stats.errors)
+	require.Equal(t, deviceRefreshOutcomeNoProfiles, state.outcome)
+	require.Equal(t, base, state.lastAttempt)
+	require.Equal(t, previousSuccess, state.lastSuccess)
+	require.Equal(t, base.Add(defaultRefreshEvery), state.nextRetry)
+	require.Zero(t, state.consecutiveFailures)
+	require.Same(t, previous, state.generation)
+	require.Same(t, previous, coll.topologyRegistry.acquireGeneration().devices[0])
+}
+
+func TestFailedRefreshRetryDelayCapsAtRefreshInterval(t *testing.T) {
+	require.Equal(t, time.Minute, failedRefreshRetryDelay(time.Minute, 30*time.Minute, 1))
+	require.Equal(t, 2*time.Minute, failedRefreshRetryDelay(time.Minute, 30*time.Minute, 2))
+	require.Equal(t, 16*time.Minute, failedRefreshRetryDelay(time.Minute, 30*time.Minute, 5))
+	require.Equal(t, 30*time.Minute, failedRefreshRetryDelay(time.Minute, 30*time.Minute, 6))
+	require.Equal(t, 30*time.Minute, failedRefreshRetryDelay(time.Minute, 30*time.Minute, 100))
 }
 
 func TestCollectorRefreshTopologyRecoveringHandlesPanic(t *testing.T) {
@@ -312,7 +476,7 @@ func TestCollectorCancelsInFlightVLANContextRefresh(t *testing.T) {
 func TestCollectorNewDeviceCollectionCacheUsesEffectiveDeviceCheckEvery(t *testing.T) {
 	coll := newTestSNMPTopologyCollector()
 
-	cache := coll.newDeviceCollectionCache(ddsnmp.DeviceConnectionInfo{Hostname: "switch-a"})
+	cache := coll.newDeviceTopologyBuilder(ddsnmp.DeviceConnectionInfo{Hostname: "switch-a"})
 
 	require.Equal(t, defaultRefreshEvery+2*defaultDeviceCheckEvery, cache.staleAfter)
 }
@@ -441,11 +605,23 @@ func TestCollectorRefreshResolvesOnlyDueDNSTargets(t *testing.T) {
 	for _, dev := range []ddsnmp.DeviceConnectionInfo{fresh, due, literal} {
 		registerTestDeviceState(store, dev)
 	}
-	freshKey := fresh.Hostname + ":161"
-	freshCache := newTopologyCache()
-	coll.deviceCaches[freshKey] = freshCache
-	coll.deviceLastCollected[freshKey] = time.Now()
-	coll.topologyRegistry.register(freshCache)
+	var freshKey, dueKey string
+	for _, entry := range store.Entries() {
+		switch entry.Info.Hostname {
+		case fresh.Hostname:
+			freshKey = entry.Key
+		case due.Hostname:
+			dueKey = entry.Key
+		}
+	}
+	require.NotEmpty(t, freshKey)
+	require.NotEmpty(t, dueKey)
+	coll.deviceStates[freshKey] = deviceRefreshState{
+		lastAttempt: time.Now(),
+		lastSuccess: time.Now(),
+		nextRetry:   time.Now().Add(time.Hour),
+		outcome:     deviceRefreshOutcomeSuccess,
+	}
 
 	mockHandler := snmpmock.NewMockHandler(ctrl)
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
@@ -475,8 +651,9 @@ func TestCollectorRefreshResolvesOnlyDueDNSTargets(t *testing.T) {
 	mu.Unlock()
 	require.Equal(t, []string{"switch-due.example"}, gotCalls)
 
-	dueSnapshot, ok := coll.deviceCaches[due.Hostname+":161"].snapshotEngineObservations()
-	require.True(t, ok)
+	dueGeneration := coll.deviceStates[dueKey].generation
+	require.NotNil(t, dueGeneration)
+	dueSnapshot := dueGeneration.observation
 	require.Len(t, dueSnapshot.L2Observations, 1)
 	require.Equal(t, "192.0.2.20", dueSnapshot.L2Observations[0].ManagementIP)
 
@@ -693,9 +870,10 @@ func TestCollectorRefreshPrefersResolvedTargetManagementIP(t *testing.T) {
 	}
 
 	key := dev.Hostname + ":161"
-	require.True(t, coll.refreshDeviceTopology(context.Background(), key, dev, []netip.Addr{netip.MustParseAddr("192.0.2.50")}))
-	snapshot, ok := coll.deviceCaches[key].snapshotEngineObservations()
-	require.True(t, ok)
+	generation, outcome := coll.refreshDeviceTopology(context.Background(), key, dev, []netip.Addr{netip.MustParseAddr("192.0.2.50")})
+	require.Equal(t, deviceRefreshOutcomeSuccess, outcome)
+	require.NotNil(t, generation)
+	snapshot := generation.observation
 	require.Len(t, snapshot.L2Observations, 1)
 	require.Equal(t, "192.0.2.50", snapshot.L2Observations[0].ManagementIP)
 }
@@ -747,15 +925,13 @@ func TestCollectorRefreshSelectsNextDNSTargetAfterMaskRejection(t *testing.T) {
 
 	require.Zero(t, stats.errors)
 	require.Equal(t, 1, resolverCalls)
-	cache := coll.deviceCaches[dev.Hostname+":161"]
-	require.NotNil(t, cache)
-	cache.mu.RLock()
-	local := cache.localDevice
-	trapMethods := maps.Clone(cache.trapMatchMethodByIP)
-	storedTargets := append([]netip.Addr(nil), cache.targetManagementIPs...)
-	cache.mu.RUnlock()
+	entries := store.Entries()
+	require.Len(t, entries, 1)
+	generation := coll.deviceStates[entries[0].Key].generation
+	require.NotNil(t, generation)
+	local := generation.observation.LocalDevice
+	trapMethods := generation.trap.matchMethodByIP
 	require.Equal(t, "198.51.100.10", local.ManagementIP)
-	require.Empty(t, storedTargets)
 	require.NotContains(t, local.ManagementAddresses, topologymodel.ManagementAddress{
 		Address:     "192.0.2.0",
 		AddressType: "ipv4",
@@ -789,7 +965,7 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	expectTopologyRefreshSNMPClient(mockHandler, dev)
 
 	key := "10.0.0.10:161"
-	published := newTopologyCache()
+	published := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(published)
 
 	started := make(chan struct{})
@@ -797,8 +973,9 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	done := make(chan struct{})
 
 	coll := newTestSNMPTopologyCollector()
-	coll.deviceCaches[key] = published
-	coll.topologyRegistry.register(published)
+	publishedGeneration := newTopologyDeviceGeneration(key, published)
+	coll.deviceStates[key] = deviceRefreshState{generation: publishedGeneration}
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
 		return &blockingTopologyCollector{
@@ -815,8 +992,9 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 
 	<-started
 
-	snapshot, ok := published.snapshotEngineObservations()
-	require.True(t, ok)
+	visible := coll.topologyRegistry.acquireGeneration()
+	require.Same(t, publishedGeneration, visible.devices[0])
+	snapshot := visible.devices[0].observation
 	require.Len(t, snapshot.L2Observations, 1)
 	require.Len(t, snapshot.L2Observations[0].FDBEntries, 1)
 	require.Len(t, snapshot.L2Observations[0].ARPNDEntries, 1)
@@ -839,12 +1017,13 @@ func TestCollector_RefreshFailureKeepsPublishedSnapshot(t *testing.T) {
 	mockHandler.EXPECT().Close().Return(nil)
 
 	key := "10.0.0.10:161"
-	published := newTopologyCache()
+	published := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(published)
 
 	coll := newTestSNMPTopologyCollector()
-	coll.deviceCaches[key] = published
-	coll.topologyRegistry.register(published)
+	publishedGeneration := newTopologyDeviceGeneration(key, published)
+	coll.deviceStates[key] = deviceRefreshState{generation: publishedGeneration}
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
 		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) {
@@ -852,10 +1031,13 @@ func TestCollector_RefreshFailureKeepsPublishedSnapshot(t *testing.T) {
 		})
 	}
 
-	require.False(t, coll.refreshDeviceTopology(context.Background(), key, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")}))
+	generation, outcome := coll.refreshDeviceTopology(context.Background(), key, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")})
+	require.Nil(t, generation)
+	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
 
-	snapshot, ok := published.snapshotEngineObservations()
-	require.True(t, ok)
+	visible := coll.topologyRegistry.acquireGeneration()
+	require.Same(t, publishedGeneration, visible.devices[0])
+	snapshot := visible.devices[0].observation
 	require.Len(t, snapshot.L2Observations, 1)
 	require.Len(t, snapshot.L2Observations[0].FDBEntries, 1)
 	require.Len(t, snapshot.L2Observations[0].ARPNDEntries, 1)
@@ -903,7 +1085,19 @@ func expectTopologyRefreshSNMPClientConnect(mockHandler *snmpmock.MockHandler, d
 	mockHandler.EXPECT().Connect().Return(nil)
 }
 
-func seedPublishedEndpointSnapshot(cache *topologyCache) {
+func expectTopologyRefreshSNMPClientConnectError(mockHandler *snmpmock.MockHandler, dev ddsnmp.DeviceConnectionInfo, err error) {
+	mockHandler.EXPECT().SetTarget(dev.Hostname)
+	mockHandler.EXPECT().SetPort(uint16(dev.Port))
+	mockHandler.EXPECT().SetRetries(dev.Retries)
+	mockHandler.EXPECT().SetTimeout(time.Duration(dev.Timeout) * time.Second)
+	mockHandler.EXPECT().SetMaxOids(dev.MaxOIDs)
+	mockHandler.EXPECT().SetMaxRepetitions(uint32(dev.MaxRepetitions))
+	mockHandler.EXPECT().SetCommunity(dev.Community)
+	mockHandler.EXPECT().SetVersion(gosnmp.Version2c)
+	mockHandler.EXPECT().Connect().Return(err)
+}
+
+func seedPublishedEndpointSnapshot(cache *topologyBuilder) {
 	now := time.Now()
 	cache.updateTime = now
 	cache.lastUpdate = now
@@ -958,11 +1152,4 @@ func replacementEndpointProfileMetrics() []*ddsnmp.ProfileMetrics {
 			},
 		},
 	}}
-}
-
-func topologyRegistryHasCache(registry *topologyRegistry, cache *topologyCache) bool {
-	registry.mu.RLock()
-	defer registry.mu.RUnlock()
-	_, ok := registry.caches[cache]
-	return ok
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -150,7 +150,7 @@ func TestCollectorRefreshPrunesUnregisteredDeviceStateFromPublishedGeneration(t 
 	coll := newTestSNMPTopologyCollector()
 	cache := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(cache)
-	generation := newTopologyDeviceGeneration("gone", cache)
+	generation := freezeTestTopologyBuilder("gone", cache)
 	coll.deviceStates["gone"] = deviceRefreshState{generation: generation}
 	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 
@@ -197,6 +197,72 @@ func TestCollectorRefreshKeepsDistinctRegistrationKeysForSharedEndpoint(t *testi
 	require.Contains(t, coll.deviceStates, "job-b")
 	require.NotSame(t, coll.deviceStates["job-a"].generation, coll.deviceStates["job-b"].generation)
 	require.Equal(t, 2, coll.topologyRegistry.acquireGeneration().deviceCount())
+}
+
+func TestCollectorRefreshPublishesOnlyAfterCompleteMultiDeviceSweep(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	devA := ddsnmp.DeviceConnectionInfo{Hostname: "192.0.2.10", Port: 161, SNMPVersion: gosnmp.Version2c.String()}
+	devB := ddsnmp.DeviceConnectionInfo{Hostname: "192.0.2.20", Port: 161, SNMPVersion: gosnmp.Version2c.String()}
+	clientA := snmpmock.NewMockHandler(ctrl)
+	clientB := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(clientA, devA)
+	expectTopologyRefreshSNMPClient(clientB, devB)
+
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.Register("job-a", devA)
+	store.Register("job-b", devB)
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	clients := []gosnmp.Handler{clientA, clientB}
+	coll.newSnmpClient = func() gosnmp.Handler {
+		client := clients[0]
+		clients = clients[1:]
+		return client
+	}
+
+	secondStarted := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	collectorCalls := 0
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		collectorCalls++
+		if collectorCalls == 1 {
+			return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
+		}
+		return &blockingTopologyCollector{started: secondStarted, release: releaseSecond}
+	}
+
+	previous := testTopologyGenerationVector(7, time.Now(), "previous")
+	previous.devices[0].key = "job-a"
+	previous.devices[1].key = "job-b"
+	coll.deviceStates = map[string]deviceRefreshState{
+		"job-a": {generation: previous.devices[0]},
+		"job-b": {generation: previous.devices[1]},
+	}
+	coll.generationSequence = previous.sequence
+	coll.topologyRegistry.publishGeneration(previous)
+
+	done := make(chan refreshStats, 1)
+	go func() { done <- coll.refreshTopology(context.Background()) }()
+
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second device refresh did not start")
+	}
+	require.Same(t, previous, coll.topologyRegistry.acquireGeneration())
+	require.Same(t, previous.devices[0], coll.deviceStates["job-a"].generation)
+	require.Same(t, previous.devices[1], coll.deviceStates["job-b"].generation)
+
+	close(releaseSecond)
+	stats := <-done
+	require.Zero(t, stats.errors)
+	published := coll.topologyRegistry.acquireGeneration()
+	require.NotSame(t, previous, published)
+	require.EqualValues(t, 8, published.sequence)
+	require.Len(t, published.devices, 2)
+	require.Same(t, coll.deviceStates["job-a"].generation, published.devices[0])
+	require.Same(t, coll.deviceStates["job-b"].generation, published.devices[1])
 }
 
 func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *testing.T) {
@@ -267,6 +333,8 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 	require.Same(t, lastSuccessGeneration, failedState.generation)
 	require.Equal(t, now.Add(defaultDeviceCheckEvery), failedState.nextRetry)
 	require.EqualValues(t, 1, failedState.consecutiveFailures)
+	require.False(t, failedState.generation.freshAt(failedState.generation.expiresAt.Add(time.Nanosecond)),
+		"failure retention must not extend the last successful collection's display freshness")
 }
 
 func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(t *testing.T) {
@@ -295,7 +363,7 @@ func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(
 	previousSuccess := base.Add(-time.Hour)
 	builder := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(builder)
-	previous := newTopologyDeviceGeneration("job-a", builder)
+	previous := freezeTestTopologyBuilder("job-a", builder)
 	coll.deviceStates["job-a"] = deviceRefreshState{
 		generation:          previous,
 		lastSuccess:         previousSuccess,
@@ -334,9 +402,19 @@ func TestCollectorRefreshTopologyRecoveringHandlesPanic(t *testing.T) {
 	coll.newSnmpClient = func() gosnmp.Handler {
 		panic("boom")
 	}
+	builder := newTopologyBuilder()
+	seedPublishedEndpointSnapshot(builder)
+	previousDevice := freezeTestTopologyBuilder("test:192.0.2.10:161:0", builder)
+	coll.deviceStates[previousDevice.key] = deviceRefreshState{generation: previousDevice}
+	previous := newTopologyGeneration(1, time.Now(), coll.deviceStates)
+	coll.generationSequence = previous.sequence
+	coll.topologyRegistry.publishGeneration(previous)
 
 	require.NotPanics(t, func() { coll.refreshTopologyRecovering(context.Background()) })
 	require.NotPanics(t, func() { coll.refreshTopologyRecovering(context.Background()) })
+	require.Same(t, previous, coll.topologyRegistry.acquireGeneration())
+	require.Same(t, previousDevice, coll.deviceStates[previousDevice.key].generation)
+	require.EqualValues(t, 1, coll.generationSequence)
 }
 
 func TestCollectorRunCancelsInFlightRefresh(t *testing.T) {
@@ -973,7 +1051,7 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	done := make(chan struct{})
 
 	coll := newTestSNMPTopologyCollector()
-	publishedGeneration := newTopologyDeviceGeneration(key, published)
+	publishedGeneration := freezeTestTopologyBuilder(key, published)
 	coll.deviceStates[key] = deviceRefreshState{generation: publishedGeneration}
 	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
@@ -1021,7 +1099,7 @@ func TestCollector_RefreshFailureKeepsPublishedSnapshot(t *testing.T) {
 	seedPublishedEndpointSnapshot(published)
 
 	coll := newTestSNMPTopologyCollector()
-	publishedGeneration := newTopologyDeviceGeneration(key, published)
+	publishedGeneration := freezeTestTopologyBuilder(key, published)
 	coll.deviceStates[key] = deviceRefreshState{generation: publishedGeneration}
 	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
@@ -1152,4 +1230,39 @@ func replacementEndpointProfileMetrics() []*ddsnmp.ProfileMetrics {
 			},
 		},
 	}}
+}
+
+func BenchmarkCollectorRefreshNoDueDevices(b *testing.B) {
+	for _, deviceCount := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("devices=%d", deviceCount), func(b *testing.B) {
+			coll, store := newTestSNMPTopologyCollectorWithStore()
+			now := time.Now()
+			coll.now = func() time.Time { return now }
+			for i := range deviceCount {
+				key := fmt.Sprintf("job-%06d", i)
+				store.Register(key, ddsnmp.DeviceConnectionInfo{
+					Hostname:       fmt.Sprintf("192.0.%d.%d", i/254, i%254+1),
+					Port:           161,
+					ManualProfiles: []string{"generic-device"},
+					VnodeLabels:    map[string]string{"site": "benchmark"},
+				})
+				coll.deviceStates[key] = deviceRefreshState{
+					generation:  &topologyDeviceGeneration{key: key, collectedAt: now, expiresAt: now.Add(time.Hour)},
+					lastSuccess: now,
+					nextRetry:   now.Add(time.Hour),
+					outcome:     deviceRefreshOutcomeSuccess,
+				}
+			}
+			coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, now, coll.deviceStates))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				stats := coll.refreshTopology(context.Background())
+				if stats.registeredDevices != deviceCount || stats.errors != 0 {
+					b.Fatalf("refresh stats: registered=%d errors=%d", stats.registeredDevices, stats.errors)
+				}
+			}
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -154,8 +154,9 @@ func TestCollectorRefreshPrunesUnregisteredDeviceStateFromPublishedGeneration(t 
 	coll := newTestSNMPTopologyCollector()
 	cache := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(cache)
-	generation := freezeTestTopologyBuilder("gone", cache)
-	coll.deviceStates["gone"] = deviceRefreshState{generation: generation}
+	const registrationID ddsnmp.DeviceRegistrationID = 1
+	generation := freezeTestTopologyBuilder(registrationID, cache)
+	coll.deviceStates[registrationID] = deviceRefreshState{generation: generation}
 	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 
 	coll.refreshTopology(context.Background())
@@ -194,13 +195,63 @@ func TestCollectorRefreshKeepsDistinctRegistrationKeysForSharedEndpoint(t *testi
 
 	stats := coll.refreshTopology(context.Background())
 
+	entries := store.Entries()
+	require.Len(t, entries, 2)
+	firstRegistrationID := entries[0].RegistrationID
+	secondRegistrationID := entries[1].RegistrationID
 	require.Zero(t, stats.errors)
 	require.Equal(t, 2, stats.registeredDevices)
 	require.Equal(t, 2, stats.cachedDevices)
-	require.Contains(t, coll.deviceStates, "job-a")
-	require.Contains(t, coll.deviceStates, "job-b")
-	require.NotSame(t, coll.deviceStates["job-a"].generation, coll.deviceStates["job-b"].generation)
+	require.Contains(t, coll.deviceStates, firstRegistrationID)
+	require.Contains(t, coll.deviceStates, secondRegistrationID)
+	require.NotSame(t, coll.deviceStates[firstRegistrationID].generation, coll.deviceStates[secondRegistrationID].generation)
 	require.Equal(t, 2, coll.topologyRegistry.acquireGeneration().deviceCount())
+}
+
+func TestCollectorRefreshTreatsReregisteredOwnerAsNewDevice(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: gosnmp.Version2c.String(),
+	}
+	mockHandler := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(mockHandler, dev)
+
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
+	}
+	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
+
+	base := time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC)
+	coll.now = func() time.Time { return base }
+	store.Register("owner-a", dev)
+	oldEntry := store.Entries()[0]
+	oldBuilder := newTopologyBuilder()
+	seedPublishedEndpointSnapshot(oldBuilder)
+	oldGeneration := freezeTestTopologyBuilder(oldEntry.RegistrationID, oldBuilder)
+	coll.deviceStates[oldEntry.RegistrationID] = deviceRefreshState{
+		generation: oldGeneration,
+		nextRetry:  base.Add(time.Hour),
+		outcome:    deviceRefreshOutcomeSuccess,
+	}
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, base, coll.deviceStates))
+
+	store.Unregister("owner-a")
+	store.Register("owner-a", dev)
+	newEntry := store.Entries()[0]
+
+	stats := coll.refreshTopology(context.Background())
+
+	require.Zero(t, stats.errors)
+	require.NotEqual(t, oldEntry.RegistrationID, newEntry.RegistrationID)
+	require.NotContains(t, coll.deviceStates, oldEntry.RegistrationID)
+	require.Equal(t, deviceRefreshOutcomeSuccess, coll.deviceStates[newEntry.RegistrationID].outcome)
+	require.NotSame(t, oldGeneration, coll.deviceStates[newEntry.RegistrationID].generation)
 }
 
 func TestCollectorRefreshPublishesOnlyAfterCompleteMultiDeviceSweep(t *testing.T) {
@@ -217,6 +268,10 @@ func TestCollectorRefreshPublishesOnlyAfterCompleteMultiDeviceSweep(t *testing.T
 	coll, store := newTestSNMPTopologyCollectorWithStore()
 	store.Register("job-a", devA)
 	store.Register("job-b", devB)
+	entries := store.Entries()
+	require.Len(t, entries, 2)
+	registrationA := entries[0].RegistrationID
+	registrationB := entries[1].RegistrationID
 	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
 	clients := []gosnmp.Handler{clientA, clientB}
 	coll.newSnmpClient = func() gosnmp.Handler {
@@ -237,11 +292,11 @@ func TestCollectorRefreshPublishesOnlyAfterCompleteMultiDeviceSweep(t *testing.T
 	}
 
 	previous := testTopologyGenerationVector(7, time.Now(), "previous")
-	previous.devices[0].key = "job-a"
-	previous.devices[1].key = "job-b"
-	coll.deviceStates = map[string]deviceRefreshState{
-		"job-a": {generation: previous.devices[0]},
-		"job-b": {generation: previous.devices[1]},
+	previous.devices[0].registrationID = registrationA
+	previous.devices[1].registrationID = registrationB
+	coll.deviceStates = map[ddsnmp.DeviceRegistrationID]deviceRefreshState{
+		registrationA: {generation: previous.devices[0]},
+		registrationB: {generation: previous.devices[1]},
 	}
 	coll.generationSequence = previous.sequence
 	coll.topologyRegistry.publishGeneration(previous)
@@ -255,8 +310,8 @@ func TestCollectorRefreshPublishesOnlyAfterCompleteMultiDeviceSweep(t *testing.T
 		t.Fatal("second device refresh did not start")
 	}
 	require.Same(t, previous, coll.topologyRegistry.acquireGeneration())
-	require.Same(t, previous.devices[0], coll.deviceStates["job-a"].generation)
-	require.Same(t, previous.devices[1], coll.deviceStates["job-b"].generation)
+	require.Same(t, previous.devices[0], coll.deviceStates[registrationA].generation)
+	require.Same(t, previous.devices[1], coll.deviceStates[registrationB].generation)
 
 	close(releaseSecond)
 	stats := <-done
@@ -265,8 +320,8 @@ func TestCollectorRefreshPublishesOnlyAfterCompleteMultiDeviceSweep(t *testing.T
 	require.NotSame(t, previous, published)
 	require.EqualValues(t, 8, published.sequence)
 	require.Len(t, published.devices, 2)
-	require.Same(t, coll.deviceStates["job-a"].generation, published.devices[0])
-	require.Same(t, coll.deviceStates["job-b"].generation, published.devices[1])
+	require.Same(t, coll.deviceStates[registrationA].generation, published.devices[0])
+	require.Same(t, coll.deviceStates[registrationB].generation, published.devices[1])
 }
 
 func TestCollectorRefreshActivatesFreshnessAtAtomicPublication(t *testing.T) {
@@ -283,6 +338,10 @@ func TestCollectorRefreshActivatesFreshnessAtAtomicPublication(t *testing.T) {
 	coll, store := newTestSNMPTopologyCollectorWithStore()
 	store.Register("job-a", devA)
 	store.Register("job-b", devB)
+	entries := store.Entries()
+	require.Len(t, entries, 2)
+	registrationA := entries[0].RegistrationID
+	registrationB := entries[1].RegistrationID
 	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
 	clients := []gosnmp.Handler{clientA, clientB}
 	coll.newSnmpClient = func() gosnmp.Handler {
@@ -308,11 +367,11 @@ func TestCollectorRefreshActivatesFreshnessAtAtomicPublication(t *testing.T) {
 	coll.now = func() time.Time { return time.Unix(0, clock.Load()).UTC() }
 
 	previous := testTopologyGenerationVector(1, base, "previous")
-	previous.devices[0].key = "job-a"
-	previous.devices[1].key = "job-b"
-	coll.deviceStates = map[string]deviceRefreshState{
-		"job-a": {generation: previous.devices[0]},
-		"job-b": {generation: previous.devices[1]},
+	previous.devices[0].registrationID = registrationA
+	previous.devices[1].registrationID = registrationB
+	coll.deviceStates = map[ddsnmp.DeviceRegistrationID]deviceRefreshState{
+		registrationA: {generation: previous.devices[0]},
+		registrationB: {generation: previous.devices[1]},
 	}
 	coll.generationSequence = previous.sequence
 	coll.topologyRegistry.publishGeneration(previous)
@@ -336,11 +395,11 @@ func TestCollectorRefreshActivatesFreshnessAtAtomicPublication(t *testing.T) {
 	published := coll.topologyRegistry.acquireGeneration()
 	require.Len(t, topologyObservationSnapshots(published), 2,
 		"every successful result must be fresh when its sweep is first published")
-	require.Equal(t, base, coll.deviceStates["job-a"].generation.collectedAt,
+	require.Equal(t, base, coll.deviceStates[registrationA].generation.collectedAt,
 		"activation must preserve the exact device acquisition time")
 	require.Equal(t,
 		published.publishedAt.Add(coll.refreshEvery()+2*coll.deviceCheckEvery()),
-		coll.deviceStates["job-a"].generation.expiresAt,
+		coll.deviceStates[registrationA].generation.expiresAt,
 		"the freshness window must begin at atomic publication",
 	)
 }
@@ -381,14 +440,14 @@ func TestCollectorDeviceRefreshWarningsAreLimitedPerRegistrationAndFailureClass(
 	}
 
 	for range 2 {
-		snapshot, outcome := coll.refreshDeviceTopology(context.Background(), "job-a", dev, nil)
+		snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil)
 		require.Nil(t, snapshot)
 		require.Equal(t, deviceRefreshOutcomeFailed, outcome)
 	}
-	snapshot, outcome := coll.refreshDeviceTopology(context.Background(), "job-a", dev, nil)
+	snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil)
 	require.Nil(t, snapshot)
 	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
-	snapshot, outcome = coll.refreshDeviceTopology(context.Background(), "job-b", dev, nil)
+	snapshot, outcome = coll.refreshDeviceTopology(context.Background(), 2, dev, nil)
 	require.Nil(t, snapshot)
 	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
 
@@ -418,6 +477,7 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 
 	coll, store := newTestSNMPTopologyCollectorWithStore()
 	store.Register("job-a", dev)
+	registrationID := store.Entries()[0].RegistrationID
 	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
 		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
@@ -434,7 +494,7 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 	coll.now = func() time.Time { return now }
 
 	firstStats := coll.refreshTopology(context.Background())
-	firstState := coll.deviceStates["job-a"]
+	firstState := coll.deviceStates[registrationID]
 	require.Equal(t, 1, firstStats.errors)
 	require.Equal(t, deviceRefreshOutcomeFailed, firstState.outcome)
 	require.Equal(t, base, firstState.lastAttempt)
@@ -450,7 +510,7 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 
 	now = base.Add(defaultDeviceCheckEvery)
 	successStats := coll.refreshTopology(context.Background())
-	successState := coll.deviceStates["job-a"]
+	successState := coll.deviceStates[registrationID]
 	require.Zero(t, successStats.errors)
 	require.Equal(t, deviceRefreshOutcomeSuccess, successState.outcome)
 	require.Equal(t, now, successState.lastSuccess)
@@ -461,7 +521,7 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 
 	now = successState.nextRetry
 	failedStats := coll.refreshTopology(context.Background())
-	failedState := coll.deviceStates["job-a"]
+	failedState := coll.deviceStates[registrationID]
 	require.Equal(t, 1, failedStats.errors)
 	require.Equal(t, deviceRefreshOutcomeFailed, failedState.outcome)
 	require.Equal(t, successState.lastSuccess, failedState.lastSuccess)
@@ -487,6 +547,7 @@ func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(
 
 	coll, store := newTestSNMPTopologyCollectorWithStore()
 	store.Register("job-a", dev)
+	registrationID := store.Entries()[0].RegistrationID
 	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return nil }
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
@@ -498,8 +559,8 @@ func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(
 	previousSuccess := base.Add(-time.Hour)
 	builder := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(builder)
-	previous := freezeTestTopologyBuilder("job-a", builder)
-	coll.deviceStates["job-a"] = deviceRefreshState{
+	previous := freezeTestTopologyBuilder(registrationID, builder)
+	coll.deviceStates[registrationID] = deviceRefreshState{
 		generation:          previous,
 		lastSuccess:         previousSuccess,
 		consecutiveFailures: 3,
@@ -508,7 +569,7 @@ func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(
 	coll.now = func() time.Time { return base }
 
 	stats := coll.refreshTopology(context.Background())
-	state := coll.deviceStates["job-a"]
+	state := coll.deviceStates[registrationID]
 
 	require.Zero(t, stats.errors)
 	require.Equal(t, deviceRefreshOutcomeNoProfiles, state.outcome)
@@ -539,8 +600,9 @@ func TestCollectorRefreshTopologyRecoveringHandlesPanic(t *testing.T) {
 	}
 	builder := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(builder)
-	previousDevice := freezeTestTopologyBuilder("test:192.0.2.10:161:0", builder)
-	coll.deviceStates[previousDevice.key] = deviceRefreshState{generation: previousDevice}
+	registrationID := store.Entries()[0].RegistrationID
+	previousDevice := freezeTestTopologyBuilder(registrationID, builder)
+	coll.deviceStates[previousDevice.registrationID] = deviceRefreshState{generation: previousDevice}
 	previous := newTopologyGeneration(1, time.Now(), coll.deviceStates)
 	coll.generationSequence = previous.sequence
 	coll.topologyRegistry.publishGeneration(previous)
@@ -548,7 +610,7 @@ func TestCollectorRefreshTopologyRecoveringHandlesPanic(t *testing.T) {
 	require.NotPanics(t, func() { coll.refreshTopologyRecovering(context.Background()) })
 	require.NotPanics(t, func() { coll.refreshTopologyRecovering(context.Background()) })
 	require.Same(t, previous, coll.topologyRegistry.acquireGeneration())
-	require.Same(t, previousDevice, coll.deviceStates[previousDevice.key].generation)
+	require.Same(t, previousDevice, coll.deviceStates[previousDevice.registrationID].generation)
 	require.EqualValues(t, 1, coll.generationSequence)
 }
 
@@ -818,18 +880,18 @@ func TestCollectorRefreshResolvesOnlyDueDNSTargets(t *testing.T) {
 	for _, dev := range []ddsnmp.DeviceConnectionInfo{fresh, due, literal} {
 		registerTestDeviceState(store, dev)
 	}
-	var freshKey, dueKey string
+	var freshRegistrationID, dueRegistrationID ddsnmp.DeviceRegistrationID
 	for _, entry := range store.Entries() {
 		switch entry.Info.Hostname {
 		case fresh.Hostname:
-			freshKey = entry.Key
+			freshRegistrationID = entry.RegistrationID
 		case due.Hostname:
-			dueKey = entry.Key
+			dueRegistrationID = entry.RegistrationID
 		}
 	}
-	require.NotEmpty(t, freshKey)
-	require.NotEmpty(t, dueKey)
-	coll.deviceStates[freshKey] = deviceRefreshState{
+	require.NotZero(t, freshRegistrationID)
+	require.NotZero(t, dueRegistrationID)
+	coll.deviceStates[freshRegistrationID] = deviceRefreshState{
 		lastAttempt: time.Now(),
 		lastSuccess: time.Now(),
 		nextRetry:   time.Now().Add(time.Hour),
@@ -864,7 +926,7 @@ func TestCollectorRefreshResolvesOnlyDueDNSTargets(t *testing.T) {
 	mu.Unlock()
 	require.Equal(t, []string{"switch-due.example"}, gotCalls)
 
-	dueGeneration := coll.deviceStates[dueKey].generation
+	dueGeneration := coll.deviceStates[dueRegistrationID].generation
 	require.NotNil(t, dueGeneration)
 	dueSnapshot := dueGeneration.observation
 	require.Len(t, dueSnapshot.L2Observations, 1)
@@ -890,8 +952,8 @@ func TestCollectorResolveTopologyTargetManagementIPsUsesStableBoundedSharedBudge
 	for i := deviceCount - 1; i >= 0; i-- {
 		host := fmt.Sprintf("switch-%02d.example", i)
 		plans = append(plans, topologyRefreshDevicePlan{
-			key:    host + ":161",
-			device: ddsnmp.DeviceConnectionInfo{Hostname: host, Port: 161},
+			registrationID: ddsnmp.DeviceRegistrationID(i + 1),
+			device:         ddsnmp.DeviceConnectionInfo{Hostname: host, Port: 161},
 		})
 	}
 
@@ -942,9 +1004,9 @@ func TestCollectorResolveTopologyTargetManagementIPsUsesStableBoundedSharedBudge
 func TestCollectorResolveTopologyTargetManagementIPsAssociatesResultsAndBypassesLiterals(t *testing.T) {
 	coll := newTestSNMPTopologyCollector()
 	plans := []topologyRefreshDevicePlan{
-		{key: "switch-b.example:161", device: ddsnmp.DeviceConnectionInfo{Hostname: "switch-b.example"}},
-		{key: "literal:161", device: ddsnmp.DeviceConnectionInfo{Hostname: "::ffff:192.0.2.10"}},
-		{key: "switch-a.example:161", device: ddsnmp.DeviceConnectionInfo{Hostname: "switch-a.example"}},
+		{registrationID: 2, device: ddsnmp.DeviceConnectionInfo{Hostname: "switch-b.example"}},
+		{registrationID: 3, device: ddsnmp.DeviceConnectionInfo{Hostname: "::ffff:192.0.2.10"}},
+		{registrationID: 1, device: ddsnmp.DeviceConnectionInfo{Hostname: "switch-a.example"}},
 	}
 
 	var mu sync.Mutex
@@ -1002,8 +1064,8 @@ func TestCollectorResolveTopologyTargetManagementIPsJoinsWorkersOnCancellation(t
 	for i := range plans {
 		host := fmt.Sprintf("switch-%02d.example", i)
 		plans[i] = topologyRefreshDevicePlan{
-			key:    host + ":161",
-			device: ddsnmp.DeviceConnectionInfo{Hostname: host},
+			registrationID: ddsnmp.DeviceRegistrationID(i + 1),
+			device:         ddsnmp.DeviceConnectionInfo{Hostname: host},
 		}
 	}
 
@@ -1082,8 +1144,7 @@ func TestCollectorRefreshPrefersResolvedTargetManagementIP(t *testing.T) {
 		})
 	}
 
-	key := dev.Hostname + ":161"
-	generation, outcome := coll.refreshDeviceTopology(context.Background(), key, dev, []netip.Addr{netip.MustParseAddr("192.0.2.50")})
+	generation, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, []netip.Addr{netip.MustParseAddr("192.0.2.50")})
 	require.Equal(t, deviceRefreshOutcomeSuccess, outcome)
 	require.NotNil(t, generation)
 	snapshot := generation.observation
@@ -1140,7 +1201,7 @@ func TestCollectorRefreshSelectsNextDNSTargetAfterMaskRejection(t *testing.T) {
 	require.Equal(t, 1, resolverCalls)
 	entries := store.Entries()
 	require.Len(t, entries, 1)
-	generation := coll.deviceStates[entries[0].Key].generation
+	generation := coll.deviceStates[entries[0].RegistrationID].generation
 	require.NotNil(t, generation)
 	local := generation.observation.LocalDevice
 	trapMethods := generation.trap.matchMethodByIP
@@ -1177,7 +1238,7 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	mockHandler := snmpmock.NewMockHandler(ctrl)
 	expectTopologyRefreshSNMPClient(mockHandler, dev)
 
-	key := "10.0.0.10:161"
+	const registrationID ddsnmp.DeviceRegistrationID = 1
 	published := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(published)
 
@@ -1186,8 +1247,8 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	done := make(chan struct{})
 
 	coll := newTestSNMPTopologyCollector()
-	publishedGeneration := freezeTestTopologyBuilder(key, published)
-	coll.deviceStates[key] = deviceRefreshState{generation: publishedGeneration}
+	publishedGeneration := freezeTestTopologyBuilder(registrationID, published)
+	coll.deviceStates[registrationID] = deviceRefreshState{generation: publishedGeneration}
 	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
@@ -1200,7 +1261,7 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 
 	go func() {
 		defer close(done)
-		coll.refreshDeviceTopology(context.Background(), key, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")})
+		coll.refreshDeviceTopology(context.Background(), registrationID, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")})
 	}()
 
 	<-started
@@ -1229,13 +1290,13 @@ func TestCollector_RefreshFailureKeepsPublishedSnapshot(t *testing.T) {
 	expectTopologyRefreshSNMPClientConnect(mockHandler, dev)
 	mockHandler.EXPECT().Close().Return(nil)
 
-	key := "10.0.0.10:161"
+	const registrationID ddsnmp.DeviceRegistrationID = 1
 	published := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(published)
 
 	coll := newTestSNMPTopologyCollector()
-	publishedGeneration := freezeTestTopologyBuilder(key, published)
-	coll.deviceStates[key] = deviceRefreshState{generation: publishedGeneration}
+	publishedGeneration := freezeTestTopologyBuilder(registrationID, published)
+	coll.deviceStates[registrationID] = deviceRefreshState{generation: publishedGeneration}
 	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
@@ -1244,7 +1305,7 @@ func TestCollector_RefreshFailureKeepsPublishedSnapshot(t *testing.T) {
 		})
 	}
 
-	generation, outcome := coll.refreshDeviceTopology(context.Background(), key, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")})
+	generation, outcome := coll.refreshDeviceTopology(context.Background(), registrationID, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")})
 	require.Nil(t, generation)
 	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
 
@@ -1374,15 +1435,18 @@ func BenchmarkCollectorRefreshNoDueDevices(b *testing.B) {
 			now := time.Now()
 			coll.now = func() time.Time { return now }
 			for i := range deviceCount {
-				key := fmt.Sprintf("job-%06d", i)
-				store.Register(key, ddsnmp.DeviceConnectionInfo{
+				ownerKey := fmt.Sprintf("job-%06d", i)
+				store.Register(ownerKey, ddsnmp.DeviceConnectionInfo{
 					Hostname:       fmt.Sprintf("192.0.%d.%d", i/254, i%254+1),
 					Port:           161,
 					ManualProfiles: []string{"generic-device"},
 					VnodeLabels:    map[string]string{"site": "benchmark"},
 				})
-				coll.deviceStates[key] = deviceRefreshState{
-					generation:  &topologyDeviceGeneration{key: key, collectedAt: now, expiresAt: now.Add(time.Hour)},
+			}
+			for _, entry := range store.Entries() {
+				registrationID := entry.RegistrationID
+				coll.deviceStates[registrationID] = deviceRefreshState{
+					generation:  &topologyDeviceGeneration{registrationID: registrationID, collectedAt: now, expiresAt: now.Add(time.Hour)},
 					lastSuccess: now,
 					nextRetry:   now.Add(time.Hour),
 					outcome:     deviceRefreshOutcomeSuccess,

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -3,12 +3,15 @@
 package snmptopology
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net/netip"
 	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +22,7 @@ import (
 	snmpmock "github.com/gosnmp/gosnmp/mocks"
 	"github.com/stretchr/testify/require"
 
+	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
@@ -263,6 +267,137 @@ func TestCollectorRefreshPublishesOnlyAfterCompleteMultiDeviceSweep(t *testing.T
 	require.Len(t, published.devices, 2)
 	require.Same(t, coll.deviceStates["job-a"].generation, published.devices[0])
 	require.Same(t, coll.deviceStates["job-b"].generation, published.devices[1])
+}
+
+func TestCollectorRefreshActivatesFreshnessAtAtomicPublication(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	devA := ddsnmp.DeviceConnectionInfo{Hostname: "192.0.2.10", Port: 161, SNMPVersion: gosnmp.Version2c.String()}
+	devB := ddsnmp.DeviceConnectionInfo{Hostname: "192.0.2.20", Port: 161, SNMPVersion: gosnmp.Version2c.String()}
+	clientA := snmpmock.NewMockHandler(ctrl)
+	clientB := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(clientA, devA)
+	expectTopologyRefreshSNMPClient(clientB, devB)
+
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.Register("job-a", devA)
+	store.Register("job-b", devB)
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	clients := []gosnmp.Handler{clientA, clientB}
+	coll.newSnmpClient = func() gosnmp.Handler {
+		client := clients[0]
+		clients = clients[1:]
+		return client
+	}
+
+	secondStarted := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	collectorCalls := 0
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		collectorCalls++
+		if collectorCalls == 1 {
+			return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
+		}
+		return &blockingTopologyCollector{started: secondStarted, release: releaseSecond}
+	}
+
+	base := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	var clock atomic.Int64
+	clock.Store(base.UnixNano())
+	coll.now = func() time.Time { return time.Unix(0, clock.Load()).UTC() }
+
+	previous := testTopologyGenerationVector(1, base, "previous")
+	previous.devices[0].key = "job-a"
+	previous.devices[1].key = "job-b"
+	coll.deviceStates = map[string]deviceRefreshState{
+		"job-a": {generation: previous.devices[0]},
+		"job-b": {generation: previous.devices[1]},
+	}
+	coll.generationSequence = previous.sequence
+	coll.topologyRegistry.publishGeneration(previous)
+
+	done := make(chan refreshStats, 1)
+	go func() { done <- coll.refreshTopology(context.Background()) }()
+
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second device refresh did not start")
+	}
+	clock.Store(base.Add(2 * time.Hour).UnixNano())
+	visibleDuringSweep := topologyObservationSnapshots(coll.topologyRegistry.acquireGeneration())
+
+	close(releaseSecond)
+	stats := <-done
+	require.Zero(t, stats.errors)
+	require.Len(t, visibleDuringSweep, 2,
+		"published membership must remain fixed while the next sweep is in flight")
+	published := coll.topologyRegistry.acquireGeneration()
+	require.Len(t, topologyObservationSnapshots(published), 2,
+		"every successful result must be fresh when its sweep is first published")
+	require.Equal(t, base, coll.deviceStates["job-a"].generation.collectedAt,
+		"activation must preserve the exact device acquisition time")
+	require.Equal(t,
+		published.publishedAt.Add(coll.refreshEvery()+2*coll.deviceCheckEvery()),
+		coll.deviceStates["job-a"].generation.expiresAt,
+		"the freshness window must begin at atomic publication",
+	)
+}
+
+func TestCollectorDeviceRefreshWarningsAreLimitedPerRegistrationAndFailureClass(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: gosnmp.Version2c.String(),
+	}
+	first := snmpmock.NewMockHandler(ctrl)
+	second := snmpmock.NewMockHandler(ctrl)
+	collectionFailure := snmpmock.NewMockHandler(ctrl)
+	otherRegistration := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClientConnectError(first, dev, errors.New("first failure"))
+	expectTopologyRefreshSNMPClientConnectError(second, dev, errors.New("second failure"))
+	expectTopologyRefreshSNMPClientConnect(collectionFailure, dev)
+	collectionFailure.EXPECT().Close().Return(nil)
+	expectTopologyRefreshSNMPClientConnectError(otherRegistration, dev, errors.New("other registration failure"))
+
+	coll := newTestSNMPTopologyCollector()
+	var logs bytes.Buffer
+	coll.Logger = logger.NewWithWriter(&logs)
+	clients := []gosnmp.Handler{first, second, collectionFailure, otherRegistration}
+	coll.newSnmpClient = func() gosnmp.Handler {
+		client := clients[0]
+		clients = clients[1:]
+		return client
+	}
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) {
+			return nil, errors.New("collection failure")
+		})
+	}
+
+	for range 2 {
+		snapshot, outcome := coll.refreshDeviceTopology(context.Background(), "job-a", dev, nil)
+		require.Nil(t, snapshot)
+		require.Equal(t, deviceRefreshOutcomeFailed, outcome)
+	}
+	snapshot, outcome := coll.refreshDeviceTopology(context.Background(), "job-a", dev, nil)
+	require.Nil(t, snapshot)
+	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
+	snapshot, outcome = coll.refreshDeviceTopology(context.Background(), "job-b", dev, nil)
+	require.Nil(t, snapshot)
+	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
+
+	require.Equal(t, 2, strings.Count(logs.String(), "failed to connect"), logs.String())
+	require.Equal(t, 1, strings.Count(logs.String(), "topology collection failed"), logs.String())
+	require.Contains(t, logs.String(), "first failure")
+	require.NotContains(t, logs.String(), "second failure")
+	require.Contains(t, logs.String(), "collection failure")
+	require.Contains(t, logs.String(), "other registration failure")
 }
 
 func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -84,20 +84,27 @@ func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableObservation(
 	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID))
 }
 
-func TestSNMPTopologyFunctionAvailabilityExpiresWithPublishedGeneration(t *testing.T) {
+func TestSNMPTopologyFunctionAvailabilityChangesOnlyWithPublishedGeneration(t *testing.T) {
 	coll := newTestSNMPTopologyCollector()
-	now := time.Now()
+	publishedAt := time.Now()
 	builder := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(builder)
-	builder.updateTime = now
-	builder.lastUpdate = now
+	builder.updateTime = publishedAt
+	builder.lastUpdate = publishedAt
 	builder.staleAfter = 20 * time.Millisecond
-	publishTestTopologyBuilder(coll.topologyRegistry, builder)
+	device := freezeTestTopologyBuilderAt("job-a", publishedAt, builder)
+	states := map[string]deviceRefreshState{"job-a": {generation: device}}
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, publishedAt, states))
 
 	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID))
-	require.Eventually(t, func() bool {
-		return !coll.FunctionAvailable(snmptopologyfunc.MethodID)
-	}, time.Second, 5*time.Millisecond)
+	require.True(t, device.freshAt(publishedAt.Add(10*time.Millisecond)))
+	require.False(t, device.freshAt(publishedAt.Add(21*time.Millisecond)))
+	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID),
+		"one published generation must not decay between completed sweeps")
+
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(2, publishedAt.Add(21*time.Millisecond), states))
+	require.False(t, coll.FunctionAvailable(snmptopologyfunc.MethodID),
+		"the next completed sweep must remove an expired retained generation from renderable membership")
 }
 
 func TestSNMPTopologyFunctionAvailabilityResetsWhenCollectorRuns(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -81,9 +81,23 @@ func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableObservation(
 	seedPublishedEndpointSnapshot(cache)
 	publishTestTopologyBuilder(coll.topologyRegistry, cache)
 
-	coll.updateFunctionAvailability()
+	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID))
+}
+
+func TestSNMPTopologyFunctionAvailabilityExpiresWithPublishedGeneration(t *testing.T) {
+	coll := newTestSNMPTopologyCollector()
+	now := time.Now()
+	builder := newTopologyBuilder()
+	seedPublishedEndpointSnapshot(builder)
+	builder.updateTime = now
+	builder.lastUpdate = now
+	builder.staleAfter = 20 * time.Millisecond
+	publishTestTopologyBuilder(coll.topologyRegistry, builder)
 
 	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID))
+	require.Eventually(t, func() bool {
+		return !coll.FunctionAvailable(snmptopologyfunc.MethodID)
+	}, time.Second, 5*time.Millisecond)
 }
 
 func TestSNMPTopologyFunctionAvailabilityResetsWhenCollectorRuns(t *testing.T) {
@@ -94,7 +108,9 @@ func TestSNMPTopologyFunctionAvailabilityResetsWhenCollectorRuns(t *testing.T) {
 
 	coll, ok := creator.CreateV2().(*Collector)
 	require.True(t, ok)
-	coll.functionAvailability.Store(true)
+	builder := newTopologyBuilder()
+	seedPublishedEndpointSnapshot(builder)
+	publishTestTopologyBuilder(coll.topologyRegistry, builder)
 	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID))
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -77,9 +77,9 @@ func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableObservation(
 	coll, ok := creator.CreateV2().(*Collector)
 	require.True(t, ok)
 	require.False(t, coll.FunctionAvailable(snmptopologyfunc.MethodID))
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(cache)
-	coll.topologyRegistry.register(cache)
+	publishTestTopologyBuilder(coll.topologyRegistry, cache)
 
 	coll.updateFunctionAvailability()
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -92,8 +92,9 @@ func TestSNMPTopologyFunctionAvailabilityChangesOnlyWithPublishedGeneration(t *t
 	builder.updateTime = publishedAt
 	builder.lastUpdate = publishedAt
 	builder.staleAfter = 20 * time.Millisecond
-	device := freezeTestTopologyBuilderAt("job-a", publishedAt, builder)
-	states := map[string]deviceRefreshState{"job-a": {generation: device}}
+	const registrationID ddsnmp.DeviceRegistrationID = 1
+	device := freezeTestTopologyBuilderAt(registrationID, publishedAt, builder)
+	states := map[ddsnmp.DeviceRegistrationID]deviceRefreshState{registrationID: {generation: device}}
 	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, publishedAt, states))
 
 	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID))

--- a/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
@@ -54,10 +54,10 @@ func topologyMethods() []funcapi.FunctionConfig {
 }
 
 func (c *Collector) FunctionAvailable(functionID string) bool {
-	if functionID != snmptopologyfunc.MethodID {
+	if c == nil || functionID != snmptopologyfunc.MethodID || c.topologyRegistry == nil {
 		return false
 	}
-	return c.functionAvailability.Load()
+	return c.topologyRegistry.hasRenderableObservations()
 }
 
 func topologyFunctionHandler(job collectorapi.RuntimeJob) funcapi.MethodHandler {

--- a/src/go/plugin/go.d/collector/snmp_topology/func_deps_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_deps_test.go
@@ -56,9 +56,9 @@ func TestFuncDepsAdapterSnapshotUsesCachedReverseDNSWithoutLiveLookup(t *testing
 	registry.reverseDNS = dns.resolver
 	registry.reverseDNSWarmer = dns.topologyReverseDNSWarmer
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(cache)
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	data, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(topologyoptions.QueryOptions{})
 	require.NoError(t, err)
@@ -86,9 +86,9 @@ func TestFuncDepsAdapterSnapshotEnqueuesReverseDNSWarmCandidates(t *testing.T) {
 	registry.reverseDNSWarmer = dns.topologyReverseDNSWarmer
 	registry.setReverseDNSWarmContext(context.Background())
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(cache)
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	_, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(topologyoptions.QueryOptions{})
 	require.NoError(t, err)

--- a/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_topology_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestTopologyFunctionAdapter_MethodParamsUsesRegistryFocusTargets(t *testing.T) {
 	registry := newTopologyRegistry()
-	registry.register(newTestTopologyCacheLLDP(
+	publishTestTopologyBuilder(registry, newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
 		"00:11:22:33:44:55",
@@ -56,7 +56,7 @@ func TestTopologyFunctionAdapter_MethodParamsUsesRegistryFocusTargets(t *testing
 
 func TestTopologyFunctionAdapter_HandleDefaultManagedFabric(t *testing.T) {
 	registry := newTopologyRegistry()
-	registry.register(newTestTopologyCacheLLDP(
+	publishTestTopologyBuilder(registry, newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
 		"00:11:22:33:44:55",
@@ -100,7 +100,7 @@ func TestTopologyFunctionAdapter_HandleDefaultManagedFabric(t *testing.T) {
 
 func TestTopologyFunctionAdapter_HandleSelectorParams(t *testing.T) {
 	registry := newTopologyRegistry()
-	registry.register(newTestTopologyCacheLLDP(
+	publishTestTopologyBuilder(registry, newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
 		"00:11:22:33:44:55",
@@ -135,7 +135,7 @@ func TestTopologyFunctionAdapter_HandleSelectorParams(t *testing.T) {
 
 func TestTopologyFunctionAdapter_HandleUnknownSelectorsFallbackToDefaults(t *testing.T) {
 	registry := newTopologyRegistry()
-	registry.register(newTestTopologyCacheLLDP(
+	publishTestTopologyBuilder(registry, newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
 		"00:11:22:33:44:55",
@@ -1489,8 +1489,8 @@ func newTestTopologyCacheLLDP(
 	ts time.Time,
 	localChassis, localSysName, localMgmtIP, localPortID string,
 	remoteChassis, remoteSysName, remoteMgmtIP, remotePortID string,
-) *topologyCache {
-	cache := newTopologyCache()
+) *topologyBuilder {
+	cache := newTopologyBuilder()
 	cache.updateTime = ts
 	cache.lastUpdate = ts
 	cache.agentID = agentID

--- a/src/go/plugin/go.d/collector/snmp_topology/metrix_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/metrix_test.go
@@ -81,7 +81,7 @@ type fatalDeviceSource struct {
 	t *testing.T
 }
 
-func (s fatalDeviceSource) Devices() []ddsnmp.DeviceConnectionInfo {
+func (s fatalDeviceSource) Entries() []ddsnmp.DeviceEntry {
 	s.t.Helper()
 	s.t.Fatal("Collect must not poll SNMP devices")
 	return nil

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_bgp_peers.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_bgp_peers.go
@@ -13,13 +13,10 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 )
 
-func (c *topologyCache) ingestTopologyBGPPeers(pms []*ddsnmp.ProfileMetrics) {
+func (c *topologyBuilder) ingestTopologyBGPPeers(pms []*ddsnmp.ProfileMetrics) {
 	if c == nil {
 		return
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if c.bgpPeersByKey == nil {
 		c.bgpPeersByKey = make(map[string]topologymodel.BGPPeer)
@@ -86,7 +83,7 @@ func topologyBGPPeerCacheKey(row ddsnmp.BGPRow, peer topologymodel.BGPPeer) stri
 	)
 }
 
-func (c *topologyCache) snapshotBGPPeers(localDeviceID string) []topologymodel.BGPPeer {
+func (c *topologyBuilder) snapshotBGPPeers(localDeviceID string) []topologymodel.BGPPeer {
 	if c == nil || len(c.bgpPeersByKey) == 0 {
 		return nil
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_bgp_peers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_bgp_peers_test.go
@@ -97,7 +97,7 @@ func TestTopologyBGPPeerFromRowKeepsOnlyDiagnosticRawAddresses(t *testing.T) {
 }
 
 func TestTopologyCacheIngestTopologyBGPPeersSkipsErrorsAndInvalidRows(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	cache.ingestTopologyBGPPeers([]*ddsnmp.ProfileMetrics{
 		nil,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
@@ -22,7 +22,7 @@ type topologyBuilder struct {
 	agentID     string
 	localDevice topologymodel.Device
 	// localManagementAddressKeys deduplicates high-cardinality IP-MIB rows during collection.
-	// It is build-only state and is released when the cache is finalized.
+	// It is build-only state and is released when the builder is finalized.
 	localManagementAddressKeys map[managementAddressKey]struct{}
 	// targetManagementIPs is private pre-finalization selection evidence.
 	targetManagementIPs []netip.Addr

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
@@ -4,14 +4,14 @@ package snmptopology
 
 import (
 	"net/netip"
-	"sync"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 )
 
-type topologyCache struct {
-	mu         sync.RWMutex
+// topologyBuilder is a mutable, collection-only builder. Runtime readers only
+// receive immutable topologyDeviceGeneration values produced from it.
+type topologyBuilder struct {
 	lastUpdate time.Time
 	updateTime time.Time
 	staleAfter time.Duration

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_cdp.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_cdp.go
@@ -5,10 +5,10 @@ package snmptopology
 import "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 
 func init() {
-	registerTopologyMetricHandler(ddsnmp.KindCdpCache, (*topologyCache).updateCdpRemote)
+	registerTopologyMetricHandler(ddsnmp.KindCdpCache, (*topologyBuilder).updateCdpRemote)
 }
 
-func (c *topologyCache) updateCdpRemote(tags map[string]string) {
+func (c *topologyBuilder) updateCdpRemote(tags map[string]string) {
 	ifIndex := tags[tagCdpIfIndex]
 	if ifIndex == "" {
 		return

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_fdb.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_fdb.go
@@ -11,13 +11,13 @@ import (
 )
 
 func init() {
-	registerTopologyMetricHandler(ddsnmp.KindFdbEntry, (*topologyCache).updateFdbEntry)
-	registerTopologyMetricHandler(ddsnmp.KindQbridgeFdbEntry, (*topologyCache).updateFdbEntry)
-	registerTopologyMetricHandler(ddsnmp.KindQbridgeVlanEntry, (*topologyCache).updateDot1qVlanMap)
-	registerTopologyMetricHandler(ddsnmp.KindVtpVlan, (*topologyCache).updateVtpVlanEntry)
+	registerTopologyMetricHandler(ddsnmp.KindFdbEntry, (*topologyBuilder).updateFdbEntry)
+	registerTopologyMetricHandler(ddsnmp.KindQbridgeFdbEntry, (*topologyBuilder).updateFdbEntry)
+	registerTopologyMetricHandler(ddsnmp.KindQbridgeVlanEntry, (*topologyBuilder).updateDot1qVlanMap)
+	registerTopologyMetricHandler(ddsnmp.KindVtpVlan, (*topologyBuilder).updateVtpVlanEntry)
 }
 
-func (c *topologyCache) updateFdbEntry(tags map[string]string) {
+func (c *topologyBuilder) updateFdbEntry(tags map[string]string) {
 	mac := topologyutil.NormalizeMAC(topologyutil.FirstNonEmptyString(tags[tagFdbMac], tags[tagDot1qFdbMac]))
 	if mac == "" {
 		c.fdbRowsDroppedNoMAC++
@@ -59,7 +59,7 @@ func (c *topologyCache) updateFdbEntry(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) updateDot1qVlanMap(tags map[string]string) {
+func (c *topologyBuilder) updateDot1qVlanMap(tags map[string]string) {
 	fdbID := strings.TrimSpace(tags[tagDot1qVlanFdbID])
 	if fdbID == "" {
 		return
@@ -83,7 +83,7 @@ func (c *topologyCache) updateDot1qVlanMap(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) updateVtpVlanEntry(tags map[string]string) {
+func (c *topologyBuilder) updateVtpVlanEntry(tags map[string]string) {
 	vlanID := strings.TrimSpace(tags[tagVtpVlanIndex])
 	vlanName := strings.TrimSpace(tags[tagVtpVlanName])
 	if vlanID == "" || vlanName == "" {
@@ -109,7 +109,7 @@ func (c *topologyCache) updateVtpVlanEntry(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) finalizeFDBVLANs() {
+func (c *topologyBuilder) finalizeFDBVLANs() {
 	for _, entry := range c.fdbEntries {
 		if entry == nil {
 			continue

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_ingest.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_ingest.go
@@ -8,13 +8,10 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
-func (c *topologyCache) updateTopologyProfileTags(pms []*ddsnmp.ProfileMetrics) {
+func (c *topologyBuilder) updateTopologyProfileTags(pms []*ddsnmp.ProfileMetrics) {
 	if c == nil {
 		return
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	profileIdentity := make(map[string]ddsnmp.MetaTag, 2)
 	for _, pm := range pms {
@@ -45,27 +42,21 @@ func (c *topologyCache) updateTopologyProfileTags(pms []*ddsnmp.ProfileMetrics) 
 	}
 }
 
-func (c *topologyCache) updateTopologyCacheEntry(m ddsnmp.Metric) {
+func (c *topologyBuilder) updateTopologyCacheEntry(m ddsnmp.Metric) {
 	if c == nil {
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.ingestMetric(m.TopologyKind, m.Tags)
 }
 
-func (c *topologyCache) updateTopologySysUptime(value int64) {
+func (c *topologyBuilder) updateTopologySysUptime(value int64) {
 	if c == nil {
 		return
 	}
 	if value <= 0 {
 		return
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	local := c.localDevice
 	local.SysUptime = value
@@ -74,13 +65,13 @@ func (c *topologyCache) updateTopologySysUptime(value int64) {
 	c.localDevice = local
 }
 
-func (c *topologyCache) ingestTopologyProfileMetrics(pms []*ddsnmp.ProfileMetrics) {
+func (c *topologyBuilder) ingestTopologyProfileMetrics(pms []*ddsnmp.ProfileMetrics) {
 	for _, pm := range pms {
 		c.ingestTopologyMetricSet(pm.TopologyMetrics)
 	}
 }
 
-func (c *topologyCache) ingestTopologyMetricSet(metrics []ddsnmp.Metric) {
+func (c *topologyBuilder) ingestTopologyMetricSet(metrics []ddsnmp.Metric) {
 	for _, metric := range metrics {
 		c.updateTopologyCacheEntry(metric)
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_interfaces.go
@@ -13,14 +13,14 @@ import (
 )
 
 func init() {
-	registerTopologyMetricHandler(ddsnmp.KindIfName, (*topologyCache).updateIfNameByIndex)
-	registerTopologyMetricHandler(ddsnmp.KindIfStatus, (*topologyCache).updateIfNameByIndex)
-	registerTopologyMetricHandler(ddsnmp.KindIfDuplex, (*topologyCache).updateIfNameByIndex)
-	registerTopologyMetricHandler(ddsnmp.KindIpIfIndex, (*topologyCache).updateIfIndexByIP)
-	registerTopologyMetricHandler(ddsnmp.KindBridgePortIfIndex, (*topologyCache).updateBridgePortMap)
+	registerTopologyMetricHandler(ddsnmp.KindIfName, (*topologyBuilder).updateIfNameByIndex)
+	registerTopologyMetricHandler(ddsnmp.KindIfStatus, (*topologyBuilder).updateIfNameByIndex)
+	registerTopologyMetricHandler(ddsnmp.KindIfDuplex, (*topologyBuilder).updateIfNameByIndex)
+	registerTopologyMetricHandler(ddsnmp.KindIpIfIndex, (*topologyBuilder).updateIfIndexByIP)
+	registerTopologyMetricHandler(ddsnmp.KindBridgePortIfIndex, (*topologyBuilder).updateBridgePortMap)
 }
 
-func (c *topologyCache) updateIfNameByIndex(tags map[string]string) {
+func (c *topologyBuilder) updateIfNameByIndex(tags map[string]string) {
 	ifIndex := strings.TrimSpace(tags[tagTopoIfIndex])
 	if ifIndex == "" {
 		return
@@ -78,7 +78,7 @@ func (c *topologyCache) updateIfNameByIndex(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) updateIfIndexByIP(tags map[string]string) {
+func (c *topologyBuilder) updateIfIndexByIP(tags map[string]string) {
 	ifIndex := strings.TrimSpace(tags[tagTopoIfIndex])
 	if ifIndex == "" {
 		return
@@ -108,7 +108,7 @@ func (c *topologyCache) updateIfIndexByIP(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) updateBridgePortMap(tags map[string]string) {
+func (c *topologyBuilder) updateBridgePortMap(tags map[string]string) {
 	basePort := strings.TrimSpace(tags[tagBridgeBasePort])
 	if basePort == "" {
 		return

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -4,14 +4,13 @@ package snmptopology
 
 import (
 	"strings"
-	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
 
-func newTopologyCache() *topologyCache {
-	return &topologyCache{
+func newTopologyBuilder() *topologyBuilder {
+	return &topologyBuilder{
 		lldpLocPorts:       make(map[string]*lldpLocPort),
 		lldpRemotes:        make(map[string]*lldpRemote),
 		cdpRemotes:         make(map[string]*cdpRemote),
@@ -31,74 +30,12 @@ func newTopologyCache() *topologyCache {
 	}
 }
 
-func (c *topologyCache) replaceWith(src *topologyCache) {
-	if c == nil || src == nil {
-		return
-	}
-
-	c.lastUpdate = src.lastUpdate
-	c.updateTime = src.updateTime
-	c.staleAfter = src.staleAfter
-	c.preparedSnapshot = src.preparedSnapshot
-	c.hasPreparedSnapshot = src.hasPreparedSnapshot
-	c.agentID = src.agentID
-	c.localDevice = src.localDevice
-	c.lldpLocPorts = src.lldpLocPorts
-	c.lldpRemotes = src.lldpRemotes
-	c.cdpRemotes = src.cdpRemotes
-	c.ifNamesByIndex = src.ifNamesByIndex
-	c.ifStatusByIndex = src.ifStatusByIndex
-	c.ifIndexByIP = src.ifIndexByIP
-	c.ifNetmaskByIP = src.ifNetmaskByIP
-	c.l3InterfacesByIP = src.l3InterfacesByIP
-	c.trapMatchMethodByIP = src.trapMatchMethodByIP
-	c.bridgePortToIf = src.bridgePortToIf
-	c.fdbEntries = src.fdbEntries
-	c.vlanByFDBID = src.vlanByFDBID
-	c.vlanNameByID = src.vlanNameByID
-	c.fdbRowsDroppedNoMAC = src.fdbRowsDroppedNoMAC
-	c.fdbRowsUnmappedPort = src.fdbRowsUnmappedPort
-	c.bridgeBaseAddress = src.bridgeBaseAddress
-	c.stpPorts = src.stpPorts
-	c.arpEntries = src.arpEntries
-	c.ospfNeighborsByKey = src.ospfNeighborsByKey
-	c.bgpPeersByKey = src.bgpPeersByKey
-}
-
-func (c *topologyCache) hasFreshSnapshotAt(now time.Time) bool {
-	if c == nil || c.lastUpdate.IsZero() {
-		return false
-	}
-	if c.staleAfter > 0 && now.After(c.lastUpdate.Add(c.staleAfter)) {
-		return false
-	}
-	return true
-}
-
-func (c *topologyCache) hasRenderableObservationAt(now time.Time) bool {
-	if c == nil {
-		return false
-	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	if !c.hasFreshSnapshotAt(now) {
-		return false
-	}
-
-	local := normalizeTopologyDevice(c.localDevice)
-	localManagementIP := topologyutil.NormalizeIPAddress(local.ManagementIP)
-	baseBridgeAddress := c.resolveLocalBaseBridgeAddress(localManagementIP)
-	return strings.TrimSpace(ensureTopologyObservationDeviceID(local, baseBridgeAddress)) != ""
-}
-
-func (c *Collector) finalizeTopologyCache(cache *topologyCache) {
+func (c *Collector) freezeTopologyBuilder(key string, cache *topologyBuilder) *topologyDeviceGeneration {
 	if cache == nil {
-		return
+		return nil
 	}
 
-	stats := cache.finalizeTopologyCache()
+	stats := cache.finalize()
 
 	if stats.droppedNoMAC > 0 {
 		c.Warningf("device '%s': dropped %d topology FDB row(s) with empty MAC", stats.agentID, stats.droppedNoMAC)
@@ -106,38 +43,38 @@ func (c *Collector) finalizeTopologyCache(cache *topologyCache) {
 	if stats.unmappedPort > 0 {
 		c.Warningf("device '%s': observed %d topology FDB row(s) with bridge ports missing ifIndex mapping", stats.agentID, stats.unmappedPort)
 	}
+	return newTopologyDeviceGeneration(key, cache)
 }
 
-type topologyCacheFinalizeStats struct {
+type topologyBuilderFinalizeStats struct {
 	agentID      string
 	droppedNoMAC int
 	unmappedPort int
 }
 
-func (c *topologyCache) finalizeTopologyCache() topologyCacheFinalizeStats {
+func (c *topologyBuilder) finalize() topologyBuilderFinalizeStats {
 	if c == nil {
-		return topologyCacheFinalizeStats{}
+		return topologyBuilderFinalizeStats{}
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	finalizeLocalManagementAddresses(&c.localDevice, c.targetManagementIPs, c.ifNetmaskByIP)
 	c.localManagementAddressKeys = nil
 	c.rebuildTrapSourceMatchMethods()
 	c.finalizeFDBVLANs()
 	c.updateFDBDiagnostics()
-	stats := topologyCacheFinalizeStats{
+	stats := topologyBuilderFinalizeStats{
 		agentID:      c.agentID,
 		droppedNoMAC: c.fdbRowsDroppedNoMAC,
 		unmappedPort: c.fdbRowsUnmappedPort,
 	}
-	c.lastUpdate = c.updateTime
-	c.preparedSnapshot, c.hasPreparedSnapshot = c.buildObservationSnapshotLocked()
+	if !c.updateTime.IsZero() {
+		c.lastUpdate = c.updateTime
+	}
+	c.preparedSnapshot, c.hasPreparedSnapshot = c.buildObservationSnapshot()
 	return stats
 }
 
-func (c *topologyCache) rebuildTrapSourceMatchMethods() {
+func (c *topologyBuilder) rebuildTrapSourceMatchMethods() {
 	methods := make(map[string]string, len(c.ifIndexByIP)+len(c.localDevice.ManagementAddresses)+1)
 	for value := range c.ifIndexByIP {
 		if addr, ok := topologyutil.ParseIPAddress(value); ok {
@@ -155,7 +92,7 @@ func (c *topologyCache) rebuildTrapSourceMatchMethods() {
 	c.trapMatchMethodByIP = methods
 }
 
-func (c *topologyCache) updateFDBDiagnostics() {
+func (c *topologyBuilder) updateFDBDiagnostics() {
 	c.fdbRowsUnmappedPort = 0
 	for _, entry := range c.fdbEntries {
 		if entry == nil || strings.TrimSpace(entry.mac) == "" {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -30,8 +30,8 @@ func newTopologyBuilder() *topologyBuilder {
 	}
 }
 
-func (c *Collector) freezeTopologyBuilder(key string, cache *topologyBuilder) *topologyDeviceGeneration {
-	generation, stats := freezeTopologyBuilder(key, cache)
+func (c *Collector) freezeTopologyBuilder(cache *topologyBuilder) *topologyDeviceSnapshot {
+	snapshot, stats := freezeTopologyBuilder(cache)
 
 	if stats.droppedNoMAC > 0 {
 		c.Warningf("device '%s': dropped %d topology FDB row(s) with empty MAC", stats.agentID, stats.droppedNoMAC)
@@ -39,7 +39,7 @@ func (c *Collector) freezeTopologyBuilder(key string, cache *topologyBuilder) *t
 	if stats.unmappedPort > 0 {
 		c.Warningf("device '%s': observed %d topology FDB row(s) with bridge ports missing ifIndex mapping", stats.agentID, stats.unmappedPort)
 	}
-	return generation
+	return snapshot
 }
 
 type topologyBuilderFinalizeStats struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -31,11 +31,7 @@ func newTopologyBuilder() *topologyBuilder {
 }
 
 func (c *Collector) freezeTopologyBuilder(key string, cache *topologyBuilder) *topologyDeviceGeneration {
-	if cache == nil {
-		return nil
-	}
-
-	stats := cache.finalize()
+	generation, stats := freezeTopologyBuilder(key, cache)
 
 	if stats.droppedNoMAC > 0 {
 		c.Warningf("device '%s': dropped %d topology FDB row(s) with empty MAC", stats.agentID, stats.droppedNoMAC)
@@ -43,7 +39,7 @@ func (c *Collector) freezeTopologyBuilder(key string, cache *topologyBuilder) *t
 	if stats.unmappedPort > 0 {
 		c.Warningf("device '%s': observed %d topology FDB row(s) with bridge ports missing ifIndex mapping", stats.agentID, stats.unmappedPort)
 	}
-	return newTopologyDeviceGeneration(key, cache)
+	return generation
 }
 
 type topologyBuilderFinalizeStats struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lldp.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lldp.go
@@ -11,14 +11,14 @@ import (
 )
 
 func init() {
-	registerTopologyMetricHandler(ddsnmp.KindLldpLocPort, (*topologyCache).updateLldpLocPort)
-	registerTopologyMetricHandler(ddsnmp.KindLldpLocManAddr, (*topologyCache).updateLldpLocManAddr)
-	registerTopologyMetricHandler(ddsnmp.KindLldpRem, (*topologyCache).updateLldpRemote)
-	registerTopologyMetricHandler(ddsnmp.KindLldpRemManAddr, (*topologyCache).updateLldpRemManAddr)
-	registerTopologyMetricHandler(ddsnmp.KindLldpRemManAddrCompat, (*topologyCache).updateLldpRemManAddr)
+	registerTopologyMetricHandler(ddsnmp.KindLldpLocPort, (*topologyBuilder).updateLldpLocPort)
+	registerTopologyMetricHandler(ddsnmp.KindLldpLocManAddr, (*topologyBuilder).updateLldpLocManAddr)
+	registerTopologyMetricHandler(ddsnmp.KindLldpRem, (*topologyBuilder).updateLldpRemote)
+	registerTopologyMetricHandler(ddsnmp.KindLldpRemManAddr, (*topologyBuilder).updateLldpRemManAddr)
+	registerTopologyMetricHandler(ddsnmp.KindLldpRemManAddrCompat, (*topologyBuilder).updateLldpRemManAddr)
 }
 
-func (c *topologyCache) updateLldpLocPort(tags map[string]string) {
+func (c *topologyBuilder) updateLldpLocPort(tags map[string]string) {
 	portNum := tags[tagLldpLocPortNum]
 	if portNum == "" {
 		return
@@ -41,7 +41,7 @@ func (c *topologyCache) updateLldpLocPort(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) updateLldpLocManAddr(tags map[string]string) {
+func (c *topologyBuilder) updateLldpLocManAddr(tags map[string]string) {
 	addrHex := tags[tagLldpLocMgmtAddr]
 	if addrHex == "" {
 		return
@@ -64,7 +64,7 @@ func (c *topologyCache) updateLldpLocManAddr(tags map[string]string) {
 	c.appendLocalManagementAddress(mgmt)
 }
 
-func (c *topologyCache) updateLldpRemote(tags map[string]string) {
+func (c *topologyBuilder) updateLldpRemote(tags map[string]string) {
 	localPort := tags[tagLldpLocPortNum]
 	if localPort == "" {
 		return
@@ -124,7 +124,7 @@ func (c *topologyCache) updateLldpRemote(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) updateLldpRemManAddr(tags map[string]string) {
+func (c *topologyBuilder) updateLldpRemManAddr(tags map[string]string) {
 	localPort := tags[tagLldpLocPortNum]
 	if localPort == "" {
 		return

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_metric_dispatch.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_metric_dispatch.go
@@ -4,7 +4,7 @@ package snmptopology
 
 import "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 
-type topologyMetricHandler func(*topologyCache, map[string]string)
+type topologyMetricHandler func(*topologyBuilder, map[string]string)
 
 var topologyMetricHandlers = make(map[ddsnmp.TopologyKind]topologyMetricHandler)
 
@@ -21,7 +21,7 @@ func registerTopologyMetricHandler(kind ddsnmp.TopologyKind, handler topologyMet
 	topologyMetricHandlers[kind] = handler
 }
 
-func (c *topologyCache) ingestMetric(kind ddsnmp.TopologyKind, tags map[string]string) {
+func (c *topologyBuilder) ingestMetric(kind ddsnmp.TopologyKind, tags map[string]string) {
 	if handler := topologyMetricHandlers[kind]; handler != nil {
 		handler(c, tags)
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_profile_tags.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_profile_tags.go
@@ -8,7 +8,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
 
-func (c *topologyCache) applyLLDPLocalDeviceProfileTags(tags map[string]string) {
+func (c *topologyBuilder) applyLLDPLocalDeviceProfileTags(tags map[string]string) {
 	if c == nil || len(tags) == 0 {
 		return
 	}
@@ -46,7 +46,7 @@ func (c *topologyCache) applyLLDPLocalDeviceProfileTags(tags map[string]string) 
 	}
 }
 
-func (c *topologyCache) applyOSPFProfileTags(tags map[string]string) {
+func (c *topologyBuilder) applyOSPFProfileTags(tags map[string]string) {
 	if c == nil || len(tags) == 0 {
 		return
 	}
@@ -57,7 +57,7 @@ func (c *topologyCache) applyOSPFProfileTags(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) applyAuthoritativeBridgeIdentity(mac string) {
+func (c *topologyBuilder) applyAuthoritativeBridgeIdentity(mac string) {
 	mac = topologyutil.NormalizeMAC(mac)
 	if mac == "" || mac == "00:00:00:00:00:00" {
 		return
@@ -67,7 +67,7 @@ func (c *topologyCache) applyAuthoritativeBridgeIdentity(mac string) {
 	c.localDevice.ChassisIDType = "macAddress"
 }
 
-func (c *topologyCache) applyBridgeProfileTags(tags map[string]string) {
+func (c *topologyBuilder) applyBridgeProfileTags(tags map[string]string) {
 	if c == nil || len(tags) == 0 {
 		return
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_stp_arp.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_stp_arp.go
@@ -11,12 +11,12 @@ import (
 )
 
 func init() {
-	registerTopologyMetricHandler(ddsnmp.KindStpPort, (*topologyCache).updateStpPortEntry)
-	registerTopologyMetricHandler(ddsnmp.KindArpEntry, (*topologyCache).updateArpEntry)
-	registerTopologyMetricHandler(ddsnmp.KindArpLegacyEntry, (*topologyCache).updateArpEntry)
+	registerTopologyMetricHandler(ddsnmp.KindStpPort, (*topologyBuilder).updateStpPortEntry)
+	registerTopologyMetricHandler(ddsnmp.KindArpEntry, (*topologyBuilder).updateArpEntry)
+	registerTopologyMetricHandler(ddsnmp.KindArpLegacyEntry, (*topologyBuilder).updateArpEntry)
 }
 
-func (c *topologyCache) updateStpPortEntry(tags map[string]string) {
+func (c *topologyBuilder) updateStpPortEntry(tags map[string]string) {
 	port := strings.TrimSpace(tags[tagStpPort])
 	if port == "" {
 		return
@@ -64,7 +64,7 @@ func (c *topologyCache) updateStpPortEntry(tags map[string]string) {
 	}
 }
 
-func (c *topologyCache) updateArpEntry(tags map[string]string) {
+func (c *topologyBuilder) updateArpEntry(tags map[string]string) {
 	ip := topologyutil.NormalizeIPAddress(tags[tagArpIP])
 	mac := topologyutil.NormalizeMAC(tags[tagArpMac])
 	if ip == "" || mac == "" {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestTopologyCache(dev ddsnmp.DeviceConnectionInfo) *topologyCache {
-	cache := newTopologyCache()
+func newTestTopologyCache(dev ddsnmp.DeviceConnectionInfo) *topologyBuilder {
+	cache := newTopologyBuilder()
 	cache.localDevice = buildLocalTopologyDevice(dev)
 	cache.agentID = dev.Hostname
 	cache.updateTime = time.Now()
@@ -100,7 +100,7 @@ func TestTopologyCache_LldpSnapshot(t *testing.T) {
 		},
 	})
 
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	data, ok := snapshotTopologyCacheForTest(cache)
 
@@ -117,7 +117,7 @@ func TestTopologyCache_LldpSnapshot(t *testing.T) {
 }
 
 func TestTopologyCache_CdpSnapshot(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -246,7 +246,7 @@ func TestTopologyCache_UpdateTopologyProfileTagsResolvesDeviceMetadata(t *testin
 }
 
 func TestTopologyCache_UpdateFdbEntry_DoesNotSetBridgeIdentityFromRowTags(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.localDevice = topologymodel.Device{
 		ChassisID:     "10.20.4.2",
 		ChassisIDType: "management_ip",
@@ -265,7 +265,7 @@ func TestTopologyCache_UpdateFdbEntry_DoesNotSetBridgeIdentityFromRowTags(t *tes
 }
 
 func TestTopologyCache_BuildEngineObservation_DerivesBaseBridgeMACFromInterfacePhysAddress(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -291,7 +291,7 @@ func TestTopologyCache_BuildEngineObservation_DerivesBaseBridgeMACFromInterfaceP
 }
 
 func TestTopologyCache_UpdateIfIndexByIP_PreservesInventoryAndFiltersManagementCandidates(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	rows := []map[string]string{
 		{tagTopoIfIndex: "1", tagTopoIPAddr: "10.20.4.1", tagTopoIPMask: "255.255.255.0"},
@@ -365,7 +365,7 @@ func TestTopologyCache_FinalizeRejectsMaskProvenManagementAddressesAcrossSources
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cache := newTopologyCache()
+			cache := newTopologyBuilder()
 			cache.localDevice.ManagementIP = "192.0.2.0"
 			addLLDP := func() {
 				cache.updateLldpLocManAddr(map[string]string{
@@ -393,7 +393,7 @@ func TestTopologyCache_FinalizeRejectsMaskProvenManagementAddressesAcrossSources
 				addIPMIB()
 				addLLDP()
 			}
-			cache.finalizeTopologyCache()
+			cache.finalize()
 
 			require.Equal(t, "1", cache.ifIndexByIP["192.0.2.0"])
 			require.Contains(t, cache.l3InterfacesByIP, "192.0.2.0")
@@ -411,7 +411,7 @@ func TestTopologyCache_FinalizeRejectsMaskProvenManagementAddressesAcrossSources
 }
 
 func TestTopologyCache_LLDPExplicitNonIPFamilyDoesNotBecomeManagementIP(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.localDevice = topologymodel.Device{
 		ChassisID:     "00:11:22:33:44:55",
@@ -426,9 +426,9 @@ func TestTopologyCache_LLDPExplicitNonIPFamilyDoesNotBecomeManagementIP(t *testi
 		tagLldpLocMgmtAddrSubtype: "16",
 		tagLldpLocMgmtAddr:        "636f7265", // IANA AFN 16 (DNS), bytes "core".
 	})
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
-	snapshot, ok := cache.snapshotEngineObservations()
+	snapshot, ok := snapshotTestTopologyBuilder(cache)
 	require.True(t, ok)
 	require.Len(t, snapshot.L2Observations, 1)
 	require.Equal(t, "192.0.2.10", snapshot.L2Observations[0].ManagementIP)
@@ -440,7 +440,7 @@ func TestTopologyCache_LLDPExplicitNonIPFamilyDoesNotBecomeManagementIP(t *testi
 }
 
 func TestTopologyCacheFinalizePreparesStableObservationSnapshot(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.staleAfter = time.Hour
 	cache.agentID = "agent-test"
@@ -461,17 +461,17 @@ func TestTopologyCacheFinalizePreparesStableObservationSnapshot(t *testing.T) {
 		tagTopoIPAddr:  "192.0.2.1",
 		tagTopoIPMask:  "255.255.255.255",
 	})
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	require.True(t, cache.hasPreparedSnapshot)
 	prepared := cache.preparedSnapshot
-	rebuilt, ok := cache.buildObservationSnapshotLocked()
+	rebuilt, ok := cache.buildObservationSnapshot()
 	require.True(t, ok)
 	require.Equal(t, rebuilt, prepared)
 
-	first, ok := cache.snapshotEngineObservations()
+	first, ok := snapshotTestTopologyBuilder(cache)
 	require.True(t, ok)
-	second, ok := cache.snapshotEngineObservations()
+	second, ok := snapshotTestTopologyBuilder(cache)
 	require.True(t, ok)
 	require.Equal(t, prepared, first)
 	require.Equal(t, first, second)
@@ -479,22 +479,22 @@ func TestTopologyCacheFinalizePreparesStableObservationSnapshot(t *testing.T) {
 
 func TestTopologyCache_LLDPExplicitNonIPFamilyIsRejectedAcrossIngresses(t *testing.T) {
 	tests := map[string]struct {
-		update func(*topologyCache)
-		addrs  func(*topologyCache) []topologymodel.ManagementAddress
+		update func(*topologyBuilder)
+		addrs  func(*topologyBuilder) []topologymodel.ManagementAddress
 	}{
 		"local management table": {
-			update: func(cache *topologyCache) {
+			update: func(cache *topologyBuilder) {
 				cache.updateLldpLocManAddr(map[string]string{
 					tagLldpLocMgmtAddrSubtype: "16",
 					tagLldpLocMgmtAddr:        "636f7265",
 				})
 			},
-			addrs: func(cache *topologyCache) []topologymodel.ManagementAddress {
+			addrs: func(cache *topologyBuilder) []topologymodel.ManagementAddress {
 				return cache.localDevice.ManagementAddresses
 			},
 		},
 		"inline remote": {
-			update: func(cache *topologyCache) {
+			update: func(cache *topologyBuilder) {
 				cache.updateLldpRemote(map[string]string{
 					tagLldpLocPortNum:         "1",
 					tagLldpRemIndex:           "1",
@@ -502,12 +502,12 @@ func TestTopologyCache_LLDPExplicitNonIPFamilyIsRejectedAcrossIngresses(t *testi
 					tagLldpRemMgmtAddr:        "636f7265",
 				})
 			},
-			addrs: func(cache *topologyCache) []topologymodel.ManagementAddress {
+			addrs: func(cache *topologyBuilder) []topologymodel.ManagementAddress {
 				return cache.lldpRemotes["1:1"].managementAddrs
 			},
 		},
 		"remote management table": {
-			update: func(cache *topologyCache) {
+			update: func(cache *topologyBuilder) {
 				cache.updateLldpRemManAddr(map[string]string{
 					tagLldpLocPortNum:         "1",
 					tagLldpRemIndex:           "1",
@@ -515,12 +515,12 @@ func TestTopologyCache_LLDPExplicitNonIPFamilyIsRejectedAcrossIngresses(t *testi
 					tagLldpRemMgmtAddr:        "636f7265",
 				})
 			},
-			addrs: func(cache *topologyCache) []topologymodel.ManagementAddress {
+			addrs: func(cache *topologyBuilder) []topologymodel.ManagementAddress {
 				return cache.lldpRemotes["1:1"].managementAddrs
 			},
 		},
 		"reconstructed remote index": {
-			update: func(cache *topologyCache) {
+			update: func(cache *topologyBuilder) {
 				cache.updateLldpRemManAddr(map[string]string{
 					tagLldpLocPortNum:                 "1",
 					tagLldpRemIndex:                   "1",
@@ -532,7 +532,7 @@ func TestTopologyCache_LLDPExplicitNonIPFamilyIsRejectedAcrossIngresses(t *testi
 					tagLldpRemMgmtAddrOctetPref + "4": "101",
 				})
 			},
-			addrs: func(cache *topologyCache) []topologymodel.ManagementAddress {
+			addrs: func(cache *topologyBuilder) []topologymodel.ManagementAddress {
 				return cache.lldpRemotes["1:1"].managementAddrs
 			},
 		},
@@ -540,7 +540,7 @@ func TestTopologyCache_LLDPExplicitNonIPFamilyIsRejectedAcrossIngresses(t *testi
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cache := newTopologyCache()
+			cache := newTopologyBuilder()
 			tc.update(cache)
 			addrs := tc.addrs(cache)
 			require.Len(t, addrs, 1)
@@ -557,7 +557,7 @@ func TestTopologyCache_CDPExplicitNonIPFamilyDoesNotBecomeManagementIP(t *testin
 		"IP-looking text":    "10.0.0.3",
 	} {
 		t.Run(name, func(t *testing.T) {
-			cache := newTopologyCache()
+			cache := newTopologyBuilder()
 			cache.updateCdpRemote(map[string]string{
 				tagCdpIfIndex:             "2",
 				tagCdpDeviceIndex:         "1",
@@ -576,7 +576,7 @@ func TestTopologyCache_CDPExplicitNonIPFamilyDoesNotBecomeManagementIP(t *testin
 }
 
 func TestTopologyCache_CDPManagementAddressFamiliesAcrossSources(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateCdpRemote(map[string]string{
 		tagCdpIfIndex:               "2",
 		tagCdpDeviceIndex:           "1",
@@ -619,7 +619,7 @@ func TestTopologyCache_UpdateTopologyProfileTags_LLDPDoesNotOverrideExistingSNMP
 }
 
 func TestTopologyCache_CdpSnapshotHexAddress(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -640,7 +640,7 @@ func TestTopologyCache_CdpSnapshotHexAddress(t *testing.T) {
 		tagCdpAddressType: "1",
 		tagCdpAddress:     "0A000003",
 	})
-	observations, observationsOK := cache.snapshotEngineObservations()
+	observations, observationsOK := snapshotTestTopologyBuilder(cache)
 	require.True(t, observationsOK)
 	require.Len(t, observations.L2Observations, 1)
 	require.Len(t, observations.L2Observations[0].CDPRemotes, 1)
@@ -661,7 +661,7 @@ func TestTopologyCache_CdpSnapshotHexAddress(t *testing.T) {
 }
 
 func TestTopologyCache_UpdateLldpRemote_IgnoresRowsWithoutRemoteIndex(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	cache.updateLldpRemote(map[string]string{
 		tagLldpLocPortNum: "7",
@@ -672,7 +672,7 @@ func TestTopologyCache_UpdateLldpRemote_IgnoresRowsWithoutRemoteIndex(t *testing
 }
 
 func TestTopologyCache_CdpSnapshotIgnoresRawAddressWithoutIP(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -693,7 +693,7 @@ func TestTopologyCache_CdpSnapshotIgnoresRawAddressWithoutIP(t *testing.T) {
 		tagCdpAddressType: "2",
 		tagCdpAddress:     "edge-sw3.mgmt.local",
 	})
-	observations, observationsOK := cache.snapshotEngineObservations()
+	observations, observationsOK := snapshotTestTopologyBuilder(cache)
 	require.True(t, observationsOK)
 	require.Len(t, observations.L2Observations, 1)
 	require.Len(t, observations.L2Observations[0].CDPRemotes, 1)
@@ -712,7 +712,7 @@ func TestTopologyCache_CdpSnapshotIgnoresRawAddressWithoutIP(t *testing.T) {
 }
 
 func TestTopologyCache_SnapshotBidirectionalPairMetadata(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -742,7 +742,7 @@ func TestTopologyCache_SnapshotBidirectionalPairMetadata(t *testing.T) {
 		},
 	}
 
-	remoteCache := newTopologyCache()
+	remoteCache := newTopologyBuilder()
 	remoteCache.updateTime = cache.updateTime
 	remoteCache.lastUpdate = cache.lastUpdate
 	remoteCache.agentID = "agent2"
@@ -773,8 +773,8 @@ func TestTopologyCache_SnapshotBidirectionalPairMetadata(t *testing.T) {
 	}
 
 	registry := newTopologyRegistry()
-	registry.register(cache)
-	registry.register(remoteCache)
+	publishTestTopologyBuilder(registry, cache)
+	publishTestTopologyBuilder(registry, remoteCache)
 	data, ok := snapshotTopologyRegistryForTest(registry)
 
 	require.True(t, ok)
@@ -789,7 +789,7 @@ func TestTopologyCache_SnapshotBidirectionalPairMetadata(t *testing.T) {
 }
 
 func TestTopologyCache_SnapshotMergesRemoteIdentityAcrossProtocols(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -921,7 +921,7 @@ func TestTopologyCache_LLDPManagementAddressesAndCaps(t *testing.T) {
 		},
 	})
 
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	data, ok := snapshotTopologyCacheForTest(cache)
 
@@ -965,7 +965,7 @@ func TestTopologyCache_LLDPCapabilitiesDriveLocalActorType(t *testing.T) {
 					},
 				}})
 			}
-			cache.finalizeTopologyCache()
+			cache.finalize()
 
 			data, ok := snapshotTopologyCacheForTest(cache)
 			require.True(t, ok)
@@ -978,7 +978,7 @@ func TestTopologyCache_LLDPCapabilitiesDriveLocalActorType(t *testing.T) {
 }
 
 func TestTopologyCache_CDPManagementAddresses(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1005,7 +1005,7 @@ func TestTopologyCache_CDPManagementAddresses(t *testing.T) {
 }
 
 func TestTopologyCache_FDBAndARPEnrichment(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1057,7 +1057,7 @@ func TestTopologyCache_FDBAndARPEnrichment(t *testing.T) {
 }
 
 func TestTopologyCache_Dot1qVLANEnrichment(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1081,7 +1081,7 @@ func TestTopologyCache_Dot1qVLANEnrichment(t *testing.T) {
 		tagDot1qVlanID:    "200",
 		tagDot1qVlanFdbID: "100",
 	})
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	obs := cache.buildEngineObservation(cache.localDevice)
 	require.Len(t, obs.FDBEntries, 1)
@@ -1091,7 +1091,7 @@ func TestTopologyCache_Dot1qVLANEnrichment(t *testing.T) {
 }
 
 func TestTopologyCache_Dot1qUnmappedFDBKeepsDomainWithoutFalseVLAN(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1111,7 +1111,7 @@ func TestTopologyCache_Dot1qUnmappedFDBKeepsDomainWithoutFalseVLAN(t *testing.T)
 		tagDot1qFdbPort:   "7",
 		tagDot1qFdbStatus: "learned",
 	})
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	obs := cache.buildEngineObservation(cache.localDevice)
 	require.Len(t, obs.FDBEntries, 1)
@@ -1120,7 +1120,7 @@ func TestTopologyCache_Dot1qUnmappedFDBKeepsDomainWithoutFalseVLAN(t *testing.T)
 }
 
 func TestTopologyCache_Dot1qAmbiguousFDBMappingKeepsDomainWithoutFalseVLAN(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateFdbEntry(map[string]string{
 		tagDot1qFdbID:     "100",
 		tagDot1qFdbMac:    "7049a26572cd",
@@ -1132,8 +1132,8 @@ func TestTopologyCache_Dot1qAmbiguousFDBMappingKeepsDomainWithoutFalseVLAN(t *te
 	cache.vlanNameByID["10"] = vlanNameMapping{name: "users"}
 	cache.vlanNameByID["20"] = vlanNameMapping{name: "servers"}
 
-	cache.finalizeTopologyCache()
-	cache.finalizeTopologyCache()
+	cache.finalize()
+	cache.finalize()
 
 	obs := cache.buildEngineObservation(cache.localDevice)
 	require.Len(t, obs.FDBEntries, 1)
@@ -1143,7 +1143,7 @@ func TestTopologyCache_Dot1qAmbiguousFDBMappingKeepsDomainWithoutFalseVLAN(t *te
 }
 
 func TestTopologyCache_Dot1qRepeatedTimeMarkRowsKeepUniqueMapping(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateFdbEntry(map[string]string{
 		tagDot1qFdbID:     "100",
 		tagDot1qFdbMac:    "7049a26572cd",
@@ -1160,7 +1160,7 @@ func TestTopologyCache_Dot1qRepeatedTimeMarkRowsKeepUniqueMapping(t *testing.T) 
 		tagDot1qVlanID:    "200",
 		tagDot1qVlanFdbID: "100",
 	})
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	obs := cache.buildEngineObservation(cache.localDevice)
 	require.Len(t, obs.FDBEntries, 1)
@@ -1168,8 +1168,8 @@ func TestTopologyCache_Dot1qRepeatedTimeMarkRowsKeepUniqueMapping(t *testing.T) 
 }
 
 func TestTopologyCache_FDBVLANFinalizationIsCollectionOrderIndependent(t *testing.T) {
-	operations := []func(*topologyCache){
-		func(cache *topologyCache) {
+	operations := []func(*topologyBuilder){
+		func(cache *topologyBuilder) {
 			cache.updateFdbEntry(map[string]string{
 				tagDot1qFdbID:     "100",
 				tagDot1qFdbMac:    "7049a26572cd",
@@ -1177,13 +1177,13 @@ func TestTopologyCache_FDBVLANFinalizationIsCollectionOrderIndependent(t *testin
 				tagDot1qFdbStatus: "learned",
 			})
 		},
-		func(cache *topologyCache) {
+		func(cache *topologyBuilder) {
 			cache.updateDot1qVlanMap(map[string]string{
 				tagDot1qVlanID:    "200",
 				tagDot1qVlanFdbID: "100",
 			})
 		},
-		func(cache *topologyCache) {
+		func(cache *topologyBuilder) {
 			cache.updateVtpVlanEntry(map[string]string{
 				tagVtpVlanIndex: "200",
 				tagVtpVlanState: "operational",
@@ -1200,12 +1200,12 @@ func TestTopologyCache_FDBVLANFinalizationIsCollectionOrderIndependent(t *testin
 
 	for _, order := range orders {
 		t.Run(strconv.Itoa(order[0])+strconv.Itoa(order[1])+strconv.Itoa(order[2]), func(t *testing.T) {
-			cache := newTopologyCache()
+			cache := newTopologyBuilder()
 			for _, index := range order {
 				operations[index](cache)
 			}
-			cache.finalizeTopologyCache()
-			cache.finalizeTopologyCache()
+			cache.finalize()
+			cache.finalize()
 
 			obs := cache.buildEngineObservation(cache.localDevice)
 			require.Len(t, obs.FDBEntries, 1)
@@ -1217,7 +1217,7 @@ func TestTopologyCache_FDBVLANFinalizationIsCollectionOrderIndependent(t *testin
 }
 
 func TestTopologyCache_FDBVLANFinalizationPreservesExplicitContext(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateDot1qVlanMap(map[string]string{
 		tagDot1qVlanID:    "200",
 		tagDot1qVlanFdbID: "100",
@@ -1235,7 +1235,7 @@ func TestTopologyCache_FDBVLANFinalizationPreservesExplicitContext(t *testing.T)
 		tagTopologyContextVLANName: "explicit-name",
 	})
 
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	obs := cache.buildEngineObservation(cache.localDevice)
 	require.Len(t, obs.FDBEntries, 1)
@@ -1245,7 +1245,7 @@ func TestTopologyCache_FDBVLANFinalizationPreservesExplicitContext(t *testing.T)
 }
 
 func TestTopologyCache_VTPVLANNameConflictRemainsUnresolved(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateDot1qVlanMap(map[string]string{
 		tagDot1qVlanID:    "200",
 		tagDot1qVlanFdbID: "100",
@@ -1269,7 +1269,7 @@ func TestTopologyCache_VTPVLANNameConflictRemainsUnresolved(t *testing.T) {
 		tagDot1qFdbStatus: "learned",
 	})
 
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	obs := cache.buildEngineObservation(cache.localDevice)
 	require.Len(t, obs.FDBEntries, 1)
@@ -1289,12 +1289,12 @@ func BenchmarkTopologyCache_FinalizeFDBVLANsScaling(b *testing.B) {
 		{vlans: 4095, fdbEntries: 4095},
 	} {
 		b.Run(fmt.Sprintf("vlans=%d/fdb_entries=%d", tc.vlans, tc.fdbEntries), func(b *testing.B) {
-			published := newTopologyCache()
+			published := newTopologyBuilder()
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
 				b.StopTimer()
-				cache := newTopologyCache()
+				cache := newTopologyBuilder()
 				for index := 1; index <= tc.fdbEntries; index++ {
 					cache.updateFdbEntry(map[string]string{
 						tagDot1qFdbID:     strconv.Itoa((index-1)%tc.vlans + 1),
@@ -1310,11 +1310,9 @@ func BenchmarkTopologyCache_FinalizeFDBVLANsScaling(b *testing.B) {
 					})
 				}
 				b.StartTimer()
-				cache.finalizeTopologyCache()
+				cache.finalize()
 				b.StopTimer()
-				published.mu.Lock()
-				published.replaceWith(cache)
-				published.mu.Unlock()
+				published = cache
 				b.StartTimer()
 			}
 			b.StopTimer()
@@ -1324,7 +1322,7 @@ func BenchmarkTopologyCache_FinalizeFDBVLANsScaling(b *testing.B) {
 }
 
 func TestTopologyCache_FDBDiagnostics(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	cache.updateFdbEntry(map[string]string{
 		tagDot1qFdbID:     "100",
@@ -1351,7 +1349,7 @@ func TestTopologyCache_FDBDiagnostics(t *testing.T) {
 }
 
 func TestTopologyCache_VTPVLANNameEnrichment(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1381,7 +1379,7 @@ func TestTopologyCache_VTPVLANNameEnrichment(t *testing.T) {
 		tagDot1qFdbPort:   "7",
 		tagDot1qFdbStatus: "learned",
 	})
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	obs := cache.buildEngineObservation(cache.localDevice)
 	require.Len(t, obs.FDBEntries, 1)
@@ -1390,7 +1388,7 @@ func TestTopologyCache_VTPVLANNameEnrichment(t *testing.T) {
 }
 
 func TestTopologyCache_STPObservation(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1427,7 +1425,7 @@ func TestTopologyCache_STPObservation(t *testing.T) {
 }
 
 func TestTopologyCache_BuildEngineObservation_DerivesBaseBridgeMACFromFDBSelfEntries(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1449,7 +1447,7 @@ func TestTopologyCache_BuildEngineObservation_DerivesBaseBridgeMACFromFDBSelfEnt
 }
 
 func TestTopologyCache_InterfaceStatusObservation(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1474,7 +1472,7 @@ func TestTopologyCache_InterfaceStatusObservation(t *testing.T) {
 }
 
 func TestTopologyCache_InterfaceStatusObservation_FallsBackToIfIndexWhenIfNameMissing(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1555,7 +1553,7 @@ func TestStpBridgeAddressToMAC_ParsesAndRejectsSentinels(t *testing.T) {
 }
 
 func TestTopologyCache_VTPVLANContexts_SortedAndValidated(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.vlanNameByID["200"] = vlanNameMapping{name: "servers"}
 	cache.vlanNameByID["10"] = vlanNameMapping{name: "users"}
 	cache.vlanNameByID["abc"] = vlanNameMapping{name: "invalid"}
@@ -1570,7 +1568,7 @@ func TestTopologyCache_VTPVLANContexts_SortedAndValidated(t *testing.T) {
 }
 
 func TestTopologyCache_VLANContextFDBEntriesRemainDistinct(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateBridgePortMap(map[string]string{
 		tagBridgeBasePort: "7",
 		tagBridgeIfIndex:  "3",
@@ -1605,10 +1603,10 @@ func TestTopologyCache_VLANContextFDBEntriesRemainDistinct(t *testing.T) {
 
 func TestTopologyCache_OverlappingFDBSourcesRemainUsableInProjection(t *testing.T) {
 	tests := map[string]struct {
-		addOverlap func(*topologyCache)
+		addOverlap func(*topologyBuilder)
 	}{
 		"bridge and q-bridge": {
-			addOverlap: func(cache *topologyCache) {
+			addOverlap: func(cache *topologyBuilder) {
 				cache.updateFdbEntry(map[string]string{
 					tagFdbMac:        "020000000101",
 					tagFdbBridgePort: "7",
@@ -1617,7 +1615,7 @@ func TestTopologyCache_OverlappingFDBSourcesRemainUsableInProjection(t *testing.
 			},
 		},
 		"q-bridge and vlan context": {
-			addOverlap: func(cache *topologyCache) {
+			addOverlap: func(cache *topologyBuilder) {
 				cache.ingestTopologyVLANContextMetrics("100", "users", []*ddsnmp.ProfileMetrics{{
 					TopologyMetrics: []ddsnmp.Metric{{
 						TopologyKind: ddsnmp.KindFdbEntry,
@@ -1634,7 +1632,7 @@ func TestTopologyCache_OverlappingFDBSourcesRemainUsableInProjection(t *testing.
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			cache := newTopologyCache()
+			cache := newTopologyBuilder()
 			cache.localDevice = topologymodel.Device{
 				ChassisID:     "02:00:00:00:00:01",
 				ChassisIDType: "macAddress",
@@ -1659,7 +1657,7 @@ func TestTopologyCache_OverlappingFDBSourcesRemainUsableInProjection(t *testing.
 				tagDot1qVlanFdbID: "500",
 			})
 			tt.addOverlap(cache)
-			cache.finalizeTopologyCache()
+			cache.finalize()
 
 			local := cache.buildEngineObservation(cache.localDevice)
 			require.Len(t, local.FDBEntries, 2)
@@ -1716,7 +1714,7 @@ func TestPickManagementIP_DeterministicAcrossInputOrder(t *testing.T) {
 }
 
 func TestTopologyCache_ObservedNeighborsUseCommonManagementSelection(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.lldpRemotes["1:1"] = &lldpRemote{
 		localPortNum: "1",
 		remIndex:     "1",
@@ -1743,7 +1741,7 @@ func TestTopologyCache_ObservedNeighborsUseCommonManagementSelection(t *testing.
 }
 
 func TestTopologyCache_SnapshotDeterministicEndpointIPSelection(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1795,7 +1793,7 @@ func TestTopologyCache_SnapshotDeterministicEndpointIPSelection(t *testing.T) {
 }
 
 func TestTopologyCache_SnapshotDeterministicOrdering(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent1"
@@ -1932,7 +1930,7 @@ func TestNormalizeInterfaceTypeAcceptsEnumStrings(t *testing.T) {
 }
 
 func TestTopologyCache_UpdateIfNameByIndex_StoresStatusWithoutIfName(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	cache.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "7",
@@ -1951,7 +1949,7 @@ func TestTopologyCache_UpdateIfNameByIndex_StoresStatusWithoutIfName(t *testing.
 }
 
 func TestTopologyCache_UpdateIfNameByIndex_StoresExtendedInterfaceFields(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	cache.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex:  "9",
@@ -2012,7 +2010,7 @@ func TestBuildLocalTopologyDevice_IncludesSysContactVendorAndModel(t *testing.T)
 }
 
 func TestTopologyCache_UpdateTopologySysUptime_StoresSysUptime(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.localDevice = topologymodel.Device{}
 
 	cache.updateTopologySysUptime(4321)
@@ -2022,7 +2020,7 @@ func TestTopologyCache_UpdateTopologySysUptime_StoresSysUptime(t *testing.T) {
 }
 
 func TestTopologyCache_IngestTopologyProfileMetrics_IncludesTopologyMetrics(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	cache.ingestTopologyProfileMetrics([]*ddsnmp.ProfileMetrics{
 		{
@@ -2063,7 +2061,7 @@ func TestTopologyCache_IngestTopologyProfileMetrics_IncludesTopologyMetrics(t *t
 
 func TestTopologyCache_IngestTopologyBGPPeers_IncludesOnlyPeerRows(t *testing.T) {
 	established := int64(300)
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	cache.ingestTopologyBGPPeers([]*ddsnmp.ProfileMetrics{
 		{

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
@@ -70,7 +70,7 @@ func TestTopologyProductionPath_StockIOSXEFixture(t *testing.T) {
 	cache := newTestTopologyCache(dev)
 	cache.updateTopologyProfileTags(profileMetrics)
 	cache.ingestTopologyProfileMetrics(profileMetrics)
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	observation := cache.buildEngineObservation(cache.localDevice)
 	require.NotEmpty(t, observation.FDBEntries, "cache should retain collected FDB rows")
@@ -93,11 +93,11 @@ func TestTopologyProductionPath_StockIOSXEFixture(t *testing.T) {
 	peer.localDevice.ChassisIDType = "macAddress"
 	peer.localDevice.Capabilities = []string{"bridge"}
 	peer.localDevice.Labels = map[string]string{"type": "switch"}
-	peer.finalizeTopologyCache()
+	peer.finalize()
 
 	registry := newTopologyRegistry()
-	registry.register(cache)
-	registry.register(peer)
+	publishTestTopologyBuilder(registry, cache)
+	publishTestTopologyBuilder(registry, peer)
 	data, ok := snapshotTopologyRegistryForTest(registry)
 	require.True(t, ok, "default managed-fabric inference should render the collected cache")
 	require.GreaterOrEqual(t, testCountTopologyLinksByType(data.Links, "bridge"), 1,
@@ -150,7 +150,7 @@ func TestTopologyProductionPath_LegacyARPPhysicalOnly(t *testing.T) {
 
 	cache := newTestTopologyCache(dev)
 	cache.ingestTopologyProfileMetrics(profileMetrics)
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	observation := cache.buildEngineObservation(cache.localDevice)
 	require.Len(t, observation.ARPNDEntries, 1)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_device.go
@@ -13,7 +13,7 @@ import (
 
 func normalizeTopologyDevice(dev topologymodel.Device) topologymodel.Device {
 	// dev is a shallow copy of the caller's value, so dev.Labels still aliases
-	// the caller's map (e.g. a live topologyCache.localDevice read under RLock).
+	// the caller's map (e.g. a live topologyBuilder.localDevice read under RLock).
 	// Clone it before the mutations below so concurrent snapshot readers never
 	// write a shared map (fatal "concurrent map writes").
 	dev.Labels = maps.Clone(dev.Labels)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_device.go
@@ -13,9 +13,8 @@ import (
 
 func normalizeTopologyDevice(dev topologymodel.Device) topologymodel.Device {
 	// dev is a shallow copy of the caller's value, so dev.Labels still aliases
-	// the caller's map (e.g. a live topologyBuilder.localDevice read under RLock).
-	// Clone it before the mutations below so concurrent snapshot readers never
-	// write a shared map (fatal "concurrent map writes").
+	// the builder's map. Clone it before normalization mutates labels so the
+	// immutable generation never shares writable label state with its builder.
 	dev.Labels = maps.Clone(dev.Labels)
 
 	if dev.ChartIDPrefix == "" {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
@@ -28,10 +28,11 @@ type topologyGeneration struct {
 	devices     []*topologyDeviceGeneration
 }
 
-func newTopologyDeviceGeneration(key string, builder *topologyBuilder) *topologyDeviceGeneration {
+func freezeTopologyBuilder(key string, builder *topologyBuilder) (*topologyDeviceGeneration, topologyBuilderFinalizeStats) {
 	if builder == nil {
-		return nil
+		return nil, topologyBuilderFinalizeStats{}
 	}
+	stats := builder.finalize()
 
 	collectedAt := builder.lastUpdate
 	if collectedAt.IsZero() {
@@ -42,19 +43,14 @@ func newTopologyDeviceGeneration(key string, builder *topologyBuilder) *topology
 		expiresAt = collectedAt.Add(builder.staleAfter)
 	}
 
-	observation, ok := builder.preparedSnapshot, builder.hasPreparedSnapshot
-	if !ok {
-		observation, ok = builder.buildObservationSnapshot()
-	}
-
 	return &topologyDeviceGeneration{
 		key:            key,
 		collectedAt:    collectedAt,
 		expiresAt:      expiresAt,
-		observation:    observation,
-		hasObservation: ok,
+		observation:    builder.preparedSnapshot,
+		hasObservation: builder.hasPreparedSnapshot,
 		trap:           newTopologyTrapDeviceGeneration(builder),
-	}
+	}, stats
 }
 
 func newTopologyGeneration(sequence uint64, publishedAt time.Time, states map[string]deviceRefreshState) *topologyGeneration {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"sort"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+)
+
+// topologyDeviceGeneration is the immutable output of one successful device
+// collection. Builders are never published to runtime readers.
+type topologyDeviceGeneration struct {
+	key            string
+	collectedAt    time.Time
+	expiresAt      time.Time
+	observation    topologymodel.ObservationSnapshot
+	hasObservation bool
+	trap           topologyTrapDeviceGeneration
+}
+
+// topologyGeneration is the immutable device vector published after one
+// complete refresh sweep.
+type topologyGeneration struct {
+	sequence    uint64
+	publishedAt time.Time
+	devices     []*topologyDeviceGeneration
+}
+
+func newTopologyDeviceGeneration(key string, builder *topologyBuilder) *topologyDeviceGeneration {
+	if builder == nil {
+		return nil
+	}
+
+	collectedAt := builder.lastUpdate
+	if collectedAt.IsZero() {
+		collectedAt = builder.updateTime
+	}
+	expiresAt := time.Time{}
+	if !collectedAt.IsZero() && builder.staleAfter > 0 {
+		expiresAt = collectedAt.Add(builder.staleAfter)
+	}
+
+	observation, ok := builder.preparedSnapshot, builder.hasPreparedSnapshot
+	if !ok {
+		observation, ok = builder.buildObservationSnapshot()
+	}
+
+	return &topologyDeviceGeneration{
+		key:            key,
+		collectedAt:    collectedAt,
+		expiresAt:      expiresAt,
+		observation:    observation,
+		hasObservation: ok,
+		trap:           newTopologyTrapDeviceGeneration(builder),
+	}
+}
+
+func newTopologyGeneration(sequence uint64, publishedAt time.Time, states map[string]deviceRefreshState) *topologyGeneration {
+	keys := make([]string, 0, len(states))
+	for key, state := range states {
+		if state.generation != nil {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	devices := make([]*topologyDeviceGeneration, 0, len(keys))
+	for _, key := range keys {
+		devices = append(devices, states[key].generation)
+	}
+	return &topologyGeneration{
+		sequence:    sequence,
+		publishedAt: publishedAt,
+		devices:     devices,
+	}
+}
+
+func (g *topologyDeviceGeneration) freshAt(now time.Time) bool {
+	if g == nil || g.collectedAt.IsZero() {
+		return false
+	}
+	return g.expiresAt.IsZero() || !now.After(g.expiresAt)
+}
+
+func (g *topologyGeneration) observationSnapshotsAt(now time.Time) []topologymodel.ObservationSnapshot {
+	if g == nil || len(g.devices) == 0 {
+		return nil
+	}
+
+	snapshots := make([]topologymodel.ObservationSnapshot, 0, len(g.devices))
+	for _, device := range g.devices {
+		if device == nil || !device.hasObservation || !device.freshAt(now) {
+			continue
+		}
+		snapshots = append(snapshots, device.observation)
+	}
+	return snapshots
+}
+
+func (g *topologyGeneration) hasRenderableObservationsAt(now time.Time) bool {
+	if g == nil {
+		return false
+	}
+	for _, device := range g.devices {
+		if device != nil && device.hasObservation && device.freshAt(now) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *topologyGeneration) deviceCount() int {
+	if g == nil {
+		return 0
+	}
+	return len(g.devices)
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
@@ -3,9 +3,10 @@
 package snmptopology
 
 import (
-	"sort"
+	"slices"
 	"time"
 
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 )
 
@@ -23,7 +24,7 @@ type topologyDeviceSnapshot struct {
 // global publication boundary. Builders and unactivated snapshots are never
 // published to runtime readers.
 type topologyDeviceGeneration struct {
-	key            string
+	registrationID ddsnmp.DeviceRegistrationID
 	collectedAt    time.Time
 	expiresAt      time.Time
 	observation    topologymodel.ObservationSnapshot
@@ -60,7 +61,7 @@ func freezeTopologyBuilder(builder *topologyBuilder) (*topologyDeviceSnapshot, t
 }
 
 func activateTopologyDeviceSnapshot(
-	key string,
+	registrationID ddsnmp.DeviceRegistrationID,
 	publishedAt time.Time,
 	snapshot *topologyDeviceSnapshot,
 ) *topologyDeviceGeneration {
@@ -72,7 +73,7 @@ func activateTopologyDeviceSnapshot(
 		expiresAt = publishedAt.Add(snapshot.freshFor)
 	}
 	return &topologyDeviceGeneration{
-		key:            key,
+		registrationID: registrationID,
 		collectedAt:    snapshot.collectedAt,
 		expiresAt:      expiresAt,
 		observation:    snapshot.observation,
@@ -81,19 +82,19 @@ func activateTopologyDeviceSnapshot(
 	}
 }
 
-func newTopologyGeneration(sequence uint64, publishedAt time.Time, states map[string]deviceRefreshState) *topologyGeneration {
-	keys := make([]string, 0, len(states))
-	for key, state := range states {
+func newTopologyGeneration(sequence uint64, publishedAt time.Time, states map[ddsnmp.DeviceRegistrationID]deviceRefreshState) *topologyGeneration {
+	registrationIDs := make([]ddsnmp.DeviceRegistrationID, 0, len(states))
+	for registrationID, state := range states {
 		if state.generation != nil {
-			keys = append(keys, key)
+			registrationIDs = append(registrationIDs, registrationID)
 		}
 	}
-	sort.Strings(keys)
+	slices.Sort(registrationIDs)
 
-	devices := make([]*topologyDeviceGeneration, 0, len(keys))
-	renderableDevices := make([]*topologyDeviceGeneration, 0, len(keys))
-	for _, key := range keys {
-		device := states[key].generation
+	devices := make([]*topologyDeviceGeneration, 0, len(registrationIDs))
+	renderableDevices := make([]*topologyDeviceGeneration, 0, len(registrationIDs))
+	for _, registrationID := range registrationIDs {
+		device := states[registrationID].generation
 		devices = append(devices, device)
 		if device.hasObservation && device.freshAt(publishedAt) {
 			renderableDevices = append(renderableDevices, device)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
@@ -9,8 +9,19 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 )
 
-// topologyDeviceGeneration is the immutable output of one successful device
-// collection. Builders are never published to runtime readers.
+// topologyDeviceSnapshot is the immutable output of one successful device
+// collection. It is not visible to readers until activated at global publish.
+type topologyDeviceSnapshot struct {
+	collectedAt    time.Time
+	freshFor       time.Duration
+	observation    topologymodel.ObservationSnapshot
+	hasObservation bool
+	trap           topologyTrapDeviceGeneration
+}
+
+// topologyDeviceGeneration is an immutable collected snapshot activated at a
+// global publication boundary. Builders and unactivated snapshots are never
+// published to runtime readers.
 type topologyDeviceGeneration struct {
 	key            string
 	collectedAt    time.Time
@@ -23,12 +34,13 @@ type topologyDeviceGeneration struct {
 // topologyGeneration is the immutable device vector published after one
 // complete refresh sweep.
 type topologyGeneration struct {
-	sequence    uint64
-	publishedAt time.Time
-	devices     []*topologyDeviceGeneration
+	sequence          uint64
+	publishedAt       time.Time
+	devices           []*topologyDeviceGeneration
+	renderableDevices []*topologyDeviceGeneration
 }
 
-func freezeTopologyBuilder(key string, builder *topologyBuilder) (*topologyDeviceGeneration, topologyBuilderFinalizeStats) {
+func freezeTopologyBuilder(builder *topologyBuilder) (*topologyDeviceSnapshot, topologyBuilderFinalizeStats) {
 	if builder == nil {
 		return nil, topologyBuilderFinalizeStats{}
 	}
@@ -38,19 +50,35 @@ func freezeTopologyBuilder(key string, builder *topologyBuilder) (*topologyDevic
 	if collectedAt.IsZero() {
 		collectedAt = builder.updateTime
 	}
-	expiresAt := time.Time{}
-	if !collectedAt.IsZero() && builder.staleAfter > 0 {
-		expiresAt = collectedAt.Add(builder.staleAfter)
-	}
-
-	return &topologyDeviceGeneration{
-		key:            key,
+	return &topologyDeviceSnapshot{
 		collectedAt:    collectedAt,
-		expiresAt:      expiresAt,
+		freshFor:       builder.staleAfter,
 		observation:    builder.preparedSnapshot,
 		hasObservation: builder.hasPreparedSnapshot,
 		trap:           newTopologyTrapDeviceGeneration(builder),
 	}, stats
+}
+
+func activateTopologyDeviceSnapshot(
+	key string,
+	publishedAt time.Time,
+	snapshot *topologyDeviceSnapshot,
+) *topologyDeviceGeneration {
+	if snapshot == nil {
+		return nil
+	}
+	expiresAt := time.Time{}
+	if snapshot.freshFor > 0 {
+		expiresAt = publishedAt.Add(snapshot.freshFor)
+	}
+	return &topologyDeviceGeneration{
+		key:            key,
+		collectedAt:    snapshot.collectedAt,
+		expiresAt:      expiresAt,
+		observation:    snapshot.observation,
+		hasObservation: snapshot.hasObservation,
+		trap:           snapshot.trap,
+	}
 }
 
 func newTopologyGeneration(sequence uint64, publishedAt time.Time, states map[string]deviceRefreshState) *topologyGeneration {
@@ -63,13 +91,19 @@ func newTopologyGeneration(sequence uint64, publishedAt time.Time, states map[st
 	sort.Strings(keys)
 
 	devices := make([]*topologyDeviceGeneration, 0, len(keys))
+	renderableDevices := make([]*topologyDeviceGeneration, 0, len(keys))
 	for _, key := range keys {
-		devices = append(devices, states[key].generation)
+		device := states[key].generation
+		devices = append(devices, device)
+		if device.hasObservation && device.freshAt(publishedAt) {
+			renderableDevices = append(renderableDevices, device)
+		}
 	}
 	return &topologyGeneration{
-		sequence:    sequence,
-		publishedAt: publishedAt,
-		devices:     devices,
+		sequence:          sequence,
+		publishedAt:       publishedAt,
+		devices:           devices,
+		renderableDevices: renderableDevices,
 	}
 }
 
@@ -80,31 +114,20 @@ func (g *topologyDeviceGeneration) freshAt(now time.Time) bool {
 	return g.expiresAt.IsZero() || !now.After(g.expiresAt)
 }
 
-func (g *topologyGeneration) observationSnapshotsAt(now time.Time) []topologymodel.ObservationSnapshot {
-	if g == nil || len(g.devices) == 0 {
+func (g *topologyGeneration) observationSnapshots() []topologymodel.ObservationSnapshot {
+	if g == nil || len(g.renderableDevices) == 0 {
 		return nil
 	}
 
-	snapshots := make([]topologymodel.ObservationSnapshot, 0, len(g.devices))
-	for _, device := range g.devices {
-		if device == nil || !device.hasObservation || !device.freshAt(now) {
-			continue
-		}
+	snapshots := make([]topologymodel.ObservationSnapshot, 0, len(g.renderableDevices))
+	for _, device := range g.renderableDevices {
 		snapshots = append(snapshots, device.observation)
 	}
 	return snapshots
 }
 
-func (g *topologyGeneration) hasRenderableObservationsAt(now time.Time) bool {
-	if g == nil {
-		return false
-	}
-	for _, device := range g.devices {
-		if device != nil && device.hasObservation && device.freshAt(now) {
-			return true
-		}
-	}
-	return false
+func (g *topologyGeneration) hasRenderableObservations() bool {
+	return g != nil && len(g.renderableDevices) > 0
 }
 
 func (g *topologyGeneration) deviceCount() int {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+)
+
+func TestTopologyRegistryPublishesWholeGenerationVectors(t *testing.T) {
+	registry := newTopologyRegistry()
+	now := time.Now()
+	generationA := testTopologyGenerationVector(1, now, "generation-a")
+	generationB := testTopologyGenerationVector(2, now, "generation-b")
+	registry.publishGeneration(generationA)
+
+	const iterations = 2000
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(5)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range iterations {
+			if i%2 == 0 {
+				registry.publishGeneration(generationB)
+			} else {
+				registry.publishGeneration(generationA)
+			}
+		}
+	}()
+
+	errors := make(chan string, 4)
+	for range 4 {
+		go func() {
+			defer wg.Done()
+			<-start
+			for range iterations {
+				generation := registry.acquireGeneration()
+				snapshots := topologyObservationSnapshotsAt(generation, now)
+				if len(snapshots) != 2 {
+					errors <- fmt.Sprintf("sequence %d exposed %d devices", generation.sequence, len(snapshots))
+					return
+				}
+				if snapshots[0].AgentID != snapshots[1].AgentID {
+					errors <- fmt.Sprintf("sequence %d mixed %q and %q", generation.sequence, snapshots[0].AgentID, snapshots[1].AgentID)
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errors)
+	require.Empty(t, errors)
+}
+
+func testTopologyGenerationVector(sequence uint64, now time.Time, identity string) *topologyGeneration {
+	devices := make([]*topologyDeviceGeneration, 2)
+	for i := range devices {
+		devices[i] = &topologyDeviceGeneration{
+			key:            fmt.Sprintf("%s-device-%d", identity, i),
+			collectedAt:    now,
+			expiresAt:      now.Add(time.Hour),
+			hasObservation: true,
+			observation: topologymodel.ObservationSnapshot{
+				AgentID:       identity,
+				LocalDeviceID: fmt.Sprintf("device-%d", i),
+				CollectedAt:   now,
+			},
+		}
+	}
+	return &topologyGeneration{
+		sequence:    sequence,
+		publishedAt: now,
+		devices:     devices,
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation_test.go
@@ -65,7 +65,7 @@ func TestTopologyRegistryPublishesWholeGenerationVectors(t *testing.T) {
 			<-start
 			for range iterations {
 				generation := registry.acquireGeneration()
-				snapshots := topologyObservationSnapshotsAt(generation, now)
+				snapshots := topologyObservationSnapshots(generation)
 				if len(snapshots) != 2 {
 					errors <- fmt.Sprintf("sequence %d exposed %d devices", generation.sequence, len(snapshots))
 					return
@@ -99,8 +99,9 @@ func testTopologyGenerationVector(sequence uint64, now time.Time, identity strin
 		}
 	}
 	return &topologyGeneration{
-		sequence:    sequence,
-		publishedAt: now,
-		devices:     devices,
+		sequence:          sequence,
+		publishedAt:       now,
+		devices:           devices,
+		renderableDevices: append([]*topologyDeviceGeneration(nil), devices...),
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 )
 
@@ -87,7 +88,7 @@ func testTopologyGenerationVector(sequence uint64, now time.Time, identity strin
 	devices := make([]*topologyDeviceGeneration, 2)
 	for i := range devices {
 		devices[i] = &topologyDeviceGeneration{
-			key:            fmt.Sprintf("%s-device-%d", identity, i),
+			registrationID: ddsnmp.DeviceRegistrationID(i + 1),
 			collectedAt:    now,
 			expiresAt:      now.Add(time.Hour),
 			hasObservation: true,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation_test.go
@@ -4,6 +4,7 @@ package snmptopology
 
 import (
 	"fmt"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +13,27 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 )
+
+func TestPublishTestTopologyBuilderUsesProductionFinalization(t *testing.T) {
+	registry := newTopologyRegistry()
+	builder := newTopologyBuilder()
+	builder.updateTime = time.Now()
+	builder.staleAfter = time.Hour
+	builder.agentID = "agent-test"
+	builder.localDevice = topologymodel.Device{
+		ChassisID:     "00:11:22:33:44:55",
+		ChassisIDType: "macAddress",
+		SysName:       "switch-a",
+	}
+	builder.targetManagementIPs = []netip.Addr{netip.MustParseAddr("192.0.2.10")}
+
+	publishTestTopologyBuilder(registry, builder)
+	generation := registry.acquireGeneration()
+	require.NotNil(t, generation)
+	require.Len(t, generation.devices, 1)
+	require.Equal(t, "192.0.2.10", generation.devices[0].observation.LocalDevice.ManagementIP)
+	require.Equal(t, "management_ip", generation.devices[0].trap.matchMethodByIP["192.0.2.10"])
+}
 
 func TestTopologyRegistryPublishesWholeGenerationVectors(t *testing.T) {
 	registry := newTopologyRegistry()

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_integration_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_integration_test.go
@@ -107,18 +107,12 @@ func collectTopologySnapshotFromDevice(t *testing.T, dev ddsnmp.DeviceConnection
 	coll.refreshTopology(context.Background())
 
 	var snapshot topologymodel.Data
-	cacheKey := dev.Hostname + ":" + strconv.Itoa(dev.Port)
 	require.Eventuallyf(t, func() bool {
-		cache := coll.deviceCaches[cacheKey]
-		if cache == nil {
-			return false
-		}
-
-		var ok bool
 		options := defaultTopologyQueryOptionsForTest()
 		options.CollapseActorsByIP = false
 		options.EliminateNonIPInferred = false
-		snapshot, ok = snapshotTopologyCacheForTestWithOptions(cache, options)
+		var ok bool
+		snapshot, ok = snapshotTopologyRegistryForTestWithOptions(coll.topologyRegistry, options)
 		return ok
 	}, 5*time.Second, 100*time.Millisecond, "topology snapshot did not become available for %q", dev.SysName)
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
@@ -10,7 +10,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
 
-func (c *topologyCache) snapshotL3Interfaces(localDeviceID string) []topologymodel.L3Interface {
+func (c *topologyBuilder) snapshotL3Interfaces(localDeviceID string) []topologymodel.L3Interface {
 	if c == nil || len(c.l3InterfacesByIP) == 0 {
 		return nil
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_management_address.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_management_address.go
@@ -87,7 +87,7 @@ func appendManagementAddress(addrs []topologymodel.ManagementAddress, addr topol
 	return append(addrs, addr)
 }
 
-func (c *topologyCache) appendLocalManagementAddress(addr topologymodel.ManagementAddress) {
+func (c *topologyBuilder) appendLocalManagementAddress(addr topologymodel.ManagementAddress) {
 	if c == nil {
 		return
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_management_address_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_management_address_test.go
@@ -167,7 +167,7 @@ func TestAppendManagementAddressFiltersUnusableIPsAndKeepsNonIPFamilies(t *testi
 }
 
 func TestTopologyCacheManagementAddressIngestionPreservesOrderSourceAndDedup(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.ingestTopologyProfileMetrics([]*ddsnmp.ProfileMetrics{{TopologyMetrics: []ddsnmp.Metric{
 		{TopologyKind: ddsnmp.KindIpIfIndex, Tags: map[string]string{
@@ -214,7 +214,7 @@ func TestTopologyCacheManagementAddressIngestionPreservesOrderSourceAndDedup(t *
 		{Address: "198.51.100.20", AddressType: "ipv4", Source: "ip_mib"},
 	}, cache.localDevice.ManagementAddresses)
 
-	cache.finalizeTopologyCache()
+	cache.finalize()
 	require.Nil(t, cache.localManagementAddressKeys)
 }
 
@@ -236,7 +236,7 @@ func BenchmarkTopologyCacheIPManagementAddressIngest(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
-				cache := newTopologyCache()
+				cache := newTopologyBuilder()
 				cache.ingestTopologyProfileMetrics(pms)
 				runtime.KeepAlive(cache)
 			}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local.go
@@ -11,7 +11,7 @@ import (
 	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 )
 
-func (c *topologyCache) buildEngineObservation(local topologymodel.Device) topologyengine.L2Observation {
+func (c *topologyBuilder) buildEngineObservation(local topologymodel.Device) topologyengine.L2Observation {
 	localManagementIP := normalizeEligibleManagementIP(local.ManagementIP)
 
 	baseBridgeAddress := c.resolveLocalBaseBridgeAddress(localManagementIP)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_forwarding.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_forwarding.go
@@ -12,7 +12,7 @@ import (
 	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 )
 
-func (c *topologyCache) appendObservedFDBEntries(observation *topologyengine.L2Observation) {
+func (c *topologyBuilder) appendObservedFDBEntries(observation *topologyengine.L2Observation) {
 	if observation == nil {
 		return
 	}
@@ -47,7 +47,7 @@ func (c *topologyCache) appendObservedFDBEntries(observation *topologyengine.L2O
 	}
 }
 
-func (c *topologyCache) appendObservedSTPPorts(observation *topologyengine.L2Observation) {
+func (c *topologyBuilder) appendObservedSTPPorts(observation *topologyengine.L2Observation) {
 	if observation == nil {
 		return
 	}
@@ -88,7 +88,7 @@ func (c *topologyCache) appendObservedSTPPorts(observation *topologyengine.L2Obs
 	}
 }
 
-func (c *topologyCache) appendObservedARPNDEntries(observation *topologyengine.L2Observation) {
+func (c *topologyBuilder) appendObservedARPNDEntries(observation *topologyengine.L2Observation) {
 	if observation == nil {
 		return
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_identity.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_identity.go
@@ -9,7 +9,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
 
-func (c *topologyCache) resolveLocalBaseBridgeAddress(localManagementIP string) string {
+func (c *topologyBuilder) resolveLocalBaseBridgeAddress(localManagementIP string) string {
 	baseBridgeAddress := strings.TrimSpace(c.bridgeBaseAddress)
 	if baseBridgeAddress == "" {
 		baseBridgeAddress = c.deriveLocalBridgeMACFromFDBSelfEntries()
@@ -20,7 +20,7 @@ func (c *topologyCache) resolveLocalBaseBridgeAddress(localManagementIP string) 
 	return baseBridgeAddress
 }
 
-func (c *topologyCache) deriveLocalBridgeMACFromFDBSelfEntries() string {
+func (c *topologyBuilder) deriveLocalBridgeMACFromFDBSelfEntries() string {
 	if len(c.fdbEntries) == 0 {
 		return ""
 	}
@@ -46,7 +46,7 @@ func (c *topologyCache) deriveLocalBridgeMACFromFDBSelfEntries() string {
 	return ""
 }
 
-func (c *topologyCache) deriveLocalBridgeMACFromInterfacePhysAddress(localManagementIP string) string {
+func (c *topologyBuilder) deriveLocalBridgeMACFromInterfacePhysAddress(localManagementIP string) string {
 	if len(c.ifStatusByIndex) == 0 {
 		return ""
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_interfaces.go
@@ -11,7 +11,7 @@ import (
 	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 )
 
-func (c *topologyCache) appendObservedInterfaces(observation *topologyengine.L2Observation) {
+func (c *topologyBuilder) appendObservedInterfaces(observation *topologyengine.L2Observation) {
 	if observation == nil {
 		return
 	}
@@ -60,7 +60,7 @@ func (c *topologyCache) appendObservedInterfaces(observation *topologyengine.L2O
 	}
 }
 
-func (c *topologyCache) appendObservedBridgePorts(observation *topologyengine.L2Observation) {
+func (c *topologyBuilder) appendObservedBridgePorts(observation *topologyengine.L2Observation) {
 	if observation == nil {
 		return
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_neighbors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_neighbors.go
@@ -10,7 +10,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
 
-func (c *topologyCache) appendObservedLLDPRemotes(observation *topologyengine.L2Observation) {
+func (c *topologyBuilder) appendObservedLLDPRemotes(observation *topologyengine.L2Observation) {
 	if observation == nil {
 		return
 	}
@@ -55,7 +55,7 @@ func (c *topologyCache) appendObservedLLDPRemotes(observation *topologyengine.L2
 	}
 }
 
-func (c *topologyCache) appendObservedCDPRemotes(observation *topologyengine.L2Observation) {
+func (c *topologyBuilder) appendObservedCDPRemotes(observation *topologyengine.L2Observation) {
 	if observation == nil {
 		return
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
@@ -15,10 +15,10 @@ import (
 )
 
 func init() {
-	registerTopologyMetricHandler(ddsnmp.KindOSPFNeighbor, (*topologyCache).updateOSPFNeighbor)
+	registerTopologyMetricHandler(ddsnmp.KindOSPFNeighbor, (*topologyBuilder).updateOSPFNeighbor)
 }
 
-func (c *topologyCache) updateOSPFNeighbor(tags map[string]string) {
+func (c *topologyBuilder) updateOSPFNeighbor(tags map[string]string) {
 	neighborRouterID := topologyutil.NormalizeTopologyRouterID(tags[tagOSPFNeighborRouterID])
 	neighborIP := topologyutil.NormalizeNonUnspecifiedIPAddress(tags[tagOSPFNeighborIP])
 	if neighborRouterID == "" && neighborIP == "" {
@@ -42,7 +42,7 @@ func (c *topologyCache) updateOSPFNeighbor(tags map[string]string) {
 	c.ospfNeighborsByKey[topologyOSPFNeighborCacheKey(row)] = row
 }
 
-func (c *topologyCache) snapshotOSPFNeighbors(localDeviceID string) []topologymodel.OSPFNeighbor {
+func (c *topologyBuilder) snapshotOSPFNeighbors(localDeviceID string) []topologymodel.OSPFNeighbor {
 	if c == nil || len(c.ospfNeighborsByKey) == 0 {
 		return nil
 	}
@@ -78,7 +78,7 @@ type topologyOSPFLocalInterfaceMatch struct {
 	Prefix  int
 }
 
-func (c *topologyCache) matchOSPFNeighborLocalInterface(neighborIP string) (topologyOSPFLocalInterfaceMatch, bool) {
+func (c *topologyBuilder) matchOSPFNeighborLocalInterface(neighborIP string) (topologyOSPFLocalInterfaceMatch, bool) {
 	neighbor, err := netip.ParseAddr(topologyutil.NormalizeIPAddress(neighborIP))
 	if err != nil || !neighbor.Is4() {
 		return topologyOSPFLocalInterfaceMatch{}, false

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestTopologyCache_OSPFNeighborDropsUnspecifiedOnlyNeighborIdentity(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 
 	cache.updateOSPFNeighbor(map[string]string{
 		tagOSPFNeighborRouterID: "0.0.0.0",
@@ -23,7 +23,7 @@ func TestTopologyCache_OSPFNeighborDropsUnspecifiedOnlyNeighborIdentity(t *testi
 }
 
 func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.l3InterfacesByIP = map[string]topologymodel.L3Interface{
 		"10.0.0.1": {
 			IP:      "10.0.0.1",

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
@@ -18,7 +18,7 @@ import (
 
 type topologyRegistry struct {
 	mu                    sync.RWMutex
-	caches                map[*topologyCache]struct{}
+	generation            atomic.Pointer[topologyGeneration]
 	producerScopeID       string
 	reverseDNS            *reversedns.Resolver
 	reverseDNSWarmer      *topologyReverseDNSWarmer
@@ -31,29 +31,24 @@ func newTopologyRegistryWithResolver(reverseDNS *reversedns.Resolver) *topologyR
 		panic("snmp_topology registry requires a non-nil reverse DNS resolver")
 	}
 	return &topologyRegistry{
-		caches:           make(map[*topologyCache]struct{}),
 		producerScopeID:  strings.TrimSpace(pluginconfig.RegistryUniqueID()),
 		reverseDNS:       reverseDNS,
 		reverseDNSWarmer: newTopologyReverseDNSWarmer(reverseDNS),
 	}
 }
 
-func (r *topologyRegistry) register(cache *topologyCache) {
-	if r == nil || cache == nil {
+func (r *topologyRegistry) publishGeneration(generation *topologyGeneration) {
+	if r == nil {
 		return
 	}
-	r.mu.Lock()
-	r.caches[cache] = struct{}{}
-	r.mu.Unlock()
+	r.generation.Store(generation)
 }
 
-func (r *topologyRegistry) unregister(cache *topologyCache) {
-	if r == nil || cache == nil {
-		return
+func (r *topologyRegistry) acquireGeneration() *topologyGeneration {
+	if r == nil {
+		return nil
 	}
-	r.mu.Lock()
-	delete(r.caches, cache)
-	r.mu.Unlock()
+	return r.generation.Load()
 }
 
 func (r *topologyRegistry) snapshotWithOptions(options topologyoptions.QueryOptions) (topologymodel.Data, bool, error) {
@@ -62,7 +57,8 @@ func (r *topologyRegistry) snapshotWithOptions(options topologyoptions.QueryOpti
 	}
 	options = topologyoptions.NormalizeQueryOptions(options)
 
-	aggregate, ok := aggregateTopologyObservationSnapshots(r.observationSnapshots())
+	generation := r.acquireGeneration()
+	aggregate, ok := aggregateTopologyObservationSnapshots(topologyObservationSnapshotsAt(generation, time.Now()))
 	if !ok {
 		return topologymodel.Data{}, false, nil
 	}
@@ -75,13 +71,8 @@ func (r *topologyRegistry) hasRenderableObservations() bool {
 	if r == nil {
 		return false
 	}
-	now := time.Now()
-	for _, cache := range r.activeCaches() {
-		if cache.hasRenderableObservationAt(now) {
-			return true
-		}
-	}
-	return false
+	generation := r.acquireGeneration()
+	return generation != nil && generation.hasRenderableObservationsAt(time.Now())
 }
 
 func (r *topologyRegistry) producerScope() string {
@@ -111,7 +102,8 @@ func (r *topologyRegistry) managedDeviceFocusTargets() []topologyoptions.Managed
 	if r == nil {
 		return nil
 	}
-	return buildTopologyManagedFocusTargets(r.observationSnapshots())
+	generation := r.acquireGeneration()
+	return buildTopologyManagedFocusTargets(topologyObservationSnapshotsAt(generation, time.Now()))
 }
 
 func (r *topologyRegistry) setReverseDNSWarmContext(ctx context.Context) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
@@ -58,7 +57,7 @@ func (r *topologyRegistry) snapshotWithOptions(options topologyoptions.QueryOpti
 	options = topologyoptions.NormalizeQueryOptions(options)
 
 	generation := r.acquireGeneration()
-	aggregate, ok := aggregateTopologyObservationSnapshots(topologyObservationSnapshotsAt(generation, time.Now()))
+	aggregate, ok := aggregateTopologyObservationSnapshots(topologyObservationSnapshots(generation))
 	if !ok {
 		return topologymodel.Data{}, false, nil
 	}
@@ -72,7 +71,7 @@ func (r *topologyRegistry) hasRenderableObservations() bool {
 		return false
 	}
 	generation := r.acquireGeneration()
-	return generation != nil && generation.hasRenderableObservationsAt(time.Now())
+	return generation != nil && generation.hasRenderableObservations()
 }
 
 func (r *topologyRegistry) producerScope() string {
@@ -103,7 +102,7 @@ func (r *topologyRegistry) managedDeviceFocusTargets() []topologyoptions.Managed
 		return nil
 	}
 	generation := r.acquireGeneration()
-	return buildTopologyManagedFocusTargets(topologyObservationSnapshotsAt(generation, time.Now()))
+	return buildTopologyManagedFocusTargets(topologyObservationSnapshots(generation))
 }
 
 func (r *topologyRegistry) setReverseDNSWarmContext(ctx context.Context) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
@@ -432,36 +432,27 @@ func benchmarkTopologyRetainedSnapshotBytes(
 	return retainedBytes
 }
 
-func BenchmarkTopologyCacheFDBSnapshotReadLock(b *testing.B) {
+func BenchmarkTopologyGenerationFDBSnapshotRead(b *testing.B) {
 	registry := benchmarkManagedFabricFDBTopologyRegistry(1, 1600, false)
-	var cache *topologyCache
-	for candidate := range registry.caches {
-		cache = candidate
-		break
-	}
-	if cache == nil {
-		b.Fatal("benchmark cache is missing")
-	}
-	if _, ok := cache.snapshotEngineObservations(); !ok {
-		b.Fatal("benchmark cache is not renderable")
+	generation := registry.acquireGeneration()
+	if generation == nil || len(generation.devices) != 1 || !generation.devices[0].hasObservation {
+		b.Fatal("benchmark generation is not renderable")
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		snapshot, ok := cache.snapshotEngineObservations()
-		if !ok {
-			b.Fatal("benchmark cache became unavailable")
-		}
+		generation := registry.acquireGeneration()
+		snapshot := generation.devices[0].observation
 		runtime.KeepAlive(snapshot)
 	}
 }
 
-func BenchmarkTopologyCacheAliasSnapshotReadLock(b *testing.B) {
+func BenchmarkTopologyGenerationAliasSnapshotRead(b *testing.B) {
 	for _, aliases := range []int{256, 4096} {
 		b.Run(fmt.Sprintf("aliases=%d", aliases), func(b *testing.B) {
 			now := time.Now()
-			cache := newTopologyCache()
+			cache := newTopologyBuilder()
 			cache.updateTime = now
 			cache.staleAfter = time.Hour
 			cache.agentID = "benchmark-agent"
@@ -484,18 +475,16 @@ func BenchmarkTopologyCacheAliasSnapshotReadLock(b *testing.B) {
 					IfIndex: fmt.Sprintf("%d", i+1),
 				}
 			}
-			cache.finalizeTopologyCache()
-			if _, ok := cache.snapshotEngineObservations(); !ok {
+			cache.finalize()
+			generation := newTopologyDeviceGeneration("benchmark", cache)
+			if generation == nil || !generation.hasObservation {
 				b.Fatal("benchmark cache is not renderable")
 			}
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				snapshot, ok := cache.snapshotEngineObservations()
-				if !ok {
-					b.Fatal("benchmark cache became unavailable")
-				}
+				snapshot := generation.observation
 				runtime.KeepAlive(snapshot)
 			}
 		})
@@ -535,16 +524,15 @@ func BenchmarkSNMPTopologyFunctionDefaultManagedFabricMixedReadPublish(b *testin
 	registry := benchmarkManagedFabricFDBTopologyRegistry(8, 128, true)
 	deps := funcDepsAdapter{registry: registry}
 	options := topologyoptions.DefaultQueryOptions()
-	var published *topologyCache
-	for cache := range registry.caches {
-		published = cache
-		break
-	}
+	published := registry.acquireGeneration()
 	if published == nil {
-		b.Fatal("benchmark cache is missing")
+		b.Fatal("benchmark generation is missing")
 	}
-	replacement := newTopologyCache()
-	replacement.replaceWith(published)
+	replacement := &topologyGeneration{
+		sequence:    published.sequence + 1,
+		publishedAt: published.publishedAt.Add(time.Second),
+		devices:     append([]*topologyDeviceGeneration(nil), published.devices...),
+	}
 
 	if payload, ok, err := deps.Snapshot(options); err != nil || !ok || payload.Links.Rows == 0 {
 		b.Fatalf("default managed-fabric Function probe rows=%d ok=%t err=%v", payload.Links.Rows, ok, err)
@@ -559,9 +547,7 @@ func BenchmarkSNMPTopologyFunctionDefaultManagedFabricMixedReadPublish(b *testin
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			if operations.Add(1)%128 == 0 {
-				published.mu.Lock()
-				published.replaceWith(replacement)
-				published.mu.Unlock()
+				registry.publishGeneration(replacement)
 				publications.Add(1)
 			}
 			payload, ok, err := deps.Snapshot(options)
@@ -584,7 +570,7 @@ func benchmarkManagedFabricFDBTopologyRegistry(deviceCount, fdbEntriesPerDevice 
 	registry := newTopologyRegistry()
 	now := time.Now()
 	for deviceIndex := range deviceCount {
-		cache := newTopologyCache()
+		cache := newTopologyBuilder()
 		cache.lastUpdate = now
 		cache.updateTime = now
 		cache.agentID = fmt.Sprintf("benchmark-agent-%d", deviceIndex)
@@ -613,7 +599,7 @@ func benchmarkManagedFabricFDBTopologyRegistry(deviceCount, fdbEntriesPerDevice 
 				status:     "learned",
 			}
 		}
-		registry.register(cache)
+		publishTestTopologyBuilder(registry, cache)
 	}
 	return registry
 }
@@ -628,9 +614,9 @@ func benchmarkManagedFabricFDBSegmentDensityRegistry(deviceCount, fdbEntryCount,
 
 	registry := newTopologyRegistry()
 	now := time.Now()
-	caches := make([]*topologyCache, 0, deviceCount)
+	caches := make([]*topologyBuilder, 0, deviceCount)
 	for deviceIndex := range deviceCount {
-		cache := newTopologyCache()
+		cache := newTopologyBuilder()
 		cache.lastUpdate = now
 		cache.updateTime = now
 		cache.agentID = fmt.Sprintf("segment-benchmark-agent-%d", deviceIndex)
@@ -641,7 +627,6 @@ func benchmarkManagedFabricFDBSegmentDensityRegistry(deviceCount, fdbEntryCount,
 			ManagementIP:  fmt.Sprintf("198.18.%d.%d", deviceIndex/254, deviceIndex%254+1),
 		}
 		caches = append(caches, cache)
-		registry.register(cache)
 	}
 
 	hub := caches[0]
@@ -668,6 +653,9 @@ func benchmarkManagedFabricFDBSegmentDensityRegistry(deviceCount, fdbEntryCount,
 			status:     "learned",
 		}
 	}
+	for _, cache := range caches {
+		publishTestTopologyBuilder(registry, cache)
+	}
 	return registry
 }
 
@@ -690,7 +678,7 @@ func benchmarkManagedFabricEndpointMAC(deviceIndex, entryIndex int, shared bool)
 
 func benchmarkInferredLLDPTopologyRegistry(linkCount, aliasCount int) *topologyRegistry {
 	now := time.Now()
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.lastUpdate = now
 	cache.updateTime = now
 	cache.agentID = "benchmark-agent"
@@ -719,10 +707,10 @@ func benchmarkInferredLLDPTopologyRegistry(linkCount, aliasCount int) *topologyR
 		}
 	}
 
-	return &topologyRegistry{
-		caches:          map[*topologyCache]struct{}{cache: {}},
-		producerScopeID: "benchmark-producer",
-	}
+	registry := newTopologyRegistry()
+	registry.producerScopeID = "benchmark-producer"
+	publishTestTopologyBuilder(registry, cache)
+	return registry
 }
 
 func BenchmarkSNMPTopologyFunctionAliasScaling(b *testing.B) {
@@ -789,16 +777,14 @@ func BenchmarkSNMPTopologyFunctionAliasScaling(b *testing.B) {
 }
 
 func benchmarkAliasRichTopologyRegistry(deviceCount, aliasCount int, sharedPrimary, ipOnly bool, logicalPeerCount int) *topologyRegistry {
-	registry := &topologyRegistry{
-		caches:          make(map[*topologyCache]struct{}, deviceCount),
-		producerScopeID: "benchmark-producer",
-	}
+	registry := newTopologyRegistry()
+	registry.producerScopeID = "benchmark-producer"
 	now := time.Now()
 	selectedIPs := make([]string, deviceCount)
-	caches := make([]*topologyCache, 0, deviceCount)
+	caches := make([]*topologyBuilder, 0, deviceCount)
 
 	for deviceIndex := range deviceCount {
-		cache := newTopologyCache()
+		cache := newTopologyBuilder()
 		cache.lastUpdate = now
 		cache.updateTime = now
 		cache.agentID = fmt.Sprintf("benchmark-agent-%d", deviceIndex)
@@ -829,7 +815,6 @@ func benchmarkAliasRichTopologyRegistry(deviceCount, aliasCount int, sharedPrima
 			ManagementAddresses: addresses,
 			OSPFRouterID:        fmt.Sprintf("192.0.2.%d", deviceIndex+1),
 		}
-		registry.caches[cache] = struct{}{}
 		caches = append(caches, cache)
 	}
 
@@ -871,7 +856,8 @@ func benchmarkAliasRichTopologyRegistry(deviceCount, aliasCount int, sharedPrima
 		}
 	}
 	for _, cache := range caches {
-		cache.finalizeTopologyCache()
+		cache.finalize()
+		publishTestTopologyBuilder(registry, cache)
 	}
 
 	return registry

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
@@ -515,11 +515,11 @@ func BenchmarkTopologyBuilderBuildAndFreeze(b *testing.B) {
 					}
 				}
 
-				generation, _ := freezeTopologyBuilder("benchmark", builder)
-				if generation == nil || !generation.hasObservation {
-					b.Fatal("frozen generation is not renderable")
+				snapshot, _ := freezeTopologyBuilder(builder)
+				if snapshot == nil || !snapshot.hasObservation {
+					b.Fatal("frozen snapshot is not renderable")
 				}
-				runtime.KeepAlive(generation)
+				runtime.KeepAlive(snapshot)
 			}
 		})
 	}
@@ -563,9 +563,10 @@ func BenchmarkSNMPTopologyFunctionDefaultManagedFabricMixedReadPublish(b *testin
 		b.Fatal("benchmark generation is missing")
 	}
 	replacement := &topologyGeneration{
-		sequence:    published.sequence + 1,
-		publishedAt: published.publishedAt.Add(time.Second),
-		devices:     append([]*topologyDeviceGeneration(nil), published.devices...),
+		sequence:          published.sequence + 1,
+		publishedAt:       published.publishedAt.Add(time.Second),
+		devices:           append([]*topologyDeviceGeneration(nil), published.devices...),
+		renderableDevices: append([]*topologyDeviceGeneration(nil), published.renderableDevices...),
 	}
 
 	if payload, ok, err := deps.Snapshot(options); err != nil || !ok || payload.Links.Rows == 0 {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
@@ -475,8 +475,7 @@ func BenchmarkTopologyGenerationAliasSnapshotRead(b *testing.B) {
 					IfIndex: fmt.Sprintf("%d", i+1),
 				}
 			}
-			cache.finalize()
-			generation := newTopologyDeviceGeneration("benchmark", cache)
+			generation := freezeTestTopologyBuilder("benchmark", cache)
 			if generation == nil || !generation.hasObservation {
 				b.Fatal("benchmark cache is not renderable")
 			}
@@ -486,6 +485,41 @@ func BenchmarkTopologyGenerationAliasSnapshotRead(b *testing.B) {
 			for b.Loop() {
 				snapshot := generation.observation
 				runtime.KeepAlive(snapshot)
+			}
+		})
+	}
+}
+
+func BenchmarkTopologyBuilderBuildAndFreeze(b *testing.B) {
+	for _, fdbEntries := range []int{0, 1600} {
+		b.Run(fmt.Sprintf("fdb_entries=%d", fdbEntries), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				now := time.Now()
+				builder := newTopologyBuilder()
+				builder.updateTime = now
+				builder.staleAfter = time.Hour
+				builder.agentID = "benchmark-agent"
+				builder.localDevice = topologymodel.Device{
+					ChassisID:     "02:00:00:00:00:01",
+					ChassisIDType: "macAddress",
+					SysName:       "benchmark-switch",
+					ManagementIP:  "192.0.2.1",
+				}
+				builder.bridgePortToIf["1"] = "1"
+				builder.ifNamesByIndex["1"] = "uplink"
+				for entryIndex := range fdbEntries {
+					mac := benchmarkManagedFabricEndpointMAC(0, entryIndex+1, false)
+					builder.fdbEntries[mac+"|1||"] = &fdbEntry{
+						mac: mac, bridgePort: "1", status: "learned",
+					}
+				}
+
+				generation, _ := freezeTopologyBuilder("benchmark", builder)
+				if generation == nil || !generation.hasObservation {
+					b.Fatal("frozen generation is not renderable")
+				}
+				runtime.KeepAlive(generation)
 			}
 		})
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
@@ -475,7 +475,7 @@ func BenchmarkTopologyGenerationAliasSnapshotRead(b *testing.B) {
 					IfIndex: fmt.Sprintf("%d", i+1),
 				}
 			}
-			generation := freezeTestTopologyBuilder("benchmark", cache)
+			generation := freezeTestTopologyBuilder(1, cache)
 			if generation == nil || !generation.hasObservation {
 				b.Fatal("benchmark cache is not renderable")
 			}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_observations.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_observations.go
@@ -4,19 +4,18 @@ package snmptopology
 
 import (
 	"sort"
-	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 
 	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 )
 
-func topologyObservationSnapshotsAt(generation *topologyGeneration, now time.Time) []topologymodel.ObservationSnapshot {
+func topologyObservationSnapshots(generation *topologyGeneration) []topologymodel.ObservationSnapshot {
 	if generation == nil {
 		return nil
 	}
 
-	snapshots := generation.observationSnapshotsAt(now)
+	snapshots := generation.observationSnapshots()
 	if len(snapshots) == 0 {
 		return nil
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_observations.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_observations.go
@@ -4,40 +4,19 @@ package snmptopology
 
 import (
 	"sort"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 
 	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 )
 
-func (r *topologyRegistry) activeCaches() []*topologyCache {
-	if r == nil {
+func topologyObservationSnapshotsAt(generation *topologyGeneration, now time.Time) []topologymodel.ObservationSnapshot {
+	if generation == nil {
 		return nil
 	}
 
-	r.mu.RLock()
-	caches := make([]*topologyCache, 0, len(r.caches))
-	for cache := range r.caches {
-		caches = append(caches, cache)
-	}
-	r.mu.RUnlock()
-	return caches
-}
-
-func (r *topologyRegistry) observationSnapshots() []topologymodel.ObservationSnapshot {
-	caches := r.activeCaches()
-	if len(caches) == 0 {
-		return nil
-	}
-
-	snapshots := make([]topologymodel.ObservationSnapshot, 0, len(caches))
-	for _, cache := range caches {
-		snapshot, ok := cache.snapshotEngineObservations()
-		if !ok {
-			continue
-		}
-		snapshots = append(snapshots, snapshot)
-	}
+	snapshots := generation.observationSnapshotsAt(now)
 	if len(snapshots) == 0 {
 		return nil
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_snapshot.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_snapshot.go
@@ -4,7 +4,6 @@ package snmptopology
 
 import (
 	"strings"
-	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
@@ -12,25 +11,10 @@ import (
 	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
 )
 
-func (c *topologyCache) snapshotEngineObservations() (topologymodel.ObservationSnapshot, bool) {
+func (c *topologyBuilder) buildObservationSnapshot() (topologymodel.ObservationSnapshot, bool) {
 	if c == nil {
 		return topologymodel.ObservationSnapshot{}, false
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	if !c.hasFreshSnapshotAt(time.Now()) {
-		return topologymodel.ObservationSnapshot{}, false
-	}
-	if c.hasPreparedSnapshot {
-		return c.preparedSnapshot, true
-	}
-
-	return c.buildObservationSnapshotLocked()
-}
-
-func (c *topologyCache) buildObservationSnapshotLocked() (topologymodel.ObservationSnapshot, bool) {
 	local := normalizeTopologyDevice(c.localDevice)
 	localObservation := c.buildEngineObservation(local)
 	localObservation.DeviceID = strings.TrimSpace(localObservation.DeviceID)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -333,14 +333,17 @@ func TestTopologyRegistry_HasRenderableObservations(t *testing.T) {
 			},
 			want: false,
 		},
-		"cache-stale": {
+		"retained-generation-stale": {
 			setup: func(registry *topologyRegistry) {
 				cache := newTopologyBuilder()
 				seedPublishedEndpointSnapshot(cache)
-				cache.lastUpdate = time.Now().Add(-2 * time.Hour)
+				publishedAt := time.Now().Add(-2 * time.Hour)
+				cache.lastUpdate = publishedAt
 				cache.updateTime = cache.lastUpdate
 				cache.staleAfter = time.Hour
-				publishTestTopologyBuilder(registry, cache)
+				device := freezeTestTopologyBuilderAt("job-a", publishedAt, cache)
+				states := map[string]deviceRefreshState{"job-a": {generation: device}}
+				registry.publishGeneration(newTopologyGeneration(2, time.Now(), states))
 			},
 			want: false,
 		},

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -338,6 +338,7 @@ func TestTopologyRegistry_HasRenderableObservations(t *testing.T) {
 				cache := newTopologyBuilder()
 				seedPublishedEndpointSnapshot(cache)
 				cache.lastUpdate = time.Now().Add(-2 * time.Hour)
+				cache.updateTime = cache.lastUpdate
 				cache.staleAfter = time.Hour
 				publishTestTopologyBuilder(registry, cache)
 			},

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -25,7 +25,7 @@ import (
 func TestTopologyRegistry_SnapshotAggregatesAcrossCaches(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = time.Now()
 	cacheA.lastUpdate = cacheA.updateTime
 	cacheA.agentID = "agent-test"
@@ -53,7 +53,7 @@ func TestTopologyRegistry_SnapshotAggregatesAcrossCaches(t *testing.T) {
 		},
 	}
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = time.Now().Add(time.Second)
 	cacheB.lastUpdate = cacheB.updateTime
 	cacheB.agentID = "agent-test"
@@ -81,8 +81,8 @@ func TestTopologyRegistry_SnapshotAggregatesAcrossCaches(t *testing.T) {
 		},
 	}
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 	require.True(t, ok)
@@ -246,9 +246,9 @@ func TestTopologyRegistry_EnqueueReverseDNSWarmFromDefaultSnapshotUsesDisplayCan
 	registry.reverseDNSWarmer = dns.topologyReverseDNSWarmer
 	registry.setReverseDNSWarmContext(context.Background())
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(cache)
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	require.True(t, registry.enqueueReverseDNSWarmFromDefaultSnapshot())
 	require.Eventually(t, func() bool {
@@ -276,13 +276,13 @@ func TestTopologyRegistry_ReverseDNSCandidatesExcludeDeviceAliases(t *testing.T)
 
 	registry := newTopologyRegistry()
 	registry.reverseDNS = dns.resolver
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(cache)
 	cache.localDevice.ManagementAddresses = []topologymodel.ManagementAddress{
 		{Address: "10.0.0.10", AddressType: "ipv4", Source: managementAddressSourceCollectorTarget},
 		{Address: "198.51.100.8", AddressType: "ipv4", Source: "lldp_local"},
 	}
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	candidates := registry.reverseDNSCandidateCollector()
 	options := defaultTopologyQueryOptionsForTest()
@@ -329,37 +329,37 @@ func TestTopologyRegistry_HasRenderableObservations(t *testing.T) {
 		},
 		"cache-not-yet-published": {
 			setup: func(registry *topologyRegistry) {
-				registry.register(newTopologyCache())
+				publishTestTopologyBuilder(registry, newTopologyBuilder())
 			},
 			want: false,
 		},
 		"cache-stale": {
 			setup: func(registry *topologyRegistry) {
-				cache := newTopologyCache()
+				cache := newTopologyBuilder()
 				seedPublishedEndpointSnapshot(cache)
 				cache.lastUpdate = time.Now().Add(-2 * time.Hour)
 				cache.staleAfter = time.Hour
-				registry.register(cache)
+				publishTestTopologyBuilder(registry, cache)
 			},
 			want: false,
 		},
 		"fresh-local-observation": {
 			setup: func(registry *topologyRegistry) {
-				cache := newTopologyCache()
+				cache := newTopologyBuilder()
 				now := time.Now()
 				cache.updateTime = now
 				cache.lastUpdate = now
 				cache.staleAfter = time.Hour
 				cache.localDevice = topologymodel.Device{ManagementIP: "10.0.0.1"}
-				registry.register(cache)
+				publishTestTopologyBuilder(registry, cache)
 			},
 			want: true,
 		},
 		"fresh-published-endpoint-snapshot": {
 			setup: func(registry *topologyRegistry) {
-				cache := newTopologyCache()
+				cache := newTopologyBuilder()
 				seedPublishedEndpointSnapshot(cache)
-				registry.register(cache)
+				publishTestTopologyBuilder(registry, cache)
 			},
 			want: true,
 		},
@@ -380,7 +380,7 @@ func TestTopologyRegistry_HasRenderableObservations(t *testing.T) {
 func TestTopologyRegistry_SnapshotSingleCacheKeepsLLDPUnidirectional(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent-test"
@@ -408,7 +408,7 @@ func TestTopologyRegistry_SnapshotSingleCacheKeepsLLDPUnidirectional(t *testing.
 		},
 	}
 
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 	require.True(t, ok)
@@ -423,7 +423,7 @@ func TestTopologyRegistry_SnapshotSingleCacheKeepsLLDPUnidirectional(t *testing.
 func TestTopologyRegistry_DefaultMapEmitsL3SubnetForManagedRoutersWithoutLLDP(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = time.Now()
 	cacheA.lastUpdate = cacheA.updateTime
 	cacheA.agentID = "agent-test"
@@ -443,7 +443,7 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetForManagedRoutersWithoutLLDP(t 
 		tagTopoIfName:  "wan0",
 	})
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = time.Now().Add(time.Second)
 	cacheB.lastUpdate = cacheB.updateTime
 	cacheB.agentID = "agent-test"
@@ -463,8 +463,8 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetForManagedRoutersWithoutLLDP(t 
 		tagTopoIfName:  "wan7",
 	})
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 
@@ -490,15 +490,15 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetForManagedRoutersWithoutLLDP(t 
 func TestTopologyRegistry_WeakDevicesUseSelectedManagementIPIdentity(t *testing.T) {
 	registry := newTopologyRegistry()
 	for i, ip := range []string{"192.0.2.10", "198.51.100.10"} {
-		cache := newTopologyCache()
+		cache := newTopologyBuilder()
 		cache.updateTime = time.Now().Add(time.Duration(i) * time.Millisecond)
 		cache.updateIfIndexByIP(map[string]string{
 			tagTopoIfIndex: "1",
 			tagTopoIPAddr:  ip,
 			tagTopoIPMask:  "255.255.255.0",
 		})
-		cache.finalizeTopologyCache()
-		registry.register(cache)
+		cache.finalize()
+		publishTestTopologyBuilder(registry, cache)
 	}
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
@@ -521,7 +521,7 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *tes
 	registry := newTopologyRegistry()
 	registry.producerScopeID = "producer-a"
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = time.Now()
 	cacheA.lastUpdate = cacheA.updateTime
 	cacheA.agentID = "agent-test"
@@ -541,7 +541,7 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *tes
 		tagTopoIfName:  "wan0",
 	})
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = time.Now().Add(time.Second)
 	cacheB.lastUpdate = cacheB.updateTime
 	cacheB.agentID = "agent-test"
@@ -561,7 +561,7 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *tes
 		tagTopoIfName:  "wan7",
 	})
 
-	cacheC := newTopologyCache()
+	cacheC := newTopologyBuilder()
 	cacheC.updateTime = time.Now().Add(2 * time.Second)
 	cacheC.lastUpdate = cacheC.updateTime
 	cacheC.agentID = "agent-test"
@@ -581,9 +581,9 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *tes
 		tagTopoIfName:  "wan9",
 	})
 
-	registry.register(cacheA)
-	registry.register(cacheB)
-	registry.register(cacheC)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
+	publishTestTopologyBuilder(registry, cacheC)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 
@@ -630,7 +630,7 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *tes
 func TestTopologyRegistry_OSPFSnapshotEnrichesSubnetAfterNeighborIngest(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = time.Now()
 	cacheA.lastUpdate = cacheA.updateTime
 	cacheA.agentID = "agent-test"
@@ -660,7 +660,7 @@ func TestTopologyRegistry_OSPFSnapshotEnrichesSubnetAfterNeighborIngest(t *testi
 		tagTopoIPMask:  "255.255.255.252",
 	})
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = time.Now().Add(time.Second)
 	cacheB.lastUpdate = cacheB.updateTime
 	cacheB.agentID = "agent-test"
@@ -681,8 +681,8 @@ func TestTopologyRegistry_OSPFSnapshotEnrichesSubnetAfterNeighborIngest(t *testi
 		tagTopoIPMask:  "255.255.255.252",
 	})
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 
@@ -699,7 +699,7 @@ func TestTopologyRegistry_OSPFSnapshotEnrichesSubnetAfterNeighborIngest(t *testi
 func TestTopologyRegistry_BGPAdjacencyEmitsEstablishedManagedPeerLinkAndDetailRows(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = time.Now()
 	cacheA.lastUpdate = cacheA.updateTime
 	cacheA.agentID = "agent-test"
@@ -720,7 +720,7 @@ func TestTopologyRegistry_BGPAdjacencyEmitsEstablishedManagedPeerLinkAndDetailRo
 		State:           "established",
 	}
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = time.Now().Add(time.Second)
 	cacheB.lastUpdate = cacheB.updateTime
 	cacheB.agentID = "agent-test"
@@ -741,8 +741,8 @@ func TestTopologyRegistry_BGPAdjacencyEmitsEstablishedManagedPeerLinkAndDetailRo
 		State:           "established",
 	}
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 
@@ -777,7 +777,7 @@ func TestTopologyRegistry_BGPAdjacencyEmitsEstablishedManagedPeerLinkAndDetailRo
 func TestTopologyRegistry_BGPAdjacencyKeepsUnresolvedAndNonEstablishedPeersAsDetails(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent-test"
@@ -808,7 +808,7 @@ func TestTopologyRegistry_BGPAdjacencyKeepsUnresolvedAndNonEstablishedPeersAsDet
 		State:           "idle",
 	}
 
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 
@@ -830,7 +830,7 @@ func TestTopologyRegistry_BGPAdjacencyKeepsUnresolvedAndNonEstablishedPeersAsDet
 
 func TestTopologyRegistry_SnapshotWithOptions_LLDPManagedKeepsRequestedMapType(t *testing.T) {
 	registry := newTopologyRegistry()
-	registry.register(newTestTopologyCacheLLDP(
+	publishTestTopologyBuilder(registry, newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
 		"00:11:22:33:44:55",
@@ -858,7 +858,7 @@ func TestTopologyRegistry_SnapshotWithOptions_LLDPManagedKeepsRequestedMapType(t
 
 func TestTopologyRegistry_DefaultSnapshotSuppressesInferredNeighborWithOnlyIneligibleManagementAddress(t *testing.T) {
 	registry := newTopologyRegistry()
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now().UTC()
 	cache.agentID = "agent-test"
 	cache.localDevice = topologymodel.Device{
@@ -883,8 +883,8 @@ func TestTopologyRegistry_DefaultSnapshotSuppressesInferredNeighborWithOnlyIneli
 		tagLldpRemMgmtAddr:         "169.254.0.1",
 		tagLldpRemMgmtAddrSubtype:  "1",
 	})
-	cache.finalizeTopologyCache()
-	registry.register(cache)
+	cache.finalize()
+	publishTestTopologyBuilder(registry, cache)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 	require.True(t, ok)
@@ -898,7 +898,7 @@ func TestTopologyRegistry_DefaultSnapshotSuppressesInferredNeighborWithOnlyIneli
 func TestTopologyRegistry_SnapshotWithOptions_CollapseByIPPreservesEngineManagedOverlapPruning(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now().UTC()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent-test"
@@ -938,7 +938,7 @@ func TestTopologyRegistry_SnapshotWithOptions_CollapseByIPPreservesEngineManaged
 		ip:      "10.20.4.22",
 		mac:     "9c:6b:00:7b:98:c7",
 	}
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	withoutCollapse, ok, err := registry.snapshotWithOptions(topologyoptions.QueryOptions{
 		MapType:            topologyoptions.MapTypeAllDevicesLowConfidence,
@@ -964,7 +964,7 @@ func TestTopologyRegistry_SnapshotWithOptions_CollapseByIPPreservesEngineManaged
 
 func TestTopologyRegistry_ManagedDeviceFocusTargets_ReturnsPerDeviceIPTargets(t *testing.T) {
 	registry := newTopologyRegistry()
-	registry.register(newTestTopologyCacheLLDP(
+	publishTestTopologyBuilder(registry, newTestTopologyCacheLLDP(
 		"agent-test",
 		time.Now().UTC(),
 		"00:11:22:33:44:55",
@@ -1003,12 +1003,12 @@ func TestTopologyRegistry_ManagedFocusRejectsTypedNonIPManagementEvidence(t *tes
 			ManagementIP:  "192.0.2.20",
 		},
 	} {
-		cache := newTopologyCache()
+		cache := newTopologyBuilder()
 		cache.updateTime = now
 		cache.lastUpdate = now
 		cache.agentID = device.SysName
 		cache.localDevice = device
-		registry.register(cache)
+		publishTestTopologyBuilder(registry, cache)
 	}
 
 	options := defaultTopologyQueryOptionsForTest()
@@ -1026,7 +1026,7 @@ func TestTopologyRegistry_ManagedFocusUsesOnlyReconciledManagementAddresses(t *t
 	registry := newTopologyRegistry()
 	now := time.Now().UTC()
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = now
 	cacheA.lastUpdate = now
 	cacheA.agentID = "sw-a"
@@ -1042,7 +1042,7 @@ func TestTopologyRegistry_ManagedFocusUsesOnlyReconciledManagementAddresses(t *t
 		tagTopoIPMask:  "255.255.255.0",
 	})
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = now
 	cacheB.lastUpdate = now
 	cacheB.agentID = "sw-b"
@@ -1053,8 +1053,8 @@ func TestTopologyRegistry_ManagedFocusUsesOnlyReconciledManagementAddresses(t *t
 		ManagementIP:  "192.0.2.20",
 	}
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 	baseline, ok := snapshotTopologyRegistryForTest(registry)
 	require.True(t, ok)
 	baselineA := findDeviceActorBySysName(baseline, "sw-a")
@@ -1078,7 +1078,7 @@ func TestTopologyRegistry_ManagedFocusRetainsUniqueReconciledLocalAlias(t *testi
 	registry := newTopologyRegistry()
 	now := time.Now().UTC()
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = now
 	cacheA.lastUpdate = now
 	cacheA.agentID = "sw-a"
@@ -1094,7 +1094,7 @@ func TestTopologyRegistry_ManagedFocusRetainsUniqueReconciledLocalAlias(t *testi
 		tagTopoIPMask:  "255.255.255.0",
 	})
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = now
 	cacheB.lastUpdate = now
 	cacheB.agentID = "sw-b"
@@ -1105,8 +1105,8 @@ func TestTopologyRegistry_ManagedFocusRetainsUniqueReconciledLocalAlias(t *testi
 		ManagementIP:  "192.0.2.20",
 	}
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	options := defaultTopologyQueryOptionsForTest()
 	options.ManagedDeviceFocus = "ip:192.0.2.11"
@@ -1121,7 +1121,7 @@ func TestTopologyRegistry_ManagedFocusRetainsUniqueReconciledLocalAlias(t *testi
 }
 
 func TestTopologyCache_SnapshotEngineObservationsUsesDirectLocalObservation(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent-test"
@@ -1159,7 +1159,7 @@ func TestTopologyCache_SnapshotEngineObservationsUsesDirectLocalObservation(t *t
 		},
 	}
 
-	snapshot, ok := cache.snapshotEngineObservations()
+	snapshot, ok := snapshotTestTopologyBuilder(cache)
 	require.True(t, ok)
 	require.Len(t, snapshot.L2Observations, 1)
 	require.Equal(t, snapshot.LocalDeviceID, snapshot.L2Observations[0].DeviceID)
@@ -1168,7 +1168,7 @@ func TestTopologyCache_SnapshotEngineObservationsUsesDirectLocalObservation(t *t
 }
 
 func TestTopologyCache_SnapshotEngineObservationsIncludesL3Interfaces(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent-test"
@@ -1193,7 +1193,7 @@ func TestTopologyCache_SnapshotEngineObservationsIncludesL3Interfaces(t *testing
 		tagTopoIPAddr:  "2001:db8::1",
 	})
 
-	snapshot, ok := cache.snapshotEngineObservations()
+	snapshot, ok := snapshotTestTopologyBuilder(cache)
 
 	require.True(t, ok)
 	require.Len(t, snapshot.L3Interfaces, 1)
@@ -1235,8 +1235,8 @@ func TestAggregateTopologyObservationSnapshotsIncludesL3Interfaces(t *testing.T)
 
 func TestTopologyRegistry_SnapshotReturnsFalseWithoutCollectedCaches(t *testing.T) {
 	registry := newTopologyRegistry()
-	cache := newTopologyCache()
-	registry.register(cache)
+	cache := newTopologyBuilder()
+	publishTestTopologyBuilder(registry, cache)
 
 	_, ok := snapshotTopologyRegistryForTest(registry)
 	require.False(t, ok)
@@ -1245,7 +1245,7 @@ func TestTopologyRegistry_SnapshotReturnsFalseWithoutCollectedCaches(t *testing.
 func TestTopologyRegistry_SnapshotDeterministicAcrossRepeatedCalls(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = time.Now()
 	cacheA.lastUpdate = cacheA.updateTime
 	cacheA.agentID = "agent-test"
@@ -1273,7 +1273,7 @@ func TestTopologyRegistry_SnapshotDeterministicAcrossRepeatedCalls(t *testing.T)
 		},
 	}
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = time.Now().Add(time.Second)
 	cacheB.lastUpdate = cacheB.updateTime
 	cacheB.agentID = "agent-test"
@@ -1301,8 +1301,8 @@ func TestTopologyRegistry_SnapshotDeterministicAcrossRepeatedCalls(t *testing.T)
 		},
 	}
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	baseline, ok := snapshotTopologyRegistryForTest(registry)
 	require.True(t, ok)
@@ -1319,7 +1319,7 @@ func TestTopologyRegistry_SnapshotDeterministicAcrossRepeatedCalls(t *testing.T)
 func TestTopologyRegistry_SnapshotDeduplicatesDuplicateDeviceObservations(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.updateTime = time.Now()
 	cacheA.lastUpdate = cacheA.updateTime
 	cacheA.agentID = "agent-test"
@@ -1347,7 +1347,7 @@ func TestTopologyRegistry_SnapshotDeduplicatesDuplicateDeviceObservations(t *tes
 		},
 	}
 
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.updateTime = cacheA.updateTime
 	cacheB.lastUpdate = cacheA.lastUpdate
 	cacheB.agentID = cacheA.agentID
@@ -1355,8 +1355,8 @@ func TestTopologyRegistry_SnapshotDeduplicatesDuplicateDeviceObservations(t *tes
 	cacheB.lldpLocPorts["1"] = cacheA.lldpLocPorts["1"]
 	cacheB.lldpRemotes["1:1"] = cacheA.lldpRemotes["1:1"]
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	data, ok := snapshotTopologyRegistryForTest(registry)
 	require.True(t, ok)
@@ -1371,7 +1371,7 @@ func TestTopologyRegistry_DuplicateCachesPreserveReconciledManagementPrimary(t *
 	now := time.Now().UTC()
 
 	for _, managementIP := range []string{"192.0.2.30", "192.0.2.20"} {
-		cache := newTopologyCache()
+		cache := newTopologyBuilder()
 		cache.updateTime = now
 		cache.lastUpdate = now
 		cache.agentID = managementIP
@@ -1381,7 +1381,7 @@ func TestTopologyRegistry_DuplicateCachesPreserveReconciledManagementPrimary(t *
 			SysName:       "sw-a",
 			ManagementIP:  managementIP,
 		}
-		registry.register(cache)
+		publishTestTopologyBuilder(registry, cache)
 	}
 
 	data, ok := snapshotTopologyRegistryForTest(registry)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -341,8 +341,9 @@ func TestTopologyRegistry_HasRenderableObservations(t *testing.T) {
 				cache.lastUpdate = publishedAt
 				cache.updateTime = cache.lastUpdate
 				cache.staleAfter = time.Hour
-				device := freezeTestTopologyBuilderAt("job-a", publishedAt, cache)
-				states := map[string]deviceRefreshState{"job-a": {generation: device}}
+				const registrationID ddsnmp.DeviceRegistrationID = 1
+				device := freezeTestTopologyBuilderAt(registrationID, publishedAt, cache)
+				states := map[ddsnmp.DeviceRegistrationID]deviceRefreshState{registrationID: {generation: device}}
 				registry.publishGeneration(newTopologyGeneration(2, time.Now(), states))
 			},
 			want: false,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_builder_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_builder_test.go
@@ -234,7 +234,7 @@ func (s *topologyScenario) render(t testing.TB) topologyapi.Data {
 		registry.reverseDNS = dns.resolver
 	}
 	for _, dev := range s.devs {
-		registry.register(s.cacheForDevice(t, dev))
+		publishTestTopologyBuilder(registry, s.cacheForDevice(t, dev))
 	}
 
 	payload, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(s.opts)
@@ -244,7 +244,7 @@ func (s *topologyScenario) render(t testing.TB) topologyapi.Data {
 	return payload
 }
 
-func (s *topologyScenario) cacheForDevice(t testing.TB, dev *topologyScenarioDevice) *topologyCache {
+func (s *topologyScenario) cacheForDevice(t testing.TB, dev *topologyScenarioDevice) *topologyBuilder {
 	t.Helper()
 
 	cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{
@@ -264,7 +264,7 @@ func (s *topologyScenario) cacheForDevice(t testing.TB, dev *topologyScenarioDev
 	cache.updateTopologyProfileTags([]*ddsnmp.ProfileMetrics{pm})
 	cache.ingestTopologyProfileMetrics([]*ddsnmp.ProfileMetrics{pm})
 	cache.ingestTopologyBGPPeers([]*ddsnmp.ProfileMetrics{pm})
-	cache.finalizeTopologyCache()
+	cache.finalize()
 	return cache
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_race_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snapshot_race_test.go
@@ -11,18 +11,12 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
 )
 
-// TestTopologyRegistry_ConcurrentSnapshotsDoNotRaceOnDeviceLabels reproduces the
-// concurrent-map-write crash where the snapshot read path mutated a cache-shared
-// map. snapshotEngineObservations holds only an RLock and passes c.localDevice
-// (by value, so Labels still aliases the cache map) to normalizeTopologyDevice,
-// which writes Labels. Two concurrent snapshot readers then write the same map.
-//
-// Run with -race. Before the fix this reports a data race / fatal concurrent map
-// writes; after the fix (normalizeTopologyDevice clones Labels) it passes.
-func TestTopologyRegistry_ConcurrentSnapshotsDoNotRaceOnDeviceLabels(t *testing.T) {
+// Run with -race. The builder is frozen once before publication; every reader
+// then traverses the same immutable generation without a cache lock.
+func TestTopologyRegistry_ConcurrentSnapshotsReadImmutableGeneration(t *testing.T) {
 	registry := newTopologyRegistry()
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.lastUpdate = time.Now()
 	cache.localDevice = topologymodel.Device{
 		ManagementIP:  "192.0.2.1",
@@ -46,7 +40,7 @@ func TestTopologyRegistry_ConcurrentSnapshotsDoNotRaceOnDeviceLabels(t *testing.
 		portID:           "Gi0/2",
 		portIDSubtype:    "interfaceName",
 	}
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	const goroutines = 64
 	var wg sync.WaitGroup

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_forwarding_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_forwarding_test.go
@@ -94,7 +94,7 @@ func TestTopologyCache_RealSnmprecForwardingFixtures(t *testing.T) {
 	}
 }
 
-func replaySnmprecForwardingFixture(t *testing.T, fixture string, data snmprecForwardingFixture) *topologyCache {
+func replaySnmprecForwardingFixture(t *testing.T, fixture string, data snmprecForwardingFixture) *topologyBuilder {
 	t.Helper()
 
 	cache := newTestTopologyCache(ddsnmp.DeviceConnectionInfo{
@@ -136,7 +136,7 @@ func replaySnmprecForwardingFixture(t *testing.T, fixture string, data snmprecFo
 	for _, tags := range data.arpEntries {
 		cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindArpEntry, Tags: tags})
 	}
-	cache.finalizeTopologyCache()
+	cache.finalize()
 
 	return cache
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_test.go
@@ -68,7 +68,7 @@ func TestTopologyCache_RealSnmprecFixtures(t *testing.T) {
 			for _, tags := range data.cdpRemotes {
 				cache.updateTopologyCacheEntry(ddsnmp.Metric{TopologyKind: ddsnmp.KindCdpCache, Tags: tags})
 			}
-			cache.finalizeTopologyCache()
+			cache.finalize()
 
 			options := defaultTopologyQueryOptionsForTest()
 			options.CollapseActorsByIP = false

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -46,12 +46,12 @@ func publishTestTopologyBuilder(r *topologyRegistry, cache *topologyBuilder) {
 		}
 	}
 	key := fmt.Sprintf("test:%d", sequence)
-	states[key] = deviceRefreshState{generation: newTopologyDeviceGeneration(key, cache)}
+	states[key] = deviceRefreshState{generation: freezeTestTopologyBuilder(key, cache)}
 	r.publishGeneration(newTopologyGeneration(sequence, time.Now(), states))
 }
 
 func snapshotTestTopologyBuilder(c *topologyBuilder) (topologymodel.ObservationSnapshot, bool) {
-	generation := newTopologyDeviceGeneration("test", c)
+	generation := freezeTestTopologyBuilder("test", c)
 	if generation == nil || !generation.freshAt(time.Now()) || !generation.hasObservation {
 		return topologymodel.ObservationSnapshot{}, false
 	}
@@ -63,7 +63,16 @@ func trapEnrichmentForTest(c *topologyBuilder, ip, trapIfIndex string) *TrapTopo
 	if !ok {
 		return nil
 	}
-	return newTopologyTrapDeviceGeneration(c).enrichmentForCanonicalSource(addr.String(), trapIfIndex)
+	generation := freezeTestTopologyBuilder("test", c)
+	if generation == nil {
+		return nil
+	}
+	return generation.trap.enrichmentForCanonicalSource(addr.String(), trapIfIndex)
+}
+
+func freezeTestTopologyBuilder(key string, builder *topologyBuilder) *topologyDeviceGeneration {
+	generation, _ := freezeTopologyBuilder(key, builder)
+	return generation
 }
 
 func registerTestDeviceState(store *ddsnmp.DeviceStore, devices ...ddsnmp.DeviceConnectionInfo) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -4,9 +4,11 @@ package snmptopology
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/reversedns"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
@@ -26,6 +28,42 @@ func newTestReverseDNSResolver() *reversedns.Resolver { return reversedns.New(re
 
 func newTopologyRegistry() *topologyRegistry {
 	return newTopologyRegistryWithResolver(newTestReverseDNSResolver())
+}
+
+// publishTestTopologyBuilder freezes a build-only cache and republishes the
+// complete immutable test generation. Production publishes through sweeps.
+func publishTestTopologyBuilder(r *topologyRegistry, cache *topologyBuilder) {
+	if r == nil || cache == nil {
+		return
+	}
+	current := r.acquireGeneration()
+	sequence := uint64(1)
+	states := make(map[string]deviceRefreshState)
+	if current != nil {
+		sequence = current.sequence + 1
+		for _, device := range current.devices {
+			states[device.key] = deviceRefreshState{generation: device}
+		}
+	}
+	key := fmt.Sprintf("test:%d", sequence)
+	states[key] = deviceRefreshState{generation: newTopologyDeviceGeneration(key, cache)}
+	r.publishGeneration(newTopologyGeneration(sequence, time.Now(), states))
+}
+
+func snapshotTestTopologyBuilder(c *topologyBuilder) (topologymodel.ObservationSnapshot, bool) {
+	generation := newTopologyDeviceGeneration("test", c)
+	if generation == nil || !generation.freshAt(time.Now()) || !generation.hasObservation {
+		return topologymodel.ObservationSnapshot{}, false
+	}
+	return generation.observation, true
+}
+
+func trapEnrichmentForTest(c *topologyBuilder, ip, trapIfIndex string) *TrapTopologyEnrichment {
+	addr, ok := topologyutil.ParseIPAddress(ip)
+	if !ok {
+		return nil
+	}
+	return newTopologyTrapDeviceGeneration(c).enrichmentForCanonicalSource(addr.String(), trapIfIndex)
 }
 
 func registerTestDeviceState(store *ddsnmp.DeviceStore, devices ...ddsnmp.DeviceConnectionInfo) {
@@ -53,13 +91,13 @@ func snapshotTopologyRegistryForTestWithOptions(registry *topologyRegistry, opti
 	return data, ok && err == nil
 }
 
-func snapshotTopologyCacheForTest(cache *topologyCache) (topologymodel.Data, bool) {
+func snapshotTopologyCacheForTest(cache *topologyBuilder) (topologymodel.Data, bool) {
 	return snapshotTopologyCacheForTestWithOptions(cache, defaultTopologyQueryOptionsForTest())
 }
 
-func snapshotTopologyCacheForTestWithOptions(cache *topologyCache, options topologyoptions.QueryOptions) (topologymodel.Data, bool) {
+func snapshotTopologyCacheForTestWithOptions(cache *topologyBuilder, options topologyoptions.QueryOptions) (topologymodel.Data, bool) {
 	registry := newTopologyRegistry()
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 	return snapshotTopologyRegistryForTestWithOptions(registry, options)
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -38,21 +38,21 @@ func publishTestTopologyBuilder(r *topologyRegistry, cache *topologyBuilder) {
 	}
 	current := r.acquireGeneration()
 	sequence := uint64(1)
-	states := make(map[string]deviceRefreshState)
+	states := make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState)
 	if current != nil {
 		sequence = current.sequence + 1
 		for _, device := range current.devices {
-			states[device.key] = deviceRefreshState{generation: device}
+			states[device.registrationID] = deviceRefreshState{generation: device}
 		}
 	}
-	key := fmt.Sprintf("test:%d", sequence)
+	registrationID := ddsnmp.DeviceRegistrationID(sequence)
 	publishedAt := time.Now()
-	states[key] = deviceRefreshState{generation: freezeTestTopologyBuilderAt(key, publishedAt, cache)}
+	states[registrationID] = deviceRefreshState{generation: freezeTestTopologyBuilderAt(registrationID, publishedAt, cache)}
 	r.publishGeneration(newTopologyGeneration(sequence, publishedAt, states))
 }
 
 func snapshotTestTopologyBuilder(c *topologyBuilder) (topologymodel.ObservationSnapshot, bool) {
-	generation := freezeTestTopologyBuilder("test", c)
+	generation := freezeTestTopologyBuilder(1, c)
 	if generation == nil || !generation.hasObservation {
 		return topologymodel.ObservationSnapshot{}, false
 	}
@@ -64,20 +64,20 @@ func trapEnrichmentForTest(c *topologyBuilder, ip, trapIfIndex string) *TrapTopo
 	if !ok {
 		return nil
 	}
-	generation := freezeTestTopologyBuilder("test", c)
+	generation := freezeTestTopologyBuilder(1, c)
 	if generation == nil {
 		return nil
 	}
 	return generation.trap.enrichmentForCanonicalSource(addr.String(), trapIfIndex)
 }
 
-func freezeTestTopologyBuilder(key string, builder *topologyBuilder) *topologyDeviceGeneration {
-	return freezeTestTopologyBuilderAt(key, time.Now(), builder)
+func freezeTestTopologyBuilder(registrationID ddsnmp.DeviceRegistrationID, builder *topologyBuilder) *topologyDeviceGeneration {
+	return freezeTestTopologyBuilderAt(registrationID, time.Now(), builder)
 }
 
-func freezeTestTopologyBuilderAt(key string, publishedAt time.Time, builder *topologyBuilder) *topologyDeviceGeneration {
+func freezeTestTopologyBuilderAt(registrationID ddsnmp.DeviceRegistrationID, publishedAt time.Time, builder *topologyBuilder) *topologyDeviceGeneration {
 	snapshot, _ := freezeTopologyBuilder(builder)
-	return activateTopologyDeviceSnapshot(key, publishedAt, snapshot)
+	return activateTopologyDeviceSnapshot(registrationID, publishedAt, snapshot)
 }
 
 func registerTestDeviceState(store *ddsnmp.DeviceStore, devices ...ddsnmp.DeviceConnectionInfo) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -46,13 +46,14 @@ func publishTestTopologyBuilder(r *topologyRegistry, cache *topologyBuilder) {
 		}
 	}
 	key := fmt.Sprintf("test:%d", sequence)
-	states[key] = deviceRefreshState{generation: freezeTestTopologyBuilder(key, cache)}
-	r.publishGeneration(newTopologyGeneration(sequence, time.Now(), states))
+	publishedAt := time.Now()
+	states[key] = deviceRefreshState{generation: freezeTestTopologyBuilderAt(key, publishedAt, cache)}
+	r.publishGeneration(newTopologyGeneration(sequence, publishedAt, states))
 }
 
 func snapshotTestTopologyBuilder(c *topologyBuilder) (topologymodel.ObservationSnapshot, bool) {
 	generation := freezeTestTopologyBuilder("test", c)
-	if generation == nil || !generation.freshAt(time.Now()) || !generation.hasObservation {
+	if generation == nil || !generation.hasObservation {
 		return topologymodel.ObservationSnapshot{}, false
 	}
 	return generation.observation, true
@@ -71,8 +72,12 @@ func trapEnrichmentForTest(c *topologyBuilder, ip, trapIfIndex string) *TrapTopo
 }
 
 func freezeTestTopologyBuilder(key string, builder *topologyBuilder) *topologyDeviceGeneration {
-	generation, _ := freezeTopologyBuilder(key, builder)
-	return generation
+	return freezeTestTopologyBuilderAt(key, time.Now(), builder)
+}
+
+func freezeTestTopologyBuilderAt(key string, publishedAt time.Time, builder *topologyBuilder) *topologyDeviceGeneration {
+	snapshot, _ := freezeTopologyBuilder(builder)
+	return activateTopologyDeviceSnapshot(key, publishedAt, snapshot)
 }
 
 func registerTestDeviceState(store *ddsnmp.DeviceStore, devices ...ddsnmp.DeviceConnectionInfo) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich.go
@@ -3,6 +3,7 @@
 package snmptopology
 
 import (
+	"maps"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -171,9 +172,7 @@ func newTopologyTrapDeviceGeneration(builder *topologyBuilder) topologyTrapDevic
 	} else {
 		generation.sourceVnodeID = strings.TrimSpace(builder.localDevice.AgentID)
 	}
-	for ip, method := range builder.trapMatchMethodByIP {
-		generation.matchMethodByIP[ip] = method
-	}
+	maps.Copy(generation.matchMethodByIP, builder.trapMatchMethodByIP)
 	for ifIndex, ifName := range builder.ifNamesByIndex {
 		if ifName = strings.TrimSpace(ifName); ifName != "" {
 			generation.interfaceByIndex[ifIndex] = ifName

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich.go
@@ -25,6 +25,15 @@ type TrapTopologyEnrichment struct {
 	Neighbors       []string
 }
 
+type topologyTrapDeviceGeneration struct {
+	matchMethodByIP  map[string]string
+	deviceHostname   string
+	deviceVendor     string
+	sourceVnodeID    string
+	interfaceByIndex map[string]string
+	neighborsByIndex map[string][]string
+}
+
 // TrapEnrichmentHandle exposes the currently running topology registry to trap enrichment consumers.
 type TrapEnrichmentHandle struct {
 	registry atomic.Pointer[topologyRegistry]
@@ -50,7 +59,7 @@ func (c *Collector) unpublishTrapTopologyEnrichment() {
 // EnrichmentForSource returns topology enrichment data for a trap received
 // from the given source IP and, when available, the trap subject ifIndex.
 // Interface and neighbor enrichment only use the trap ifIndex after the source
-// IP matches exactly one local topology cache. The caller owns the returned
+// IP matches exactly one published device generation. The caller owns the returned
 // value and its Neighbors slice.
 func (h *TrapEnrichmentHandle) EnrichmentForSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
 	if h == nil {
@@ -63,8 +72,8 @@ func (h *TrapEnrichmentHandle) EnrichmentForSource(ip, trapIfIndex string) *Trap
 	return registry.trapEnrichmentForSource(ip, trapIfIndex)
 }
 
-// trapEnrichmentForSource copies active cache pointers under the registry lock,
-// reads each cache under its own lock, and never blocks on I/O.
+// trapEnrichmentForSource acquires one immutable topology generation and never
+// blocks on collection or I/O.
 func (r *topologyRegistry) trapEnrichmentForSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
 	if r == nil {
 		return nil
@@ -76,14 +85,17 @@ func (r *topologyRegistry) trapEnrichmentForSource(ip, trapIfIndex string) *Trap
 	}
 	ip = addr.String()
 
-	caches := r.activeCaches()
-	if len(caches) == 0 {
+	generation := r.acquireGeneration()
+	if generation == nil {
 		return nil
 	}
 
 	matches := make([]*TrapTopologyEnrichment, 0, 1)
-	for _, cache := range caches {
-		if enrichment := cache.trapEnrichmentForCanonicalSource(ip, trapIfIndex); enrichment != nil {
+	for _, device := range generation.devices {
+		if device == nil {
+			continue
+		}
+		if enrichment := device.trap.enrichmentForCanonicalSource(ip, trapIfIndex); enrichment != nil {
 			matches = append(matches, enrichment)
 		}
 	}
@@ -102,19 +114,8 @@ func (r *topologyRegistry) trapEnrichmentForSource(ip, trapIfIndex string) *Trap
 	return matches[0]
 }
 
-func (c *topologyCache) trapEnrichmentForSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
-	addr, ok := topologyutil.ParseIPAddress(ip)
-	if !ok {
-		return nil
-	}
-	return c.trapEnrichmentForCanonicalSource(addr.String(), trapIfIndex)
-}
-
-func (c *topologyCache) trapEnrichmentForCanonicalSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	method := c.localDeviceIPMatchMethod(ip)
+func (g topologyTrapDeviceGeneration) enrichmentForCanonicalSource(ip, trapIfIndex string) *TrapTopologyEnrichment {
+	method := g.matchMethodByIP[ip]
 	if method == "" {
 		return nil
 	}
@@ -127,17 +128,9 @@ func (c *topologyCache) trapEnrichmentForCanonicalSource(ip, trapIfIndex string)
 		DeviceMatches: 1,
 	}
 
-	if sysName := strings.TrimSpace(c.localDevice.SysName); sysName != "" {
-		enrich.DeviceHostname = sysName
-	}
-	if vendor := strings.TrimSpace(c.localDevice.Vendor); vendor != "" {
-		enrich.DeviceVendor = vendor
-	}
-	if nodeID := strings.TrimSpace(c.localDevice.NetdataHostID); nodeID != "" {
-		enrich.SourceVnodeID = nodeID
-	} else if nodeID := strings.TrimSpace(c.localDevice.AgentID); nodeID != "" {
-		enrich.SourceVnodeID = nodeID
-	}
+	enrich.DeviceHostname = g.deviceHostname
+	enrich.DeviceVendor = g.deviceVendor
+	enrich.SourceVnodeID = g.sourceVnodeID
 
 	if trapIfIndex == "" {
 		enrich.InterfaceStatus = "skipped"
@@ -147,13 +140,13 @@ func (c *topologyCache) trapEnrichmentForCanonicalSource(ip, trapIfIndex string)
 
 	enrich.InterfaceIndex = trapIfIndex
 	enrich.InterfaceStatus = "no_match"
-	if ifName, ok := c.ifNamesByIndex[trapIfIndex]; ok && strings.TrimSpace(ifName) != "" {
+	if ifName := g.interfaceByIndex[trapIfIndex]; ifName != "" {
 		enrich.Interface = ifName
 		enrich.InterfaceStatus = "matched"
 	}
 
 	enrich.NeighborStatus = "no_match"
-	enrich.Neighbors = c.trapNeighborNamesForInterface(trapIfIndex)
+	enrich.Neighbors = append([]string(nil), g.neighborsByIndex[trapIfIndex]...)
 	if len(enrich.Neighbors) > 0 {
 		enrich.NeighborStatus = "matched"
 	}
@@ -161,34 +154,63 @@ func (c *topologyCache) trapEnrichmentForCanonicalSource(ip, trapIfIndex string)
 	return enrich
 }
 
-func (c *topologyCache) trapNeighborNamesForInterface(ifIndex string) []string {
-	neighborNames := make(map[string]struct{})
-	for key, r := range c.lldpRemotes {
-		if r == nil || lldpRemoteLocalPortNum(key, r) != ifIndex {
-			continue
-		}
-		if name := strings.TrimSpace(r.sysName); name != "" {
-			neighborNames[name] = struct{}{}
-		}
-	}
-	for key, r := range c.cdpRemotes {
-		if r == nil || cdpRemoteIfIndex(key, r) != ifIndex {
-			continue
-		}
-		if name := strings.TrimSpace(r.sysName); name != "" {
-			neighborNames[name] = struct{}{}
-		}
-	}
-	if len(neighborNames) == 0 {
-		return nil
+func newTopologyTrapDeviceGeneration(builder *topologyBuilder) topologyTrapDeviceGeneration {
+	if builder == nil {
+		return topologyTrapDeviceGeneration{}
 	}
 
-	neighbors := make([]string, 0, len(neighborNames))
-	for name := range neighborNames {
-		neighbors = append(neighbors, name)
+	generation := topologyTrapDeviceGeneration{
+		matchMethodByIP:  make(map[string]string, len(builder.trapMatchMethodByIP)),
+		interfaceByIndex: make(map[string]string, len(builder.ifNamesByIndex)),
+		neighborsByIndex: make(map[string][]string),
+		deviceHostname:   strings.TrimSpace(builder.localDevice.SysName),
+		deviceVendor:     strings.TrimSpace(builder.localDevice.Vendor),
 	}
-	sort.Strings(neighbors)
-	return neighbors
+	if nodeID := strings.TrimSpace(builder.localDevice.NetdataHostID); nodeID != "" {
+		generation.sourceVnodeID = nodeID
+	} else {
+		generation.sourceVnodeID = strings.TrimSpace(builder.localDevice.AgentID)
+	}
+	for ip, method := range builder.trapMatchMethodByIP {
+		generation.matchMethodByIP[ip] = method
+	}
+	for ifIndex, ifName := range builder.ifNamesByIndex {
+		if ifName = strings.TrimSpace(ifName); ifName != "" {
+			generation.interfaceByIndex[ifIndex] = ifName
+		}
+	}
+
+	neighborSets := make(map[string]map[string]struct{})
+	addNeighbor := func(ifIndex, name string) {
+		ifIndex = strings.TrimSpace(ifIndex)
+		name = strings.TrimSpace(name)
+		if ifIndex == "" || name == "" {
+			return
+		}
+		if neighborSets[ifIndex] == nil {
+			neighborSets[ifIndex] = make(map[string]struct{})
+		}
+		neighborSets[ifIndex][name] = struct{}{}
+	}
+	for key, remote := range builder.lldpRemotes {
+		if remote != nil {
+			addNeighbor(lldpRemoteLocalPortNum(key, remote), remote.sysName)
+		}
+	}
+	for key, remote := range builder.cdpRemotes {
+		if remote != nil {
+			addNeighbor(cdpRemoteIfIndex(key, remote), remote.sysName)
+		}
+	}
+	for ifIndex, names := range neighborSets {
+		neighbors := make([]string, 0, len(names))
+		for name := range names {
+			neighbors = append(neighbors, name)
+		}
+		sort.Strings(neighbors)
+		generation.neighborsByIndex[ifIndex] = neighbors
+	}
+	return generation
 }
 
 func lldpRemoteLocalPortNum(key string, r *lldpRemote) string {
@@ -209,8 +231,4 @@ func cdpRemoteIfIndex(key string, r *cdpRemote) string {
 		return strings.TrimSpace(before)
 	}
 	return ""
-}
-
-func (c *topologyCache) localDeviceIPMatchMethod(ip string) string {
-	return c.trapMatchMethodByIP[ip]
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestTopologyCacheTrapEnrichment(t *testing.T) {
 	tests := map[string]struct {
-		setup               func(*topologyCache)
+		setup               func(*topologyBuilder)
 		source              string
 		ifIndex             string
 		wantDeviceStatus    string
@@ -26,7 +26,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 		wantNeighbors       []string
 	}{
 		"uses-trap-if-index": {
-			setup: func(cache *topologyCache) {
+			setup: func(cache *topologyBuilder) {
 				cache.localDevice.ManagementIP = "192.0.2.30"
 				cache.ifIndexByIP["192.0.2.10"] = "99"
 				cache.ifNamesByIndex["7"] = "Gi0/7"
@@ -46,7 +46,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 			wantNeighbors:       []string{"dist-a", "dist-b"},
 		},
 		"remote-map-key-fallback": {
-			setup: func(cache *topologyCache) {
+			setup: func(cache *topologyBuilder) {
 				cache.localDevice.ManagementIP = "192.0.2.30"
 				cache.lldpRemotes["7:2"] = &lldpRemote{sysName: "dist-b"}
 				cache.lldpRemotes["8:1"] = &lldpRemote{sysName: "dist-c"}
@@ -58,7 +58,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 			wantNeighbors: []string{"dist-a", "dist-b"},
 		},
 		"does-not-infer-interface-from-source-ip": {
-			setup: func(cache *topologyCache) {
+			setup: func(cache *topologyBuilder) {
 				cache.ifIndexByIP["192.0.2.10"] = "7"
 				cache.ifNamesByIndex["7"] = "Gi0/7"
 				cache.lldpRemotes["7:1"] = &lldpRemote{sysName: "dist-a"}
@@ -70,7 +70,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 			wantNeighborStatus:  "skipped",
 		},
 		"management-address-outranks-interface-address": {
-			setup: func(cache *topologyCache) {
+			setup: func(cache *topologyBuilder) {
 				cache.localDevice.ManagementAddresses = []topologymodel.ManagementAddress{{
 					Address: "192.0.2.10", AddressType: "ipv4", Source: "lldp_local",
 				}}
@@ -83,7 +83,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 			wantNeighborStatus:  "skipped",
 		},
 		"no-interface-match": {
-			setup: func(cache *topologyCache) {
+			setup: func(cache *topologyBuilder) {
 				cache.localDevice.ManagementIP = "192.0.2.30"
 				cache.lldpRemotes["7:1"] = &lldpRemote{sysName: "dist-a"}
 			},
@@ -96,11 +96,11 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cache := newTopologyCache()
+			cache := newTopologyBuilder()
 			tc.setup(cache)
 			cache.rebuildTrapSourceMatchMethods()
 
-			enrich := cache.trapEnrichmentForSource(tc.source, tc.ifIndex)
+			enrich := trapEnrichmentForTest(cache, tc.source, tc.ifIndex)
 			require.NotNil(t, enrich)
 			if tc.wantDeviceStatus != "" {
 				require.Equal(t, tc.wantDeviceStatus, enrich.DeviceStatus)
@@ -125,7 +125,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 }
 
 func TestTopologyCacheTrapEnrichmentIncludesLocalDeviceIdentity(t *testing.T) {
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.localDevice.ManagementIP = "192.0.2.30"
 	cache.localDevice.SysName = "core-sw-01"
 	cache.localDevice.Vendor = "cisco"
@@ -133,7 +133,7 @@ func TestTopologyCacheTrapEnrichmentIncludesLocalDeviceIdentity(t *testing.T) {
 	cache.localDevice.NetdataHostID = "vnode-node-id"
 	cache.rebuildTrapSourceMatchMethods()
 
-	enrich := cache.trapEnrichmentForSource("192.0.2.30", "")
+	enrich := trapEnrichmentForTest(cache, "192.0.2.30", "")
 	require.NotNil(t, enrich)
 	require.Equal(t, "core-sw-01", enrich.DeviceHostname)
 	require.Equal(t, "cisco", enrich.DeviceVendor)
@@ -144,13 +144,13 @@ func TestTrapEnrichmentHandleForSourceUsesPublishedRegistry(t *testing.T) {
 	registry := newTopologyRegistry()
 	handle := publishTrapTopologyRegistryForTest(registry)
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.localDevice.ManagementIP = "192.0.2.20"
 	cache.ifNamesByIndex["11"] = "Gi0/11"
 	cache.lldpRemotes["11:1"] = &lldpRemote{sysName: "dist-c"}
 	cache.rebuildTrapSourceMatchMethods()
 
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	enrich := handle.EnrichmentForSource("192.0.2.20", "11")
 	require.NotNil(t, enrich)
@@ -169,13 +169,13 @@ func TestTrapEnrichmentHandleRejectsTypedNonIPManagementEvidence(t *testing.T) {
 	registry := newTopologyRegistry()
 	handle := publishTrapTopologyRegistryForTest(registry)
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.localDevice.ManagementIP = "192.0.2.20"
 	cache.localDevice.ManagementAddresses = []topologymodel.ManagementAddress{
 		{Address: "c0000263", AddressType: "16", Source: "lldp_local"},
 	}
 	cache.rebuildTrapSourceMatchMethods()
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	enrich := handle.EnrichmentForSource("192.0.2.99", "")
 	require.NotNil(t, enrich)
@@ -187,17 +187,17 @@ func TestTrapEnrichmentHandleForSourceAmbiguousRegistryMatchDoesNotEnrich(t *tes
 	registry := newTopologyRegistry()
 	handle := publishTrapTopologyRegistryForTest(registry)
 
-	cacheA := newTopologyCache()
+	cacheA := newTopologyBuilder()
 	cacheA.localDevice.ManagementIP = "192.0.2.20"
 	cacheA.ifNamesByIndex["11"] = "Gi0/11"
 	cacheA.rebuildTrapSourceMatchMethods()
-	cacheB := newTopologyCache()
+	cacheB := newTopologyBuilder()
 	cacheB.localDevice.ManagementIP = "192.0.2.20"
 	cacheB.ifNamesByIndex["11"] = "Gi0/11"
 	cacheB.rebuildTrapSourceMatchMethods()
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	enrich := handle.EnrichmentForSource("192.0.2.20", "11")
 	require.NotNil(t, enrich)
@@ -207,8 +207,8 @@ func TestTrapEnrichmentHandleForSourceAmbiguousRegistryMatchDoesNotEnrich(t *tes
 	require.Empty(t, enrich.Neighbors)
 }
 
-func BenchmarkTopologyCacheTrapEnrichmentForSource(b *testing.B) {
-	cache := newTopologyCache()
+func BenchmarkTopologyGenerationTrapEnrichmentForSource(b *testing.B) {
+	cache := newTopologyBuilder()
 	for i := 1; i <= 200; i++ {
 		cache.localDevice.ManagementAddresses = append(cache.localDevice.ManagementAddresses, topologymodel.ManagementAddress{
 			Address:     fmt.Sprintf("192.0.2.%d", i),
@@ -217,11 +217,12 @@ func BenchmarkTopologyCacheTrapEnrichmentForSource(b *testing.B) {
 		})
 	}
 	cache.rebuildTrapSourceMatchMethods()
+	generation := newTopologyTrapDeviceGeneration(cache)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		if enrichment := cache.trapEnrichmentForCanonicalSource("192.0.2.200", ""); enrichment == nil {
+		if enrichment := generation.enrichmentForCanonicalSource("192.0.2.200", ""); enrichment == nil {
 			b.Fatal("expected trap enrichment")
 		}
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
@@ -69,7 +69,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 			wantInterfaceStatus: "skipped",
 			wantNeighborStatus:  "skipped",
 		},
-		"management-address-outranks-interface-address": {
+		"selected-management-ip-outranks-interface-address": {
 			setup: func(cache *topologyBuilder) {
 				cache.localDevice.ManagementAddresses = []topologymodel.ManagementAddress{{
 					Address: "192.0.2.10", AddressType: "ipv4", Source: "lldp_local",
@@ -78,7 +78,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 			},
 			source:              "192.0.2.10",
 			wantDeviceStatus:    "matched",
-			wantDeviceMethod:    "management_address",
+			wantDeviceMethod:    "management_ip",
 			wantInterfaceStatus: "skipped",
 			wantNeighborStatus:  "skipped",
 		},
@@ -98,7 +98,6 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cache := newTopologyBuilder()
 			tc.setup(cache)
-			cache.rebuildTrapSourceMatchMethods()
 
 			enrich := trapEnrichmentForTest(cache, tc.source, tc.ifIndex)
 			require.NotNil(t, enrich)
@@ -208,23 +207,28 @@ func TestTrapEnrichmentHandleForSourceAmbiguousRegistryMatchDoesNotEnrich(t *tes
 }
 
 func BenchmarkTopologyGenerationTrapEnrichmentForSource(b *testing.B) {
-	cache := newTopologyBuilder()
-	for i := 1; i <= 200; i++ {
-		cache.localDevice.ManagementAddresses = append(cache.localDevice.ManagementAddresses, topologymodel.ManagementAddress{
-			Address:     fmt.Sprintf("192.0.2.%d", i),
-			AddressType: "ipv4",
-			Source:      "lldp_local",
-		})
-	}
-	cache.rebuildTrapSourceMatchMethods()
-	generation := newTopologyTrapDeviceGeneration(cache)
+	for _, deviceCount := range []int{1, 128, 1024} {
+		b.Run(fmt.Sprintf("devices=%d", deviceCount), func(b *testing.B) {
+			devices := make([]*topologyDeviceGeneration, deviceCount)
+			for i := range devices {
+				devices[i] = &topologyDeviceGeneration{trap: topologyTrapDeviceGeneration{
+					matchMethodByIP: map[string]string{
+						fmt.Sprintf("198.51.%d.%d", i/254, i%254+1): "management_ip",
+					},
+				}}
+			}
+			devices[len(devices)-1].trap.matchMethodByIP["192.0.2.200"] = "management_ip"
+			registry := newTopologyRegistry()
+			registry.publishGeneration(&topologyGeneration{devices: devices})
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
-		if enrichment := generation.enrichmentForCanonicalSource("192.0.2.200", ""); enrichment == nil {
-			b.Fatal("expected trap enrichment")
-		}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if enrichment := registry.trapEnrichmentForSource("192.0.2.200", ""); enrichment == nil {
+					b.Fatal("expected trap enrichment")
+				}
+			}
+		})
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ubiquiti_profile_test.go
@@ -77,7 +77,7 @@ func TestTopologyProductionPath_UniFiQBridgeRendersDefaultManagedFabric(t *testi
 	switchCache := newTestTopologyCache(switchDevice)
 	switchCache.updateTopologyProfileTags(switchMetrics)
 	switchCache.ingestTopologyProfileMetrics(switchMetrics)
-	switchCache.finalizeTopologyCache()
+	switchCache.finalize()
 
 	switchObservation := switchCache.buildEngineObservation(switchCache.localDevice)
 	require.Len(t, switchObservation.FDBEntries, 2)
@@ -97,7 +97,7 @@ func TestTopologyProductionPath_UniFiQBridgeRendersDefaultManagedFabric(t *testi
 	gatewayMetrics := collectTopologyProfileMetrics(t, gatewayDevice, topologyUniFiGatewayPDUs())
 	gatewayCache := newTestTopologyCache(gatewayDevice)
 	gatewayCache.ingestTopologyProfileMetrics(gatewayMetrics)
-	gatewayCache.finalizeTopologyCache()
+	gatewayCache.finalize()
 	apDevice := ddsnmp.DeviceConnectionInfo{
 		Hostname:    "192.0.2.20",
 		SysObjectID: "1.3.6.1.4.1.41112",
@@ -107,12 +107,12 @@ func TestTopologyProductionPath_UniFiQBridgeRendersDefaultManagedFabric(t *testi
 	apMetrics := collectTopologyProfileMetrics(t, apDevice, topologyUniFiAPPDUs())
 	apCache := newTestTopologyCache(apDevice)
 	apCache.ingestTopologyProfileMetrics(apMetrics)
-	apCache.finalizeTopologyCache()
+	apCache.finalize()
 
 	registry := newTopologyRegistry()
-	registry.register(switchCache)
-	registry.register(gatewayCache)
-	registry.register(apCache)
+	publishTestTopologyBuilder(registry, switchCache)
+	publishTestTopologyBuilder(registry, gatewayCache)
+	publishTestTopologyBuilder(registry, apCache)
 	data, ok := snapshotTopologyRegistryForTest(registry)
 	require.True(t, ok)
 	assert.GreaterOrEqual(t, testCountTopologyLinksByType(data.Links, "bridge"), 1)
@@ -273,10 +273,10 @@ func TestTopologyProductionPath_UniFiActorsUseProfileIdentity(t *testing.T) {
 			cache := newTestTopologyCache(device)
 			cache.updateTopologyProfileTags(metrics)
 			cache.ingestTopologyProfileMetrics(metrics)
-			cache.finalizeTopologyCache()
+			cache.finalize()
 
 			registry := newTopologyRegistry()
-			registry.register(cache)
+			publishTestTopologyBuilder(registry, cache)
 			data, ok := snapshotTopologyRegistryForTest(registry)
 			require.True(t, ok)
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_v1_stats_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_v1_stats_test.go
@@ -53,8 +53,8 @@ func TestSNMPTopologyToV1_RealPipelineStatsCensus(t *testing.T) {
 		State:           "established",
 	}
 
-	registry.register(cacheA)
-	registry.register(cacheB)
+	publishTestTopologyBuilder(registry, cacheA)
+	publishTestTopologyBuilder(registry, cacheB)
 
 	options := defaultTopologyQueryOptionsForTest()
 	options.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
@@ -179,7 +179,7 @@ func TestSNMPTopologyToV1_RealPipelineStatsCensus(t *testing.T) {
 
 func TestSNMPTopologyToV1_RealPipelineStatsCensusNoProtocolDataEmitsZeroProtocolKeys(t *testing.T) {
 	registry := newTopologyRegistry()
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Date(2026, time.June, 20, 12, 0, 0, 0, time.UTC)
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent-test"
@@ -189,7 +189,7 @@ func TestSNMPTopologyToV1_RealPipelineStatsCensusNoProtocolDataEmitsZeroProtocol
 		SysName:       "switch-a",
 		ManagementIP:  "10.0.0.1",
 	}
-	registry.register(cache)
+	publishTestTopologyBuilder(registry, cache)
 
 	options := defaultTopologyQueryOptionsForTest()
 	options.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
@@ -240,10 +240,10 @@ func TestTopologyStatsToV1_OmitsFocusKeysWhenFocusFilterReturnsEarly(t *testing.
 	require.NotContains(t, stats, "links_focus_depth_filtered")
 }
 
-func newTopologyStatsCensusRouterCache(t *testing.T, sysName, chassisID, managementIP, routerID, ifIP, ifIndex string) *topologyCache {
+func newTopologyStatsCensusRouterCache(t *testing.T, sysName, chassisID, managementIP, routerID, ifIP, ifIndex string) *topologyBuilder {
 	t.Helper()
 
-	cache := newTopologyCache()
+	cache := newTopologyBuilder()
 	cache.updateTime = time.Date(2026, time.June, 20, 12, 0, 0, 0, time.UTC)
 	cache.lastUpdate = cache.updateTime
 	cache.agentID = "agent-test"
@@ -266,7 +266,7 @@ func newTopologyStatsCensusRouterCache(t *testing.T, sysName, chassisID, managem
 	return cache
 }
 
-func addTopologyStatsCensusLLDP(cache *topologyCache, localPortID, remoteChassis, remoteSysName, remoteMgmtIP, remotePortID string) {
+func addTopologyStatsCensusLLDP(cache *topologyBuilder, localPortID, remoteChassis, remoteSysName, remoteMgmtIP, remotePortID string) {
 	cache.lldpLocPorts["1"] = &lldpLocPort{
 		portNum:       "1",
 		portID:        localPortID,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context.go
@@ -8,7 +8,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
-func (c *Collector) collectTopologyVTPVLANContexts(ctx context.Context, cache *topologyCache, dev ddsnmp.DeviceConnectionInfo) {
+func (c *Collector) collectTopologyVTPVLANContexts(ctx context.Context, cache *topologyBuilder, dev ddsnmp.DeviceConnectionInfo) {
 	if cache == nil {
 		return
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context_ingest.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context_ingest.go
@@ -9,7 +9,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
-func (c *topologyCache) ingestTopologyVLANContextMetrics(vlanID, vlanName string, pms []*ddsnmp.ProfileMetrics) {
+func (c *topologyBuilder) ingestTopologyVLANContextMetrics(vlanID, vlanName string, pms []*ddsnmp.ProfileMetrics) {
 	if c == nil {
 		return
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context_inventory.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context_inventory.go
@@ -13,10 +13,7 @@ type topologyVLANContext struct {
 	vlanName string
 }
 
-func (c *topologyCache) vtpVLANContexts() []topologyVLANContext {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
+func (c *topologyBuilder) vtpVLANContexts() []topologyVLANContext {
 	contexts := make([]topologyVLANContext, 0, len(c.vlanNameByID))
 	for vlanID, mapping := range c.vlanNameByID {
 		id := strings.TrimSpace(vlanID)


### PR DESCRIPTION
## Summary

- Rework how SNMP topology updates are stored and published.
- Keep the last successful topology when a device refresh fails, with automatic retries.
- Ensure all topology consumers see one complete, consistent update.
- Preserve the existing topology output and behavior.

## Why

Topology state was difficult to reason about during refreshes and was not suitable for reliable diagnostics. This creates a stable foundation for the diagnostic capture and replay work planned in the next PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the `snmp_topology` collector to publish immutable topology generations instead of live caches, so all consumers read one complete, consistent update and a failed device refresh keeps the last successful topology.

**Refactors**
- Freezes collected device state into immutable generations at publish time; runtime readers never touch build-time state.
- Replaces the registered-cache map and per-cache locking with a single atomically published generation.
- Renames `topologyCache` to `topologyBuilder` and its finalization method to `finalize()`.
- `DeviceStore.Devices()` is now `DeviceStore.Entries()`, returning deterministic sorted entries keyed by a unique, never-reused registration ID. Re-registering a device yields a fresh ID, so stale topology is never attributed to a new registration.

**Bug Fixes**
- Device refresh failures retain the last published device generation and retry on the next sweep.
- Function availability now follows the published generation, expiring when the generation goes stale.

<sup>Written for commit 2222fd830dbccef4162bd7c4aa3ac8f3eaee34f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable registration identities for monitored SNMP devices.
  * Improved topology refresh handling with per-device retries and bounded backoff.
  * Topology data is now published as consistent snapshots, improving concurrent reads and preventing partial updates.
  * Device re-registration preserves identity until the device is removed.

* **Bug Fixes**
  * Improved handling of refresh failures, stale topology data, and devices without matching profiles.
  * Ensured topology availability reflects published, renderable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->