### PR TITLE
build(go): raise main toolchain baseline to 1.27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -506,7 +506,7 @@ jobs:
         if: needs.file-check.outputs.run == 'true'
         uses: actions/setup-go@v7
         with:
-          go-version: "^1.26"
+          go-version: "^1.27"
       - name: Set Up Dependencies
         id: deps
         if: needs.file-check.outputs.run == 'true'

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -119,12 +119,13 @@ jobs:
           go fmt ./... | tee modified-files
           [ "$(wc -l modified-files | cut -f 1 -d ' ')" -eq 0 ] || exit 1
         working-directory: ${{ matrix.module }}
-      - name: Go fix
-        if: needs.file-check.outputs.run == 'true'
-        run: |
-          go fix ./...
-          git diff --exit-code
-        working-directory: ${{ matrix.module }}
+      # Re-enable after the Go 1.27 go fix source migration is applied and reviewed.
+      # - name: Go fix
+      #   if: needs.file-check.outputs.run == 'true'
+      #   run: |
+      #     go fix ./...
+      #     git diff --exit-code
+      #   working-directory: ${{ matrix.module }}
       - name: Go vet
         if: needs.file-check.outputs.run == 'true'
         run: |

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -323,9 +323,9 @@ BuildRequires: cups-devel
 # distro handling of versioning).
 %if %{?_upstream_go_toolchain:0}%{!?_upstream_go_toolchain:1}
 %if 0%{?suse_version}
-BuildRequires: go >= 1.26
+BuildRequires: go >= 1.27
 %else
-BuildRequires: golang >= 1.26
+BuildRequires: golang >= 1.27
 %endif
 %endif
 # end - go.d.plugin plugin dependencies

--- a/packaging/check-for-go-toolchain.sh
+++ b/packaging/check-for-go-toolchain.sh
@@ -12,8 +12,8 @@
 # GOLANG_FAILURE_REASON set to an error message indicating what went wrong.
 
 GOLANG_MIN_MAJOR_VERSION='1'
-GOLANG_MIN_MINOR_VERSION='26'
-GOLANG_MIN_PATCH_VERSION='2'
+GOLANG_MIN_MINOR_VERSION='27'
+GOLANG_MIN_PATCH_VERSION='0'
 GOLANG_MIN_VERSION="${GOLANG_MIN_MAJOR_VERSION}.${GOLANG_MIN_MINOR_VERSION}.${GOLANG_MIN_PATCH_VERSION}"
 
 GOLANG_TEMP_PATH="${TMPDIR}/go-toolchain"
@@ -133,32 +133,32 @@ install_go_toolchain() {
 
       case "${GOLANG_HOST_MACHINE}" in
         i?86)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-386.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="88c162b204e6eefcc32499453b492e80209f4a4c78c33092636901c540fb0d05"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.linux-386.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="eac4abaca4113170a1cf261b8bf1d38480e61e99deecbc6a14767deb8b19e8ad"
           ;;
         x86_64)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-amd64.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.linux-amd64.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685"
           ;;
         aarch64)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-arm64.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.linux-arm64.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda"
           ;;
         armv*)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-armv6l.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="6dae9edab81c13bccf962dec15f1fd2ec26c14a6821b4d2c92dab4130c289d7a"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.linux-armv6l.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="e337ecd9c321377c0d8832690c2cb10463447c0bd0e65e2e3413dfff63a3435b"
           ;;
         ppc64le)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-ppc64le.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="c5d60e2b303bb612f20cd82786594b64874e73b35134025e27d3390bf284ae43"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.linux-ppc64le.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="068085e257a6014c036c723ca62943edbf48fd168b8d00a6d39527d10b656255"
           ;;
         riscv64)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-riscv64.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="d4a24dd4484d3f86b99c2d300af0dea5d184557e6d61eb7aba19ff61662750e3"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.linux-riscv64.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="e631e2e1e5aec4979960787f5f8cdb549001bb144c279e134447e54ffe8bd2d3"
           ;;
         s390x)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.linux-s390x.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="09ce3c504c0323968b75a717244dca4f25cd4cf0443e5ff6bc0bfa74add89fa7"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.linux-s390x.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="cb5c89fa48cba4123c68aee62b217ca030f281546df0898a0c32889c340b928c"
           ;;
         *)
           GOLANG_FAILURE_REASON="Linux ${GOLANG_HOST_MACHINE} platform is not supported out-of-box by Go, you must install a toolchain for it yourself."
@@ -169,26 +169,21 @@ install_go_toolchain() {
     FreeBSD)
       case "$(uname -m)" in
         386)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.freebsd-386.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="1a0226fc025d97d30a112ad0d09b13dcacedc5b24b04bf8f21a0cd29aac4d947"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.freebsd-386.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="db350b8961e4b01e0d0f3d4e4f98d6218bdab84ca112dedb27f1463c887d437f"
           ;;
         amd64)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.freebsd-amd64.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="0e5ddc51a62018211d461d6bf409939b04eaa4d6dd6d7097910090ef755ed947"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.freebsd-amd64.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="2c24ddcca6dbd5e0be775a48cec4171e9ca616e654b63b02c9cbc515238dae31"
           ;;
         arm)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.freebsd-arm.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="f8a59e86427158d89b2ba158d7f6004881e378fa3d7e4aefd4df17e4ee3a6bd1"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.freebsd-arm.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="79d202335f72966d4bd0ba3ac6b4e584337afe60e8cff1ad608d2b04284e039a"
           ;;
         arm64)
-          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.freebsd-arm64.tar.gz"
-          GOLANG_ARCHIVE_CHECKSUM="ae3825c8c57cc0e64c2233bfb9bba2e091f2126728e4c33492592c24b60dfcd0"
+          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.27.0.freebsd-arm64.tar.gz"
+          GOLANG_ARCHIVE_CHECKSUM="0d33b993d26337cd4cedaa57d4d0fec71c4b578a5b47d8d08cb153eb337b27c7"
           ;;
-# broken: https://go.dev/doc/go1.26#freebsd
-#        riscv64)
-#          GOLANG_ARCHIVE_URL="https://go.dev/dl/go1.26.5.freebsd-riscv64.tar.gz"
-#          GOLANG_ARCHIVE_CHECKSUM="7b0cc61246cf6fc9e576135cfcd2b95e870b0f2ee5bf057325b2d76119001e4e"
-#          ;;
         *)
           GOLANG_FAILURE_REASON="FreeBSD $(uname -m) platform is not supported out-of-box by Go, you must install a toolchain for it yourself."
           return 1

--- a/src/collectors/ebpf.plugin/ebpfgo.plugin/go.mod
+++ b/src/collectors/ebpf.plugin/ebpfgo.plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/netdata/netdata/src/collectors/ebpf.plugin/ebpfgo.plugin
 
-go 1.26.2
+go 1.27.0
 
 // Packages from go/plugins (netipc, netdataapi) are co-developed in this
 // repository.  The replace directive lets the module resolve them from the

--- a/src/collectors/ebpf.plugin/ebpfgo.plugin/go.sum
+++ b/src/collectors/ebpf.plugin/ebpfgo.plugin/go.sum
@@ -1,8 +1,4 @@
-github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
-github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -1,23 +1,39 @@
 module github.com/netdata/netdata/go/plugins
 
-go 1.26.2
+go 1.27.0
 
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.302.0
 
 replace github.com/gosnmp/gosnmp => github.com/ilyam8/gosnmp v0.0.0-20250912202722-388b2cb5192e
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
+	github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/PaloAltoNetworks/pango v0.10.2
 	github.com/Wing924/ltsv v0.4.0
+	github.com/alexbrainman/odbc v0.0.0-20250601004241-49e6b2bc0cf0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
+	github.com/aws/aws-sdk-go-v2 v1.43.7
+	github.com/aws/aws-sdk-go-v2/config v1.32.38
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.37
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.66.6
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.36.2
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
+	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7
+	github.com/aws/smithy-go v1.27.8
 	github.com/axiomhq/hyperloglog v0.2.6
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/catonetworks/cato-go-sdk v0.3.3
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/clbanning/rfile/v2 v2.0.0-20231024120205-ac3fca974b0e
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/coreos/go-systemd/v22 v22.7.0
+	github.com/docker/go-units v0.5.0
 	github.com/facebook/time v0.0.0-20250211113239-e3e1421a0980
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-ldap/ldap/v3 v3.4.14
@@ -30,75 +46,56 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorcon/rcon v1.4.0
 	github.com/gosnmp/gosnmp v1.42.1
+	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc
+	github.com/ibm-messaging/mq-golang/v5 v5.7.2
 	github.com/ibmdb/go_ibm_db v0.5.4 // Used by ibm.d.plugin (requires CGO)
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7
+	github.com/klauspost/compress v1.19.2
 	github.com/likexian/whois v1.15.7
 	github.com/likexian/whois-parser v1.24.21
 	github.com/lmittmann/tint v1.2.0
 	github.com/mattn/go-isatty v0.0.24
 	github.com/mattn/go-xmlrpc v0.0.3
+	github.com/maxmind/mmdbwriter v1.2.0
+	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/miekg/dns v1.1.73
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/moby/moby/api v1.55.0
+	github.com/moby/moby/client v0.5.1
+	github.com/netdata/systemd-journal-sdk/go v0.8.1
+	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus-community/pro-bing v0.9.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1
 	github.com/prometheus/prometheus v2.55.1+incompatible
 	github.com/redis/go-redis/v9 v9.22.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
 	github.com/stretchr/testify v1.12.1
 	github.com/tidwall/gjson v1.19.0
 	github.com/valyala/fastjson v1.6.10
 	github.com/vmware/govmomi v0.56.0
+	go.mongodb.org/mongo-driver/v2 v2.8.0
 	go.opentelemetry.io/proto/otlp v1.11.0
 	go.uber.org/automaxprocs v1.6.0
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba
 	golang.org/x/net v0.58.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.41.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20220504211119-3d4a969bb56b
 	google.golang.org/grpc v1.83.1
 	gopkg.in/ini.v1 v1.67.3
 	gopkg.in/rethinkdb/rethinkdb-go.v6 v6.2.2
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.4
 	k8s.io/apimachinery v0.36.4
 	k8s.io/client-go v0.36.4
 	layeh.com/radius v0.0.0-20190322222518-890bc1058917
-)
-
-require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics v1.3.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0
-	github.com/alexbrainman/odbc v0.0.0-20250601004241-49e6b2bc0cf0
-	github.com/aws/aws-sdk-go-v2 v1.43.7
-	github.com/aws/aws-sdk-go-v2/config v1.32.38
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.37
-	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.66.6
-	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.36.2
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
-	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7
-	github.com/aws/smithy-go v1.27.8
-	github.com/catonetworks/cato-go-sdk v0.3.3
-	github.com/cespare/xxhash/v2 v2.3.0
-	github.com/docker/go-units v0.5.0
-	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc
-	github.com/ibm-messaging/mq-golang/v5 v5.7.2
-	github.com/klauspost/compress v1.19.2
-	github.com/maxmind/mmdbwriter v1.2.0
-	github.com/microsoft/go-mssqldb v1.10.0
-	github.com/moby/moby/api v1.55.0
-	github.com/moby/moby/client v0.5.1
-	github.com/netdata/systemd-journal-sdk/go v0.8.1
-	github.com/oschwald/maxminddb-golang v1.13.1
-	github.com/prometheus/client_model v0.6.2
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
-	go.mongodb.org/mongo-driver/v2 v2.8.0
-	golang.org/x/sys v0.47.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/src/go/plugin/agent/jobmgr/secrets/test_capability_test.go
+++ b/src/go/plugin/agent/jobmgr/secrets/test_capability_test.go
@@ -273,20 +273,20 @@ func newStoreTestCapabilityController(
 	config := storeTestCapabilityConfig()
 	key := config.ExposedKey()
 	return &Controller{
-			store:        store,
-			dependencies: NewSecretDependencyIndex(),
-			entries: map[string]secretEntry{
-				key: {
-					config: config,
-					status: dyncfg.StatusRunning,
-				},
+		store:        store,
+		dependencies: NewSecretDependencyIndex(),
+		entries: map[string]secretEntry{
+			key: {
+				config: config,
+				status: dyncfg.StatusRunning,
 			},
-		}, secretTarget{
-			command: dyncfg.CommandTest,
-			key:     key,
-			kind:    secretstore.KindVault,
-			name:    "main",
-		}
+		},
+	}, secretTarget{
+		command: dyncfg.CommandTest,
+		key:     key,
+		kind:    secretstore.KindVault,
+		name:    "main",
+	}
 }
 
 func storeTestCapabilityConfig() secretstore.Config {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the main Go toolchain baseline from 1.26 to 1.27 across CI, packaging, and Go modules.

- Updates GitHub Actions, RPM package requirements, the toolchain check script, and Go 1.27.0 archive checksums.
- Updates `src/go/go.mod` and the ebpf plugin `go.mod`/`go.sum` to Go 1.27.0, merging direct dependency blocks.
- Reformats the secrets capability test to match gofmt.
- Defers the `go fix` CI check until the Go 1.27 source migration is applied and reviewed.

<sup>Written for commit 0172ff02db74d0f7c1bc9aac60d0f636d3bdf686. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Go version to 1.27.0 across builds, packaging, and Go modules.
  * Updated toolchain downloads and verification checks for Go 1.27.0 on supported platforms.
  * Refreshed Go module dependency declarations for compatibility with the updated toolchain.

* **Tests**
  * Temporarily disabled automatic Go code formatting checks pending migration review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->