### PR TITLE
feat(go.d/snmp-topology): retain bounded diagnostic evidence

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -564,6 +564,11 @@ flowchart TD
    - **One bad collector cannot dirty Job Manager.** A normal `Init`, `Check`, validation, or Function-staging failure
      is isolated to that candidate once rejection cleanup completes. Only a *failed or unprovable* cleanup retains
      process ownership and fails the run closed.
+   - A collector creator may expose one diagnostic configuration-lifecycle hook. Job Manager binds an opaque exact-config
+     identity before `Init`, captures one detached typed snapshot after probing and before rejection cleanup, and
+     reconciles it only after the matching running/failed graph transition commits. Replacement/removal reconciles the
+     prior incarnation from the graph preimage. Hook panic is fail-open and cannot change candidate, graph, or cleanup
+     behavior. This is a latest-state projection, not an event bus or retry history.
 4. **Reserve and retire** — only a timely successful candidate is wrapped in an inactive run permit. Replacement then
    fences the incumbent's ordinary output and detaches its run projections immediately; its physical managed loop,
    `Stop`, Function drain, and collector cleanup remain process-owned until they return.

--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -564,11 +564,15 @@ flowchart TD
    - **One bad collector cannot dirty Job Manager.** A normal `Init`, `Check`, validation, or Function-staging failure
      is isolated to that candidate once rejection cleanup completes. Only a *failed or unprovable* cleanup retains
      process ownership and fails the run closed.
-   - A collector creator may expose one diagnostic configuration-lifecycle hook. Job Manager binds an opaque exact-config
-     identity before `Init`, captures one detached typed snapshot after probing and before rejection cleanup, and
-     reconciles it only after the matching running/failed graph transition commits. Replacement/removal reconciles the
-     prior incarnation from the graph preimage. Hook panic is fail-open and cannot change candidate, graph, or cleanup
-     behavior. This is a latest-state projection, not an event bus or retry history.
+   - A collector creator may expose one diagnostic configuration-lifecycle hook. For a running/failed graph postimage,
+     Job Manager projects a credential-free baseline directly from the accepted configuration, so failures before
+     runtime construction still have a row. When construction succeeds, Job Manager binds an opaque exact-config
+     identity before `Init` and captures one detached value after probing and before rejection cleanup. Reconciliation
+     occurs only after the matching graph commit, or after a successful transaction confirms that the fallback graph
+     already matches. A successfully accepted runtime is passed only during that callback so its pending operational
+     state can join the same commit; failed candidates leave no runtime reference behind. Replacement/removal reconciles
+     the prior incarnation from the graph preimage. Hook panic is fail-open and cannot change candidate, graph, or
+     cleanup behavior. This is a latest-state projection, not an event bus or retry history.
 4. **Reserve and retire** — only a timely successful candidate is wrapped in an inactive run permit. Replacement then
    fences the incumbent's ordinary output and detaches its run projections immediately; its physical managed loop,
    `Stop`, Function drain, and collector cleanup remain process-owned until they return.

--- a/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
@@ -904,6 +904,7 @@ func (pjc *preparedJobCandidate) run(
 	}
 	probeErr := probeConstructed(ctx, candidate, candidate.autoDetection)
 	if probeErr != nil {
+		captureJobConfigLifecycle(&candidate)
 		factory = nil
 		cleanupErr := cleanupConstructed(context.Background(), candidate)
 		if cleanupErr != nil {
@@ -912,6 +913,7 @@ func (pjc *preparedJobCandidate) run(
 		}
 		var failure *autoDetectionFailure
 		if errors.As(probeErr, &failure) {
+			failure.jobConfigLifecycle = candidate.jobConfigSnapshot
 			workerResult <- stagedJobResult{failure: failure}
 			return nil
 		}
@@ -922,6 +924,8 @@ func (pjc *preparedJobCandidate) run(
 	factory = nil
 	if stageErr != nil {
 		failure := autoDetectionFailureFor(candidate, stageErr)
+		captureJobConfigLifecycle(&candidate)
+		failure.jobConfigLifecycle = candidate.jobConfigSnapshot
 		cleanupErr := cleanupConstructed(context.Background(), candidate)
 		if lifecycle.OwnershipRetained(stageErr) || cleanupErr != nil {
 			return joinRetainedCleanup(stageErr, cleanupErr)
@@ -933,6 +937,7 @@ func (pjc *preparedJobCandidate) run(
 		cleanupErr := cleanupConstructed(context.Background(), candidate)
 		return joinRetainedCleanup(err, cleanupErr)
 	}
+	captureJobConfigLifecycle(&candidate)
 	storeSnapshot := candidate.storeSnapshot
 	candidate.storeSnapshot = nil
 	owner := newStagedJobOwner(

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
@@ -1909,17 +1909,17 @@ func TestFailedAutoDetectionPublishesConfigLifecycleOnlyAfterGraphCommit(t *test
 	)
 	require.NoError(t, err)
 	require.Equal(t, []string{"bind", "check", "capture", "cleanup"}, events)
-	require.Empty(t, lifecycleHook.commits, "candidate cleanup must not publish before graph commit")
+	require.Empty(t, lifecycleHook.reconciliations, "candidate cleanup must not publish before graph commit")
 
 	_, err = transaction.Apply(context.Background())
 	require.NoError(t, err)
 	record, ok := graph.Lookup(config.FullName())
 	require.True(t, ok)
 	require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
-	require.Len(t, lifecycleHook.commits, 1)
-	require.Equal(t, lifecycleHook.bound, lifecycleHook.commits[0].current)
-	require.Equal(t, lifecycleHook.bound, lifecycleHook.commits[0].previous)
-	require.Equal(t, "commit", events[len(events)-1])
+	require.Len(t, lifecycleHook.reconciliations, 1)
+	require.Equal(t, lifecycleHook.bound, lifecycleHook.reconciliations[0].current)
+	require.Equal(t, lifecycleHook.bound, lifecycleHook.reconciliations[0].previous)
+	require.Equal(t, "reconcile", events[len(events)-1])
 
 	removeScope := lifecycle.ResourceTransactionScope{ID: config.FullName()}
 	removeTransaction, err := controller.prepareMutation(
@@ -1975,26 +1975,26 @@ func TestTransientPreConstructionFailurePublishesConfigLifecycleAfterGraphCommit
 		permit,
 	)
 	require.NoError(t, err)
-	require.Empty(t, lifecycleHook.commits)
+	require.Empty(t, lifecycleHook.reconciliations)
 
 	_, err = transaction.Apply(context.Background())
 	require.NoError(t, err)
 	record, ok := graph.Lookup(config.FullName())
 	require.True(t, ok)
 	require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
-	require.Len(t, lifecycleHook.commits, 1)
-	require.Equal(t, jobConfigIdentity(config), lifecycleHook.commits[0].current)
-	require.Equal(t, jobConfigIdentity(config), lifecycleHook.commits[0].previous)
+	require.Len(t, lifecycleHook.reconciliations, 1)
+	require.Equal(t, jobConfigIdentity(config), lifecycleHook.reconciliations[0].current)
+	require.Equal(t, jobConfigIdentity(config), lifecycleHook.reconciliations[0].previous)
 }
 
 type recordingJobConfigLifecycle struct {
-	events  *[]string
-	bound   collectorapi.JobConfigIdentity
-	commits []recordingJobConfigLifecycleCommit
-	removed []collectorapi.JobConfigIdentity
+	events          *[]string
+	bound           collectorapi.JobConfigIdentity
+	reconciliations []recordingJobConfigLifecycleReconciliation
+	removed         []collectorapi.JobConfigIdentity
 }
 
-type recordingJobConfigLifecycleCommit struct {
+type recordingJobConfigLifecycleReconciliation struct {
 	current  collectorapi.JobConfigIdentity
 	previous collectorapi.JobConfigIdentity
 }
@@ -2020,12 +2020,12 @@ func (r *recordingJobConfigLifecycle) Capture(
 	return &recordingJobConfigLifecycleSnapshot{identity: identity}
 }
 
-func (r *recordingJobConfigLifecycle) Commit(
+func (r *recordingJobConfigLifecycle) Reconcile(
 	previous collectorapi.JobConfigIdentity,
 	snapshot collectorapi.JobConfigLifecycleSnapshot,
 	_ collectorapi.RuntimeJob,
 ) {
-	r.recordCommit(previous, snapshot)
+	r.recordReconciliation(previous, snapshot)
 }
 
 func (r *recordingJobConfigLifecycle) Remove(identity collectorapi.JobConfigIdentity) {
@@ -2041,7 +2041,7 @@ func (r *recordingJobConfigLifecycleSnapshot) Identity() collectorapi.JobConfigI
 	return r.identity
 }
 
-func (r *recordingJobConfigLifecycle) recordCommit(
+func (r *recordingJobConfigLifecycle) recordReconciliation(
 	previous collectorapi.JobConfigIdentity,
 	snapshot collectorapi.JobConfigLifecycleSnapshot,
 ) {
@@ -2049,11 +2049,11 @@ func (r *recordingJobConfigLifecycle) recordCommit(
 	if current == nil {
 		return
 	}
-	r.commits = append(r.commits, recordingJobConfigLifecycleCommit{
+	r.reconciliations = append(r.reconciliations, recordingJobConfigLifecycleReconciliation{
 		current:  current.identity,
 		previous: previous,
 	})
-	*r.events = append(*r.events, "commit")
+	*r.events = append(*r.events, "reconcile")
 }
 
 type jobDependencyIndexFunc func(string, *dyncfg.GraphConfig) (func(), error)

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
@@ -1863,6 +1863,131 @@ func seedDynCfgJobGraphRecord(
 	require.NoError(t, graph.Commit(mutation))
 }
 
+func TestFailedAutoDetectionPublishesConfigLifecycleOnlyAfterGraphCommit(t *testing.T) {
+	controller, graph, _, _, state := newDynCfgJobTestHarness(t)
+	events := []string{}
+	lifecycleHook := &recordingJobConfigLifecycle{events: &events}
+	creator := controller.modules["module"]
+	creator.JobConfigLifecycle = lifecycleHook
+	creator.Create = func() collectorapi.CollectorV1 {
+		return &collectorapi.MockCollectorV1{
+			CheckFunc: func(context.Context) error {
+				events = append(events, "check")
+				return errors.New("check failed")
+			},
+			CleanupFunc: func(context.Context) {
+				state.collectorCleanup++
+				events = append(events, "cleanup")
+			},
+		}
+	}
+	controller.modules["module"] = creator
+
+	config := factoryTestConfig(false)
+	config.SetSourceType(confgroup.TypeDyncfg)
+	config.SetSource("user=test")
+	config.SetProvider("test")
+	seedDynCfgJobGraphRecord(t, graph, config, dyncfg.StatusRunning)
+	currentIdentity := lifecycle.ResourceIdentity{ID: config.FullName(), Generation: 1}
+	current := &transactionTestReadyResource{identity: currentIdentity, prefix: "current", events: &events}
+	permit, _ := issueTestJobPermit(t, config.FullName(), 2)
+	scope := lifecycle.ResourceTransactionScope{
+		ID:      config.FullName(),
+		Current: currentIdentity,
+		Successor: lifecycle.ResourceIdentity{
+			ID:         config.FullName(),
+			Generation: 2,
+		},
+	}
+
+	transaction, err := controller.prepareDiscovered(
+		context.Background(),
+		DiscoveredJobChange{Config: config, Status: dyncfg.StatusRunning, Restart: true},
+		current,
+		scope,
+		permit,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"bind", "check", "capture", "cleanup"}, events)
+	require.Empty(t, lifecycleHook.commits, "candidate cleanup must not publish before graph commit")
+
+	_, err = transaction.Apply(context.Background())
+	require.NoError(t, err)
+	record, ok := graph.Lookup(config.FullName())
+	require.True(t, ok)
+	require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
+	require.Len(t, lifecycleHook.commits, 1)
+	require.Equal(t, lifecycleHook.bound, lifecycleHook.commits[0].current)
+	require.Equal(t, lifecycleHook.bound, lifecycleHook.commits[0].previous)
+	require.Equal(t, "commit", events[len(events)-1])
+
+	removeScope := lifecycle.ResourceTransactionScope{ID: config.FullName()}
+	removeTransaction, err := controller.prepareMutation(
+		removeScope,
+		nil,
+		nil,
+		lifecycle.LongLivedPermit{},
+		lifecycle.ResourceTransactionUnchanged,
+		nil,
+		mustDynCfgMessage(200, ""),
+		func() error { return nil },
+	)
+	require.NoError(t, err)
+	require.Empty(t, lifecycleHook.removed)
+	_, err = removeTransaction.Apply(context.Background())
+	require.NoError(t, err)
+	_, ok = graph.Lookup(config.FullName())
+	require.False(t, ok)
+	require.Equal(t, []collectorapi.JobConfigIdentity{lifecycleHook.bound}, lifecycleHook.removed)
+}
+
+type recordingJobConfigLifecycle struct {
+	events  *[]string
+	bound   collectorapi.JobConfigIdentity
+	commits []recordingJobConfigLifecycleCommit
+	removed []collectorapi.JobConfigIdentity
+}
+
+type recordingJobConfigLifecycleCommit struct {
+	current  collectorapi.JobConfigIdentity
+	previous collectorapi.JobConfigIdentity
+}
+
+func (r *recordingJobConfigLifecycle) Bind(identity collectorapi.JobConfigIdentity, _ collectorapi.RuntimeJob) {
+	r.bound = identity
+	*r.events = append(*r.events, "bind")
+}
+
+func (r *recordingJobConfigLifecycle) Capture(
+	identity collectorapi.JobConfigIdentity,
+	_ collectorapi.RuntimeJob,
+) collectorapi.JobConfigLifecycleSnapshot {
+	*r.events = append(*r.events, "capture")
+	return &recordingJobConfigLifecycleSnapshot{owner: r, identity: identity}
+}
+
+func (r *recordingJobConfigLifecycle) Remove(identity collectorapi.JobConfigIdentity) {
+	r.removed = append(r.removed, identity)
+	*r.events = append(*r.events, "remove")
+}
+
+type recordingJobConfigLifecycleSnapshot struct {
+	owner    *recordingJobConfigLifecycle
+	identity collectorapi.JobConfigIdentity
+}
+
+func (r *recordingJobConfigLifecycleSnapshot) Identity() collectorapi.JobConfigIdentity {
+	return r.identity
+}
+
+func (r *recordingJobConfigLifecycleSnapshot) Commit(previous collectorapi.JobConfigIdentity) {
+	r.owner.commits = append(r.owner.commits, recordingJobConfigLifecycleCommit{
+		current:  r.identity,
+		previous: previous,
+	})
+	*r.owner.events = append(*r.owner.events, "commit")
+}
+
 type jobDependencyIndexFunc func(string, *dyncfg.GraphConfig) (func(), error)
 
 func (fn jobDependencyIndexFunc) PrepareJobChange(id string, postimage *dyncfg.GraphConfig) (func(), error) {

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs_test.go
@@ -1941,6 +1941,52 @@ func TestFailedAutoDetectionPublishesConfigLifecycleOnlyAfterGraphCommit(t *test
 	require.Equal(t, []collectorapi.JobConfigIdentity{lifecycleHook.bound}, lifecycleHook.removed)
 }
 
+func TestTransientPreConstructionFailurePublishesConfigLifecycleAfterGraphCommit(t *testing.T) {
+	controller, graph, _, _, _ := newDynCfgJobTestHarness(t)
+	events := []string{}
+	lifecycleHook := &recordingJobConfigLifecycle{events: &events}
+	creator := controller.modules["module"]
+	creator.JobConfigLifecycle = lifecycleHook
+	controller.modules["module"] = creator
+
+	config := factoryTestConfig(false)
+	config.SetSourceType(confgroup.TypeDyncfg)
+	config.SetSource("user=test")
+	config.SetProvider("test")
+	config.Set("vnode", "missing-vnode")
+	seedDynCfgJobGraphRecord(t, graph, config, dyncfg.StatusRunning)
+	currentIdentity := lifecycle.ResourceIdentity{ID: config.FullName(), Generation: 1}
+	current := &transactionTestReadyResource{identity: currentIdentity, prefix: "current", events: &events}
+	permit, _ := issueTestJobPermit(t, config.FullName(), 2)
+	scope := lifecycle.ResourceTransactionScope{
+		ID:      config.FullName(),
+		Current: currentIdentity,
+		Successor: lifecycle.ResourceIdentity{
+			ID:         config.FullName(),
+			Generation: 2,
+		},
+	}
+
+	transaction, err := controller.prepareDiscovered(
+		context.Background(),
+		DiscoveredJobChange{Config: config, Status: dyncfg.StatusRunning, Restart: true},
+		current,
+		scope,
+		permit,
+	)
+	require.NoError(t, err)
+	require.Empty(t, lifecycleHook.commits)
+
+	_, err = transaction.Apply(context.Background())
+	require.NoError(t, err)
+	record, ok := graph.Lookup(config.FullName())
+	require.True(t, ok)
+	require.Equal(t, dyncfg.StatusFailed.String(), record.Status)
+	require.Len(t, lifecycleHook.commits, 1)
+	require.Equal(t, jobConfigIdentity(config), lifecycleHook.commits[0].current)
+	require.Equal(t, jobConfigIdentity(config), lifecycleHook.commits[0].previous)
+}
+
 type recordingJobConfigLifecycle struct {
 	events  *[]string
 	bound   collectorapi.JobConfigIdentity
@@ -1953,6 +1999,14 @@ type recordingJobConfigLifecycleCommit struct {
 	previous collectorapi.JobConfigIdentity
 }
 
+func (r *recordingJobConfigLifecycle) Project(
+	identity collectorapi.JobConfigIdentity,
+	_ map[string]any,
+) collectorapi.JobConfigLifecycleSnapshot {
+	*r.events = append(*r.events, "project")
+	return &recordingJobConfigLifecycleSnapshot{identity: identity}
+}
+
 func (r *recordingJobConfigLifecycle) Bind(identity collectorapi.JobConfigIdentity, _ collectorapi.RuntimeJob) {
 	r.bound = identity
 	*r.events = append(*r.events, "bind")
@@ -1963,7 +2017,15 @@ func (r *recordingJobConfigLifecycle) Capture(
 	_ collectorapi.RuntimeJob,
 ) collectorapi.JobConfigLifecycleSnapshot {
 	*r.events = append(*r.events, "capture")
-	return &recordingJobConfigLifecycleSnapshot{owner: r, identity: identity}
+	return &recordingJobConfigLifecycleSnapshot{identity: identity}
+}
+
+func (r *recordingJobConfigLifecycle) Commit(
+	previous collectorapi.JobConfigIdentity,
+	snapshot collectorapi.JobConfigLifecycleSnapshot,
+	_ collectorapi.RuntimeJob,
+) {
+	r.recordCommit(previous, snapshot)
 }
 
 func (r *recordingJobConfigLifecycle) Remove(identity collectorapi.JobConfigIdentity) {
@@ -1972,7 +2034,6 @@ func (r *recordingJobConfigLifecycle) Remove(identity collectorapi.JobConfigIden
 }
 
 type recordingJobConfigLifecycleSnapshot struct {
-	owner    *recordingJobConfigLifecycle
 	identity collectorapi.JobConfigIdentity
 }
 
@@ -1980,12 +2041,19 @@ func (r *recordingJobConfigLifecycleSnapshot) Identity() collectorapi.JobConfigI
 	return r.identity
 }
 
-func (r *recordingJobConfigLifecycleSnapshot) Commit(previous collectorapi.JobConfigIdentity) {
-	r.owner.commits = append(r.owner.commits, recordingJobConfigLifecycleCommit{
-		current:  r.identity,
+func (r *recordingJobConfigLifecycle) recordCommit(
+	previous collectorapi.JobConfigIdentity,
+	snapshot collectorapi.JobConfigLifecycleSnapshot,
+) {
+	current, _ := snapshot.(*recordingJobConfigLifecycleSnapshot)
+	if current == nil {
+		return
+	}
+	r.commits = append(r.commits, recordingJobConfigLifecycleCommit{
+		current:  current.identity,
 		previous: previous,
 	})
-	*r.owner.events = append(*r.owner.events, "commit")
+	*r.events = append(*r.events, "commit")
 }
 
 type jobDependencyIndexFunc func(string, *dyncfg.GraphConfig) (func(), error)

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
@@ -105,7 +105,7 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApplyAndFallback(
 	busyFallback *ResourceActivationFallback,
 	quarantinedFallback *ResourceActivationFallback,
 ) (lifecycle.PreparedResourceTransaction, error) {
-	jobConfigCommit := dcjc.prepareJobConfigLifecycleCommit(scope.ID, postimage, jobConfig)
+	jobConfigReconcile := dcjc.prepareJobConfigLifecycleReconcile(scope.ID, postimage, jobConfig)
 	afterApply = composeAfterApply(dcjc.retrySettlement(scope.ID, retry), afterApply)
 	acceptedAfterApply, err := dcjc.acceptedActivationAfterApply(scope.ID, postimage)
 	if err != nil {
@@ -126,10 +126,10 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApplyAndFallback(
 			return nil, err
 		}
 	}
-	dependencyCommit = composeAfterApply(dependencyCommit, jobConfigCommit)
+	dependencyCommit = composeAfterApply(dependencyCommit, jobConfigReconcile)
 	mutation, err := dcjc.graph.PrepareMutation([]dyncfg.GraphChange{{ID: scope.ID, Config: postimage}})
 	if errors.Is(err, dyncfg.ErrGraphNoChange) {
-		afterApply = composeAfterApply(afterApply, jobConfigCommit)
+		afterApply = composeAfterApply(afterApply, jobConfigReconcile)
 		if successor != nil {
 			return dcjc.prepareResourceTransaction(
 				ResourceTransactionSpec{
@@ -208,7 +208,7 @@ func (dcjc *DynCfgJobController) newActivationFallback(
 	}
 	dependencyCommit = composeAfterApply(
 		dependencyCommit,
-		dcjc.prepareJobConfigLifecycleCommit(id, postimage, preparedJobConfigLifecycle{snapshot: jobConfigSnapshot}),
+		dcjc.prepareJobConfigLifecycleReconcile(id, postimage, preparedJobConfigLifecycle{snapshot: jobConfigSnapshot}),
 	)
 	return &ResourceActivationFallback{
 		Change: dyncfg.GraphChange{

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
@@ -84,7 +84,7 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApply(
 		cleanup,
 		retry,
 		afterApply,
-		preparedJobConfigLifecycleSnapshot(successor),
+		preparedJobConfigLifecycleState(successor),
 		nil,
 		nil,
 	)
@@ -101,11 +101,11 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApplyAndFallback(
 	cleanup lifecycle.TaskCleanup,
 	retry autoDetectionRetryToken,
 	afterApply func(),
-	jobConfigSnapshot collectorapi.JobConfigLifecycleSnapshot,
+	jobConfig preparedJobConfigLifecycle,
 	busyFallback *ResourceActivationFallback,
 	quarantinedFallback *ResourceActivationFallback,
 ) (lifecycle.PreparedResourceTransaction, error) {
-	jobConfigCommit := dcjc.prepareJobConfigLifecycleCommit(scope.ID, postimage, jobConfigSnapshot)
+	jobConfigCommit := dcjc.prepareJobConfigLifecycleCommit(scope.ID, postimage, jobConfig)
 	afterApply = composeAfterApply(dcjc.retrySettlement(scope.ID, retry), afterApply)
 	acceptedAfterApply, err := dcjc.acceptedActivationAfterApply(scope.ID, postimage)
 	if err != nil {
@@ -208,17 +208,17 @@ func (dcjc *DynCfgJobController) newActivationFallback(
 	}
 	dependencyCommit = composeAfterApply(
 		dependencyCommit,
-		dcjc.prepareJobConfigLifecycleCommit(id, postimage, jobConfigSnapshot),
+		dcjc.prepareJobConfigLifecycleCommit(id, postimage, preparedJobConfigLifecycle{snapshot: jobConfigSnapshot}),
 	)
 	return &ResourceActivationFallback{
 		Change: dyncfg.GraphChange{
 			ID:     id,
 			Config: postimage,
 		},
-		AfterGraphCommit: dependencyCommit,
-		AfterApply:       afterApply,
-		Result:           result,
-		Cleanup:          cleanup,
+		AfterGraphReconcile: dependencyCommit,
+		AfterApply:          afterApply,
+		Result:              result,
+		Cleanup:             cleanup,
 	}, nil
 }
 
@@ -242,14 +242,14 @@ func (dcjc *DynCfgJobController) prepareMutationWithActivationFallbacks(
 	busy activationFallbackPlan,
 	quarantined activationFallbackPlan,
 ) (lifecycle.PreparedResourceTransaction, error) {
-	jobConfigSnapshot := preparedJobConfigLifecycleSnapshot(successor)
+	jobConfig := preparedJobConfigLifecycleState(successor)
 	busyFallback, err := dcjc.newActivationFallback(
 		scope.ID,
 		busy.postimage,
 		busy.result,
 		busy.cleanup,
 		busy.afterApply,
-		jobConfigSnapshot,
+		jobConfig.snapshot,
 	)
 	if err != nil {
 		return nil, rollbackSuccessorMutation(successor, err)
@@ -260,7 +260,7 @@ func (dcjc *DynCfgJobController) prepareMutationWithActivationFallbacks(
 		quarantined.result,
 		quarantined.cleanup,
 		quarantined.afterApply,
-		jobConfigSnapshot,
+		jobConfig.snapshot,
 	)
 	if err != nil {
 		return nil, rollbackSuccessorMutation(successor, err)
@@ -276,7 +276,7 @@ func (dcjc *DynCfgJobController) prepareMutationWithActivationFallbacks(
 		cleanup,
 		retry,
 		afterApply,
-		jobConfigSnapshot,
+		jobConfig,
 		busyFallback,
 		quarantinedFallback,
 	)
@@ -389,7 +389,7 @@ func (dcjc *DynCfgJobController) prepareProbeFailure(
 		cleanup,
 		retry,
 		afterApply,
-		failure.jobConfigLifecycle,
+		preparedJobConfigLifecycle{snapshot: failure.jobConfigLifecycle},
 		nil,
 		nil,
 	)

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_mutation.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 )
@@ -83,6 +84,7 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApply(
 		cleanup,
 		retry,
 		afterApply,
+		preparedJobConfigLifecycleSnapshot(successor),
 		nil,
 		nil,
 	)
@@ -99,9 +101,11 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApplyAndFallback(
 	cleanup lifecycle.TaskCleanup,
 	retry autoDetectionRetryToken,
 	afterApply func(),
+	jobConfigSnapshot collectorapi.JobConfigLifecycleSnapshot,
 	busyFallback *ResourceActivationFallback,
 	quarantinedFallback *ResourceActivationFallback,
 ) (lifecycle.PreparedResourceTransaction, error) {
+	jobConfigCommit := dcjc.prepareJobConfigLifecycleCommit(scope.ID, postimage, jobConfigSnapshot)
 	afterApply = composeAfterApply(dcjc.retrySettlement(scope.ID, retry), afterApply)
 	acceptedAfterApply, err := dcjc.acceptedActivationAfterApply(scope.ID, postimage)
 	if err != nil {
@@ -122,8 +126,10 @@ func (dcjc *DynCfgJobController) prepareMutationWithRetryAfterApplyAndFallback(
 			return nil, err
 		}
 	}
+	dependencyCommit = composeAfterApply(dependencyCommit, jobConfigCommit)
 	mutation, err := dcjc.graph.PrepareMutation([]dyncfg.GraphChange{{ID: scope.ID, Config: postimage}})
 	if errors.Is(err, dyncfg.ErrGraphNoChange) {
+		afterApply = composeAfterApply(afterApply, jobConfigCommit)
 		if successor != nil {
 			return dcjc.prepareResourceTransaction(
 				ResourceTransactionSpec{
@@ -182,6 +188,7 @@ func (dcjc *DynCfgJobController) newActivationFallback(
 	result lifecycle.SealedResult,
 	cleanup lifecycle.TaskCleanup,
 	afterApply func(),
+	jobConfigSnapshot collectorapi.JobConfigLifecycleSnapshot,
 ) (*ResourceActivationFallback, error) {
 	if dcjc == nil || id == "" || cleanup == nil {
 		return nil, errors.New("job output: invalid activation fallback")
@@ -199,6 +206,10 @@ func (dcjc *DynCfgJobController) newActivationFallback(
 			return nil, err
 		}
 	}
+	dependencyCommit = composeAfterApply(
+		dependencyCommit,
+		dcjc.prepareJobConfigLifecycleCommit(id, postimage, jobConfigSnapshot),
+	)
 	return &ResourceActivationFallback{
 		Change: dyncfg.GraphChange{
 			ID:     id,
@@ -231,12 +242,14 @@ func (dcjc *DynCfgJobController) prepareMutationWithActivationFallbacks(
 	busy activationFallbackPlan,
 	quarantined activationFallbackPlan,
 ) (lifecycle.PreparedResourceTransaction, error) {
+	jobConfigSnapshot := preparedJobConfigLifecycleSnapshot(successor)
 	busyFallback, err := dcjc.newActivationFallback(
 		scope.ID,
 		busy.postimage,
 		busy.result,
 		busy.cleanup,
 		busy.afterApply,
+		jobConfigSnapshot,
 	)
 	if err != nil {
 		return nil, rollbackSuccessorMutation(successor, err)
@@ -247,6 +260,7 @@ func (dcjc *DynCfgJobController) prepareMutationWithActivationFallbacks(
 		quarantined.result,
 		quarantined.cleanup,
 		quarantined.afterApply,
+		jobConfigSnapshot,
 	)
 	if err != nil {
 		return nil, rollbackSuccessorMutation(successor, err)
@@ -262,6 +276,7 @@ func (dcjc *DynCfgJobController) prepareMutationWithActivationFallbacks(
 		cleanup,
 		retry,
 		afterApply,
+		jobConfigSnapshot,
 		busyFallback,
 		quarantinedFallback,
 	)
@@ -363,7 +378,7 @@ func (dcjc *DynCfgJobController) prepareProbeFailure(
 			plan.afterApply(failure)
 		}
 	}
-	return dcjc.prepareMutationWithRetryAfterApply(
+	return dcjc.prepareMutationWithRetryAfterApplyAndFallback(
 		scope,
 		current,
 		nil,
@@ -374,6 +389,9 @@ func (dcjc *DynCfgJobController) prepareProbeFailure(
 		cleanup,
 		retry,
 		afterApply,
+		failure.jobConfigLifecycle,
+		nil,
+		nil,
 	)
 }
 

--- a/src/go/plugin/agent/jobmgr/joboutput/factory.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory.go
@@ -296,7 +296,9 @@ func (f *Factory) build(
 	}
 	jobConfigIdentity := jobConfigIdentity(config)
 	jobConfigLifecycle := creator.JobConfigLifecycle
-	if jobConfigLifecycle != nil && !callJobConfigLifecycle(func() {
+	if nilInterfaceValue(jobConfigLifecycle) {
+		jobConfigLifecycle = nil
+	} else if !callJobConfigLifecycle(func() {
 		jobConfigLifecycle.Bind(jobConfigIdentity, job)
 	}) {
 		jobConfigLifecycle = nil

--- a/src/go/plugin/agent/jobmgr/joboutput/factory.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory.go
@@ -134,6 +134,9 @@ func (fa factoryAttachment) attach(
 	attached.vnodeStage = candidate.vnodeStage
 	attached.outputGate = candidate.outputGate
 	attached.StagedHandlers = candidate.StagedHandlers
+	attached.jobConfigIdentity = candidate.jobConfigIdentity
+	attached.jobConfigLifecycle = candidate.jobConfigLifecycle
+	attached.jobConfigSnapshot = candidate.jobConfigSnapshot
 	if candidate.runtimeStage != nil || candidate.vnodeStage != nil {
 		attached.attachProjections = func() error {
 			var runtimeErr error
@@ -291,6 +294,13 @@ func (f *Factory) build(
 	if err != nil {
 		return ConstructedJob{}, err
 	}
+	jobConfigIdentity := jobConfigIdentity(config)
+	jobConfigLifecycle := creator.JobConfigLifecycle
+	if jobConfigLifecycle != nil && !callJobConfigLifecycle(func() {
+		jobConfigLifecycle.Bind(jobConfigIdentity, job)
+	}) {
+		jobConfigLifecycle = nil
+	}
 	cleanup := &factoryJobCleanup{
 		job:          job,
 		runtimeStage: runtimeStage,
@@ -311,6 +321,8 @@ func (f *Factory) build(
 		vnodeStage:         vnodeStage,
 		outputGate:         outputGate,
 		storeSnapshot:      storeSnapshot,
+		jobConfigIdentity:  jobConfigIdentity,
+		jobConfigLifecycle: jobConfigLifecycle,
 	}
 	if hasFunctions && f.config.HandlerStager == nil {
 		return constructed, errors.New("job output: function-bearing job has no handler lifecycle")

--- a/src/go/plugin/agent/jobmgr/joboutput/generation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/jobruntime"
 )
@@ -21,11 +22,12 @@ var (
 )
 
 type autoDetectionFailure struct {
-	cause      error
-	retry      bool
-	retryAfter int
-	coded      bool
-	code       int
+	cause              error
+	retry              bool
+	retryAfter         int
+	coded              bool
+	code               int
+	jobConfigLifecycle collectorapi.JobConfigLifecycleSnapshot
 }
 
 func (adf *autoDetectionFailure) Error() string {
@@ -113,6 +115,9 @@ type ConstructedJob struct {
 	outputGate         *generationOutputGate
 	storeSnapshot      secretresolver.AtomicScopeSnapshot
 	processOwner       *stagedJobOwner
+	jobConfigIdentity  collectorapi.JobConfigIdentity
+	jobConfigLifecycle collectorapi.JobConfigLifecycle
+	jobConfigSnapshot  collectorapi.JobConfigLifecycleSnapshot
 }
 
 // constructedJobAttachment reports whether process ownership transferred even
@@ -200,6 +205,18 @@ func (pj PreparedJob) Identity() lifecycle.ResourceIdentity {
 		ID:         pj.state.id,
 		Generation: pj.state.generation,
 	}
+}
+
+func (pj PreparedJob) jobConfigLifecycleSnapshot() collectorapi.JobConfigLifecycleSnapshot {
+	if pj.state == nil {
+		return nil
+	}
+	pj.state.mu.Lock()
+	defer pj.state.mu.Unlock()
+	if pj.state.consumed {
+		return nil
+	}
+	return pj.state.constructed.jobConfigSnapshot
 }
 
 func (pj PreparedJob) AcceptStart(ctx context.Context, expected uint64) (lifecycle.ReadyResource, error) {

--- a/src/go/plugin/agent/jobmgr/joboutput/generation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/generation.go
@@ -207,16 +207,20 @@ func (pj PreparedJob) Identity() lifecycle.ResourceIdentity {
 	}
 }
 
-func (pj PreparedJob) jobConfigLifecycleSnapshot() collectorapi.JobConfigLifecycleSnapshot {
+func (pj PreparedJob) jobConfigLifecycleState() preparedJobConfigLifecycle {
 	if pj.state == nil {
-		return nil
+		return preparedJobConfigLifecycle{}
 	}
 	pj.state.mu.Lock()
 	defer pj.state.mu.Unlock()
 	if pj.state.consumed {
-		return nil
+		return preparedJobConfigLifecycle{}
 	}
-	return pj.state.constructed.jobConfigSnapshot
+	return preparedJobConfigLifecycle{
+		identity: pj.state.constructed.jobConfigIdentity,
+		snapshot: pj.state.constructed.jobConfigSnapshot,
+		runtime:  pj.state.constructed.candidateJob,
+	}
 }
 
 func (pj PreparedJob) AcceptStart(ctx context.Context, expected uint64) (lifecycle.ReadyResource, error) {

--- a/src/go/plugin/agent/jobmgr/joboutput/job_config_lifecycle.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/job_config_lifecycle.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package joboutput
+
+import (
+	"crypto/sha256"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
+	"gopkg.in/yaml.v2"
+)
+
+func jobConfigIdentity(config confgroup.Config) collectorapi.JobConfigIdentity {
+	if config == nil {
+		return collectorapi.JobConfigIdentity{}
+	}
+	return sha256.Sum256([]byte(config.UID()))
+}
+
+func captureJobConfigLifecycle(constructed *ConstructedJob) {
+	if constructed == nil || constructed.jobConfigSnapshot != nil ||
+		constructed.jobConfigLifecycle == nil || !constructed.jobConfigIdentity.Valid() ||
+		constructed.candidateJob == nil {
+		return
+	}
+	var snapshot collectorapi.JobConfigLifecycleSnapshot
+	if !callJobConfigLifecycle(func() {
+		snapshot = constructed.jobConfigLifecycle.Capture(
+			constructed.jobConfigIdentity,
+			constructed.candidateJob,
+		)
+	}) || nilInterfaceValue(snapshot) {
+		return
+	}
+	identity, ok := jobConfigLifecycleSnapshotIdentity(snapshot)
+	if !ok || identity != constructed.jobConfigIdentity {
+		return
+	}
+	constructed.jobConfigSnapshot = snapshot
+}
+
+func callJobConfigLifecycle(call func()) (completed bool) {
+	if call == nil {
+		return false
+	}
+	defer func() {
+		if recover() != nil {
+			completed = false
+		}
+	}()
+	call()
+	return true
+}
+
+func jobConfigLifecycleSnapshotIdentity(
+	snapshot collectorapi.JobConfigLifecycleSnapshot,
+) (identity collectorapi.JobConfigIdentity, ok bool) {
+	if nilInterfaceValue(snapshot) {
+		return collectorapi.JobConfigIdentity{}, false
+	}
+	ok = callJobConfigLifecycle(func() { identity = snapshot.Identity() })
+	return identity, ok && identity.Valid()
+}
+
+func preparedJobConfigLifecycleSnapshot(
+	successor lifecycle.PreparedResource,
+) collectorapi.JobConfigLifecycleSnapshot {
+	if successor == nil {
+		return nil
+	}
+	provider, ok := successor.(interface {
+		jobConfigLifecycleSnapshot() collectorapi.JobConfigLifecycleSnapshot
+	})
+	if !ok {
+		return nil
+	}
+	snapshot := provider.jobConfigLifecycleSnapshot()
+	if nilInterfaceValue(snapshot) {
+		return nil
+	}
+	return snapshot
+}
+
+type jobConfigLifecycleGraphState struct {
+	identity collectorapi.JobConfigIdentity
+	hook     collectorapi.JobConfigLifecycle
+	valid    bool
+}
+
+func (dcjc *DynCfgJobController) prepareJobConfigLifecycleCommit(
+	id string,
+	postimage *dyncfg.GraphConfig,
+	snapshot collectorapi.JobConfigLifecycleSnapshot,
+) func() {
+	if dcjc == nil || dcjc.graph == nil || id == "" {
+		return nil
+	}
+	previous := dcjc.currentJobConfigLifecycleGraphState(id)
+	next := dcjc.postimageJobConfigLifecycleGraphState(postimage)
+	if snapshotIdentity, ok := jobConfigLifecycleSnapshotIdentity(snapshot); ok &&
+		next.valid && snapshotIdentity == next.identity {
+		return func() {
+			callJobConfigLifecycle(func() { snapshot.Commit(previous.identity) })
+		}
+	}
+	if previous.valid && (!next.valid || next.identity != previous.identity) && previous.hook != nil {
+		return func() {
+			callJobConfigLifecycle(func() { previous.hook.Remove(previous.identity) })
+		}
+	}
+	return nil
+}
+
+func (dcjc *DynCfgJobController) currentJobConfigLifecycleGraphState(id string) jobConfigLifecycleGraphState {
+	record, ok := dcjc.graph.Lookup(id)
+	if !ok {
+		return jobConfigLifecycleGraphState{}
+	}
+	config, err := graphRecordConfig(record)
+	if err != nil {
+		return jobConfigLifecycleGraphState{}
+	}
+	return dcjc.jobConfigLifecycleGraphState(record.Module, record.Name, record.Status, config)
+}
+
+func (dcjc *DynCfgJobController) postimageJobConfigLifecycleGraphState(
+	postimage *dyncfg.GraphConfig,
+) jobConfigLifecycleGraphState {
+	if postimage == nil {
+		return jobConfigLifecycleGraphState{}
+	}
+	var config confgroup.Config
+	if err := yaml.Unmarshal(postimage.Payload, &config); err != nil || config == nil ||
+		config.Module() != postimage.Module || config.Name() != postimage.Name {
+		return jobConfigLifecycleGraphState{}
+	}
+	return dcjc.jobConfigLifecycleGraphState(postimage.Module, postimage.Name, postimage.Status, config)
+}
+
+func (dcjc *DynCfgJobController) jobConfigLifecycleGraphState(
+	module string,
+	name string,
+	status string,
+	config confgroup.Config,
+) jobConfigLifecycleGraphState {
+	if config == nil || config.Module() != module || config.Name() != name {
+		return jobConfigLifecycleGraphState{}
+	}
+	if status != dyncfg.StatusRunning.String() && status != dyncfg.StatusFailed.String() {
+		return jobConfigLifecycleGraphState{}
+	}
+	creator, ok := dcjc.modules.Lookup(module)
+	if !ok || creator.JobConfigLifecycle == nil {
+		return jobConfigLifecycleGraphState{}
+	}
+	identity := jobConfigIdentity(config)
+	return jobConfigLifecycleGraphState{
+		identity: identity,
+		hook:     creator.JobConfigLifecycle,
+		valid:    identity.Valid(),
+	}
+}

--- a/src/go/plugin/agent/jobmgr/joboutput/job_config_lifecycle.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/job_config_lifecycle.go
@@ -102,7 +102,7 @@ type jobConfigLifecycleGraphState struct {
 	valid    bool
 }
 
-func (dcjc *DynCfgJobController) prepareJobConfigLifecycleCommit(
+func (dcjc *DynCfgJobController) prepareJobConfigLifecycleReconcile(
 	id string,
 	postimage *dyncfg.GraphConfig,
 	prepared preparedJobConfigLifecycle,
@@ -133,7 +133,7 @@ func (dcjc *DynCfgJobController) prepareJobConfigLifecycleCommit(
 			if prepared.identity == next.identity && prepared.runtime != nil {
 				runtime = prepared.runtime
 			}
-			callJobConfigLifecycle(func() { next.hook.Commit(previous.identity, snapshot, runtime) })
+			callJobConfigLifecycle(func() { next.hook.Reconcile(previous.identity, snapshot, runtime) })
 		}
 	}
 	if previous.valid && (!next.valid || next.identity != previous.identity) && previous.hook != nil {

--- a/src/go/plugin/agent/jobmgr/joboutput/job_config_lifecycle.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/job_config_lifecycle.go
@@ -64,45 +64,76 @@ func jobConfigLifecycleSnapshotIdentity(
 	return identity, ok && identity.Valid()
 }
 
-func preparedJobConfigLifecycleSnapshot(
-	successor lifecycle.PreparedResource,
-) collectorapi.JobConfigLifecycleSnapshot {
+type preparedJobConfigLifecycle struct {
+	identity collectorapi.JobConfigIdentity
+	snapshot collectorapi.JobConfigLifecycleSnapshot
+	runtime  collectorapi.RuntimeJob
+}
+
+func preparedJobConfigLifecycleState(successor lifecycle.PreparedResource) preparedJobConfigLifecycle {
 	if successor == nil {
-		return nil
+		return preparedJobConfigLifecycle{}
 	}
 	provider, ok := successor.(interface {
-		jobConfigLifecycleSnapshot() collectorapi.JobConfigLifecycleSnapshot
+		jobConfigLifecycleState() preparedJobConfigLifecycle
 	})
 	if !ok {
-		return nil
+		return preparedJobConfigLifecycle{}
 	}
-	snapshot := provider.jobConfigLifecycleSnapshot()
-	if nilInterfaceValue(snapshot) {
-		return nil
+	state := provider.jobConfigLifecycleState()
+	if !state.identity.Valid() || state.runtime == nil {
+		return preparedJobConfigLifecycle{}
 	}
-	return snapshot
+	if nilInterfaceValue(state.snapshot) {
+		state.snapshot = nil
+		return state
+	}
+	snapshotIdentity, ok := jobConfigLifecycleSnapshotIdentity(state.snapshot)
+	if !ok || snapshotIdentity != state.identity {
+		state.snapshot = nil
+	}
+	return state
 }
 
 type jobConfigLifecycleGraphState struct {
 	identity collectorapi.JobConfigIdentity
 	hook     collectorapi.JobConfigLifecycle
+	config   confgroup.Config
 	valid    bool
 }
 
 func (dcjc *DynCfgJobController) prepareJobConfigLifecycleCommit(
 	id string,
 	postimage *dyncfg.GraphConfig,
-	snapshot collectorapi.JobConfigLifecycleSnapshot,
+	prepared preparedJobConfigLifecycle,
 ) func() {
 	if dcjc == nil || dcjc.graph == nil || id == "" {
 		return nil
 	}
 	previous := dcjc.currentJobConfigLifecycleGraphState(id)
 	next := dcjc.postimageJobConfigLifecycleGraphState(postimage)
+	snapshot := prepared.snapshot
+	if snapshotIdentity, ok := jobConfigLifecycleSnapshotIdentity(snapshot); !ok ||
+		!next.valid || snapshotIdentity != next.identity {
+		snapshot = nil
+	}
+	if next.valid && snapshot == nil {
+		callJobConfigLifecycle(func() {
+			snapshot = next.hook.Project(next.identity, map[string]any(next.config))
+		})
+		if snapshotIdentity, ok := jobConfigLifecycleSnapshotIdentity(snapshot); !ok ||
+			snapshotIdentity != next.identity {
+			snapshot = nil
+		}
+	}
 	if snapshotIdentity, ok := jobConfigLifecycleSnapshotIdentity(snapshot); ok &&
 		next.valid && snapshotIdentity == next.identity {
 		return func() {
-			callJobConfigLifecycle(func() { snapshot.Commit(previous.identity) })
+			var runtime collectorapi.RuntimeJob
+			if prepared.identity == next.identity && prepared.runtime != nil {
+				runtime = prepared.runtime
+			}
+			callJobConfigLifecycle(func() { next.hook.Commit(previous.identity, snapshot, runtime) })
 		}
 	}
 	if previous.valid && (!next.valid || next.identity != previous.identity) && previous.hook != nil {
@@ -118,11 +149,15 @@ func (dcjc *DynCfgJobController) currentJobConfigLifecycleGraphState(id string) 
 	if !ok {
 		return jobConfigLifecycleGraphState{}
 	}
+	hook := dcjc.jobConfigLifecycleHook(record.Module, record.Status)
+	if hook == nil {
+		return jobConfigLifecycleGraphState{}
+	}
 	config, err := graphRecordConfig(record)
 	if err != nil {
 		return jobConfigLifecycleGraphState{}
 	}
-	return dcjc.jobConfigLifecycleGraphState(record.Module, record.Name, record.Status, config)
+	return dcjc.jobConfigLifecycleGraphState(record.Module, record.Name, config, hook)
 }
 
 func (dcjc *DynCfgJobController) postimageJobConfigLifecycleGraphState(
@@ -131,34 +166,46 @@ func (dcjc *DynCfgJobController) postimageJobConfigLifecycleGraphState(
 	if postimage == nil {
 		return jobConfigLifecycleGraphState{}
 	}
+	hook := dcjc.jobConfigLifecycleHook(postimage.Module, postimage.Status)
+	if hook == nil {
+		return jobConfigLifecycleGraphState{}
+	}
 	var config confgroup.Config
 	if err := yaml.Unmarshal(postimage.Payload, &config); err != nil || config == nil ||
 		config.Module() != postimage.Module || config.Name() != postimage.Name {
 		return jobConfigLifecycleGraphState{}
 	}
-	return dcjc.jobConfigLifecycleGraphState(postimage.Module, postimage.Name, postimage.Status, config)
+	return dcjc.jobConfigLifecycleGraphState(postimage.Module, postimage.Name, config, hook)
 }
 
 func (dcjc *DynCfgJobController) jobConfigLifecycleGraphState(
 	module string,
 	name string,
-	status string,
 	config confgroup.Config,
+	hook collectorapi.JobConfigLifecycle,
 ) jobConfigLifecycleGraphState {
 	if config == nil || config.Module() != module || config.Name() != name {
-		return jobConfigLifecycleGraphState{}
-	}
-	if status != dyncfg.StatusRunning.String() && status != dyncfg.StatusFailed.String() {
-		return jobConfigLifecycleGraphState{}
-	}
-	creator, ok := dcjc.modules.Lookup(module)
-	if !ok || creator.JobConfigLifecycle == nil {
 		return jobConfigLifecycleGraphState{}
 	}
 	identity := jobConfigIdentity(config)
 	return jobConfigLifecycleGraphState{
 		identity: identity,
-		hook:     creator.JobConfigLifecycle,
+		hook:     hook,
+		config:   config,
 		valid:    identity.Valid(),
 	}
+}
+
+func (dcjc *DynCfgJobController) jobConfigLifecycleHook(
+	module string,
+	status string,
+) collectorapi.JobConfigLifecycle {
+	if status != dyncfg.StatusRunning.String() && status != dyncfg.StatusFailed.String() {
+		return nil
+	}
+	creator, ok := dcjc.modules.Lookup(module)
+	if !ok || nilInterfaceValue(creator.JobConfigLifecycle) {
+		return nil
+	}
+	return creator.JobConfigLifecycle
 }

--- a/src/go/plugin/agent/jobmgr/joboutput/transaction.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/transaction.go
@@ -34,11 +34,11 @@ type ResourceTransactionSpec struct {
 // successor cannot acquire its installed-runtime identity after the incumbent
 // has been logically removed.
 type ResourceActivationFallback struct {
-	Change           dyncfg.GraphChange // failed or removed graph postimage
-	AfterGraphCommit func()             // commits source/dependency projections
-	AfterApply       func()             // records pending/retry state
-	Result           lifecycle.SealedResult
-	Cleanup          lifecycle.TaskCleanup
+	Change              dyncfg.GraphChange // failed or removed graph postimage
+	AfterGraphReconcile func()             // reconciles projections after commit or confirmed equality
+	AfterApply          func()             // records pending/retry state
+	Result              lifecycle.SealedResult
+	Cleanup             lifecycle.TaskCleanup
 }
 
 func resourceRemovalDisposition(current lifecycle.ReadyResource) lifecycle.ResourceTransactionDisposition {
@@ -356,16 +356,18 @@ func (prt *PreparedResourceTransaction) Apply(ctx context.Context) (
 				fallbackMutation, mutationErr := spec.Graph.PrepareMutation(
 					[]dyncfg.GraphChange{fallback.Change},
 				)
+				var reconcileAfterSeal func()
 				switch {
 				case mutationErr == nil:
 					if commitErr := commitGraphMutation(spec.Graph, fallbackMutation); commitErr != nil {
 						return lifecycle.AppliedResourceTransaction{}, commitErr
 					}
-					if fallback.AfterGraphCommit != nil {
-						fallback.AfterGraphCommit()
+					if fallback.AfterGraphReconcile != nil {
+						fallback.AfterGraphReconcile()
 					}
 				case errors.Is(mutationErr, dyncfg.ErrGraphNoChange):
-				// The graph already represents the fallback outcome.
+					// The graph already represents the fallback outcome.
+					reconcileAfterSeal = fallback.AfterGraphReconcile
 				default:
 					return lifecycle.AppliedResourceTransaction{}, mutationErr
 				}
@@ -380,6 +382,9 @@ func (prt *PreparedResourceTransaction) Apply(ctx context.Context) (
 					return lifecycle.AppliedResourceTransaction{}, applyErr
 				}
 				appliedSealed = true
+				if reconcileAfterSeal != nil {
+					reconcileAfterSeal()
+				}
 				if fallback.AfterApply != nil {
 					fallback.AfterApply()
 				}

--- a/src/go/plugin/agent/jobmgr/joboutput/transaction_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/transaction_test.go
@@ -736,7 +736,7 @@ func TestPreparedResourceTransactionCommitsBusyFallbackAfterIncumbentRemoval(t *
 		MutationPrepared: true,
 		ActivationBusyFallback: &ResourceActivationFallback{
 			Change: dyncfg.GraphChange{ID: "job", Config: &failed},
-			AfterGraphCommit: func() {
+			AfterGraphReconcile: func() {
 				events = append(events, "fallback-graph-commit")
 			},
 			AfterApply: func() {
@@ -774,6 +774,69 @@ func TestPreparedResourceTransactionCommitsBusyFallbackAfterIncumbentRemoval(t *
 	nextMutation, err := graph.PrepareMutation([]dyncfg.GraphChange{{ID: "job", Config: &next}})
 	require.NoError(t, err)
 	require.NoError(t, graph.Abort(nextMutation))
+}
+
+func TestPreparedResourceTransactionReconcilesBusyFallbackWhenGraphAlreadyMatches(t *testing.T) {
+	var events []string
+	currentIdentity := lifecycle.ResourceIdentity{ID: "job", Generation: 1}
+	successorIdentity := lifecycle.ResourceIdentity{ID: "job", Generation: 2}
+	current := &transactionTestReadyResource{
+		identity: currentIdentity,
+		prefix:   "current",
+		events:   &events,
+	}
+	successor := &transactionTestPreparedResource{
+		identity:  successorIdentity,
+		events:    &events,
+		acceptErr: jobmgr.ErrProcessAttemptBusy,
+	}
+	failed := dyncfg.GraphConfig{
+		ID: "job", Module: "module", Name: "job", Status: dyncfg.StatusFailed.String(),
+		Payload: []byte(`{"version":2}`),
+	}
+	graph, err := dyncfg.NewGraph([]dyncfg.GraphConfig{failed})
+	require.NoError(t, err)
+	running := failed
+	running.Status = dyncfg.StatusRunning.String()
+	mutation, err := graph.PrepareMutation([]dyncfg.GraphChange{{ID: "job", Config: &running}})
+	require.NoError(t, err)
+	result, err := lifecycle.NewSealedResult(200, "application/json", nil)
+	require.NoError(t, err)
+	busyResult, err := lifecycle.NewSealedResult(503, "application/json", nil)
+	require.NoError(t, err)
+	transaction, err := PrepareResourceTransaction(ResourceTransactionSpec{
+		Scope: lifecycle.ResourceTransactionScope{
+			ID:        "job",
+			Current:   currentIdentity,
+			Successor: successorIdentity,
+		},
+		Disposition:      lifecycle.ResourceTransactionReplaced,
+		Current:          current,
+		Successor:        successor,
+		Graph:            graph,
+		Mutation:         mutation,
+		MutationPrepared: true,
+		ActivationBusyFallback: &ResourceActivationFallback{
+			Change: dyncfg.GraphChange{ID: "job", Config: &failed},
+			AfterGraphReconcile: func() {
+				events = append(events, "fallback-reconcile")
+			},
+			Result:  busyResult,
+			Cleanup: func() error { return nil },
+		},
+		Result:  result,
+		Cleanup: func() error { return nil },
+	})
+	require.NoError(t, err)
+
+	_, err = transaction.Apply(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"current-stop",
+		"current-finalize",
+		"successor-accept",
+		"fallback-reconcile",
+	}, events)
 }
 
 func TestPreparedResourceTransactionCommitsQuarantineFallbackWithoutPending(t *testing.T) {
@@ -833,7 +896,7 @@ func TestPreparedResourceTransactionCommitsQuarantineFallbackWithoutPending(t *t
 		},
 		ActivationQuarantinedFallback: &ResourceActivationFallback{
 			Change: dyncfg.GraphChange{ID: "job", Config: &failed},
-			AfterGraphCommit: func() {
+			AfterGraphReconcile: func() {
 				events = append(events, "fallback-graph-commit")
 			},
 			AfterApply: func() {

--- a/src/go/plugin/framework/collectorapi/job_config_lifecycle.go
+++ b/src/go/plugin/framework/collectorapi/job_config_lifecycle.go
@@ -22,13 +22,14 @@ func (id JobConfigIdentity) String() string {
 // JobConfigLifecycle projects a small diagnostic lifecycle snapshot at the
 // authoritative Job Manager configuration-commit boundary. Implementations
 // must be fail-open. Project must not retain config, and snapshots must contain
-// no configuration or runtime objects. Commit receives a runtime only for a
-// successfully accepted job; failed or pre-construction states receive nil.
+// no configuration or runtime objects. Reconcile receives the prior graph
+// incarnation plus a runtime only for a successfully accepted job; failed or
+// pre-construction states receive nil.
 type JobConfigLifecycle interface {
 	Project(JobConfigIdentity, map[string]any) JobConfigLifecycleSnapshot
 	Bind(JobConfigIdentity, RuntimeJob)
 	Capture(JobConfigIdentity, RuntimeJob) JobConfigLifecycleSnapshot
-	Commit(JobConfigIdentity, JobConfigLifecycleSnapshot, RuntimeJob)
+	Reconcile(JobConfigIdentity, JobConfigLifecycleSnapshot, RuntimeJob)
 	Remove(JobConfigIdentity)
 }
 

--- a/src/go/plugin/framework/collectorapi/job_config_lifecycle.go
+++ b/src/go/plugin/framework/collectorapi/job_config_lifecycle.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package collectorapi
+
+import "encoding/hex"
+
+// JobConfigIdentity is an opaque identity for one exact job configuration.
+// Job Manager derives it; collectors must not derive or decode it.
+type JobConfigIdentity [32]byte
+
+func (id JobConfigIdentity) Valid() bool {
+	return id != JobConfigIdentity{}
+}
+
+func (id JobConfigIdentity) String() string {
+	if !id.Valid() {
+		return ""
+	}
+	return hex.EncodeToString(id[:])
+}
+
+// JobConfigLifecycle lets a collector project a small diagnostic lifecycle
+// snapshot at the authoritative Job Manager configuration-commit boundary.
+// Implementations must be fail-open and must not retain configuration values.
+type JobConfigLifecycle interface {
+	Bind(JobConfigIdentity, RuntimeJob)
+	Capture(JobConfigIdentity, RuntimeJob) JobConfigLifecycleSnapshot
+	Remove(JobConfigIdentity)
+}
+
+// JobConfigLifecycleSnapshot is detached from candidate cleanup. Commit is
+// called only after the matching configuration graph transition commits.
+type JobConfigLifecycleSnapshot interface {
+	Identity() JobConfigIdentity
+	Commit(previous JobConfigIdentity)
+}

--- a/src/go/plugin/framework/collectorapi/job_config_lifecycle.go
+++ b/src/go/plugin/framework/collectorapi/job_config_lifecycle.go
@@ -19,18 +19,21 @@ func (id JobConfigIdentity) String() string {
 	return hex.EncodeToString(id[:])
 }
 
-// JobConfigLifecycle lets a collector project a small diagnostic lifecycle
-// snapshot at the authoritative Job Manager configuration-commit boundary.
-// Implementations must be fail-open and must not retain configuration values.
+// JobConfigLifecycle projects a small diagnostic lifecycle snapshot at the
+// authoritative Job Manager configuration-commit boundary. Implementations
+// must be fail-open. Project must not retain config, and snapshots must contain
+// no configuration or runtime objects. Commit receives a runtime only for a
+// successfully accepted job; failed or pre-construction states receive nil.
 type JobConfigLifecycle interface {
+	Project(JobConfigIdentity, map[string]any) JobConfigLifecycleSnapshot
 	Bind(JobConfigIdentity, RuntimeJob)
 	Capture(JobConfigIdentity, RuntimeJob) JobConfigLifecycleSnapshot
+	Commit(JobConfigIdentity, JobConfigLifecycleSnapshot, RuntimeJob)
 	Remove(JobConfigIdentity)
 }
 
-// JobConfigLifecycleSnapshot is detached from candidate cleanup. Commit is
-// called only after the matching configuration graph transition commits.
+// JobConfigLifecycleSnapshot is a credential-free value detached from runtime
+// and candidate cleanup.
 type JobConfigLifecycleSnapshot interface {
 	Identity() JobConfigIdentity
-	Commit(previous JobConfigIdentity)
 }

--- a/src/go/plugin/framework/collectorapi/registry.go
+++ b/src/go/plugin/framework/collectorapi/registry.go
@@ -54,10 +54,11 @@ type (
 	// modules that set these fields can expose data functions to the UI.
 	Creator struct {
 		Defaults
-		Create          func() CollectorV1
-		CreateV2        func() CollectorV2
-		JobConfigSchema string
-		Config          func() any
+		Create             func() CollectorV1
+		CreateV2           func() CollectorV2
+		JobConfigSchema    string
+		Config             func() any
+		JobConfigLifecycle JobConfigLifecycle
 
 		// InstancePolicy defaults to InstancePolicyPerJob when omitted.
 		InstancePolicy InstancePolicy

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -46,39 +46,43 @@ func newCreator(store *ddsnmp.DeviceStore) collectorapi.Creator {
 	}
 }
 
+func defaultConfig() Config {
+	return Config{
+		CreateVnode:              true,
+		VnodeDeviceDownThreshold: 3,
+		Community:                "public",
+		Options: OptionsConfig{
+			Port:           161,
+			Retries:        1,
+			Timeout:        5,
+			Version:        gosnmp.Version2c.String(),
+			MaxOIDs:        20,
+			MaxRepetitions: 25,
+		},
+		User: UserConfig{
+			SecurityLevel: "authPriv",
+			AuthProto:     "sha512",
+			PrivProto:     "aes192c",
+		},
+		Ping: PingConfig{
+			Enabled: true,
+			ProbeConfig: pinger.ProbeConfig{
+				Privileged: true,
+				Packets:    3,
+				Interval:   confopt.Duration(time.Millisecond * 100),
+				Network:    "ip",
+			},
+		},
+	}
+}
+
 // New returns an SNMP collector using the provided SNMP-family device store.
 func New(store *ddsnmp.DeviceStore) *Collector {
 	if store == nil {
 		panic("snmp New requires a non-nil device store")
 	}
 	c := &Collector{
-		Config: Config{
-			CreateVnode:              true,
-			VnodeDeviceDownThreshold: 3,
-			Community:                "public",
-			Options: OptionsConfig{
-				Port:           161,
-				Retries:        1,
-				Timeout:        5,
-				Version:        gosnmp.Version2c.String(),
-				MaxOIDs:        20,
-				MaxRepetitions: 25,
-			},
-			User: UserConfig{
-				SecurityLevel: "authPriv",
-				AuthProto:     "sha512",
-				PrivProto:     "aes192c",
-			},
-			Ping: PingConfig{
-				Enabled: true,
-				ProbeConfig: pinger.ProbeConfig{
-					Privileged: true,
-					Packets:    3,
-					Interval:   confopt.Duration(time.Millisecond * 100),
-					Network:    "ip",
-				},
-			},
-		},
+		Config: defaultConfig(),
 
 		charts:               &collectorapi.Charts{},
 		seenScalarMetrics:    make(map[string]bool),
@@ -158,7 +162,16 @@ func (c *Collector) Configuration() any {
 
 func (c *Collector) Init(context.Context) (err error) {
 	c.beginDeviceLifecycle()
-	defer func() { c.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseInit, err) }()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			c.recordDeviceLifecycle(
+				ddsnmp.DeviceLifecyclePhaseInit,
+				ddsnmp.DeviceLifecycleOutcomeFailed,
+			)
+			panic(recovered)
+		}
+		c.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseInit, err)
+	}()
 
 	if err := c.validateConfig(); err != nil {
 		return fmt.Errorf("config validation failed: %v", err)
@@ -180,7 +193,16 @@ func (c *Collector) Init(context.Context) (err error) {
 }
 
 func (c *Collector) Check(ctx context.Context) (err error) {
-	defer func() { c.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseCheck, err) }()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			c.recordDeviceLifecycle(
+				ddsnmp.DeviceLifecyclePhaseCheck,
+				ddsnmp.DeviceLifecycleOutcomeFailed,
+			)
+			panic(recovered)
+		}
+		c.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseCheck, err)
+	}()
 
 	if c.snmpClient == nil {
 		snmpClient, err := c.initAndConnectSNMPClient()
@@ -227,9 +249,7 @@ func (c *Collector) Cleanup(ctx context.Context) {
 	}
 	if c.deviceStore != nil {
 		ownerKey, managed := c.deviceStoreCleanupKey()
-		if managed {
-			c.deviceStore.UnregisterDevice(ownerKey)
-		} else {
+		if !managed {
 			c.deviceStore.Unregister(ownerKey)
 		}
 	}

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -37,10 +38,11 @@ func newCreator(store *ddsnmp.DeviceStore) collectorapi.Creator {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 10,
 		},
-		Create:          func() collectorapi.CollectorV1 { return New(store) },
-		Config:          func() any { return &Config{} },
-		SharedFunctions: snmpMethods,
-		MethodHandler:   snmpFunctionHandler,
+		Create:             func() collectorapi.CollectorV1 { return New(store) },
+		Config:             func() any { return &Config{} },
+		JobConfigLifecycle: newSNMPJobConfigLifecycle(store),
+		SharedFunctions:    snmpMethods,
+		MethodHandler:      snmpFunctionHandler,
 	}
 }
 
@@ -108,12 +110,19 @@ type (
 
 		vnode *vnodes.VirtualNode
 
-		charts               *collectorapi.Charts
-		seenScalarMetrics    map[string]bool
-		seenTableMetrics     map[string]bool
-		seenProfiles         map[string]bool
-		deviceStore          *ddsnmp.DeviceStore
-		deviceLifecycleStore deviceLifecycleStore
+		charts                   *collectorapi.Charts
+		seenScalarMetrics        map[string]bool
+		seenTableMetrics         map[string]bool
+		seenProfiles             map[string]bool
+		deviceStore              *ddsnmp.DeviceStore
+		deviceLifecycleStore     deviceLifecycleStore
+		deviceLifecycleMu        sync.Mutex
+		deviceLifecycleOwner     string
+		deviceLifecycleInfo      ddsnmp.DeviceLifecycleInfo
+		deviceLifecycleStatus    ddsnmp.DeviceLifecycleStatus
+		deviceLifecyclePending   *ddsnmp.DeviceConnectionInfo
+		deviceLifecycleManaged   bool
+		deviceLifecycleCommitted bool
 
 		ifaceCache *ifaceCache // interface metrics cache for functions
 		licensing  *licensingIntegration
@@ -217,7 +226,12 @@ func (c *Collector) Cleanup(ctx context.Context) {
 		c.funcRouter.Cleanup(ctx)
 	}
 	if c.deviceStore != nil {
-		c.deviceStore.Unregister(c.deviceStoreOwnerKey())
+		ownerKey, managed := c.deviceStoreCleanupKey()
+		if managed {
+			c.deviceStore.UnregisterDevice(ownerKey)
+		} else {
+			c.deviceStore.Unregister(ownerKey)
+		}
 	}
 	if c.snmpClient != nil {
 		_ = c.snmpClient.Close()

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -78,11 +78,12 @@ func New(store *ddsnmp.DeviceStore) *Collector {
 			},
 		},
 
-		charts:            &collectorapi.Charts{},
-		seenScalarMetrics: make(map[string]bool),
-		seenTableMetrics:  make(map[string]bool),
-		seenProfiles:      make(map[string]bool),
-		deviceStore:       store,
+		charts:               &collectorapi.Charts{},
+		seenScalarMetrics:    make(map[string]bool),
+		seenTableMetrics:     make(map[string]bool),
+		seenProfiles:         make(map[string]bool),
+		deviceStore:          store,
+		deviceLifecycleStore: store,
 
 		ifaceCache: newIfaceCache(),
 		licensing:  newLicensingIntegration(),
@@ -107,11 +108,12 @@ type (
 
 		vnode *vnodes.VirtualNode
 
-		charts            *collectorapi.Charts
-		seenScalarMetrics map[string]bool
-		seenTableMetrics  map[string]bool
-		seenProfiles      map[string]bool
-		deviceStore       *ddsnmp.DeviceStore
+		charts               *collectorapi.Charts
+		seenScalarMetrics    map[string]bool
+		seenTableMetrics     map[string]bool
+		seenProfiles         map[string]bool
+		deviceStore          *ddsnmp.DeviceStore
+		deviceLifecycleStore deviceLifecycleStore
 
 		ifaceCache *ifaceCache // interface metrics cache for functions
 		licensing  *licensingIntegration
@@ -145,7 +147,10 @@ func (c *Collector) Configuration() any {
 	return c.Config
 }
 
-func (c *Collector) Init(context.Context) error {
+func (c *Collector) Init(context.Context) (err error) {
+	c.beginDeviceLifecycle()
+	defer func() { c.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseInit, err) }()
+
 	if err := c.validateConfig(); err != nil {
 		return fmt.Errorf("config validation failed: %v", err)
 	}
@@ -165,7 +170,9 @@ func (c *Collector) Init(context.Context) error {
 	return nil
 }
 
-func (c *Collector) Check(ctx context.Context) error {
+func (c *Collector) Check(ctx context.Context) (err error) {
+	defer func() { c.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseCheck, err) }()
+
 	if c.snmpClient == nil {
 		snmpClient, err := c.initAndConnectSNMPClient()
 		if err != nil {
@@ -193,6 +200,7 @@ func (c *Collector) Charts() *collectorapi.Charts {
 
 func (c *Collector) Collect(ctx context.Context) map[string]int64 {
 	mx, err := c.collect(ctx)
+	c.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseCollect, err)
 	if err != nil {
 		c.Error(err)
 	}

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -262,7 +262,7 @@ func TestCollector_InitFailurePublishesSafeLifecycle(t *testing.T) {
 	require.NotContains(t, serialized, collr.ManualProfiles[0])
 }
 
-func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilCommit(t *testing.T) {
+func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilReconcile(t *testing.T) {
 	store := ddsnmp.NewDeviceStore()
 	collr := New(store)
 	collr.Hostname = ""
@@ -276,7 +276,7 @@ func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilCommit(t *testing.
 	collr.Cleanup(context.Background())
 	require.Empty(t, store.LifecycleCut().Entries)
 
-	hook.Commit(collectorapi.JobConfigIdentity{}, snapshot, nil)
+	hook.Reconcile(collectorapi.JobConfigIdentity{}, snapshot, nil)
 	cut := store.LifecycleCut()
 	require.Len(t, cut.Entries, 1)
 	require.Equal(t, ddsnmp.DeviceLifecyclePhaseInit, cut.Entries[0].LastCompleted.Phase)
@@ -303,7 +303,7 @@ func TestSNMPJobConfigLifecycleProjectsCredentialFreeBaseline(t *testing.T) {
 
 	snapshot := hook.Project(identity, config)
 	config["hostname"] = "changed-after-projection.example"
-	hook.Commit(collectorapi.JobConfigIdentity{}, snapshot, nil)
+	hook.Reconcile(collectorapi.JobConfigIdentity{}, snapshot, nil)
 
 	cut := store.LifecycleCut()
 	require.Len(t, cut.Entries, 1)
@@ -353,7 +353,7 @@ func TestCollectorManagedLifecycleSnapshotIsDetachedAtCapture(t *testing.T) {
 	}
 	collr.deviceLifecycleMu.Unlock()
 
-	hook.Commit(collectorapi.JobConfigIdentity{}, snapshot, nil)
+	hook.Reconcile(collectorapi.JobConfigIdentity{}, snapshot, nil)
 	cut := store.LifecycleCut()
 	require.Len(t, cut.Entries, 1)
 	require.Equal(t, prepareV2Config().Hostname, cut.Entries[0].Info.Hostname)
@@ -397,7 +397,7 @@ func TestCollectorLifecycleRecordsPanicsAsFailures(t *testing.T) {
 	})
 }
 
-func TestCollectorManagedConnectionCollectedBeforeCommitIsPublishedAtCommit(t *testing.T) {
+func TestCollectorManagedConnectionCollectedBeforeReconcileIsPublishedAtReconcile(t *testing.T) {
 	store := ddsnmp.NewDeviceStore()
 	collr := New(store)
 	collr.Config = prepareV2Config()
@@ -419,7 +419,7 @@ func TestCollectorManagedConnectionCollectedBeforeCommitIsPublishedAtCommit(t *t
 
 	snapshot := hook.Capture(identity, job)
 	require.NotNil(t, snapshot)
-	hook.Commit(collectorapi.JobConfigIdentity{}, snapshot, job)
+	hook.Reconcile(collectorapi.JobConfigIdentity{}, snapshot, job)
 	require.Len(t, store.Entries(), 1)
 	require.Equal(t, []string{"profile-a"}, store.Entries()[0].Info.ManualProfiles)
 	cut := store.LifecycleCut()

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -276,12 +276,125 @@ func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilCommit(t *testing.
 	collr.Cleanup(context.Background())
 	require.Empty(t, store.LifecycleCut().Entries)
 
-	snapshot.Commit(collectorapi.JobConfigIdentity{})
+	hook.Commit(collectorapi.JobConfigIdentity{}, snapshot, nil)
 	cut := store.LifecycleCut()
 	require.Len(t, cut.Entries, 1)
 	require.Equal(t, ddsnmp.DeviceLifecyclePhaseInit, cut.Entries[0].LastCompleted.Phase)
 	require.Equal(t, ddsnmp.DeviceLifecycleOutcomeFailed, cut.Entries[0].LastCompleted.Outcome)
 	require.False(t, cut.Entries[0].TopologyReady)
+}
+
+func TestSNMPJobConfigLifecycleProjectsCredentialFreeBaseline(t *testing.T) {
+	store := ddsnmp.NewDeviceStore()
+	hook := newCreator(store).JobConfigLifecycle
+	identity := collectorapi.JobConfigIdentity{1}
+	config := map[string]any{
+		"hostname":  "switch-a.example",
+		"community": "must-not-appear",
+		"user": map[any]any{
+			"auth_key": "must-not-appear",
+			"priv_key": "must-not-appear",
+		},
+		"options": map[any]any{
+			"port":    1161,
+			"version": "3",
+		},
+	}
+
+	snapshot := hook.Project(identity, config)
+	config["hostname"] = "changed-after-projection.example"
+	hook.Commit(collectorapi.JobConfigIdentity{}, snapshot, nil)
+
+	cut := store.LifecycleCut()
+	require.Len(t, cut.Entries, 1)
+	require.Equal(t, ddsnmp.DeviceLifecycleInfo{
+		Hostname:    "switch-a.example",
+		Port:        1161,
+		SNMPVersion: "3",
+	}, cut.Entries[0].Info)
+	require.Equal(t, ddsnmp.DeviceLifecyclePhaseUnknown, cut.Entries[0].LastCompleted.Phase)
+	require.Equal(t, ddsnmp.DeviceLifecycleOutcomeUnknown, cut.Entries[0].LastCompleted.Outcome)
+	require.NotContains(t, fmt.Sprintf("%+v", snapshot), "must-not-appear")
+}
+
+func TestCollectorRejectedManagedCandidateDoesNotRemoveIncumbentConnection(t *testing.T) {
+	store := ddsnmp.NewDeviceStore()
+	identity := collectorapi.JobConfigIdentity{1}
+	store.Register(identity.String(), ddsnmp.DeviceConnectionInfo{Hostname: "incumbent.example"})
+	collr := New(store)
+	job := snmpLifecycleTestRuntimeJob{collector: collr}
+	hook := newCreator(store).JobConfigLifecycle
+
+	hook.Bind(identity, job)
+	collr.Cleanup(context.Background())
+
+	require.Len(t, store.Entries(), 1)
+	require.Equal(t, "incumbent.example", store.Entries()[0].Info.Hostname)
+}
+
+func TestCollectorManagedLifecycleSnapshotIsDetachedAtCapture(t *testing.T) {
+	store := ddsnmp.NewDeviceStore()
+	collr := New(store)
+	collr.Config = prepareV2Config()
+	job := snmpLifecycleTestRuntimeJob{collector: collr}
+	hook := newCreator(store).JobConfigLifecycle
+	identity := collectorapi.JobConfigIdentity{1}
+
+	hook.Bind(identity, job)
+	collr.beginDeviceLifecycle()
+	collr.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseInit, errors.New("initial failure"))
+	snapshot := hook.Capture(identity, job)
+
+	collr.deviceLifecycleMu.Lock()
+	collr.deviceLifecycleInfo.Hostname = "changed-after-capture.example"
+	collr.deviceLifecycleStatus = ddsnmp.DeviceLifecycleStatus{
+		Phase:   ddsnmp.DeviceLifecyclePhaseCollect,
+		Outcome: ddsnmp.DeviceLifecycleOutcomeSuccess,
+	}
+	collr.deviceLifecycleMu.Unlock()
+
+	hook.Commit(collectorapi.JobConfigIdentity{}, snapshot, nil)
+	cut := store.LifecycleCut()
+	require.Len(t, cut.Entries, 1)
+	require.Equal(t, prepareV2Config().Hostname, cut.Entries[0].Info.Hostname)
+	require.Equal(t, ddsnmp.DeviceLifecyclePhaseInit, cut.Entries[0].LastCompleted.Phase)
+	require.Equal(t, ddsnmp.DeviceLifecycleOutcomeFailed, cut.Entries[0].LastCompleted.Outcome)
+}
+
+func TestCollectorLifecycleRecordsPanicsAsFailures(t *testing.T) {
+	t.Run("init", func(t *testing.T) {
+		store := ddsnmp.NewDeviceStore()
+		collr := New(store)
+		collr.Config = prepareV2Config()
+		collr.newSnmpClient = func() gosnmp.Handler { panic("init panic") }
+
+		require.Panics(t, func() { _ = collr.Init(context.Background()) })
+		cut := store.LifecycleCut()
+		require.Len(t, cut.Entries, 1)
+		require.Equal(t, ddsnmp.DeviceLifecyclePhaseInit, cut.Entries[0].LastCompleted.Phase)
+		require.Equal(t, ddsnmp.DeviceLifecycleOutcomeFailed, cut.Entries[0].LastCompleted.Outcome)
+	})
+
+	t.Run("check", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		store := ddsnmp.NewDeviceStore()
+		collr := New(store)
+		collr.Config = prepareV2Config()
+		mockSNMP := snmpmock.NewMockHandler(ctrl)
+		mockSNMP.EXPECT().WalkAll(gomock.Any()).DoAndReturn(func(string) ([]gosnmp.SnmpPDU, error) {
+			panic("check panic")
+		})
+		collr.snmpClient = mockSNMP
+		collr.beginDeviceLifecycle()
+
+		require.Panics(t, func() { _ = collr.Check(context.Background()) })
+		cut := store.LifecycleCut()
+		require.Len(t, cut.Entries, 1)
+		require.Equal(t, ddsnmp.DeviceLifecyclePhaseCheck, cut.Entries[0].LastCompleted.Phase)
+		require.Equal(t, ddsnmp.DeviceLifecycleOutcomeFailed, cut.Entries[0].LastCompleted.Outcome)
+	})
 }
 
 func TestCollectorManagedConnectionCollectedBeforeCommitIsPublishedAtCommit(t *testing.T) {
@@ -306,7 +419,7 @@ func TestCollectorManagedConnectionCollectedBeforeCommitIsPublishedAtCommit(t *t
 
 	snapshot := hook.Capture(identity, job)
 	require.NotNil(t, snapshot)
-	snapshot.Commit(collectorapi.JobConfigIdentity{})
+	hook.Commit(collectorapi.JobConfigIdentity{}, snapshot, job)
 	require.Len(t, store.Entries(), 1)
 	require.Equal(t, []string{"profile-a"}, store.Entries()[0].Info.ManualProfiles)
 	cut := store.LifecycleCut()

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -5,6 +5,7 @@ package snmp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -205,7 +206,9 @@ func TestCollector_CollectRegistersAndCleanupUnregistersDevice(t *testing.T) {
 	}
 
 	require.NoError(t, collr.Init(context.Background()))
+	assertDeviceLifecycle(t, deviceStore, ddsnmp.DeviceLifecyclePhaseInit, ddsnmp.DeviceLifecycleOutcomeSuccess, false)
 	require.NoError(t, collr.Check(context.Background()))
+	assertDeviceLifecycle(t, deviceStore, ddsnmp.DeviceLifecyclePhaseCheck, ddsnmp.DeviceLifecycleOutcomeSuccess, false)
 	require.Empty(t, deviceStore.Entries())
 
 	_ = collr.Collect(context.Background())
@@ -220,9 +223,110 @@ func TestCollector_CollectRegistersAndCleanupUnregistersDevice(t *testing.T) {
 	assert.Equal(t, "mock sysDescr", entries[0].Info.SysDescr)
 	assert.Equal(t, "mock sysContact", entries[0].Info.SysContact)
 	assert.Equal(t, "mock sysLocation", entries[0].Info.SysLocation)
+	assertDeviceLifecycle(t, deviceStore, ddsnmp.DeviceLifecyclePhaseCollect, ddsnmp.DeviceLifecycleOutcomeSuccess, true)
 
 	collr.Cleanup(context.Background())
 	require.Empty(t, deviceStore.Entries())
+	require.Empty(t, deviceStore.LifecycleCut().Entries)
+}
+
+func TestCollector_InitFailurePublishesSafeLifecycle(t *testing.T) {
+	deviceStore := ddsnmp.NewDeviceStore()
+	collr := New(deviceStore)
+	collr.Config = prepareV3Config()
+	collr.User.Name = ""
+	collr.Community = "must-not-appear-in-lifecycle"
+	collr.User.AuthKey = "must-not-appear-in-lifecycle"
+	collr.User.PrivKey = "must-not-appear-in-lifecycle"
+	collr.ManualProfiles = []string{"/must/not/appear/in/lifecycle.yaml"}
+
+	require.Error(t, collr.Init(context.Background()))
+	cut := deviceStore.LifecycleCut()
+	require.Len(t, cut.Entries, 1)
+	entry := cut.Entries[0]
+	require.Equal(t, ddsnmp.DeviceLifecycleInfo{
+		Hostname:    collr.Hostname,
+		Port:        collr.Options.Port,
+		SNMPVersion: collr.Options.Version,
+	}, entry.Info)
+	require.Equal(t, ddsnmp.DeviceLifecyclePhaseInit, entry.LastCompleted.Phase)
+	require.Equal(t, ddsnmp.DeviceLifecycleOutcomeFailed, entry.LastCompleted.Outcome)
+	require.False(t, entry.TopologyReady)
+	require.NotZero(t, entry.LastCompleted.CompletedAt)
+
+	serialized := fmt.Sprintf("%+v", cut)
+	require.NotContains(t, serialized, collr.Community)
+	require.NotContains(t, serialized, collr.User.AuthKey)
+	require.NotContains(t, serialized, collr.User.PrivKey)
+	require.NotContains(t, serialized, collr.ManualProfiles[0])
+}
+
+func TestCollector_CheckFailureUpdatesLifecycleWithoutTopologyRegistration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSNMP := snmpmock.NewMockHandler(ctrl)
+	setMockClientSetterExpect(mockSNMP)
+	mockSNMP.EXPECT().Connect().Return(errors.New("connect failed")).AnyTimes()
+
+	deviceStore := ddsnmp.NewDeviceStore()
+	collr := New(deviceStore)
+	collr.Config = prepareV2Config()
+	collr.CreateVnode = false
+	collr.Ping.Enabled = false
+	collr.newSnmpClient = func() gosnmp.Handler { return mockSNMP }
+
+	require.NoError(t, collr.Init(context.Background()))
+	require.Error(t, collr.Check(context.Background()))
+	assertDeviceLifecycle(t, deviceStore, ddsnmp.DeviceLifecyclePhaseCheck, ddsnmp.DeviceLifecycleOutcomeFailed, false)
+	require.Empty(t, deviceStore.Entries())
+
+	require.Nil(t, collr.Collect(context.Background()))
+	assertDeviceLifecycle(t, deviceStore, ddsnmp.DeviceLifecyclePhaseCollect, ddsnmp.DeviceLifecycleOutcomeFailed, false)
+	require.Empty(t, deviceStore.Entries())
+}
+
+func TestCollector_LifecycleDiagnosticsFailOpenOnPanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSNMP := snmpmock.NewMockHandler(ctrl)
+	setMockClientInitExpect(mockSNMP)
+
+	collr := New(ddsnmp.NewDeviceStore())
+	collr.Config = prepareV2Config()
+	collr.deviceLifecycleStore = panickingDeviceLifecycleStore{}
+	collr.newSnmpClient = func() gosnmp.Handler { return mockSNMP }
+
+	require.NotPanics(t, func() {
+		require.NoError(t, collr.Init(context.Background()))
+	})
+}
+
+func assertDeviceLifecycle(
+	t *testing.T,
+	store *ddsnmp.DeviceStore,
+	phase ddsnmp.DeviceLifecyclePhase,
+	outcome ddsnmp.DeviceLifecycleOutcome,
+	topologyReady bool,
+) {
+	t.Helper()
+	cut := store.LifecycleCut()
+	require.Len(t, cut.Entries, 1)
+	require.Equal(t, phase, cut.Entries[0].LastCompleted.Phase)
+	require.Equal(t, outcome, cut.Entries[0].LastCompleted.Outcome)
+	require.Equal(t, topologyReady, cut.Entries[0].TopologyReady)
+	require.NotZero(t, cut.Entries[0].LastCompleted.CompletedAt)
+}
+
+type panickingDeviceLifecycleStore struct{}
+
+func (panickingDeviceLifecycleStore) RegisterJob(string, ddsnmp.DeviceLifecycleInfo) {
+	panic("register lifecycle")
+}
+
+func (panickingDeviceLifecycleStore) RecordJobLifecycle(string, ddsnmp.DeviceLifecycleStatus) {
+	panic("record lifecycle")
 }
 
 func TestCollector_CollectSynchronizesDeviceMetadataOnceWithoutVnode(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
@@ -260,6 +261,68 @@ func TestCollector_InitFailurePublishesSafeLifecycle(t *testing.T) {
 	require.NotContains(t, serialized, collr.User.PrivKey)
 	require.NotContains(t, serialized, collr.ManualProfiles[0])
 }
+
+func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilCommit(t *testing.T) {
+	store := ddsnmp.NewDeviceStore()
+	collr := New(store)
+	collr.Hostname = ""
+	job := snmpLifecycleTestRuntimeJob{collector: collr}
+	hook := newCreator(store).JobConfigLifecycle
+	identity := collectorapi.JobConfigIdentity{1}
+
+	hook.Bind(identity, job)
+	require.Error(t, collr.Init(context.Background()))
+	snapshot := hook.Capture(identity, job)
+	collr.Cleanup(context.Background())
+	require.Empty(t, store.LifecycleCut().Entries)
+
+	snapshot.Commit(collectorapi.JobConfigIdentity{})
+	cut := store.LifecycleCut()
+	require.Len(t, cut.Entries, 1)
+	require.Equal(t, ddsnmp.DeviceLifecyclePhaseInit, cut.Entries[0].LastCompleted.Phase)
+	require.Equal(t, ddsnmp.DeviceLifecycleOutcomeFailed, cut.Entries[0].LastCompleted.Outcome)
+	require.False(t, cut.Entries[0].TopologyReady)
+}
+
+func TestCollectorManagedConnectionCollectedBeforeCommitIsPublishedAtCommit(t *testing.T) {
+	store := ddsnmp.NewDeviceStore()
+	collr := New(store)
+	collr.Config = prepareV2Config()
+	collr.ManualProfiles = []string{"profile-a"}
+	job := snmpLifecycleTestRuntimeJob{collector: collr}
+	hook := newCreator(store).JobConfigLifecycle
+	identity := collectorapi.JobConfigIdentity{1}
+
+	hook.Bind(identity, job)
+	collr.beginDeviceLifecycle()
+	collr.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseInit, nil)
+	collr.registerDeviceState(&snmputils.SysInfo{
+		SysObjectID: "1.3.6.1.4.1.8072.3.2.10",
+		Name:        "switch-a",
+	}, nil)
+	collr.ManualProfiles[0] = "changed"
+	require.Empty(t, store.Entries())
+	require.Empty(t, store.LifecycleCut().Entries)
+
+	snapshot := hook.Capture(identity, job)
+	require.NotNil(t, snapshot)
+	snapshot.Commit(collectorapi.JobConfigIdentity{})
+	require.Len(t, store.Entries(), 1)
+	require.Equal(t, []string{"profile-a"}, store.Entries()[0].Info.ManualProfiles)
+	cut := store.LifecycleCut()
+	require.Len(t, cut.Entries, 1)
+	require.True(t, cut.Entries[0].TopologyReady)
+}
+
+type snmpLifecycleTestRuntimeJob struct {
+	collector *Collector
+}
+
+func (snmpLifecycleTestRuntimeJob) FullName() string   { return "snmp_test" }
+func (snmpLifecycleTestRuntimeJob) ModuleName() string { return "snmp" }
+func (snmpLifecycleTestRuntimeJob) Name() string       { return "test" }
+func (snmpLifecycleTestRuntimeJob) IsRunning() bool    { return false }
+func (j snmpLifecycleTestRuntimeJob) Collector() any   { return j.collector }
 
 func TestCollector_CheckFailureUpdatesLifecycleWithoutTopologyRegistration(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -259,20 +259,6 @@ func (s *DeviceStore) Register(ownerKey string, info DeviceConnectionInfo) {
 	s.mu.Unlock()
 }
 
-// UnregisterDevice removes topology-ready connection state while retaining the
-// configuration-owned lifecycle incarnation.
-func (s *DeviceStore) UnregisterDevice(ownerKey string) {
-	s.mu.Lock()
-	if registrationID, ok := s.ownerRegistrations[ownerKey]; ok {
-		if info, exists := s.devices[registrationID]; exists {
-			s.removeHostnameIndexLocked(ownerKey, info.Hostname)
-			delete(s.devices, registrationID)
-			s.lifecycleSequence++
-		}
-	}
-	s.mu.Unlock()
-}
-
 // Unregister removes a complete job incarnation from the store.
 func (s *DeviceStore) Unregister(ownerKey string) {
 	s.mu.Lock()

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // DeviceConnectionInfo holds SNMP connection parameters for a device.
@@ -60,11 +61,66 @@ type DeviceEntry struct {
 	Info           DeviceConnectionInfo
 }
 
+// DeviceLifecycleInfo is the credential-free configured identity of an SNMP
+// job. It is available before the job has enough device state for topology.
+type DeviceLifecycleInfo struct {
+	Hostname    string
+	Port        int
+	SNMPVersion string
+}
+
+// DeviceLifecyclePhase identifies the last completed collector lifecycle call.
+type DeviceLifecyclePhase uint8
+
+const (
+	DeviceLifecyclePhaseUnknown DeviceLifecyclePhase = iota
+	DeviceLifecyclePhaseInit
+	DeviceLifecyclePhaseCheck
+	DeviceLifecyclePhaseCollect
+)
+
+// DeviceLifecycleOutcome identifies the result of a completed lifecycle call.
+type DeviceLifecycleOutcome uint8
+
+const (
+	DeviceLifecycleOutcomeUnknown DeviceLifecycleOutcome = iota
+	DeviceLifecycleOutcomeSuccess
+	DeviceLifecycleOutcomeFailed
+)
+
+// DeviceLifecycleStatus describes the last completed lifecycle call.
+type DeviceLifecycleStatus struct {
+	Phase       DeviceLifecyclePhase
+	Outcome     DeviceLifecycleOutcome
+	CompletedAt time.Time
+}
+
+// DeviceLifecycleEntry is one current normal-SNMP job incarnation.
+type DeviceLifecycleEntry struct {
+	RegistrationID DeviceRegistrationID
+	Info           DeviceLifecycleInfo
+	LastCompleted  DeviceLifecycleStatus
+	TopologyReady  bool
+}
+
+// DeviceLifecycleCut is an immutable, independently sequenced snapshot of all
+// current normal-SNMP job incarnations.
+type DeviceLifecycleCut struct {
+	Sequence uint64
+	Entries  []DeviceLifecycleEntry
+}
+
+type deviceLifecycleRecord struct {
+	info          DeviceLifecycleInfo
+	lastCompleted DeviceLifecycleStatus
+}
+
 // NewDeviceStore returns an empty SNMP device connection-state store.
 func NewDeviceStore() *DeviceStore {
 	return &DeviceStore{
 		ownerRegistrations: make(map[string]DeviceRegistrationID),
 		devices:            make(map[DeviceRegistrationID]DeviceConnectionInfo),
+		lifecycles:         make(map[DeviceRegistrationID]deviceLifecycleRecord),
 		byHostname:         make(map[string]map[string]struct{}),
 	}
 }
@@ -74,8 +130,71 @@ type DeviceStore struct {
 	mu                 sync.RWMutex
 	ownerRegistrations map[string]DeviceRegistrationID
 	devices            map[DeviceRegistrationID]DeviceConnectionInfo
+	lifecycles         map[DeviceRegistrationID]deviceLifecycleRecord
 	byHostname         map[string]map[string]struct{}
 	lastRegistrationID DeviceRegistrationID
+	lifecycleSequence  uint64
+}
+
+// RegisterJob starts or updates the credential-free lifecycle row for a
+// normal-SNMP job. Its registration ID is retained if connection state is
+// registered later.
+func (s *DeviceStore) RegisterJob(ownerKey string, info DeviceLifecycleInfo) {
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	registrationID, exists := s.ownerRegistrations[ownerKey]
+	if !exists {
+		registrationID = s.nextRegistrationIDLocked()
+		s.ownerRegistrations[ownerKey] = registrationID
+	}
+	record := s.lifecycles[registrationID]
+	record.info = info
+	s.lifecycles[registrationID] = record
+	s.lifecycleSequence++
+	s.mu.Unlock()
+}
+
+// RecordJobLifecycle updates the last completed lifecycle call for a current
+// normal-SNMP job. Unknown owner keys are ignored so diagnostics cannot create
+// a second, incomplete incarnation.
+func (s *DeviceStore) RecordJobLifecycle(ownerKey string, status DeviceLifecycleStatus) {
+	s.mu.Lock()
+	if registrationID, ok := s.ownerRegistrations[ownerKey]; ok {
+		record := s.lifecycles[registrationID]
+		record.lastCompleted = status
+		s.lifecycles[registrationID] = record
+		s.lifecycleSequence++
+	}
+	s.mu.Unlock()
+}
+
+// LifecycleCut returns a deterministic snapshot of all current normal-SNMP
+// jobs, including jobs that are not yet topology-ready.
+func (s *DeviceStore) LifecycleCut() DeviceLifecycleCut {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	registrationIDs := make([]DeviceRegistrationID, 0, len(s.ownerRegistrations))
+	for _, registrationID := range s.ownerRegistrations {
+		registrationIDs = append(registrationIDs, registrationID)
+	}
+	slices.Sort(registrationIDs)
+
+	cut := DeviceLifecycleCut{
+		Sequence: s.lifecycleSequence,
+		Entries:  make([]DeviceLifecycleEntry, 0, len(registrationIDs)),
+	}
+	for _, registrationID := range registrationIDs {
+		record := s.lifecycles[registrationID]
+		_, topologyReady := s.devices[registrationID]
+		cut.Entries = append(cut.Entries, DeviceLifecycleEntry{
+			RegistrationID: registrationID,
+			Info:           record.info,
+			LastCompleted:  record.lastCompleted,
+			TopologyReady:  topologyReady,
+		})
+	}
+	return cut
 }
 
 // Register adds or updates a device by its caller-owned lookup key. An update
@@ -92,7 +211,11 @@ func (s *DeviceStore) Register(ownerKey string, info DeviceConnectionInfo) {
 		s.ownerRegistrations[ownerKey] = registrationID
 	}
 	s.devices[registrationID] = cloneDeviceConnectionInfo(info)
+	record := s.lifecycles[registrationID]
+	record.info = lifecycleInfoFromDeviceConnection(info)
+	s.lifecycles[registrationID] = record
 	s.addHostnameIndexLocked(ownerKey, info.Hostname)
+	s.lifecycleSequence++
 	s.mu.Unlock()
 }
 
@@ -100,9 +223,13 @@ func (s *DeviceStore) Register(ownerKey string, info DeviceConnectionInfo) {
 func (s *DeviceStore) Unregister(ownerKey string) {
 	s.mu.Lock()
 	if registrationID, ok := s.ownerRegistrations[ownerKey]; ok {
-		s.removeHostnameIndexLocked(ownerKey, s.devices[registrationID].Hostname)
+		if info, exists := s.devices[registrationID]; exists {
+			s.removeHostnameIndexLocked(ownerKey, info.Hostname)
+		}
 		delete(s.devices, registrationID)
+		delete(s.lifecycles, registrationID)
 		delete(s.ownerRegistrations, ownerKey)
+		s.lifecycleSequence++
 	}
 	s.mu.Unlock()
 }
@@ -183,6 +310,14 @@ func cloneDeviceConnectionInfo(info DeviceConnectionInfo) DeviceConnectionInfo {
 	return dev
 }
 
+func lifecycleInfoFromDeviceConnection(info DeviceConnectionInfo) DeviceLifecycleInfo {
+	return DeviceLifecycleInfo{
+		Hostname:    info.Hostname,
+		Port:        info.Port,
+		SNMPVersion: info.SNMPVersion,
+	}
+}
+
 func (s *DeviceStore) ensureMapsLocked() {
 	if s.ownerRegistrations == nil {
 		s.ownerRegistrations = make(map[string]DeviceRegistrationID)
@@ -190,10 +325,20 @@ func (s *DeviceStore) ensureMapsLocked() {
 	if s.devices == nil {
 		s.devices = make(map[DeviceRegistrationID]DeviceConnectionInfo)
 	}
+	if s.lifecycles == nil {
+		s.lifecycles = make(map[DeviceRegistrationID]deviceLifecycleRecord)
+		for _, registrationID := range s.ownerRegistrations {
+			if info, ok := s.devices[registrationID]; ok {
+				s.lifecycles[registrationID] = deviceLifecycleRecord{info: lifecycleInfoFromDeviceConnection(info)}
+			}
+		}
+	}
 	if s.byHostname == nil {
 		s.byHostname = make(map[string]map[string]struct{})
 		for ownerKey, registrationID := range s.ownerRegistrations {
-			s.addHostnameIndexLocked(ownerKey, s.devices[registrationID].Hostname)
+			if info, ok := s.devices[registrationID]; ok {
+				s.addHostnameIndexLocked(ownerKey, info.Hostname)
+			}
 		}
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -106,8 +106,9 @@ type DeviceLifecycleEntry struct {
 // DeviceLifecycleCut is an immutable, independently sequenced snapshot of all
 // current normal-SNMP job incarnations.
 type DeviceLifecycleCut struct {
-	Sequence uint64
-	Entries  []DeviceLifecycleEntry
+	Sequence   uint64
+	CapturedAt time.Time
+	Entries    []DeviceLifecycleEntry
 }
 
 type deviceLifecycleRecord struct {
@@ -181,8 +182,9 @@ func (s *DeviceStore) LifecycleCut() DeviceLifecycleCut {
 	slices.Sort(registrationIDs)
 
 	cut := DeviceLifecycleCut{
-		Sequence: s.lifecycleSequence,
-		Entries:  make([]DeviceLifecycleEntry, 0, len(registrationIDs)),
+		Sequence:   s.lifecycleSequence,
+		CapturedAt: time.Now(),
+		Entries:    make([]DeviceLifecycleEntry, 0, len(registrationIDs)),
 	}
 	for _, registrationID := range registrationIDs {
 		record := s.lifecycles[registrationID]
@@ -195,6 +197,44 @@ func (s *DeviceStore) LifecycleCut() DeviceLifecycleCut {
 		})
 	}
 	return cut
+}
+
+// ReplaceJob atomically removes a prior configuration incarnation, when
+// different, and publishes the current lifecycle plus any topology-ready state.
+func (s *DeviceStore) ReplaceJob(
+	previousOwnerKey string,
+	ownerKey string,
+	info DeviceLifecycleInfo,
+	status DeviceLifecycleStatus,
+	device *DeviceConnectionInfo,
+) {
+	if ownerKey == "" {
+		return
+	}
+	s.mu.Lock()
+	s.ensureMapsLocked()
+	if previousOwnerKey != "" && previousOwnerKey != ownerKey {
+		s.removeRegistrationLocked(previousOwnerKey)
+	}
+	registrationID, exists := s.ownerRegistrations[ownerKey]
+	if !exists {
+		registrationID = s.nextRegistrationIDLocked()
+		s.ownerRegistrations[ownerKey] = registrationID
+	} else if device, ok := s.devices[registrationID]; ok {
+		s.removeHostnameIndexLocked(ownerKey, device.Hostname)
+		delete(s.devices, registrationID)
+	}
+	s.lifecycles[registrationID] = deviceLifecycleRecord{
+		info:          info,
+		lastCompleted: status,
+	}
+	if device != nil {
+		cloned := cloneDeviceConnectionInfo(*device)
+		s.devices[registrationID] = cloned
+		s.addHostnameIndexLocked(ownerKey, cloned.Hostname)
+	}
+	s.lifecycleSequence++
+	s.mu.Unlock()
 }
 
 // Register adds or updates a device by its caller-owned lookup key. An update
@@ -219,19 +259,41 @@ func (s *DeviceStore) Register(ownerKey string, info DeviceConnectionInfo) {
 	s.mu.Unlock()
 }
 
-// Unregister removes a device from the store.
-func (s *DeviceStore) Unregister(ownerKey string) {
+// UnregisterDevice removes topology-ready connection state while retaining the
+// configuration-owned lifecycle incarnation.
+func (s *DeviceStore) UnregisterDevice(ownerKey string) {
 	s.mu.Lock()
 	if registrationID, ok := s.ownerRegistrations[ownerKey]; ok {
 		if info, exists := s.devices[registrationID]; exists {
 			s.removeHostnameIndexLocked(ownerKey, info.Hostname)
+			delete(s.devices, registrationID)
+			s.lifecycleSequence++
 		}
-		delete(s.devices, registrationID)
-		delete(s.lifecycles, registrationID)
-		delete(s.ownerRegistrations, ownerKey)
+	}
+	s.mu.Unlock()
+}
+
+// Unregister removes a complete job incarnation from the store.
+func (s *DeviceStore) Unregister(ownerKey string) {
+	s.mu.Lock()
+	if _, ok := s.ownerRegistrations[ownerKey]; ok {
+		s.removeRegistrationLocked(ownerKey)
 		s.lifecycleSequence++
 	}
 	s.mu.Unlock()
+}
+
+func (s *DeviceStore) removeRegistrationLocked(ownerKey string) {
+	registrationID, ok := s.ownerRegistrations[ownerKey]
+	if !ok {
+		return
+	}
+	if info, exists := s.devices[registrationID]; exists {
+		s.removeHostnameIndexLocked(ownerKey, info.Hostname)
+	}
+	delete(s.devices, registrationID)
+	delete(s.lifecycles, registrationID)
+	delete(s.ownerRegistrations, ownerKey)
 }
 
 // Entries returns a deterministic, deep-copied snapshot of all registered jobs.

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
@@ -70,23 +70,6 @@ func TestDeviceStoreLifecyclePrecedesTopologyRegistration(t *testing.T) {
 	}, cut.Entries[0].Info)
 }
 
-func TestDeviceStoreConnectionCleanupRetainsLifecycle(t *testing.T) {
-	store := NewDeviceStore()
-	store.RegisterJob("switch-a", DeviceLifecycleInfo{Hostname: "192.0.2.10"})
-	store.Register("switch-a", DeviceConnectionInfo{Hostname: "192.0.2.10"})
-
-	before := store.LifecycleCut()
-	require.True(t, before.Entries[0].TopologyReady)
-
-	store.UnregisterDevice("switch-a")
-
-	after := store.LifecycleCut()
-	require.Len(t, after.Entries, 1)
-	require.Equal(t, before.Entries[0].RegistrationID, after.Entries[0].RegistrationID)
-	require.False(t, after.Entries[0].TopologyReady)
-	require.Empty(t, store.Entries())
-}
-
 func TestDeviceStoreReplaceJobCommitsOneIncarnationTransition(t *testing.T) {
 	store := NewDeviceStore()
 	store.RegisterJob("old-config", DeviceLifecycleInfo{Hostname: "192.0.2.10"})

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
@@ -17,8 +17,12 @@ func TestDeviceStoreLifecyclePrecedesTopologyRegistration(t *testing.T) {
 		SNMPVersion: "2c",
 	})
 
+	beforeCut := time.Now()
 	cut := store.LifecycleCut()
+	afterCut := time.Now()
 	require.NotZero(t, cut.Sequence)
+	require.False(t, cut.CapturedAt.Before(beforeCut))
+	require.False(t, cut.CapturedAt.After(afterCut))
 	require.Len(t, cut.Entries, 1)
 	entry := cut.Entries[0]
 	require.NotZero(t, entry.RegistrationID)
@@ -64,6 +68,50 @@ func TestDeviceStoreLifecyclePrecedesTopologyRegistration(t *testing.T) {
 		Port:        161,
 		SNMPVersion: "2c",
 	}, cut.Entries[0].Info)
+}
+
+func TestDeviceStoreConnectionCleanupRetainsLifecycle(t *testing.T) {
+	store := NewDeviceStore()
+	store.RegisterJob("switch-a", DeviceLifecycleInfo{Hostname: "192.0.2.10"})
+	store.Register("switch-a", DeviceConnectionInfo{Hostname: "192.0.2.10"})
+
+	before := store.LifecycleCut()
+	require.True(t, before.Entries[0].TopologyReady)
+
+	store.UnregisterDevice("switch-a")
+
+	after := store.LifecycleCut()
+	require.Len(t, after.Entries, 1)
+	require.Equal(t, before.Entries[0].RegistrationID, after.Entries[0].RegistrationID)
+	require.False(t, after.Entries[0].TopologyReady)
+	require.Empty(t, store.Entries())
+}
+
+func TestDeviceStoreReplaceJobCommitsOneIncarnationTransition(t *testing.T) {
+	store := NewDeviceStore()
+	store.RegisterJob("old-config", DeviceLifecycleInfo{Hostname: "192.0.2.10"})
+	store.Register("old-config", DeviceConnectionInfo{Hostname: "192.0.2.10"})
+	oldCut := store.LifecycleCut()
+	status := DeviceLifecycleStatus{
+		Phase:       DeviceLifecyclePhaseInit,
+		Outcome:     DeviceLifecycleOutcomeFailed,
+		CompletedAt: time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC),
+	}
+
+	store.ReplaceJob("old-config", "new-config", DeviceLifecycleInfo{
+		Hostname:    "192.0.2.20",
+		Port:        1161,
+		SNMPVersion: "3",
+	}, status, nil)
+
+	newCut := store.LifecycleCut()
+	require.Equal(t, oldCut.Sequence+1, newCut.Sequence)
+	require.Len(t, newCut.Entries, 1)
+	require.Greater(t, newCut.Entries[0].RegistrationID, oldCut.Entries[0].RegistrationID)
+	require.Equal(t, "192.0.2.20", newCut.Entries[0].Info.Hostname)
+	require.Equal(t, status, newCut.Entries[0].LastCompleted)
+	require.False(t, newCut.Entries[0].TopologyReady)
+	require.Empty(t, store.Entries())
 }
 
 func TestDeviceStoreLifecycleCleanupAndReincarnation(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
@@ -4,9 +4,113 @@ package ddsnmp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestDeviceStoreLifecyclePrecedesTopologyRegistration(t *testing.T) {
+	store := NewDeviceStore()
+	store.RegisterJob("switch-a", DeviceLifecycleInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: "2c",
+	})
+
+	cut := store.LifecycleCut()
+	require.NotZero(t, cut.Sequence)
+	require.Len(t, cut.Entries, 1)
+	entry := cut.Entries[0]
+	require.NotZero(t, entry.RegistrationID)
+	require.Equal(t, "192.0.2.10", entry.Info.Hostname)
+	require.Equal(t, 161, entry.Info.Port)
+	require.Equal(t, "2c", entry.Info.SNMPVersion)
+	require.Equal(t, DeviceLifecyclePhaseUnknown, entry.LastCompleted.Phase)
+	require.Equal(t, DeviceLifecycleOutcomeUnknown, entry.LastCompleted.Outcome)
+	require.False(t, entry.TopologyReady)
+
+	completedAt := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	store.RecordJobLifecycle("switch-a", DeviceLifecycleStatus{
+		Phase:       DeviceLifecyclePhaseInit,
+		Outcome:     DeviceLifecycleOutcomeFailed,
+		CompletedAt: completedAt,
+	})
+
+	cut = store.LifecycleCut()
+	require.Len(t, cut.Entries, 1)
+	require.Equal(t, entry.RegistrationID, cut.Entries[0].RegistrationID)
+	require.Equal(t, DeviceLifecyclePhaseInit, cut.Entries[0].LastCompleted.Phase)
+	require.Equal(t, DeviceLifecycleOutcomeFailed, cut.Entries[0].LastCompleted.Outcome)
+	require.Equal(t, completedAt, cut.Entries[0].LastCompleted.CompletedAt)
+	require.False(t, cut.Entries[0].TopologyReady)
+
+	store.Register("switch-a", DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: "2c",
+		Community:   "must-not-appear-in-lifecycle",
+		V3AuthKey:   "must-not-appear-in-lifecycle",
+		V3PrivKey:   "must-not-appear-in-lifecycle",
+	})
+
+	require.Len(t, store.Entries(), 1)
+	require.Equal(t, entry.RegistrationID, store.Entries()[0].RegistrationID)
+	cut = store.LifecycleCut()
+	require.Len(t, cut.Entries, 1)
+	require.Equal(t, entry.RegistrationID, cut.Entries[0].RegistrationID)
+	require.True(t, cut.Entries[0].TopologyReady)
+	require.Equal(t, DeviceLifecycleInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: "2c",
+	}, cut.Entries[0].Info)
+}
+
+func TestDeviceStoreLifecycleCleanupAndReincarnation(t *testing.T) {
+	store := NewDeviceStore()
+	store.RegisterJob("switch-a", DeviceLifecycleInfo{Hostname: "192.0.2.10"})
+	first := store.LifecycleCut()
+	require.Len(t, first.Entries, 1)
+
+	store.Unregister("switch-a")
+	require.Empty(t, store.LifecycleCut().Entries)
+	require.Empty(t, store.Entries())
+
+	store.RegisterJob("switch-a", DeviceLifecycleInfo{Hostname: "192.0.2.10"})
+	second := store.LifecycleCut()
+	require.Len(t, second.Entries, 1)
+	require.Greater(t, second.Entries[0].RegistrationID, first.Entries[0].RegistrationID)
+}
+
+func TestDeviceStoreLifecycleCutIsSortedAndIndependent(t *testing.T) {
+	store := NewDeviceStore()
+	store.RegisterJob("switch-b", DeviceLifecycleInfo{Hostname: "switch-b"})
+	store.RegisterJob("switch-a", DeviceLifecycleInfo{Hostname: "switch-a"})
+
+	cut := store.LifecycleCut()
+	require.Len(t, cut.Entries, 2)
+	require.Less(t, cut.Entries[0].RegistrationID, cut.Entries[1].RegistrationID)
+
+	cut.Entries[0].Info.Hostname = "changed"
+	again := store.LifecycleCut()
+	require.Equal(t, "switch-b", again.Entries[0].Info.Hostname)
+}
+
+func BenchmarkDeviceStoreRecordJobLifecycle(b *testing.B) {
+	store := NewDeviceStore()
+	store.RegisterJob("switch-a", DeviceLifecycleInfo{Hostname: "192.0.2.10"})
+	status := DeviceLifecycleStatus{
+		Phase:       DeviceLifecyclePhaseCollect,
+		Outcome:     DeviceLifecycleOutcomeSuccess,
+		CompletedAt: time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		store.RecordJobLifecycle("switch-a", status)
+	}
+}
 
 func TestDeviceStoreDevicesByHostname(t *testing.T) {
 	store := NewDeviceStore()

--- a/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+const deviceLifecycleWarningEvery = time.Hour
+
+type deviceLifecycleStore interface {
+	RegisterJob(string, ddsnmp.DeviceLifecycleInfo)
+	RecordJobLifecycle(string, ddsnmp.DeviceLifecycleStatus)
+}
+
+func (c *Collector) beginDeviceLifecycle() {
+	c.reportDeviceLifecycle(func(store deviceLifecycleStore) {
+		store.RegisterJob(c.deviceStoreOwnerKey(), ddsnmp.DeviceLifecycleInfo{
+			Hostname:    c.Hostname,
+			Port:        c.Options.Port,
+			SNMPVersion: c.Options.Version,
+		})
+	})
+}
+
+func (c *Collector) completeDeviceLifecycle(phase ddsnmp.DeviceLifecyclePhase, err error) {
+	outcome := ddsnmp.DeviceLifecycleOutcomeSuccess
+	if err != nil {
+		outcome = ddsnmp.DeviceLifecycleOutcomeFailed
+	}
+	c.reportDeviceLifecycle(func(store deviceLifecycleStore) {
+		store.RecordJobLifecycle(c.deviceStoreOwnerKey(), ddsnmp.DeviceLifecycleStatus{
+			Phase:       phase,
+			Outcome:     outcome,
+			CompletedAt: time.Now(),
+		})
+	})
+}
+
+func (c *Collector) reportDeviceLifecycle(report func(deviceLifecycleStore)) {
+	if c == nil || c.deviceLifecycleStore == nil {
+		return
+	}
+	defer func() {
+		if recover() != nil {
+			c.Limit("snmp:device-lifecycle", 1, deviceLifecycleWarningEvery).
+				Warningf("failed to update SNMP job lifecycle diagnostics")
+		}
+	}()
+	report(c.deviceLifecycleStore)
+}

--- a/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
@@ -38,6 +38,13 @@ func (c *Collector) completeDeviceLifecycle(phase ddsnmp.DeviceLifecyclePhase, e
 	if err != nil {
 		outcome = ddsnmp.DeviceLifecycleOutcomeFailed
 	}
+	c.recordDeviceLifecycle(phase, outcome)
+}
+
+func (c *Collector) recordDeviceLifecycle(
+	phase ddsnmp.DeviceLifecyclePhase,
+	outcome ddsnmp.DeviceLifecycleOutcome,
+) {
 	status := ddsnmp.DeviceLifecycleStatus{
 		Phase:       phase,
 		Outcome:     outcome,

--- a/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
@@ -16,12 +16,20 @@ type deviceLifecycleStore interface {
 }
 
 func (c *Collector) beginDeviceLifecycle() {
+	info := ddsnmp.DeviceLifecycleInfo{
+		Hostname:    c.Hostname,
+		Port:        c.Options.Port,
+		SNMPVersion: c.Options.Version,
+	}
+	c.deviceLifecycleMu.Lock()
+	c.deviceLifecycleInfo = info
+	publish := !c.deviceLifecycleManaged || c.deviceLifecycleCommitted
+	c.deviceLifecycleMu.Unlock()
+	if !publish {
+		return
+	}
 	c.reportDeviceLifecycle(func(store deviceLifecycleStore) {
-		store.RegisterJob(c.deviceStoreOwnerKey(), ddsnmp.DeviceLifecycleInfo{
-			Hostname:    c.Hostname,
-			Port:        c.Options.Port,
-			SNMPVersion: c.Options.Version,
-		})
+		store.RegisterJob(c.deviceStoreOwnerKey(), info)
 	})
 }
 
@@ -30,13 +38,67 @@ func (c *Collector) completeDeviceLifecycle(phase ddsnmp.DeviceLifecyclePhase, e
 	if err != nil {
 		outcome = ddsnmp.DeviceLifecycleOutcomeFailed
 	}
+	status := ddsnmp.DeviceLifecycleStatus{
+		Phase:       phase,
+		Outcome:     outcome,
+		CompletedAt: time.Now(),
+	}
+	c.deviceLifecycleMu.Lock()
+	c.deviceLifecycleStatus = status
+	publish := !c.deviceLifecycleManaged || c.deviceLifecycleCommitted
+	c.deviceLifecycleMu.Unlock()
+	if !publish {
+		return
+	}
 	c.reportDeviceLifecycle(func(store deviceLifecycleStore) {
-		store.RecordJobLifecycle(c.deviceStoreOwnerKey(), ddsnmp.DeviceLifecycleStatus{
-			Phase:       phase,
-			Outcome:     outcome,
-			CompletedAt: time.Now(),
-		})
+		store.RecordJobLifecycle(c.deviceStoreOwnerKey(), status)
 	})
+}
+
+func (c *Collector) bindDeviceLifecycle(owner string) {
+	if c == nil || owner == "" {
+		return
+	}
+	c.deviceLifecycleMu.Lock()
+	defer c.deviceLifecycleMu.Unlock()
+	if c.deviceLifecycleOwner != "" && c.deviceLifecycleOwner != owner {
+		return
+	}
+	c.deviceLifecycleOwner = owner
+	c.deviceLifecycleManaged = true
+	c.deviceLifecycleCommitted = false
+}
+
+func (c *Collector) commitDeviceLifecycle(previousOwner string) {
+	if c == nil || c.deviceStore == nil {
+		return
+	}
+	c.deviceLifecycleMu.Lock()
+	defer c.deviceLifecycleMu.Unlock()
+	defer func() {
+		if recover() != nil {
+			c.Limit("snmp:device-lifecycle", 1, deviceLifecycleWarningEvery).
+				Warningf("failed to update SNMP job lifecycle diagnostics")
+		}
+	}()
+	c.deviceStore.ReplaceJob(
+		previousOwner,
+		c.deviceLifecycleOwner,
+		c.deviceLifecycleInfo,
+		c.deviceLifecycleStatus,
+		c.deviceLifecyclePending,
+	)
+	c.deviceLifecyclePending = nil
+	c.deviceLifecycleCommitted = true
+}
+
+func (c *Collector) deviceLifecycleBoundTo(owner string) bool {
+	if c == nil || owner == "" {
+		return false
+	}
+	c.deviceLifecycleMu.Lock()
+	defer c.deviceLifecycleMu.Unlock()
+	return c.deviceLifecycleManaged && c.deviceLifecycleOwner == owner
 }
 
 func (c *Collector) reportDeviceLifecycle(report func(deviceLifecycleStore)) {

--- a/src/go/plugin/go.d/collector/snmp/device_state.go
+++ b/src/go/plugin/go.d/collector/snmp/device_state.go
@@ -5,6 +5,7 @@ package snmp
 import (
 	"fmt"
 	"maps"
+	"slices"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
@@ -43,7 +44,21 @@ func (c *Collector) vnodeLabels() map[string]string {
 }
 
 func (c *Collector) deviceStoreOwnerKey() string {
+	c.deviceLifecycleMu.Lock()
+	defer c.deviceLifecycleMu.Unlock()
+	if c.deviceLifecycleOwner != "" {
+		return c.deviceLifecycleOwner
+	}
 	return fmt.Sprintf("%p:%s:%d", c, c.Hostname, c.Options.Port)
+}
+
+func (c *Collector) deviceStoreCleanupKey() (string, bool) {
+	c.deviceLifecycleMu.Lock()
+	defer c.deviceLifecycleMu.Unlock()
+	if c.deviceLifecycleOwner != "" {
+		return c.deviceLifecycleOwner, c.deviceLifecycleManaged
+	}
+	return fmt.Sprintf("%p:%s:%d", c, c.Hostname, c.Options.Port), false
 }
 
 // registerDeviceState exposes the already-configured SNMP job to SNMP-family
@@ -60,7 +75,7 @@ func (c *Collector) registerDeviceState(si *snmputils.SysInfo, profileMetadata m
 		vnodeLabels,
 	)
 
-	c.deviceStore.Register(c.deviceStoreOwnerKey(), ddsnmp.DeviceConnectionInfo{
+	c.publishDeviceState(ddsnmp.DeviceConnectionInfo{
 		Hostname:        c.Hostname,
 		Port:            c.Options.Port,
 		SNMPVersion:     c.Options.Version,
@@ -85,11 +100,29 @@ func (c *Collector) registerDeviceState(si *snmputils.SysInfo, profileMetadata m
 		Model:           model,
 
 		DisableBulkWalk: c.disableBulkWalk,
-		ManualProfiles:  c.ManualProfiles,
+		ManualProfiles:  slices.Clone(c.ManualProfiles),
 		VnodeGUID:       c.vnodeGUID(),
 		VnodeHostname:   c.vnodeHostname(),
 		VnodeLabels:     vnodeLabels,
 	})
+}
+
+func (c *Collector) publishDeviceState(info ddsnmp.DeviceConnectionInfo) {
+	c.deviceLifecycleMu.Lock()
+	if c.deviceLifecycleManaged && !c.deviceLifecycleCommitted {
+		pending := info
+		pending.ManualProfiles = slices.Clone(info.ManualProfiles)
+		pending.VnodeLabels = maps.Clone(info.VnodeLabels)
+		c.deviceLifecyclePending = &pending
+		c.deviceLifecycleMu.Unlock()
+		return
+	}
+	ownerKey := c.deviceLifecycleOwner
+	if ownerKey == "" {
+		ownerKey = fmt.Sprintf("%p:%s:%d", c, c.Hostname, c.Options.Port)
+	}
+	c.deviceLifecycleMu.Unlock()
+	c.deviceStore.Register(ownerKey, info)
 }
 
 func (c *Collector) syncDeviceMetadata(pms []*ddsnmp.ProfileMetrics) {

--- a/src/go/plugin/go.d/collector/snmp/device_state.go
+++ b/src/go/plugin/go.d/collector/snmp/device_state.go
@@ -36,9 +36,7 @@ func (c *Collector) vnodeHostname() string {
 
 func (c *Collector) vnodeLabels() map[string]string {
 	if c.vnode != nil && len(c.vnode.Labels) > 0 {
-		cp := make(map[string]string, len(c.vnode.Labels))
-		maps.Copy(cp, c.vnode.Labels)
-		return cp
+		return c.vnode.Labels
 	}
 	return nil
 }
@@ -100,7 +98,7 @@ func (c *Collector) registerDeviceState(si *snmputils.SysInfo, profileMetadata m
 		Model:           model,
 
 		DisableBulkWalk: c.disableBulkWalk,
-		ManualProfiles:  slices.Clone(c.ManualProfiles),
+		ManualProfiles:  c.ManualProfiles,
 		VnodeGUID:       c.vnodeGUID(),
 		VnodeHostname:   c.vnodeHostname(),
 		VnodeLabels:     vnodeLabels,

--- a/src/go/plugin/go.d/collector/snmp/job_config_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/job_config_lifecycle.go
@@ -15,6 +15,26 @@ func newSNMPJobConfigLifecycle(store *ddsnmp.DeviceStore) collectorapi.JobConfig
 	return &snmpJobConfigLifecycle{store: store}
 }
 
+func (*snmpJobConfigLifecycle) Project(
+	identity collectorapi.JobConfigIdentity,
+	config map[string]any,
+) collectorapi.JobConfigLifecycleSnapshot {
+	if !identity.Valid() {
+		return nil
+	}
+	defaults := defaultConfig()
+	info := ddsnmp.DeviceLifecycleInfo{
+		Hostname:    stringConfigValue(config, "hostname", defaults.Hostname),
+		Port:        defaults.Options.Port,
+		SNMPVersion: defaults.Options.Version,
+	}
+	if options := nestedConfigMap(config["options"]); options != nil {
+		info.Port = intConfigValue(options, "port", info.Port)
+		info.SNMPVersion = stringConfigValue(options, "version", info.SNMPVersion)
+	}
+	return &snmpJobConfigLifecycleSnapshot{identity: identity, info: info}
+}
+
 func (*snmpJobConfigLifecycle) Bind(identity collectorapi.JobConfigIdentity, job collectorapi.RuntimeJob) {
 	if collector := snmpCollectorFromRuntimeJob(job); collector != nil {
 		collector.bindDeviceLifecycle(identity.String())
@@ -29,7 +49,31 @@ func (*snmpJobConfigLifecycle) Capture(
 	if collector == nil || !collector.deviceLifecycleBoundTo(identity.String()) {
 		return nil
 	}
-	return &snmpJobConfigLifecycleSnapshot{identity: identity, collector: collector}
+	collector.deviceLifecycleMu.Lock()
+	snapshot := &snmpJobConfigLifecycleSnapshot{
+		identity: identity,
+		info:     collector.deviceLifecycleInfo,
+		status:   collector.deviceLifecycleStatus,
+	}
+	collector.deviceLifecycleMu.Unlock()
+	return snapshot
+}
+
+func (l *snmpJobConfigLifecycle) Commit(
+	previous collectorapi.JobConfigIdentity,
+	snapshot collectorapi.JobConfigLifecycleSnapshot,
+	job collectorapi.RuntimeJob,
+) {
+	current, ok := snmpLifecycleSnapshot(snapshot)
+	if !ok || l == nil || l.store == nil {
+		return
+	}
+	collector := snmpCollectorFromRuntimeJob(job)
+	if collector == nil || !collector.deviceLifecycleBoundTo(current.identity.String()) {
+		l.store.ReplaceJob(previous.String(), current.identity.String(), current.info, current.status, nil)
+		return
+	}
+	collector.commitDeviceLifecycle(previous.String())
 }
 
 func (l *snmpJobConfigLifecycle) Remove(identity collectorapi.JobConfigIdentity) {
@@ -47,8 +91,9 @@ func snmpCollectorFromRuntimeJob(job collectorapi.RuntimeJob) *Collector {
 }
 
 type snmpJobConfigLifecycleSnapshot struct {
-	identity  collectorapi.JobConfigIdentity
-	collector *Collector
+	identity collectorapi.JobConfigIdentity
+	info     ddsnmp.DeviceLifecycleInfo
+	status   ddsnmp.DeviceLifecycleStatus
 }
 
 func (s *snmpJobConfigLifecycleSnapshot) Identity() collectorapi.JobConfigIdentity {
@@ -58,8 +103,50 @@ func (s *snmpJobConfigLifecycleSnapshot) Identity() collectorapi.JobConfigIdenti
 	return s.identity
 }
 
-func (s *snmpJobConfigLifecycleSnapshot) Commit(previous collectorapi.JobConfigIdentity) {
-	if s != nil && s.collector != nil {
-		s.collector.commitDeviceLifecycle(previous.String())
+func snmpLifecycleSnapshot(
+	snapshot collectorapi.JobConfigLifecycleSnapshot,
+) (*snmpJobConfigLifecycleSnapshot, bool) {
+	current, ok := snapshot.(*snmpJobConfigLifecycleSnapshot)
+	return current, ok && current != nil && current.identity.Valid()
+}
+
+func nestedConfigMap(value any) map[string]any {
+	switch value := value.(type) {
+	case map[string]any:
+		return value
+	case map[any]any:
+		result := make(map[string]any, len(value))
+		for key, item := range value {
+			if key, ok := key.(string); ok {
+				result[key] = item
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func stringConfigValue(config map[string]any, key string, fallback string) string {
+	if value, ok := config[key].(string); ok {
+		return value
+	}
+	return fallback
+}
+
+func intConfigValue(config map[string]any, key string, fallback int) int {
+	switch value := config[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case uint:
+		return int(value)
+	case uint64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return fallback
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/job_config_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/job_config_lifecycle.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+type snmpJobConfigLifecycle struct {
+	store *ddsnmp.DeviceStore
+}
+
+func newSNMPJobConfigLifecycle(store *ddsnmp.DeviceStore) collectorapi.JobConfigLifecycle {
+	return &snmpJobConfigLifecycle{store: store}
+}
+
+func (*snmpJobConfigLifecycle) Bind(identity collectorapi.JobConfigIdentity, job collectorapi.RuntimeJob) {
+	if collector := snmpCollectorFromRuntimeJob(job); collector != nil {
+		collector.bindDeviceLifecycle(identity.String())
+	}
+}
+
+func (*snmpJobConfigLifecycle) Capture(
+	identity collectorapi.JobConfigIdentity,
+	job collectorapi.RuntimeJob,
+) collectorapi.JobConfigLifecycleSnapshot {
+	collector := snmpCollectorFromRuntimeJob(job)
+	if collector == nil || !collector.deviceLifecycleBoundTo(identity.String()) {
+		return nil
+	}
+	return &snmpJobConfigLifecycleSnapshot{identity: identity, collector: collector}
+}
+
+func (l *snmpJobConfigLifecycle) Remove(identity collectorapi.JobConfigIdentity) {
+	if l != nil && l.store != nil {
+		l.store.Unregister(identity.String())
+	}
+}
+
+func snmpCollectorFromRuntimeJob(job collectorapi.RuntimeJob) *Collector {
+	if job == nil {
+		return nil
+	}
+	collector, _ := job.Collector().(*Collector)
+	return collector
+}
+
+type snmpJobConfigLifecycleSnapshot struct {
+	identity  collectorapi.JobConfigIdentity
+	collector *Collector
+}
+
+func (s *snmpJobConfigLifecycleSnapshot) Identity() collectorapi.JobConfigIdentity {
+	if s == nil {
+		return collectorapi.JobConfigIdentity{}
+	}
+	return s.identity
+}
+
+func (s *snmpJobConfigLifecycleSnapshot) Commit(previous collectorapi.JobConfigIdentity) {
+	if s != nil && s.collector != nil {
+		s.collector.commitDeviceLifecycle(previous.String())
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/job_config_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/job_config_lifecycle.go
@@ -59,7 +59,7 @@ func (*snmpJobConfigLifecycle) Capture(
 	return snapshot
 }
 
-func (l *snmpJobConfigLifecycle) Commit(
+func (l *snmpJobConfigLifecycle) Reconcile(
 	previous collectorapi.JobConfigIdentity,
 	snapshot collectorapi.JobConfigLifecycleSnapshot,
 	job collectorapi.RuntimeJob,

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -229,6 +229,20 @@ Ingestion is split by source area:
 - `topology_bgp_peers.go`
 - `topology_vlan_context_*.go`
 
+Every successful device refresh also retains a bounded semantic replay input.
+The live builder and the replay path share one ordered event dispatcher for
+system uptime, profile tags, topology rows, BGP rows, and successful VLAN-context
+rows. The retained projection keeps only fields consumed by those builder
+operations; credentials, profile source paths, metric names, values, and other
+collector output are not copied.
+
+Semantic capture has direct per-device record and logical-byte limits. The
+projection checks an event before copying it. Limit exhaustion, projection
+errors, or projection panics mark the generation's capture unavailable and
+release partial evidence without changing collection, builder ingestion, or
+topology publication. Replay reconstructs the allowlisted inputs and invokes
+the same event dispatcher; it rejects a missing or reordered main phase.
+
 `topology_cache_metric_dispatch.go` maps `ddsnmp.TopologyKind` values to the
 right builder ingester. Profile tags and device metadata are applied separately
 because they describe the device itself rather than one topology row.
@@ -240,6 +254,7 @@ Finalization converts the builder into an immutable `topologyDeviceGeneration`:
 - immutable trap-match, interface-name, and neighbor indexes;
 - collection and expiry timestamps;
 - the typed DeviceStore registration ID.
+- a generation-local evidence reference and semantic capture state/input.
 
 The collector separately owns `deviceRefreshState` per registration ID. It
 tracks `lastAttempt`, `lastSuccess`, `nextRetry`, the latest outcome,

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -38,7 +38,7 @@ flowchart LR
     Init --> Traps
     ReverseDNS --> Topology
     ReverseDNS --> Traps
-    SNMP -->|"registers devices"| Store
+    SNMP -->|"committed lifecycle and device state"| Store
     Store -->|"device connection state"| Topology
     Topology -->|"trap topology enrichment"| TrapHandle
     TrapHandle -->|"interface/device context"| Traps
@@ -100,13 +100,13 @@ refreshTopology(ctx)
   build a plan of jobs whose next retry/refresh is due
   resolve planned DNS targets with up to eight workers under one shared 5s budget
   for each planned job, in registration-ID order:
-    refreshDeviceTopology(ctx, registrationID, device, targetManagementIPs)
+    refreshDeviceTopology(ctx, registrationID, device, targetManagementIPs, remainingSemanticLimits)
     update lastAttempt, lastSuccess, nextRetry, outcome, and failure count
   prune state for jobs no longer registered
   activate successful snapshots with one publication-based freshness deadline
   atomically publish one immutable TopologyGeneration for the complete sweep
 
-refreshDeviceTopology(ctx, registrationID, device, targetManagementIPs)
+refreshDeviceTopology(ctx, registrationID, device, targetManagementIPs, semanticLimits)
   connect to the device with gosnmp
   select topology profiles
   collect topology ProfileMetrics with ddsnmpcollector
@@ -135,14 +135,22 @@ rebuilt `hostname:port` key. Two SNMP jobs targeting the same endpoint therefore
 keep independent refresh state and device generations, and a replacement job
 cannot inherit the removed job's retry or warning-limiter state.
 
-The registration lifetime now begins when the normal SNMP job enters `Init`,
-before system information, profile selection, or vnode setup can succeed.
-`LifecycleCut` provides a separately sequenced snapshot of every current job's
-credential-free configured identity, last completed lifecycle phase/outcome,
-and topology-readiness state. Later connection-state registration reuses the
-same registration ID, while `Entries` remains limited to topology-ready jobs.
-Lifecycle reporting is diagnostic-only: failures or panics are rate-limited and
-cannot change collector lifecycle results. Cleanup removes both views together.
+The normal SNMP collector records lifecycle phase/outcome locally from `Init`,
+before system information, profile selection, or vnode setup can succeed. Job
+Manager publishes that snapshot only after the matching running/failed DynCfg
+graph row commits. Failed candidate cleanup therefore cannot erase the job, and
+an uncommitted candidate cannot appear in topology. Configuration replacement
+atomically replaces the prior lifecycle incarnation; configuration removal owns
+full deletion. Normal collector cleanup removes only topology-ready connection
+state.
+
+`LifecycleCut` provides a separately sequenced and timestamped snapshot of every
+committed job's credential-free configured identity, last completed lifecycle
+phase/outcome, and topology-readiness state. Connection state collected before
+graph commit is held once by the collector and flushed atomically with the
+lifecycle row; later updates retain the same registration ID. `Entries` remains
+limited to topology-ready jobs. Lifecycle reporting is diagnostic-only:
+failures or panics are rate-limited and cannot change collector or graph results.
 
 Only due DNS targets enter the lookup phase; IP literals bypass the resolver.
 The workers are joined before SNMP collection begins, stop with the refresh
@@ -177,11 +185,15 @@ last successful evidence reference and capture state, and whether that retained
 generation is renderable or expired. Registrations removed since the preceding
 cut are recorded separately. A canceled or panicking sweep leaves both the
 published topology generation and its cut unchanged and replaces only one
-bounded last-aborted marker.
+bounded last-aborted marker. That marker records the sweep phase and, during
+device refresh, the active registration ID.
 
 Per-device semantic limits and one global latest-view record/logical-byte limit
-are checked directly. The global limit includes retained semantic evidence and
-sweep rows; lifecycle rows are admitted independently against the remaining
+are checked directly. One serial usage counter includes sweep rows, non-due
+retained evidence, and each due device's new-or-retained evidence in registration
+order. The remaining allowance reaches the recorder before it copies an event,
+so peak optional evidence is globally bounded rather than capped after all due
+devices finish. Lifecycle rows are admitted independently against the remaining
 budget when diagnostics are acquired. There are no reservations, sessions,
 queues, or attempt ledgers.
 
@@ -253,9 +265,10 @@ Ingestion is split by source area:
 Every successful device refresh also retains a bounded semantic replay input.
 The live builder and the replay path share one ordered event dispatcher for
 system uptime, profile tags, topology rows, BGP rows, and successful VLAN-context
-rows. The retained projection keeps only fields consumed by those builder
-operations; credentials, profile source paths, metric names, values, and other
-collector output are not copied.
+rows. The retained projection uses positive per-event/per-topology-kind field
+allowlists. It keeps only metadata, tags, rows, and BGP fallback tags consumed by
+those builder operations; non-VLAN rows in VLAN events, credentials, profile
+source paths, metric names, values, and other collector output are not copied.
 
 Semantic capture has direct per-device record and logical-byte limits. The
 projection checks an event before copying it. Limit exhaustion, projection

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -186,13 +186,13 @@ Diagnostics preserve two intentionally independent inventory cuts:
 - the topology sweep cut attached to the same immutable generation as the
   Function-visible device vector.
 
-The topology cut retains the exact start-of-sweep registration vector. Each row
-separates whether the job was selected, its committed outcome/retry state, its
-last successful evidence reference and capture state, and whether that retained
-generation is renderable or expired. Registrations removed since the preceding
-cut are recorded separately. A canceled or panicking sweep leaves both the
-published topology generation and its cut unchanged and replaces only one
-bounded last-aborted marker. That marker records the sweep phase and, during
+The topology cut's ordered device rows are the exact start-of-sweep registration
+inventory. Each row separates whether the job was selected, its committed
+outcome/retry state, its last successful evidence reference and capture state,
+and whether that retained generation is renderable or expired. Registrations
+removed since the preceding cut are recorded separately. A canceled or
+panicking sweep leaves both the published topology generation and its cut
+unchanged and replaces only one bounded last-aborted marker. That marker records the sweep phase and, during
 device refresh, the active registration ID.
 
 Per-device semantic limits and one global latest-view record/logical-byte limit

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -135,6 +135,15 @@ rebuilt `hostname:port` key. Two SNMP jobs targeting the same endpoint therefore
 keep independent refresh state and device generations, and a replacement job
 cannot inherit the removed job's retry or warning-limiter state.
 
+The registration lifetime now begins when the normal SNMP job enters `Init`,
+before system information, profile selection, or vnode setup can succeed.
+`LifecycleCut` provides a separately sequenced snapshot of every current job's
+credential-free configured identity, last completed lifecycle phase/outcome,
+and topology-readiness state. Later connection-state registration reuses the
+same registration ID, while `Entries` remains limited to topology-ready jobs.
+Lifecycle reporting is diagnostic-only: failures or panics are rate-limited and
+cannot change collector lifecycle results. Cleanup removes both views together.
+
 Only due DNS targets enter the lookup phase; IP literals bypass the resolver.
 The workers are joined before SNMP collection begins, stop with the refresh
 context, and use a lookup-only child context, so expiry of the shared lookup

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -135,22 +135,29 @@ rebuilt `hostname:port` key. Two SNMP jobs targeting the same endpoint therefore
 keep independent refresh state and device generations, and a replacement job
 cannot inherit the removed job's retry or warning-limiter state.
 
-The normal SNMP collector records lifecycle phase/outcome locally from `Init`,
-before system information, profile selection, or vnode setup can succeed. Job
-Manager publishes that snapshot only after the matching running/failed DynCfg
-graph row commits. Failed candidate cleanup therefore cannot erase the job, and
-an uncommitted candidate cannot appear in topology. Configuration replacement
-atomically replaces the prior lifecycle incarnation; configuration removal owns
-full deletion. Normal collector cleanup removes only topology-ready connection
-state.
+Job Manager projects a credential-free normal-SNMP baseline from each committed
+running/failed configuration. The baseline has an unknown phase when vnode,
+secret, or configuration application fails before a runtime collector exists.
+When construction succeeds, the collector records lifecycle phase/outcome
+locally from `Init`, before system information or profile selection can succeed,
+and Job Manager uses that detached value instead. Publication occurs only after
+the matching DynCfg graph row commits, or after a successful transaction confirms
+that its fallback row already matches. Failed candidate cleanup therefore cannot
+erase the incumbent or publish the candidate. Graph reconciliation owns
+connection demotion, incarnation replacement, and full removal; managed
+collector cleanup does not mutate the shared `DeviceStore`.
 
 `LifecycleCut` provides a separately sequenced and timestamped snapshot of every
 committed job's credential-free configured identity, last completed lifecycle
 phase/outcome, and topology-readiness state. Connection state collected before
-graph commit is held once by the collector and flushed atomically with the
-lifecycle row; later updates retain the same registration ID. `Entries` remains
-limited to topology-ready jobs. Lifecycle reporting is diagnostic-only:
-failures or panics are rate-limited and cannot change collector or graph results.
+graph commit is held once by the collector. A successfully accepted runtime is
+consulted transiently during graph reconciliation so that state is flushed
+atomically with the lifecycle row; the detached snapshot never retains the
+collector, its configuration, or its SNMP client. Later updates retain the same
+registration ID. `Entries` remains limited to topology-ready jobs. Lifecycle
+reporting is diagnostic-only: failures or panics are rate-limited and cannot
+change collector or graph results, while a panic in `Init` or `Check` is recorded
+as a failed phase before the framework recovers it.
 
 Only due DNS targets enter the lookup phase; IP literals bypass the resolver.
 The workers are joined before SNMP collection begins, stop with the refresh

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -164,6 +164,27 @@ sweeps. A failed attempt retains the last successful device generation and its
 original freshness deadline; a canceled or panicking sweep does not publish a
 partial vector.
 
+Diagnostics preserve two intentionally independent inventory cuts:
+
+- the current `DeviceStore` lifecycle cut, which can advance when a normal SNMP
+  job initializes, checks, collects, becomes topology-ready, or exits;
+- the topology sweep cut attached to the same immutable generation as the
+  Function-visible device vector.
+
+The topology cut retains the exact start-of-sweep registration vector. Each row
+separates whether the job was selected, its committed outcome/retry state, its
+last successful evidence reference and capture state, and whether that retained
+generation is renderable or expired. Registrations removed since the preceding
+cut are recorded separately. A canceled or panicking sweep leaves both the
+published topology generation and its cut unchanged and replaces only one
+bounded last-aborted marker.
+
+Per-device semantic limits and one global latest-view record/logical-byte limit
+are checked directly. The global limit includes retained semantic evidence and
+sweep rows; lifecycle rows are admitted independently against the remaining
+budget when diagnostics are acquired. There are no reservations, sessions,
+queues, or attempt ledgers.
+
 ## Topology Profile Composition
 
 Topology profile selection uses the shared SNMP profile catalog. Matching is

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/netip"
 	"runtime/debug"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -390,16 +389,14 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	pruneUnregisteredDeviceStates(nextStates, seen)
 	publishedAt := c.currentTime()
 	nextSequence := c.generationSequence + 1
-	registrationIDs := make([]ddsnmp.DeviceRegistrationID, 0, len(successfulSnapshots))
-	for registrationID := range successfulSnapshots {
-		registrationIDs = append(registrationIDs, registrationID)
-	}
-	slices.Sort(registrationIDs)
-	for _, registrationID := range registrationIDs {
-		snapshot := successfulSnapshots[registrationID]
-		state := nextStates[registrationID]
-		state.generation = activateTopologyDeviceSnapshot(registrationID, nextSequence, publishedAt, snapshot)
-		nextStates[registrationID] = state
+	for _, plan := range plans {
+		snapshot, ok := successfulSnapshots[plan.registrationID]
+		if !ok {
+			continue
+		}
+		state := nextStates[plan.registrationID]
+		state.generation = activateTopologyDeviceSnapshot(plan.registrationID, nextSequence, publishedAt, snapshot)
+		nextStates[plan.registrationID] = state
 	}
 	c.deviceStates = nextStates
 	c.generationSequence = nextSequence
@@ -632,15 +629,6 @@ func closeSNMPClientOnContextCancel(ctx context.Context, client gosnmp.Handler) 
 		}
 	}()
 	return func() { close(done) }
-}
-
-func (c *Collector) newDeviceTopologyBuilder(dev ddsnmp.DeviceConnectionInfo) *topologyBuilder {
-	return newTopologyBuilderFromSemanticInput(
-		topologySemanticDeviceInputFromConnection(dev),
-		nil,
-		c.currentTime(),
-		c.refreshEvery()+2*c.deviceCheckEvery(),
-	)
 }
 
 func (c *Collector) currentTopologySemanticLimits() topologySemanticLimits {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -334,10 +334,10 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 			plan.targetManagementIPs,
 			effectiveLimits,
 		)
-		hasActiveRegistration = false
 		if ctx.Err() != nil {
 			break
 		}
+		hasActiveRegistration = false
 		completedAt := c.currentTime()
 
 		state.outcome = outcome

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -11,9 +11,11 @@ import (
 	"net"
 	"net/netip"
 	"runtime/debug"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -75,21 +77,24 @@ func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmen
 	}
 	metricStore := metrix.NewCollectorStore()
 	return &Collector{
-		deviceStates:     make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState),
-		topologyRegistry: newTopologyRegistryWithResolver(reverseDNS),
-		deviceSource:     deviceStore,
-		trapEnrichment:   trapEnrichment,
-		newSnmpClient:    gosnmp.NewHandler,
+		deviceStates:          make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState),
+		topologyRegistry:      newTopologyRegistryWithResolver(reverseDNS),
+		deviceSource:          deviceStore,
+		deviceLifecycleSource: deviceStore,
+		trapEnrichment:        trapEnrichment,
+		newSnmpClient:         gosnmp.NewHandler,
 		newDdSnmpColl: func(cfg ddsnmpcollector.Config) ddCollector {
 			return ddsnmpcollector.New(cfg)
 		},
 		resolveTargetIPs: func(ctx context.Context, host string) ([]netip.Addr, error) {
 			return net.DefaultResolver.LookupNetIP(ctx, "ip", host)
 		},
-		now:            time.Now,
-		semanticLimits: defaultTopologySemanticLimits,
-		store:          metricStore,
-		metrics:        newCollectorMetrics(metricStore),
+		now:                          time.Now,
+		semanticLimits:               defaultTopologySemanticLimits,
+		diagnosticGlobalLimits:       defaultTopologyDiagnosticGlobalLimits,
+		projectTopologyDiagnosticCut: projectTopologyDiagnosticCut,
+		store:                        metricStore,
+		metrics:                      newCollectorMetrics(metricStore),
 	}
 }
 
@@ -98,11 +103,14 @@ type (
 		collectorapi.Base `yaml:",inline"`
 		Config            `yaml:",inline"`
 
-		deviceStates       map[ddsnmp.DeviceRegistrationID]deviceRefreshState
-		generationSequence uint64
-		topologyRegistry   *topologyRegistry
-		deviceSource       deviceSource
-		trapEnrichment     *TrapEnrichmentHandle
+		deviceStates                    map[ddsnmp.DeviceRegistrationID]deviceRefreshState
+		generationSequence              uint64
+		topologyRegistry                *topologyRegistry
+		deviceSource                    deviceSource
+		deviceLifecycleSource           deviceLifecycleSource
+		trapEnrichment                  *TrapEnrichmentHandle
+		lastAbortedTopologyDiagnostic   atomic.Pointer[topologyAbortedSweepDiagnostic]
+		topologyDiagnosticAbortSequence atomic.Uint64
 
 		refreshMu sync.Mutex
 		statsMu   sync.RWMutex
@@ -111,12 +119,14 @@ type (
 		store   metrix.CollectorStore
 		metrics *collectorMetrics
 
-		topologyProfiles func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile
-		newSnmpClient    func() gosnmp.Handler
-		newDdSnmpColl    func(ddsnmpcollector.Config) ddCollector
-		resolveTargetIPs func(context.Context, string) ([]netip.Addr, error)
-		now              func() time.Time
-		semanticLimits   topologySemanticLimits
+		topologyProfiles             func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile
+		newSnmpClient                func() gosnmp.Handler
+		newDdSnmpColl                func(ddsnmpcollector.Config) ddCollector
+		resolveTargetIPs             func(context.Context, string) ([]netip.Addr, error)
+		now                          func() time.Time
+		semanticLimits               topologySemanticLimits
+		diagnosticGlobalLimits       topologySemanticLimits
+		projectTopologyDiagnosticCut topologyDiagnosticCutProjector
 	}
 	deviceSource interface {
 		Entries() []ddsnmp.DeviceEntry
@@ -231,6 +241,7 @@ func (c *Collector) Cleanup(context.Context) {
 
 	c.deviceStates = make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState)
 	c.topologyRegistry.publishGeneration(nil)
+	c.lastAbortedTopologyDiagnostic.Store(nil)
 	c.recordCleanupStats()
 }
 
@@ -240,6 +251,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	defer c.refreshMu.Unlock()
 
 	entries := c.getRegisteredDevices()
+	previousStates := c.deviceStates
 	refreshEvery := c.refreshEvery()
 	now := c.currentTime()
 	seen := make(map[ddsnmp.DeviceRegistrationID]bool, len(entries))
@@ -251,6 +263,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	successfulSnapshots := make(map[ddsnmp.DeviceRegistrationID]*topologyDeviceSnapshot)
 
 	plans := make([]topologyRefreshDevicePlan, 0, len(entries))
+	var selected map[ddsnmp.DeviceRegistrationID]bool
 	for _, entry := range entries {
 		registrationID := entry.RegistrationID
 		dev := entry.Info
@@ -259,6 +272,10 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 		state, exists := nextStates[registrationID]
 		if !exists || state.nextRetry.IsZero() || !now.Before(state.nextRetry) {
 			plans = append(plans, topologyRefreshDevicePlan{registrationID: registrationID, device: dev})
+			if selected == nil {
+				selected = make(map[ddsnmp.DeviceRegistrationID]bool)
+			}
+			selected[registrationID] = true
 		}
 	}
 
@@ -308,6 +325,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	}
 
 	if ctx.Err() != nil {
+		c.publishAbortedTopologyDiagnostic(start, topologyDiagnosticAbortCanceled, len(entries), len(plans))
 		stats.cachedDevices = c.topologyRegistry.acquireGeneration().deviceCount()
 		stats.completedAt = c.currentTime()
 		stats.duration = stats.completedAt.Sub(start)
@@ -315,9 +333,16 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	}
 
 	pruneUnregisteredDeviceStates(nextStates, seen)
+	applyTopologySemanticGlobalLimits(nextStates, successfulSnapshots, c.currentTopologyDiagnosticGlobalLimits())
 	publishedAt := c.currentTime()
 	nextSequence := c.generationSequence + 1
-	for registrationID, snapshot := range successfulSnapshots {
+	registrationIDs := make([]ddsnmp.DeviceRegistrationID, 0, len(successfulSnapshots))
+	for registrationID := range successfulSnapshots {
+		registrationIDs = append(registrationIDs, registrationID)
+	}
+	slices.Sort(registrationIDs)
+	for _, registrationID := range registrationIDs {
+		snapshot := successfulSnapshots[registrationID]
 		state := nextStates[registrationID]
 		state.generation = activateTopologyDeviceSnapshot(registrationID, nextSequence, publishedAt, snapshot)
 		nextStates[registrationID] = state
@@ -325,6 +350,17 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	c.deviceStates = nextStates
 	c.generationSequence = nextSequence
 	generation := newTopologyGeneration(c.generationSequence, publishedAt, nextStates)
+	generation.diagnostic = c.projectCommittedTopologyDiagnosticCut(topologyDiagnosticCutInput{
+		sequence:       c.generationSequence,
+		startedAt:      start,
+		publishedAt:    publishedAt,
+		entries:        entries,
+		selected:       selected,
+		seen:           seen,
+		previousStates: previousStates,
+		states:         nextStates,
+		limits:         c.currentTopologyDiagnosticGlobalLimits(),
+	})
 	c.topologyRegistry.publishGeneration(generation)
 	stats.cachedDevices = generation.deviceCount()
 	stats.completedAt = c.currentTime()
@@ -343,6 +379,7 @@ func (c *Collector) refreshTopologyRecovering(ctx context.Context) {
 	start := time.Now()
 	defer func() {
 		if r := recover(); r != nil {
+			c.publishAbortedTopologyDiagnostic(start, topologyDiagnosticAbortPanic, 0, 0)
 			c.recordRefreshStats(refreshStats{
 				errors:      1,
 				completedAt: time.Now(),
@@ -557,6 +594,13 @@ func (c *Collector) currentTopologySemanticLimits() topologySemanticLimits {
 		return defaultTopologySemanticLimits
 	}
 	return c.semanticLimits
+}
+
+func (c *Collector) currentTopologyDiagnosticGlobalLimits() topologySemanticLimits {
+	if c.diagnosticGlobalLimits.maxRecords == 0 || c.diagnosticGlobalLimits.maxLogicalBytes == 0 {
+		return defaultTopologyDiagnosticGlobalLimits
+	}
+	return c.diagnosticGlobalLimits
 }
 
 func (c *Collector) currentTime() time.Time {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -246,11 +246,30 @@ func (c *Collector) Cleanup(context.Context) {
 }
 
 func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
-	start := c.currentTime()
+	start := safeTopologyDiagnosticTime(c)
+	phase := topologyDiagnosticSweepPhaseRegistrationCut
+	var activeRegistrationID ddsnmp.DeviceRegistrationID
+	var hasActiveRegistration bool
+	var registrationCount, selectedCount int
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			c.publishAbortedTopologyDiagnostic(
+				start,
+				topologyDiagnosticAbortPanic,
+				phase,
+				activeRegistrationID,
+				hasActiveRegistration,
+				registrationCount,
+				selectedCount,
+			)
+			panic(recovered)
+		}
+	}()
 	c.refreshMu.Lock()
 	defer c.refreshMu.Unlock()
 
 	entries := c.getRegisteredDevices()
+	registrationCount = len(entries)
 	previousStates := c.deviceStates
 	refreshEvery := c.refreshEvery()
 	now := c.currentTime()
@@ -278,7 +297,17 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 			selected[registrationID] = true
 		}
 	}
+	selectedCount = len(plans)
+	semanticUsage := newTopologySemanticUsage(
+		entries,
+		seen,
+		selected,
+		previousStates,
+		nextStates,
+		c.currentTopologyDiagnosticGlobalLimits(),
+	)
 
+	phase = topologyDiagnosticSweepPhaseTargetResolution
 	c.resolveTopologyTargetManagementIPs(
 		ctx,
 		plans,
@@ -291,9 +320,21 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 			break
 		}
 		attemptedAt := c.currentTime()
+		phase = topologyDiagnosticSweepPhaseDeviceRefresh
+		activeRegistrationID = plan.registrationID
+		hasActiveRegistration = true
 		state := nextStates[plan.registrationID]
 		state.lastAttempt = attemptedAt
-		snapshot, outcome := c.refreshDeviceTopology(ctx, plan.registrationID, plan.device, plan.targetManagementIPs)
+		perDeviceLimits := c.currentTopologySemanticLimits()
+		effectiveLimits := semanticUsage.availableLimits(perDeviceLimits)
+		snapshot, outcome := c.refreshDeviceTopology(
+			ctx,
+			plan.registrationID,
+			plan.device,
+			plan.targetManagementIPs,
+			effectiveLimits,
+		)
+		hasActiveRegistration = false
 		if ctx.Err() != nil {
 			break
 		}
@@ -302,14 +343,18 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 		state.outcome = outcome
 		switch outcome {
 		case deviceRefreshOutcomeSuccess:
+			snapshot.semantic = classifyTopologySemanticCaptureLimit(snapshot.semantic, effectiveLimits, perDeviceLimits)
+			snapshot.semantic = semanticUsage.include(snapshot.semantic)
 			successfulSnapshots[plan.registrationID] = snapshot
 			state.lastSuccess = completedAt
 			state.consecutiveFailures = 0
 			state.nextRetry = completedAt.Add(refreshEvery)
 		case deviceRefreshOutcomeNoProfiles:
+			state = semanticUsage.includeRetained(state)
 			state.consecutiveFailures = 0
 			state.nextRetry = completedAt.Add(refreshEvery)
 		default:
+			state = semanticUsage.includeRetained(state)
 			if ctx.Err() != nil {
 				break
 			}
@@ -325,15 +370,24 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	}
 
 	if ctx.Err() != nil {
-		c.publishAbortedTopologyDiagnostic(start, topologyDiagnosticAbortCanceled, len(entries), len(plans))
+		c.publishAbortedTopologyDiagnostic(
+			start,
+			topologyDiagnosticAbortCanceled,
+			phase,
+			activeRegistrationID,
+			hasActiveRegistration,
+			registrationCount,
+			selectedCount,
+		)
 		stats.cachedDevices = c.topologyRegistry.acquireGeneration().deviceCount()
 		stats.completedAt = c.currentTime()
 		stats.duration = stats.completedAt.Sub(start)
 		return stats
 	}
 
+	phase = topologyDiagnosticSweepPhaseCommit
+	hasActiveRegistration = false
 	pruneUnregisteredDeviceStates(nextStates, seen)
-	applyTopologySemanticGlobalLimits(nextStates, successfulSnapshots, c.currentTopologyDiagnosticGlobalLimits())
 	publishedAt := c.currentTime()
 	nextSequence := c.generationSequence + 1
 	registrationIDs := make([]ddsnmp.DeviceRegistrationID, 0, len(successfulSnapshots))
@@ -379,7 +433,6 @@ func (c *Collector) refreshTopologyRecovering(ctx context.Context) {
 	start := time.Now()
 	defer func() {
 		if r := recover(); r != nil {
-			c.publishAbortedTopologyDiagnostic(start, topologyDiagnosticAbortPanic, 0, 0)
 			c.recordRefreshStats(refreshStats{
 				errors:      1,
 				completedAt: time.Now(),
@@ -402,6 +455,7 @@ func (c *Collector) refreshDeviceTopology(
 	registrationID ddsnmp.DeviceRegistrationID,
 	dev ddsnmp.DeviceConnectionInfo,
 	targetManagementIPs []netip.Addr,
+	semanticLimits topologySemanticLimits,
 ) (*topologyDeviceSnapshot, deviceRefreshOutcome) {
 	if ctx.Err() != nil {
 		return nil, deviceRefreshOutcomeFailed
@@ -486,7 +540,7 @@ func (c *Collector) refreshDeviceTopology(
 		targetManagementIPs,
 		next.updateTime,
 		next.staleAfter,
-		c.currentTopologySemanticLimits(),
+		semanticLimits,
 	)
 
 	consumeTopologySemanticEvent(next, recorder, topologySemanticEvent{kind: topologySemanticEventSysUptime, sysUptime: sysUptime})

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -86,9 +86,10 @@ func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmen
 		resolveTargetIPs: func(ctx context.Context, host string) ([]netip.Addr, error) {
 			return net.DefaultResolver.LookupNetIP(ctx, "ip", host)
 		},
-		now:     time.Now,
-		store:   metricStore,
-		metrics: newCollectorMetrics(metricStore),
+		now:            time.Now,
+		semanticLimits: defaultTopologySemanticLimits,
+		store:          metricStore,
+		metrics:        newCollectorMetrics(metricStore),
 	}
 }
 
@@ -115,6 +116,7 @@ type (
 		newDdSnmpColl    func(ddsnmpcollector.Config) ddCollector
 		resolveTargetIPs func(context.Context, string) ([]netip.Addr, error)
 		now              func() time.Time
+		semanticLimits   topologySemanticLimits
 	}
 	deviceSource interface {
 		Entries() []ddsnmp.DeviceEntry
@@ -314,13 +316,14 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 
 	pruneUnregisteredDeviceStates(nextStates, seen)
 	publishedAt := c.currentTime()
+	nextSequence := c.generationSequence + 1
 	for registrationID, snapshot := range successfulSnapshots {
 		state := nextStates[registrationID]
-		state.generation = activateTopologyDeviceSnapshot(registrationID, publishedAt, snapshot)
+		state.generation = activateTopologyDeviceSnapshot(registrationID, nextSequence, publishedAt, snapshot)
 		nextStates[registrationID] = state
 	}
 	c.deviceStates = nextStates
-	c.generationSequence++
+	c.generationSequence = nextSequence
 	generation := newTopologyGeneration(c.generationSequence, publishedAt, nextStates)
 	c.topologyRegistry.publishGeneration(generation)
 	stats.cachedDevices = generation.deviceCount()
@@ -434,18 +437,32 @@ func (c *Collector) refreshDeviceTopology(
 
 	// Build the next device generation off-registry. Function readers keep
 	// seeing the previous global generation until collection is fully ingested.
-	next := c.newDeviceTopologyBuilder(dev)
-	next.targetManagementIPs = append([]netip.Addr(nil), targetManagementIPs...)
+	deviceInput := topologySemanticDeviceInputFromConnection(dev)
+	next := newTopologyBuilderFromSemanticInput(
+		deviceInput,
+		targetManagementIPs,
+		c.currentTime(),
+		c.refreshEvery()+2*c.deviceCheckEvery(),
+	)
+	recorder := newTopologySemanticRecorder(
+		deviceInput,
+		targetManagementIPs,
+		next.updateTime,
+		next.staleAfter,
+		c.currentTopologySemanticLimits(),
+	)
 
-	next.updateTopologySysUptime(sysUptime)
-	next.updateTopologyProfileTags(pms)
-	next.ingestTopologyProfileMetrics(pms)
-	next.ingestTopologyBGPPeers(pms)
-	c.collectTopologyVTPVLANContexts(ctx, next, dev)
+	consumeTopologySemanticEvent(next, recorder, topologySemanticEvent{kind: topologySemanticEventSysUptime, sysUptime: sysUptime})
+	consumeTopologySemanticEvent(next, recorder, topologySemanticEvent{kind: topologySemanticEventProfileTags, profiles: pms})
+	consumeTopologySemanticEvent(next, recorder, topologySemanticEvent{kind: topologySemanticEventTopologyMetrics, profiles: pms})
+	consumeTopologySemanticEvent(next, recorder, topologySemanticEvent{kind: topologySemanticEventBGPPeers, profiles: pms})
+	c.collectTopologyVTPVLANContexts(ctx, next, dev, recorder)
 	if ctx.Err() != nil {
 		return nil, deviceRefreshOutcomeFailed
 	}
-	return c.freezeTopologyBuilder(next), deviceRefreshOutcomeSuccess
+	snapshot := c.freezeTopologyBuilder(next)
+	snapshot.semantic = recorder.finish()
+	return snapshot, deviceRefreshOutcomeSuccess
 }
 
 func (c *Collector) warnTopologyRefreshFailure(registrationID ddsnmp.DeviceRegistrationID, class, format string, args ...any) {
@@ -527,12 +544,19 @@ func closeSNMPClientOnContextCancel(ctx context.Context, client gosnmp.Handler) 
 }
 
 func (c *Collector) newDeviceTopologyBuilder(dev ddsnmp.DeviceConnectionInfo) *topologyBuilder {
-	cache := newTopologyBuilder()
-	cache.updateTime = c.currentTime()
-	cache.staleAfter = c.refreshEvery() + 2*c.deviceCheckEvery()
-	cache.agentID = dev.Hostname
-	cache.localDevice = buildLocalTopologyDevice(dev)
-	return cache
+	return newTopologyBuilderFromSemanticInput(
+		topologySemanticDeviceInputFromConnection(dev),
+		nil,
+		c.currentTime(),
+		c.refreshEvery()+2*c.deviceCheckEvery(),
+	)
+}
+
+func (c *Collector) currentTopologySemanticLimits() topologySemanticLimits {
+	if c.semanticLimits.maxRecords == 0 || c.semanticLimits.maxLogicalBytes == 0 {
+		return defaultTopologySemanticLimits
+	}
+	return c.semanticLimits
 }
 
 func (c *Collector) currentTime() time.Time {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -517,6 +517,13 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 	require.Equal(t, now.Add(defaultRefreshEvery), successState.nextRetry)
 	require.Zero(t, successState.consecutiveFailures)
 	require.NotNil(t, successState.generation)
+	require.Equal(t, topologySemanticCaptureAvailable, successState.generation.semantic.state)
+	require.NotNil(t, successState.generation.semantic.evidence)
+	require.Equal(t, registrationID, successState.generation.evidenceRef.registrationID)
+	require.NotZero(t, successState.generation.evidenceRef.generation)
+	replayed, err := replayTopologySemanticEvidence(successState.generation.semantic.evidence)
+	require.NoError(t, err)
+	require.Equal(t, successState.generation.observation, replayed.observation)
 	lastSuccessGeneration := successState.generation
 
 	now = successState.nextRetry
@@ -530,6 +537,40 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 	require.EqualValues(t, 1, failedState.consecutiveFailures)
 	require.False(t, failedState.generation.freshAt(failedState.generation.expiresAt.Add(time.Nanosecond)),
 		"failure retention must not extend the last successful collection's display freshness")
+}
+
+func TestCollectorSuccessfulRefreshSurvivesSemanticCaptureLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: gosnmp.Version2c.String(),
+	}
+	mockHandler := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(mockHandler, dev)
+
+	coll := newTestSNMPTopologyCollector()
+	coll.semanticLimits = topologySemanticLimits{maxRecords: 1, maxLogicalBytes: 1 << 20}
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) {
+			return []*ddsnmp.ProfileMetrics{{TopologyMetrics: []ddsnmp.Metric{{
+				TopologyKind: ddsnmp.KindIfName,
+				Tags:         map[string]string{tagTopoIfIndex: "7", tagTopoIfName: "Gi1/0/7"},
+			}}}}, nil
+		})
+	}
+
+	snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil)
+	require.Equal(t, deviceRefreshOutcomeSuccess, outcome)
+	require.NotNil(t, snapshot)
+	require.True(t, snapshot.hasObservation)
+	require.Equal(t, topologySemanticCaptureLimitExceeded, snapshot.semantic.state)
+	require.Equal(t, topologySemanticCaptureReasonRecordLimit, snapshot.semantic.reason)
+	require.Nil(t, snapshot.semantic.evidence)
 }
 
 func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -446,14 +446,14 @@ func TestCollectorDeviceRefreshWarningsAreLimitedPerRegistrationAndFailureClass(
 	}
 
 	for range 2 {
-		snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil)
+		snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil, coll.currentTopologySemanticLimits())
 		require.Nil(t, snapshot)
 		require.Equal(t, deviceRefreshOutcomeFailed, outcome)
 	}
-	snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil)
+	snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil, coll.currentTopologySemanticLimits())
 	require.Nil(t, snapshot)
 	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
-	snapshot, outcome = coll.refreshDeviceTopology(context.Background(), 2, dev, nil)
+	snapshot, outcome = coll.refreshDeviceTopology(context.Background(), 2, dev, nil, coll.currentTopologySemanticLimits())
 	require.Nil(t, snapshot)
 	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
 
@@ -586,7 +586,7 @@ func TestCollectorSuccessfulRefreshSurvivesSemanticCaptureLimit(t *testing.T) {
 		})
 	}
 
-	snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil)
+	snapshot, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, nil, coll.currentTopologySemanticLimits())
 	require.Equal(t, deviceRefreshOutcomeSuccess, outcome)
 	require.NotNil(t, snapshot)
 	require.True(t, snapshot.hasObservation)
@@ -1223,7 +1223,7 @@ func TestCollectorRefreshPrefersResolvedTargetManagementIP(t *testing.T) {
 		})
 	}
 
-	generation, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, []netip.Addr{netip.MustParseAddr("192.0.2.50")})
+	generation, outcome := coll.refreshDeviceTopology(context.Background(), 1, dev, []netip.Addr{netip.MustParseAddr("192.0.2.50")}, coll.currentTopologySemanticLimits())
 	require.Equal(t, deviceRefreshOutcomeSuccess, outcome)
 	require.NotNil(t, generation)
 	snapshot := generation.observation
@@ -1340,7 +1340,7 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 
 	go func() {
 		defer close(done)
-		coll.refreshDeviceTopology(context.Background(), registrationID, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")})
+		coll.refreshDeviceTopology(context.Background(), registrationID, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")}, coll.currentTopologySemanticLimits())
 	}()
 
 	<-started
@@ -1384,7 +1384,7 @@ func TestCollector_RefreshFailureKeepsPublishedSnapshot(t *testing.T) {
 		})
 	}
 
-	generation, outcome := coll.refreshDeviceTopology(context.Background(), registrationID, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")})
+	generation, outcome := coll.refreshDeviceTopology(context.Background(), registrationID, dev, []netip.Addr{netip.MustParseAddr("10.0.0.10")}, coll.currentTopologySemanticLimits())
 	require.Nil(t, generation)
 	require.Equal(t, deviceRefreshOutcomeFailed, outcome)
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -163,6 +163,12 @@ func TestCollectorRefreshPrunesUnregisteredDeviceStateFromPublishedGeneration(t 
 
 	require.Empty(t, coll.deviceStates)
 	require.Zero(t, coll.topologyRegistry.acquireGeneration().deviceCount())
+	diagnostics := coll.acquireTopologyDiagnostics()
+	require.NotNil(t, diagnostics.topology)
+	require.Empty(t, diagnostics.topology.registrationVector)
+	require.Len(t, diagnostics.topology.removed, 1)
+	require.Equal(t, registrationID, diagnostics.topology.removed[0].registrationID)
+	require.True(t, diagnostics.topology.removed[0].hasRetainedSuccess)
 }
 
 func TestCollectorRefreshKeepsDistinctRegistrationKeysForSharedEndpoint(t *testing.T) {
@@ -502,11 +508,21 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 	require.Equal(t, base.Add(defaultDeviceCheckEvery), firstState.nextRetry)
 	require.EqualValues(t, 1, firstState.consecutiveFailures)
 	require.Nil(t, firstState.generation)
+	firstCut := coll.acquireTopologyDiagnostics().topology
+	require.NotNil(t, firstCut)
+	require.Len(t, firstCut.devices, 1)
+	require.True(t, firstCut.devices[0].selected)
+	require.Equal(t, deviceRefreshOutcomeFailed, firstCut.devices[0].outcome)
+	require.False(t, firstCut.devices[0].hasRetainedSuccess)
 
 	now = base.Add(30 * time.Second)
 	skippedStats := coll.refreshTopology(context.Background())
 	require.Zero(t, skippedStats.errors)
 	require.Len(t, clients, 2, "refresh before nextRetry must not create a client")
+	skippedCut := coll.acquireTopologyDiagnostics().topology
+	require.NotNil(t, skippedCut)
+	require.False(t, skippedCut.devices[0].selected)
+	require.Equal(t, deviceRefreshOutcomeFailed, skippedCut.devices[0].outcome)
 
 	now = base.Add(defaultDeviceCheckEvery)
 	successStats := coll.refreshTopology(context.Background())
@@ -517,7 +533,7 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 	require.Equal(t, now.Add(defaultRefreshEvery), successState.nextRetry)
 	require.Zero(t, successState.consecutiveFailures)
 	require.NotNil(t, successState.generation)
-	require.Equal(t, topologySemanticCaptureAvailable, successState.generation.semantic.state)
+	require.Equal(t, diagnosticCaptureAvailable, successState.generation.semantic.state)
 	require.NotNil(t, successState.generation.semantic.evidence)
 	require.Equal(t, registrationID, successState.generation.evidenceRef.registrationID)
 	require.NotZero(t, successState.generation.evidenceRef.generation)
@@ -537,6 +553,12 @@ func TestCollectorRefreshFailureUsesExponentialRetryAndPreservesLastSuccess(t *t
 	require.EqualValues(t, 1, failedState.consecutiveFailures)
 	require.False(t, failedState.generation.freshAt(failedState.generation.expiresAt.Add(time.Nanosecond)),
 		"failure retention must not extend the last successful collection's display freshness")
+	failedCut := coll.acquireTopologyDiagnostics().topology
+	require.NotNil(t, failedCut)
+	require.True(t, failedCut.devices[0].selected)
+	require.Equal(t, deviceRefreshOutcomeFailed, failedCut.devices[0].outcome)
+	require.True(t, failedCut.devices[0].hasRetainedSuccess)
+	require.Equal(t, lastSuccessGeneration.evidenceRef, failedCut.devices[0].retainedSuccess)
 }
 
 func TestCollectorSuccessfulRefreshSurvivesSemanticCaptureLimit(t *testing.T) {
@@ -568,8 +590,8 @@ func TestCollectorSuccessfulRefreshSurvivesSemanticCaptureLimit(t *testing.T) {
 	require.Equal(t, deviceRefreshOutcomeSuccess, outcome)
 	require.NotNil(t, snapshot)
 	require.True(t, snapshot.hasObservation)
-	require.Equal(t, topologySemanticCaptureLimitExceeded, snapshot.semantic.state)
-	require.Equal(t, topologySemanticCaptureReasonRecordLimit, snapshot.semantic.reason)
+	require.Equal(t, diagnosticCaptureLimitExceeded, snapshot.semantic.state)
+	require.Equal(t, diagnosticCaptureReasonRecordLimit, snapshot.semantic.reason)
 	require.Nil(t, snapshot.semantic.evidence)
 }
 
@@ -620,6 +642,13 @@ func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(
 	require.Zero(t, state.consecutiveFailures)
 	require.Same(t, previous, state.generation)
 	require.Same(t, previous, coll.topologyRegistry.acquireGeneration().devices[0])
+	cut := coll.acquireTopologyDiagnostics().topology
+	require.NotNil(t, cut)
+	require.Len(t, cut.devices, 1)
+	require.True(t, cut.devices[0].selected)
+	require.Equal(t, deviceRefreshOutcomeNoProfiles, cut.devices[0].outcome)
+	require.True(t, cut.devices[0].hasRetainedSuccess)
+	require.Equal(t, previous.evidenceRef, cut.devices[0].retainedSuccess)
 }
 
 func TestFailedRefreshRetryDelayCapsAtRefreshInterval(t *testing.T) {
@@ -653,6 +682,9 @@ func TestCollectorRefreshTopologyRecoveringHandlesPanic(t *testing.T) {
 	require.Same(t, previous, coll.topologyRegistry.acquireGeneration())
 	require.Same(t, previousDevice, coll.deviceStates[previousDevice.registrationID].generation)
 	require.EqualValues(t, 1, coll.generationSequence)
+	aborted := coll.acquireTopologyDiagnostics().lastAborted
+	require.NotNil(t, aborted)
+	require.Equal(t, topologyDiagnosticAbortPanic, aborted.reason)
 }
 
 func TestCollectorRunCancelsInFlightRefresh(t *testing.T) {
@@ -724,6 +756,12 @@ func TestCollectorRunCancelsInFlightRefresh(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail(t, "runner did not stop after context cancellation")
 	}
+	diagnostics := coll.acquireTopologyDiagnostics()
+	require.Nil(t, diagnostics.topology)
+	require.NotNil(t, diagnostics.lastAborted)
+	require.Equal(t, topologyDiagnosticAbortCanceled, diagnostics.lastAborted.reason)
+	require.Equal(t, 1, diagnostics.lastAborted.registrationCount)
+	require.Equal(t, 1, diagnostics.lastAborted.selectedCount)
 }
 
 func TestCollectorCancelsInFlightVLANContextRefresh(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -165,7 +165,7 @@ func TestCollectorRefreshPrunesUnregisteredDeviceStateFromPublishedGeneration(t 
 	require.Zero(t, coll.topologyRegistry.acquireGeneration().deviceCount())
 	diagnostics := coll.acquireTopologyDiagnostics()
 	require.NotNil(t, diagnostics.topology)
-	require.Empty(t, diagnostics.topology.registrationVector)
+	require.Empty(t, diagnostics.topology.devices)
 	require.Len(t, diagnostics.topology.removed, 1)
 	require.Equal(t, registrationID, diagnostics.topology.removed[0].registrationID)
 	require.True(t, diagnostics.topology.removed[0].hasRetainedSuccess)
@@ -828,14 +828,6 @@ func TestCollectorCancelsInFlightVLANContextRefresh(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail(t, "vlan-context refresh did not stop after context cancellation")
 	}
-}
-
-func TestCollectorNewDeviceCollectionCacheUsesEffectiveDeviceCheckEvery(t *testing.T) {
-	coll := newTestSNMPTopologyCollector()
-
-	cache := coll.newDeviceTopologyBuilder(ddsnmp.DeviceConnectionInfo{Hostname: "switch-a"})
-
-	require.Equal(t, defaultRefreshEvery+2*defaultDeviceCheckEvery, cache.staleAfter)
 }
 
 func TestCollectorResolveDeviceTargetManagementIPs(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -760,6 +760,9 @@ func TestCollectorRunCancelsInFlightRefresh(t *testing.T) {
 	require.Nil(t, diagnostics.topology)
 	require.NotNil(t, diagnostics.lastAborted)
 	require.Equal(t, topologyDiagnosticAbortCanceled, diagnostics.lastAborted.reason)
+	require.Equal(t, topologyDiagnosticSweepPhaseDeviceRefresh, diagnostics.lastAborted.phase)
+	require.True(t, diagnostics.lastAborted.hasActiveRegistration)
+	require.Equal(t, store.Entries()[0].RegistrationID, diagnostics.lastAborted.activeRegistrationID)
 	require.Equal(t, 1, diagnostics.lastAborted.registrationCount)
 	require.Equal(t, 1, diagnostics.lastAborted.selectedCount)
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"slices"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+const (
+	topologyDiagnosticCutLogicalBytes = 32
+	topologyDiagnosticRowLogicalBytes = 128
+)
+
+type deviceLifecycleSource interface {
+	LifecycleCut() ddsnmp.DeviceLifecycleCut
+}
+
+type topologyJobLifecycleDiagnosticCut struct {
+	state  diagnosticCaptureState
+	reason diagnosticCaptureReason
+	cut    ddsnmp.DeviceLifecycleCut
+}
+
+type topologySweepDeviceDiagnostic struct {
+	registrationID ddsnmp.DeviceRegistrationID
+	selected       bool
+	outcome        deviceRefreshOutcome
+	lastAttempt    time.Time
+	lastSuccess    time.Time
+	nextRetry      time.Time
+
+	retainedSuccess    topologyEvidenceRef
+	hasRetainedSuccess bool
+	semantic           topologySemanticCapture
+	hasObservation     bool
+	expiresAt          time.Time
+	renderable         bool
+	expired            bool
+}
+
+type topologyRemovedDeviceDiagnostic struct {
+	registrationID     ddsnmp.DeviceRegistrationID
+	retainedSuccess    topologyEvidenceRef
+	hasRetainedSuccess bool
+}
+
+type topologySweepDiagnosticCut struct {
+	sequence           uint64
+	startedAt          time.Time
+	publishedAt        time.Time
+	captureState       diagnosticCaptureState
+	captureReason      diagnosticCaptureReason
+	recordCount        uint64
+	logicalBytes       uint64
+	registrationVector []ddsnmp.DeviceRegistrationID
+	devices            []topologySweepDeviceDiagnostic
+	removed            []topologyRemovedDeviceDiagnostic
+}
+
+type topologyDiagnosticAbortReason uint8
+
+const (
+	topologyDiagnosticAbortUnknown topologyDiagnosticAbortReason = iota
+	topologyDiagnosticAbortCanceled
+	topologyDiagnosticAbortPanic
+)
+
+type topologyAbortedSweepDiagnostic struct {
+	sequence          uint64
+	startedAt         time.Time
+	abortedAt         time.Time
+	reason            topologyDiagnosticAbortReason
+	registrationCount int
+	selectedCount     int
+}
+
+type topologyDiagnostics struct {
+	lifecycle   topologyJobLifecycleDiagnosticCut
+	topology    *topologySweepDiagnosticCut
+	lastAborted *topologyAbortedSweepDiagnostic
+}
+
+type topologyDiagnosticCutInput struct {
+	sequence       uint64
+	startedAt      time.Time
+	publishedAt    time.Time
+	entries        []ddsnmp.DeviceEntry
+	selected       map[ddsnmp.DeviceRegistrationID]bool
+	seen           map[ddsnmp.DeviceRegistrationID]bool
+	previousStates map[ddsnmp.DeviceRegistrationID]deviceRefreshState
+	states         map[ddsnmp.DeviceRegistrationID]deviceRefreshState
+	limits         topologySemanticLimits
+}
+
+type topologyDiagnosticCutProjector func(topologyDiagnosticCutInput) (*topologySweepDiagnosticCut, error)
+
+func (c *Collector) acquireTopologyDiagnostics() topologyDiagnostics {
+	limits := c.currentTopologyDiagnosticGlobalLimits()
+	diagnostics := topologyDiagnostics{lastAborted: c.lastAbortedTopologyDiagnostic.Load()}
+	if generation := c.topologyRegistry.acquireGeneration(); generation != nil {
+		diagnostics.topology = generation.diagnostic
+	}
+	if diagnostics.topology != nil {
+		if diagnostics.topology.recordCount >= limits.maxRecords || diagnostics.topology.logicalBytes >= limits.maxLogicalBytes {
+			limits = topologySemanticLimits{}
+		} else {
+			limits.maxRecords -= diagnostics.topology.recordCount
+			limits.maxLogicalBytes -= diagnostics.topology.logicalBytes
+		}
+	}
+	diagnostics.lifecycle = acquireTopologyJobLifecycleCut(c.deviceLifecycleSource, limits)
+	return diagnostics
+}
+
+func acquireTopologyJobLifecycleCut(source deviceLifecycleSource, limits topologySemanticLimits) (result topologyJobLifecycleDiagnosticCut) {
+	result.state = diagnosticCaptureAvailable
+	defer func() {
+		if recover() != nil {
+			result = topologyJobLifecycleDiagnosticCut{
+				state:  diagnosticCaptureUnavailable,
+				reason: diagnosticCaptureReasonProjectionPanic,
+			}
+		}
+	}()
+	if source == nil {
+		result.state = diagnosticCaptureUnavailable
+		result.reason = diagnosticCaptureReasonProjectionError
+		return result
+	}
+	result.cut = source.LifecycleCut()
+	records := uint64(1 + len(result.cut.Entries))
+	logicalBytes := uint64(topologyDiagnosticCutLogicalBytes)
+	for _, entry := range result.cut.Entries {
+		logicalBytes += uint64(64 + len(entry.Info.Hostname) + len(entry.Info.SNMPVersion))
+	}
+	if records > limits.maxRecords {
+		result.state = diagnosticCaptureLimitExceeded
+		result.reason = diagnosticCaptureReasonGlobalRecordLimit
+		result.cut.Entries = nil
+		return result
+	}
+	if logicalBytes > limits.maxLogicalBytes {
+		result.state = diagnosticCaptureLimitExceeded
+		result.reason = diagnosticCaptureReasonGlobalByteLimit
+		result.cut.Entries = nil
+	}
+	return result
+}
+
+func (c *Collector) projectCommittedTopologyDiagnosticCut(input topologyDiagnosticCutInput) (cut *topologySweepDiagnosticCut) {
+	cut = unavailableTopologyDiagnosticCut(input, diagnosticCaptureReasonProjectionError)
+	defer func() {
+		if recover() != nil {
+			cut = unavailableTopologyDiagnosticCut(input, diagnosticCaptureReasonProjectionPanic)
+			c.Limit("snmp_topology:diagnostic-cut", 1, topologyRefreshWarningEvery).
+				Warningf("failed to project SNMP topology diagnostics")
+		}
+	}()
+	if c.projectTopologyDiagnosticCut == nil {
+		return cut
+	}
+	projected, err := c.projectTopologyDiagnosticCut(input)
+	if err != nil || projected == nil {
+		c.Limit("snmp_topology:diagnostic-cut", 1, topologyRefreshWarningEvery).
+			Warningf("failed to project SNMP topology diagnostics")
+		return cut
+	}
+	return projected
+}
+
+func projectTopologyDiagnosticCut(input topologyDiagnosticCutInput) (*topologySweepDiagnosticCut, error) {
+	cut := &topologySweepDiagnosticCut{
+		sequence:      input.sequence,
+		startedAt:     input.startedAt,
+		publishedAt:   input.publishedAt,
+		captureState:  diagnosticCaptureAvailable,
+		captureReason: diagnosticCaptureReasonNone,
+	}
+
+	seen := input.seen
+	if seen == nil {
+		seen = make(map[ddsnmp.DeviceRegistrationID]bool, len(input.entries))
+		for _, entry := range input.entries {
+			seen[entry.RegistrationID] = true
+		}
+	}
+	removedIDs := make([]ddsnmp.DeviceRegistrationID, 0)
+	for registrationID := range input.previousStates {
+		if !seen[registrationID] {
+			removedIDs = append(removedIDs, registrationID)
+		}
+	}
+	slices.Sort(removedIDs)
+
+	rowCount := uint64(len(input.entries) + len(removedIDs))
+	records := 1 + rowCount
+	logicalBytes := uint64(topologyDiagnosticCutLogicalBytes) + rowCount*topologyDiagnosticRowLogicalBytes
+	if records > input.limits.maxRecords {
+		cut.captureState = diagnosticCaptureLimitExceeded
+		cut.captureReason = diagnosticCaptureReasonRecordLimit
+		cut.recordCount = 1
+		cut.logicalBytes = topologyDiagnosticCutLogicalBytes
+		return cut, nil
+	}
+	if logicalBytes > input.limits.maxLogicalBytes {
+		cut.captureState = diagnosticCaptureLimitExceeded
+		cut.captureReason = diagnosticCaptureReasonByteLimit
+		cut.recordCount = 1
+		cut.logicalBytes = topologyDiagnosticCutLogicalBytes
+		return cut, nil
+	}
+	for _, entry := range input.entries {
+		generation := input.states[entry.RegistrationID].generation
+		if generation == nil || generation.semantic.state != diagnosticCaptureAvailable {
+			continue
+		}
+		if generation.semantic.recordCount > input.limits.maxRecords-records {
+			cut.captureState = diagnosticCaptureLimitExceeded
+			cut.captureReason = diagnosticCaptureReasonGlobalRecordLimit
+			cut.recordCount = 1
+			cut.logicalBytes = topologyDiagnosticCutLogicalBytes
+			return cut, nil
+		}
+		if generation.semantic.logicalBytes > input.limits.maxLogicalBytes-logicalBytes {
+			cut.captureState = diagnosticCaptureLimitExceeded
+			cut.captureReason = diagnosticCaptureReasonGlobalByteLimit
+			cut.recordCount = 1
+			cut.logicalBytes = topologyDiagnosticCutLogicalBytes
+			return cut, nil
+		}
+		records += generation.semantic.recordCount
+		logicalBytes += generation.semantic.logicalBytes
+	}
+	cut.recordCount = records
+	cut.logicalBytes = logicalBytes
+
+	cut.registrationVector = make([]ddsnmp.DeviceRegistrationID, 0, len(input.entries))
+	cut.devices = make([]topologySweepDeviceDiagnostic, 0, len(input.entries))
+	for _, entry := range input.entries {
+		registrationID := entry.RegistrationID
+		state := input.states[registrationID]
+		row := topologySweepDeviceDiagnostic{
+			registrationID: registrationID,
+			selected:       input.selected[registrationID],
+			outcome:        state.outcome,
+			lastAttempt:    state.lastAttempt,
+			lastSuccess:    state.lastSuccess,
+			nextRetry:      state.nextRetry,
+		}
+		if generation := state.generation; generation != nil {
+			row.retainedSuccess = generation.evidenceRef
+			row.hasRetainedSuccess = true
+			row.semantic = generation.semantic
+			row.hasObservation = generation.hasObservation
+			row.expiresAt = generation.expiresAt
+			row.renderable = generation.hasObservation && generation.freshAt(input.publishedAt)
+			row.expired = !generation.expiresAt.IsZero() && input.publishedAt.After(generation.expiresAt)
+		}
+		cut.registrationVector = append(cut.registrationVector, registrationID)
+		cut.devices = append(cut.devices, row)
+	}
+
+	cut.removed = make([]topologyRemovedDeviceDiagnostic, 0, len(removedIDs))
+	for _, registrationID := range removedIDs {
+		row := topologyRemovedDeviceDiagnostic{registrationID: registrationID}
+		if generation := input.previousStates[registrationID].generation; generation != nil {
+			row.retainedSuccess = generation.evidenceRef
+			row.hasRetainedSuccess = true
+		}
+		cut.removed = append(cut.removed, row)
+	}
+	return cut, nil
+}
+
+func unavailableTopologyDiagnosticCut(input topologyDiagnosticCutInput, reason diagnosticCaptureReason) *topologySweepDiagnosticCut {
+	return &topologySweepDiagnosticCut{
+		sequence:      input.sequence,
+		startedAt:     input.startedAt,
+		publishedAt:   input.publishedAt,
+		captureState:  diagnosticCaptureUnavailable,
+		captureReason: reason,
+		recordCount:   1,
+		logicalBytes:  topologyDiagnosticCutLogicalBytes,
+	}
+}
+
+func (c *Collector) publishAbortedTopologyDiagnostic(
+	startedAt time.Time,
+	reason topologyDiagnosticAbortReason,
+	registrationCount int,
+	selectedCount int,
+) {
+	if c == nil {
+		return
+	}
+	c.lastAbortedTopologyDiagnostic.Store(&topologyAbortedSweepDiagnostic{
+		sequence:          c.topologyDiagnosticAbortSequence.Add(1),
+		startedAt:         startedAt,
+		abortedAt:         safeTopologyDiagnosticTime(c),
+		reason:            reason,
+		registrationCount: registrationCount,
+		selectedCount:     selectedCount,
+	})
+}
+
+func safeTopologyDiagnosticTime(c *Collector) (now time.Time) {
+	now = time.Now()
+	defer func() { _ = recover() }()
+	if c != nil && c.now != nil {
+		now = c.now()
+	}
+	return now
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
@@ -48,16 +48,15 @@ type topologyRemovedDeviceDiagnostic struct {
 }
 
 type topologySweepDiagnosticCut struct {
-	sequence           uint64
-	startedAt          time.Time
-	publishedAt        time.Time
-	captureState       diagnosticCaptureState
-	captureReason      diagnosticCaptureReason
-	recordCount        uint64
-	logicalBytes       uint64
-	registrationVector []ddsnmp.DeviceRegistrationID
-	devices            []topologySweepDeviceDiagnostic
-	removed            []topologyRemovedDeviceDiagnostic
+	sequence      uint64
+	startedAt     time.Time
+	publishedAt   time.Time
+	captureState  diagnosticCaptureState
+	captureReason diagnosticCaptureReason
+	recordCount   uint64
+	logicalBytes  uint64
+	devices       []topologySweepDeviceDiagnostic
+	removed       []topologyRemovedDeviceDiagnostic
 }
 
 type topologyDiagnosticAbortReason uint8
@@ -250,7 +249,6 @@ func projectTopologyDiagnosticCut(input topologyDiagnosticCutInput) (*topologySw
 	cut.recordCount = records
 	cut.logicalBytes = logicalBytes
 
-	cut.registrationVector = make([]ddsnmp.DeviceRegistrationID, 0, len(input.entries))
 	cut.devices = make([]topologySweepDeviceDiagnostic, 0, len(input.entries))
 	for _, entry := range input.entries {
 		registrationID := entry.RegistrationID
@@ -272,7 +270,6 @@ func projectTopologyDiagnosticCut(input topologyDiagnosticCutInput) (*topologySw
 			row.renderable = generation.hasObservation && generation.freshAt(input.publishedAt)
 			row.expired = !generation.expiresAt.IsZero() && input.publishedAt.After(generation.expiresAt)
 		}
-		cut.registrationVector = append(cut.registrationVector, registrationID)
 		cut.devices = append(cut.devices, row)
 	}
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
@@ -68,13 +68,26 @@ const (
 	topologyDiagnosticAbortPanic
 )
 
+type topologyDiagnosticSweepPhase uint8
+
+const (
+	topologyDiagnosticSweepPhaseUnknown topologyDiagnosticSweepPhase = iota
+	topologyDiagnosticSweepPhaseRegistrationCut
+	topologyDiagnosticSweepPhaseTargetResolution
+	topologyDiagnosticSweepPhaseDeviceRefresh
+	topologyDiagnosticSweepPhaseCommit
+)
+
 type topologyAbortedSweepDiagnostic struct {
-	sequence          uint64
-	startedAt         time.Time
-	abortedAt         time.Time
-	reason            topologyDiagnosticAbortReason
-	registrationCount int
-	selectedCount     int
+	sequence              uint64
+	startedAt             time.Time
+	abortedAt             time.Time
+	reason                topologyDiagnosticAbortReason
+	phase                 topologyDiagnosticSweepPhase
+	activeRegistrationID  ddsnmp.DeviceRegistrationID
+	hasActiveRegistration bool
+	registrationCount     int
+	selectedCount         int
 }
 
 type topologyDiagnostics struct {
@@ -290,6 +303,9 @@ func unavailableTopologyDiagnosticCut(input topologyDiagnosticCutInput, reason d
 func (c *Collector) publishAbortedTopologyDiagnostic(
 	startedAt time.Time,
 	reason topologyDiagnosticAbortReason,
+	phase topologyDiagnosticSweepPhase,
+	activeRegistrationID ddsnmp.DeviceRegistrationID,
+	hasActiveRegistration bool,
 	registrationCount int,
 	selectedCount int,
 ) {
@@ -297,12 +313,15 @@ func (c *Collector) publishAbortedTopologyDiagnostic(
 		return
 	}
 	c.lastAbortedTopologyDiagnostic.Store(&topologyAbortedSweepDiagnostic{
-		sequence:          c.topologyDiagnosticAbortSequence.Add(1),
-		startedAt:         startedAt,
-		abortedAt:         safeTopologyDiagnosticTime(c),
-		reason:            reason,
-		registrationCount: registrationCount,
-		selectedCount:     selectedCount,
+		sequence:              c.topologyDiagnosticAbortSequence.Add(1),
+		startedAt:             startedAt,
+		abortedAt:             safeTopologyDiagnosticTime(c),
+		reason:                reason,
+		phase:                 phase,
+		activeRegistrationID:  activeRegistrationID,
+		hasActiveRegistration: hasActiveRegistration,
+		registrationCount:     registrationCount,
+		selectedCount:         selectedCount,
 	})
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics_test.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gosnmp/gosnmp"
+	snmpmock "github.com/gosnmp/gosnmp/mocks"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+)
+
+func TestCollectorDiagnosticsReadsLifecycleIndependently(t *testing.T) {
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.RegisterJob("job-a", ddsnmp.DeviceLifecycleInfo{Hostname: "192.0.2.10", Port: 161})
+
+	first := coll.acquireTopologyDiagnostics()
+	require.Equal(t, diagnosticCaptureAvailable, first.lifecycle.state)
+	require.Len(t, first.lifecycle.cut.Entries, 1)
+	require.Nil(t, first.topology)
+
+	store.RecordJobLifecycle("job-a", ddsnmp.DeviceLifecycleStatus{
+		Phase:       ddsnmp.DeviceLifecyclePhaseInit,
+		Outcome:     ddsnmp.DeviceLifecycleOutcomeFailed,
+		CompletedAt: time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC),
+	})
+	second := coll.acquireTopologyDiagnostics()
+	require.Greater(t, second.lifecycle.cut.Sequence, first.lifecycle.cut.Sequence)
+	require.Equal(t, ddsnmp.DeviceLifecycleOutcomeFailed, second.lifecycle.cut.Entries[0].LastCompleted.Outcome)
+	require.Same(t, first.topology, second.topology)
+}
+
+func TestCollectorDiagnosticsPublishesCommittedSweepCut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:    "192.0.2.10",
+		Port:        161,
+		SNMPVersion: gosnmp.Version2c.String(),
+	}
+	mockHandler := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(mockHandler, dev)
+
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.Register("job-a", dev)
+	registrationID := store.Entries()[0].RegistrationID
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
+	}
+	base := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	coll.now = func() time.Time { return base }
+
+	stats := coll.refreshTopology(context.Background())
+	require.Zero(t, stats.errors)
+	diagnostics := coll.acquireTopologyDiagnostics()
+	require.NotNil(t, diagnostics.topology)
+	require.Equal(t, diagnosticCaptureAvailable, diagnostics.topology.captureState)
+	require.Equal(t, []ddsnmp.DeviceRegistrationID{registrationID}, diagnostics.topology.registrationVector)
+	require.Len(t, diagnostics.topology.devices, 1)
+	row := diagnostics.topology.devices[0]
+	require.Equal(t, registrationID, row.registrationID)
+	require.True(t, row.selected)
+	require.Equal(t, deviceRefreshOutcomeSuccess, row.outcome)
+	require.Equal(t, coll.deviceStates[registrationID].nextRetry, row.nextRetry)
+	require.True(t, row.hasRetainedSuccess)
+	require.Equal(t, coll.deviceStates[registrationID].generation.evidenceRef, row.retainedSuccess)
+	require.Equal(t, diagnosticCaptureAvailable, row.semantic.state)
+	require.True(t, row.hasObservation)
+	require.True(t, row.renderable)
+	require.False(t, row.expired)
+
+	previousRef := row.retainedSuccess
+	base = base.Add(time.Minute)
+	stats = coll.refreshTopology(context.Background())
+	require.Zero(t, stats.errors)
+	diagnostics = coll.acquireTopologyDiagnostics()
+	require.Len(t, diagnostics.topology.devices, 1)
+	row = diagnostics.topology.devices[0]
+	require.False(t, row.selected)
+	require.True(t, row.hasRetainedSuccess)
+	require.Equal(t, previousRef, row.retainedSuccess)
+
+	previousCut := diagnostics.topology
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stats = coll.refreshTopology(ctx)
+	require.Zero(t, stats.errors)
+	diagnostics = coll.acquireTopologyDiagnostics()
+	require.Same(t, previousCut, diagnostics.topology)
+	require.NotNil(t, diagnostics.lastAborted)
+	require.Equal(t, topologyDiagnosticAbortCanceled, diagnostics.lastAborted.reason)
+}
+
+func TestCollectorDiagnosticProjectionFailureDoesNotAffectTopologyCommit(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		projector topologyDiagnosticCutProjector
+		reason    diagnosticCaptureReason
+	}{
+		{
+			name: "error",
+			projector: func(topologyDiagnosticCutInput) (*topologySweepDiagnosticCut, error) {
+				return nil, errors.New("projection failed")
+			},
+			reason: diagnosticCaptureReasonProjectionError,
+		},
+		{
+			name: "panic",
+			projector: func(topologyDiagnosticCutInput) (*topologySweepDiagnosticCut, error) {
+				panic("projection failed")
+			},
+			reason: diagnosticCaptureReasonProjectionPanic,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			dev := ddsnmp.DeviceConnectionInfo{Hostname: "192.0.2.10", Port: 161, SNMPVersion: gosnmp.Version2c.String()}
+			mockHandler := snmpmock.NewMockHandler(ctrl)
+			expectTopologyRefreshSNMPClient(mockHandler, dev)
+
+			coll, store := newTestSNMPTopologyCollectorWithStore()
+			store.Register("job-a", dev)
+			coll.projectTopologyDiagnosticCut = tc.projector
+			coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+			coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
+			coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+				return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
+			}
+
+			require.NotPanics(t, func() {
+				stats := coll.refreshTopology(context.Background())
+				require.Zero(t, stats.errors)
+			})
+			require.Equal(t, 1, coll.topologyRegistry.acquireGeneration().deviceCount())
+			diagnostics := coll.acquireTopologyDiagnostics()
+			require.NotNil(t, diagnostics.topology)
+			require.Equal(t, diagnosticCaptureUnavailable, diagnostics.topology.captureState)
+			require.Equal(t, tc.reason, diagnostics.topology.captureReason)
+		})
+	}
+}
+
+func TestApplyTopologySemanticGlobalLimitsIsDeterministic(t *testing.T) {
+	first := &topologyDeviceSnapshot{semantic: topologySemanticCapture{
+		state: diagnosticCaptureAvailable, recordCount: 6, logicalBytes: 60, evidence: &topologySemanticEvidence{},
+	}}
+	second := &topologyDeviceSnapshot{semantic: topologySemanticCapture{
+		state: diagnosticCaptureAvailable, recordCount: 6, logicalBytes: 60, evidence: &topologySemanticEvidence{},
+	}}
+	snapshots := map[ddsnmp.DeviceRegistrationID]*topologyDeviceSnapshot{2: second, 1: first}
+
+	applyTopologySemanticGlobalLimits(nil, snapshots, topologySemanticLimits{maxRecords: 10, maxLogicalBytes: 1000})
+	require.Equal(t, diagnosticCaptureAvailable, first.semantic.state)
+	require.Equal(t, diagnosticCaptureLimitExceeded, second.semantic.state)
+	require.Equal(t, diagnosticCaptureReasonGlobalRecordLimit, second.semantic.reason)
+	require.Nil(t, second.semantic.evidence)
+}
+
+func TestProjectTopologyDiagnosticCutMarksExpiredRetainedGeneration(t *testing.T) {
+	base := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	registrationID := ddsnmp.DeviceRegistrationID(1)
+	generation := &topologyDeviceGeneration{
+		registrationID: registrationID,
+		evidenceRef:    topologyEvidenceRef{registrationID: registrationID, generation: 1},
+		collectedAt:    base.Add(-time.Hour),
+		expiresAt:      base.Add(-time.Minute),
+		hasObservation: true,
+		semantic:       topologySemanticCapture{state: diagnosticCaptureAvailable},
+	}
+	cut, err := projectTopologyDiagnosticCut(topologyDiagnosticCutInput{
+		sequence:    2,
+		startedAt:   base,
+		publishedAt: base,
+		entries:     []ddsnmp.DeviceEntry{{RegistrationID: registrationID}},
+		selected:    map[ddsnmp.DeviceRegistrationID]bool{},
+		states: map[ddsnmp.DeviceRegistrationID]deviceRefreshState{
+			registrationID: {generation: generation},
+		},
+		limits: defaultTopologyDiagnosticGlobalLimits,
+	})
+	require.NoError(t, err)
+	require.Len(t, cut.devices, 1)
+	require.True(t, cut.devices[0].expired)
+	require.False(t, cut.devices[0].renderable)
+	require.True(t, cut.devices[0].hasRetainedSuccess)
+}
+
+func TestAcquireTopologyDiagnosticsContainsLifecyclePanic(t *testing.T) {
+	coll := newTestSNMPTopologyCollector()
+	coll.deviceLifecycleSource = panickingTopologyLifecycleSource{}
+
+	diagnostics := coll.acquireTopologyDiagnostics()
+	require.Equal(t, diagnosticCaptureUnavailable, diagnostics.lifecycle.state)
+	require.Equal(t, diagnosticCaptureReasonProjectionPanic, diagnostics.lifecycle.reason)
+}
+
+func TestAcquireTopologyDiagnosticsBoundsLifecycleCut(t *testing.T) {
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	coll.diagnosticGlobalLimits = topologySemanticLimits{maxRecords: 2, maxLogicalBytes: 1 << 20}
+	store.RegisterJob("job-a", ddsnmp.DeviceLifecycleInfo{Hostname: "192.0.2.10"})
+	store.RegisterJob("job-b", ddsnmp.DeviceLifecycleInfo{Hostname: "192.0.2.20"})
+
+	diagnostics := coll.acquireTopologyDiagnostics()
+	require.Equal(t, diagnosticCaptureLimitExceeded, diagnostics.lifecycle.state)
+	require.Equal(t, diagnosticCaptureReasonGlobalRecordLimit, diagnostics.lifecycle.reason)
+	require.NotZero(t, diagnostics.lifecycle.cut.Sequence)
+	require.Empty(t, diagnostics.lifecycle.cut.Entries)
+}
+
+func TestCollectorDiagnosticCutLimitDoesNotAffectTopologyCommit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dev := ddsnmp.DeviceConnectionInfo{Hostname: "192.0.2.10", Port: 161, SNMPVersion: gosnmp.Version2c.String()}
+	mockHandler := snmpmock.NewMockHandler(ctrl)
+	expectTopologyRefreshSNMPClient(mockHandler, dev)
+
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.Register("job-a", dev)
+	coll.diagnosticGlobalLimits = topologySemanticLimits{maxRecords: 10, maxLogicalBytes: 64}
+	coll.topologyProfiles = func(ddsnmp.DeviceConnectionInfo) []*ddsnmp.Profile { return []*ddsnmp.Profile{{}} }
+	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
+	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
+		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) { return nil, nil })
+	}
+
+	stats := coll.refreshTopology(context.Background())
+	require.Zero(t, stats.errors)
+	require.Equal(t, 1, coll.topologyRegistry.acquireGeneration().deviceCount())
+	diagnostics := coll.acquireTopologyDiagnostics()
+	require.NotNil(t, diagnostics.topology)
+	require.Equal(t, diagnosticCaptureLimitExceeded, diagnostics.topology.captureState)
+	require.Equal(t, diagnosticCaptureReasonByteLimit, diagnostics.topology.captureReason)
+	require.Empty(t, diagnostics.topology.devices)
+}
+
+func TestCollectorDiagnosticsConcurrentLifecycleAndGenerationReads(t *testing.T) {
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.RegisterJob("job-a", ddsnmp.DeviceLifecycleInfo{Hostname: "192.0.2.10"})
+
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			store.RecordJobLifecycle("job-a", ddsnmp.DeviceLifecycleStatus{
+				Phase:       ddsnmp.DeviceLifecyclePhaseCollect,
+				Outcome:     ddsnmp.DeviceLifecycleOutcomeSuccess,
+				CompletedAt: time.Unix(int64(i+1), 0),
+			})
+			cut := &topologySweepDiagnosticCut{
+				sequence:     uint64(i + 1),
+				captureState: diagnosticCaptureAvailable,
+				recordCount:  1,
+				logicalBytes: 32,
+			}
+			coll.topologyRegistry.publishGeneration(&topologyGeneration{sequence: uint64(i + 1), diagnostic: cut})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			diagnostics := coll.acquireTopologyDiagnostics()
+			if diagnostics.lifecycle.state != diagnosticCaptureAvailable {
+				t.Errorf("lifecycle capture state = %d", diagnostics.lifecycle.state)
+				return
+			}
+			if diagnostics.topology != nil {
+				if diagnostics.topology.sequence == 0 || diagnostics.topology.captureState != diagnosticCaptureAvailable {
+					t.Errorf("invalid topology cut: sequence=%d state=%d", diagnostics.topology.sequence, diagnostics.topology.captureState)
+					return
+				}
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+type panickingTopologyLifecycleSource struct{}
+
+func (panickingTopologyLifecycleSource) LifecycleCut() ddsnmp.DeviceLifecycleCut {
+	panic("lifecycle cut")
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics_test.go
@@ -100,6 +100,26 @@ func TestCollectorDiagnosticsPublishesCommittedSweepCut(t *testing.T) {
 	require.Same(t, previousCut, diagnostics.topology)
 	require.NotNil(t, diagnostics.lastAborted)
 	require.Equal(t, topologyDiagnosticAbortCanceled, diagnostics.lastAborted.reason)
+	require.Equal(t, topologyDiagnosticSweepPhaseTargetResolution, diagnostics.lastAborted.phase)
+	require.False(t, diagnostics.lastAborted.hasActiveRegistration)
+}
+
+func TestCollectorPanicDiagnosticIdentifiesActiveDeviceRefresh(t *testing.T) {
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.Register("job-a", ddsnmp.DeviceConnectionInfo{Hostname: "192.0.2.10"})
+	registrationID := store.Entries()[0].RegistrationID
+	coll.newSnmpClient = func() gosnmp.Handler { panic("device refresh panic") }
+
+	require.NotPanics(t, func() { coll.refreshTopologyRecovering(context.Background()) })
+
+	diagnostics := coll.acquireTopologyDiagnostics()
+	require.NotNil(t, diagnostics.lastAborted)
+	require.Equal(t, topologyDiagnosticAbortPanic, diagnostics.lastAborted.reason)
+	require.Equal(t, topologyDiagnosticSweepPhaseDeviceRefresh, diagnostics.lastAborted.phase)
+	require.True(t, diagnostics.lastAborted.hasActiveRegistration)
+	require.Equal(t, registrationID, diagnostics.lastAborted.activeRegistrationID)
+	require.Equal(t, 1, diagnostics.lastAborted.registrationCount)
+	require.Equal(t, 1, diagnostics.lastAborted.selectedCount)
 }
 
 func TestCollectorDiagnosticProjectionFailureDoesNotAffectTopologyCommit(t *testing.T) {
@@ -153,20 +173,32 @@ func TestCollectorDiagnosticProjectionFailureDoesNotAffectTopologyCommit(t *test
 	}
 }
 
-func TestApplyTopologySemanticGlobalLimitsIsDeterministic(t *testing.T) {
-	first := &topologyDeviceSnapshot{semantic: topologySemanticCapture{
+func TestTopologySemanticUsageBoundsRetainedEvidenceDeterministically(t *testing.T) {
+	first := &topologyDeviceGeneration{semantic: topologySemanticCapture{
 		state: diagnosticCaptureAvailable, recordCount: 6, logicalBytes: 60, evidence: &topologySemanticEvidence{},
 	}}
-	second := &topologyDeviceSnapshot{semantic: topologySemanticCapture{
+	second := &topologyDeviceGeneration{semantic: topologySemanticCapture{
 		state: diagnosticCaptureAvailable, recordCount: 6, logicalBytes: 60, evidence: &topologySemanticEvidence{},
 	}}
-	snapshots := map[ddsnmp.DeviceRegistrationID]*topologyDeviceSnapshot{2: second, 1: first}
+	states := map[ddsnmp.DeviceRegistrationID]deviceRefreshState{
+		2: {generation: second},
+		1: {generation: first},
+	}
+	entries := []ddsnmp.DeviceEntry{{RegistrationID: 1}, {RegistrationID: 2}}
+	seen := map[ddsnmp.DeviceRegistrationID]bool{1: true, 2: true}
 
-	applyTopologySemanticGlobalLimits(nil, snapshots, topologySemanticLimits{maxRecords: 10, maxLogicalBytes: 1000})
-	require.Equal(t, diagnosticCaptureAvailable, first.semantic.state)
-	require.Equal(t, diagnosticCaptureLimitExceeded, second.semantic.state)
-	require.Equal(t, diagnosticCaptureReasonGlobalRecordLimit, second.semantic.reason)
-	require.Nil(t, second.semantic.evidence)
+	usage := newTopologySemanticUsage(entries, seen, nil, states, states, topologySemanticLimits{
+		maxRecords:      10,
+		maxLogicalBytes: 1000,
+	})
+	require.Equal(t, diagnosticCaptureAvailable, states[1].generation.semantic.state)
+	require.Equal(t, diagnosticCaptureLimitExceeded, states[2].generation.semantic.state)
+	require.Equal(t, diagnosticCaptureReasonGlobalRecordLimit, states[2].generation.semantic.reason)
+	require.Nil(t, states[2].generation.semantic.evidence)
+	require.NotSame(t, second, states[2].generation)
+
+	require.Equal(t, topologySemanticLimits{maxRecords: 1, maxLogicalBytes: 652},
+		usage.availableLimits(defaultTopologySemanticLimits))
 }
 
 func TestProjectTopologyDiagnosticCutMarksExpiredRetainedGeneration(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics_test.go
@@ -66,7 +66,6 @@ func TestCollectorDiagnosticsPublishesCommittedSweepCut(t *testing.T) {
 	diagnostics := coll.acquireTopologyDiagnostics()
 	require.NotNil(t, diagnostics.topology)
 	require.Equal(t, diagnosticCaptureAvailable, diagnostics.topology.captureState)
-	require.Equal(t, []ddsnmp.DeviceRegistrationID{registrationID}, diagnostics.topology.registrationVector)
 	require.Len(t, diagnostics.topology.devices, 1)
 	row := diagnostics.topology.devices[0]
 	require.Equal(t, registrationID, row.registrationID)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
@@ -47,6 +47,7 @@ type topologyGeneration struct {
 	publishedAt       time.Time
 	devices           []*topologyDeviceGeneration
 	renderableDevices []*topologyDeviceGeneration
+	diagnostic        *topologySweepDiagnosticCut
 }
 
 func freezeTopologyBuilder(builder *topologyBuilder) (*topologyDeviceSnapshot, topologyBuilderFinalizeStats) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
@@ -18,6 +18,12 @@ type topologyDeviceSnapshot struct {
 	observation    topologymodel.ObservationSnapshot
 	hasObservation bool
 	trap           topologyTrapDeviceGeneration
+	semantic       topologySemanticCapture
+}
+
+type topologyEvidenceRef struct {
+	registrationID ddsnmp.DeviceRegistrationID
+	generation     uint64
 }
 
 // topologyDeviceGeneration is an immutable collected snapshot activated at a
@@ -25,11 +31,13 @@ type topologyDeviceSnapshot struct {
 // published to runtime readers.
 type topologyDeviceGeneration struct {
 	registrationID ddsnmp.DeviceRegistrationID
+	evidenceRef    topologyEvidenceRef
 	collectedAt    time.Time
 	expiresAt      time.Time
 	observation    topologymodel.ObservationSnapshot
 	hasObservation bool
 	trap           topologyTrapDeviceGeneration
+	semantic       topologySemanticCapture
 }
 
 // topologyGeneration is the immutable device vector published after one
@@ -62,6 +70,7 @@ func freezeTopologyBuilder(builder *topologyBuilder) (*topologyDeviceSnapshot, t
 
 func activateTopologyDeviceSnapshot(
 	registrationID ddsnmp.DeviceRegistrationID,
+	generation uint64,
 	publishedAt time.Time,
 	snapshot *topologyDeviceSnapshot,
 ) *topologyDeviceGeneration {
@@ -74,11 +83,16 @@ func activateTopologyDeviceSnapshot(
 	}
 	return &topologyDeviceGeneration{
 		registrationID: registrationID,
+		evidenceRef: topologyEvidenceRef{
+			registrationID: registrationID,
+			generation:     generation,
+		},
 		collectedAt:    snapshot.collectedAt,
 		expiresAt:      expiresAt,
 		observation:    snapshot.observation,
 		hasObservation: snapshot.hasObservation,
 		trap:           snapshot.trap,
+		semantic:       snapshot.semantic,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
@@ -127,28 +127,35 @@ var defaultTopologySemanticLimits = topologySemanticLimits{
 	maxLogicalBytes: 32 << 20,
 }
 
-type topologySemanticCaptureState uint8
+var defaultTopologyDiagnosticGlobalLimits = topologySemanticLimits{
+	maxRecords:      250_000,
+	maxLogicalBytes: 64 << 20,
+}
+
+type diagnosticCaptureState uint8
 
 const (
-	topologySemanticCaptureUnknown topologySemanticCaptureState = iota
-	topologySemanticCaptureAvailable
-	topologySemanticCaptureLimitExceeded
-	topologySemanticCaptureUnavailable
+	diagnosticCaptureUnknown diagnosticCaptureState = iota
+	diagnosticCaptureAvailable
+	diagnosticCaptureLimitExceeded
+	diagnosticCaptureUnavailable
 )
 
-type topologySemanticCaptureReason uint8
+type diagnosticCaptureReason uint8
 
 const (
-	topologySemanticCaptureReasonNone topologySemanticCaptureReason = iota
-	topologySemanticCaptureReasonRecordLimit
-	topologySemanticCaptureReasonByteLimit
-	topologySemanticCaptureReasonProjectionError
-	topologySemanticCaptureReasonProjectionPanic
+	diagnosticCaptureReasonNone diagnosticCaptureReason = iota
+	diagnosticCaptureReasonRecordLimit
+	diagnosticCaptureReasonByteLimit
+	diagnosticCaptureReasonProjectionError
+	diagnosticCaptureReasonProjectionPanic
+	diagnosticCaptureReasonGlobalRecordLimit
+	diagnosticCaptureReasonGlobalByteLimit
 )
 
 type topologySemanticCapture struct {
-	state        topologySemanticCaptureState
-	reason       topologySemanticCaptureReason
+	state        diagnosticCaptureState
+	reason       diagnosticCaptureReason
 	recordCount  uint64
 	logicalBytes uint64
 	evidence     *topologySemanticEvidence
@@ -217,8 +224,8 @@ type topologySemanticEventProjector func(*topologySemanticRecorder, topologySema
 
 type topologySemanticRecorder struct {
 	limits       topologySemanticLimits
-	state        topologySemanticCaptureState
-	reason       topologySemanticCaptureReason
+	state        diagnosticCaptureState
+	reason       diagnosticCaptureReason
 	recordCount  uint64
 	logicalBytes uint64
 	evidence     *topologySemanticEvidence
@@ -234,12 +241,12 @@ func newTopologySemanticRecorder(
 ) (r *topologySemanticRecorder) {
 	r = &topologySemanticRecorder{
 		limits:       limits,
-		state:        topologySemanticCaptureAvailable,
+		state:        diagnosticCaptureAvailable,
 		projectEvent: projectTopologySemanticEvent,
 	}
 	defer func() {
 		if recover() != nil {
-			r.fail(topologySemanticCaptureReasonProjectionPanic)
+			r.fail(diagnosticCaptureReasonProjectionPanic)
 		}
 	}()
 	records := uint64(1 + len(targets))
@@ -260,26 +267,26 @@ func newTopologySemanticRecorder(
 }
 
 func (r *topologySemanticRecorder) record(event topologySemanticEvent) {
-	if r == nil || r.state != topologySemanticCaptureAvailable {
+	if r == nil || r.state != diagnosticCaptureAvailable {
 		return
 	}
 	defer func() {
 		if recover() != nil {
-			r.fail(topologySemanticCaptureReasonProjectionPanic)
+			r.fail(diagnosticCaptureReasonProjectionPanic)
 		}
 	}()
 	if r.projectEvent == nil {
-		r.fail(topologySemanticCaptureReasonProjectionError)
+		r.fail(diagnosticCaptureReasonProjectionError)
 		return
 	}
 	if err := r.projectEvent(r, event); err != nil {
-		r.fail(topologySemanticCaptureReasonProjectionError)
+		r.fail(diagnosticCaptureReasonProjectionError)
 	}
 }
 
 func (r *topologySemanticRecorder) finish() topologySemanticCapture {
 	if r == nil {
-		return topologySemanticCapture{state: topologySemanticCaptureUnavailable}
+		return topologySemanticCapture{state: diagnosticCaptureUnavailable}
 	}
 	return topologySemanticCapture{
 		state:        r.state,
@@ -292,11 +299,11 @@ func (r *topologySemanticRecorder) finish() topologySemanticCapture {
 
 func (r *topologySemanticRecorder) admit(records, logicalBytes uint64) bool {
 	if records > r.limits.maxRecords-r.recordCount {
-		r.limit(topologySemanticCaptureReasonRecordLimit)
+		r.limit(diagnosticCaptureReasonRecordLimit)
 		return false
 	}
 	if logicalBytes > r.limits.maxLogicalBytes-r.logicalBytes {
-		r.limit(topologySemanticCaptureReasonByteLimit)
+		r.limit(diagnosticCaptureReasonByteLimit)
 		return false
 	}
 	r.recordCount += records
@@ -304,14 +311,14 @@ func (r *topologySemanticRecorder) admit(records, logicalBytes uint64) bool {
 	return true
 }
 
-func (r *topologySemanticRecorder) limit(reason topologySemanticCaptureReason) {
-	r.state = topologySemanticCaptureLimitExceeded
+func (r *topologySemanticRecorder) limit(reason diagnosticCaptureReason) {
+	r.state = diagnosticCaptureLimitExceeded
 	r.reason = reason
 	r.evidence = nil
 }
 
-func (r *topologySemanticRecorder) fail(reason topologySemanticCaptureReason) {
-	r.state = topologySemanticCaptureUnavailable
+func (r *topologySemanticRecorder) fail(reason diagnosticCaptureReason) {
+	r.state = diagnosticCaptureUnavailable
 	r.reason = reason
 	r.evidence = nil
 }
@@ -502,4 +509,59 @@ func topologySemanticBGPRowLogicalBytes(row ddsnmp.BGPRow) uint64 {
 		len(row.Descriptors.LocalAddress)+len(row.Descriptors.LocalAS)+len(row.Descriptors.LocalIdentifier)+
 		len(row.Descriptors.PeerIdentifier)+len(row.Descriptors.PeerType)+len(row.Descriptors.BGPVersion)+
 		len(row.Descriptors.Description)+len(row.State.State)+len(row.State.Raw)+19) + topologySemanticStringMapBytes(row.Tags)
+}
+
+func applyTopologySemanticGlobalLimits(
+	states map[ddsnmp.DeviceRegistrationID]deviceRefreshState,
+	snapshots map[ddsnmp.DeviceRegistrationID]*topologyDeviceSnapshot,
+	limits topologySemanticLimits,
+) {
+	records := uint64(1 + len(states))
+	if len(states) == 0 {
+		records += uint64(len(snapshots))
+	} else {
+		for registrationID := range snapshots {
+			if _, ok := states[registrationID]; !ok {
+				records++
+			}
+		}
+	}
+	logicalBytes := uint64(topologyDiagnosticCutLogicalBytes) + (records-1)*topologyDiagnosticRowLogicalBytes
+	for registrationID, state := range states {
+		if _, replaced := snapshots[registrationID]; replaced || state.generation == nil {
+			continue
+		}
+		capture := state.generation.semantic
+		if capture.state == diagnosticCaptureAvailable {
+			records += capture.recordCount
+			logicalBytes += capture.logicalBytes
+		}
+	}
+
+	registrationIDs := make([]ddsnmp.DeviceRegistrationID, 0, len(snapshots))
+	for registrationID := range snapshots {
+		registrationIDs = append(registrationIDs, registrationID)
+	}
+	slices.Sort(registrationIDs)
+	for _, registrationID := range registrationIDs {
+		snapshot := snapshots[registrationID]
+		if snapshot == nil || snapshot.semantic.state != diagnosticCaptureAvailable {
+			continue
+		}
+		capture := &snapshot.semantic
+		if records > limits.maxRecords || capture.recordCount > limits.maxRecords-records {
+			capture.state = diagnosticCaptureLimitExceeded
+			capture.reason = diagnosticCaptureReasonGlobalRecordLimit
+			capture.evidence = nil
+			continue
+		}
+		if logicalBytes > limits.maxLogicalBytes || capture.logicalBytes > limits.maxLogicalBytes-logicalBytes {
+			capture.state = diagnosticCaptureLimitExceeded
+			capture.reason = diagnosticCaptureReasonGlobalByteLimit
+			capture.evidence = nil
+			continue
+		}
+		records += capture.recordCount
+		logicalBytes += capture.logicalBytes
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
@@ -84,7 +84,7 @@ func topologySemanticDeviceInputFromConnection(dev ddsnmp.DeviceConnectionInfo) 
 		vendor:      dev.Vendor,
 		model:       dev.Model,
 		vnodeGUID:   dev.VnodeGUID,
-		vnodeLabels: maps.Clone(dev.VnodeLabels),
+		vnodeLabels: dev.VnodeLabels,
 	}
 }
 
@@ -99,7 +99,7 @@ func (d topologySemanticDeviceInput) connectionInfo() ddsnmp.DeviceConnectionInf
 		Vendor:      d.vendor,
 		Model:       d.model,
 		VnodeGUID:   d.vnodeGUID,
-		VnodeLabels: maps.Clone(d.vnodeLabels),
+		VnodeLabels: d.vnodeLabels,
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -365,16 +366,22 @@ func topologySemanticEventShape(event topologySemanticEvent) (uint64, uint64, er
 		}
 		switch event.kind {
 		case topologySemanticEventProfileTags:
-			logicalBytes += topologySemanticMetaTagMapBytes(profile.DeviceMetadata)
-			logicalBytes += topologySemanticStringMapBytes(profile.Tags)
+			logicalBytes += topologySemanticFilteredMetaTagMapBytes(profile.DeviceMetadata, topologySemanticProfileMetadataAllowed)
+			logicalBytes += topologySemanticFilteredStringMapBytes(profile.Tags, topologySemanticProfileTagAllowed)
 		case topologySemanticEventTopologyMetrics, topologySemanticEventVLANContext:
 			if event.kind == topologySemanticEventVLANContext {
-				logicalBytes += topologySemanticMetaTagMapBytes(profile.DeviceMetadata)
-				logicalBytes += topologySemanticStringMapBytes(profile.Tags)
+				logicalBytes += topologySemanticFilteredMetaTagMapBytes(profile.DeviceMetadata, topologySemanticProfileMetadataAllowed)
+				logicalBytes += topologySemanticFilteredStringMapBytes(profile.Tags, topologySemanticProfileTagAllowed)
 			}
-			records += uint64(len(profile.TopologyMetrics))
 			for _, metric := range profile.TopologyMetrics {
-				logicalBytes += uint64(len(metric.TopologyKind)) + topologySemanticStringMapBytes(metric.Tags)
+				if !topologySemanticMetricConsumed(event.kind, metric.TopologyKind) {
+					continue
+				}
+				records++
+				logicalBytes += uint64(len(metric.TopologyKind)) + topologySemanticFilteredStringMapBytes(
+					metric.Tags,
+					func(key string) bool { return topologySemanticMetricTagAllowed(metric.TopologyKind, key) },
+				)
 			}
 		case topologySemanticEventBGPPeers:
 			if profile.BGPCollectError != nil {
@@ -399,29 +406,38 @@ func projectTopologySemanticProfile(kind topologySemanticEventKind, profile *dds
 	result := topologySemanticProfileEvidence{}
 	switch kind {
 	case topologySemanticEventProfileTags:
-		result.metadata = maps.Clone(profile.DeviceMetadata)
-		result.tags = maps.Clone(profile.Tags)
+		result.metadata = cloneTopologySemanticMetaTags(profile.DeviceMetadata, topologySemanticProfileMetadataAllowed)
+		result.tags = cloneTopologySemanticStringTags(profile.Tags, topologySemanticProfileTagAllowed)
 	case topologySemanticEventTopologyMetrics:
-		result.metrics = projectTopologySemanticMetrics(profile.TopologyMetrics)
+		result.metrics = projectTopologySemanticMetrics(kind, profile.TopologyMetrics)
 	case topologySemanticEventBGPPeers:
 		result.bgpFailed = profile.BGPCollectError != nil
 		if !result.bgpFailed {
 			result.bgpRows = projectTopologySemanticBGPRows(profile.BGPRows)
 		}
 	case topologySemanticEventVLANContext:
-		result.metadata = maps.Clone(profile.DeviceMetadata)
-		result.tags = maps.Clone(profile.Tags)
-		result.metrics = projectTopologySemanticMetrics(profile.TopologyMetrics)
+		result.metadata = cloneTopologySemanticMetaTags(profile.DeviceMetadata, topologySemanticProfileMetadataAllowed)
+		result.tags = cloneTopologySemanticStringTags(profile.Tags, topologySemanticProfileTagAllowed)
+		result.metrics = projectTopologySemanticMetrics(kind, profile.TopologyMetrics)
 	}
 	return result
 }
 
-func projectTopologySemanticMetrics(metrics []ddsnmp.Metric) []topologySemanticMetricEvidence {
+func projectTopologySemanticMetrics(
+	eventKind topologySemanticEventKind,
+	metrics []ddsnmp.Metric,
+) []topologySemanticMetricEvidence {
 	result := make([]topologySemanticMetricEvidence, 0, len(metrics))
 	for _, metric := range metrics {
+		if !topologySemanticMetricConsumed(eventKind, metric.TopologyKind) {
+			continue
+		}
 		result = append(result, topologySemanticMetricEvidence{
 			kind: metric.TopologyKind,
-			tags: maps.Clone(metric.Tags),
+			tags: cloneTopologySemanticStringTags(
+				metric.Tags,
+				func(key string) bool { return topologySemanticMetricTagAllowed(metric.TopologyKind, key) },
+			),
 		})
 	}
 	return result
@@ -455,7 +471,7 @@ func projectTopologySemanticBGPRows(rows []ddsnmp.BGPRow) []topologySemanticBGPR
 			established:     row.Connection.EstablishedUptime.Value,
 			updateAgeHas:    row.Connection.LastReceivedUpdateAge.Has,
 			updateAge:       row.Connection.LastReceivedUpdateAge.Value,
-			tags:            maps.Clone(row.Tags),
+			tags:            cloneTopologySemanticStringTags(row.Tags, topologySemanticBGPTagAllowed),
 		})
 	}
 	return result
@@ -495,10 +511,22 @@ func topologySemanticStringMapBytes(values map[string]string) uint64 {
 	return total
 }
 
-func topologySemanticMetaTagMapBytes(values map[string]ddsnmp.MetaTag) uint64 {
+func topologySemanticFilteredStringMapBytes(values map[string]string, allowed func(string) bool) uint64 {
 	var total uint64
 	for key, value := range values {
-		total += uint64(len(key) + len(value.Value) + 1)
+		if allowed(key) {
+			total += uint64(len(key) + len(value))
+		}
+	}
+	return total
+}
+
+func topologySemanticFilteredMetaTagMapBytes(values map[string]ddsnmp.MetaTag, allowed func(string) bool) uint64 {
+	var total uint64
+	for key, value := range values {
+		if allowed(key) {
+			total += uint64(len(key) + len(value.Value) + 1)
+		}
 	}
 	return total
 }
@@ -508,60 +536,284 @@ func topologySemanticBGPRowLogicalBytes(row ddsnmp.BGPRow) uint64 {
 		len(row.Identity.RoutingInstance)+len(row.Identity.Neighbor)+len(row.Identity.RemoteAS)+
 		len(row.Descriptors.LocalAddress)+len(row.Descriptors.LocalAS)+len(row.Descriptors.LocalIdentifier)+
 		len(row.Descriptors.PeerIdentifier)+len(row.Descriptors.PeerType)+len(row.Descriptors.BGPVersion)+
-		len(row.Descriptors.Description)+len(row.State.State)+len(row.State.Raw)+19) + topologySemanticStringMapBytes(row.Tags)
+		len(row.Descriptors.Description)+len(row.State.State)+len(row.State.Raw)+19) +
+		topologySemanticFilteredStringMapBytes(row.Tags, topologySemanticBGPTagAllowed)
 }
 
-func applyTopologySemanticGlobalLimits(
-	states map[ddsnmp.DeviceRegistrationID]deviceRefreshState,
-	snapshots map[ddsnmp.DeviceRegistrationID]*topologyDeviceSnapshot,
-	limits topologySemanticLimits,
-) {
-	records := uint64(1 + len(states))
-	if len(states) == 0 {
-		records += uint64(len(snapshots))
-	} else {
-		for registrationID := range snapshots {
-			if _, ok := states[registrationID]; !ok {
-				records++
-			}
-		}
-	}
-	logicalBytes := uint64(topologyDiagnosticCutLogicalBytes) + (records-1)*topologyDiagnosticRowLogicalBytes
-	for registrationID, state := range states {
-		if _, replaced := snapshots[registrationID]; replaced || state.generation == nil {
+func cloneTopologySemanticStringTags(values map[string]string, allowed func(string) bool) map[string]string {
+	var result map[string]string
+	for key, value := range values {
+		if !allowed(key) {
 			continue
 		}
-		capture := state.generation.semantic
-		if capture.state == diagnosticCaptureAvailable {
-			records += capture.recordCount
-			logicalBytes += capture.logicalBytes
+		if result == nil {
+			result = make(map[string]string)
 		}
+		result[key] = value
+	}
+	return result
+}
+
+func cloneTopologySemanticMetaTags(values map[string]ddsnmp.MetaTag, allowed func(string) bool) map[string]ddsnmp.MetaTag {
+	var result map[string]ddsnmp.MetaTag
+	for key, value := range values {
+		if !allowed(key) {
+			continue
+		}
+		if result == nil {
+			result = make(map[string]ddsnmp.MetaTag)
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func topologySemanticProfileMetadataAllowed(key string) bool {
+	if key == "vendor" || key == "model" {
+		return true
+	}
+	return topologySemanticProfileTagAllowed(key)
+}
+
+func topologySemanticProfileTagAllowed(key string) bool {
+	switch key {
+	case tagLldpLocChassisID, tagLldpLocChassisIDSubtype,
+		tagLldpLocSysName, tagLldpLocSysDesc,
+		tagLldpLocSysCapSupported, tagLldpLocSysCapEnabled,
+		tagBridgeBaseAddress, tagOSPFRouterID:
+		return true
+	default:
+		return false
+	}
+}
+
+func topologySemanticMetricConsumed(eventKind topologySemanticEventKind, kind ddsnmp.TopologyKind) bool {
+	if eventKind == topologySemanticEventVLANContext {
+		return isTopologyVLANContextMetric(kind)
+	}
+	return eventKind == topologySemanticEventTopologyMetrics
+}
+
+func topologySemanticMetricTagAllowed(kind ddsnmp.TopologyKind, key string) bool {
+	switch kind {
+	case ddsnmp.KindIfName, ddsnmp.KindIfStatus, ddsnmp.KindIfDuplex:
+		switch key {
+		case
+			tagTopoIfIndex, tagTopoIfName, tagTopoIfType, tagTopoIfAdmin, tagTopoIfOper,
+			tagTopoIfPhys, tagTopoIfDescr, tagTopoIfAlias, tagTopoIfSpeed, tagTopoIfHigh,
+			tagTopoIfLast, tagTopoIfDuplex:
+			return true
+		}
+	case ddsnmp.KindIpIfIndex:
+		switch key {
+		case tagTopoIfIndex, tagTopoIPAddr, tagTopoIPMask:
+			return true
+		}
+	case ddsnmp.KindBridgePortIfIndex:
+		switch key {
+		case tagBridgeBasePort, tagBridgeIfIndex:
+			return true
+		}
+	case ddsnmp.KindLldpLocPort:
+		switch key {
+		case tagLldpLocPortNum, tagLldpLocPortID, tagLldpLocPortIDSubtype, tagLldpLocPortDesc:
+			return true
+		}
+	case ddsnmp.KindLldpLocManAddr:
+		switch key {
+		case tagLldpLocMgmtAddr, tagLldpLocMgmtAddrSubtype,
+			tagLldpLocMgmtAddrIfSubtype, tagLldpLocMgmtAddrIfID, tagLldpLocMgmtAddrOID:
+			return true
+		}
+	case ddsnmp.KindLldpRem:
+		switch key {
+		case
+			tagLldpLocPortNum, tagLldpRemIndex, tagLldpRemChassisID, tagLldpRemChassisIDSubtype,
+			tagLldpRemPortID, tagLldpRemPortIDSubtype, tagLldpRemPortDesc, tagLldpRemSysName,
+			tagLldpRemSysDesc, tagLldpRemSysCapSupported, tagLldpRemSysCapEnabled,
+			tagLldpRemMgmtAddr, tagLldpRemMgmtAddrSubtype:
+			return true
+		}
+	case ddsnmp.KindLldpRemManAddr, ddsnmp.KindLldpRemManAddrCompat:
+		switch key {
+		case
+			tagLldpLocPortNum, tagLldpRemIndex, tagLldpRemMgmtAddr, tagLldpRemMgmtAddrSubtype,
+			tagLldpRemMgmtAddrLen, tagLldpRemMgmtAddrIfSubtype, tagLldpRemMgmtAddrIfID,
+			tagLldpRemMgmtAddrOID:
+			return true
+		}
+		return topologySemanticLldpRemOctetTagAllowed(key)
+	case ddsnmp.KindCdpCache:
+		switch key {
+		case
+			tagCdpIfIndex, tagCdpIfName, tagCdpDeviceIndex, tagCdpDeviceID, tagCdpAddressType,
+			tagCdpDevicePort, tagCdpVersion, tagCdpPlatform, tagCdpCaps, tagCdpAddress,
+			tagCdpVTPDomain, tagCdpNativeVLAN, tagCdpDuplex, tagCdpPower, tagCdpMTU,
+			tagCdpSysName, tagCdpSysObjectID, tagCdpPrimaryMgmtAddrType, tagCdpPrimaryMgmtAddr,
+			tagCdpSecondaryMgmtAddrType, tagCdpSecondaryMgmtAddr, tagCdpPhysicalLocation,
+			tagCdpLastChange:
+			return true
+		}
+	case ddsnmp.KindFdbEntry, ddsnmp.KindQbridgeFdbEntry:
+		switch key {
+		case
+			tagFdbMac, tagFdbBridgePort, tagFdbStatus, tagDot1qFdbID, tagDot1qFdbMac,
+			tagDot1qFdbPort, tagDot1qFdbStatus, tagTopologyContextVLANID, tagTopologyContextVLANName:
+			return true
+		}
+	case ddsnmp.KindQbridgeVlanEntry:
+		switch key {
+		case tagDot1qVlanID, tagDot1qVlanID1, tagDot1qVlanFdbID:
+			return true
+		}
+	case ddsnmp.KindStpPort:
+		switch key {
+		case
+			tagStpPort, tagStpPortPriority, tagStpPortState, tagStpPortEnable,
+			tagStpPortPathCost, tagStpPortDesignatedRoot, tagStpPortDesignatedCost,
+			tagStpPortDesignatedBridge, tagStpPortDesignatedPort,
+			tagTopologyContextVLANID, tagTopologyContextVLANName:
+			return true
+		}
+	case ddsnmp.KindVtpVlan:
+		switch key {
+		case tagVtpVlanIndex, tagVtpVlanState, tagVtpVlanType, tagVtpVlanName:
+			return true
+		}
+	case ddsnmp.KindArpEntry, ddsnmp.KindArpLegacyEntry:
+		switch key {
+		case tagArpIfIndex, tagArpIfName, tagArpIP, tagArpMac, tagArpType, tagArpState, tagArpAddrType:
+			return true
+		}
+	case ddsnmp.KindOSPFNeighbor:
+		switch key {
+		case tagOSPFNeighborIP, tagOSPFNeighborAddresslessIndex, tagOSPFNeighborRouterID, tagOSPFNeighborState:
+			return true
+		}
+	}
+	return false
+}
+
+func topologySemanticBGPTagAllowed(key string) bool {
+	switch key {
+	case "neighbor", "remote_as", "routing_instance":
+		return true
+	default:
+		return false
+	}
+}
+
+func topologySemanticLldpRemOctetTagAllowed(key string) bool {
+	suffix := strings.TrimPrefix(key, tagLldpRemMgmtAddrOctetPref)
+	index, err := strconv.Atoi(suffix)
+	return err == nil && index >= 1 && index <= 16 && strconv.Itoa(index) == suffix
+}
+
+type topologySemanticUsage struct {
+	limits       topologySemanticLimits
+	recordCount  uint64
+	logicalBytes uint64
+}
+
+func newTopologySemanticUsage(
+	entries []ddsnmp.DeviceEntry,
+	seen map[ddsnmp.DeviceRegistrationID]bool,
+	selected map[ddsnmp.DeviceRegistrationID]bool,
+	previousStates map[ddsnmp.DeviceRegistrationID]deviceRefreshState,
+	states map[ddsnmp.DeviceRegistrationID]deviceRefreshState,
+	limits topologySemanticLimits,
+) topologySemanticUsage {
+	removed := 0
+	for registrationID := range previousStates {
+		if !seen[registrationID] {
+			removed++
+		}
+	}
+	rows := uint64(len(entries) + removed)
+	usage := topologySemanticUsage{
+		limits:       limits,
+		recordCount:  1 + rows,
+		logicalBytes: topologyDiagnosticCutLogicalBytes + rows*topologyDiagnosticRowLogicalBytes,
 	}
 
-	registrationIDs := make([]ddsnmp.DeviceRegistrationID, 0, len(snapshots))
-	for registrationID := range snapshots {
-		registrationIDs = append(registrationIDs, registrationID)
-	}
-	slices.Sort(registrationIDs)
-	for _, registrationID := range registrationIDs {
-		snapshot := snapshots[registrationID]
-		if snapshot == nil || snapshot.semantic.state != diagnosticCaptureAvailable {
+	for _, entry := range entries {
+		registrationID := entry.RegistrationID
+		if selected[registrationID] {
 			continue
 		}
-		capture := &snapshot.semantic
-		if records > limits.maxRecords || capture.recordCount > limits.maxRecords-records {
-			capture.state = diagnosticCaptureLimitExceeded
+		state := states[registrationID]
+		states[registrationID] = usage.includeRetained(state)
+	}
+	return usage
+}
+
+func (u *topologySemanticUsage) availableLimits(perDevice topologySemanticLimits) topologySemanticLimits {
+	return topologySemanticLimits{
+		maxRecords:      min(perDevice.maxRecords, topologySemanticRemaining(u.limits.maxRecords, u.recordCount)),
+		maxLogicalBytes: min(perDevice.maxLogicalBytes, topologySemanticRemaining(u.limits.maxLogicalBytes, u.logicalBytes)),
+	}
+}
+
+func (u *topologySemanticUsage) include(capture topologySemanticCapture) topologySemanticCapture {
+	if capture.state != diagnosticCaptureAvailable {
+		return capture
+	}
+	if u.recordCount > u.limits.maxRecords || capture.recordCount > u.limits.maxRecords-u.recordCount {
+		return limitTopologySemanticCapture(capture, diagnosticCaptureReasonGlobalRecordLimit)
+	}
+	if u.logicalBytes > u.limits.maxLogicalBytes || capture.logicalBytes > u.limits.maxLogicalBytes-u.logicalBytes {
+		return limitTopologySemanticCapture(capture, diagnosticCaptureReasonGlobalByteLimit)
+	}
+	u.recordCount += capture.recordCount
+	u.logicalBytes += capture.logicalBytes
+	return capture
+}
+
+func (u *topologySemanticUsage) includeRetained(state deviceRefreshState) deviceRefreshState {
+	if state.generation == nil || state.generation.semantic.state != diagnosticCaptureAvailable {
+		return state
+	}
+	capture := u.include(state.generation.semantic)
+	if capture.state == diagnosticCaptureAvailable {
+		return state
+	}
+	generation := *state.generation
+	generation.semantic = capture
+	state.generation = &generation
+	return state
+}
+
+func topologySemanticRemaining(limit, used uint64) uint64 {
+	if used >= limit {
+		return 0
+	}
+	return limit - used
+}
+
+func classifyTopologySemanticCaptureLimit(
+	capture topologySemanticCapture,
+	effective topologySemanticLimits,
+	perDevice topologySemanticLimits,
+) topologySemanticCapture {
+	if capture.state != diagnosticCaptureLimitExceeded {
+		return capture
+	}
+	switch capture.reason {
+	case diagnosticCaptureReasonRecordLimit:
+		if effective.maxRecords < perDevice.maxRecords {
 			capture.reason = diagnosticCaptureReasonGlobalRecordLimit
-			capture.evidence = nil
-			continue
 		}
-		if logicalBytes > limits.maxLogicalBytes || capture.logicalBytes > limits.maxLogicalBytes-logicalBytes {
-			capture.state = diagnosticCaptureLimitExceeded
+	case diagnosticCaptureReasonByteLimit:
+		if effective.maxLogicalBytes < perDevice.maxLogicalBytes {
 			capture.reason = diagnosticCaptureReasonGlobalByteLimit
-			capture.evidence = nil
-			continue
 		}
-		records += capture.recordCount
-		logicalBytes += capture.logicalBytes
 	}
+	return capture
+}
+
+func limitTopologySemanticCapture(capture topologySemanticCapture, reason diagnosticCaptureReason) topologySemanticCapture {
+	capture.state = diagnosticCaptureLimitExceeded
+	capture.reason = reason
+	capture.evidence = nil
+	return capture
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"errors"
+	"maps"
+	"net/netip"
+	"path"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+type topologySemanticEventKind uint8
+
+const (
+	topologySemanticEventUnknown topologySemanticEventKind = iota
+	topologySemanticEventSysUptime
+	topologySemanticEventProfileTags
+	topologySemanticEventTopologyMetrics
+	topologySemanticEventBGPPeers
+	topologySemanticEventVLANContext
+)
+
+type topologySemanticEvent struct {
+	kind      topologySemanticEventKind
+	sysUptime int64
+	profiles  []*ddsnmp.ProfileMetrics
+	vlanID    string
+	vlanName  string
+}
+
+func consumeTopologySemanticEvent(builder *topologyBuilder, recorder *topologySemanticRecorder, event topologySemanticEvent) {
+	applyTopologySemanticEvent(builder, event)
+	if recorder != nil {
+		recorder.record(event)
+	}
+}
+
+func applyTopologySemanticEvent(builder *topologyBuilder, event topologySemanticEvent) {
+	if builder == nil {
+		return
+	}
+	switch event.kind {
+	case topologySemanticEventSysUptime:
+		builder.updateTopologySysUptime(event.sysUptime)
+	case topologySemanticEventProfileTags:
+		builder.updateTopologyProfileTags(event.profiles)
+	case topologySemanticEventTopologyMetrics:
+		builder.ingestTopologyProfileMetrics(event.profiles)
+	case topologySemanticEventBGPPeers:
+		builder.ingestTopologyBGPPeers(event.profiles)
+	case topologySemanticEventVLANContext:
+		builder.ingestTopologyVLANContextMetrics(event.vlanID, event.vlanName, event.profiles)
+	}
+}
+
+type topologySemanticDeviceInput struct {
+	hostname    string
+	sysObjectID string
+	sysName     string
+	sysDescr    string
+	sysContact  string
+	sysLocation string
+	vendor      string
+	model       string
+	vnodeGUID   string
+	vnodeLabels map[string]string
+}
+
+func topologySemanticDeviceInputFromConnection(dev ddsnmp.DeviceConnectionInfo) topologySemanticDeviceInput {
+	return topologySemanticDeviceInput{
+		hostname:    dev.Hostname,
+		sysObjectID: dev.SysObjectID,
+		sysName:     dev.SysName,
+		sysDescr:    dev.SysDescr,
+		sysContact:  dev.SysContact,
+		sysLocation: dev.SysLocation,
+		vendor:      dev.Vendor,
+		model:       dev.Model,
+		vnodeGUID:   dev.VnodeGUID,
+		vnodeLabels: maps.Clone(dev.VnodeLabels),
+	}
+}
+
+func (d topologySemanticDeviceInput) connectionInfo() ddsnmp.DeviceConnectionInfo {
+	return ddsnmp.DeviceConnectionInfo{
+		Hostname:    d.hostname,
+		SysObjectID: d.sysObjectID,
+		SysName:     d.sysName,
+		SysDescr:    d.sysDescr,
+		SysContact:  d.sysContact,
+		SysLocation: d.sysLocation,
+		Vendor:      d.vendor,
+		Model:       d.model,
+		VnodeGUID:   d.vnodeGUID,
+		VnodeLabels: maps.Clone(d.vnodeLabels),
+	}
+}
+
+func newTopologyBuilderFromSemanticInput(
+	device topologySemanticDeviceInput,
+	targets []netip.Addr,
+	collectedAt time.Time,
+	freshFor time.Duration,
+) *topologyBuilder {
+	builder := newTopologyBuilder()
+	builder.updateTime = collectedAt
+	builder.staleAfter = freshFor
+	builder.agentID = device.hostname
+	builder.localDevice = buildLocalTopologyDevice(device.connectionInfo())
+	builder.targetManagementIPs = slices.Clone(targets)
+	return builder
+}
+
+type topologySemanticLimits struct {
+	maxRecords      uint64
+	maxLogicalBytes uint64
+}
+
+var defaultTopologySemanticLimits = topologySemanticLimits{
+	maxRecords:      100_000,
+	maxLogicalBytes: 32 << 20,
+}
+
+type topologySemanticCaptureState uint8
+
+const (
+	topologySemanticCaptureUnknown topologySemanticCaptureState = iota
+	topologySemanticCaptureAvailable
+	topologySemanticCaptureLimitExceeded
+	topologySemanticCaptureUnavailable
+)
+
+type topologySemanticCaptureReason uint8
+
+const (
+	topologySemanticCaptureReasonNone topologySemanticCaptureReason = iota
+	topologySemanticCaptureReasonRecordLimit
+	topologySemanticCaptureReasonByteLimit
+	topologySemanticCaptureReasonProjectionError
+	topologySemanticCaptureReasonProjectionPanic
+)
+
+type topologySemanticCapture struct {
+	state        topologySemanticCaptureState
+	reason       topologySemanticCaptureReason
+	recordCount  uint64
+	logicalBytes uint64
+	evidence     *topologySemanticEvidence
+}
+
+type topologySemanticEvidence struct {
+	device      topologySemanticDeviceInput
+	targets     []netip.Addr
+	collectedAt time.Time
+	freshFor    time.Duration
+	events      []topologySemanticEventEvidence
+}
+
+type topologySemanticEventEvidence struct {
+	kind      topologySemanticEventKind
+	sysUptime int64
+	profiles  []topologySemanticProfileEvidence
+	vlanID    string
+	vlanName  string
+}
+
+type topologySemanticProfileEvidence struct {
+	metadata  map[string]ddsnmp.MetaTag
+	tags      map[string]string
+	metrics   []topologySemanticMetricEvidence
+	bgpRows   []topologySemanticBGPRowEvidence
+	bgpFailed bool
+}
+
+type topologySemanticMetricEvidence struct {
+	kind ddsnmp.TopologyKind
+	tags map[string]string
+}
+
+type topologySemanticBGPRowEvidence struct {
+	originProfileID string
+	table           string
+	rowKey          string
+	structuralID    string
+	kind            ddprofiledefinition.BGPRowKind
+
+	routingInstance string
+	neighbor        string
+	remoteAS        string
+	localAddress    string
+	localAS         string
+	localIdentifier string
+	peerIdentifier  string
+	peerType        string
+	bgpVersion      string
+	description     string
+
+	adminHas       bool
+	adminEnabled   bool
+	stateHas       bool
+	state          ddprofiledefinition.BGPPeerState
+	stateRaw       string
+	establishedHas bool
+	established    int64
+	updateAgeHas   bool
+	updateAge      int64
+	tags           map[string]string
+}
+
+type topologySemanticEventProjector func(*topologySemanticRecorder, topologySemanticEvent) error
+
+type topologySemanticRecorder struct {
+	limits       topologySemanticLimits
+	state        topologySemanticCaptureState
+	reason       topologySemanticCaptureReason
+	recordCount  uint64
+	logicalBytes uint64
+	evidence     *topologySemanticEvidence
+	projectEvent topologySemanticEventProjector
+}
+
+func newTopologySemanticRecorder(
+	device topologySemanticDeviceInput,
+	targets []netip.Addr,
+	collectedAt time.Time,
+	freshFor time.Duration,
+	limits topologySemanticLimits,
+) (r *topologySemanticRecorder) {
+	r = &topologySemanticRecorder{
+		limits:       limits,
+		state:        topologySemanticCaptureAvailable,
+		projectEvent: projectTopologySemanticEvent,
+	}
+	defer func() {
+		if recover() != nil {
+			r.fail(topologySemanticCaptureReasonProjectionPanic)
+		}
+	}()
+	records := uint64(1 + len(targets))
+	logicalBytes := topologySemanticDeviceLogicalBytes(device)
+	for _, target := range targets {
+		logicalBytes += uint64(len(target.String()))
+	}
+	if !r.admit(records, logicalBytes) {
+		return r
+	}
+	r.evidence = &topologySemanticEvidence{
+		device:      cloneTopologySemanticDeviceInput(device),
+		targets:     slices.Clone(targets),
+		collectedAt: collectedAt,
+		freshFor:    freshFor,
+	}
+	return r
+}
+
+func (r *topologySemanticRecorder) record(event topologySemanticEvent) {
+	if r == nil || r.state != topologySemanticCaptureAvailable {
+		return
+	}
+	defer func() {
+		if recover() != nil {
+			r.fail(topologySemanticCaptureReasonProjectionPanic)
+		}
+	}()
+	if r.projectEvent == nil {
+		r.fail(topologySemanticCaptureReasonProjectionError)
+		return
+	}
+	if err := r.projectEvent(r, event); err != nil {
+		r.fail(topologySemanticCaptureReasonProjectionError)
+	}
+}
+
+func (r *topologySemanticRecorder) finish() topologySemanticCapture {
+	if r == nil {
+		return topologySemanticCapture{state: topologySemanticCaptureUnavailable}
+	}
+	return topologySemanticCapture{
+		state:        r.state,
+		reason:       r.reason,
+		recordCount:  r.recordCount,
+		logicalBytes: r.logicalBytes,
+		evidence:     r.evidence,
+	}
+}
+
+func (r *topologySemanticRecorder) admit(records, logicalBytes uint64) bool {
+	if records > r.limits.maxRecords-r.recordCount {
+		r.limit(topologySemanticCaptureReasonRecordLimit)
+		return false
+	}
+	if logicalBytes > r.limits.maxLogicalBytes-r.logicalBytes {
+		r.limit(topologySemanticCaptureReasonByteLimit)
+		return false
+	}
+	r.recordCount += records
+	r.logicalBytes += logicalBytes
+	return true
+}
+
+func (r *topologySemanticRecorder) limit(reason topologySemanticCaptureReason) {
+	r.state = topologySemanticCaptureLimitExceeded
+	r.reason = reason
+	r.evidence = nil
+}
+
+func (r *topologySemanticRecorder) fail(reason topologySemanticCaptureReason) {
+	r.state = topologySemanticCaptureUnavailable
+	r.reason = reason
+	r.evidence = nil
+}
+
+func projectTopologySemanticEvent(r *topologySemanticRecorder, event topologySemanticEvent) error {
+	records, logicalBytes, err := topologySemanticEventShape(event)
+	if err != nil {
+		return err
+	}
+	if !r.admit(records, logicalBytes) {
+		return nil
+	}
+
+	projected := topologySemanticEventEvidence{
+		kind:      event.kind,
+		sysUptime: event.sysUptime,
+		vlanID:    event.vlanID,
+		vlanName:  event.vlanName,
+		profiles:  make([]topologySemanticProfileEvidence, 0, len(event.profiles)),
+	}
+	for _, profile := range event.profiles {
+		projected.profiles = append(projected.profiles, projectTopologySemanticProfile(event.kind, profile))
+	}
+	r.evidence.events = append(r.evidence.events, projected)
+	return nil
+}
+
+func topologySemanticEventShape(event topologySemanticEvent) (uint64, uint64, error) {
+	switch event.kind {
+	case topologySemanticEventSysUptime,
+		topologySemanticEventProfileTags,
+		topologySemanticEventTopologyMetrics,
+		topologySemanticEventBGPPeers,
+		topologySemanticEventVLANContext:
+	default:
+		return 0, 0, errors.New("unknown semantic event kind")
+	}
+	records := uint64(1)
+	logicalBytes := uint64(len(event.vlanID) + len(event.vlanName) + 8)
+	for _, profile := range event.profiles {
+		records++
+		if profile == nil {
+			continue
+		}
+		switch event.kind {
+		case topologySemanticEventProfileTags:
+			logicalBytes += topologySemanticMetaTagMapBytes(profile.DeviceMetadata)
+			logicalBytes += topologySemanticStringMapBytes(profile.Tags)
+		case topologySemanticEventTopologyMetrics, topologySemanticEventVLANContext:
+			if event.kind == topologySemanticEventVLANContext {
+				logicalBytes += topologySemanticMetaTagMapBytes(profile.DeviceMetadata)
+				logicalBytes += topologySemanticStringMapBytes(profile.Tags)
+			}
+			records += uint64(len(profile.TopologyMetrics))
+			for _, metric := range profile.TopologyMetrics {
+				logicalBytes += uint64(len(metric.TopologyKind)) + topologySemanticStringMapBytes(metric.Tags)
+			}
+		case topologySemanticEventBGPPeers:
+			if profile.BGPCollectError != nil {
+				continue
+			}
+			records += uint64(len(profile.BGPRows))
+			for _, row := range profile.BGPRows {
+				if !portableTopologySemanticOrigin(row.OriginProfileID) {
+					return 0, 0, errors.New("non-portable BGP origin profile ID")
+				}
+				logicalBytes += topologySemanticBGPRowLogicalBytes(row)
+			}
+		}
+	}
+	return records, logicalBytes, nil
+}
+
+func projectTopologySemanticProfile(kind topologySemanticEventKind, profile *ddsnmp.ProfileMetrics) topologySemanticProfileEvidence {
+	if profile == nil {
+		return topologySemanticProfileEvidence{}
+	}
+	result := topologySemanticProfileEvidence{}
+	switch kind {
+	case topologySemanticEventProfileTags:
+		result.metadata = maps.Clone(profile.DeviceMetadata)
+		result.tags = maps.Clone(profile.Tags)
+	case topologySemanticEventTopologyMetrics:
+		result.metrics = projectTopologySemanticMetrics(profile.TopologyMetrics)
+	case topologySemanticEventBGPPeers:
+		result.bgpFailed = profile.BGPCollectError != nil
+		if !result.bgpFailed {
+			result.bgpRows = projectTopologySemanticBGPRows(profile.BGPRows)
+		}
+	case topologySemanticEventVLANContext:
+		result.metadata = maps.Clone(profile.DeviceMetadata)
+		result.tags = maps.Clone(profile.Tags)
+		result.metrics = projectTopologySemanticMetrics(profile.TopologyMetrics)
+	}
+	return result
+}
+
+func projectTopologySemanticMetrics(metrics []ddsnmp.Metric) []topologySemanticMetricEvidence {
+	result := make([]topologySemanticMetricEvidence, 0, len(metrics))
+	for _, metric := range metrics {
+		result = append(result, topologySemanticMetricEvidence{
+			kind: metric.TopologyKind,
+			tags: maps.Clone(metric.Tags),
+		})
+	}
+	return result
+}
+
+func projectTopologySemanticBGPRows(rows []ddsnmp.BGPRow) []topologySemanticBGPRowEvidence {
+	result := make([]topologySemanticBGPRowEvidence, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, topologySemanticBGPRowEvidence{
+			originProfileID: row.OriginProfileID,
+			table:           row.Table,
+			rowKey:          row.RowKey,
+			structuralID:    row.StructuralID,
+			kind:            row.Kind,
+			routingInstance: row.Identity.RoutingInstance,
+			neighbor:        row.Identity.Neighbor,
+			remoteAS:        row.Identity.RemoteAS,
+			localAddress:    row.Descriptors.LocalAddress,
+			localAS:         row.Descriptors.LocalAS,
+			localIdentifier: row.Descriptors.LocalIdentifier,
+			peerIdentifier:  row.Descriptors.PeerIdentifier,
+			peerType:        row.Descriptors.PeerType,
+			bgpVersion:      row.Descriptors.BGPVersion,
+			description:     row.Descriptors.Description,
+			adminHas:        row.Admin.Enabled.Has,
+			adminEnabled:    row.Admin.Enabled.Value,
+			stateHas:        row.State.Has,
+			state:           row.State.State,
+			stateRaw:        row.State.Raw,
+			establishedHas:  row.Connection.EstablishedUptime.Has,
+			established:     row.Connection.EstablishedUptime.Value,
+			updateAgeHas:    row.Connection.LastReceivedUpdateAge.Has,
+			updateAge:       row.Connection.LastReceivedUpdateAge.Value,
+			tags:            maps.Clone(row.Tags),
+		})
+	}
+	return result
+}
+
+func portableTopologySemanticOrigin(value string) bool {
+	if value == "" {
+		return true
+	}
+	if strings.ContainsAny(value, `\:`) || path.IsAbs(value) || path.Clean(value) != value {
+		return false
+	}
+	for _, component := range strings.Split(value, "/") {
+		if component == "" || component == "." || component == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneTopologySemanticDeviceInput(value topologySemanticDeviceInput) topologySemanticDeviceInput {
+	value.vnodeLabels = maps.Clone(value.vnodeLabels)
+	return value
+}
+
+func topologySemanticDeviceLogicalBytes(value topologySemanticDeviceInput) uint64 {
+	return uint64(len(value.hostname)+len(value.sysObjectID)+len(value.sysName)+len(value.sysDescr)+
+		len(value.sysContact)+len(value.sysLocation)+len(value.vendor)+len(value.model)+len(value.vnodeGUID)) +
+		topologySemanticStringMapBytes(value.vnodeLabels)
+}
+
+func topologySemanticStringMapBytes(values map[string]string) uint64 {
+	var total uint64
+	for key, value := range values {
+		total += uint64(len(key) + len(value))
+	}
+	return total
+}
+
+func topologySemanticMetaTagMapBytes(values map[string]ddsnmp.MetaTag) uint64 {
+	var total uint64
+	for key, value := range values {
+		total += uint64(len(key) + len(value.Value) + 1)
+	}
+	return total
+}
+
+func topologySemanticBGPRowLogicalBytes(row ddsnmp.BGPRow) uint64 {
+	return uint64(len(row.OriginProfileID)+len(row.Table)+len(row.RowKey)+len(row.StructuralID)+len(row.Kind)+
+		len(row.Identity.RoutingInstance)+len(row.Identity.Neighbor)+len(row.Identity.RemoteAS)+
+		len(row.Descriptors.LocalAddress)+len(row.Descriptors.LocalAS)+len(row.Descriptors.LocalIdentifier)+
+		len(row.Descriptors.PeerIdentifier)+len(row.Descriptors.PeerType)+len(row.Descriptors.BGPVersion)+
+		len(row.Descriptors.Description)+len(row.State.State)+len(row.State.Raw)+19) + topologySemanticStringMapBytes(row.Tags)
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
@@ -484,7 +484,7 @@ func portableTopologySemanticOrigin(value string) bool {
 	if strings.ContainsAny(value, `\:`) || path.IsAbs(value) || path.Clean(value) != value {
 		return false
 	}
-	for _, component := range strings.Split(value, "/") {
+	for component := range strings.SplitSeq(value, "/") {
 		if component == "" || component == "." || component == ".." {
 			return false
 		}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_benchmark_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+func BenchmarkTopologySemanticIngest(b *testing.B) {
+	for _, metricCount := range []int{100, 1000, 10_000} {
+		pms := []*ddsnmp.ProfileMetrics{{TopologyMetrics: make([]ddsnmp.Metric, metricCount)}}
+		for i := range metricCount {
+			pms[0].TopologyMetrics[i] = ddsnmp.Metric{
+				TopologyKind: ddsnmp.KindIfName,
+				Tags: map[string]string{
+					tagTopoIfIndex: fmt.Sprintf("%d", i+1),
+					tagTopoIfName:  fmt.Sprintf("Ethernet%d", i+1),
+				},
+			}
+		}
+		input := topologySemanticDeviceInput{hostname: "192.0.2.1"}
+		collectedAt := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+
+		for _, capture := range []bool{false, true} {
+			b.Run(fmt.Sprintf("metrics=%d/capture=%t", metricCount, capture), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					builder := newTopologyBuilderFromSemanticInput(input, nil, collectedAt, time.Hour)
+					var recorder *topologySemanticRecorder
+					if capture {
+						recorder = newTopologySemanticRecorder(
+							input,
+							nil,
+							collectedAt,
+							time.Hour,
+							defaultTopologySemanticLimits,
+						)
+					}
+					consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventSysUptime, sysUptime: 1})
+					consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventProfileTags, profiles: pms})
+					consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventTopologyMetrics, profiles: pms})
+					consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventBGPPeers, profiles: pms})
+					if recorder != nil && recorder.finish().state != topologySemanticCaptureAvailable {
+						b.Fatal("semantic capture unavailable")
+					}
+				}
+			})
+		}
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_benchmark_test.go
@@ -44,7 +44,7 @@ func BenchmarkTopologySemanticIngest(b *testing.B) {
 					consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventProfileTags, profiles: pms})
 					consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventTopologyMetrics, profiles: pms})
 					consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventBGPPeers, profiles: pms})
-					if recorder != nil && recorder.finish().state != topologySemanticCaptureAvailable {
+					if recorder != nil && recorder.finish().state != diagnosticCaptureAvailable {
 						b.Fatal("semantic capture unavailable")
 					}
 				}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_replay.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_replay.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+var errTopologySemanticBGPCollection = errors.New("captured BGP collection failure")
+
+func replayTopologySemanticEvidence(evidence *topologySemanticEvidence) (*topologyDeviceSnapshot, error) {
+	if err := validateTopologySemanticEvidence(evidence); err != nil {
+		return nil, err
+	}
+	builder := newTopologyBuilderFromSemanticInput(
+		evidence.device,
+		evidence.targets,
+		evidence.collectedAt,
+		evidence.freshFor,
+	)
+	for _, event := range evidence.events {
+		applyTopologySemanticEvent(builder, topologySemanticEventFromEvidence(event))
+	}
+	snapshot, _ := freezeTopologyBuilder(builder)
+	return snapshot, nil
+}
+
+func validateTopologySemanticEvidence(evidence *topologySemanticEvidence) error {
+	if evidence == nil {
+		return errors.New("semantic evidence is missing")
+	}
+	if evidence.collectedAt.IsZero() {
+		return errors.New("semantic collected time is missing")
+	}
+	if evidence.freshFor <= 0 {
+		return errors.New("semantic freshness duration must be positive")
+	}
+	want := []topologySemanticEventKind{
+		topologySemanticEventSysUptime,
+		topologySemanticEventProfileTags,
+		topologySemanticEventTopologyMetrics,
+		topologySemanticEventBGPPeers,
+	}
+	if len(evidence.events) < len(want) {
+		return fmt.Errorf("semantic event order: got %d events, need at least %d", len(evidence.events), len(want))
+	}
+	for i, kind := range want {
+		if evidence.events[i].kind != kind {
+			return fmt.Errorf("semantic event order: event %d is %d, expected %d", i, evidence.events[i].kind, kind)
+		}
+	}
+	for i := len(want); i < len(evidence.events); i++ {
+		if evidence.events[i].kind != topologySemanticEventVLANContext {
+			return fmt.Errorf("semantic event order: event %d is not a VLAN context", i)
+		}
+	}
+	return nil
+}
+
+func topologySemanticEventFromEvidence(event topologySemanticEventEvidence) topologySemanticEvent {
+	profiles := make([]*ddsnmp.ProfileMetrics, 0, len(event.profiles))
+	for _, profile := range event.profiles {
+		profiles = append(profiles, topologySemanticProfileFromEvidence(profile))
+	}
+	return topologySemanticEvent{
+		kind:      event.kind,
+		sysUptime: event.sysUptime,
+		profiles:  profiles,
+		vlanID:    event.vlanID,
+		vlanName:  event.vlanName,
+	}
+}
+
+func topologySemanticProfileFromEvidence(profile topologySemanticProfileEvidence) *ddsnmp.ProfileMetrics {
+	result := &ddsnmp.ProfileMetrics{
+		DeviceMetadata: maps.Clone(profile.metadata),
+		Tags:           maps.Clone(profile.tags),
+	}
+	for _, metric := range profile.metrics {
+		result.TopologyMetrics = append(result.TopologyMetrics, ddsnmp.Metric{
+			TopologyKind: metric.kind,
+			Tags:         maps.Clone(metric.tags),
+		})
+	}
+	for _, row := range profile.bgpRows {
+		result.BGPRows = append(result.BGPRows, topologySemanticBGPRowFromEvidence(row))
+	}
+	if profile.bgpFailed {
+		result.BGPCollectError = errTopologySemanticBGPCollection
+	}
+	return result
+}
+
+func topologySemanticBGPRowFromEvidence(row topologySemanticBGPRowEvidence) ddsnmp.BGPRow {
+	return ddsnmp.BGPRow{
+		OriginProfileID: row.originProfileID,
+		Table:           row.table,
+		RowKey:          row.rowKey,
+		StructuralID:    row.structuralID,
+		Kind:            row.kind,
+		Identity: ddsnmp.BGPIdentity{
+			RoutingInstance: row.routingInstance,
+			Neighbor:        row.neighbor,
+			RemoteAS:        row.remoteAS,
+		},
+		Descriptors: ddsnmp.BGPDescriptors{
+			LocalAddress:    row.localAddress,
+			LocalAS:         row.localAS,
+			LocalIdentifier: row.localIdentifier,
+			PeerIdentifier:  row.peerIdentifier,
+			PeerType:        row.peerType,
+			BGPVersion:      row.bgpVersion,
+			Description:     row.description,
+		},
+		Admin: ddsnmp.BGPAdmin{Enabled: ddsnmp.BGPBool{
+			Has:   row.adminHas,
+			Value: row.adminEnabled,
+		}},
+		State: ddsnmp.BGPState{
+			Has:   row.stateHas,
+			State: row.state,
+			Raw:   row.stateRaw,
+		},
+		Connection: ddsnmp.BGPConnection{
+			EstablishedUptime: ddsnmp.BGPInt64{
+				Has:   row.establishedHas,
+				Value: row.established,
+			},
+			LastReceivedUpdateAge: ddsnmp.BGPInt64{
+				Has:   row.updateAgeHas,
+				Value: row.updateAge,
+			},
+		},
+		Tags: maps.Clone(row.tags),
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestTopologySemanticReplayMatchesLiveBuilder(t *testing.T) {
+	collectedAt := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	freshFor := 32 * time.Minute
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:       "192.0.2.1",
+		Community:      "must-not-appear-in-semantic-evidence",
+		V3AuthKey:      "must-not-appear-in-semantic-evidence",
+		V3PrivKey:      "must-not-appear-in-semantic-evidence",
+		ManualProfiles: []string{"/must/not/appear/profile.yaml"},
+		SysObjectID:    "1.3.6.1.4.1.9.1.1",
+		SysName:        "switch-a",
+		SysDescr:       "test switch",
+		Vendor:         "Cisco",
+		Model:          "C9300",
+		VnodeGUID:      "vnode-guid",
+		VnodeLabels:    map[string]string{"site": "lab"},
+	}
+	deviceInput := topologySemanticDeviceInputFromConnection(dev)
+	targets := []netip.Addr{netip.MustParseAddr("192.0.2.1")}
+	builder := newTopologyBuilderFromSemanticInput(deviceInput, targets, collectedAt, freshFor)
+	recorder := newTopologySemanticRecorder(deviceInput, targets, collectedAt, freshFor, defaultTopologySemanticLimits)
+
+	pms := []*ddsnmp.ProfileMetrics{{
+		Source: "/must/not/appear/profile.yaml",
+		DeviceMetadata: map[string]ddsnmp.MetaTag{
+			tagLldpLocChassisID:        {Value: "001122334455", IsExactMatch: true},
+			tagLldpLocChassisIDSubtype: {Value: "4", IsExactMatch: true},
+		},
+		Tags: map[string]string{tagLldpLocSysName: "switch-a"},
+		TopologyMetrics: []ddsnmp.Metric{
+			{
+				Name:         "/must/not/appear/metric",
+				TopologyKind: ddsnmp.KindIfName,
+				Tags: map[string]string{
+					tagTopoIfIndex: "7",
+					tagTopoIfName:  "Gi1/0/7",
+					tagTopoIfOper:  "up",
+				},
+			},
+			{
+				TopologyKind: ddsnmp.KindLldpLocPort,
+				Tags: map[string]string{
+					tagLldpLocPortNum:       "7",
+					tagLldpLocPortID:        "Gi1/0/7",
+					tagLldpLocPortIDSubtype: "5",
+				},
+			},
+		},
+		BGPRows: []ddsnmp.BGPRow{{
+			OriginProfileID: "_std-bgp4-mib.yaml",
+			Table:           "bgpPeerTable",
+			RowKey:          "192.0.2.2",
+			StructuralID:    "peer-1",
+			Kind:            ddprofiledefinition.BGPRowKindPeer,
+			Identity: ddsnmp.BGPIdentity{
+				RoutingInstance: "default",
+				Neighbor:        "192.0.2.2",
+				RemoteAS:        "65002",
+			},
+			Descriptors: ddsnmp.BGPDescriptors{
+				LocalAddress: "192.0.2.1",
+				LocalAS:      "65001",
+			},
+			Admin: ddsnmp.BGPAdmin{Enabled: ddsnmp.BGPBool{Has: true, Value: true}},
+			State: ddsnmp.BGPState{Has: true, State: ddprofiledefinition.BGPPeerStateEstablished},
+		}},
+	}}
+
+	consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventSysUptime, sysUptime: 1234})
+	consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventProfileTags, profiles: pms})
+	consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventTopologyMetrics, profiles: pms})
+	consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventBGPPeers, profiles: pms})
+	consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{
+		kind:     topologySemanticEventVLANContext,
+		vlanID:   "100",
+		vlanName: "users",
+		profiles: []*ddsnmp.ProfileMetrics{{
+			Source: "/must/not/appear/vlan-profile.yaml",
+			TopologyMetrics: []ddsnmp.Metric{{
+				Name:         "/must/not/appear/vlan-metric",
+				TopologyKind: ddsnmp.KindIfName,
+				Tags: map[string]string{
+					tagTopoIfIndex: "7",
+					tagTopoIfName:  "Gi1/0/7",
+				},
+			}},
+		}},
+	})
+
+	live, _ := freezeTopologyBuilder(builder)
+	capture := recorder.finish()
+	require.Equal(t, topologySemanticCaptureAvailable, capture.state)
+	require.NotNil(t, capture.evidence)
+	require.NotZero(t, capture.recordCount)
+	require.NotZero(t, capture.logicalBytes)
+
+	dev.VnodeLabels["site"] = "changed"
+	pms[0].DeviceMetadata[tagLldpLocChassisID] = ddsnmp.MetaTag{Value: "ffffffffffff"}
+	pms[0].Tags[tagLldpLocSysName] = "changed"
+	pms[0].TopologyMetrics[0].Tags[tagTopoIfName] = "changed"
+	pms[0].BGPRows[0].Identity.Neighbor = "198.51.100.2"
+
+	replayed, err := replayTopologySemanticEvidence(capture.evidence)
+	require.NoError(t, err)
+	require.Equal(t, live.observation, replayed.observation)
+	require.Equal(t, live.hasObservation, replayed.hasObservation)
+	require.Equal(t, live.collectedAt, replayed.collectedAt)
+	require.Equal(t, live.freshFor, replayed.freshFor)
+
+	text := fmt.Sprintf("%+v", capture)
+	require.NotContains(t, text, dev.Community)
+	require.NotContains(t, text, dev.V3AuthKey)
+	require.NotContains(t, text, dev.V3PrivKey)
+	require.NotContains(t, text, dev.ManualProfiles[0])
+	require.NotContains(t, text, pms[0].Source)
+	require.NotContains(t, text, pms[0].TopologyMetrics[0].Name)
+}
+
+func TestTopologySemanticCaptureIgnoresRejectedBGPRows(t *testing.T) {
+	collectedAt := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	input := topologySemanticDeviceInput{hostname: "192.0.2.1"}
+	recorder := newTopologySemanticRecorder(input, nil, collectedAt, time.Minute, defaultTopologySemanticLimits)
+	pms := []*ddsnmp.ProfileMetrics{{
+		BGPCollectError: errors.New("collection failed"),
+		BGPRows: []ddsnmp.BGPRow{{
+			OriginProfileID: "/ignored/private/profile.yaml",
+			Kind:            ddprofiledefinition.BGPRowKindPeer,
+		}},
+	}}
+
+	recorder.record(topologySemanticEvent{kind: topologySemanticEventBGPPeers, profiles: pms})
+	capture := recorder.finish()
+	require.Equal(t, topologySemanticCaptureAvailable, capture.state)
+	require.Len(t, capture.evidence.events, 1)
+	require.True(t, capture.evidence.events[0].profiles[0].bgpFailed)
+	require.Empty(t, capture.evidence.events[0].profiles[0].bgpRows)
+	require.NotContains(t, fmt.Sprintf("%+v", capture), pms[0].BGPRows[0].OriginProfileID)
+}
+
+func TestTopologySemanticReplayRejectsMissingOrReorderedPhases(t *testing.T) {
+	evidence := completeTestTopologySemanticEvidence(t)
+
+	missing := cloneTopologySemanticEvidence(evidence)
+	missing.events = append(missing.events[:1], missing.events[2:]...)
+	_, err := replayTopologySemanticEvidence(missing)
+	require.ErrorContains(t, err, "semantic event order")
+
+	reordered := cloneTopologySemanticEvidence(evidence)
+	reordered.events[1], reordered.events[2] = reordered.events[2], reordered.events[1]
+	_, err = replayTopologySemanticEvidence(reordered)
+	require.ErrorContains(t, err, "semantic event order")
+}
+
+func TestTopologySemanticCaptureLimitFailsOpen(t *testing.T) {
+	collectedAt := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	input := topologySemanticDeviceInput{hostname: "192.0.2.1"}
+	builder := newTopologyBuilderFromSemanticInput(input, nil, collectedAt, time.Minute)
+	recorder := newTopologySemanticRecorder(input, nil, collectedAt, time.Minute, topologySemanticLimits{
+		maxRecords:      1,
+		maxLogicalBytes: 1024,
+	})
+
+	consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventSysUptime, sysUptime: 1234})
+	capture := recorder.finish()
+	require.Equal(t, topologySemanticCaptureLimitExceeded, capture.state)
+	require.Equal(t, topologySemanticCaptureReasonRecordLimit, capture.reason)
+	require.Nil(t, capture.evidence)
+	require.EqualValues(t, 1234, builder.localDevice.SysUptime, "capture limits must not change live ingestion")
+}
+
+func TestTopologySemanticCaptureErrorAndPanicFailOpen(t *testing.T) {
+	collectedAt := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	input := topologySemanticDeviceInput{hostname: "192.0.2.1"}
+
+	t.Run("projection error", func(t *testing.T) {
+		builder := newTopologyBuilderFromSemanticInput(input, nil, collectedAt, time.Minute)
+		recorder := newTopologySemanticRecorder(input, nil, collectedAt, time.Minute, defaultTopologySemanticLimits)
+		pms := []*ddsnmp.ProfileMetrics{{BGPRows: []ddsnmp.BGPRow{{
+			OriginProfileID: "/private/profile.yaml",
+			StructuralID:    "peer-1",
+			Kind:            ddprofiledefinition.BGPRowKindPeer,
+			Identity:        ddsnmp.BGPIdentity{Neighbor: "192.0.2.2", RemoteAS: "65002"},
+		}}}}
+
+		consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventBGPPeers, profiles: pms})
+		capture := recorder.finish()
+		require.Equal(t, topologySemanticCaptureUnavailable, capture.state)
+		require.Equal(t, topologySemanticCaptureReasonProjectionError, capture.reason)
+		require.Nil(t, capture.evidence)
+		require.Len(t, builder.bgpPeersByKey, 1, "projection errors must not change live ingestion")
+		require.NotContains(t, fmt.Sprintf("%+v", capture), pms[0].BGPRows[0].OriginProfileID)
+	})
+
+	t.Run("projection panic", func(t *testing.T) {
+		builder := newTopologyBuilderFromSemanticInput(input, nil, collectedAt, time.Minute)
+		recorder := newTopologySemanticRecorder(input, nil, collectedAt, time.Minute, defaultTopologySemanticLimits)
+		recorder.projectEvent = func(*topologySemanticRecorder, topologySemanticEvent) error {
+			panic("projection panic")
+		}
+
+		require.NotPanics(t, func() {
+			consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventSysUptime, sysUptime: 1234})
+		})
+		capture := recorder.finish()
+		require.Equal(t, topologySemanticCaptureUnavailable, capture.state)
+		require.Equal(t, topologySemanticCaptureReasonProjectionPanic, capture.reason)
+		require.EqualValues(t, 1234, builder.localDevice.SysUptime)
+	})
+}
+
+func completeTestTopologySemanticEvidence(t *testing.T) *topologySemanticEvidence {
+	t.Helper()
+	collectedAt := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	input := topologySemanticDeviceInput{hostname: "192.0.2.1"}
+	recorder := newTopologySemanticRecorder(input, nil, collectedAt, time.Minute, defaultTopologySemanticLimits)
+	for _, event := range []topologySemanticEvent{
+		{kind: topologySemanticEventSysUptime, sysUptime: 1},
+		{kind: topologySemanticEventProfileTags},
+		{kind: topologySemanticEventTopologyMetrics},
+		{kind: topologySemanticEventBGPPeers},
+	} {
+		recorder.record(event)
+	}
+	capture := recorder.finish()
+	require.Equal(t, topologySemanticCaptureAvailable, capture.state)
+	return capture.evidence
+}
+
+func cloneTopologySemanticEvidence(value *topologySemanticEvidence) *topologySemanticEvidence {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	cloned.events = slices.Clone(value.events)
+	return &cloned
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_test.go
@@ -107,7 +107,7 @@ func TestTopologySemanticReplayMatchesLiveBuilder(t *testing.T) {
 
 	live, _ := freezeTopologyBuilder(builder)
 	capture := recorder.finish()
-	require.Equal(t, topologySemanticCaptureAvailable, capture.state)
+	require.Equal(t, diagnosticCaptureAvailable, capture.state)
 	require.NotNil(t, capture.evidence)
 	require.NotZero(t, capture.recordCount)
 	require.NotZero(t, capture.logicalBytes)
@@ -148,7 +148,7 @@ func TestTopologySemanticCaptureIgnoresRejectedBGPRows(t *testing.T) {
 
 	recorder.record(topologySemanticEvent{kind: topologySemanticEventBGPPeers, profiles: pms})
 	capture := recorder.finish()
-	require.Equal(t, topologySemanticCaptureAvailable, capture.state)
+	require.Equal(t, diagnosticCaptureAvailable, capture.state)
 	require.Len(t, capture.evidence.events, 1)
 	require.True(t, capture.evidence.events[0].profiles[0].bgpFailed)
 	require.Empty(t, capture.evidence.events[0].profiles[0].bgpRows)
@@ -180,8 +180,8 @@ func TestTopologySemanticCaptureLimitFailsOpen(t *testing.T) {
 
 	consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventSysUptime, sysUptime: 1234})
 	capture := recorder.finish()
-	require.Equal(t, topologySemanticCaptureLimitExceeded, capture.state)
-	require.Equal(t, topologySemanticCaptureReasonRecordLimit, capture.reason)
+	require.Equal(t, diagnosticCaptureLimitExceeded, capture.state)
+	require.Equal(t, diagnosticCaptureReasonRecordLimit, capture.reason)
 	require.Nil(t, capture.evidence)
 	require.EqualValues(t, 1234, builder.localDevice.SysUptime, "capture limits must not change live ingestion")
 }
@@ -202,8 +202,8 @@ func TestTopologySemanticCaptureErrorAndPanicFailOpen(t *testing.T) {
 
 		consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventBGPPeers, profiles: pms})
 		capture := recorder.finish()
-		require.Equal(t, topologySemanticCaptureUnavailable, capture.state)
-		require.Equal(t, topologySemanticCaptureReasonProjectionError, capture.reason)
+		require.Equal(t, diagnosticCaptureUnavailable, capture.state)
+		require.Equal(t, diagnosticCaptureReasonProjectionError, capture.reason)
 		require.Nil(t, capture.evidence)
 		require.Len(t, builder.bgpPeersByKey, 1, "projection errors must not change live ingestion")
 		require.NotContains(t, fmt.Sprintf("%+v", capture), pms[0].BGPRows[0].OriginProfileID)
@@ -220,8 +220,8 @@ func TestTopologySemanticCaptureErrorAndPanicFailOpen(t *testing.T) {
 			consumeTopologySemanticEvent(builder, recorder, topologySemanticEvent{kind: topologySemanticEventSysUptime, sysUptime: 1234})
 		})
 		capture := recorder.finish()
-		require.Equal(t, topologySemanticCaptureUnavailable, capture.state)
-		require.Equal(t, topologySemanticCaptureReasonProjectionPanic, capture.reason)
+		require.Equal(t, diagnosticCaptureUnavailable, capture.state)
+		require.Equal(t, diagnosticCaptureReasonProjectionPanic, capture.reason)
 		require.EqualValues(t, 1234, builder.localDevice.SysUptime)
 	})
 }
@@ -240,7 +240,7 @@ func completeTestTopologySemanticEvidence(t *testing.T) *topologySemanticEvidenc
 		recorder.record(event)
 	}
 	capture := recorder.finish()
-	require.Equal(t, topologySemanticCaptureAvailable, capture.state)
+	require.Equal(t, diagnosticCaptureAvailable, capture.state)
 	return capture.evidence
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_test.go
@@ -43,16 +43,22 @@ func TestTopologySemanticReplayMatchesLiveBuilder(t *testing.T) {
 		DeviceMetadata: map[string]ddsnmp.MetaTag{
 			tagLldpLocChassisID:        {Value: "001122334455", IsExactMatch: true},
 			tagLldpLocChassisIDSubtype: {Value: "4", IsExactMatch: true},
+			"unused_metadata":          {Value: "must-not-appear-unused-metadata"},
 		},
-		Tags: map[string]string{tagLldpLocSysName: "switch-a"},
+		Tags: map[string]string{
+			tagLldpLocSysName: "switch-a",
+			"vendor":          "must-not-appear-profile-tag-vendor",
+			"unused_profile":  "must-not-appear-unused-profile-tag",
+		},
 		TopologyMetrics: []ddsnmp.Metric{
 			{
 				Name:         "/must/not/appear/metric",
 				TopologyKind: ddsnmp.KindIfName,
 				Tags: map[string]string{
-					tagTopoIfIndex: "7",
-					tagTopoIfName:  "Gi1/0/7",
-					tagTopoIfOper:  "up",
+					tagTopoIfIndex:  "7",
+					tagTopoIfName:   "Gi1/0/7",
+					tagTopoIfOper:   "up",
+					"unused_metric": "must-not-appear-unused-metric-tag",
 				},
 			},
 			{
@@ -61,6 +67,20 @@ func TestTopologySemanticReplayMatchesLiveBuilder(t *testing.T) {
 					tagLldpLocPortNum:       "7",
 					tagLldpLocPortID:        "Gi1/0/7",
 					tagLldpLocPortIDSubtype: "5",
+				},
+			},
+			{
+				TopologyKind: ddsnmp.KindLldpRemManAddr,
+				Tags: map[string]string{
+					tagLldpLocPortNum:                      "7",
+					tagLldpRemIndex:                        "1",
+					tagLldpRemMgmtAddrSubtype:              "1",
+					tagLldpRemMgmtAddrLen:                  "4",
+					tagLldpRemMgmtAddrOctetPref + "1":      "192",
+					tagLldpRemMgmtAddrOctetPref + "2":      "0",
+					tagLldpRemMgmtAddrOctetPref + "3":      "2",
+					tagLldpRemMgmtAddrOctetPref + "4":      "2",
+					tagLldpRemMgmtAddrOctetPref + "unused": "must-not-appear-invalid-octet-tag",
 				},
 			},
 		},
@@ -81,6 +101,12 @@ func TestTopologySemanticReplayMatchesLiveBuilder(t *testing.T) {
 			},
 			Admin: ddsnmp.BGPAdmin{Enabled: ddsnmp.BGPBool{Has: true, Value: true}},
 			State: ddsnmp.BGPState{Has: true, State: ddprofiledefinition.BGPPeerStateEstablished},
+			Tags: map[string]string{
+				"neighbor":         "192.0.2.2",
+				"remote_as":        "65002",
+				"routing_instance": "default",
+				"unused_bgp":       "must-not-appear-unused-bgp-tag",
+			},
 		}},
 	}}
 
@@ -94,14 +120,22 @@ func TestTopologySemanticReplayMatchesLiveBuilder(t *testing.T) {
 		vlanName: "users",
 		profiles: []*ddsnmp.ProfileMetrics{{
 			Source: "/must/not/appear/vlan-profile.yaml",
-			TopologyMetrics: []ddsnmp.Metric{{
-				Name:         "/must/not/appear/vlan-metric",
-				TopologyKind: ddsnmp.KindIfName,
-				Tags: map[string]string{
-					tagTopoIfIndex: "7",
-					tagTopoIfName:  "Gi1/0/7",
+			TopologyMetrics: []ddsnmp.Metric{
+				{
+					Name:         "/must/not/appear/vlan-metric",
+					TopologyKind: ddsnmp.KindIfName,
+					Tags: map[string]string{
+						tagTopoIfIndex: "7",
+						tagTopoIfName:  "Gi1/0/7",
+					},
 				},
-			}},
+				{
+					TopologyKind: ddsnmp.KindIpIfIndex,
+					Tags: map[string]string{
+						tagTopoIPAddr: "must-not-appear-non-vlan-context-row",
+					},
+				},
+			},
 		}},
 	})
 
@@ -132,6 +166,17 @@ func TestTopologySemanticReplayMatchesLiveBuilder(t *testing.T) {
 	require.NotContains(t, text, dev.ManualProfiles[0])
 	require.NotContains(t, text, pms[0].Source)
 	require.NotContains(t, text, pms[0].TopologyMetrics[0].Name)
+	require.NotContains(t, text, "must-not-appear-unused-metadata")
+	require.NotContains(t, text, "must-not-appear-unused-profile-tag")
+	require.NotContains(t, text, "must-not-appear-profile-tag-vendor")
+	require.NotContains(t, text, "must-not-appear-unused-metric-tag")
+	require.NotContains(t, text, "must-not-appear-unused-bgp-tag")
+	require.NotContains(t, text, "must-not-appear-non-vlan-context-row")
+	require.NotContains(t, text, "must-not-appear-invalid-octet-tag")
+	require.Contains(t, capture.evidence.events[1].profiles[0].metadata, tagLldpLocChassisID)
+	require.Contains(t, capture.evidence.events[1].profiles[0].tags, tagLldpLocSysName)
+	require.Contains(t, capture.evidence.events[2].profiles[0].metrics[0].tags, tagTopoIfIndex)
+	require.Contains(t, capture.evidence.events[3].profiles[0].bgpRows[0].tags, "neighbor")
 }
 
 func TestTopologySemanticCaptureIgnoresRejectedBGPRows(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -77,7 +77,7 @@ func freezeTestTopologyBuilder(registrationID ddsnmp.DeviceRegistrationID, build
 
 func freezeTestTopologyBuilderAt(registrationID ddsnmp.DeviceRegistrationID, publishedAt time.Time, builder *topologyBuilder) *topologyDeviceGeneration {
 	snapshot, _ := freezeTopologyBuilder(builder)
-	return activateTopologyDeviceSnapshot(registrationID, publishedAt, snapshot)
+	return activateTopologyDeviceSnapshot(registrationID, 1, publishedAt, snapshot)
 }
 
 func registerTestDeviceState(store *ddsnmp.DeviceStore, devices ...ddsnmp.DeviceConnectionInfo) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context.go
@@ -8,7 +8,12 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
-func (c *Collector) collectTopologyVTPVLANContexts(ctx context.Context, cache *topologyBuilder, dev ddsnmp.DeviceConnectionInfo) {
+func (c *Collector) collectTopologyVTPVLANContexts(
+	ctx context.Context,
+	cache *topologyBuilder,
+	dev ddsnmp.DeviceConnectionInfo,
+	recorder *topologySemanticRecorder,
+) {
 	if cache == nil {
 		return
 	}
@@ -40,6 +45,11 @@ func (c *Collector) collectTopologyVTPVLANContexts(ctx context.Context, cache *t
 			c.Warningf("device '%s': topology vlan-context polling failed for vlan %s: %v", dev.Hostname, context.vlanID, err)
 			continue
 		}
-		cache.ingestTopologyVLANContextMetrics(context.vlanID, context.vlanName, pms)
+		consumeTopologySemanticEvent(cache, recorder, topologySemanticEvent{
+			kind:     topologySemanticEventVLANContext,
+			profiles: pms,
+			vlanID:   context.vlanID,
+			vlanName: context.vlanName,
+		})
 	}
 }


### PR DESCRIPTION
##### Summary

Preserve bounded information about SNMP device lifecycle and completed topology refreshes, including enough evidence to reproduce and explain missing devices or links later.
Diagnostics remain isolated from live collection and topology results.

This establishes the foundation for exportable topology diagnostics, reducing the need for screenshots and repeated troubleshooting questions.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves bounded, credential-free diagnostic evidence for SNMP device lifecycle and completed topology refreshes so missing devices or links can be reproduced later without screenshots or repeated troubleshooting. Live collection and topology results are unaffected.

**New Features**
- Job Manager can call an optional collector-provided lifecycle hook that projects credential-free snapshots at configuration-commit boundaries, failing open, reconciling after commit or confirmed graph equality, and passing a runtime only for accepted jobs.
- The SNMP collector records device lifecycle phases and outcomes in the store before topology consumes the device.
- Topology refreshes retain replayable semantic evidence (metrics, profiles, uptime, VLAN context, BGP) bounded by byte and entry caps, with expiry and per-device success/removal diagnostics.
- Captured evidence never contains SNMP credentials, config values, or runtime objects.

<sup>Written for commit 0177ff336f3d4ba5c09a26867f0040e2206a05e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SNMP device lifecycle diagnostics covering initialization, checks, collection, failures, and cleanup.
  * Added topology diagnostics for device status, selection, retained evidence, and interrupted refreshes.
  * Added bounded semantic evidence capture for metrics, profiles, uptime, VLAN context, and BGP data.
  * Added credential-free configuration lifecycle projections for safer diagnostics.
* **Reliability**
  * Diagnostic updates now publish only after topology and configuration changes are reconciled.
  * Capture failures, panics, cancellations, and limit exhaustion no longer block topology updates.
* **Documentation**
  * Updated architecture guidance for lifecycle diagnostics, evidence retention, and semantic limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->