### PR TITLE
docs: fix typo configuraton -> configuration

### DIFF
--- a/src/daemon/dyncfg/dyncfg-files.c
+++ b/src/daemon/dyncfg/dyncfg-files.c
@@ -270,7 +270,7 @@ void dyncfg_file_load(const char *d_name) {
     if(strcmp(filename, fixed_filename) != 0) {
         if(rename(filename, fixed_filename) != 0)
             nd_log(NDLS_DAEMON, NDLP_ERR,
-                "DYNCFG: cannot rename file '%s' into '%s'. Saving a new configuraton may not overwrite the old one.",
+                "DYNCFG: cannot rename file '%s' into '%s'. Saving a new configuration may not overwrite the old one.",
                 filename, fixed_filename);
     }
 }


### PR DESCRIPTION
Corrects the misspelling `configuraton` -> `configuration` in `src/daemon/dyncfg/dyncfg-files.c`.

Documentation only, no behaviour change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the typo `configuraton` to `configuration` in a DYNCFG log message. Documentation only, no behavior change.

<sup>Written for commit d1a56d5b9d38bf1e13ced1343d4549f55cf73633. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in the configuration rename error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->