### PR TITLE
feat(go.d/snmp_topology): add hermetic topology graph replay

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -335,17 +335,21 @@ tracks `lastAttempt`, `lastSuccess`, `nextRetry`, the latest outcome,
 consecutive failures, the monotonic attempt ordinal, the latest completed
 attempt capture, and the last successful device generation.
 
+The published `topologyGeneration` also owns the producer scope captured at the
+same commit boundary. Graph readers therefore cannot combine an observation
+vector from one sweep with a later registry scope.
+
 ## Registry And Snapshot
 
 `topology_registry.go` owns one atomic pointer to the latest immutable
 `topologyGeneration`. The generation contains the complete, registration-ID
-ordered vector produced by one refresh sweep.
+ordered vector and producer scope produced by one refresh sweep.
 
 ```text
-topologyRegistry.snapshotWithOptions(options)
+topologyRegistry.snapshotWithEnvironment(options, environment)
   normalize query options
   acquire one topology generation
-  read the generation's fixed renderable device membership
+  read the generation's fixed renderable device membership and producer scope
   aggregate per-device observations
   build a topology graph
 ```
@@ -413,11 +417,12 @@ instead of copying or hashing those IDs per link:
 - the renderer validates unique actors and resolved link handles, then maps
   handles to final actor rows without serializing the handles.
 
-The aggregate also carries the producer scope id read from the parent Agent
-registry id. L3 subnet segment actor ids use that scope so identical private
-subnets observed by different Agents do not collide after Cloud aggregation.
-If the registry id is unavailable, L3 subnet segment actors are omitted; direct
-L3 subnet links, OSPF, and BGP enrichment still run.
+The aggregate also carries the producer scope id captured in its immutable
+generation from the parent Agent registry id. L3 subnet segment actor ids use
+that scope so identical private subnets observed by different Agents do not
+collide after Cloud aggregation. If the registry id is unavailable, L3 subnet
+segment actors are omitted; direct L3 subnet links, OSPF, and BGP enrichment
+still run.
 
 Renderable membership is fixed when a complete topology generation publishes;
 Function, focus, availability, and reverse-DNS readers therefore see one stable
@@ -504,8 +509,8 @@ and adapters to shared SNMP-family state.
 The internal packages are deliberately narrower:
 
 - `internal/topologymodel`: typed internal graph model used by SNMP topology.
-- `internal/topologyoptions`: Function/query option constants and
-  normalization.
+- `internal/topologyoptions`: comparable scalar Function/query option constants
+  and normalization.
 - `internal/topologyshape`: graph shaping and policy passes, such as collapse,
   map type filtering, probable-link marking, and depth/focus filtering.
 - `internal/topologyenrich`: pure graph enrichment for L3 subnet, OSPF, and BGP
@@ -560,7 +565,7 @@ flowchart TD
     Request["snmp:topology:snmp request"]
     Handler["snmptopologyfunc.Handle"]
     Options["resolve QueryOptions"]
-    Registry["topologyRegistry.snapshotWithOptions"]
+    Registry["topologyRegistry.snapshotWithEnvironment"]
     Snapshot["fresh device-generation snapshots"]
     Aggregate["aggregate observations"]
     L2["l2topology BuildL2Result -> ToGraph"]
@@ -577,7 +582,7 @@ flowchart TD
 snmp:topology:snmp request
   -> snmptopologyfunc.Handle
   -> funcDepsAdapter.Snapshot(options)
-  -> topologyRegistry.snapshotWithOptions(options)
+  -> topologyRegistry.snapshotWithEnvironment(options, cache-only DNS)
   -> topologyv1.Render(data)
   -> Function response with type "topology"
 ```
@@ -596,6 +601,42 @@ Reverse DNS is cache-backed and non-blocking on the Function path:
   sysName, hostname, IP, and MAC display-name order.
 
 Function requests must not perform live DNS I/O while serving a response.
+
+## Offline Graph Replay
+
+`topology_graph_replay.go` rebuilds a typed `netdata.topology.v1` payload from
+the committed diagnostic cut without retaining Function requests or rendered
+payloads:
+
+```text
+committed topology diagnostic cut
+  -> replay each renderable device's acquisition evidence
+  -> sort and aggregate observation snapshots
+  -> apply caller-supplied scalar query options
+  -> run the shared graph, enrichment, shaping, and topology-v1 renderer
+```
+
+The replay contract is hermetic:
+
+- query options contain only comparable scalar selectors; replay callers supply
+  the desired option set instead of selecting retained query history;
+- collection time comes from acquisition evidence, and replay rejects missing
+  collection timestamps instead of allowing the renderer's current-time
+  fallback;
+- producer scope comes from the same immutable generation as the diagnostic
+  cut;
+- the offline build environment has no reverse-DNS resolver, so PTR-derived DNS
+  names and display choices deterministically fall back to collected identity;
+- OUI enrichment uses the compiled-in lookup table and needs no captured
+  environment revision;
+- a renderable device without available acquisition evidence makes complete
+  replay fail rather than silently emitting a partial graph.
+
+Live Function and offline replay use the same graph and renderer. Their typed
+topology structure is identical for the same scalar options; only PTR-derived
+presentation fields may differ. This replay entry point consumes trusted,
+already-bounded in-memory diagnostics. Validation and structural limits for
+untrusted archive input belong to the later archive reader boundary.
 
 ## Trap Enrichment
 
@@ -626,8 +667,8 @@ and retained device-generation state; they are not the topology payload.
 - A completed sweep fixes renderable membership and publishes one immutable
   `topologyGeneration` through an atomic pointer. Cancellation or panic leaves
   the previous generation visible.
-- Function, focus, availability, reverse-DNS, and trap readers each load that
-  pointer once and never block on collection or builder locks.
+- Function, focus, availability, reverse-DNS, diagnostics, and trap readers each
+  load that pointer once and never block on collection or builder locks.
 - The registry mutex only protects producer-scope discovery and the reverse-DNS
   warmer context; it does not protect topology generations.
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -409,7 +409,12 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	}
 	c.deviceStates = nextStates
 	c.generationSequence = nextSequence
-	generation := newTopologyGeneration(c.generationSequence, publishedAt, nextStates)
+	generation := newTopologyGeneration(
+		c.generationSequence,
+		publishedAt,
+		c.topologyRegistry.producerScope(),
+		nextStates,
+	)
 	generation.diagnostic = c.projectCommittedTopologyDiagnosticCut(topologyDiagnosticCutInput{
 		sequence:       c.generationSequence,
 		startedAt:      start,

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -157,7 +157,9 @@ func TestCollectorRefreshPrunesUnregisteredDeviceStateFromPublishedGeneration(t 
 	const registrationID ddsnmp.DeviceRegistrationID = 1
 	generation := freezeTestTopologyBuilder(registrationID, cache)
 	coll.deviceStates[registrationID] = deviceRefreshState{generation: generation}
-	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(
+		1, time.Now(), coll.topologyRegistry.producerScope(), coll.deviceStates,
+	))
 
 	coll.refreshTopology(context.Background())
 
@@ -245,7 +247,9 @@ func TestCollectorRefreshTreatsReregisteredOwnerAsNewDevice(t *testing.T) {
 		nextRetry:  base.Add(time.Hour),
 		outcome:    deviceRefreshOutcomeSuccess,
 	}
-	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, base, coll.deviceStates))
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(
+		1, base, coll.topologyRegistry.producerScope(), coll.deviceStates,
+	))
 
 	store.Unregister("owner-a")
 	store.Register("owner-a", dev)
@@ -804,7 +808,9 @@ func TestCollectorRefreshWithoutProfilesRetainsLastSuccessAndUsesNormalInterval(
 		lastSuccess:         previousSuccess,
 		consecutiveFailures: 3,
 	}
-	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, base, coll.deviceStates))
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(
+		1, base, coll.topologyRegistry.producerScope(), coll.deviceStates,
+	))
 	coll.now = func() time.Time { return base }
 
 	stats := coll.refreshTopology(context.Background())
@@ -853,7 +859,7 @@ func TestCollectorRefreshTopologyRecoveringHandlesPanic(t *testing.T) {
 	registrationID := store.Entries()[0].RegistrationID
 	previousDevice := freezeTestTopologyBuilder(registrationID, builder)
 	coll.deviceStates[previousDevice.registrationID] = deviceRefreshState{generation: previousDevice}
-	previous := newTopologyGeneration(1, time.Now(), coll.deviceStates)
+	previous := newTopologyGeneration(1, time.Now(), coll.topologyRegistry.producerScope(), coll.deviceStates)
 	coll.generationSequence = previous.sequence
 	coll.topologyRegistry.publishGeneration(previous)
 
@@ -1650,7 +1656,9 @@ func TestCollector_RefreshKeepsPublishedSnapshotWhileCollectionRuns(t *testing.T
 	coll := newTestSNMPTopologyCollector()
 	publishedGeneration := freezeTestTopologyBuilder(registrationID, published)
 	coll.deviceStates[registrationID] = deviceRefreshState{generation: publishedGeneration}
-	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(
+		1, time.Now(), coll.topologyRegistry.producerScope(), coll.deviceStates,
+	))
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
 		return &blockingTopologyCollector{
@@ -1704,7 +1712,9 @@ func TestCollector_RefreshFailureKeepsPublishedSnapshot(t *testing.T) {
 	coll := newTestSNMPTopologyCollector()
 	publishedGeneration := freezeTestTopologyBuilder(registrationID, published)
 	coll.deviceStates[registrationID] = deviceRefreshState{generation: publishedGeneration}
-	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, time.Now(), coll.deviceStates))
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(
+		1, time.Now(), coll.topologyRegistry.producerScope(), coll.deviceStates,
+	))
 	coll.newSnmpClient = func() gosnmp.Handler { return mockHandler }
 	coll.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
 		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) {
@@ -1907,7 +1917,9 @@ func BenchmarkCollectorRefreshNoDueDevices(b *testing.B) {
 					outcome:        deviceRefreshOutcomeSuccess,
 				}
 			}
-			coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, now, coll.deviceStates))
+			coll.topologyRegistry.publishGeneration(newTopologyGeneration(
+				1, now, coll.topologyRegistry.producerScope(), coll.deviceStates,
+			))
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -95,7 +95,7 @@ func TestSNMPTopologyFunctionAvailabilityChangesOnlyWithPublishedGeneration(t *t
 	const registrationID ddsnmp.DeviceRegistrationID = 1
 	device := freezeTestTopologyBuilderAt(registrationID, publishedAt, builder)
 	states := map[ddsnmp.DeviceRegistrationID]deviceRefreshState{registrationID: {generation: device}}
-	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, publishedAt, states))
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(1, publishedAt, coll.topologyRegistry.producerScope(), states))
 
 	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID))
 	require.True(t, device.freshAt(publishedAt.Add(10*time.Millisecond)))
@@ -103,7 +103,12 @@ func TestSNMPTopologyFunctionAvailabilityChangesOnlyWithPublishedGeneration(t *t
 	require.True(t, coll.FunctionAvailable(snmptopologyfunc.MethodID),
 		"one published generation must not decay between completed sweeps")
 
-	coll.topologyRegistry.publishGeneration(newTopologyGeneration(2, publishedAt.Add(21*time.Millisecond), states))
+	coll.topologyRegistry.publishGeneration(newTopologyGeneration(
+		2,
+		publishedAt.Add(21*time.Millisecond),
+		coll.topologyRegistry.producerScope(),
+		states,
+	))
 	require.False(t, coll.FunctionAvailable(snmptopologyfunc.MethodID),
 		"the next completed sweep must remove an expired retained generation from renderable membership")
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/func_deps.go
@@ -21,10 +21,11 @@ func (a funcDepsAdapter) Snapshot(options topologyoptions.QueryOptions) (topolog
 	}
 
 	dnsCandidates := a.registry.reverseDNSCandidateCollector()
+	environment := topologyGraphBuildEnvironment{}
 	if dnsCandidates != nil {
-		options.ResolveDNSName = dnsCandidates.lookupCached
+		environment.resolveDNSName = dnsCandidates.lookupCached
 	}
-	data, ok, err := a.registry.snapshotWithOptions(options)
+	data, ok, err := a.registry.snapshotWithEnvironment(options, environment)
 	if err != nil {
 		return topologyv1.Data{}, false, err
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyoptions/options.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyoptions/options.go
@@ -35,7 +35,6 @@ type QueryOptions struct {
 	InferenceStrategy      string
 	ManagedDeviceFocus     string
 	Depth                  int
-	ResolveDNSName         func(ip string) string
 }
 
 type ManagedFocusTarget struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyoptions/options_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyoptions/options_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestQueryOptionsContainsOnlyComparableScalarValues(t *testing.T) {
 	typeOfOptions := reflect.TypeFor[QueryOptions]()
-	assert.True(t, typeOfOptions.Comparable())
 	for field := range typeOfOptions.Fields() {
 		switch field.Type.Kind() {
 		case reflect.Bool, reflect.Int, reflect.String:

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologyoptions/options_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologyoptions/options_test.go
@@ -3,10 +3,23 @@
 package topologyoptions
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestQueryOptionsContainsOnlyComparableScalarValues(t *testing.T) {
+	typeOfOptions := reflect.TypeFor[QueryOptions]()
+	assert.True(t, typeOfOptions.Comparable())
+	for field := range typeOfOptions.Fields() {
+		switch field.Type.Kind() {
+		case reflect.Bool, reflect.Int, reflect.String:
+		default:
+			t.Errorf("QueryOptions.%s has non-scalar type %s", field.Name, field.Type)
+		}
+	}
+}
 
 func TestParseDepth(t *testing.T) {
 	tests := map[string]struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
@@ -91,9 +91,10 @@ type topologyAbortedSweepDiagnostic struct {
 }
 
 type topologyDiagnostics struct {
-	lifecycle   topologyJobLifecycleDiagnosticCut
-	topology    *topologySweepDiagnosticCut
-	lastAborted *topologyAbortedSweepDiagnostic
+	lifecycle       topologyJobLifecycleDiagnosticCut
+	producerScopeID string
+	topology        *topologySweepDiagnosticCut
+	lastAborted     *topologyAbortedSweepDiagnostic
 }
 
 type topologyDiagnosticCutInput struct {
@@ -114,6 +115,7 @@ func (c *Collector) acquireTopologyDiagnostics() topologyDiagnostics {
 	limits := c.currentTopologyDiagnosticGlobalLimits()
 	diagnostics := topologyDiagnostics{lastAborted: c.lastAbortedTopologyDiagnostic.Load()}
 	if generation := c.topologyRegistry.acquireGeneration(); generation != nil {
+		diagnostics.producerScopeID = generation.producerScopeID
 		diagnostics.topology = generation.diagnostic
 	}
 	if diagnostics.topology != nil {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_generation.go
@@ -4,6 +4,7 @@ package snmptopology
 
 import (
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
@@ -45,6 +46,7 @@ type topologyDeviceGeneration struct {
 type topologyGeneration struct {
 	sequence          uint64
 	publishedAt       time.Time
+	producerScopeID   string
 	devices           []*topologyDeviceGeneration
 	renderableDevices []*topologyDeviceGeneration
 	diagnostic        *topologySweepDiagnosticCut
@@ -97,7 +99,12 @@ func activateTopologyDeviceSnapshot(
 	}
 }
 
-func newTopologyGeneration(sequence uint64, publishedAt time.Time, states map[ddsnmp.DeviceRegistrationID]deviceRefreshState) *topologyGeneration {
+func newTopologyGeneration(
+	sequence uint64,
+	publishedAt time.Time,
+	producerScopeID string,
+	states map[ddsnmp.DeviceRegistrationID]deviceRefreshState,
+) *topologyGeneration {
 	registrationIDs := make([]ddsnmp.DeviceRegistrationID, 0, len(states))
 	for registrationID, state := range states {
 		if state.generation != nil {
@@ -118,6 +125,7 @@ func newTopologyGeneration(sequence uint64, publishedAt time.Time, states map[dd
 	return &topologyGeneration{
 		sequence:          sequence,
 		publishedAt:       publishedAt,
+		producerScopeID:   strings.TrimSpace(producerScopeID),
 		devices:           devices,
 		renderableDevices: renderableDevices,
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"fmt"
+
+	topologyapi "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
+	topologyv1renderer "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyv1"
+)
+
+func replayTopologyDiagnostics(
+	diagnostics topologyDiagnostics,
+	options topologyoptions.QueryOptions,
+) (topologyapi.Data, bool, error) {
+	cut := diagnostics.topology
+	if cut == nil || cut.captureState != diagnosticCaptureAvailable {
+		return topologyapi.Data{}, false, nil
+	}
+
+	snapshots := make([]topologymodel.ObservationSnapshot, 0, len(cut.devices))
+	for _, device := range cut.devices {
+		if !device.renderable {
+			continue
+		}
+		capture := device.acquisition
+		if capture == nil || capture.state != diagnosticCaptureAvailable || capture.evidence == nil {
+			return topologyapi.Data{}, false, fmt.Errorf(
+				"replay renderable device %s: acquisition evidence is unavailable",
+				device.registrationID.String(),
+			)
+		}
+		snapshot, err := replayTopologyAcquisitionEvidence(capture.evidence)
+		if err != nil {
+			return topologyapi.Data{}, false, fmt.Errorf(
+				"replay renderable device %s: %w",
+				device.registrationID.String(),
+				err,
+			)
+		}
+		if snapshot == nil || !snapshot.hasObservation {
+			return topologyapi.Data{}, false, fmt.Errorf(
+				"replay renderable device %s: observation is unavailable",
+				device.registrationID.String(),
+			)
+		}
+		snapshots = append(snapshots, snapshot.observation)
+	}
+	if len(snapshots) == 0 {
+		return topologyapi.Data{}, false, nil
+	}
+
+	sortTopologyObservationSnapshots(snapshots)
+	data, ok, err := buildTopologyObservationSnapshot(
+		snapshots,
+		diagnostics.producerScopeID,
+		options,
+		topologyGraphBuildEnvironment{},
+	)
+	if err != nil || !ok {
+		return topologyapi.Data{}, ok, err
+	}
+	payload, err := topologyv1renderer.Render(data)
+	if err != nil {
+		return topologyapi.Data{}, false, err
+	}
+	return payload, true, nil
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay_benchmark_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
+)
+
+func BenchmarkSNMPTopologyTypedGraphReplayScaling(b *testing.B) {
+	tests := []struct {
+		devices             int
+		fdbEntriesPerDevice int
+		sharedEndpoints     bool
+	}{
+		{devices: 8, fdbEntriesPerDevice: 128},
+		{devices: 40, fdbEntriesPerDevice: 1600, sharedEndpoints: true},
+	}
+
+	for _, tc := range tests {
+		name := fmt.Sprintf(
+			"devices=%d/fdb_entries_per_device=%d/shared_endpoints=%t",
+			tc.devices,
+			tc.fdbEntriesPerDevice,
+			tc.sharedEndpoints,
+		)
+		b.Run(name, func(b *testing.B) {
+			scenario := benchmarkTopologyReplayScenario(
+				tc.devices,
+				tc.fdbEntriesPerDevice,
+				tc.sharedEndpoints,
+			)
+			registry, diagnostics := newTopologyScenarioReplayFixture(b, scenario)
+			options := topologyoptions.DefaultQueryOptions()
+
+			b.Run("source=live", func(b *testing.B) {
+				deps := funcDepsAdapter{registry: registry}
+				probe, ok, err := deps.Snapshot(options)
+				if err != nil || !ok || probe.Links.Rows == 0 {
+					b.Fatalf("live probe links=%d ok=%t err=%v", probe.Links.Rows, ok, err)
+				}
+				b.ReportMetric(float64(probe.Actors.Rows), "actors/op")
+				b.ReportMetric(float64(probe.Links.Rows), "links/op")
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					payload, ok, err := deps.Snapshot(options)
+					if err != nil || !ok {
+						b.Fatalf("live typed graph ok=%t err=%v", ok, err)
+					}
+					runtime.KeepAlive(payload)
+				}
+			})
+
+			b.Run("source=offline_replay", func(b *testing.B) {
+				probe, ok, err := replayTopologyDiagnostics(diagnostics, options)
+				if err != nil || !ok || probe.Links.Rows == 0 {
+					b.Fatalf("replay probe links=%d ok=%t err=%v", probe.Links.Rows, ok, err)
+				}
+				b.ReportMetric(float64(probe.Actors.Rows), "actors/op")
+				b.ReportMetric(float64(probe.Links.Rows), "links/op")
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					payload, ok, err := replayTopologyDiagnostics(diagnostics, options)
+					if err != nil || !ok {
+						b.Fatalf("offline typed graph replay ok=%t err=%v", ok, err)
+					}
+					runtime.KeepAlive(payload)
+				}
+			})
+		})
+	}
+}
+
+func benchmarkTopologyReplayScenario(
+	deviceCount int,
+	fdbEntriesPerDevice int,
+	sharedEndpoints bool,
+) *topologyScenario {
+	scenario := newTopologyScenario("benchmark-fdb-replay")
+	devices := make([]*topologyScenarioDevice, 0, deviceCount)
+	ports := make([]*topologyScenarioPort, 0, deviceCount)
+	for deviceIndex := range deviceCount {
+		device := scenario.Switch(
+			fmt.Sprintf("benchmark-switch-%d", deviceIndex),
+			fmt.Sprintf("192.0.2.%d", deviceIndex+1),
+			benchmarkManagedFabricDeviceMAC(deviceIndex),
+		)
+		devices = append(devices, device)
+		ports = append(ports, device.Port("uplink", 1))
+	}
+	for deviceIndex := range devices {
+		if fdbEntriesPerDevice > 0 {
+			scenario.FDB(ports[deviceIndex], devices[(deviceIndex+1)%deviceCount].chassisMAC)
+		}
+		for entryIndex := 1; entryIndex < fdbEntriesPerDevice; entryIndex++ {
+			scenario.FDB(
+				ports[deviceIndex],
+				benchmarkManagedFabricEndpointMAC(deviceIndex, entryIndex, sharedEndpoints),
+			)
+		}
+	}
+	return scenario
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay_test.go
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyv1test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopologyDiagnosticsReplayMatchesLiveTypedPayload(t *testing.T) {
+	tests := map[string]struct {
+		build     func() *topologyScenario
+		configure func(*topologyoptions.QueryOptions)
+	}{
+		"managed-fabric-l2-l3": {build: newMixedL2L3ControlScenario},
+		"lldp-cdp-managed": {
+			build: newMixedL2L3ControlScenario,
+			configure: func(options *topologyoptions.QueryOptions) {
+				options.MapType = topologyoptions.MapTypeLLDPCDPManaged
+			},
+		},
+		"high-confidence-fdb-minimum": {
+			build: newMixedL2L3ControlScenario,
+			configure: func(options *topologyoptions.QueryOptions) {
+				options.MapType = topologyoptions.MapTypeHighConfidenceInferred
+				options.InferenceStrategy = topologyoptions.InferenceStrategyFDBMinimumKnowledge
+			},
+		},
+		"probable-fdb-minimum": {
+			build: newMixedL2L3ControlScenario,
+			configure: func(options *topologyoptions.QueryOptions) {
+				options.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
+				options.InferenceStrategy = topologyoptions.InferenceStrategyFDBMinimumKnowledge
+			},
+		},
+		"stp-parent-tree": {build: newSTPInferredScenario},
+		"fdb-pairwise":    {build: newFDBPairwiseScenario},
+		"stp-fdb-correlated": {
+			build: newMixedL2L3ControlScenario,
+			configure: func(options *topologyoptions.QueryOptions) {
+				options.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
+				options.InferenceStrategy = topologyoptions.InferenceStrategySTPFDBCorrelated
+			},
+		},
+		"cdp-fdb-hybrid": {
+			build: newMixedL2L3ControlScenario,
+			configure: func(options *topologyoptions.QueryOptions) {
+				options.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
+				options.InferenceStrategy = topologyoptions.InferenceStrategyCDPFDBHybrid
+			},
+		},
+		"focus-depth": {build: newFocusDepthL2Scenario},
+		"include-non-ip-inferred": {
+			build: newMixedL2L3ControlScenario,
+			configure: func(options *topologyoptions.QueryOptions) {
+				options.EliminateNonIPInferred = false
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			scenario := tc.build()
+			if tc.configure != nil {
+				tc.configure(&scenario.opts)
+			}
+			registry, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+
+			live, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(scenario.opts)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			replayed, ok, err := replayTopologyDiagnostics(diagnostics, scenario.opts)
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t,
+				topologyv1test.NormalizeData(t, live),
+				topologyv1test.NormalizeData(t, replayed),
+			)
+			require.NoError(t, topologyv1test.ValidateData(replayed))
+			require.Equal(t, topologyScenarioCollectedAt, replayed.CollectedAt)
+		})
+	}
+}
+
+func TestTopologyDiagnosticsReplayExcludesOnlyPTRDerivedPresentation(t *testing.T) {
+	scenario := newLLDPDirectScenario().PTR("192.0.2.71", "ptr-switch-a.example")
+	registry, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	configureTopologyScenarioReverseDNS(t, registry, scenario)
+
+	live, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(scenario.opts)
+	require.NoError(t, err)
+	require.True(t, ok)
+	replayed, ok, err := replayTopologyDiagnostics(diagnostics, scenario.opts)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	liveNormalized := topologyv1test.NormalizeData(t, live)
+	replayedNormalized := topologyv1test.NormalizeData(t, replayed)
+	require.NotEqual(t, liveNormalized, replayedNormalized)
+	liveActorID := topologyNormalizedActorIDByManagementIP(t, liveNormalized, "192.0.2.71")
+	replayedActorID := topologyNormalizedActorIDByManagementIP(t, replayedNormalized, "192.0.2.71")
+	require.Equal(t, liveActorID, replayedActorID)
+	require.Equal(t,
+		stripTopologyPTRPresentation(liveNormalized, liveActorID),
+		stripTopologyPTRPresentation(replayedNormalized, replayedActorID),
+	)
+}
+
+func TestTopologyDiagnosticsReplayUsesCompiledOUIKernel(t *testing.T) {
+	scenario := newTopologyScenario("compiled-oui-replay")
+	switchA := scenario.Switch("oui-switch-a", "192.0.2.81", "08:ea:44:11:22:33")
+	switchB := scenario.Switch("oui-switch-b", "192.0.2.82", "02:00:00:00:09:02")
+	scenario.LLDP(switchA.Port("a-b", 1), switchB.Port("b-a", 1))
+	registry, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+
+	live, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(scenario.opts)
+	require.NoError(t, err)
+	require.True(t, ok)
+	replayed, ok, err := replayTopologyDiagnostics(diagnostics, scenario.opts)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	liveNormalized := topologyv1test.NormalizeData(t, live)
+	replayedNormalized := topologyv1test.NormalizeData(t, replayed)
+	require.Equal(t, liveNormalized, replayedNormalized)
+	require.Equal(t,
+		"Extreme Networks Headquarters",
+		topologyNormalizedActorByManagementIP(t, replayedNormalized, "192.0.2.81")["vendor"],
+	)
+}
+
+func TestTopologyDiagnosticsReplayRejectsIncompleteRenderableEvidence(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	require.NotEmpty(t, diagnostics.topology.devices)
+	diagnostics.topology.devices[0].acquisition = nil
+
+	_, ok, err := replayTopologyDiagnostics(diagnostics, scenario.opts)
+	require.Error(t, err)
+	require.False(t, ok)
+}
+
+func TestTopologyGenerationOwnsProducerScope(t *testing.T) {
+	scenario := newMixedL2L3ControlScenario()
+	registry, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	registry.mu.Lock()
+	registry.producerScopeID = "later-registry-scope"
+	registry.mu.Unlock()
+
+	live, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(scenario.opts)
+	require.NoError(t, err)
+	require.True(t, ok)
+	replayed, ok, err := replayTopologyDiagnostics(diagnostics, scenario.opts)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t,
+		topologyv1test.NormalizeData(t, live),
+		topologyv1test.NormalizeData(t, replayed),
+	)
+}
+
+func TestTopologyDiagnosticsReplayRejectsMissingObservationTime(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	require.NotNil(t, diagnostics.topology.devices[0].acquisition.evidence)
+	diagnostics.topology.devices[0].acquisition.evidence.collectedAt = time.Time{}
+
+	_, ok, err := replayTopologyDiagnostics(diagnostics, scenario.opts)
+	require.Error(t, err)
+	require.False(t, ok)
+}
+
+func newTopologyScenarioReplayFixture(
+	t testing.TB,
+	scenario *topologyScenario,
+) (*topologyRegistry, topologyDiagnostics) {
+	t.Helper()
+
+	const sequence = uint64(1)
+	registry := newTopologyRegistry()
+	registry.producerScopeID = topologyScenarioProducerScopeID
+	states := make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState, len(scenario.devs))
+	entries := make([]ddsnmp.DeviceEntry, 0, len(scenario.devs))
+	selected := make(map[ddsnmp.DeviceRegistrationID]bool, len(scenario.devs))
+	seen := make(map[ddsnmp.DeviceRegistrationID]bool, len(scenario.devs))
+
+	for index, device := range scenario.devs {
+		registrationID := ddsnmp.DeviceRegistrationID(index + 1)
+		info := ddsnmp.DeviceConnectionInfo{
+			Hostname:    device.target,
+			SysObjectID: device.sysObjectID,
+			SysName:     device.name,
+			SysDescr:    topologyScenarioSysDescr,
+		}
+		metrics := &ddsnmp.ProfileMetrics{
+			DeviceMetadata:  scenario.deviceMetadata(device),
+			TopologyMetrics: scenario.topologyMetricsForDevice(device),
+			BGPRows:         scenario.bgpRowsForDevice(device),
+		}
+		recorder := newTopologyAcquisitionRecorder(
+			topologyAcquisitionAttemptID{registrationID: registrationID, ordinal: 1},
+			topologySemanticDeviceInputFromConnection(info),
+			topologyTargetResolutionEvidence{outcome: topologyTargetResolutionEmpty},
+			defaultTopologyAcquisitionLimits,
+		)
+		observer := recorder.beginContext(0, "", "")
+		observer.ObserveProfile(acquisitionReportForMetrics(
+			0,
+			ddsnmpcollector.AcquisitionProfileOutcomeSuccess,
+			metrics,
+		), metrics)
+		recorder.completeContext(0, successfulAcquisitionPhase())
+		recorder.setCollectedShape(topologyScenarioCollectedAt, time.Hour, 3600)
+		capture := recorder.finish()
+		require.Equal(t, diagnosticCaptureAvailable, capture.state)
+
+		snapshot, _ := freezeTopologyBuilder(scenario.cacheForDevice(t, device))
+		snapshot.acquisition = capture
+		generation := activateTopologyDeviceSnapshot(
+			registrationID,
+			sequence,
+			topologyScenarioCollectedAt,
+			snapshot,
+		)
+		state := deviceRefreshState{
+			generation:     generation,
+			latestAttempt:  capture,
+			attemptOrdinal: 1,
+			lastAttempt:    topologyScenarioCollectedAt,
+			lastSuccess:    topologyScenarioCollectedAt,
+			outcome:        deviceRefreshOutcomeSuccess,
+		}
+		states[registrationID] = state
+		entries = append(entries, ddsnmp.DeviceEntry{RegistrationID: registrationID, Info: info})
+		selected[registrationID] = true
+		seen[registrationID] = true
+	}
+
+	generation := newTopologyGeneration(
+		sequence,
+		topologyScenarioCollectedAt,
+		topologyScenarioProducerScopeID,
+		states,
+	)
+	cut, err := projectTopologyDiagnosticCut(topologyDiagnosticCutInput{
+		sequence:    sequence,
+		startedAt:   topologyScenarioCollectedAt.Add(-time.Minute),
+		publishedAt: topologyScenarioCollectedAt,
+		entries:     entries,
+		selected:    selected,
+		seen:        seen,
+		states:      states,
+		limits:      defaultTopologyDiagnosticGlobalLimits,
+	})
+	require.NoError(t, err)
+	generation.diagnostic = cut
+	registry.publishGeneration(generation)
+
+	return registry, topologyDiagnostics{
+		producerScopeID: generation.producerScopeID,
+		topology:        generation.diagnostic,
+	}
+}
+
+func configureTopologyScenarioReverseDNS(
+	t testing.TB,
+	registry *topologyRegistry,
+	scenario *topologyScenario,
+) {
+	t.Helper()
+	if len(scenario.ptr) == 0 {
+		return
+	}
+	dns := newTestTopologyReverseDNSWarmer(testTopologyReverseDNSConfig{
+		now: newReverseDNSTestClock().Now,
+		lookup: func(_ context.Context, ip string) ([]string, error) {
+			if name := scenario.ptr[ip]; name != "" {
+				return []string{name}, nil
+			}
+			return nil, nil
+		},
+	})
+	ips := make([]string, 0, len(scenario.ptr))
+	for ip := range scenario.ptr {
+		ips = append(ips, ip)
+	}
+	sort.Strings(ips)
+	dns.warm(context.Background(), ips)
+	registry.reverseDNS = dns.resolver
+}
+
+func topologyNormalizedActorIDByManagementIP(
+	t testing.TB,
+	data topologyv1test.NormalizedData,
+	managementIP string,
+) string {
+	t.Helper()
+	actor := topologyNormalizedActorByManagementIP(t, data, managementIP)
+	actorID, ok := actor["id"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, actorID)
+	return actorID
+}
+
+func topologyNormalizedActorByManagementIP(
+	t testing.TB,
+	data topologyv1test.NormalizedData,
+	managementIP string,
+) map[string]any {
+	t.Helper()
+	for _, row := range data.Actors.Rows {
+		if row["management_ip"] == managementIP {
+			return row
+		}
+	}
+	require.FailNow(t, "topology actor not found", "management_ip=%s", managementIP)
+	return nil
+}
+
+func stripTopologyPTRPresentation(data topologyv1test.NormalizedData, actorID string) topologyv1test.NormalizedData {
+	for _, row := range data.Actors.Rows {
+		if row["id"] != actorID {
+			continue
+		}
+		delete(row, "display_name")
+		delete(row, "dns_names")
+	}
+	if data.Tables == nil {
+		return data
+	}
+	for tableID, ref := range data.Tables.Actor {
+		rows := ref.Table.Rows[:0]
+		for _, row := range ref.Table.Rows {
+			if row["actor"] != actorID {
+				rows = append(rows, row)
+				continue
+			}
+			key, _ := row["key"].(string)
+			if key == "display_name" || key == "display_source" || key == "dns_name" {
+				continue
+			}
+			if labels, ok := row["labels"].(map[string]any); ok {
+				delete(labels, "display_name")
+				delete(labels, "display_source")
+			}
+			rows = append(rows, row)
+		}
+		ref.Table.Rows = rows
+		data.Tables.Actor[tableID] = ref
+	}
+	return data
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry.go
@@ -51,19 +51,42 @@ func (r *topologyRegistry) acquireGeneration() *topologyGeneration {
 }
 
 func (r *topologyRegistry) snapshotWithOptions(options topologyoptions.QueryOptions) (topologymodel.Data, bool, error) {
+	return r.snapshotWithEnvironment(options, topologyGraphBuildEnvironment{})
+}
+
+func (r *topologyRegistry) snapshotWithEnvironment(
+	options topologyoptions.QueryOptions,
+	environment topologyGraphBuildEnvironment,
+) (topologymodel.Data, bool, error) {
 	if r == nil {
 		return topologymodel.Data{}, false, nil
 	}
-	options = topologyoptions.NormalizeQueryOptions(options)
-
 	generation := r.acquireGeneration()
-	aggregate, ok := aggregateTopologyObservationSnapshots(topologyObservationSnapshots(generation))
+	producerScopeID := ""
+	if generation != nil {
+		producerScopeID = generation.producerScopeID
+	}
+	return buildTopologyObservationSnapshot(
+		topologyObservationSnapshots(generation),
+		producerScopeID,
+		options,
+		environment,
+	)
+}
+
+func buildTopologyObservationSnapshot(
+	snapshots []topologymodel.ObservationSnapshot,
+	producerScopeID string,
+	options topologyoptions.QueryOptions,
+	environment topologyGraphBuildEnvironment,
+) (topologymodel.Data, bool, error) {
+	options = topologyoptions.NormalizeQueryOptions(options)
+	aggregate, ok := aggregateTopologyObservationSnapshots(snapshots)
 	if !ok {
 		return topologymodel.Data{}, false, nil
 	}
-	aggregate.ProducerScopeID = r.producerScope()
-
-	return buildSNMPTopologySnapshot(aggregate, options)
+	aggregate.ProducerScopeID = strings.TrimSpace(producerScopeID)
+	return buildSNMPTopologySnapshot(aggregate, options, environment)
 }
 
 func (r *topologyRegistry) hasRenderableObservations() bool {
@@ -160,9 +183,10 @@ func (r *topologyRegistry) enqueueReverseDNSWarmFromDefaultSnapshot() bool {
 		if collector == nil {
 			return
 		}
-		options := topologyoptions.DefaultQueryOptions()
-		options.ResolveDNSName = collector.lookupCached
-		if _, ok, err := r.snapshotWithOptions(options); err != nil || !ok {
+		if _, ok, err := r.snapshotWithEnvironment(
+			topologyoptions.DefaultQueryOptions(),
+			topologyGraphBuildEnvironment{resolveDNSName: collector.lookupCached},
+		); err != nil || !ok {
 			return
 		}
 		r.reverseDNSWarmer.warm(ctx, collector.collectedCandidates())

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
@@ -199,9 +199,10 @@ func BenchmarkSNMPTopologyFDBSnapshotMapTypeScaling(b *testing.B) {
 			options.MapType = mapType
 			snapshot := func() (topologymodel.Data, bool, error) {
 				candidates := registry.reverseDNSCandidateCollector()
-				current := options
-				current.ResolveDNSName = candidates.lookupCached
-				data, ok, err := registry.snapshotWithOptions(current)
+				data, ok, err := registry.snapshotWithEnvironment(
+					options,
+					topologyGraphBuildEnvironment{resolveDNSName: candidates.lookupCached},
+				)
 				runtime.KeepAlive(candidates.collectedCandidates())
 				return data, ok, err
 			}
@@ -565,8 +566,10 @@ func BenchmarkSNMPTopologyFunctionDefaultManagedFabricMixedReadPublish(b *testin
 	replacement := &topologyGeneration{
 		sequence:          published.sequence + 1,
 		publishedAt:       published.publishedAt.Add(time.Second),
+		producerScopeID:   published.producerScopeID,
 		devices:           append([]*topologyDeviceGeneration(nil), published.devices...),
 		renderableDevices: append([]*topologyDeviceGeneration(nil), published.renderableDevices...),
+		diagnostic:        published.diagnostic,
 	}
 
 	if payload, ok, err := deps.Snapshot(options); err != nil || !ok || payload.Links.Rows == 0 {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_build.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_build.go
@@ -16,19 +16,31 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyshape"
 )
 
-func buildSNMPTopologySnapshot(aggregate topologymodel.ObservationAggregate, options topologyoptions.QueryOptions) (topologymodel.Data, bool, error) {
+type topologyGraphBuildEnvironment struct {
+	resolveDNSName func(ip string) string
+}
+
+func buildSNMPTopologySnapshot(
+	aggregate topologymodel.ObservationAggregate,
+	options topologyoptions.QueryOptions,
+	environment topologyGraphBuildEnvironment,
+) (topologymodel.Data, bool, error) {
 	if len(aggregate.L2Observations) == 0 {
 		return topologymodel.Data{}, false, nil
 	}
 
 	if options.MapType != topologyoptions.MapTypeAllDevicesLowConfidence {
-		return buildSingleMapTopologySnapshot(aggregate, options)
+		return buildSingleMapTopologySnapshot(aggregate, options, environment)
 	}
 
-	return buildProbableTopologySnapshot(aggregate, options)
+	return buildProbableTopologySnapshot(aggregate, options, environment)
 }
 
-func buildSingleMapTopologySnapshot(aggregate topologymodel.ObservationAggregate, options topologyoptions.QueryOptions) (topologymodel.Data, bool, error) {
+func buildSingleMapTopologySnapshot(
+	aggregate topologymodel.ObservationAggregate,
+	options topologyoptions.QueryOptions,
+	environment topologyGraphBuildEnvironment,
+) (topologymodel.Data, bool, error) {
 	result, ok, err := buildSNMPL2TopologyResult(aggregate.L2Observations)
 	if err != nil || !ok {
 		return topologymodel.Data{}, false, err
@@ -38,6 +50,7 @@ func buildSingleMapTopologySnapshot(aggregate topologymodel.ObservationAggregate
 		aggregate.AgentID,
 		aggregate.CollectedAt,
 		options,
+		environment,
 	)
 	if err != nil {
 		return topologymodel.Data{}, false, err
@@ -49,7 +62,11 @@ func buildSingleMapTopologySnapshot(aggregate topologymodel.ObservationAggregate
 	return data, true, nil
 }
 
-func buildProbableTopologySnapshot(aggregate topologymodel.ObservationAggregate, options topologyoptions.QueryOptions) (topologymodel.Data, bool, error) {
+func buildProbableTopologySnapshot(
+	aggregate topologymodel.ObservationAggregate,
+	options topologyoptions.QueryOptions,
+	environment topologyGraphBuildEnvironment,
+) (topologymodel.Data, bool, error) {
 	result, ok, err := buildSNMPL2TopologyResult(aggregate.L2Observations)
 	if err != nil {
 		return topologymodel.Data{}, false, fmt.Errorf("build strict topology: %w", err)
@@ -65,6 +82,7 @@ func buildProbableTopologySnapshot(aggregate topologymodel.ObservationAggregate,
 		aggregate.AgentID,
 		aggregate.CollectedAt,
 		strictOptions,
+		environment,
 	)
 	if err != nil {
 		return topologymodel.Data{}, false, fmt.Errorf("build strict topology: %w", err)
@@ -79,6 +97,7 @@ func buildProbableTopologySnapshot(aggregate topologymodel.ObservationAggregate,
 		aggregate.AgentID,
 		aggregate.CollectedAt,
 		probableOptions,
+		environment,
 	)
 	if err != nil {
 		return topologymodel.Data{}, false, fmt.Errorf("build probable topology: %w", err)
@@ -146,6 +165,7 @@ func projectSNMPL2TopologyData(
 	agentID string,
 	collectedAt time.Time,
 	options topologyoptions.QueryOptions,
+	environment topologyGraphBuildEnvironment,
 ) (topologymodel.Data, error) {
 	projection := topologyengine.ToGraph(result, topologyengine.GraphOptions{
 		SchemaVersion:             topologymodel.SchemaVersion,
@@ -154,7 +174,7 @@ func projectSNMPL2TopologyData(
 		View:                      "summary",
 		AgentID:                   agentID,
 		CollectedAt:               collectedAt,
-		ResolveDNSName:            options.ResolveDNSName,
+		ResolveDNSName:            environment.resolveDNSName,
 		CollapseActorsByIP:        options.CollapseActorsByIP,
 		EliminateNonIPInferred:    options.EliminateNonIPInferred,
 		ProbabilisticConnectivity: topologyoptions.IsMapTypeProbable(options.MapType),

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -98,7 +98,7 @@ func TestTopologyRegistry_SnapshotAggregatesAcrossCaches(t *testing.T) {
 func TestBuildSNMPTopologySnapshotPreservesL2BuildError(t *testing.T) {
 	_, ok, err := buildSNMPTopologySnapshot(topologymodel.ObservationAggregate{
 		L2Observations: []topologyengine.L2Observation{{}},
-	}, topologyoptions.DefaultQueryOptions())
+	}, topologyoptions.DefaultQueryOptions(), topologyGraphBuildEnvironment{})
 	require.ErrorContains(t, err, "empty device id")
 	require.False(t, ok)
 }
@@ -175,7 +175,7 @@ func TestBuildProbableTopologySnapshotMatchesIndependentLegacyPath(t *testing.T)
 	options := topologyoptions.DefaultQueryOptions()
 	options.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
 
-	got, ok, err := buildProbableTopologySnapshot(aggregate, options)
+	got, ok, err := buildProbableTopologySnapshot(aggregate, options, topologyGraphBuildEnvironment{})
 	require.NoError(t, err)
 	require.True(t, ok)
 
@@ -203,7 +203,7 @@ func buildProbableTopologySnapshotIndependentLegacyForTest(
 	strictOptions := options
 	strictOptions.MapType = topologyoptions.MapTypeHighConfidenceInferred
 	strictData, err := projectSNMPL2TopologyData(
-		strictResult, aggregate.AgentID, aggregate.CollectedAt, strictOptions,
+		strictResult, aggregate.AgentID, aggregate.CollectedAt, strictOptions, topologyGraphBuildEnvironment{},
 	)
 	require.NoError(t, err)
 	augmentTopologySnapshotLocals(&strictData, aggregate.Snapshots)
@@ -215,7 +215,7 @@ func buildProbableTopologySnapshotIndependentLegacyForTest(
 	probableOptions := options
 	probableOptions.MapType = topologyoptions.MapTypeAllDevicesLowConfidence
 	probableData, err := projectSNMPL2TopologyData(
-		probableResult, aggregate.AgentID, aggregate.CollectedAt, probableOptions,
+		probableResult, aggregate.AgentID, aggregate.CollectedAt, probableOptions, topologyGraphBuildEnvironment{},
 	)
 	require.NoError(t, err)
 	augmentTopologySnapshotLocals(&probableData, aggregate.Snapshots)
@@ -286,8 +286,10 @@ func TestTopologyRegistry_ReverseDNSCandidatesExcludeDeviceAliases(t *testing.T)
 
 	candidates := registry.reverseDNSCandidateCollector()
 	options := defaultTopologyQueryOptionsForTest()
-	options.ResolveDNSName = candidates.lookupCached
-	data, ok, err := registry.snapshotWithOptions(options)
+	data, ok, err := registry.snapshotWithEnvironment(
+		options,
+		topologyGraphBuildEnvironment{resolveDNSName: candidates.lookupCached},
+	)
 	require.NoError(t, err)
 
 	require.True(t, ok)
@@ -344,7 +346,7 @@ func TestTopologyRegistry_HasRenderableObservations(t *testing.T) {
 				const registrationID ddsnmp.DeviceRegistrationID = 1
 				device := freezeTestTopologyBuilderAt(registrationID, publishedAt, cache)
 				states := map[ddsnmp.DeviceRegistrationID]deviceRefreshState{registrationID: {generation: device}}
-				registry.publishGeneration(newTopologyGeneration(2, time.Now(), states))
+				registry.publishGeneration(newTopologyGeneration(2, time.Now(), registry.producerScope(), states))
 			},
 			want: false,
 		},

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -48,7 +48,7 @@ func publishTestTopologyBuilder(r *topologyRegistry, cache *topologyBuilder) {
 	registrationID := ddsnmp.DeviceRegistrationID(sequence)
 	publishedAt := time.Now()
 	states[registrationID] = deviceRefreshState{generation: freezeTestTopologyBuilderAt(registrationID, publishedAt, cache)}
-	r.publishGeneration(newTopologyGeneration(sequence, publishedAt, states))
+	r.publishGeneration(newTopologyGeneration(sequence, publishedAt, r.producerScope(), states))
 }
 
 func snapshotTestTopologyBuilder(c *topologyBuilder) (topologymodel.ObservationSnapshot, bool) {


### PR DESCRIPTION
##### Summary

Rebuilds SNMP topology offline from captured acquisition evidence using the same graph pipeline as the live Function. This establishes the replay foundation needed for useful diagnostic archives without retaining query history or rendered responses.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hermetic offline replay for the SNMP topology collector: the committed diagnostic cut can now be rebuilt into a typed `netdata.topology.v1` payload through the same graph, enrichment, shaping, and renderer pipeline used by the live Function. This is the foundation for diagnostic archives that don't retain query history or rendered responses.

- `topologyGeneration` now captures the producer scope ID at publish time so replay cannot pair observations from one sweep with a later registry scope.
- DNS lookup moved out of `QueryOptions` into a per-build environment, leaving `QueryOptions` comparable scalar-only.
- Replay rejects missing acquisition collection timestamps and fails completely when a renderable device lacks acquisition evidence, instead of emitting a partial graph.
- Replay has no reverse-DNS resolver, so PTR-derived display fields deterministically fall back to collected identity; live Function output and performance are unchanged.

<sup>Written for commit 4111d88913c7dd9d7d86e9e1eda0203b6c06bdcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline replay of captured SNMP topology diagnostics.
  * Preserved topology generation context for consistent graph ownership and diagnostics.
  * Improved DNS handling during topology reconstruction using cached information.
  * Retained vendor attribution when rebuilding topology data.

* **Bug Fixes**
  * Replay now rejects incomplete evidence and missing observation timestamps.
  * Ensured replayed topology results match live snapshots, including reverse-DNS presentation differences.

* **Documentation**
  * Updated architecture documentation for generation scope, registry snapshots, DNS handling, and offline replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->