### PR TITLE
health: batch health log cleanup

### DIFF
--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -364,7 +364,7 @@ void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae)
 // The rowid-IN form is used rather than "DELETE ... LIMIT": both produce an identical query
 // plan, but DELETE-with-LIMIT needs SQLITE_ENABLE_UPDATE_DELETE_LIMIT, which is not enabled
 // in every SQLite build netdata may link against.
-#define HEALTH_LOG_CLEANUP_BATCH_SIZE (5000)
+#define HEALTH_LOG_CLEANUP_BATCH_SIZE (2000)
 
 #define SQL_CLEANUP_HEALTH_LOG_DETAIL                                                                                  \
     "DELETE FROM health_log_detail WHERE rowid IN ("                                                                   \
@@ -372,54 +372,74 @@ void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae)
     "   (SELECT health_log_id FROM health_log WHERE host_id = @host_id) AND d.when_key < UNIXEPOCH() - @history "      \
     "   AND d.updated_by_id <> 0 AND d.transition_id NOT IN "                                                          \
     "   (SELECT last_transition_id FROM health_log hl WHERE hl.host_id = @host_id)"                                    \
-    "  LIMIT @batch)"
+    "  LIMIT @batch) RETURNING 1"
 
-// Returns true when rows may still be eligible for this host - the caller's runtime budget
-// expired or the WAL grew too large - so the caller can retry sooner than its normal interval.
-// "started" is the caller's pass start, so the budget bounds the whole pass, not each host.
+// Returns true when this host still has eligible rows and the caller should come back sooner
+// than its normal interval. Only the two throttles set it - an oversized WAL and the runtime
+// budget - because only they stop with work that is known to be drainable. A failed statement
+// is reported and left for the next normal pass: retrying it once a minute for every host
+// would only repeat a permanent failure.
+//
+// "started" is the caller's pass start, so the runtime budget bounds the whole pass rather
+// than each host.
 bool sql_health_alarm_log_cleanup(RRDHOST *host, time_t started)
 {
     sqlite3_stmt *res = NULL;
     int rc;
     int param = 0;
-    bool more_work = false;
+    bool retry_soon = false;
 
-    if (!PREPARE_STATEMENT(db_meta, SQL_CLEANUP_HEALTH_LOG_DETAIL, &res))
+    if (!PREPARE_STATEMENT(db_meta, SQL_CLEANUP_HEALTH_LOG_DETAIL, &res)) {
+        health_alarm_log_cleanup(host);
         return false;
+    }
 
     // Each iteration is its own transaction, so the WAL can be checkpointed and other writers
     // can make progress between batches. We stop early on the same two conditions the other
     // cleanups in run_metadata_cleanup() respect - an oversized WAL and a runtime budget - and
     // whatever is left is picked up by the next cleanup cycle.
     while (true) {
-        if (!sql_metadata_wal_size_acceptable()) {
-            more_work = true;
-            break;
-        }
-
         param = 0;
         SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC));
         SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)host->health_log.health_log_retention_s));
         SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)HEALTH_LOG_CLEANUP_BATCH_SIZE));
 
         param = 0;
-        rc = sqlite3_step_monitored(res);
+
+        // The statement RETURNs one row per deleted row: counting them is statement local.
+        // sqlite3_changes() cannot be used here - it reports the last statement completed on
+        // the connection, and db_meta is shared with the health and ACLK threads, which makes
+        // its value unpredictable rather than merely stale.
+        //
+        // Never leave this drain on a SQLITE_ROW: finalizing or resetting a half drained
+        // RETURNING statement commits the rows it already deleted instead of rolling them
+        // back, so we would lose exactly the count we came here for.
+        //
+        // The delete itself completes inside the first step and the rows are replayed from an
+        // ephemeral table, so the implicit commit lands on the step that returns SQLITE_DONE.
+        // A busy there makes sqlite3_step() reset, and the retry inside sqlite3_step_monitored()
+        // restarts the delete rather than resuming it, counting the same rows twice. That can
+        // only inflate the count, so it costs one extra batch and can never fake an exhausted
+        // set.
+        int deleted = 0;
+        while ((rc = sqlite3_step_monitored(res)) == SQLITE_ROW)
+            deleted++;
+
         if (unlikely(rc != SQLITE_DONE)) {
             error_report("Failed to cleanup health log detail table, rc = %d", rc);
             break;
         }
 
-        // sqlite3_changes() counts the last statement completed on the connection, not on our
-        // statement, and db_meta is shared with the health and ACLK threads. A concurrent write
-        // landing between the step above and this read can only clobber the count downwards to
-        // something below the batch size, so only a zero proves the eligible set is exhausted.
-        // Any other value keeps us looping, bounded by the WAL gate and the budget below, at
-        // the cost of one delete that matches nothing per host per pass.
-        if (sqlite3_changes(db_meta) == 0)
+        // a short batch means the eligible set for this host is exhausted
+        if (deleted < HEALTH_LOG_CLEANUP_BATCH_SIZE)
             break;
 
-        if (now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD) {
-            more_work = true;
+        // Both throttles are checked after a batch, never before the first one: the caller
+        // gates on the WAL immediately before calling us, so checking it here again would only
+        // repeat that stat once per host.
+        if (!sql_metadata_wal_size_acceptable() ||
+            now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD) {
+            retry_soon = true;
             break;
         }
 
@@ -433,7 +453,7 @@ done:
     // After cleaning up SQLite entries, also clean up in-memory entries
     health_alarm_log_cleanup(host);
 
-    return more_work;
+    return retry_soon;
 }
 
 #define SQL_UPDATE_TRANSITION_IN_HEALTH_LOG                                                                            \

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -3,6 +3,7 @@
 #include "sqlite_health.h"
 #include "sqlite_functions.h"
 #include "sqlite_db_migration.h"
+#include "sqlite_metadata.h"
 #include "health/health_internals.h"
 #include "health/health-alert-entry.h"
 
@@ -353,33 +354,71 @@ void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae)
  *
  */
 
+// Rows are deleted in bounded batches. The eligible set is extremely bimodal: on a large
+// parent most hourly runs have a few dozen rows to delete, but roughly three times a day a
+// run finds ~800k rows that crossed the retention boundary together. Deleting those in one
+// transaction rewrites the table plus every index on it, and the resulting fsync storm
+// saturates the database disk long enough to starve dbengine queries - which stalls health
+// evaluation itself, since health is the biggest query consumer on a parent.
+//
+// The rowid-IN form is used rather than "DELETE ... LIMIT": both produce an identical query
+// plan, but DELETE-with-LIMIT needs SQLITE_ENABLE_UPDATE_DELETE_LIMIT, which is not enabled
+// in every SQLite build netdata may link against.
+#define HEALTH_LOG_CLEANUP_BATCH_SIZE (5000)
+
 #define SQL_CLEANUP_HEALTH_LOG_DETAIL                                                                                  \
-    "DELETE FROM health_log_detail WHERE health_log_id IN "                                                            \
-    " (SELECT health_log_id FROM health_log WHERE host_id = @host_id) AND when_key < UNIXEPOCH() - @history "          \
-    " AND updated_by_id <> 0 AND transition_id NOT IN "                                                                \
-    " (SELECT last_transition_id FROM health_log hl WHERE hl.host_id = @host_id)"
+    "DELETE FROM health_log_detail WHERE rowid IN ("                                                                   \
+    "  SELECT d.rowid FROM health_log_detail d WHERE d.health_log_id IN "                                              \
+    "   (SELECT health_log_id FROM health_log WHERE host_id = @host_id) AND d.when_key < UNIXEPOCH() - @history "      \
+    "   AND d.updated_by_id <> 0 AND d.transition_id NOT IN "                                                          \
+    "   (SELECT last_transition_id FROM health_log hl WHERE hl.host_id = @host_id)"                                    \
+    "  LIMIT @batch)"
 
 void sql_health_alarm_log_cleanup(RRDHOST *host)
 {
     sqlite3_stmt *res = NULL;
     int rc;
+    int param = 0;
 
     if (!PREPARE_STATEMENT(db_meta, SQL_CLEANUP_HEALTH_LOG_DETAIL, &res))
         return;
 
-    int param = 0;
-    SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC));
-    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)host->health_log.health_log_retention_s));
+    time_t started = now_monotonic_sec();
 
-    param = 0;
-    rc = sqlite3_step_monitored(res);
-    if (unlikely(rc != SQLITE_DONE))
-        error_report("Failed to cleanup health log detail table, rc = %d", rc);
+    // Each iteration is its own transaction, so the WAL can be checkpointed and other writers
+    // can make progress between batches. We stop early on the same two conditions the other
+    // cleanups in run_metadata_cleanup() respect - an oversized WAL and a runtime budget - and
+    // whatever is left is picked up by the next cleanup cycle.
+    while (true) {
+        param = 0;
+        SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC));
+        SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)host->health_log.health_log_retention_s));
+        SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)HEALTH_LOG_CLEANUP_BATCH_SIZE));
+
+        param = 0;
+        rc = sqlite3_step_monitored(res);
+        if (unlikely(rc != SQLITE_DONE)) {
+            error_report("Failed to cleanup health log detail table, rc = %d", rc);
+            break;
+        }
+
+        // a short batch means the eligible set for this host is exhausted
+        if (sqlite3_changes(db_meta) < HEALTH_LOG_CLEANUP_BATCH_SIZE)
+            break;
+
+        if (!sql_metadata_wal_size_acceptable())
+            break;
+
+        if (now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD)
+            break;
+
+        SQLITE_RESET(res);
+    }
 
 done:
     REPORT_BIND_FAIL(res, param);
     SQLITE_FINALIZE(res);
-    
+
     // After cleaning up SQLite entries, also clean up in-memory entries
     health_alarm_log_cleanup(host);
 }

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -390,6 +390,9 @@ void sql_health_alarm_log_cleanup(RRDHOST *host)
     // cleanups in run_metadata_cleanup() respect - an oversized WAL and a runtime budget - and
     // whatever is left is picked up by the next cleanup cycle.
     while (true) {
+        if (!sql_metadata_wal_size_acceptable())
+            break;
+
         param = 0;
         SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC));
         SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)host->health_log.health_log_retention_s));
@@ -404,9 +407,6 @@ void sql_health_alarm_log_cleanup(RRDHOST *host)
 
         // a short batch means the eligible set for this host is exhausted
         if (sqlite3_changes(db_meta) < HEALTH_LOG_CLEANUP_BATCH_SIZE)
-            break;
-
-        if (!sql_metadata_wal_size_acceptable())
             break;
 
         if (now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD)

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -374,24 +374,28 @@ void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae)
     "   (SELECT last_transition_id FROM health_log hl WHERE hl.host_id = @host_id)"                                    \
     "  LIMIT @batch)"
 
-void sql_health_alarm_log_cleanup(RRDHOST *host)
+// Returns true when rows may still be eligible for this host - the caller's runtime budget
+// expired or the WAL grew too large - so the caller can retry sooner than its normal interval.
+// "started" is the caller's pass start, so the budget bounds the whole pass, not each host.
+bool sql_health_alarm_log_cleanup(RRDHOST *host, time_t started)
 {
     sqlite3_stmt *res = NULL;
     int rc;
     int param = 0;
+    bool more_work = false;
 
     if (!PREPARE_STATEMENT(db_meta, SQL_CLEANUP_HEALTH_LOG_DETAIL, &res))
-        return;
-
-    time_t started = now_monotonic_sec();
+        return false;
 
     // Each iteration is its own transaction, so the WAL can be checkpointed and other writers
     // can make progress between batches. We stop early on the same two conditions the other
     // cleanups in run_metadata_cleanup() respect - an oversized WAL and a runtime budget - and
     // whatever is left is picked up by the next cleanup cycle.
     while (true) {
-        if (!sql_metadata_wal_size_acceptable())
+        if (!sql_metadata_wal_size_acceptable()) {
+            more_work = true;
             break;
+        }
 
         param = 0;
         SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC));
@@ -405,12 +409,19 @@ void sql_health_alarm_log_cleanup(RRDHOST *host)
             break;
         }
 
-        // a short batch means the eligible set for this host is exhausted
-        if (sqlite3_changes(db_meta) < HEALTH_LOG_CLEANUP_BATCH_SIZE)
+        // sqlite3_changes() counts the last statement completed on the connection, not on our
+        // statement, and db_meta is shared with the health and ACLK threads. A concurrent write
+        // landing between the step above and this read can only clobber the count downwards to
+        // something below the batch size, so only a zero proves the eligible set is exhausted.
+        // Any other value keeps us looping, bounded by the WAL gate and the budget below, at
+        // the cost of one delete that matches nothing per host per pass.
+        if (sqlite3_changes(db_meta) == 0)
             break;
 
-        if (now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD)
+        if (now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD) {
+            more_work = true;
             break;
+        }
 
         SQLITE_RESET(res);
     }
@@ -421,6 +432,8 @@ done:
 
     // After cleaning up SQLite entries, also clean up in-memory entries
     health_alarm_log_cleanup(host);
+
+    return more_work;
 }
 
 #define SQL_UPDATE_TRANSITION_IN_HEALTH_LOG                                                                            \

--- a/src/database/sqlite/sqlite_health.h
+++ b/src/database/sqlite/sqlite_health.h
@@ -15,7 +15,7 @@ struct sql_alert_config_data;
 struct rrd_alert_prototype;
 void sql_health_alarm_log_load(RRDHOST *host);
 void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
-void sql_health_alarm_log_cleanup(RRDHOST *host);
+bool sql_health_alarm_log_cleanup(RRDHOST *host, time_t started);
 void sql_alert_store_config(struct rrd_alert_prototype *ap);
 int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_STATUS *last_executed_status);
 void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, time_t after, const char *chart);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1635,11 +1635,25 @@ static struct cleanup_cycle label_cleanup_cycle = {
 static void cleanup_health_log(struct meta_config_s *config)
 {
     static time_t next_execution_t = 0;
+    static time_t next_orphan_sweep_t = 0;
+
+    // The host a previous pass stopped at, so the hosts at the end of the index are not starved
+    // by a large backlog on the hosts before them. The cursor is the host id and not its
+    // position: hosts are removed at runtime, which shifts every host after them and would
+    // silently skip one.
+    static nd_uuid_t resume_host_id;
+    static bool have_resume_host = false;
+
+    // A host left with rows behind has to keep the fast cadence even when the passes that follow
+    // find nothing to do, or its backlog waits for a full interval.
+    static bool cycle_incomplete = false;
 
     time_t now = now_realtime_sec();
 
-    if (!next_execution_t)
+    if (!next_execution_t) {
         next_execution_t = nd_time_t_add_saturating(now, METADATA_MAINTENANCE_FIRST_CHECK);
+        next_orphan_sweep_t = next_execution_t;
+    }
 
     if (next_execution_t && next_execution_t > now)
         return;
@@ -1650,41 +1664,78 @@ static void cleanup_health_log(struct meta_config_s *config)
     // One runtime budget for the whole pass, not one per host: otherwise a parent with many
     // children could hold the metadata event loop for hosts x METADATA_RUNTIME_THRESHOLD seconds.
     time_t started = now_monotonic_sec();
-    bool more_work = false;
+    bool resumed = have_resume_host;
+    bool seeking = resumed;
+    bool stopped_early = false;
+    bool pass_incomplete = false;
+
+    have_resume_host = false;
 
     dfe_start_reentrant(rrdhost_root_index, host)
     {
-        if (now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD) {
-            more_work = true;
+        // fast forward to the host the previous pass stopped at
+        if (seeking) {
+            if (!nd_uuid_eq(host->host_id.uuid, resume_host_id))
+                continue;
+            seeking = false;
+        }
+
+        // Stop the pass on the same conditions the rest of run_metadata_cleanup() honors.
+        // Continuing would only prepare, stat and finalize once per remaining host for no work,
+        // and walk every host's in-memory alarm list under its health log lock.
+        if (!sql_metadata_wal_size_acceptable() ||
+            now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD) {
+            uuid_copy(resume_host_id, host->host_id.uuid);
+            have_resume_host = true;
+            stopped_early = true;
             break;
         }
 
         if (sql_health_alarm_log_cleanup(host, started))
-            more_work = true;
+            pass_incomplete = true;
 
         if (unlikely(SHUTDOWN_REQUESTED(config)))
             break;
     }
     dfe_done(host);
 
-    // A pass that stopped on the WAL gate or the runtime budget left rows behind. Retry soon
-    // instead of deferring them for a full interval - the WAL can stay over its limit for hours
-    // on a busy parent, and health_log_detail would grow unbounded in the meantime.
-    next_execution_t = nd_time_t_add_saturating(
-        now, more_work ? METADATA_HEALTH_LOG_REPEAT : METADATA_HEALTH_LOG_INTERVAL);
+    // Only a pass that started at the top of the index and walked all of it knows the whole
+    // truth. One that resumed at a cursor, stopped early, or never found its cursor host
+    // because it was removed, has not seen every host, so it can only add to what we knew.
+    if (stopped_early || seeking || resumed)
+        cycle_incomplete = cycle_incomplete || pass_incomplete;
+    else
+        cycle_incomplete = pass_incomplete;
 
+    bool more_work = stopped_early || seeking || cycle_incomplete;
+
+    // no rescheduling on the way out: the metadata event loop is stopping and these statics
+    // die with the process
     if (unlikely(SHUTDOWN_REQUESTED(config))) {
         worker_is_idle();
         return;
     }
 
-    // The orphan sweeps are unbounded deletes, so run them only on a pass that completed - a
-    // retry pass is already fighting for the same disk.
-    if (!more_work) {
-        (void) db_execute(db_meta, SQL_DELETE_ORPHAN_HEALTH_LOG, NULL);
-        (void) db_execute(db_meta, SQL_DELETE_ORPHAN_HEALTH_LOG_DETAIL, NULL);
-        (void) db_execute(db_meta, SQL_DELETE_ORPHAN_ALERT_VERSION, NULL);
+    // The orphan sweeps are unbounded deletes that have nothing to do with the retention drain
+    // above, so they keep their own hourly cadence: tying them to the pass would either repeat
+    // them on every retry, or never run them while a drain persists.
+    if (next_orphan_sweep_t <= now) {
+        if (sql_metadata_wal_size_acceptable()) {
+            (void) db_execute(db_meta, SQL_DELETE_ORPHAN_HEALTH_LOG, NULL);
+            (void) db_execute(db_meta, SQL_DELETE_ORPHAN_HEALTH_LOG_DETAIL, NULL);
+            (void) db_execute(db_meta, SQL_DELETE_ORPHAN_ALERT_VERSION, NULL);
+            next_orphan_sweep_t = nd_time_t_add_saturating(now_realtime_sec(), METADATA_HEALTH_LOG_INTERVAL);
+        }
+        else
+            // due, but the WAL is over its limit - come back for it soon rather than leaving it
+            // to the next interval
+            more_work = true;
     }
+
+    // the deletes above are unbounded, so schedule from the clock after the work, not before it
+    next_execution_t = nd_time_t_add_saturating(
+        now_realtime_sec(), more_work ? METADATA_HEALTH_LOG_REPEAT : METADATA_HEALTH_LOG_INTERVAL);
+
     worker_is_idle();
 }
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -203,7 +203,6 @@ sqlite3 *db_meta = NULL;
 #define METADATA_MAINTENANCE_CTX_CLEAN_REPEAT (300) // Repeat if last run for dimensions, charts, labels needs more work
 #define METADATA_HEALTH_LOG_INTERVAL (3600)         // Repeat maintenance for health
 #define METADATA_LABEL_CHECK_INTERVAL (3600)        // Repeat maintenance for labels
-#define METADATA_RUNTIME_THRESHOLD (5)              // Run time threshold for cleanup task
 
 #define METADATA_HOST_CHECK_FIRST_CHECK (5)         // First check for pending metadata
 #define METADATA_HOST_CHECK_INTERVAL (5)            // Repeat check for pending metadata
@@ -733,7 +732,7 @@ static int64_t sql_get_wal_size(const char *database_file)
 
 #define SQLITE_METADATA_WAL_LIMIT_X (10)
 
-bool sql_metadata_wal_size_acceptable()
+bool sql_metadata_wal_size_acceptable(void)
 {
     int64_t wal_size = sql_get_wal_size("netdata-meta.db");
 

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -202,6 +202,7 @@ sqlite3 *db_meta = NULL;
 #define METADATA_MAINTENANCE_REPEAT (60)            // Repeat if last run for dimensions, charts, labels needs more work
 #define METADATA_MAINTENANCE_CTX_CLEAN_REPEAT (300) // Repeat if last run for dimensions, charts, labels needs more work
 #define METADATA_HEALTH_LOG_INTERVAL (3600)         // Repeat maintenance for health
+#define METADATA_HEALTH_LOG_REPEAT (60)             // Repeat if the last health log cleanup left work behind
 #define METADATA_LABEL_CHECK_INTERVAL (3600)        // Repeat maintenance for labels
 
 #define METADATA_HOST_CHECK_FIRST_CHECK (5)         // First check for pending metadata
@@ -1643,27 +1644,47 @@ static void cleanup_health_log(struct meta_config_s *config)
     if (next_execution_t && next_execution_t > now)
         return;
 
-    next_execution_t = nd_time_t_add_saturating(now, METADATA_HEALTH_LOG_INTERVAL);
-
     RRDHOST *host;
     worker_is_busy(UV_EVENT_HEALTH_LOG_CLEANUP);
 
+    // One runtime budget for the whole pass, not one per host: otherwise a parent with many
+    // children could hold the metadata event loop for hosts x METADATA_RUNTIME_THRESHOLD seconds.
+    time_t started = now_monotonic_sec();
+    bool more_work = false;
+
     dfe_start_reentrant(rrdhost_root_index, host)
     {
-        sql_health_alarm_log_cleanup(host);
+        if (now_monotonic_sec() - started >= METADATA_RUNTIME_THRESHOLD) {
+            more_work = true;
+            break;
+        }
+
+        if (sql_health_alarm_log_cleanup(host, started))
+            more_work = true;
+
         if (unlikely(SHUTDOWN_REQUESTED(config)))
             break;
     }
     dfe_done(host);
+
+    // A pass that stopped on the WAL gate or the runtime budget left rows behind. Retry soon
+    // instead of deferring them for a full interval - the WAL can stay over its limit for hours
+    // on a busy parent, and health_log_detail would grow unbounded in the meantime.
+    next_execution_t = nd_time_t_add_saturating(
+        now, more_work ? METADATA_HEALTH_LOG_REPEAT : METADATA_HEALTH_LOG_INTERVAL);
 
     if (unlikely(SHUTDOWN_REQUESTED(config))) {
         worker_is_idle();
         return;
     }
 
-    (void) db_execute(db_meta, SQL_DELETE_ORPHAN_HEALTH_LOG, NULL);
-    (void) db_execute(db_meta, SQL_DELETE_ORPHAN_HEALTH_LOG_DETAIL, NULL);
-    (void) db_execute(db_meta, SQL_DELETE_ORPHAN_ALERT_VERSION, NULL);
+    // The orphan sweeps are unbounded deletes, so run them only on a pass that completed - a
+    // retry pass is already fighting for the same disk.
+    if (!more_work) {
+        (void) db_execute(db_meta, SQL_DELETE_ORPHAN_HEALTH_LOG, NULL);
+        (void) db_execute(db_meta, SQL_DELETE_ORPHAN_HEALTH_LOG_DETAIL, NULL);
+        (void) db_execute(db_meta, SQL_DELETE_ORPHAN_ALERT_VERSION, NULL);
+    }
     worker_is_idle();
 }
 

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -63,6 +63,11 @@ void store_host_info_and_metadata(RRDHOST *host);
 void metadata_execute_store_statement(sqlite3_stmt *stmt);
 size_t populate_metrics_from_database(void *mrg, void (*populate_cb)(void *mrg, Word_t section, nd_uuid_t *uuid));
 
+// Throttle primitives shared by the cleanup tasks in run_metadata_cleanup(). Long-running
+// cleanups must yield on both: an oversized WAL, and a per-pass runtime budget.
+#define METADATA_RUNTIME_THRESHOLD (5)              // Run time threshold for cleanup task
+bool sql_metadata_wal_size_acceptable(void);
+
 // UNIT TEST
 int metadata_unittest(void);
 #endif //NETDATA_SQLITE_METADATA_H


### PR DESCRIPTION
##### Summary
- Batch health-log retention deletes and resume cleanup across hosts within a bounded runtime budget.
- Throttle cleanup when the metadata WAL grows too large, retrying incomplete work sooner.
- Count deleted rows from the statement result and preserve orphan cleanup on its normal cadence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Performance

- Improved health-log cleanup efficiency through controlled batching.
- Reduced unnecessary database maintenance activity.
- Cleanup now monitors runtime and database conditions between batches.

## Reliability

- Added safeguards to pause cleanup when runtime or database limits are reached.
- Improved protection against oversized write-ahead logs.
- Remaining cleanup work is resumed automatically, with periodic orphan-record maintenance.
- Removed obsolete health-log indexes during database startup cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
