### PR TITLE
fix(cpp): remove dead stores and avoid copying ML queue items

### DIFF
--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -59,8 +59,6 @@ static void bit_buffer_write(uint32_t *buf, size_t pos, uint32_t v, size_t nbits
     const size_t index = pos / bit_size<uint32_t>();
     const size_t offset = pos % bit_size<uint32_t>();
 
-    pos += nbits;
-
     if (offset == 0) {
         gorilla_data_word_store(&buf[index], v);
     } else {
@@ -86,8 +84,6 @@ static void bit_buffer_read(const uint32_t *buf, size_t pos, uint32_t *v, size_t
 
     const size_t index = pos / bit_size<uint32_t>();
     const size_t offset = pos % bit_size<uint32_t>();
-
-    pos += nbits;
 
     if (offset == 0) {
         uint32_t word = gorilla_data_word_load(&buf[index]);

--- a/src/ml/ml_queue.cc
+++ b/src/ml/ml_queue.cc
@@ -20,7 +20,7 @@ void ml_queue_destroy(ml_queue_t *q)
     delete q;
 }
 
-void ml_queue_push(ml_queue_t *q, const ml_queue_item_t req)
+void ml_queue_push(ml_queue_t *q, const ml_queue_item_t &req)
 {
     netdata_mutex_lock(&q->mutex);
 

--- a/src/ml/ml_queue.h
+++ b/src/ml/ml_queue.h
@@ -61,7 +61,7 @@ ml_queue_t *ml_queue_init();
 
 void ml_queue_destroy(ml_queue_t *q);
 
-void ml_queue_push(ml_queue_t *q, const ml_queue_item_t req);
+void ml_queue_push(ml_queue_t *q, const ml_queue_item_t &req);
 
 ml_queue_item_t ml_queue_pop(ml_queue_t *q);
 


### PR DESCRIPTION
##### Summary
- Remove redundant pos updates in Gorilla bit-buffer read/write helpers.
- Pass ml_queue_item_t to ml_queue_push() by const reference to avoid copying a 248-byte structure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary copying when adding items to the machine-learning queue.
  * Streamlined internal bit-buffer operations without changing observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->