### PR TITLE
Filter disk (Windows)

### DIFF
--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -433,11 +433,23 @@ modules:
               description: Data collection frequency.
               default_value: 1
               required: false
+            - name: exclude space metrics on paths
+              description: >-
+                Space-separated, case-insensitive Netdata simple patterns for logical-volume mount points to exclude
+                from disk space collection. Patterns support `*` wildcards and `!` negative terms. For example,
+                `*AssuredRecoveryTemp*` excludes temporary backup volumes with that path component.
+              default_value: ""
+              required: false
         examples:
           folding:
             enabled: true
-            title: ""
-          list: []
+            title: "Configuration"
+          list:
+            - name: Exclude temporary backup volumes
+              description: Exclude logical-volume disk space metrics for mount points that contain `AssuredRecoveryTemp`.
+              config: |
+                [plugin:windows:PerflibStorage]
+                  exclude space metrics on paths = *AssuredRecoveryTemp*
     troubleshooting:
       problems:
         list: []
@@ -465,12 +477,14 @@ modules:
           labels:
             - name: mount_point
               description: "Drive letter or mount point path assigned by Windows (e.g., 'C:', 'D:')."
-            - name: driver_type
+            - name: drive_type
               description: "Classification of the disk device (e.g., norootdir, removable, cdrom, ramdisk)."
             - name: filesystem
               description: "File system format used on the volume (e.g., NTFS, FAT32)."
             - name: rw_mode
               description: "Current read/write permissions status of the volume (read-only access, read and write access)."
+            - name: serial_number
+              description: "Volume serial number in hexadecimal format."
           metrics:
             - name: disk.space
               description: Disk Space Usage

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -315,98 +315,272 @@ static inline void netdata_set_hd_usage(PERF_DATA_BLOCK *pDataBlock,
     d->percentDiskFree.current.Time = totalNumberOfBytes.QuadPart;
 }
 
-static bool do_logical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every, usec_t now_ut)
+struct logical_disk_collection_ops {
+    PERF_OBJECT_TYPE *(*find_object)(PERF_DATA_BLOCK *pDataBlock, const char *name);
+    PERF_INSTANCE_DEFINITION *(*next_instance)(
+        PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjectType, PERF_INSTANCE_DEFINITION *lastInstance);
+    BOOL (*get_instance_name)(
+        PERF_DATA_BLOCK *pDataBlock,
+        PERF_OBJECT_TYPE *pObjectType,
+        PERF_INSTANCE_DEFINITION *pInstance,
+        char *buffer,
+        size_t bufferLen);
+    void (*collect_instance)(
+        PERF_DATA_BLOCK *pDataBlock,
+        PERF_OBJECT_TYPE *pObjectType,
+        PERF_INSTANCE_DEFINITION *pInstance,
+        const char *name,
+        int update_every,
+        usec_t now_ut);
+};
+
+static void logical_disk_collect_instance(
+    PERF_DATA_BLOCK *pDataBlock,
+    PERF_OBJECT_TYPE *pObjectType,
+    PERF_INSTANCE_DEFINITION *pi,
+    const char *name,
+    int update_every,
+    usec_t now_ut)
 {
     DICTIONARY *dict = logicalDisks;
 
-    PERF_OBJECT_TYPE *pObjectType = perflibFindObjectTypeByName(pDataBlock, "LogicalDisk");
+    struct logical_disk *d = dictionary_set(dict, name, NULL, sizeof(*d));
+    d->last_collected = now_ut;
+
+    if (!d->collected_metadata) {
+        d->filesystem = getFileSystemType(d, name);
+        d->collected_metadata = true;
+    }
+
+    netdata_set_hd_usage(pDataBlock, pObjectType, pi, d);
+    // perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->freeMegabytes);
+
+    if (!d->st_disk_space) {
+        d->st_disk_space = rrdset_create_localhost(
+            "disk_space",
+            name,
+            NULL,
+            name,
+            "disk.space",
+            "Disk Space Usage",
+            "GiB",
+            PLUGIN_WINDOWS_NAME,
+            "PerflibStorage",
+            NETDATA_CHART_PRIO_DISKSPACE_SPACE,
+            update_every,
+            RRDSET_TYPE_STACKED);
+
+        rrdlabels_add(d->st_disk_space->rrdlabels, "mount_point", name, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(d->st_disk_space->rrdlabels, "drive_type", drive_type_to_str(d->DriveType), RRDLABEL_SRC_AUTO);
+        rrdlabels_add(
+            d->st_disk_space->rrdlabels,
+            "filesystem",
+            d->filesystem ? string2str(d->filesystem) : "unknown",
+            RRDLABEL_SRC_AUTO);
+        rrdlabels_add(d->st_disk_space->rrdlabels, "rw_mode", d->readonly ? "ro" : "rw", RRDLABEL_SRC_AUTO);
+
+        {
+            char buf[UINT64_HEX_MAX_LENGTH];
+            print_uint64_hex(buf, d->SerialNumber);
+            rrdlabels_add(d->st_disk_space->rrdlabels, "serial_number", buf, RRDLABEL_SRC_AUTO);
+        }
+
+        d->rd_disk_space_free = rrddim_add(d->st_disk_space, "avail", NULL, 1, d->divisor, RRD_ALGORITHM_ABSOLUTE);
+        d->rd_disk_space_used = rrddim_add(d->st_disk_space, "used", NULL, 1, d->divisor, RRD_ALGORITHM_ABSOLUTE);
+    }
+
+    // percentDiskFree has the free space in Data and the size of the disk in Time, in MiB.
+    rrddim_set_by_pointer(d->st_disk_space, d->rd_disk_space_free, (collected_number)d->percentDiskFree.current.Data);
+    rrddim_set_by_pointer(
+        d->st_disk_space,
+        d->rd_disk_space_used,
+        (collected_number)(d->percentDiskFree.current.Time - d->percentDiskFree.current.Data));
+    rrdset_done(d->st_disk_space);
+}
+
+static bool do_logical_disk_with_ops(
+    PERF_DATA_BLOCK *pDataBlock,
+    int update_every,
+    usec_t now_ut,
+    const struct logical_disk_collection_ops *ops,
+    char *instance_name,
+    size_t instance_name_size)
+{
+    PERF_OBJECT_TYPE *pObjectType = ops->find_object(pDataBlock, "LogicalDisk");
     if (!pObjectType)
         return false;
 
     PERF_INSTANCE_DEFINITION *pi = NULL;
     for (LONG i = 0; i < pObjectType->NumInstances; i++) {
-        pi = perflibForEachInstance(pDataBlock, pObjectType, pi);
+        pi = ops->next_instance(pDataBlock, pObjectType, pi);
         if (!pi)
             break;
 
-        if (!getInstanceName(pDataBlock, pObjectType, pi, windows_shared_buffer, sizeof(windows_shared_buffer)))
-            strncpyz(windows_shared_buffer, "[unknown]", sizeof(windows_shared_buffer) - 1);
+        if (!ops->get_instance_name(pDataBlock, pObjectType, pi, instance_name, instance_name_size))
+            strncpyz(instance_name, "[unknown]", instance_name_size - 1);
 
-        if (strcasecmp(windows_shared_buffer, "_Total") == 0)
+        if (strcasecmp(instance_name, "_Total") == 0 || logical_disk_is_excluded(instance_name))
             continue;
 
-        if (logical_disk_is_excluded(windows_shared_buffer))
-            continue;
-
-        struct logical_disk *d = dictionary_set(dict, windows_shared_buffer, NULL, sizeof(*d));
-        d->last_collected = now_ut;
-
-        if (!d->collected_metadata) {
-            d->filesystem = getFileSystemType(d, windows_shared_buffer);
-            d->collected_metadata = true;
-        }
-
-        netdata_set_hd_usage(pDataBlock, pObjectType, pi, d);
-        // perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->freeMegabytes);
-
-        if (!d->st_disk_space) {
-            d->st_disk_space = rrdset_create_localhost(
-                "disk_space",
-                windows_shared_buffer,
-                NULL,
-                windows_shared_buffer,
-                "disk.space",
-                "Disk Space Usage",
-                "GiB",
-                PLUGIN_WINDOWS_NAME,
-                "PerflibStorage",
-                NETDATA_CHART_PRIO_DISKSPACE_SPACE,
-                update_every,
-                RRDSET_TYPE_STACKED);
-
-            rrdlabels_add(d->st_disk_space->rrdlabels, "mount_point", windows_shared_buffer, RRDLABEL_SRC_AUTO);
-            rrdlabels_add(
-                d->st_disk_space->rrdlabels, "drive_type", drive_type_to_str(d->DriveType), RRDLABEL_SRC_AUTO);
-            rrdlabels_add(
-                d->st_disk_space->rrdlabels,
-                "filesystem",
-                d->filesystem ? string2str(d->filesystem) : "unknown",
-                RRDLABEL_SRC_AUTO);
-            rrdlabels_add(d->st_disk_space->rrdlabels, "rw_mode", d->readonly ? "ro" : "rw", RRDLABEL_SRC_AUTO);
-
-            {
-                char buf[UINT64_HEX_MAX_LENGTH];
-                print_uint64_hex(buf, d->SerialNumber);
-                rrdlabels_add(d->st_disk_space->rrdlabels, "serial_number", buf, RRDLABEL_SRC_AUTO);
-            }
-
-            d->rd_disk_space_free = rrddim_add(d->st_disk_space, "avail", NULL, 1, d->divisor, RRD_ALGORITHM_ABSOLUTE);
-            d->rd_disk_space_used = rrddim_add(d->st_disk_space, "used", NULL, 1, d->divisor, RRD_ALGORITHM_ABSOLUTE);
-        }
-
-        // percentDiskFree has the free space in Data and the size of the disk in Time, in MiB.
-        rrddim_set_by_pointer(
-            d->st_disk_space, d->rd_disk_space_free, (collected_number)d->percentDiskFree.current.Data);
-        rrddim_set_by_pointer(
-            d->st_disk_space,
-            d->rd_disk_space_used,
-            (collected_number)(d->percentDiskFree.current.Time - d->percentDiskFree.current.Data));
-        rrdset_done(d->st_disk_space);
-    }
-
-    // cleanup - delete callback will handle resource cleanup
-    {
-        struct logical_disk *d;
-        dfe_start_write(dict, d)
-        {
-            if (d->last_collected < now_ut)
-                dictionary_del(dict, d_dfe.name);
-        }
-        dfe_done(d);
-        dictionary_garbage_collect(dict);
+        ops->collect_instance(pDataBlock, pObjectType, pi, instance_name, update_every, now_ut);
     }
 
     return true;
+}
+
+static const struct logical_disk_collection_ops logical_disk_production_ops = {
+    .find_object = perflibFindObjectTypeByName,
+    .next_instance = perflibForEachInstance,
+    .get_instance_name = getInstanceName,
+    .collect_instance = logical_disk_collect_instance,
+};
+
+static bool do_logical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every, usec_t now_ut)
+{
+    bool collected = do_logical_disk_with_ops(
+        pDataBlock,
+        update_every,
+        now_ut,
+        &logical_disk_production_ops,
+        windows_shared_buffer,
+        sizeof(windows_shared_buffer));
+
+    if (!collected)
+        return false;
+
+    // cleanup - delete callback will handle resource cleanup
+    struct logical_disk *d;
+    dfe_start_write(logicalDisks, d)
+    {
+        if (d->last_collected < now_ut)
+            dictionary_del(logicalDisks, d_dfe.name);
+    }
+    dfe_done(d);
+    dictionary_garbage_collect(logicalDisks);
+
+    return collected;
+}
+
+struct logical_disk_unittest_fixture {
+    PERF_OBJECT_TYPE object;
+    PERF_INSTANCE_DEFINITION instances[3];
+    const char *names[3];
+    const char *requested_object;
+    const char *collected[3];
+    size_t collected_count;
+};
+
+static struct logical_disk_unittest_fixture *logical_disk_unittest_fixture = NULL;
+
+static PERF_OBJECT_TYPE *logical_disk_unittest_find_object(PERF_DATA_BLOCK *pDataBlock __maybe_unused, const char *name)
+{
+    logical_disk_unittest_fixture->requested_object = name;
+    return strcmp(name, "LogicalDisk") == 0 ? &logical_disk_unittest_fixture->object : NULL;
+}
+
+static PERF_INSTANCE_DEFINITION *logical_disk_unittest_next_instance(
+    PERF_DATA_BLOCK *pDataBlock __maybe_unused,
+    PERF_OBJECT_TYPE *pObjectType __maybe_unused,
+    PERF_INSTANCE_DEFINITION *lastInstance)
+{
+    size_t index = lastInstance ? (size_t)(lastInstance - logical_disk_unittest_fixture->instances) + 1 : 0;
+    return index < (size_t)logical_disk_unittest_fixture->object.NumInstances ?
+               &logical_disk_unittest_fixture->instances[index] :
+               NULL;
+}
+
+static BOOL logical_disk_unittest_get_instance_name(
+    PERF_DATA_BLOCK *pDataBlock __maybe_unused,
+    PERF_OBJECT_TYPE *pObjectType __maybe_unused,
+    PERF_INSTANCE_DEFINITION *pInstance,
+    char *buffer,
+    size_t bufferLen)
+{
+    size_t index = (size_t)(pInstance - logical_disk_unittest_fixture->instances);
+    strncpyz(buffer, logical_disk_unittest_fixture->names[index], bufferLen - 1);
+    return TRUE;
+}
+
+static void logical_disk_unittest_collect_instance(
+    PERF_DATA_BLOCK *pDataBlock __maybe_unused,
+    PERF_OBJECT_TYPE *pObjectType __maybe_unused,
+    PERF_INSTANCE_DEFINITION *pInstance __maybe_unused,
+    const char *name,
+    int update_every __maybe_unused,
+    usec_t now_ut __maybe_unused)
+{
+    logical_disk_unittest_fixture->collected[logical_disk_unittest_fixture->collected_count++] = name;
+}
+
+static const struct logical_disk_collection_ops logical_disk_unittest_ops = {
+    .find_object = logical_disk_unittest_find_object,
+    .next_instance = logical_disk_unittest_next_instance,
+    .get_instance_name = logical_disk_unittest_get_instance_name,
+    .collect_instance = logical_disk_unittest_collect_instance,
+};
+
+static int logical_disk_unittest_run(
+    const char *pattern,
+    size_t expected_collected,
+    const char *expected_first,
+    const char *expected_second)
+{
+    struct logical_disk_unittest_fixture fixture = {
+        .object = {.NumInstances = 3},
+        .names = {"_Total", "C:", "Z:\\ASSUREDRECOVERYTEMP\\volume"},
+    };
+    char instance_name[128];
+    SIMPLE_PATTERN *previous_pattern = excluded_logical_disk_paths;
+    int errors = 0;
+
+    excluded_logical_disk_paths = simple_pattern_create(pattern, NULL, SIMPLE_PATTERN_EXACT, false);
+    logical_disk_unittest_fixture = &fixture;
+
+    if (!do_logical_disk_with_ops(
+            (PERF_DATA_BLOCK *)&fixture,
+            1,
+            1,
+            &logical_disk_unittest_ops,
+            instance_name,
+            sizeof(instance_name))) {
+        fprintf(stderr, "perflib storage unittest: failed to find LogicalDisk\n");
+        errors++;
+    }
+
+    if (!fixture.requested_object || strcmp(fixture.requested_object, "LogicalDisk") != 0) {
+        fprintf(stderr, "perflib storage unittest: queried the wrong Perflib object\n");
+        errors++;
+    }
+
+    if (fixture.collected_count != expected_collected ||
+        (expected_first && (!fixture.collected_count || strcmp(fixture.collected[0], expected_first) != 0)) ||
+        (expected_second && (fixture.collected_count < 2 || strcmp(fixture.collected[1], expected_second) != 0))) {
+        fprintf(stderr,
+                "perflib storage unittest: expected %zu collected instances, got %zu\n",
+                expected_collected,
+                fixture.collected_count);
+        errors++;
+    }
+
+    logical_disk_unittest_fixture = NULL;
+    simple_pattern_free(excluded_logical_disk_paths);
+    excluded_logical_disk_paths = previous_pattern;
+    return errors;
+}
+
+int perflib_storage_unittest(void)
+{
+    int errors = 0;
+
+    errors += logical_disk_unittest_run("*AssuredRecoveryTemp*", 1, "C:", NULL);
+    errors += logical_disk_unittest_run(NULL, 2, "C:", "Z:\\ASSUREDRECOVERYTEMP\\volume");
+
+    if (errors)
+        fprintf(stderr, "perflib storage unittest: %d ERROR(S)\n", errors);
+    else
+        fprintf(stderr, "perflib storage unittest: OK\n");
+
+    return errors;
 }
 
 static void physical_disk_labels(RRDSET *st, void *data)

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -8,6 +8,8 @@
 #include "../common-contexts/common-contexts.h"
 #include "libnetdata/os/windows-wmi/windows-wmi.h"
 
+#define CONFIG_SECTION_PERFLIB_STORAGE "plugin:windows:PerflibStorage"
+
 struct logical_disk {
     usec_t last_collected;
     bool collected_metadata;
@@ -181,9 +183,22 @@ static void dict_physical_disk_delete_cb(const DICTIONARY_ITEM *item __maybe_unu
 }
 
 static DICTIONARY *logicalDisks = NULL, *physicalDisks = NULL;
+static SIMPLE_PATTERN *excluded_logical_disk_paths = NULL;
+
+static inline bool logical_disk_is_excluded(const char *mount_point)
+{
+    return excluded_logical_disk_paths && simple_pattern_matches(excluded_logical_disk_paths, mount_point);
+}
+
 static void initialize(void)
 {
     physical_disk_initialize(&system_physical_total);
+
+    excluded_logical_disk_paths = simple_pattern_create(
+        inicfg_get(&netdata_config, CONFIG_SECTION_PERFLIB_STORAGE, "exclude space metrics on paths", ""),
+        NULL,
+        SIMPLE_PATTERN_EXACT,
+        false);
 
     logicalDisks = dictionary_create_advanced(
         DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct logical_disk));
@@ -318,6 +333,9 @@ static bool do_logical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every, usec_
             strncpyz(windows_shared_buffer, "[unknown]", sizeof(windows_shared_buffer) - 1);
 
         if (strcasecmp(windows_shared_buffer, "_Total") == 0)
+            continue;
+
+        if (logical_disk_is_excluded(windows_shared_buffer))
             continue;
 
         struct logical_disk *d = dictionary_set(dict, windows_shared_buffer, NULL, sizeof(*d));

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -466,7 +466,7 @@ struct logical_disk_unittest_fixture {
     PERF_INSTANCE_DEFINITION instances[3];
     const char *names[3];
     const char *requested_object;
-    const char *collected[3];
+    char collected[3][128];
     size_t collected_count;
 };
 
@@ -509,7 +509,11 @@ static void logical_disk_unittest_collect_instance(
     int update_every __maybe_unused,
     usec_t now_ut __maybe_unused)
 {
-    logical_disk_unittest_fixture->collected[logical_disk_unittest_fixture->collected_count++] = name;
+    size_t index = logical_disk_unittest_fixture->collected_count++;
+    strncpyz(
+        logical_disk_unittest_fixture->collected[index],
+        name,
+        sizeof(logical_disk_unittest_fixture->collected[index]) - 1);
 }
 
 static const struct logical_disk_collection_ops logical_disk_unittest_ops = {

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -246,6 +246,9 @@ int utf8_sanitizer_unittest(void);
 int yaml_unittest(void);
 int json_c_parser_unittest(void);
 int stream_path_json_unittest(void);
+#ifdef OS_WINDOWS
+int perflib_storage_unittest(void);
+#endif
 int query_plan_unittest(void);
 int api_v1_allmetrics_json_unittest(void);
 int exporting_json_connector_unittest(void);
@@ -502,6 +505,7 @@ int netdata_main(int argc, char **argv) {
                             if (unit_test_windows_virt_normalize()) return 1;
                             if (unit_test_windows_virt_resolution()) return 1;
                             if (unit_test_windows_container()) return 1;
+                            if (perflib_storage_unittest()) return 1;
 #endif
 
                             // No call to load the config file on this code-path


### PR DESCRIPTION
##### Summary
We have a missing option in Windows to allow users to exclude disks. This PR addresses this issue.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Windows collector option to exclude logical volumes from disk space collection, and refactors the collection loop to make it unit-testable.

- New `exclude space metrics on paths` config option accepts space-separated simple patterns for mount points to skip; defaults to empty.
- Renames the `driver_type` label to `drive_type` on disk space charts; update any dashboards using the old label name.
- Adds a `serial_number` label in hexadecimal format to the same charts.
- Refactors logical disk collection into an operations struct so the filtering logic runs in a new `perflib_storage` unit test on Windows without live Perflib data.

<sup>Written for commit 9d417f79cd9f8f5aad29ce0e733db0e2a023f225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to exclude disk space metrics for selected logical-volume mount paths.
  - Added `serial_number` to Logical Disk metrics.

- **Improvements**
  - Renamed the Logical Disk label from `driver_type` to `drive_type` for clearer reporting.
  - Added configuration guidance and an example for the exclusion option.
  - Improved logical disk collection to omit aggregate and explicitly excluded entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->