### PR TITLE
fix(go.d/l2topology): reject ambiguous FDB alias owners

### DIFF
--- a/src/go/pkg/l2topology/internal/projector/bridge_domain_test.go
+++ b/src/go/pkg/l2topology/internal/projector/bridge_domain_test.go
@@ -268,6 +268,26 @@ func TestInferFDBPairwiseBridgeLinks_ReciprocalUniquePortPerSide(t *testing.T) {
 	require.Equal(t, "sw-b", records[0].port.deviceID)
 }
 
+func TestInferFDBPairwiseBridgeLinks_RejectsAmbiguousAliasOwners(t *testing.T) {
+	attachments := []model.Attachment{
+		{DeviceID: "sw-a", IfIndex: 1, EndpointID: "mac:bb:bb:bb:bb:bb:bb", Method: "fdb"},
+		{DeviceID: "sw-b", IfIndex: 2, EndpointID: "mac:aa:aa:aa:aa:aa:aa", Method: "fdb"},
+		{DeviceID: "sw-c", IfIndex: 3, EndpointID: "mac:aa:aa:aa:aa:aa:aa", Method: "fdb"},
+	}
+	ifaceByDeviceIndex := map[string]model.Interface{
+		deviceIfIndexKey("sw-a", 1): {DeviceID: "sw-a", IfIndex: 1, IfName: "Gi0/1"},
+		deviceIfIndexKey("sw-b", 2): {DeviceID: "sw-b", IfIndex: 2, IfName: "Gi0/2"},
+		deviceIfIndexKey("sw-c", 3): {DeviceID: "sw-c", IfIndex: 3, IfName: "Gi0/3"},
+	}
+	reporterAliases := map[string][]string{
+		"sw-a": {"mac:aa:aa:aa:aa:aa:aa"},
+		"sw-b": {"mac:bb:bb:bb:bb:bb:bb"},
+		"sw-c": {"mac:bb:bb:bb:bb:bb:bb"},
+	}
+
+	require.Empty(t, inferFDBPairwiseBridgeLinks(attachments, ifaceByDeviceIndex, reporterAliases))
+}
+
 func TestInferFDBPairwiseBridgeLinks_EmitsOneRecordPerCompatibleVLANScope(t *testing.T) {
 	attachments := []model.Attachment{
 		{DeviceID: "sw-a", IfIndex: 1, EndpointID: "mac:bb:bb:bb:bb:bb:bb", Method: "fdb", Labels: map[string]string{"fdb_domain_id": "fdb:10", "vlan_id": "100"}},

--- a/src/go/pkg/l2topology/internal/projector/fdb_inference.go
+++ b/src/go/pkg/l2topology/internal/projector/fdb_inference.go
@@ -42,7 +42,7 @@ func inferFDBPairwiseBridgeLinks(
 			continue
 		}
 		owners := aliasOwnerIDs[endpointID]
-		if len(owners) == 0 {
+		if len(owners) != 1 {
 			continue
 		}
 		port := link.port

--- a/src/go/pkg/l2topology/internal/projector/fdb_inference_benchmark_test.go
+++ b/src/go/pkg/l2topology/internal/projector/fdb_inference_benchmark_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package projector
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/l2topology/internal/model"
+)
+
+func BenchmarkInferFDBPairwiseAmbiguousAliasFanout(b *testing.B) {
+	for _, ownerCount := range []int{8, 64, 256} {
+		rowCount := ownerCount * 16
+		attachments := make([]model.Attachment, 0, rowCount)
+		ifaceByDeviceIndex := make(map[string]model.Interface, rowCount)
+		for rowIndex := range rowCount {
+			ifIndex := rowIndex + 1
+			attachments = append(attachments, model.Attachment{
+				DeviceID:   "source",
+				IfIndex:    ifIndex,
+				EndpointID: "mac:bb:bb:bb:bb:bb:bb",
+				Method:     "fdb",
+			})
+			ifaceByDeviceIndex[deviceIfIndexKey("source", ifIndex)] = model.Interface{
+				DeviceID: "source",
+				IfIndex:  ifIndex,
+				IfName:   fmt.Sprintf("Gi0/%d", ifIndex),
+			}
+		}
+		reporterAliases := map[string][]string{
+			"source": {"mac:aa:aa:aa:aa:aa:aa"},
+		}
+		for ownerIndex := range ownerCount {
+			reporterAliases[fmt.Sprintf("owner-%d", ownerIndex)] = []string{"mac:bb:bb:bb:bb:bb:bb"}
+		}
+
+		b.Run(fmt.Sprintf("owners=%d/rows=%d", ownerCount, rowCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				records := inferFDBPairwiseBridgeLinks(attachments, ifaceByDeviceIndex, reporterAliases)
+				if len(records) != 0 {
+					b.Fatalf("inferred %d links from ambiguous aliases", len(records))
+				}
+				runtime.KeepAlive(records)
+			}
+		})
+	}
+}

--- a/src/go/pkg/l2topology/projection_test.go
+++ b/src/go/pkg/l2topology/projection_test.go
@@ -915,6 +915,67 @@ func TestProjectionPairwiseCoalescesOverlappingFDBSources(t *testing.T) {
 	}
 }
 
+func TestProjectionPairwiseRejectsAmbiguousAliasOwners(t *testing.T) {
+	result, err := BuildL2ResultFromObservations([]L2Observation{
+		{
+			DeviceID:    "switch-a",
+			Hostname:    "switch-a",
+			ChassisID:   "02:00:00:00:00:01",
+			Interfaces:  []ObservedInterface{{IfIndex: 1, IfName: "Ethernet1"}},
+			BridgePorts: []BridgePortObservation{{BasePort: "1", IfIndex: 1}},
+			FDBEntries: []FDBObservation{
+				{MAC: "02:00:00:00:ff:ff", BridgePort: "1", Status: "learned"},
+			},
+		},
+		{
+			DeviceID:  "switch-b",
+			Hostname:  "switch-b",
+			ChassisID: "02:00:00:00:00:02",
+			Interfaces: []ObservedInterface{
+				{IfIndex: 2, IfName: "Ethernet2", MAC: "02:00:00:00:ff:ff"},
+			},
+			BridgePorts: []BridgePortObservation{{BasePort: "2", IfIndex: 2}},
+			FDBEntries: []FDBObservation{
+				{MAC: "02:00:00:00:00:01", BridgePort: "2", Status: "learned"},
+			},
+		},
+		{
+			DeviceID:  "switch-c",
+			Hostname:  "switch-c",
+			ChassisID: "02:00:00:00:00:03",
+			Interfaces: []ObservedInterface{
+				{IfIndex: 3, IfName: "Ethernet3", MAC: "02:00:00:00:ff:ff"},
+			},
+			BridgePorts: []BridgePortObservation{{BasePort: "3", IfIndex: 3}},
+			FDBEntries: []FDBObservation{
+				{MAC: "02:00:00:00:00:01", BridgePort: "3", Status: "learned"},
+			},
+		},
+	}, DiscoverOptions{EnableBridge: true})
+	require.NoError(t, err)
+
+	for _, strategy := range []string{
+		"fdb_pairwise_minimum_knowledge",
+		"stp_fdb_correlated",
+		"cdp_fdb_hybrid",
+	} {
+		t.Run(strategy, func(t *testing.T) {
+			projection := ToGraph(result, GraphOptions{
+				Source:            "snmp",
+				Layer:             "2",
+				InferenceStrategy: strategy,
+			})
+			multiParentSegments := 0
+			for _, detail := range projection.ActorDetails {
+				if len(detail.Segment.ParentDevices) > 1 {
+					multiParentSegments++
+				}
+			}
+			require.Zero(t, multiParentSegments)
+		})
+	}
+}
+
 func TestProjectionCorrelatesBridgeMIBWithCanonicalSTPPort(t *testing.T) {
 	result, err := BuildL2ResultFromObservations([]L2Observation{
 		{


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `go.d/l2topology` FDB pairwise inference so ambiguous alias owners no longer produce incorrect bridge links.

- Previously an FDB alias with multiple owning devices was still treated as uniquely owned; now it is ignored unless exactly one device owns it.
- Adds tests covering ambiguous alias rejection for the pairwise, STP-correlated, and CDP-hybrid strategies, plus a benchmark for large ambiguous fan-out.

<sup>Written for commit e3010050f99f19892df46d1f39c169b546a6e86c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incorrect network links from being inferred when a MAC address is associated with multiple devices.
  * Ensured ambiguous device ownership is excluded across supported topology inference strategies.

* **Tests**
  * Added coverage for ambiguous MAC ownership scenarios.
  * Added performance benchmarking for larger ambiguous-alias datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->