### PR TITLE
feat(go.d/snmp_topology): add offline diagnostic inspection

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -660,14 +660,20 @@ claimed to be the registration itself or proof that one registration caused a
 collapsed actor.
 
 Link inspection resolves both endpoints through exact normalized actor identity
-keys, then matches the existing link family, protocol, direction, and
-family-specific structural fields. Endpoint reversal is accepted for
-bidirectional links and unordered direct L3/OSPF/BGP adjacencies; ordered STP
-and subnet-membership roles remain exact. Zero matches is `absent` only after
-the relevant stage completed, one is `present`, and multiple actor or link
-matches is `undetermined`. Retained acquisition rows are reported only as candidate
-family context across registrations, with each retained capture's availability
-kept explicit. They are not matched to the exact structural subject, do not
+keys, then matches the existing link family, protocol, and direction. These
+fields define a candidate subject rather than a unique link identity; the full
+matching graph rows retain interface, subnet, adjacency, routing-instance, and
+other parallel-link details. Endpoint reversal is accepted for bidirectional
+links and unordered direct L3/OSPF/BGP adjacencies; ordered STP and
+subnet-membership roles remain exact. Zero matches is `absent` only after the
+relevant stage completed, one is `present`, and multiple actor or link matches
+is `undetermined` with every candidate returned.
+
+Source facts are reported only as family-wide context across registrations.
+Each registration exposes independent `latestAttempt` and `retainedSuccess`
+branches and records whether they alias. Facts are attached once per distinct
+capture, so an aliased capture is not duplicated. Capture availability remains
+explicit. Source facts are not matched to the exact candidate subject, do not
 produce a source membership result, and are not causal provenance.
 
 One inspection invocation replays each selected retained capture at most once,

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -638,6 +638,42 @@ presentation fields may differ. This replay entry point consumes trusted,
 already-bounded in-memory diagnostics. Validation and structural limits for
 untrusted archive input belong to the later archive reader boundary.
 
+## Offline Diagnostic Inspection
+
+The `topology_inspection*.go` files add read-only, invocation-local inspection over the
+same committed diagnostic cut. It does not add live observers, retained
+reports, query history, or a second graph algorithm.
+
+Device inspection starts with one exact `DeviceRegistrationID`. Lifecycle and
+committed-sweep membership use that ID directly. The report carries both cut
+sequence/timestamp identities, any matching removed-registration row, and the
+existing last-aborted-sweep marker before keeping two independent branches:
+
+- `latestAttempt` describes the last completed attempt, including an unavailable
+  evidence marker;
+- `retainedSuccess` identifies the older successful capture, when any, that can
+  continue through semantic replay, graph construction, and typed rendering.
+
+The branches explicitly record when they alias. A graph actor is reported as an
+identity representation of the retained observation after shaping; it is not
+claimed to be the registration itself or proof that one registration caused a
+collapsed actor.
+
+Link inspection resolves both endpoints through exact normalized actor identity
+keys, then matches the existing link family, protocol, direction, and
+family-specific structural fields. Zero matches is `absent` only after the
+relevant stage completed, one is `present`, and multiple actor or link matches
+is `undetermined`. Retained acquisition rows are reported only as candidate
+source facts from endpoint registrations. They are not causal provenance.
+Failed, partial, rejected, or not-observed candidate routes prevent a negative
+source conclusion.
+
+One inspection invocation replays each selected retained capture at most once,
+builds one graph, and renders once. Existing graph counters are returned as
+graph-wide context and never determine a subject's state. Any renderable-device
+replay failure makes graph and typed-output membership `undetermined` globally,
+while an independently replayable device observation remains available.
+
 ## Trap Enrichment
 
 `topology_trap_enrich.go` publishes a separate handle used by `snmp_traps`.

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -664,9 +664,9 @@ keys, then matches the existing link family, protocol, direction, and
 family-specific structural fields. Zero matches is `absent` only after the
 relevant stage completed, one is `present`, and multiple actor or link matches
 is `undetermined`. Retained acquisition rows are reported only as candidate
-source facts from endpoint registrations. They are not causal provenance.
-Failed, partial, rejected, or not-observed candidate routes prevent a negative
-source conclusion.
+family context across registrations, with each retained capture's availability
+kept explicit. They are not matched to the exact structural subject, do not
+produce a source membership result, and are not causal provenance.
 
 One inspection invocation replays each selected retained capture at most once,
 builds one graph, and renders once. Existing graph counters are returned as

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -661,9 +661,11 @@ collapsed actor.
 
 Link inspection resolves both endpoints through exact normalized actor identity
 keys, then matches the existing link family, protocol, direction, and
-family-specific structural fields. Zero matches is `absent` only after the
-relevant stage completed, one is `present`, and multiple actor or link matches
-is `undetermined`. Retained acquisition rows are reported only as candidate
+family-specific structural fields. Endpoint reversal is accepted for
+bidirectional links and unordered direct L3/OSPF/BGP adjacencies; ordered STP
+and subnet-membership roles remain exact. Zero matches is `absent` only after
+the relevant stage completed, one is `present`, and multiple actor or link
+matches is `undetermined`. Retained acquisition rows are reported only as candidate
 family context across registrations, with each retained capture's availability
 kept explicit. They are not matched to the exact structural subject, do not
 produce a source membership result, and are not causal provenance.

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -669,6 +669,11 @@ subnet-membership roles remain exact. Zero matches is `absent` only after the
 relevant stage completed, one is `present`, and multiple actor or link matches
 is `undetermined` with every candidate returned.
 
+Every link report also carries the committed diagnostic cut's capture state,
+reason, sequence, and timestamps. A cut rejected by projection or diagnostic
+limits therefore remains distinguishable from a successfully captured empty
+cut before graph or source inspection begins.
+
 Source facts are reported only as family-wide context across registrations.
 Each registration exposes independent `latestAttempt` and `retainedSuccess`
 branches and records whether they alias. Facts are attached once per distinct

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay.go
@@ -24,11 +24,12 @@ func replayTopologyDiagnostics(
 }
 
 type topologyDiagnosticReplayedDevice struct {
-	registrationID ddsnmp.DeviceRegistrationID
-	capture        *topologyAcquisitionCapture
-	renderable     bool
-	observation    topologyInspectionState
-	snapshot       *topologyDeviceSnapshot
+	registrationID  ddsnmp.DeviceRegistrationID
+	latestAttempt   *topologyAcquisitionCapture
+	retainedSuccess *topologyAcquisitionCapture
+	renderable      bool
+	observation     topologyInspectionState
+	snapshot        *topologyDeviceSnapshot
 }
 
 type topologyDiagnosticReplayStages struct {
@@ -61,9 +62,10 @@ func replayTopologyDiagnosticStagesWithObservationScope(
 	snapshots := make([]topologymodel.ObservationSnapshot, 0, len(cut.devices))
 	for _, device := range cut.devices {
 		replayed := topologyDiagnosticReplayedDevice{
-			registrationID: device.registrationID,
-			capture:        device.acquisition,
-			renderable:     device.renderable,
+			registrationID:  device.registrationID,
+			latestAttempt:   device.latestAttempt,
+			retainedSuccess: device.acquisition,
+			renderable:      device.renderable,
 		}
 		if !device.renderable && !includeNonRenderable {
 			replay.devices = append(replay.devices, replayed)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_graph_replay.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	topologyapi "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
 	topologyv1renderer "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyv1"
@@ -15,41 +16,103 @@ func replayTopologyDiagnostics(
 	diagnostics topologyDiagnostics,
 	options topologyoptions.QueryOptions,
 ) (topologyapi.Data, bool, error) {
+	replay := replayTopologyDiagnosticStagesWithObservationScope(diagnostics, options, false)
+	if replay.typed.state != topologyInspectionPresent {
+		return topologyapi.Data{}, false, replay.err
+	}
+	return replay.payload, true, nil
+}
+
+type topologyDiagnosticReplayedDevice struct {
+	registrationID ddsnmp.DeviceRegistrationID
+	capture        *topologyAcquisitionCapture
+	renderable     bool
+	observation    topologyInspectionState
+	snapshot       *topologyDeviceSnapshot
+}
+
+type topologyDiagnosticReplayStages struct {
+	devices []topologyDiagnosticReplayedDevice
+	graph   topologyInspectionStage
+	typed   topologyInspectionStage
+	data    topologymodel.Data
+	payload topologyapi.Data
+	err     error
+}
+
+func replayTopologyDiagnosticStages(
+	diagnostics topologyDiagnostics,
+	options topologyoptions.QueryOptions,
+) topologyDiagnosticReplayStages {
+	return replayTopologyDiagnosticStagesWithObservationScope(diagnostics, options, true)
+}
+
+func replayTopologyDiagnosticStagesWithObservationScope(
+	diagnostics topologyDiagnostics,
+	options topologyoptions.QueryOptions,
+	includeNonRenderable bool,
+) topologyDiagnosticReplayStages {
+	var replay topologyDiagnosticReplayStages
 	cut := diagnostics.topology
 	if cut == nil || cut.captureState != diagnosticCaptureAvailable {
-		return topologyapi.Data{}, false, nil
+		return replay
 	}
 
 	snapshots := make([]topologymodel.ObservationSnapshot, 0, len(cut.devices))
 	for _, device := range cut.devices {
-		if !device.renderable {
+		replayed := topologyDiagnosticReplayedDevice{
+			registrationID: device.registrationID,
+			capture:        device.acquisition,
+			renderable:     device.renderable,
+		}
+		if !device.renderable && !includeNonRenderable {
+			replay.devices = append(replay.devices, replayed)
 			continue
 		}
 		capture := device.acquisition
 		if capture == nil || capture.state != diagnosticCaptureAvailable || capture.evidence == nil {
-			return topologyapi.Data{}, false, fmt.Errorf(
-				"replay renderable device %s: acquisition evidence is unavailable",
-				device.registrationID.String(),
-			)
+			replayed.observation = topologyInspectionUndetermined
+			replay.devices = append(replay.devices, replayed)
+			if device.renderable && replay.err == nil {
+				replay.err = fmt.Errorf(
+					"replay renderable device %s: acquisition evidence is unavailable",
+					device.registrationID.String(),
+				)
+			}
+			continue
 		}
 		snapshot, err := replayTopologyAcquisitionEvidence(capture.evidence)
 		if err != nil {
-			return topologyapi.Data{}, false, fmt.Errorf(
-				"replay renderable device %s: %w",
-				device.registrationID.String(),
-				err,
-			)
+			replayed.observation = topologyInspectionUndetermined
+			replay.devices = append(replay.devices, replayed)
+			if device.renderable && replay.err == nil {
+				replay.err = fmt.Errorf("replay renderable device %s: %w", device.registrationID.String(), err)
+			}
+			continue
 		}
 		if snapshot == nil || !snapshot.hasObservation {
-			return topologyapi.Data{}, false, fmt.Errorf(
-				"replay renderable device %s: observation is unavailable",
-				device.registrationID.String(),
-			)
+			replayed.observation = topologyInspectionAbsent
+			replay.devices = append(replay.devices, replayed)
+			if device.renderable && replay.err == nil {
+				replay.err = fmt.Errorf(
+					"replay renderable device %s: observation is unavailable",
+					device.registrationID.String(),
+				)
+			}
+			continue
 		}
-		snapshots = append(snapshots, snapshot.observation)
+		replayed.observation = topologyInspectionPresent
+		replayed.snapshot = snapshot
+		replay.devices = append(replay.devices, replayed)
+		if device.renderable {
+			snapshots = append(snapshots, snapshot.observation)
+		}
+	}
+	if replay.err != nil {
+		return replay
 	}
 	if len(snapshots) == 0 {
-		return topologyapi.Data{}, false, nil
+		return replay
 	}
 
 	sortTopologyObservationSnapshots(snapshots)
@@ -60,11 +123,17 @@ func replayTopologyDiagnostics(
 		topologyGraphBuildEnvironment{},
 	)
 	if err != nil || !ok {
-		return topologyapi.Data{}, ok, err
+		replay.err = err
+		return replay
 	}
+	replay.graph.state = topologyInspectionPresent
+	replay.data = data
 	payload, err := topologyv1renderer.Render(data)
 	if err != nil {
-		return topologyapi.Data{}, false, err
+		replay.err = err
+		return replay
 	}
-	return payload, true, nil
+	replay.typed.state = topologyInspectionPresent
+	replay.payload = payload
+	return replay
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
@@ -119,9 +119,14 @@ type topologyInspectionSourceFact struct {
 	bgp            *topologyAcquisitionBGPRowValue
 }
 
+type topologyInspectionSourceContext struct {
+	registrationID ddsnmp.DeviceRegistrationID
+	capture        topologyInspectionCaptureResult
+	facts          []topologyInspectionSourceFact
+}
+
 type topologyInspectionSourceResult struct {
-	membership topologyInspectionStage
-	facts      []topologyInspectionSourceFact
+	contexts []topologyInspectionSourceContext
 }
 
 type topologyInspectionGraphLinkResult struct {
@@ -227,7 +232,7 @@ func inspectTopologyLink(
 	}
 
 	replay := replayTopologyDiagnosticStages(diagnostics, options)
-	report.source = inspectTopologyLinkSources(replay.devices, subject)
+	report.source = inspectTopologyLinkSourceContext(replay.devices, subject.family)
 	if replay.graph.state != topologyInspectionPresent {
 		return report, nil
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
@@ -33,14 +33,18 @@ type topologyInspectionLifecycleResult struct {
 	entry         *ddsnmp.DeviceLifecycleEntry
 }
 
-type topologyInspectionSweepResult struct {
-	membership    topologyInspectionStage
+type topologyInspectionDiagnosticCutResult struct {
 	captureState  diagnosticCaptureState
 	captureReason diagnosticCaptureReason
 	sequence      uint64
 	startedAt     time.Time
 	publishedAt   time.Time
-	device        *topologySweepDeviceDiagnostic
+}
+
+type topologyInspectionSweepResult struct {
+	topologyInspectionDiagnosticCutResult
+	membership topologyInspectionStage
+	device     *topologySweepDeviceDiagnostic
 }
 
 type topologyInspectionRemovedResult struct {
@@ -127,14 +131,15 @@ type topologyInspectionGraphLinkResult struct {
 }
 
 type topologyLinkInspection struct {
-	subject     topologyInspectionLinkSubject
-	options     topologyoptions.QueryOptions
-	source      topologyInspectionSourceResult
-	graphLink   topologyInspectionGraphLinkResult
-	typedLink   topologyInspectionRowResult
-	graphStats  topologyInspectionStage
-	stats       topologymodel.Stats
-	lastAborted *topologyAbortedSweepDiagnostic
+	subject       topologyInspectionLinkSubject
+	options       topologyoptions.QueryOptions
+	diagnosticCut topologyInspectionDiagnosticCutResult
+	source        topologyInspectionSourceResult
+	graphLink     topologyInspectionGraphLinkResult
+	typedLink     topologyInspectionRowResult
+	graphStats    topologyInspectionStage
+	stats         topologymodel.Stats
+	lastAborted   *topologyAbortedSweepDiagnostic
 }
 
 func inspectTopologyDevice(
@@ -214,11 +219,12 @@ func inspectTopologyLink(
 ) (topologyLinkInspection, error) {
 	subject = normalizeTopologyInspectionLinkSubject(subject)
 	report := topologyLinkInspection{
-		subject:     subject,
-		options:     topologyoptions.NormalizeQueryOptions(options),
-		graphLink:   topologyInspectionGraphLinkResult{index: -1},
-		typedLink:   topologyInspectionRowResult{row: -1},
-		lastAborted: diagnostics.lastAborted,
+		subject:       subject,
+		options:       topologyoptions.NormalizeQueryOptions(options),
+		diagnosticCut: inspectTopologyDiagnosticCut(diagnostics.topology),
+		graphLink:     topologyInspectionGraphLinkResult{index: -1},
+		typedLink:     topologyInspectionRowResult{row: -1},
+		lastAborted:   diagnostics.lastAborted,
 	}
 	if subject.srcIdentity == "" || subject.dstIdentity == "" || subject.family == "" {
 		return report, fmt.Errorf("topology inspection link subject is incomplete")

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
@@ -204,7 +204,11 @@ func inspectTopologyDevice(
 
 	report.graphStats = replay.data.Stats
 	report.hasGraphStats = true
-	report.graphIdentity = inspectTopologyLocalDeviceIdentity(replay.data, replayed.snapshot.observation.LocalDevice)
+	report.graphIdentity = inspectTopologyLocalDeviceIdentity(
+		replay.data,
+		replayed.snapshot.observation.LocalDeviceID,
+		replayed.snapshot.observation.LocalDevice,
+	)
 	report.typedIdentity = topologyInspectionRenderedRow(
 		replay.typed.state,
 		report.graphIdentity.membership.state,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
@@ -83,32 +83,12 @@ type topologyDeviceInspection struct {
 	lastAborted     *topologyAbortedSweepDiagnostic
 }
 
-type topologyInspectionLinkDiscriminator struct {
-	srcIfIndex int
-	srcIfName  string
-	srcPortID  string
-	dstIfIndex int
-	dstIfName  string
-	dstPortID  string
-
-	bridgeDomain string
-	subnet       string
-	prefix       int
-
-	ospfRouterA   string
-	ospfRouterB   string
-	ospfAdjacency string
-
-	bgpRoutingInstance string
-}
-
 type topologyInspectionLinkSubject struct {
-	srcIdentity   string
-	dstIdentity   string
-	family        string
-	protocol      string
-	direction     string
-	discriminator topologyInspectionLinkDiscriminator
+	srcIdentity string
+	dstIdentity string
+	family      string
+	protocol    string
+	direction   string
 }
 
 type topologyInspectionSourceFact struct {
@@ -119,10 +99,19 @@ type topologyInspectionSourceFact struct {
 	bgp            *topologyAcquisitionBGPRowValue
 }
 
+type topologyInspectionSourceCaptureContext struct {
+	latestAttempt   bool
+	retainedSuccess bool
+	capture         topologyInspectionCaptureResult
+	facts           []topologyInspectionSourceFact
+}
+
 type topologyInspectionSourceContext struct {
-	registrationID ddsnmp.DeviceRegistrationID
-	capture        topologyInspectionCaptureResult
-	facts          []topologyInspectionSourceFact
+	registrationID  ddsnmp.DeviceRegistrationID
+	latestAttempt   topologyInspectionCaptureResult
+	retainedSuccess topologyInspectionCaptureResult
+	sameAttempt     bool
+	captures        []topologyInspectionSourceCaptureContext
 }
 
 type topologyInspectionSourceResult struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
+)
+
+type topologyInspectionState uint8
+
+const (
+	topologyInspectionUndetermined topologyInspectionState = iota
+	topologyInspectionPresent
+	topologyInspectionAbsent
+)
+
+type topologyInspectionStage struct {
+	state      topologyInspectionState
+	candidates int
+}
+
+type topologyInspectionLifecycleResult struct {
+	membership    topologyInspectionStage
+	captureState  diagnosticCaptureState
+	captureReason diagnosticCaptureReason
+	sequence      uint64
+	capturedAt    time.Time
+	entry         *ddsnmp.DeviceLifecycleEntry
+}
+
+type topologyInspectionSweepResult struct {
+	membership    topologyInspectionStage
+	captureState  diagnosticCaptureState
+	captureReason diagnosticCaptureReason
+	sequence      uint64
+	startedAt     time.Time
+	publishedAt   time.Time
+	device        *topologySweepDeviceDiagnostic
+}
+
+type topologyInspectionRemovedResult struct {
+	membership topologyInspectionStage
+	device     *topologyRemovedDeviceDiagnostic
+}
+
+type topologyInspectionCaptureResult struct {
+	membership topologyInspectionStage
+	evidence   topologyInspectionStage
+	capture    *topologyAcquisitionCapture
+}
+
+type topologyInspectionActorResult struct {
+	membership topologyInspectionStage
+	indexes    []int
+	actors     []topologymodel.Actor
+	index      int
+}
+
+type topologyInspectionRowResult struct {
+	state topologyInspectionState
+	row   int
+}
+
+type topologyDeviceInspection struct {
+	registrationID  ddsnmp.DeviceRegistrationID
+	options         topologyoptions.QueryOptions
+	lifecycle       topologyInspectionLifecycleResult
+	sweep           topologyInspectionSweepResult
+	removed         topologyInspectionRemovedResult
+	latestAttempt   topologyInspectionCaptureResult
+	retainedSuccess topologyInspectionCaptureResult
+	sameAttempt     bool
+	observation     topologyInspectionStage
+	graphIdentity   topologyInspectionActorResult
+	typedIdentity   topologyInspectionRowResult
+	graphStats      topologymodel.Stats
+	hasGraphStats   bool
+	lastAborted     *topologyAbortedSweepDiagnostic
+}
+
+type topologyInspectionLinkDiscriminator struct {
+	srcIfIndex int
+	srcIfName  string
+	srcPortID  string
+	dstIfIndex int
+	dstIfName  string
+	dstPortID  string
+
+	bridgeDomain string
+	subnet       string
+	prefix       int
+
+	ospfRouterA   string
+	ospfRouterB   string
+	ospfAdjacency string
+
+	bgpRoutingInstance string
+}
+
+type topologyInspectionLinkSubject struct {
+	srcIdentity   string
+	dstIdentity   string
+	family        string
+	protocol      string
+	direction     string
+	discriminator topologyInspectionLinkDiscriminator
+}
+
+type topologyInspectionSourceFact struct {
+	registrationID ddsnmp.DeviceRegistrationID
+	contextOrdinal uint32
+	profileOrdinal uint32
+	metric         *topologyAcquisitionMetricValue
+	bgp            *topologyAcquisitionBGPRowValue
+}
+
+type topologyInspectionSourceResult struct {
+	membership topologyInspectionStage
+	facts      []topologyInspectionSourceFact
+}
+
+type topologyInspectionGraphLinkResult struct {
+	membership topologyInspectionStage
+	srcActors  topologyInspectionActorResult
+	dstActors  topologyInspectionActorResult
+	links      []topologymodel.Link
+	index      int
+}
+
+type topologyLinkInspection struct {
+	subject     topologyInspectionLinkSubject
+	options     topologyoptions.QueryOptions
+	source      topologyInspectionSourceResult
+	graphLink   topologyInspectionGraphLinkResult
+	typedLink   topologyInspectionRowResult
+	graphStats  topologyInspectionStage
+	stats       topologymodel.Stats
+	lastAborted *topologyAbortedSweepDiagnostic
+}
+
+func inspectTopologyDevice(
+	diagnostics topologyDiagnostics,
+	options topologyoptions.QueryOptions,
+	registrationID ddsnmp.DeviceRegistrationID,
+) (topologyDeviceInspection, error) {
+	report := topologyDeviceInspection{
+		registrationID: registrationID,
+		options:        topologyoptions.NormalizeQueryOptions(options),
+		graphIdentity:  topologyInspectionActorResult{index: -1},
+		typedIdentity:  topologyInspectionRowResult{row: -1},
+		lastAborted:    diagnostics.lastAborted,
+	}
+	if registrationID == 0 {
+		return report, fmt.Errorf("topology inspection registration ID is zero")
+	}
+
+	report.lifecycle = inspectTopologyLifecycleRegistration(diagnostics.lifecycle, registrationID)
+	report.sweep = inspectTopologySweepRegistration(diagnostics.topology, registrationID)
+	report.removed = inspectTopologyRemovedRegistration(diagnostics.topology, registrationID)
+	if report.sweep.membership.state == topologyInspectionUndetermined {
+		return report, nil
+	}
+	if report.sweep.membership.state == topologyInspectionAbsent {
+		report.latestAttempt = absentTopologyInspectionCapture()
+		report.retainedSuccess = absentTopologyInspectionCapture()
+		report.observation.state = topologyInspectionAbsent
+		return report, nil
+	}
+
+	row := report.sweep.device
+	report.latestAttempt = inspectTopologyCapture(row.latestAttempt)
+	report.retainedSuccess = inspectTopologyCapture(row.acquisition)
+	report.sameAttempt = row.latestAttempt != nil && row.latestAttempt == row.acquisition
+	if report.retainedSuccess.membership.state == topologyInspectionAbsent {
+		report.observation.state = topologyInspectionAbsent
+		return report, nil
+	}
+	if report.retainedSuccess.evidence.state != topologyInspectionPresent {
+		return report, nil
+	}
+
+	replay := replayTopologyDiagnosticStages(diagnostics, options)
+	replayed := findTopologyDiagnosticReplayedDevice(replay.devices, registrationID)
+	if replayed == nil {
+		return report, nil
+	}
+	report.observation.state = replayed.observation
+	if replayed.observation != topologyInspectionPresent || replayed.snapshot == nil {
+		return report, nil
+	}
+	if replay.graph.state != topologyInspectionPresent {
+		return report, nil
+	}
+
+	report.graphStats = replay.data.Stats
+	report.hasGraphStats = true
+	report.graphIdentity = inspectTopologyLocalDeviceIdentity(replay.data, replayed.snapshot.observation.LocalDevice)
+	report.typedIdentity = topologyInspectionRenderedRow(
+		replay.typed.state,
+		report.graphIdentity.membership.state,
+		report.graphIdentity.index,
+		replay.payload.Actors.Rows,
+	)
+	return report, nil
+}
+
+func inspectTopologyLink(
+	diagnostics topologyDiagnostics,
+	options topologyoptions.QueryOptions,
+	subject topologyInspectionLinkSubject,
+) (topologyLinkInspection, error) {
+	subject = normalizeTopologyInspectionLinkSubject(subject)
+	report := topologyLinkInspection{
+		subject:     subject,
+		options:     topologyoptions.NormalizeQueryOptions(options),
+		graphLink:   topologyInspectionGraphLinkResult{index: -1},
+		typedLink:   topologyInspectionRowResult{row: -1},
+		lastAborted: diagnostics.lastAborted,
+	}
+	if subject.srcIdentity == "" || subject.dstIdentity == "" || subject.family == "" {
+		return report, fmt.Errorf("topology inspection link subject is incomplete")
+	}
+
+	replay := replayTopologyDiagnosticStages(diagnostics, options)
+	report.source = inspectTopologyLinkSources(replay.devices, subject)
+	if replay.graph.state != topologyInspectionPresent {
+		return report, nil
+	}
+	report.graphStats.state = topologyInspectionPresent
+	report.stats = replay.data.Stats
+	report.graphLink = inspectTopologyGraphLink(replay.data, subject)
+	report.typedLink = topologyInspectionRenderedRow(
+		replay.typed.state,
+		report.graphLink.membership.state,
+		report.graphLink.index,
+		replay.payload.Links.Rows,
+	)
+	return report, nil
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_benchmark_test.go
@@ -18,6 +18,7 @@ func BenchmarkSNMPTopologyOfflineInspectionScaling(b *testing.B) {
 		sharedEndpoints     bool
 	}{
 		{devices: 8, fdbEntriesPerDevice: 128},
+		{devices: 40, fdbEntriesPerDevice: 1600},
 		{devices: 40, fdbEntriesPerDevice: 1600, sharedEndpoints: true},
 	}
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_benchmark_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
+)
+
+func BenchmarkSNMPTopologyOfflineInspectionScaling(b *testing.B) {
+	tests := []struct {
+		devices             int
+		fdbEntriesPerDevice int
+		sharedEndpoints     bool
+	}{
+		{devices: 8, fdbEntriesPerDevice: 128},
+		{devices: 40, fdbEntriesPerDevice: 1600, sharedEndpoints: true},
+	}
+
+	for _, tc := range tests {
+		name := fmt.Sprintf(
+			"devices=%d/fdb_entries_per_device=%d/shared_endpoints=%t",
+			tc.devices,
+			tc.fdbEntriesPerDevice,
+			tc.sharedEndpoints,
+		)
+		b.Run(name, func(b *testing.B) {
+			scenario := benchmarkTopologyReplayScenario(tc.devices, tc.fdbEntriesPerDevice, tc.sharedEndpoints)
+			_, diagnostics := newTopologyScenarioReplayFixture(b, scenario)
+			options := topologyoptions.DefaultQueryOptions()
+			replay := replayTopologyDiagnosticStages(diagnostics, options)
+			if replay.graph.state != topologyInspectionPresent || len(replay.data.Links) == 0 {
+				b.Fatalf("inspection probe graph=%d links=%d err=%v", replay.graph.state, len(replay.data.Links), replay.err)
+			}
+			linkSubject, ok := topologyInspectionSubjectFromLink(replay.data, 0)
+			if !ok {
+				b.Fatal("inspection probe could not resolve first link")
+			}
+
+			b.Run("subject=device", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					report, err := inspectTopologyDevice(diagnostics, options, ddsnmp.DeviceRegistrationID(1))
+					if err != nil || report.graphIdentity.membership.state == topologyInspectionUndetermined {
+						b.Fatalf("device inspection state=%d err=%v", report.graphIdentity.membership.state, err)
+					}
+					runtime.KeepAlive(report)
+				}
+			})
+
+			b.Run("subject=link", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					report, err := inspectTopologyLink(diagnostics, options, linkSubject)
+					if err != nil || report.graphLink.membership.state == topologyInspectionUndetermined {
+						b.Fatalf("link inspection state=%d err=%v", report.graphLink.membership.state, err)
+					}
+					runtime.KeepAlive(report)
+				}
+			})
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
@@ -3,6 +3,7 @@
 package snmptopology
 
 import (
+	"slices"
 	"strings"
 
 	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
@@ -165,15 +166,10 @@ func topologyInspectionActorHasIdentity(actor topologymodel.Actor, identityKey s
 	if identityKey == "" {
 		return false
 	}
-	if strings.HasPrefix(identityKey, "actor:") {
-		return strings.TrimSpace(actor.ActorID) == strings.TrimPrefix(identityKey, "actor:")
+	if after, ok := strings.CutPrefix(identityKey, "actor:"); ok {
+		return strings.TrimSpace(actor.ActorID) == after
 	}
-	for _, key := range topologymodel.MatchIdentityKeys(actor.Match) {
-		if key == identityKey {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(topologymodel.MatchIdentityKeys(actor.Match), identityKey)
 }
 
 func topologyInspectionPreferredActorIdentity(actor topologymodel.Actor) string {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"strings"
+
+	topologyengine "github.com/netdata/netdata/go/plugins/pkg/l2topology"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+)
+
+func inspectTopologyLifecycleRegistration(
+	cut topologyJobLifecycleDiagnosticCut,
+	registrationID ddsnmp.DeviceRegistrationID,
+) topologyInspectionLifecycleResult {
+	result := topologyInspectionLifecycleResult{captureState: cut.state, captureReason: cut.reason}
+	if cut.state != diagnosticCaptureAvailable {
+		return result
+	}
+	result.sequence = cut.cut.Sequence
+	result.capturedAt = cut.cut.CapturedAt
+	for i := range cut.cut.Entries {
+		if cut.cut.Entries[i].RegistrationID == registrationID {
+			result.membership = topologyInspectionStage{state: topologyInspectionPresent, candidates: 1}
+			result.entry = &cut.cut.Entries[i]
+			return result
+		}
+	}
+	result.membership.state = topologyInspectionAbsent
+	return result
+}
+
+func inspectTopologySweepRegistration(
+	cut *topologySweepDiagnosticCut,
+	registrationID ddsnmp.DeviceRegistrationID,
+) topologyInspectionSweepResult {
+	var result topologyInspectionSweepResult
+	if cut == nil {
+		return result
+	}
+	result.captureState = cut.captureState
+	result.captureReason = cut.captureReason
+	if cut.captureState != diagnosticCaptureAvailable {
+		return result
+	}
+	result.sequence = cut.sequence
+	result.startedAt = cut.startedAt
+	result.publishedAt = cut.publishedAt
+	for i := range cut.devices {
+		if cut.devices[i].registrationID == registrationID {
+			result.membership = topologyInspectionStage{state: topologyInspectionPresent, candidates: 1}
+			result.device = &cut.devices[i]
+			return result
+		}
+	}
+	result.membership.state = topologyInspectionAbsent
+	return result
+}
+
+func inspectTopologyRemovedRegistration(
+	cut *topologySweepDiagnosticCut,
+	registrationID ddsnmp.DeviceRegistrationID,
+) topologyInspectionRemovedResult {
+	var result topologyInspectionRemovedResult
+	if cut == nil || cut.captureState != diagnosticCaptureAvailable {
+		return result
+	}
+	for i := range cut.removed {
+		if cut.removed[i].registrationID == registrationID {
+			result.membership = topologyInspectionStage{state: topologyInspectionPresent, candidates: 1}
+			result.device = &cut.removed[i]
+			return result
+		}
+	}
+	result.membership.state = topologyInspectionAbsent
+	return result
+}
+
+func absentTopologyInspectionCapture() topologyInspectionCaptureResult {
+	return topologyInspectionCaptureResult{
+		membership: topologyInspectionStage{state: topologyInspectionAbsent},
+		evidence:   topologyInspectionStage{state: topologyInspectionAbsent},
+	}
+}
+
+func inspectTopologyCapture(capture *topologyAcquisitionCapture) topologyInspectionCaptureResult {
+	if capture == nil {
+		return absentTopologyInspectionCapture()
+	}
+	result := topologyInspectionCaptureResult{
+		membership: topologyInspectionStage{state: topologyInspectionPresent, candidates: 1},
+		capture:    capture,
+	}
+	if capture.state == diagnosticCaptureAvailable && capture.evidence != nil {
+		result.evidence = topologyInspectionStage{state: topologyInspectionPresent, candidates: 1}
+	}
+	return result
+}
+
+func findTopologyDiagnosticReplayedDevice(
+	devices []topologyDiagnosticReplayedDevice,
+	registrationID ddsnmp.DeviceRegistrationID,
+) *topologyDiagnosticReplayedDevice {
+	for i := range devices {
+		if devices[i].registrationID == registrationID {
+			return &devices[i]
+		}
+	}
+	return nil
+}
+
+func inspectTopologyLocalDeviceIdentity(
+	data topologymodel.Data,
+	device topologymodel.Device,
+) topologyInspectionActorResult {
+	index := topologymodel.NewLocalActorMatchIndex()
+	for i := range data.Actors {
+		if topologyengine.IsDeviceActorType(data.Actors[i].ActorType) {
+			index.AddMatch(i, data.Actors[i].Match)
+		}
+	}
+	return topologyInspectionActorsAt(data, index.MatchIndexes(nil, device))
+}
+
+func inspectTopologyActorIdentity(data topologymodel.Data, identityKey string) topologyInspectionActorResult {
+	identityKey = strings.TrimSpace(identityKey)
+	indexes := make([]int, 0, 1)
+	for i := range data.Actors {
+		if topologyInspectionActorHasIdentity(data.Actors[i], identityKey) {
+			indexes = append(indexes, i)
+		}
+	}
+	return topologyInspectionActorsAt(data, indexes)
+}
+
+func topologyInspectionActorsAt(data topologymodel.Data, indexes []int) topologyInspectionActorResult {
+	result := topologyInspectionActorResult{indexes: indexes, index: -1}
+	for _, index := range indexes {
+		if index >= 0 && index < len(data.Actors) {
+			result.actors = append(result.actors, data.Actors[index])
+		}
+	}
+	result.membership.candidates = len(result.actors)
+	switch len(result.actors) {
+	case 0:
+		result.membership.state = topologyInspectionAbsent
+	case 1:
+		result.membership.state = topologyInspectionPresent
+		result.index = indexes[0]
+	default:
+		result.membership.state = topologyInspectionUndetermined
+	}
+	return result
+}
+
+func topologyInspectionActorHasIdentity(actor topologymodel.Actor, identityKey string) bool {
+	if identityKey == "" {
+		return false
+	}
+	if strings.HasPrefix(identityKey, "actor:") {
+		return strings.TrimSpace(actor.ActorID) == strings.TrimPrefix(identityKey, "actor:")
+	}
+	for _, key := range topologymodel.MatchIdentityKeys(actor.Match) {
+		if key == identityKey {
+			return true
+		}
+	}
+	return false
+}
+
+func topologyInspectionPreferredActorIdentity(actor topologymodel.Actor) string {
+	keys := topologymodel.MatchIdentityKeys(actor.Match)
+	for _, prefix := range []string{"hw:", "chassis:", "ip:", "hostname:", "sysname:", "dns:"} {
+		for _, key := range keys {
+			if strings.HasPrefix(key, prefix) {
+				return key
+			}
+		}
+	}
+	if actorID := strings.TrimSpace(actor.ActorID); actorID != "" {
+		return "actor:" + actorID
+	}
+	return ""
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
@@ -112,6 +112,7 @@ func findTopologyDiagnosticReplayedDevice(
 
 func inspectTopologyLocalDeviceIdentity(
 	data topologymodel.Data,
+	localDeviceID string,
 	device topologymodel.Device,
 ) topologyInspectionActorResult {
 	index := topologymodel.NewLocalActorMatchIndex()
@@ -120,7 +121,14 @@ func inspectTopologyLocalDeviceIdentity(
 			index.AddMatch(i, data.Actors[i].Match)
 		}
 	}
-	return topologyInspectionActorsAt(data, index.MatchIndexes(nil, device))
+	if indexes := index.MatchIndexes(nil, device); len(indexes) > 0 {
+		return topologyInspectionActorsAt(data, indexes)
+	}
+	actor, ok := topologyLocalActorFromCache(localDeviceID, device)
+	if !ok {
+		return topologyInspectionActorsAt(data, nil)
+	}
+	return inspectTopologyActorIdentity(data, "actor:"+actor.ActorID)
 }
 
 func inspectTopologyActorIdentity(data topologymodel.Data, identityKey string) topologyInspectionActorResult {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
@@ -14,12 +14,15 @@ func inspectTopologyLifecycleRegistration(
 	cut topologyJobLifecycleDiagnosticCut,
 	registrationID ddsnmp.DeviceRegistrationID,
 ) topologyInspectionLifecycleResult {
-	result := topologyInspectionLifecycleResult{captureState: cut.state, captureReason: cut.reason}
+	result := topologyInspectionLifecycleResult{
+		captureState:  cut.state,
+		captureReason: cut.reason,
+		sequence:      cut.cut.Sequence,
+		capturedAt:    cut.cut.CapturedAt,
+	}
 	if cut.state != diagnosticCaptureAvailable {
 		return result
 	}
-	result.sequence = cut.cut.Sequence
-	result.capturedAt = cut.cut.CapturedAt
 	for i := range cut.cut.Entries {
 		if cut.cut.Entries[i].RegistrationID == registrationID {
 			result.membership = topologyInspectionStage{state: topologyInspectionPresent, candidates: 1}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_device.go
@@ -39,14 +39,10 @@ func inspectTopologySweepRegistration(
 	if cut == nil {
 		return result
 	}
-	result.captureState = cut.captureState
-	result.captureReason = cut.captureReason
+	result.topologyInspectionDiagnosticCutResult = inspectTopologyDiagnosticCut(cut)
 	if cut.captureState != diagnosticCaptureAvailable {
 		return result
 	}
-	result.sequence = cut.sequence
-	result.startedAt = cut.startedAt
-	result.publishedAt = cut.publishedAt
 	for i := range cut.devices {
 		if cut.devices[i].registrationID == registrationID {
 			result.membership = topologyInspectionStage{state: topologyInspectionPresent, candidates: 1}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
@@ -92,10 +92,25 @@ func topologyInspectionLinkMatches(
 	if link.SrcActorHandle == srcHandle && link.DstActorHandle == dstHandle {
 		return actual == subject.discriminator
 	}
-	if link.SrcActorHandle == dstHandle && link.DstActorHandle == srcHandle {
+	if topologyInspectionLinkSubjectUnordered(subject) &&
+		link.SrcActorHandle == dstHandle && link.DstActorHandle == srcHandle {
 		return topologyInspectionSwapLinkDiscriminator(actual) == subject.discriminator
 	}
 	return false
+}
+
+func topologyInspectionLinkSubjectUnordered(subject topologyInspectionLinkSubject) bool {
+	if subject.direction == "bidirectional" {
+		return true
+	}
+	switch subject.family {
+	case topologymodel.L3SubnetLinkType,
+		topologymodel.OSPFAdjacencyLinkType,
+		topologymodel.BGPAdjacencyLinkType:
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeTopologyInspectionLinkSubject(subject topologyInspectionLinkSubject) topologyInspectionLinkSubject {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
@@ -42,20 +42,22 @@ func inspectTopologyGraphLink(
 		dstActors: inspectTopologyActorIdentity(data, subject.dstIdentity),
 		index:     -1,
 	}
-	if result.srcActors.membership.state == topologyInspectionUndetermined ||
-		result.dstActors.membership.state == topologyInspectionUndetermined {
-		return result
-	}
 	if result.srcActors.membership.state == topologyInspectionAbsent ||
 		result.dstActors.membership.state == topologyInspectionAbsent {
 		result.membership.state = topologyInspectionAbsent
 		return result
 	}
 
-	srcHandle := result.srcActors.actors[0].ActorHandle
-	dstHandle := result.dstActors.actors[0].ActorHandle
+	srcHandles := make(map[topologymodel.ActorHandle]struct{}, len(result.srcActors.actors))
+	for _, actor := range result.srcActors.actors {
+		srcHandles[actor.ActorHandle] = struct{}{}
+	}
+	dstHandles := make(map[topologymodel.ActorHandle]struct{}, len(result.dstActors.actors))
+	for _, actor := range result.dstActors.actors {
+		dstHandles[actor.ActorHandle] = struct{}{}
+	}
 	for i := range data.Links {
-		if topologyInspectionLinkMatches(data.Links[i], srcHandle, dstHandle, subject) {
+		if topologyInspectionLinkMatches(data.Links[i], srcHandles, dstHandles, subject) {
 			result.links = append(result.links, data.Links[i])
 			if result.index == -1 {
 				result.index = i
@@ -63,6 +65,12 @@ func inspectTopologyGraphLink(
 		}
 	}
 	result.membership.candidates = len(result.links)
+	if result.srcActors.membership.state == topologyInspectionUndetermined ||
+		result.dstActors.membership.state == topologyInspectionUndetermined {
+		result.membership.state = topologyInspectionUndetermined
+		result.index = -1
+		return result
+	}
 	switch len(result.links) {
 	case 0:
 		result.membership.state = topologyInspectionAbsent
@@ -77,8 +85,8 @@ func inspectTopologyGraphLink(
 
 func topologyInspectionLinkMatches(
 	link topologymodel.Link,
-	srcHandle topologymodel.ActorHandle,
-	dstHandle topologymodel.ActorHandle,
+	srcHandles map[topologymodel.ActorHandle]struct{},
+	dstHandles map[topologymodel.ActorHandle]struct{},
 	subject topologyInspectionLinkSubject,
 ) bool {
 	if topologyInspectionLinkFamily(link) != subject.family ||
@@ -86,14 +94,17 @@ func topologyInspectionLinkMatches(
 		normalizeTopologyInspectionDirection(link.Direction) != subject.direction {
 		return false
 	}
-	if link.SrcActorHandle == srcHandle && link.DstActorHandle == dstHandle {
+	_, srcMatchesSrc := srcHandles[link.SrcActorHandle]
+	_, dstMatchesDst := dstHandles[link.DstActorHandle]
+	if srcMatchesSrc && dstMatchesDst {
 		return true
 	}
-	if topologyInspectionLinkSubjectUnordered(subject) &&
-		link.SrcActorHandle == dstHandle && link.DstActorHandle == srcHandle {
-		return true
+	if !topologyInspectionLinkSubjectUnordered(subject) {
+		return false
 	}
-	return false
+	_, srcMatchesDst := dstHandles[link.SrcActorHandle]
+	_, dstMatchesSrc := srcHandles[link.DstActorHandle]
+	return srcMatchesDst && dstMatchesSrc
 }
 
 func topologyInspectionLinkSubjectUnordered(subject topologyInspectionLinkSubject) bool {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
@@ -3,7 +3,6 @@
 package snmptopology
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
@@ -25,12 +24,11 @@ func topologyInspectionSubjectFromLink(data topologymodel.Data, index int) (topo
 		return topologyInspectionLinkSubject{}, false
 	}
 	return normalizeTopologyInspectionLinkSubject(topologyInspectionLinkSubject{
-		srcIdentity:   srcIdentity,
-		dstIdentity:   dstIdentity,
-		family:        topologyInspectionLinkFamily(link),
-		protocol:      link.Protocol,
-		direction:     link.Direction,
-		discriminator: topologyInspectionLinkDiscriminatorForLink(link),
+		srcIdentity: srcIdentity,
+		dstIdentity: dstIdentity,
+		family:      topologyInspectionLinkFamily(link),
+		protocol:    link.Protocol,
+		direction:   link.Direction,
 	}), true
 }
 
@@ -88,13 +86,12 @@ func topologyInspectionLinkMatches(
 		normalizeTopologyInspectionDirection(link.Direction) != subject.direction {
 		return false
 	}
-	actual := topologyInspectionLinkDiscriminatorForLink(link)
 	if link.SrcActorHandle == srcHandle && link.DstActorHandle == dstHandle {
-		return actual == subject.discriminator
+		return true
 	}
 	if topologyInspectionLinkSubjectUnordered(subject) &&
 		link.SrcActorHandle == dstHandle && link.DstActorHandle == srcHandle {
-		return topologyInspectionSwapLinkDiscriminator(actual) == subject.discriminator
+		return true
 	}
 	return false
 }
@@ -122,91 +119,7 @@ func normalizeTopologyInspectionLinkSubject(subject topologyInspectionLinkSubjec
 		subject.protocol = subject.family
 	}
 	subject.direction = normalizeTopologyInspectionDirection(subject.direction)
-	subject.discriminator = normalizeTopologyInspectionLinkDiscriminator(subject.discriminator)
 	return subject
-}
-
-func normalizeTopologyInspectionLinkDiscriminator(value topologyInspectionLinkDiscriminator) topologyInspectionLinkDiscriminator {
-	value.srcIfIndex = max(value.srcIfIndex, 0)
-	value.dstIfIndex = max(value.dstIfIndex, 0)
-	value.srcIfName = strings.TrimSpace(value.srcIfName)
-	value.dstIfName = strings.TrimSpace(value.dstIfName)
-	value.srcPortID = strings.TrimSpace(value.srcPortID)
-	value.dstPortID = strings.TrimSpace(value.dstPortID)
-	value.bridgeDomain = strings.TrimSpace(value.bridgeDomain)
-	value.subnet = strings.TrimSpace(value.subnet)
-	value.ospfRouterA = topologyutil.NormalizeTopologyRouterID(value.ospfRouterA)
-	value.ospfRouterB = topologyutil.NormalizeTopologyRouterID(value.ospfRouterB)
-	if value.ospfRouterA > value.ospfRouterB {
-		value.ospfRouterA, value.ospfRouterB = value.ospfRouterB, value.ospfRouterA
-	}
-	value.ospfAdjacency = strings.TrimSpace(value.ospfAdjacency)
-	value.bgpRoutingInstance = strings.TrimSpace(value.bgpRoutingInstance)
-	return value
-}
-
-func topologyInspectionLinkDiscriminatorForLink(link topologymodel.Link) topologyInspectionLinkDiscriminator {
-	var result topologyInspectionLinkDiscriminator
-	switch topologyInspectionLinkFamily(link) {
-	case topologymodel.L3SubnetLinkType:
-		if link.Detail.L3Subnet != nil {
-			result.subnet = link.Detail.L3Subnet.Subnet
-			result.prefix = link.Detail.L3Subnet.Prefix
-		}
-	case topologymodel.L3SubnetMembershipLinkType:
-		if link.Detail.L3SubnetMembership != nil {
-			result.subnet = link.Detail.L3SubnetMembership.Subnet
-			result.prefix = link.Detail.L3SubnetMembership.Prefix
-		}
-	case topologymodel.OSPFAdjacencyLinkType:
-		if detail := link.Detail.OSPF; detail != nil {
-			result.ospfRouterA = detail.LocalRouterID
-			result.ospfRouterB = detail.NeighborRouterID
-			result.ospfAdjacency = topologyInspectionOSPFAdjacency(
-				detail.Subnet,
-				detail.Prefix,
-				detail.LocalIP,
-				detail.NeighborIP,
-			)
-		}
-	case topologymodel.BGPAdjacencyLinkType:
-		if detail := link.Detail.BGP; detail != nil {
-			result.bgpRoutingInstance = topologyutil.FirstNonEmptyString(detail.RoutingInstance, "default")
-		}
-	default:
-		result.srcIfIndex = max(link.Src.IfIndex, 0)
-		result.srcIfName = topologymodel.EndpointKey(link.Src, "if_name")
-		result.srcPortID = topologymodel.EndpointKey(link.Src, "port_id")
-		result.dstIfIndex = max(link.Dst.IfIndex, 0)
-		result.dstIfName = topologymodel.EndpointKey(link.Dst, "if_name")
-		result.dstPortID = topologymodel.EndpointKey(link.Dst, "port_id")
-		if link.L2 != nil {
-			result.bridgeDomain = link.L2.BridgeDomain
-		}
-	}
-	return normalizeTopologyInspectionLinkDiscriminator(result)
-}
-
-func topologyInspectionSwapLinkDiscriminator(value topologyInspectionLinkDiscriminator) topologyInspectionLinkDiscriminator {
-	value.srcIfIndex, value.dstIfIndex = value.dstIfIndex, value.srcIfIndex
-	value.srcIfName, value.dstIfName = value.dstIfName, value.srcIfName
-	value.srcPortID, value.dstPortID = value.dstPortID, value.srcPortID
-	return value
-}
-
-func topologyInspectionOSPFAdjacency(subnet string, prefix int, localIP, neighborIP string) string {
-	if subnet = strings.TrimSpace(subnet); subnet != "" && prefix > 0 {
-		return topologyutil.JoinKeyParts("subnet", subnet, strconv.Itoa(prefix))
-	}
-	localIP = topologyutil.NormalizeNonUnspecifiedIPAddress(localIP)
-	neighborIP = topologyutil.NormalizeNonUnspecifiedIPAddress(neighborIP)
-	if localIP != "" && neighborIP != "" {
-		if localIP > neighborIP {
-			localIP, neighborIP = neighborIP, localIP
-		}
-		return topologyutil.JoinKeyParts("ip_pair", localIP, neighborIP)
-	}
-	return "router_id"
 }
 
 func topologyInspectionLinkFamily(link topologymodel.Link) string {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
+)
+
+func topologyInspectionSubjectFromLink(data topologymodel.Data, index int) (topologyInspectionLinkSubject, bool) {
+	if index < 0 || index >= len(data.Links) {
+		return topologyInspectionLinkSubject{}, false
+	}
+	link := data.Links[index]
+	actors := make(map[topologymodel.ActorHandle]topologymodel.Actor, len(data.Actors))
+	for _, actor := range data.Actors {
+		actors[actor.ActorHandle] = actor
+	}
+	srcIdentity := topologyInspectionPreferredActorIdentity(actors[link.SrcActorHandle])
+	dstIdentity := topologyInspectionPreferredActorIdentity(actors[link.DstActorHandle])
+	if srcIdentity == "" || dstIdentity == "" {
+		return topologyInspectionLinkSubject{}, false
+	}
+	return normalizeTopologyInspectionLinkSubject(topologyInspectionLinkSubject{
+		srcIdentity:   srcIdentity,
+		dstIdentity:   dstIdentity,
+		family:        topologyInspectionLinkFamily(link),
+		protocol:      link.Protocol,
+		direction:     link.Direction,
+		discriminator: topologyInspectionLinkDiscriminatorForLink(link),
+	}), true
+}
+
+func inspectTopologyGraphLink(
+	data topologymodel.Data,
+	subject topologyInspectionLinkSubject,
+) topologyInspectionGraphLinkResult {
+	subject = normalizeTopologyInspectionLinkSubject(subject)
+	result := topologyInspectionGraphLinkResult{
+		srcActors: inspectTopologyActorIdentity(data, subject.srcIdentity),
+		dstActors: inspectTopologyActorIdentity(data, subject.dstIdentity),
+		index:     -1,
+	}
+	if result.srcActors.membership.state == topologyInspectionUndetermined ||
+		result.dstActors.membership.state == topologyInspectionUndetermined {
+		return result
+	}
+	if result.srcActors.membership.state == topologyInspectionAbsent ||
+		result.dstActors.membership.state == topologyInspectionAbsent {
+		result.membership.state = topologyInspectionAbsent
+		return result
+	}
+
+	srcHandle := result.srcActors.actors[0].ActorHandle
+	dstHandle := result.dstActors.actors[0].ActorHandle
+	for i := range data.Links {
+		if topologyInspectionLinkMatches(data.Links[i], srcHandle, dstHandle, subject) {
+			result.links = append(result.links, data.Links[i])
+			if result.index == -1 {
+				result.index = i
+			}
+		}
+	}
+	result.membership.candidates = len(result.links)
+	switch len(result.links) {
+	case 0:
+		result.membership.state = topologyInspectionAbsent
+	case 1:
+		result.membership.state = topologyInspectionPresent
+	default:
+		result.membership.state = topologyInspectionUndetermined
+		result.index = -1
+	}
+	return result
+}
+
+func topologyInspectionLinkMatches(
+	link topologymodel.Link,
+	srcHandle topologymodel.ActorHandle,
+	dstHandle topologymodel.ActorHandle,
+	subject topologyInspectionLinkSubject,
+) bool {
+	if topologyInspectionLinkFamily(link) != subject.family ||
+		normalizeTopologyInspectionToken(link.Protocol) != subject.protocol ||
+		normalizeTopologyInspectionDirection(link.Direction) != subject.direction {
+		return false
+	}
+	actual := topologyInspectionLinkDiscriminatorForLink(link)
+	if link.SrcActorHandle == srcHandle && link.DstActorHandle == dstHandle {
+		return actual == subject.discriminator
+	}
+	if link.SrcActorHandle == dstHandle && link.DstActorHandle == srcHandle {
+		return topologyInspectionSwapLinkDiscriminator(actual) == subject.discriminator
+	}
+	return false
+}
+
+func normalizeTopologyInspectionLinkSubject(subject topologyInspectionLinkSubject) topologyInspectionLinkSubject {
+	subject.srcIdentity = strings.TrimSpace(subject.srcIdentity)
+	subject.dstIdentity = strings.TrimSpace(subject.dstIdentity)
+	subject.family = normalizeTopologyInspectionToken(subject.family)
+	subject.protocol = normalizeTopologyInspectionToken(subject.protocol)
+	if subject.protocol == "" {
+		subject.protocol = subject.family
+	}
+	subject.direction = normalizeTopologyInspectionDirection(subject.direction)
+	subject.discriminator = normalizeTopologyInspectionLinkDiscriminator(subject.discriminator)
+	return subject
+}
+
+func normalizeTopologyInspectionLinkDiscriminator(value topologyInspectionLinkDiscriminator) topologyInspectionLinkDiscriminator {
+	value.srcIfIndex = max(value.srcIfIndex, 0)
+	value.dstIfIndex = max(value.dstIfIndex, 0)
+	value.srcIfName = strings.TrimSpace(value.srcIfName)
+	value.dstIfName = strings.TrimSpace(value.dstIfName)
+	value.srcPortID = strings.TrimSpace(value.srcPortID)
+	value.dstPortID = strings.TrimSpace(value.dstPortID)
+	value.bridgeDomain = strings.TrimSpace(value.bridgeDomain)
+	value.subnet = strings.TrimSpace(value.subnet)
+	value.ospfRouterA = topologyutil.NormalizeTopologyRouterID(value.ospfRouterA)
+	value.ospfRouterB = topologyutil.NormalizeTopologyRouterID(value.ospfRouterB)
+	if value.ospfRouterA > value.ospfRouterB {
+		value.ospfRouterA, value.ospfRouterB = value.ospfRouterB, value.ospfRouterA
+	}
+	value.ospfAdjacency = strings.TrimSpace(value.ospfAdjacency)
+	value.bgpRoutingInstance = strings.TrimSpace(value.bgpRoutingInstance)
+	return value
+}
+
+func topologyInspectionLinkDiscriminatorForLink(link topologymodel.Link) topologyInspectionLinkDiscriminator {
+	var result topologyInspectionLinkDiscriminator
+	switch topologyInspectionLinkFamily(link) {
+	case topologymodel.L3SubnetLinkType:
+		if link.Detail.L3Subnet != nil {
+			result.subnet = link.Detail.L3Subnet.Subnet
+			result.prefix = link.Detail.L3Subnet.Prefix
+		}
+	case topologymodel.L3SubnetMembershipLinkType:
+		if link.Detail.L3SubnetMembership != nil {
+			result.subnet = link.Detail.L3SubnetMembership.Subnet
+			result.prefix = link.Detail.L3SubnetMembership.Prefix
+		}
+	case topologymodel.OSPFAdjacencyLinkType:
+		if detail := link.Detail.OSPF; detail != nil {
+			result.ospfRouterA = detail.LocalRouterID
+			result.ospfRouterB = detail.NeighborRouterID
+			result.ospfAdjacency = topologyInspectionOSPFAdjacency(
+				detail.Subnet,
+				detail.Prefix,
+				detail.LocalIP,
+				detail.NeighborIP,
+			)
+		}
+	case topologymodel.BGPAdjacencyLinkType:
+		if detail := link.Detail.BGP; detail != nil {
+			result.bgpRoutingInstance = topologyutil.FirstNonEmptyString(detail.RoutingInstance, "default")
+		}
+	default:
+		result.srcIfIndex = max(link.Src.IfIndex, 0)
+		result.srcIfName = topologymodel.EndpointKey(link.Src, "if_name")
+		result.srcPortID = topologymodel.EndpointKey(link.Src, "port_id")
+		result.dstIfIndex = max(link.Dst.IfIndex, 0)
+		result.dstIfName = topologymodel.EndpointKey(link.Dst, "if_name")
+		result.dstPortID = topologymodel.EndpointKey(link.Dst, "port_id")
+		if link.L2 != nil {
+			result.bridgeDomain = link.L2.BridgeDomain
+		}
+	}
+	return normalizeTopologyInspectionLinkDiscriminator(result)
+}
+
+func topologyInspectionSwapLinkDiscriminator(value topologyInspectionLinkDiscriminator) topologyInspectionLinkDiscriminator {
+	value.srcIfIndex, value.dstIfIndex = value.dstIfIndex, value.srcIfIndex
+	value.srcIfName, value.dstIfName = value.dstIfName, value.srcIfName
+	value.srcPortID, value.dstPortID = value.dstPortID, value.srcPortID
+	return value
+}
+
+func topologyInspectionOSPFAdjacency(subnet string, prefix int, localIP, neighborIP string) string {
+	if subnet = strings.TrimSpace(subnet); subnet != "" && prefix > 0 {
+		return topologyutil.JoinKeyParts("subnet", subnet, strconv.Itoa(prefix))
+	}
+	localIP = topologyutil.NormalizeNonUnspecifiedIPAddress(localIP)
+	neighborIP = topologyutil.NormalizeNonUnspecifiedIPAddress(neighborIP)
+	if localIP != "" && neighborIP != "" {
+		if localIP > neighborIP {
+			localIP, neighborIP = neighborIP, localIP
+		}
+		return topologyutil.JoinKeyParts("ip_pair", localIP, neighborIP)
+	}
+	return "router_id"
+}
+
+func topologyInspectionLinkFamily(link topologymodel.Link) string {
+	return normalizeTopologyInspectionToken(topologyutil.FirstNonEmptyString(link.LinkType, link.Protocol))
+}
+
+func normalizeTopologyInspectionToken(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeTopologyInspectionDirection(value string) string {
+	return normalizeTopologyInspectionToken(topologyutil.FirstNonEmptyString(value, "observed"))
+}
+
+func topologyInspectionRenderedRow(
+	renderState topologyInspectionState,
+	membership topologyInspectionState,
+	row int,
+	rows int,
+) topologyInspectionRowResult {
+	result := topologyInspectionRowResult{row: -1}
+	if renderState != topologyInspectionPresent {
+		return result
+	}
+	switch membership {
+	case topologyInspectionAbsent:
+		result.state = topologyInspectionAbsent
+	case topologyInspectionPresent:
+		if row >= 0 && row < rows {
+			result.state = topologyInspectionPresent
+			result.row = row
+		}
+	}
+	return result
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_source.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_source.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+)
+
+func inspectTopologyLinkSources(
+	devices []topologyDiagnosticReplayedDevice,
+	subject topologyInspectionLinkSubject,
+) topologyInspectionSourceResult {
+	var result topologyInspectionSourceResult
+	complete := true
+	matchedDevices := 0
+	for i := range devices {
+		device := &devices[i]
+		if device.observation != topologyInspectionPresent || device.snapshot == nil {
+			continue
+		}
+		actor, ok := topologyLocalActorFromCache(
+			device.snapshot.observation.LocalDeviceID,
+			device.snapshot.observation.LocalDevice,
+		)
+		if !ok || (!topologyInspectionActorHasIdentity(actor, subject.srcIdentity) &&
+			!topologyInspectionActorHasIdentity(actor, subject.dstIdentity)) {
+			continue
+		}
+		matchedDevices++
+		if !topologyInspectionCaptureCompleteForFamily(device.capture, subject.family) {
+			complete = false
+		}
+		result.facts = append(result.facts, topologyInspectionCaptureFacts(device.registrationID, device.capture, subject.family)...)
+	}
+	result.membership.candidates = len(result.facts)
+	if len(result.facts) > 0 {
+		result.membership.state = topologyInspectionPresent
+	} else if matchedDevices > 0 && complete {
+		result.membership.state = topologyInspectionAbsent
+	}
+	return result
+}
+
+func topologyInspectionCaptureFacts(
+	registrationID ddsnmp.DeviceRegistrationID,
+	capture *topologyAcquisitionCapture,
+	family string,
+) []topologyInspectionSourceFact {
+	if capture == nil || capture.state != diagnosticCaptureAvailable || capture.evidence == nil {
+		return nil
+	}
+	var facts []topologyInspectionSourceFact
+	for contextIndex := range capture.evidence.collectionContexts {
+		context := &capture.evidence.collectionContexts[contextIndex]
+		for profileIndex := range context.profiles {
+			profile := &context.profiles[profileIndex]
+			for metricIndex := range profile.values.metrics {
+				metric := &profile.values.metrics[metricIndex]
+				if topologyInspectionMetricMatchesFamily(metric.kind, family) {
+					facts = append(facts, topologyInspectionSourceFact{
+						registrationID: registrationID,
+						contextOrdinal: context.ordinal,
+						profileOrdinal: profile.identity.Ordinal,
+						metric:         metric,
+					})
+				}
+			}
+			if family == topologymodel.BGPAdjacencyLinkType {
+				for rowIndex := range profile.values.bgpRows {
+					facts = append(facts, topologyInspectionSourceFact{
+						registrationID: registrationID,
+						contextOrdinal: context.ordinal,
+						profileOrdinal: profile.identity.Ordinal,
+						bgp:            &profile.values.bgpRows[rowIndex],
+					})
+				}
+			}
+		}
+	}
+	return facts
+}
+
+func topologyInspectionMetricMatchesFamily(kind ddsnmp.TopologyKind, family string) bool {
+	switch family {
+	case "lldp":
+		return kind == ddsnmp.KindLldpLocPort || kind == ddsnmp.KindLldpLocManAddr ||
+			kind == ddsnmp.KindLldpRem || kind == ddsnmp.KindLldpRemManAddr ||
+			kind == ddsnmp.KindLldpRemManAddrCompat
+	case "cdp":
+		return kind == ddsnmp.KindCdpCache
+	case "stp":
+		return kind == ddsnmp.KindStpPort
+	case "arp":
+		return kind == ddsnmp.KindArpEntry || kind == ddsnmp.KindArpLegacyEntry
+	case "fdb", "bridge":
+		return kind == ddsnmp.KindBridgePortIfIndex || kind == ddsnmp.KindFdbEntry ||
+			kind == ddsnmp.KindQbridgeFdbEntry || kind == ddsnmp.KindQbridgeVlanEntry ||
+			kind == ddsnmp.KindVtpVlan
+	case topologymodel.L3SubnetLinkType, topologymodel.L3SubnetMembershipLinkType:
+		return kind == ddsnmp.KindIfName || kind == ddsnmp.KindIpIfIndex
+	case topologymodel.OSPFAdjacencyLinkType:
+		return kind == ddsnmp.KindOSPFNeighbor
+	case topologymodel.BGPAdjacencyLinkType:
+		return false
+	default:
+		return true
+	}
+}
+
+func topologyInspectionCaptureCompleteForFamily(capture *topologyAcquisitionCapture, family string) bool {
+	if capture == nil || capture.state != diagnosticCaptureAvailable || capture.evidence == nil {
+		return false
+	}
+	observedRelevantRoute := false
+	for _, context := range capture.evidence.collectionContexts {
+		if context.collection.outcome != topologyAcquisitionPhaseSuccess {
+			return false
+		}
+		for _, profile := range context.profiles {
+			if profile.outcome != ddsnmpcollector.AcquisitionProfileOutcomeSuccess {
+				return false
+			}
+			if family == topologymodel.BGPAdjacencyLinkType && profile.values.bgpFailed {
+				return false
+			}
+			for _, route := range profile.routes {
+				if !topologyInspectionRouteMatchesFamily(route.Kind, family) {
+					continue
+				}
+				observedRelevantRoute = true
+				switch route.Outcome {
+				case ddsnmpcollector.AcquisitionRouteOutcomeMissing,
+					ddsnmpcollector.AcquisitionRouteOutcomeEmpty,
+					ddsnmpcollector.AcquisitionRouteOutcomeValues:
+				default:
+					return false
+				}
+			}
+		}
+	}
+	return observedRelevantRoute
+}
+
+func topologyInspectionRouteMatchesFamily(kind ddsnmpcollector.AcquisitionRouteKind, family string) bool {
+	if family == topologymodel.BGPAdjacencyLinkType {
+		return kind == ddsnmpcollector.AcquisitionRouteKindBGPScalar ||
+			kind == ddsnmpcollector.AcquisitionRouteKindBGPTable
+	}
+	return kind == ddsnmpcollector.AcquisitionRouteKindTopologyScalar ||
+		kind == ddsnmpcollector.AcquisitionRouteKindTopologyTable
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_source.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_source.go
@@ -7,6 +7,19 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 )
 
+func inspectTopologyDiagnosticCut(cut *topologySweepDiagnosticCut) topologyInspectionDiagnosticCutResult {
+	if cut == nil {
+		return topologyInspectionDiagnosticCutResult{}
+	}
+	return topologyInspectionDiagnosticCutResult{
+		captureState:  cut.captureState,
+		captureReason: cut.captureReason,
+		sequence:      cut.sequence,
+		startedAt:     cut.startedAt,
+		publishedAt:   cut.publishedAt,
+	}
+}
+
 func inspectTopologyLinkSourceContext(
 	devices []topologyDiagnosticReplayedDevice,
 	family string,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_source.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_source.go
@@ -16,11 +16,36 @@ func inspectTopologyLinkSourceContext(
 	}
 	for i := range devices {
 		device := &devices[i]
-		result.contexts = append(result.contexts, topologyInspectionSourceContext{
-			registrationID: device.registrationID,
-			capture:        inspectTopologyCapture(device.capture),
-			facts:          topologyInspectionCaptureFacts(device.registrationID, device.capture, family),
-		})
+		context := topologyInspectionSourceContext{
+			registrationID:  device.registrationID,
+			latestAttempt:   inspectTopologyCapture(device.latestAttempt),
+			retainedSuccess: inspectTopologyCapture(device.retainedSuccess),
+			sameAttempt:     device.latestAttempt != nil && device.latestAttempt == device.retainedSuccess,
+		}
+		if device.latestAttempt != nil {
+			context.captures = append(context.captures, topologyInspectionSourceCaptureContext{
+				latestAttempt:   true,
+				retainedSuccess: context.sameAttempt,
+				capture:         context.latestAttempt,
+				facts: topologyInspectionCaptureFacts(
+					device.registrationID,
+					device.latestAttempt,
+					family,
+				),
+			})
+		}
+		if device.retainedSuccess != nil && !context.sameAttempt {
+			context.captures = append(context.captures, topologyInspectionSourceCaptureContext{
+				retainedSuccess: true,
+				capture:         context.retainedSuccess,
+				facts: topologyInspectionCaptureFacts(
+					device.registrationID,
+					device.retainedSuccess,
+					family,
+				),
+			})
+		}
+		result.contexts = append(result.contexts, context)
 	}
 	return result
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_source.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_source.go
@@ -4,41 +4,23 @@ package snmptopology
 
 import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 )
 
-func inspectTopologyLinkSources(
+func inspectTopologyLinkSourceContext(
 	devices []topologyDiagnosticReplayedDevice,
-	subject topologyInspectionLinkSubject,
+	family string,
 ) topologyInspectionSourceResult {
-	var result topologyInspectionSourceResult
-	complete := true
-	matchedDevices := 0
+	result := topologyInspectionSourceResult{
+		contexts: make([]topologyInspectionSourceContext, 0, len(devices)),
+	}
 	for i := range devices {
 		device := &devices[i]
-		if device.observation != topologyInspectionPresent || device.snapshot == nil {
-			continue
-		}
-		actor, ok := topologyLocalActorFromCache(
-			device.snapshot.observation.LocalDeviceID,
-			device.snapshot.observation.LocalDevice,
-		)
-		if !ok || (!topologyInspectionActorHasIdentity(actor, subject.srcIdentity) &&
-			!topologyInspectionActorHasIdentity(actor, subject.dstIdentity)) {
-			continue
-		}
-		matchedDevices++
-		if !topologyInspectionCaptureCompleteForFamily(device.capture, subject.family) {
-			complete = false
-		}
-		result.facts = append(result.facts, topologyInspectionCaptureFacts(device.registrationID, device.capture, subject.family)...)
-	}
-	result.membership.candidates = len(result.facts)
-	if len(result.facts) > 0 {
-		result.membership.state = topologyInspectionPresent
-	} else if matchedDevices > 0 && complete {
-		result.membership.state = topologyInspectionAbsent
+		result.contexts = append(result.contexts, topologyInspectionSourceContext{
+			registrationID: device.registrationID,
+			capture:        inspectTopologyCapture(device.capture),
+			facts:          topologyInspectionCaptureFacts(device.registrationID, device.capture, family),
+		})
 	}
 	return result
 }
@@ -107,47 +89,4 @@ func topologyInspectionMetricMatchesFamily(kind ddsnmp.TopologyKind, family stri
 	default:
 		return true
 	}
-}
-
-func topologyInspectionCaptureCompleteForFamily(capture *topologyAcquisitionCapture, family string) bool {
-	if capture == nil || capture.state != diagnosticCaptureAvailable || capture.evidence == nil {
-		return false
-	}
-	observedRelevantRoute := false
-	for _, context := range capture.evidence.collectionContexts {
-		if context.collection.outcome != topologyAcquisitionPhaseSuccess {
-			return false
-		}
-		for _, profile := range context.profiles {
-			if profile.outcome != ddsnmpcollector.AcquisitionProfileOutcomeSuccess {
-				return false
-			}
-			if family == topologymodel.BGPAdjacencyLinkType && profile.values.bgpFailed {
-				return false
-			}
-			for _, route := range profile.routes {
-				if !topologyInspectionRouteMatchesFamily(route.Kind, family) {
-					continue
-				}
-				observedRelevantRoute = true
-				switch route.Outcome {
-				case ddsnmpcollector.AcquisitionRouteOutcomeMissing,
-					ddsnmpcollector.AcquisitionRouteOutcomeEmpty,
-					ddsnmpcollector.AcquisitionRouteOutcomeValues:
-				default:
-					return false
-				}
-			}
-		}
-	}
-	return observedRelevantRoute
-}
-
-func topologyInspectionRouteMatchesFamily(kind ddsnmpcollector.AcquisitionRouteKind, family string) bool {
-	if family == topologymodel.BGPAdjacencyLinkType {
-		return kind == ddsnmpcollector.AcquisitionRouteKindBGPScalar ||
-			kind == ddsnmpcollector.AcquisitionRouteKindBGPTable
-	}
-	return kind == ddsnmpcollector.AcquisitionRouteKindTopologyScalar ||
-		kind == ddsnmpcollector.AcquisitionRouteKindTopologyTable
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -236,12 +236,20 @@ func TestInspectTopologyLinkAmbiguousIdentityIsUndetermined(t *testing.T) {
 	for i := range data.Actors {
 		data.Actors[i].ActorHandle = allocator.Next()
 	}
-	data.Links = []topologymodel.Link{{
-		Protocol:       "lldp",
-		Direction:      "bidirectional",
-		SrcActorHandle: data.Actors[0].ActorHandle,
-		DstActorHandle: data.Actors[2].ActorHandle,
-	}}
+	data.Links = []topologymodel.Link{
+		{
+			Protocol:       "lldp",
+			Direction:      "bidirectional",
+			SrcActorHandle: data.Actors[0].ActorHandle,
+			DstActorHandle: data.Actors[2].ActorHandle,
+		},
+		{
+			Protocol:       "lldp",
+			Direction:      "bidirectional",
+			SrcActorHandle: data.Actors[1].ActorHandle,
+			DstActorHandle: data.Actors[2].ActorHandle,
+		},
+	}
 	subject := topologyInspectionLinkSubject{
 		srcIdentity: "ip:192.0.2.1",
 		dstIdentity: "ip:192.0.2.2",
@@ -253,6 +261,9 @@ func TestInspectTopologyLinkAmbiguousIdentityIsUndetermined(t *testing.T) {
 	got := inspectTopologyGraphLink(data, subject)
 	require.Equal(t, topologyInspectionUndetermined, got.membership.state)
 	require.Equal(t, 2, got.srcActors.membership.candidates)
+	require.Equal(t, 2, got.membership.candidates)
+	require.Equal(t, data.Links, got.links)
+	require.Equal(t, -1, got.index)
 }
 
 func TestInspectTopologyGraphLinkPreservesOrderedEndpointRoles(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -151,6 +151,32 @@ func TestInspectTopologyDeviceUsesOneCollapsedIdentityRepresentation(t *testing.
 	require.Equal(t, leftReport.graphIdentity.index, rightReport.graphIdentity.index)
 }
 
+func TestInspectTopologyDeviceUsesLocalDeviceIDFallbackRepresentation(t *testing.T) {
+	scenario := newTopologyScenario("inspection-local-device-id-fallback")
+	scenario.Switch("switch-fallback", "192.0.2.55", "02:00:00:00:55:01")
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	setTopologyInspectionLifecycleCut(&diagnostics, 1)
+
+	capture := diagnostics.topology.devices[0].acquisition
+	require.NotNil(t, capture)
+	require.NotNil(t, capture.evidence)
+	capture.evidence.device = topologySemanticDeviceInput{}
+	for contextIndex := range capture.evidence.collectionContexts {
+		context := &capture.evidence.collectionContexts[contextIndex]
+		for profileIndex := range context.profiles {
+			profile := &context.profiles[profileIndex]
+			profile.values = topologyAcquisitionProfileValues{}
+		}
+	}
+
+	report, err := inspectTopologyDevice(diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionPresent, report.observation.state)
+	require.Equal(t, topologyInspectionPresent, report.graphIdentity.membership.state)
+	require.Equal(t, topologyInspectionPresent, report.typedIdentity.state)
+	require.Equal(t, "local-device", report.graphIdentity.actors[0].ActorID)
+}
+
 func TestInspectTopologyActorIdentityRequiresOneMatch(t *testing.T) {
 	data := topologymodel.Data{Actors: []topologymodel.Actor{
 		{ActorID: "actor-a", Match: topologymodel.Match{IPAddresses: []string{"192.0.2.1"}}},

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/stretchr/testify/require"
 )
@@ -176,16 +175,18 @@ func TestInspectTopologyLinkUsesStructuralSubjectAndSingleRenderedRow(t *testing
 
 	report, err := inspectTopologyLink(diagnostics, scenario.opts, subject)
 	require.NoError(t, err)
-	require.Equal(t, topologyInspectionPresent, report.source.membership.state)
-	require.NotEmpty(t, report.source.facts)
+	require.Len(t, report.source.contexts, len(diagnostics.topology.devices))
+	require.NotZero(t, topologyInspectionSourceFactCount(report.source))
 	require.Equal(t, topologyInspectionPresent, report.graphLink.membership.state)
 	require.Equal(t, 1, report.graphLink.membership.candidates)
 	require.Equal(t, topologyInspectionPresent, report.typedLink.state)
 	require.Equal(t, report.graphLink.index, report.typedLink.row)
+	sourceContext := report.source
 
 	subject.discriminator.srcPortID = "missing-port"
 	report, err = inspectTopologyLink(diagnostics, scenario.opts, subject)
 	require.NoError(t, err)
+	require.Equal(t, sourceContext, report.source)
 	require.Equal(t, topologyInspectionAbsent, report.graphLink.membership.state)
 	require.Equal(t, topologyInspectionAbsent, report.typedLink.state)
 }
@@ -221,31 +222,58 @@ func TestInspectTopologyLinkAmbiguousIdentityIsUndetermined(t *testing.T) {
 	require.Equal(t, 2, got.srcActors.membership.candidates)
 }
 
-func TestInspectTopologyLinkSourceAbsenceRequiresCompleteRoutes(t *testing.T) {
-	scenario := newLLDPDirectScenario()
+func TestInspectTopologyLinkSourceContextIsFamilyWideAndKeepsCaptureAvailability(t *testing.T) {
+	scenario := newTopologyScenario("inspection-family-source-context")
+	left := scenario.Switch("switch-left", "192.0.2.51", "02:00:00:00:51:01")
+	right := scenario.Switch("switch-right", "192.0.2.52", "02:00:00:00:52:01")
+	otherLeft := scenario.Switch("switch-other-left", "192.0.2.53", "02:00:00:00:53:01")
+	otherRight := scenario.Switch("switch-other-right", "192.0.2.54", "02:00:00:00:54:01")
+	scenario.LLDP(left.Port("left-right", 1), right.Port("right-left", 1))
+	scenario.LLDP(otherLeft.Port("other-left-right", 1), otherRight.Port("other-right-left", 1))
 	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
 	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
 	require.NotEmpty(t, replay.data.Links)
 	subject, ok := topologyInspectionSubjectFromLink(replay.data, 0)
 	require.True(t, ok)
 
-	setTopologyInspectionSourceRoutes(t, diagnostics, ddsnmpcollector.AcquisitionRouteOutcomePartial)
+	var unrelatedRegistrationID ddsnmp.DeviceRegistrationID
+	for _, device := range replay.devices {
+		if device.snapshot == nil {
+			continue
+		}
+		actor, ok := topologyLocalActorFromCache(
+			device.snapshot.observation.LocalDeviceID,
+			device.snapshot.observation.LocalDevice,
+		)
+		if ok && !topologyInspectionActorHasIdentity(actor, subject.srcIdentity) &&
+			!topologyInspectionActorHasIdentity(actor, subject.dstIdentity) {
+			unrelatedRegistrationID = device.registrationID
+			break
+		}
+	}
+	require.NotZero(t, unrelatedRegistrationID)
+
+	diagnostics.topology.devices = append(diagnostics.topology.devices, topologySweepDeviceDiagnostic{
+		registrationID: 99,
+		acquisition: &topologyAcquisitionCapture{
+			state:  diagnosticCaptureUnavailable,
+			reason: diagnosticCaptureReasonProjectionError,
+		},
+	})
 	report, err := inspectTopologyLink(diagnostics, scenario.opts, subject)
 	require.NoError(t, err)
-	require.Equal(t, topologyInspectionUndetermined, report.source.membership.state)
-	require.Empty(t, report.source.facts)
+	require.Len(t, report.source.contexts, len(diagnostics.topology.devices))
 
-	setTopologyInspectionSourceRoutes(t, diagnostics, ddsnmpcollector.AcquisitionRouteOutcomeEmpty)
-	report, err = inspectTopologyLink(diagnostics, scenario.opts, subject)
-	require.NoError(t, err)
-	require.Equal(t, topologyInspectionAbsent, report.source.membership.state)
-	require.Empty(t, report.source.facts)
+	unrelated := topologyInspectionSourceContextByRegistration(report.source, unrelatedRegistrationID)
+	require.NotNil(t, unrelated)
+	require.NotEmpty(t, unrelated.facts)
 
-	clearTopologyInspectionSourceRoutes(t, diagnostics)
-	report, err = inspectTopologyLink(diagnostics, scenario.opts, subject)
-	require.NoError(t, err)
-	require.Equal(t, topologyInspectionUndetermined, report.source.membership.state)
-	require.Empty(t, report.source.facts)
+	unavailable := topologyInspectionSourceContextByRegistration(report.source, 99)
+	require.NotNil(t, unavailable)
+	require.Equal(t, topologyInspectionPresent, unavailable.capture.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, unavailable.capture.evidence.state)
+	require.Equal(t, diagnosticCaptureUnavailable, unavailable.capture.capture.state)
+	require.Empty(t, unavailable.facts)
 }
 
 func TestTopologyInspectionSubjectsDistinguishEveryRenderedLink(t *testing.T) {
@@ -331,47 +359,22 @@ func setTopologyInspectionLifecycleCut(diagnostics *topologyDiagnostics, registr
 	}
 }
 
-func setTopologyInspectionSourceRoutes(
-	t *testing.T,
-	diagnostics topologyDiagnostics,
-	outcome ddsnmpcollector.AcquisitionRouteOutcome,
-) {
-	t.Helper()
-	for deviceIndex := range diagnostics.topology.devices {
-		capture := diagnostics.topology.devices[deviceIndex].acquisition
-		require.NotNil(t, capture)
-		require.NotNil(t, capture.evidence)
-		for contextIndex := range capture.evidence.collectionContexts {
-			context := &capture.evidence.collectionContexts[contextIndex]
-			for profileIndex := range context.profiles {
-				profile := &context.profiles[profileIndex]
-				profile.values.metrics = nil
-				for routeIndex := range profile.routes {
-					route := &profile.routes[routeIndex]
-					if route.Kind == ddsnmpcollector.AcquisitionRouteKindTopologyScalar ||
-						route.Kind == ddsnmpcollector.AcquisitionRouteKindTopologyTable {
-						route.Outcome = outcome
-					}
-				}
-			}
+func topologyInspectionSourceContextByRegistration(
+	result topologyInspectionSourceResult,
+	registrationID ddsnmp.DeviceRegistrationID,
+) *topologyInspectionSourceContext {
+	for i := range result.contexts {
+		if result.contexts[i].registrationID == registrationID {
+			return &result.contexts[i]
 		}
 	}
+	return nil
 }
 
-func clearTopologyInspectionSourceRoutes(t *testing.T, diagnostics topologyDiagnostics) {
-	t.Helper()
-	for deviceIndex := range diagnostics.topology.devices {
-		capture := diagnostics.topology.devices[deviceIndex].acquisition
-		require.NotNil(t, capture)
-		require.NotNil(t, capture.evidence)
-		for contextIndex := range capture.evidence.collectionContexts {
-			context := &capture.evidence.collectionContexts[contextIndex]
-			for profileIndex := range context.profiles {
-				profile := &context.profiles[profileIndex]
-				profile.values.metrics = nil
-				profile.values.bgpRows = nil
-				profile.routes = nil
-			}
-		}
+func topologyInspectionSourceFactCount(result topologyInspectionSourceResult) int {
+	var count int
+	for _, context := range result.contexts {
+		count += len(context.facts)
 	}
+	return count
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectTopologyDeviceSeparatesLatestAttemptFromRetainedSuccess(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	setTopologyInspectionLifecycleCut(&diagnostics, 1, 2)
+
+	row := &diagnostics.topology.devices[0]
+	retained := row.acquisition
+	row.latestAttempt = &topologyAcquisitionCapture{
+		attemptID: topologyAcquisitionAttemptID{registrationID: 1, ordinal: 2},
+		state:     diagnosticCaptureUnavailable,
+		reason:    diagnosticCaptureReasonProjectionError,
+	}
+	aborted := &topologyAbortedSweepDiagnostic{sequence: 2, phase: topologyDiagnosticSweepPhaseDeviceRefresh}
+	diagnostics.lastAborted = aborted
+
+	report, err := inspectTopologyDevice(diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), report.lifecycle.sequence)
+	require.Equal(t, topologyScenarioCollectedAt, report.lifecycle.capturedAt)
+	require.Equal(t, diagnostics.topology.sequence, report.sweep.sequence)
+	require.Equal(t, diagnostics.topology.startedAt, report.sweep.startedAt)
+	require.Equal(t, diagnostics.topology.publishedAt, report.sweep.publishedAt)
+	require.Same(t, aborted, report.lastAborted)
+	require.Equal(t, topologyInspectionPresent, report.lifecycle.membership.state)
+	require.Equal(t, topologyInspectionPresent, report.sweep.membership.state)
+	require.Equal(t, topologyInspectionPresent, report.latestAttempt.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, report.latestAttempt.evidence.state)
+	require.Equal(t, topologyInspectionPresent, report.retainedSuccess.membership.state)
+	require.Equal(t, topologyInspectionPresent, report.retainedSuccess.evidence.state)
+	require.False(t, report.sameAttempt)
+	require.Same(t, retained, report.retainedSuccess.capture)
+	require.Equal(t, topologyInspectionPresent, report.observation.state)
+	require.Equal(t, topologyInspectionPresent, report.graphIdentity.membership.state)
+	require.Equal(t, topologyInspectionPresent, report.typedIdentity.state)
+}
+
+func TestInspectTopologyDeviceKeepsIncompleteCutsUndetermined(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	diagnostics.lifecycle = topologyJobLifecycleDiagnosticCut{
+		state:  diagnosticCaptureUnavailable,
+		reason: diagnosticCaptureReasonProjectionError,
+	}
+
+	report, err := inspectTopologyDevice(diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionUndetermined, report.lifecycle.membership.state)
+	require.Equal(t, diagnosticCaptureUnavailable, report.lifecycle.captureState)
+	require.Equal(t, diagnosticCaptureReasonProjectionError, report.lifecycle.captureReason)
+	require.Equal(t, topologyInspectionPresent, report.sweep.membership.state)
+
+	diagnostics.topology.captureState = diagnosticCaptureUnavailable
+	report, err = inspectTopologyDevice(diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionUndetermined, report.sweep.membership.state)
+	require.Equal(t, diagnosticCaptureUnavailable, report.sweep.captureState)
+	require.Equal(t, topologyInspectionUndetermined, report.latestAttempt.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, report.retainedSuccess.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, report.observation.state)
+	require.Equal(t, topologyInspectionUndetermined, report.graphIdentity.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, report.typedIdentity.state)
+}
+
+func TestInspectTopologyDeviceDoesNotFlattenWholeGraphReplayFailure(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	setTopologyInspectionLifecycleCut(&diagnostics, 1, 2)
+	diagnostics.topology.devices[1].acquisition = nil
+
+	report, err := inspectTopologyDevice(diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionPresent, report.observation.state)
+	require.Equal(t, topologyInspectionUndetermined, report.graphIdentity.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, report.typedIdentity.state)
+}
+
+func TestInspectTopologyDeviceReportsExactMissingRegistration(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	setTopologyInspectionLifecycleCut(&diagnostics, 1, 2)
+	diagnostics.topology.removed = append(diagnostics.topology.removed, topologyRemovedDeviceDiagnostic{registrationID: 99})
+
+	report, err := inspectTopologyDevice(diagnostics, scenario.opts, 99)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionAbsent, report.lifecycle.membership.state)
+	require.Equal(t, topologyInspectionAbsent, report.sweep.membership.state)
+	require.Equal(t, topologyInspectionPresent, report.removed.membership.state)
+	require.Equal(t, ddsnmp.DeviceRegistrationID(99), report.removed.device.registrationID)
+	require.Equal(t, topologyInspectionAbsent, report.latestAttempt.membership.state)
+	require.Equal(t, topologyInspectionAbsent, report.retainedSuccess.membership.state)
+	require.Equal(t, topologyInspectionAbsent, report.observation.state)
+	require.Equal(t, topologyInspectionUndetermined, report.graphIdentity.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, report.typedIdentity.state)
+}
+
+func TestInspectTopologyDeviceKeepsPreRegistrationSeparateFromSweep(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	setTopologyInspectionLifecycleCut(&diagnostics, 1, 2, 99)
+
+	report, err := inspectTopologyDevice(diagnostics, scenario.opts, 99)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionPresent, report.lifecycle.membership.state)
+	require.Equal(t, topologyInspectionAbsent, report.sweep.membership.state)
+	require.Equal(t, topologyInspectionAbsent, report.observation.state)
+	require.Equal(t, topologyInspectionUndetermined, report.graphIdentity.membership.state)
+}
+
+func TestInspectTopologyDeviceReportsIdentityRepresentationAfterExpiry(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	setTopologyInspectionLifecycleCut(&diagnostics, 1, 2)
+	diagnostics.topology.devices[0].renderable = false
+	diagnostics.topology.devices[0].expired = true
+
+	report, err := inspectTopologyDevice(diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	require.True(t, report.sweep.device.expired)
+	require.Equal(t, topologyInspectionPresent, report.observation.state)
+	require.Equal(t, topologyInspectionPresent, report.graphIdentity.membership.state)
+	require.Equal(t, topologyInspectionPresent, report.typedIdentity.state)
+}
+
+func TestInspectTopologyDeviceUsesOneCollapsedIdentityRepresentation(t *testing.T) {
+	scenario := newTopologyScenario("inspection-collapsed-identity")
+	left := scenario.Switch("switch-left", "192.0.2.50", "02:00:00:00:50:01")
+	right := scenario.Switch("switch-right", "192.0.2.50", "02:00:00:00:50:02")
+	scenario.LLDP(left.Port("left-right", 1), right.Port("right-left", 1))
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	setTopologyInspectionLifecycleCut(&diagnostics, 1, 2)
+
+	leftReport, err := inspectTopologyDevice(diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	rightReport, err := inspectTopologyDevice(diagnostics, scenario.opts, 2)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionPresent, leftReport.graphIdentity.membership.state)
+	require.Equal(t, topologyInspectionPresent, rightReport.graphIdentity.membership.state)
+	require.Equal(t, leftReport.graphIdentity.index, rightReport.graphIdentity.index)
+}
+
+func TestInspectTopologyActorIdentityRequiresOneMatch(t *testing.T) {
+	data := topologymodel.Data{Actors: []topologymodel.Actor{
+		{ActorID: "actor-a", Match: topologymodel.Match{IPAddresses: []string{"192.0.2.1"}}},
+		{ActorID: "actor-b", Match: topologymodel.Match{IPAddresses: []string{"192.0.2.1"}}},
+	}}
+
+	got := inspectTopologyActorIdentity(data, "ip:192.0.2.1")
+	require.Equal(t, topologyInspectionUndetermined, got.membership.state)
+	require.Equal(t, 2, got.membership.candidates)
+	require.Len(t, got.actors, 2)
+}
+
+func TestInspectTopologyLinkUsesStructuralSubjectAndSingleRenderedRow(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+
+	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
+	require.Equal(t, topologyInspectionPresent, replay.graph.state)
+	require.NotEmpty(t, replay.data.Links)
+	subject, ok := topologyInspectionSubjectFromLink(replay.data, 0)
+	require.True(t, ok)
+
+	report, err := inspectTopologyLink(diagnostics, scenario.opts, subject)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionPresent, report.source.membership.state)
+	require.NotEmpty(t, report.source.facts)
+	require.Equal(t, topologyInspectionPresent, report.graphLink.membership.state)
+	require.Equal(t, 1, report.graphLink.membership.candidates)
+	require.Equal(t, topologyInspectionPresent, report.typedLink.state)
+	require.Equal(t, report.graphLink.index, report.typedLink.row)
+
+	subject.discriminator.srcPortID = "missing-port"
+	report, err = inspectTopologyLink(diagnostics, scenario.opts, subject)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionAbsent, report.graphLink.membership.state)
+	require.Equal(t, topologyInspectionAbsent, report.typedLink.state)
+}
+
+func TestInspectTopologyLinkAmbiguousIdentityIsUndetermined(t *testing.T) {
+	data := topologymodel.Data{
+		Actors: []topologymodel.Actor{
+			{Match: topologymodel.Match{IPAddresses: []string{"192.0.2.1"}}},
+			{Match: topologymodel.Match{IPAddresses: []string{"192.0.2.1"}}},
+			{Match: topologymodel.Match{IPAddresses: []string{"192.0.2.2"}}},
+		},
+	}
+	allocator := graph.NewActorHandleAllocator()
+	for i := range data.Actors {
+		data.Actors[i].ActorHandle = allocator.Next()
+	}
+	data.Links = []topologymodel.Link{{
+		Protocol:       "lldp",
+		Direction:      "bidirectional",
+		SrcActorHandle: data.Actors[0].ActorHandle,
+		DstActorHandle: data.Actors[2].ActorHandle,
+	}}
+	subject := topologyInspectionLinkSubject{
+		srcIdentity: "ip:192.0.2.1",
+		dstIdentity: "ip:192.0.2.2",
+		family:      "lldp",
+		protocol:    "lldp",
+		direction:   "bidirectional",
+	}
+
+	got := inspectTopologyGraphLink(data, subject)
+	require.Equal(t, topologyInspectionUndetermined, got.membership.state)
+	require.Equal(t, 2, got.srcActors.membership.candidates)
+}
+
+func TestInspectTopologyLinkSourceAbsenceRequiresCompleteRoutes(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
+	require.NotEmpty(t, replay.data.Links)
+	subject, ok := topologyInspectionSubjectFromLink(replay.data, 0)
+	require.True(t, ok)
+
+	setTopologyInspectionSourceRoutes(t, diagnostics, ddsnmpcollector.AcquisitionRouteOutcomePartial)
+	report, err := inspectTopologyLink(diagnostics, scenario.opts, subject)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionUndetermined, report.source.membership.state)
+	require.Empty(t, report.source.facts)
+
+	setTopologyInspectionSourceRoutes(t, diagnostics, ddsnmpcollector.AcquisitionRouteOutcomeEmpty)
+	report, err = inspectTopologyLink(diagnostics, scenario.opts, subject)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionAbsent, report.source.membership.state)
+	require.Empty(t, report.source.facts)
+
+	clearTopologyInspectionSourceRoutes(t, diagnostics)
+	report, err = inspectTopologyLink(diagnostics, scenario.opts, subject)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionUndetermined, report.source.membership.state)
+	require.Empty(t, report.source.facts)
+}
+
+func TestTopologyInspectionSubjectsDistinguishEveryRenderedLink(t *testing.T) {
+	scenario := newMixedL2L3ControlScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
+	require.Equal(t, topologyInspectionPresent, replay.graph.state)
+	require.NotEmpty(t, replay.data.Links)
+
+	families := make(map[string]bool)
+	for i := range replay.data.Links {
+		subject, ok := topologyInspectionSubjectFromLink(replay.data, i)
+		require.Truef(t, ok, "link=%d", i)
+		match := inspectTopologyGraphLink(replay.data, subject)
+		require.Equalf(t, topologyInspectionPresent, match.membership.state, "link=%d family=%s", i, subject.family)
+		require.Equalf(t, 1, match.membership.candidates, "link=%d family=%s", i, subject.family)
+		require.Equal(t, i, match.index)
+		families[subject.family] = true
+	}
+	require.True(t, families["lldp"])
+	require.True(t, families[topologymodel.L3SubnetLinkType] || families[topologymodel.L3SubnetMembershipLinkType])
+	require.True(t, families[topologymodel.OSPFAdjacencyLinkType])
+	require.True(t, families[topologymodel.BGPAdjacencyLinkType])
+}
+
+func TestInspectTopologyGraphLinkRejectsDuplicateStructuralMatches(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
+	require.NotEmpty(t, replay.data.Links)
+	subject, ok := topologyInspectionSubjectFromLink(replay.data, 0)
+	require.True(t, ok)
+
+	replay.data.Links = append(replay.data.Links, replay.data.Links[0])
+	match := inspectTopologyGraphLink(replay.data, subject)
+	require.Equal(t, topologyInspectionUndetermined, match.membership.state)
+	require.Equal(t, 2, match.membership.candidates)
+	require.Equal(t, -1, match.index)
+}
+
+func TestTopologyInspectionLinkSubjectSeparatesParallelBGPRoutingInstances(t *testing.T) {
+	scenario := newTopologyScenario("inspection-parallel-bgp")
+	left := scenario.Router("router-left", "192.0.2.61", "02:00:00:00:61:01", "192.0.2.61", "65001")
+	right := scenario.Router("router-right", "192.0.2.62", "02:00:00:00:62:01", "192.0.2.62", "65002")
+	left.Port("left-right", 1).IPv4("198.51.100.1/30")
+	right.Port("right-left", 1).IPv4("198.51.100.2/30")
+	scenario.BGP(left, right, "blue")
+	scenario.BGP(left, right, "red")
+	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
+
+	var subjects []topologyInspectionLinkSubject
+	for i, link := range replay.data.Links {
+		if topologyInspectionLinkFamily(link) != topologymodel.BGPAdjacencyLinkType {
+			continue
+		}
+		subject, ok := topologyInspectionSubjectFromLink(replay.data, i)
+		require.True(t, ok)
+		subjects = append(subjects, subject)
+	}
+	require.Len(t, subjects, 2)
+	require.NotEqual(t, subjects[0].discriminator.bgpRoutingInstance, subjects[1].discriminator.bgpRoutingInstance)
+	for _, subject := range subjects {
+		match := inspectTopologyGraphLink(replay.data, subject)
+		require.Equal(t, topologyInspectionPresent, match.membership.state)
+		require.Equal(t, 1, match.membership.candidates)
+	}
+}
+
+func setTopologyInspectionLifecycleCut(diagnostics *topologyDiagnostics, registrationIDs ...ddsnmp.DeviceRegistrationID) {
+	diagnostics.lifecycle = topologyJobLifecycleDiagnosticCut{
+		state: diagnosticCaptureAvailable,
+		cut: ddsnmp.DeviceLifecycleCut{
+			Sequence:   1,
+			CapturedAt: topologyScenarioCollectedAt,
+		},
+	}
+	for _, registrationID := range registrationIDs {
+		diagnostics.lifecycle.cut.Entries = append(diagnostics.lifecycle.cut.Entries, ddsnmp.DeviceLifecycleEntry{
+			RegistrationID: registrationID,
+			TopologyReady:  true,
+		})
+	}
+}
+
+func setTopologyInspectionSourceRoutes(
+	t *testing.T,
+	diagnostics topologyDiagnostics,
+	outcome ddsnmpcollector.AcquisitionRouteOutcome,
+) {
+	t.Helper()
+	for deviceIndex := range diagnostics.topology.devices {
+		capture := diagnostics.topology.devices[deviceIndex].acquisition
+		require.NotNil(t, capture)
+		require.NotNil(t, capture.evidence)
+		for contextIndex := range capture.evidence.collectionContexts {
+			context := &capture.evidence.collectionContexts[contextIndex]
+			for profileIndex := range context.profiles {
+				profile := &context.profiles[profileIndex]
+				profile.values.metrics = nil
+				for routeIndex := range profile.routes {
+					route := &profile.routes[routeIndex]
+					if route.Kind == ddsnmpcollector.AcquisitionRouteKindTopologyScalar ||
+						route.Kind == ddsnmpcollector.AcquisitionRouteKindTopologyTable {
+						route.Outcome = outcome
+					}
+				}
+			}
+		}
+	}
+}
+
+func clearTopologyInspectionSourceRoutes(t *testing.T, diagnostics topologyDiagnostics) {
+	t.Helper()
+	for deviceIndex := range diagnostics.topology.devices {
+		capture := diagnostics.topology.devices[deviceIndex].acquisition
+		require.NotNil(t, capture)
+		require.NotNil(t, capture.evidence)
+		for contextIndex := range capture.evidence.collectionContexts {
+			context := &capture.evidence.collectionContexts[contextIndex]
+			for profileIndex := range context.profiles {
+				profile := &context.profiles[profileIndex]
+				profile.values.metrics = nil
+				profile.values.bgpRows = nil
+				profile.routes = nil
+			}
+		}
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -189,7 +189,7 @@ func TestInspectTopologyActorIdentityRequiresOneMatch(t *testing.T) {
 	require.Len(t, got.actors, 2)
 }
 
-func TestInspectTopologyLinkUsesStructuralSubjectAndSingleRenderedRow(t *testing.T) {
+func TestInspectTopologyLinkUsesCandidateSubjectAndSingleRenderedRow(t *testing.T) {
 	scenario := newLLDPDirectScenario()
 	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
 
@@ -211,13 +211,12 @@ func TestInspectTopologyLinkUsesStructuralSubjectAndSingleRenderedRow(t *testing
 
 	reversed := subject
 	reversed.srcIdentity, reversed.dstIdentity = reversed.dstIdentity, reversed.srcIdentity
-	reversed.discriminator = topologyInspectionSwapLinkDiscriminator(reversed.discriminator)
 	report, err = inspectTopologyLink(diagnostics, scenario.opts, reversed)
 	require.NoError(t, err)
 	require.Equal(t, topologyInspectionPresent, report.graphLink.membership.state)
 	require.Equal(t, topologyInspectionPresent, report.typedLink.state)
 
-	subject.discriminator.srcPortID = "missing-port"
+	subject.dstIdentity = "ip:192.0.2.254"
 	report, err = inspectTopologyLink(diagnostics, scenario.opts, subject)
 	require.NoError(t, err)
 	require.Equal(t, sourceContext, report.source)
@@ -291,7 +290,6 @@ func TestInspectTopologyGraphLinkPreservesOrderedEndpointRoles(t *testing.T) {
 			require.NotEmpty(t, subject.family)
 
 			subject.srcIdentity, subject.dstIdentity = subject.dstIdentity, subject.srcIdentity
-			subject.discriminator = topologyInspectionSwapLinkDiscriminator(subject.discriminator)
 			match := inspectTopologyGraphLink(replay.data, subject)
 			require.Equal(t, topologyInspectionAbsent, match.membership.state)
 		})
@@ -328,13 +326,33 @@ func TestInspectTopologyLinkSourceContextIsFamilyWideAndKeepsCaptureAvailability
 		}
 	}
 	require.NotZero(t, unrelatedRegistrationID)
+	var retained *topologyAcquisitionCapture
+	var latest *topologyAcquisitionCapture
+	for i := range diagnostics.topology.devices {
+		device := &diagnostics.topology.devices[i]
+		if device.registrationID != unrelatedRegistrationID {
+			continue
+		}
+		retained = device.acquisition
+		latest = &topologyAcquisitionCapture{
+			attemptID: topologyAcquisitionAttemptID{registrationID: unrelatedRegistrationID, ordinal: 2},
+			state:     diagnosticCaptureUnavailable,
+			reason:    diagnosticCaptureReasonProjectionError,
+		}
+		device.latestAttempt = latest
+		break
+	}
+	require.NotNil(t, retained)
+	require.NotNil(t, latest)
 
+	unavailableCapture := &topologyAcquisitionCapture{
+		state:  diagnosticCaptureUnavailable,
+		reason: diagnosticCaptureReasonProjectionError,
+	}
 	diagnostics.topology.devices = append(diagnostics.topology.devices, topologySweepDeviceDiagnostic{
 		registrationID: 99,
-		acquisition: &topologyAcquisitionCapture{
-			state:  diagnosticCaptureUnavailable,
-			reason: diagnosticCaptureReasonProjectionError,
-		},
+		acquisition:    unavailableCapture,
+		latestAttempt:  unavailableCapture,
 	})
 	report, err := inspectTopologyLink(diagnostics, scenario.opts, subject)
 	require.NoError(t, err)
@@ -342,17 +360,34 @@ func TestInspectTopologyLinkSourceContextIsFamilyWideAndKeepsCaptureAvailability
 
 	unrelated := topologyInspectionSourceContextByRegistration(report.source, unrelatedRegistrationID)
 	require.NotNil(t, unrelated)
-	require.NotEmpty(t, unrelated.facts)
+	require.False(t, unrelated.sameAttempt)
+	require.Same(t, latest, unrelated.latestAttempt.capture)
+	require.Equal(t, topologyInspectionUndetermined, unrelated.latestAttempt.evidence.state)
+	require.Same(t, retained, unrelated.retainedSuccess.capture)
+	require.Equal(t, topologyInspectionPresent, unrelated.retainedSuccess.evidence.state)
+	require.Len(t, unrelated.captures, 2)
+	require.True(t, unrelated.captures[0].latestAttempt)
+	require.False(t, unrelated.captures[0].retainedSuccess)
+	require.Empty(t, unrelated.captures[0].facts)
+	require.False(t, unrelated.captures[1].latestAttempt)
+	require.True(t, unrelated.captures[1].retainedSuccess)
+	require.NotEmpty(t, unrelated.captures[1].facts)
 
 	unavailable := topologyInspectionSourceContextByRegistration(report.source, 99)
 	require.NotNil(t, unavailable)
-	require.Equal(t, topologyInspectionPresent, unavailable.capture.membership.state)
-	require.Equal(t, topologyInspectionUndetermined, unavailable.capture.evidence.state)
-	require.Equal(t, diagnosticCaptureUnavailable, unavailable.capture.capture.state)
-	require.Empty(t, unavailable.facts)
+	require.True(t, unavailable.sameAttempt)
+	require.Equal(t, topologyInspectionPresent, unavailable.latestAttempt.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, unavailable.latestAttempt.evidence.state)
+	require.Same(t, unavailableCapture, unavailable.latestAttempt.capture)
+	require.Equal(t, unavailable.latestAttempt, unavailable.retainedSuccess)
+	require.Len(t, unavailable.captures, 1)
+	require.True(t, unavailable.captures[0].latestAttempt)
+	require.True(t, unavailable.captures[0].retainedSuccess)
+	require.Same(t, unavailableCapture, unavailable.captures[0].capture.capture)
+	require.Empty(t, unavailable.captures[0].facts)
 }
 
-func TestTopologyInspectionSubjectsDistinguishEveryRenderedLink(t *testing.T) {
+func TestTopologyInspectionSubjectsReturnEveryRenderedLinkAsCandidate(t *testing.T) {
 	scenario := newMixedL2L3ControlScenario()
 	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
 	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
@@ -364,22 +399,21 @@ func TestTopologyInspectionSubjectsDistinguishEveryRenderedLink(t *testing.T) {
 		subject, ok := topologyInspectionSubjectFromLink(replay.data, i)
 		require.Truef(t, ok, "link=%d", i)
 		match := inspectTopologyGraphLink(replay.data, subject)
-		require.Equalf(t, topologyInspectionPresent, match.membership.state, "link=%d family=%s", i, subject.family)
-		require.Equalf(t, 1, match.membership.candidates, "link=%d family=%s", i, subject.family)
-		require.Equal(t, i, match.index)
+		require.Containsf(t, match.links, replay.data.Links[i], "link=%d family=%s", i, subject.family)
+		require.Equal(t, len(match.links), match.membership.candidates)
+		if len(match.links) == 1 {
+			require.Equal(t, topologyInspectionPresent, match.membership.state)
+			require.Equal(t, i, match.index)
+		} else {
+			require.Equal(t, topologyInspectionUndetermined, match.membership.state)
+			require.Equal(t, -1, match.index)
+		}
 		if topologyInspectionLinkSubjectUnordered(subject) {
 			subject.srcIdentity, subject.dstIdentity = subject.dstIdentity, subject.srcIdentity
-			subject.discriminator = topologyInspectionSwapLinkDiscriminator(subject.discriminator)
 			reversed := inspectTopologyGraphLink(replay.data, subject)
-			require.Equalf(
-				t,
-				topologyInspectionPresent,
-				reversed.membership.state,
-				"reversed link=%d family=%s",
-				i,
-				subject.family,
-			)
-			require.Equal(t, i, reversed.index)
+			require.Containsf(t, reversed.links, replay.data.Links[i], "reversed link=%d family=%s", i, subject.family)
+			require.Equal(t, match.membership, reversed.membership)
+			require.Equal(t, match.index, reversed.index)
 		}
 		families[subject.family] = true
 	}
@@ -389,7 +423,7 @@ func TestTopologyInspectionSubjectsDistinguishEveryRenderedLink(t *testing.T) {
 	require.True(t, families[topologymodel.BGPAdjacencyLinkType])
 }
 
-func TestInspectTopologyGraphLinkRejectsDuplicateStructuralMatches(t *testing.T) {
+func TestInspectTopologyGraphLinkReturnsDuplicateCandidates(t *testing.T) {
 	scenario := newLLDPDirectScenario()
 	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
 	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
@@ -404,7 +438,7 @@ func TestInspectTopologyGraphLinkRejectsDuplicateStructuralMatches(t *testing.T)
 	require.Equal(t, -1, match.index)
 }
 
-func TestTopologyInspectionLinkSubjectSeparatesParallelBGPRoutingInstances(t *testing.T) {
+func TestTopologyInspectionLinkSubjectReturnsParallelBGPRoutingInstancesAsCandidates(t *testing.T) {
 	scenario := newTopologyScenario("inspection-parallel-bgp")
 	left := scenario.Router("router-left", "192.0.2.61", "02:00:00:00:61:01", "192.0.2.61", "65001")
 	right := scenario.Router("router-right", "192.0.2.62", "02:00:00:00:62:01", "192.0.2.62", "65002")
@@ -425,12 +459,17 @@ func TestTopologyInspectionLinkSubjectSeparatesParallelBGPRoutingInstances(t *te
 		subjects = append(subjects, subject)
 	}
 	require.Len(t, subjects, 2)
-	require.NotEqual(t, subjects[0].discriminator.bgpRoutingInstance, subjects[1].discriminator.bgpRoutingInstance)
-	for _, subject := range subjects {
-		match := inspectTopologyGraphLink(replay.data, subject)
-		require.Equal(t, topologyInspectionPresent, match.membership.state)
-		require.Equal(t, 1, match.membership.candidates)
+	require.Equal(t, subjects[0], subjects[1])
+	match := inspectTopologyGraphLink(replay.data, subjects[0])
+	require.Equal(t, topologyInspectionUndetermined, match.membership.state)
+	require.Equal(t, 2, match.membership.candidates)
+	require.Len(t, match.links, 2)
+	routingInstances := make(map[string]bool)
+	for _, link := range match.links {
+		require.NotNil(t, link.Detail.BGP)
+		routingInstances[link.Detail.BGP.RoutingInstance] = true
 	}
+	require.Equal(t, map[string]bool{"blue": true, "red": true}, routingInstances)
 }
 
 func setTopologyInspectionLifecycleCut(diagnostics *topologyDiagnostics, registrationIDs ...ddsnmp.DeviceRegistrationID) {
@@ -464,7 +503,9 @@ func topologyInspectionSourceContextByRegistration(
 func topologyInspectionSourceFactCount(result topologyInspectionSourceResult) int {
 	var count int
 	for _, context := range result.contexts {
-		count += len(context.facts)
+		for _, capture := range context.captures {
+			count += len(capture.facts)
+		}
 	}
 	return count
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -398,6 +398,54 @@ func TestInspectTopologyLinkSourceContextIsFamilyWideAndKeepsCaptureAvailability
 	require.Empty(t, unavailable.captures[0].facts)
 }
 
+func TestInspectTopologyLinkPreservesDiagnosticCutFailure(t *testing.T) {
+	scenario := newLLDPDirectScenario()
+	limitedCut, err := projectTopologyDiagnosticCut(topologyDiagnosticCutInput{
+		sequence:    7,
+		startedAt:   topologyScenarioCollectedAt,
+		publishedAt: topologyScenarioCollectedAt,
+		entries: []ddsnmp.DeviceEntry{
+			{RegistrationID: 1},
+		},
+		limits: topologyAcquisitionLimits{maxRecords: 1, maxLogicalBytes: 1024},
+	})
+	require.NoError(t, err)
+	require.Equal(t, diagnosticCaptureLimitExceeded, limitedCut.captureState)
+
+	subject := topologyInspectionLinkSubject{
+		srcIdentity: "ip:192.0.2.1",
+		dstIdentity: "ip:192.0.2.2",
+		family:      "lldp",
+		protocol:    "lldp",
+		direction:   "bidirectional",
+	}
+	report, err := inspectTopologyLink(topologyDiagnostics{topology: limitedCut}, scenario.opts, subject)
+	require.NoError(t, err)
+	require.Equal(t, diagnosticCaptureLimitExceeded, report.diagnosticCut.captureState)
+	require.Equal(t, diagnosticCaptureReasonRecordLimit, report.diagnosticCut.captureReason)
+	require.Equal(t, uint64(7), report.diagnosticCut.sequence)
+	require.Equal(t, limitedCut.startedAt, report.diagnosticCut.startedAt)
+	require.Equal(t, limitedCut.publishedAt, report.diagnosticCut.publishedAt)
+	require.Empty(t, report.source.contexts)
+	require.Equal(t, topologyInspectionUndetermined, report.graphLink.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, report.typedLink.state)
+
+	availableCut, err := projectTopologyDiagnosticCut(topologyDiagnosticCutInput{
+		sequence:    8,
+		startedAt:   topologyScenarioCollectedAt,
+		publishedAt: topologyScenarioCollectedAt,
+		limits:      topologyAcquisitionLimits{maxRecords: 1, maxLogicalBytes: 1024},
+	})
+	require.NoError(t, err)
+	report, err = inspectTopologyLink(topologyDiagnostics{topology: availableCut}, scenario.opts, subject)
+	require.NoError(t, err)
+	require.Equal(t, diagnosticCaptureAvailable, report.diagnosticCut.captureState)
+	require.Equal(t, diagnosticCaptureReasonNone, report.diagnosticCut.captureReason)
+	require.Empty(t, report.source.contexts)
+	require.Equal(t, topologyInspectionUndetermined, report.graphLink.membership.state)
+	require.Equal(t, topologyInspectionUndetermined, report.typedLink.state)
+}
+
 func TestTopologyInspectionSubjectsReturnEveryRenderedLinkAsCandidate(t *testing.T) {
 	scenario := newMixedL2L3ControlScenario()
 	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -74,6 +74,26 @@ func TestInspectTopologyDeviceKeepsIncompleteCutsUndetermined(t *testing.T) {
 	require.Equal(t, topologyInspectionUndetermined, report.typedIdentity.state)
 }
 
+func TestInspectTopologyDevicePreservesLimitedLifecycleCutIdentity(t *testing.T) {
+	coll, store := newTestSNMPTopologyCollectorWithStore()
+	store.RegisterJob("job-a", ddsnmp.DeviceLifecycleInfo{Hostname: "192.0.2.10"})
+	store.RegisterJob("job-b", ddsnmp.DeviceLifecycleInfo{Hostname: "192.0.2.20"})
+	registrationID := store.LifecycleCut().Entries[0].RegistrationID
+	coll.diagnosticGlobalLimits = topologyAcquisitionLimits{maxRecords: 2, maxLogicalBytes: 1 << 20}
+	diagnostics := coll.acquireTopologyDiagnostics()
+	require.Equal(t, diagnosticCaptureLimitExceeded, diagnostics.lifecycle.state)
+	require.NotZero(t, diagnostics.lifecycle.cut.Sequence)
+	require.False(t, diagnostics.lifecycle.cut.CapturedAt.IsZero())
+
+	report, err := inspectTopologyDevice(diagnostics, newLLDPDirectScenario().opts, registrationID)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionUndetermined, report.lifecycle.membership.state)
+	require.Equal(t, diagnosticCaptureLimitExceeded, report.lifecycle.captureState)
+	require.Equal(t, diagnosticCaptureReasonGlobalRecordLimit, report.lifecycle.captureReason)
+	require.Equal(t, diagnostics.lifecycle.cut.Sequence, report.lifecycle.sequence)
+	require.Equal(t, diagnostics.lifecycle.cut.CapturedAt, report.lifecycle.capturedAt)
+}
+
 func TestInspectTopologyDeviceDoesNotFlattenWholeGraphReplayFailure(t *testing.T) {
 	scenario := newLLDPDirectScenario()
 	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -209,6 +209,14 @@ func TestInspectTopologyLinkUsesStructuralSubjectAndSingleRenderedRow(t *testing
 	require.Equal(t, report.graphLink.index, report.typedLink.row)
 	sourceContext := report.source
 
+	reversed := subject
+	reversed.srcIdentity, reversed.dstIdentity = reversed.dstIdentity, reversed.srcIdentity
+	reversed.discriminator = topologyInspectionSwapLinkDiscriminator(reversed.discriminator)
+	report, err = inspectTopologyLink(diagnostics, scenario.opts, reversed)
+	require.NoError(t, err)
+	require.Equal(t, topologyInspectionPresent, report.graphLink.membership.state)
+	require.Equal(t, topologyInspectionPresent, report.typedLink.state)
+
 	subject.discriminator.srcPortID = "missing-port"
 	report, err = inspectTopologyLink(diagnostics, scenario.opts, subject)
 	require.NoError(t, err)
@@ -246,6 +254,48 @@ func TestInspectTopologyLinkAmbiguousIdentityIsUndetermined(t *testing.T) {
 	got := inspectTopologyGraphLink(data, subject)
 	require.Equal(t, topologyInspectionUndetermined, got.membership.state)
 	require.Equal(t, 2, got.srcActors.membership.candidates)
+}
+
+func TestInspectTopologyGraphLinkPreservesOrderedEndpointRoles(t *testing.T) {
+	tests := map[string]struct {
+		scenario func() *topologyScenario
+		family   string
+	}{
+		"stp": {
+			scenario: newSTPInferredScenario,
+			family:   "stp",
+		},
+		"l3 subnet membership": {
+			scenario: newMixedL2L3ControlScenario,
+			family:   topologymodel.L3SubnetMembershipLinkType,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			scenario := tc.scenario()
+			_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+			replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
+			require.Equal(t, topologyInspectionPresent, replay.graph.state)
+
+			var subject topologyInspectionLinkSubject
+			for i, link := range replay.data.Links {
+				if topologyInspectionLinkFamily(link) != tc.family {
+					continue
+				}
+				var ok bool
+				subject, ok = topologyInspectionSubjectFromLink(replay.data, i)
+				require.True(t, ok)
+				break
+			}
+			require.NotEmpty(t, subject.family)
+
+			subject.srcIdentity, subject.dstIdentity = subject.dstIdentity, subject.srcIdentity
+			subject.discriminator = topologyInspectionSwapLinkDiscriminator(subject.discriminator)
+			match := inspectTopologyGraphLink(replay.data, subject)
+			require.Equal(t, topologyInspectionAbsent, match.membership.state)
+		})
+	}
 }
 
 func TestInspectTopologyLinkSourceContextIsFamilyWideAndKeepsCaptureAvailability(t *testing.T) {
@@ -317,6 +367,20 @@ func TestTopologyInspectionSubjectsDistinguishEveryRenderedLink(t *testing.T) {
 		require.Equalf(t, topologyInspectionPresent, match.membership.state, "link=%d family=%s", i, subject.family)
 		require.Equalf(t, 1, match.membership.candidates, "link=%d family=%s", i, subject.family)
 		require.Equal(t, i, match.index)
+		if topologyInspectionLinkSubjectUnordered(subject) {
+			subject.srcIdentity, subject.dstIdentity = subject.dstIdentity, subject.srcIdentity
+			subject.discriminator = topologyInspectionSwapLinkDiscriminator(subject.discriminator)
+			reversed := inspectTopologyGraphLink(replay.data, subject)
+			require.Equalf(
+				t,
+				topologyInspectionPresent,
+				reversed.membership.state,
+				"reversed link=%d family=%s",
+				i,
+				subject.family,
+			)
+			require.Equal(t, i, reversed.index)
+		}
 		families[subject.family] = true
 	}
 	require.True(t, families["lldp"])


### PR DESCRIPTION
##### Summary

Add read-only inspection of captured SNMP topology data, covering devices, links, collection attempts, and graph results.

Make missing devices and links easier to diagnose offline, forming the foundation for future downloadable diagnostic archives.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read-only offline inspection of captured SNMP topology data so missing devices and links can be diagnosed without a live collector. This is the foundation for future downloadable diagnostic archives.

Device inspection takes one exact `DeviceRegistrationID` and reports lifecycle membership, sweep membership, any removed-registration row, and the last aborted sweep. It keeps the last completed attempt and the older retained success as separate branches so an unavailable latest attempt doesn’t hide a working capture.

Link inspection resolves both endpoints by normalized actor identity and matches family, protocol, and direction. Zero matches is `absent`, one is `present`, and multiple matches is `undetermined` with all candidates returned. Bidirectional and unordered L3/OSPF/BGP adjacencies accept reversed endpoints; ordered STP and subnet-membership roles stay exact.

Replay now records per-device observation states instead of aborting on the first bad device. A renderable-device failure marks graph and typed membership `undetermined` globally, while an independently replayable device observation remains available.

**Graph replay refactor**
- `replayTopologyDiagnostics` keeps its existing behavior for live output.
- The new staged replay returns per-device snapshots and observation states for inspection use.
- Source facts are reported as family-wide context, attached once per distinct capture, and never claim causal provenance.

<sup>Written for commit f4d3311e3386e91df260163e321a02d62aafbf59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added offline inspection of committed SNMP topology diagnostics.
  - Device and link results now show present, absent, or undetermined states.
  - Inspection distinguishes the latest collection attempt from previously retained successful data.
  - Added source facts and capture availability for topology links.
  - Supports identity-based matching, bidirectional links, and parallel routing instances.

- **Documentation**
  - Added guidance for inspecting and replaying offline topology diagnostics.

- **Reliability**
  - Incomplete or invalid data is reported without blocking inspection of other devices and links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->