### PR TITLE
fix(streaming): validate child-provided timestamps (REPLAY_BEGIN/BEGIN2)

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -222,6 +222,7 @@ int mqtt_wss_client_timeout_unittest(void);
 int pgc_unittest(void);
 int mrg_unittest(void);
 int pluginsd_parser_unittest(void);
+int pluginsd_timestamps_unittest(void);
 int websocket_compression_unittest(void);
 void replication_initialize(void);
 void bearer_tokens_init(void);
@@ -480,6 +481,7 @@ int netdata_main(int argc, char **argv) {
                             rrdlabels_aral_init(false);
 
                             if (pluginsd_parser_unittest()) return 1;
+                            if (pluginsd_timestamps_unittest()) return 1;
                             if (websocket_compression_unittest()) return 1;
                             if (stream_conf_unittest()) return 1;
                             if (unit_test_static_threads()) return 1;

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -16,6 +16,17 @@ PARSER_RC PLUGINSD_DISABLE_PLUGIN(PARSER *parser, const char *keyword, const cha
 
 ssize_t send_to_plugin(const char *txt, PARSER *parser, STREAM_TRAFFIC_TYPE type);
 
+// Validate the sample time of a BEGIN2 sent by a child and sanitize the child
+// wall-clock: negative/zero values can only come from integer wrap-around and
+// are rejected; an unset wall-clock falls back to end_time.
+static ALWAYS_INLINE bool pluginsd_begin_v2_times_valid(time_t end_time, time_t wall_clock_time, time_t *wall_clock_out) {
+    if(end_time <= 0)
+        return false;
+
+    *wall_clock_out = (wall_clock_time > 0) ? wall_clock_time : end_time;
+    return true;
+}
+
 static ALWAYS_INLINE RRDHOST *pluginsd_require_scope_host(PARSER *parser, const char *cmd) {
     RRDHOST *host = parser->user.host;
 

--- a/src/plugins.d/pluginsd_internals.h
+++ b/src/plugins.d/pluginsd_internals.h
@@ -16,6 +16,15 @@ PARSER_RC PLUGINSD_DISABLE_PLUGIN(PARSER *parser, const char *keyword, const cha
 
 ssize_t send_to_plugin(const char *txt, PARSER *parser, STREAM_TRAFFIC_TYPE type);
 
+// Child-provided timestamps arrive as unsigned 64-bit strings and are cast to
+// time_t, so values >= 2^63 wrap to negative. Require positive epoch seconds.
+static ALWAYS_INLINE bool pluginsd_replay_timestamps_valid(time_t start_time, time_t end_time, time_t wall_clock_time, time_t tolerance) {
+    return start_time > 0 && end_time > 0 &&
+           start_time < wall_clock_time + tolerance &&
+           end_time < wall_clock_time + tolerance &&
+           start_time < end_time;
+}
+
 // Validate the sample time of a BEGIN2 sent by a child and sanitize the child
 // wall-clock: negative/zero values can only come from integer wrap-around and
 // are rejected; an unset wall-clock falls back to end_time.

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -1723,6 +1723,115 @@ static int pluginsd_parser_unittest_slot_bounds(size_t max_slot) {
     return 0;
 }
 
+static int pluginsd_timestamps_unittest_replay(void) {
+    // Child values arrive as unsigned 64-bit strings cast to time_t:
+    // 18446744073709551614ULL / 18446744073709551615ULL wrap to -2 / -1 and
+    // used to pass the "non-zero && < wall_clock" checks.
+    time_t wrapped_start = (time_t) 18446744073709551614ULL; // -2
+    time_t wrapped_end = (time_t) 18446744073709551615ULL;   // -1
+
+    time_t now = now_realtime_sec();
+    time_t tolerance = 6;
+
+    struct {
+        time_t start, end, wall_clock, tolerance;
+        bool valid;
+    } cases[] = {
+        // the wrap-around values accepted before the fix
+        { wrapped_start, wrapped_end, now, tolerance, false, },
+        { wrapped_start, wrapped_end, wrapped_end, tolerance, false, },
+        // zero / negative
+        { 0, now, now, tolerance, false, },
+        { now, 0, now, tolerance, false, },
+        { -1, -1, now, tolerance, false, },
+        // future beyond tolerance
+        { now + 3600, now + 3601, now, tolerance, false, },
+        // boundary: end == wall_clock + tolerance is rejected (strict <)
+        { now - tolerance, now + tolerance, now, tolerance, false, },
+        // start >= end
+        { now, now, now + tolerance, tolerance, false, },
+        { now, now - 1, now + tolerance, tolerance, false, },
+        // valid replay pair
+        { now - 1, now, now, tolerance, true, },
+        { now - tolerance, now, now, tolerance, true, },
+    };
+
+    for(size_t i = 0; i < _countof(cases); i++) {
+        bool valid = pluginsd_replay_timestamps_valid(cases[i].start, cases[i].end, cases[i].wall_clock, cases[i].tolerance);
+        if(valid != cases[i].valid) {
+            netdata_log_error("PLUGINSD: replay timestamps unittest failed for case %zu "
+                              "(start=%ld, end=%ld, wall_clock=%ld, tolerance=%ld): expected %s, got %s",
+                              i, (long)cases[i].start, (long)cases[i].end, (long)cases[i].wall_clock,
+                              (long)cases[i].tolerance,
+                              cases[i].valid ? "valid" : "invalid", valid ? "valid" : "invalid");
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int pluginsd_timestamps_unittest_begin_v2(void) {
+    time_t wrapped_end = (time_t) 18446744073709551615ULL; // -1, accepted before the fix
+    time_t now = now_realtime_sec();
+
+    // invalid end_time values
+    struct {
+        time_t end_time, wall_clock;
+    } invalid[] = {
+        { wrapped_end, now, },         // the wrap-around input
+        { wrapped_end, wrapped_end, }, // '#' shorthand: wall_clock == end_time
+        { 0, now, },
+        { -1, now, },
+    };
+
+    for(size_t i = 0; i < _countof(invalid); i++) {
+        time_t wall_clock = invalid[i].wall_clock;
+        if(pluginsd_begin_v2_times_valid(invalid[i].end_time, wall_clock, &wall_clock)) {
+            netdata_log_error("PLUGINSD: begin_v2 times unittest failed: end_time %ld unexpectedly accepted",
+                              (long)invalid[i].end_time);
+            return 1;
+        }
+    }
+
+    // valid end_time: wall_clock is kept when positive, falls back to end_time otherwise
+    struct {
+        time_t end_time, wall_clock_in, wall_clock_expected;
+    } valid[] = {
+        { now, now, now, },           // positive wall_clock kept
+        { now, now - 10, now - 10, }, // positive wall_clock kept (may differ from end_time)
+        { now, wrapped_end, now, },   // wrapped wall_clock falls back to end_time
+        { now, 0, now, },             // unset wall_clock falls back to end_time
+    };
+
+    for(size_t i = 0; i < _countof(valid); i++) {
+        time_t wall_clock = valid[i].wall_clock_in;
+        if(!pluginsd_begin_v2_times_valid(valid[i].end_time, wall_clock, &wall_clock)) {
+            netdata_log_error("PLUGINSD: begin_v2 times unittest failed: end_time %ld unexpectedly rejected",
+                              (long)valid[i].end_time);
+            return 1;
+        }
+        if(wall_clock != valid[i].wall_clock_expected) {
+            netdata_log_error("PLUGINSD: begin_v2 times unittest failed: expected wall_clock %ld, got %ld",
+                              (long)valid[i].wall_clock_expected, (long)wall_clock);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int pluginsd_timestamps_unittest(void) {
+    if(pluginsd_timestamps_unittest_replay())
+        return 1;
+
+    if(pluginsd_timestamps_unittest_begin_v2())
+        return 1;
+
+    netdata_log_info("PLUGINSD: timestamps unittest passed");
+    return 0;
+}
+
 int pluginsd_parser_unittest(void) {
     if(pluginsd_parser_unittest_slot_bounds(PLUGINSD_DIMENSION_SLOT_MAX))
         return 1;

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -948,6 +948,9 @@ static ALWAYS_INLINE PARSER_RC pluginsd_begin_v2(char **words, size_t num_words,
     else
         wall_clock_time = (time_t) str2ull_encoded(wall_clock_time_str);
 
+    if (unlikely(!pluginsd_begin_v2_times_valid(end_time, wall_clock_time, &wall_clock_time)))
+        return PLUGINSD_DISABLE_PLUGIN(parser, PLUGINSD_KEYWORD_BEGIN_V2, "invalid end_time");
+
     if (unlikely(update_every != st->update_every)) {
         rrdset_set_update_every_s(st, update_every);
         update_every = st->update_every;

--- a/src/plugins.d/pluginsd_replication.c
+++ b/src/plugins.d/pluginsd_replication.c
@@ -165,7 +165,7 @@ ALWAYS_INLINE PARSER_RC pluginsd_replay_begin(char **words, size_t num_words, PA
                 st->replay.after, st->replay.before);
 #endif
 
-        if(start_time && end_time && start_time < wall_clock_time + tolerance && end_time < wall_clock_time + tolerance && start_time < end_time) {
+        if(pluginsd_replay_timestamps_valid(start_time, end_time, wall_clock_time, tolerance)) {
             if (unlikely(end_time - start_time != st->update_every))
                 rrdset_set_update_every_s(st, end_time - start_time);
 


### PR DESCRIPTION
##### Summary

Child nodes send sample and replay timestamps as unsigned 64-bit strings, which we cast to `time_t`. Values >= 2^63 wrap to negative. Two spots trusted those values too much:

- `BEGIN2` did not check `end_time` at all, and the child wall clock was used as-is, so a child could store samples at wrapped times in the parent's db and set `last_collected_time` to arbitrary values.
- `REPLAY_BEGIN` checked for non-zero and an upper bound only, so wrapped negative timestamps passed the validation and ended up in `st->last_collected_time` and the samples stored through `RSET`.

With a working streaming API key a child can poison the parent's db timeline this way, and the wrapped times then confuse replication gap calculations and tier backfilling.

This adds two small validators in `pluginsd_internals.h`:

- `pluginsd_begin_v2_times_valid()`: rejects `end_time <= 0`, and falls back to `end_time` when the child wall clock is not positive (the same fallback the replay path already used)
- `pluginsd_replay_timestamps_valid()`: requires `start_time > 0 && end_time > 0` on top of the existing checks

Unit tests for both live in `pluginsd_timestamps_unittest()`, running as part of `netdata -W unittest`.

##### Test Plan

- `netdata -c netdata.conf -W unittest`: all tests pass, including the new `pluginsd_timestamps_unittest`
- Manual check with a parent on the loopback: `RBEGIN`/`BEGIN2` with wrapped timestamps (e.g. `18446744073709551615`) are now rejected and logged, samples are not stored; normal collection with sane timestamps keeps working

##### Additional Information

Noticed while going through the streaming receiver parsers. The same cast pattern exists for `update_every`, but that one already goes through `rrdset_set_update_every_s()`.

<details> <summary>For users: How does this change affect me?</summary>
Parents now ignore out-of-range timestamps sent by children instead of storing them. Children sending sane timestamps are not affected.
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes streaming timestamp validation so children can no longer store samples at wrapped negative times or set arbitrary `last_collected_time` values in the parent's database. Previously, `BEGIN2` and `REPLAY_BEGIN` trusted child-provided timestamps that wrap negative when cast from unsigned 64-bit to `time_t`, which a child with a valid streaming API key could exploit to poison the parent's timeline and break replication gap calculations and tier backfilling.

- `BEGIN2` now rejects `end_time <= 0` and falls back to `end_time` when the child wall clock is not positive.
- `REPLAY_BEGIN` now requires both `start_time` and `end_time` to be positive.
- `REPLAY_BEGIN` upper-bound checks use `nd_time_t_add_compare()` so they do not overflow when the wall clock is near `time_t max`.
- Adds `pluginsd_timestamps_unittest()` covering wrap-around inputs and the overflow boundary, run via `netdata -W unittest`.

<sup>Written for commit 8890f934af287df8304ad8b630ea5df336c5899d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of plugin timestamps to reject invalid, zero, negative, out-of-range, or incorrectly ordered values.
  * Added fallback handling for invalid wall-clock timestamps.
  * Invalid `BEGIN2` timestamps now produce a clear error instead of being processed.

* **Tests**
  * Added comprehensive coverage for timestamp validation, boundary conditions, wraparound values, and fallback behavior.
  * Included timestamp validation tests in the standard unit-test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->