### PR TITLE
feat(go.d/snmp_topology): add portable diagnostic archive

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -722,14 +722,16 @@ live snapshot. Stable JSON v2 is used with explicit JSON v1 compatibility
 options and HTML escaping disabled, preserving archive-v1 field behavior.
 
 The reader buffers only bounded compressed input and opens two bounded zstd
-streams over it. The first JSON token pass totals elements across the DTO's
-array-valued fields and entries across its map-valued fields without constructing
-them. The second pass decodes one owned DTO. Compressed bytes, decoded bytes,
-zstd decoder memory/window, array elements, and map entries cover four resource
-classes before reconstruction. Unknown members remain accepted; a member whose
-name matches an allowlisted dynamic field is conservatively counted. There are
-no per-field limits, JSON-path schema, custom unmarshalers, or generic token,
-string, depth, record, logical-byte, canonical-order, or replay-work policy.
+streams over it. The first JSON token pass totals estimated slice backing across
+the DTO's array-valued fields and entries across its map-valued fields without
+constructing them. Array weights use the actual DTO element sizes, so compact
+wide elements cannot bypass the typed-allocation bound. The second pass decodes
+one owned DTO. Compressed bytes, decoded bytes, zstd decoder memory/window,
+estimated slice backing, and map entries cover four resource classes before
+reconstruction. Unknown members remain accepted; a member whose name matches an
+allowlisted dynamic field is conservatively counted. There are no per-field
+limits, JSON-path schema, custom unmarshalers, or generic token, string, depth,
+record, logical-byte, canonical-order, or replay-work policy.
 
 Reconstruction validates only the root format/version and the typed enum,
 capture-role/reference/generation, unique attempt-ordinal, registration,

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -717,18 +717,31 @@ graph.
 
 Writing and reading are invocation-local `io.Writer`/`io.Reader` operations.
 Both use one zstd worker. The writer streams JSON through zstd without retaining
-encoded Function output. The reader bounds compressed input, decoded JSON, and
-the zstd window, decodes once into one owned DTO, checks one complete JSON value,
-and reconstructs one immutable diagnostic snapshot. It validates only the root
-format/version and typed enum, capture-role, registration, address, and value-to-
-route references needed for safe replay and honest inspection. Standard Go JSON
-unknown-field and duplicate-key behavior is intentional; there is no token,
-string, depth, record, logical-byte, canonical-order, or generic replay-work
-policy at this boundary.
+encoded Function output or imposing another byte ceiling on the already-bounded
+live snapshot. Stable JSON v2 is used with explicit JSON v1 compatibility
+options and HTML escaping disabled, preserving archive-v1 field behavior.
+
+The reader buffers only bounded compressed input and opens two bounded zstd
+streams over it. The first JSON token pass totals elements across the DTO's
+array-valued fields and entries across its map-valued fields without constructing
+them. The second pass decodes one owned DTO. Compressed bytes, decoded bytes,
+zstd decoder memory/window, array elements, and map entries cover four resource
+classes before reconstruction. Unknown members remain accepted; a member whose
+name matches an allowlisted dynamic field is conservatively counted. There are
+no per-field limits, JSON-path schema, custom unmarshalers, or generic token,
+string, depth, record, logical-byte, canonical-order, or replay-work policy.
+
+Reconstruction validates only the root format/version and the typed enum,
+capture-role/reference/generation, unique attempt-ordinal, registration,
+address, and value-to-route invariants needed for safe replay and honest
+inspection. BGP peer state remains an open scalar, matching live evidence rather
+than inventing a closed archive enum. Standard Go JSON unknown-field and
+duplicate-key behavior is intentional.
 
 Archives are sensitive, untrusted support attachments even though the Agent is
-the only supported producer. The byte/window limits protect the maintainer
-reader from oversized input and compressed amplification. Zstd frame integrity
+the only supported producer. The reader limits protect the maintainer from
+oversized input, compressed amplification, and compact collection-cardinality
+amplification during typed decoding. Zstd frame integrity
 detects accidental corruption; it does not authenticate an archive. Arbitrary
 semantic JSON editing, signing, sanitization, filesystem publication, retention,
 and command-line behavior are separate contracts.

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -719,7 +719,8 @@ Writing and reading are invocation-local `io.Writer`/`io.Reader` operations.
 Both use one zstd worker. The writer streams JSON through zstd without retaining
 encoded Function output or imposing another byte ceiling on the already-bounded
 live snapshot. Stable JSON v2 is used with explicit JSON v1 compatibility
-options and HTML escaping disabled, preserving archive-v1 field behavior.
+options and HTML escaping disabled. Invalid in-memory strings receive the JSON
+v1 replacement behavior, so the writer always emits valid UTF-8.
 
 The reader buffers only bounded compressed input and opens two bounded zstd
 streams over it. The first JSON token pass totals estimated slice backing across
@@ -732,6 +733,13 @@ reconstruction. Unknown members remain accepted; a member whose name matches an
 allowlisted dynamic field is conservatively counted. There are no per-field
 limits, JSON-path schema, custom unmarshalers, or generic token, string, depth,
 record, logical-byte, canonical-order, or replay-work policy.
+
+Raw invalid UTF-8 is rejected during the preflight pass rather than expanded by
+replacement during typed decoding. The reader bounds are independent and their
+worst cases are additive; they do not claim one exact process heap or RSS
+ceiling. Extreme supported or crafted archives can therefore remain expensive
+to inspect, but each input, decompression, slice, and map allocation class has
+an explicit finite envelope.
 
 Reconstruction validates only the root format/version and the typed enum,
 capture-role/reference/generation, unique attempt-ordinal, registration,

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -722,24 +722,21 @@ live snapshot. Stable JSON v2 is used with explicit JSON v1 compatibility
 options and HTML escaping disabled. Invalid in-memory strings receive the JSON
 v1 replacement behavior, so the writer always emits valid UTF-8.
 
-The reader buffers only bounded compressed input and opens two bounded zstd
-streams over it. The first JSON token pass totals estimated slice backing across
-the DTO's array-valued fields and entries across its map-valued fields without
-constructing them. Array weights use the actual DTO element sizes, so compact
-wide elements cannot bypass the typed-allocation bound. The second pass decodes
-one owned DTO. Compressed bytes, decoded bytes, zstd decoder memory/window,
-estimated slice backing, and map entries cover four resource classes before
-reconstruction. Unknown members remain accepted; a member whose name matches an
-allowlisted dynamic field is conservatively counted. There are no per-field
-limits, JSON-path schema, custom unmarshalers, or generic token, string, depth,
-record, logical-byte, canonical-order, or replay-work policy.
+The reader performs one streaming decode: caller-bounded compressed input flows
+through one zstd decoder, then caller-bounded decoded bytes flow directly into
+JSON v2 and one owned DTO. Every invocation supplies both limits. The library
+provides generous defaults of 128 MiB compressed and 512 MiB decoded, and a
+maintainer tool can override either for a particular run. There is no compressed
+archive buffer, second decompression pass, DTO field classifier, allocation
+predictor, or generic token, string, depth, record, logical-byte,
+canonical-order, or replay-work policy.
 
-Raw invalid UTF-8 is rejected during the preflight pass rather than expanded by
-replacement during typed decoding. The reader bounds are independent and their
-worst cases are additive; they do not claim one exact process heap or RSS
-ceiling. Extreme supported or crafted archives can therefore remain expensive
-to inspect, but each input, decompression, slice, and map allocation class has
-an explicit finite envelope.
+Raw invalid UTF-8 is rejected during typed decoding rather than expanded by
+replacement. The two byte limits are operational stop conditions, not a typed
+allocation, exact process heap, or RSS guarantee. A deliberately hostile
+attachment can therefore remain expensive within the selected decoded-byte
+allowance; the initial source-only diagnostic tool deliberately favors a small,
+caller-controlled reader contract over schema-coupled allocation accounting.
 
 Reconstruction validates only the root format/version and the typed enum,
 capture-role/reference/generation, unique attempt-ordinal, registration,
@@ -748,13 +745,12 @@ inspection. BGP peer state remains an open scalar, matching live evidence rather
 than inventing a closed archive enum. Standard Go JSON unknown-field and
 duplicate-key behavior is intentional.
 
-Archives are sensitive, untrusted support attachments even though the Agent is
-the only supported producer. The reader limits protect the maintainer from
-oversized input, compressed amplification, and compact collection-cardinality
-amplification during typed decoding. Zstd frame integrity
-detects accidental corruption; it does not authenticate an archive. Arbitrary
-semantic JSON editing, signing, sanitization, filesystem publication, retention,
-and command-line behavior are separate contracts.
+Archives are sensitive support attachments even though the Agent is the only
+supported producer. The reader's caller-selected byte limits stop oversized
+compressed input and decompression output. Zstd frame integrity detects
+accidental corruption; it does not authenticate an archive. Arbitrary semantic
+JSON editing, signing, sanitization, filesystem publication, retention, and
+command-line behavior are separate contracts.
 
 ## Trap Enrichment
 

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -634,9 +634,10 @@ The replay contract is hermetic:
 
 Live Function and offline replay use the same graph and renderer. Their typed
 topology structure is identical for the same scalar options; only PTR-derived
-presentation fields may differ. This replay entry point consumes trusted,
-already-bounded in-memory diagnostics. Validation and structural limits for
-untrusted archive input belong to the later archive reader boundary.
+presentation fields may differ. The live replay entry point consumes trusted,
+already-bounded in-memory diagnostics. The portable archive reader below owns
+the external byte, format, enum, role, and reference boundary before it exposes
+the same immutable diagnostic snapshot to replay or inspection.
 
 ## Offline Diagnostic Inspection
 
@@ -686,6 +687,51 @@ builds one graph, and renders once. Existing graph counters are returned as
 graph-wide context and never determine a subject's state. Any renderable-device
 replay failure makes graph and typed-output membership `undetermined` globally,
 while an independently replayable device observation remains available.
+
+## Portable Diagnostic Archive
+
+`topology_diagnostic_archive*.go` defines one portable representation of the
+complete diagnostic snapshot. It is one root-versioned JSON document inside a
+zstd stream, not a member container:
+
+```text
+topologyDiagnostics
+  -> positive-allowlist archive-v1 DTO
+  -> one JSON value
+  -> one checksummed zstd stream
+```
+
+The DTO mirrors only credential-free diagnostic state. It has no manifest,
+member paths, per-section revisions, checksums outside the zstd frame, captured
+profile programs, packet material, error text, or credential-bearing connection
+state. Producer Agent version is informational. The one archive version covers
+both the DTO and the replay kernel; changes to replay-affecting semantic, graph,
+enrichment, shaping, rendering, or compiled OUI behavior require a new archive
+version.
+
+Each device owns a capture list. A capture entry has `latest_attempt`,
+`retained_success`, or both roles. One entry with both roles reconstructs one
+shared pointer; separate entries reconstruct distinct captures. This preserves
+the runtime lineage without a global object table or cross-device reference
+graph.
+
+Writing and reading are invocation-local `io.Writer`/`io.Reader` operations.
+Both use one zstd worker. The writer streams JSON through zstd without retaining
+encoded Function output. The reader bounds compressed input, decoded JSON, and
+the zstd window, decodes once into one owned DTO, checks one complete JSON value,
+and reconstructs one immutable diagnostic snapshot. It validates only the root
+format/version and typed enum, capture-role, registration, address, and value-to-
+route references needed for safe replay and honest inspection. Standard Go JSON
+unknown-field and duplicate-key behavior is intentional; there is no token,
+string, depth, record, logical-byte, canonical-order, or generic replay-work
+policy at this boundary.
+
+Archives are sensitive, untrusted support attachments even though the Agent is
+the only supported producer. The byte/window limits protect the maintainer
+reader from oversized input and compressed amplification. Zstd frame integrity
+detects accidental corruption; it does not authenticate an archive. Arbitrary
+semantic JSON editing, signing, sanitization, filesystem publication, retention,
+and command-line behavior are separate contracts.
 
 ## Trap Enrichment
 

--- a/src/go/plugin/go.d/collector/snmp_topology/testdata/topology-diagnostic-archive-v1.json
+++ b/src/go/plugin/go.d/collector/snmp_topology/testdata/topology-diagnostic-archive-v1.json
@@ -1,0 +1,77 @@
+{
+  "format": "netdata.snmp_topology.diagnostics",
+  "version": 1,
+  "producer": {
+    "agent_version": "v1.2.3"
+  },
+  "snapshot": {
+    "job_lifecycle_cut": {
+      "capture_state": "available",
+      "capture_reason": "none",
+      "cut": {
+        "sequence": 11,
+        "captured_at": "2026-08-29T12:00:03Z",
+        "entries": [
+          {
+            "registration_id": 7,
+            "hostname": "192.0.2.7",
+            "port": 161,
+            "snmp_version": "2c",
+            "last_completed": {
+              "phase": "collect",
+              "outcome": "success",
+              "completed_at": "2026-08-29T12:00:02Z"
+            },
+            "topology_ready": true
+          }
+        ]
+      }
+    },
+    "producer_scope_id": "scope-a",
+    "topology_sweep_cut": {
+      "sequence": 5,
+      "started_at": "2026-08-29T11:59:00Z",
+      "published_at": "2026-08-29T12:00:00Z",
+      "capture_state": "available",
+      "capture_reason": "none",
+      "record_count": 2,
+      "logical_bytes": 160,
+      "devices": [
+        {
+          "registration_id": 7,
+          "selected": true,
+          "outcome": "failed",
+          "last_attempt": "2026-08-29T11:59:30Z",
+          "last_success": "0001-01-01T00:00:00Z",
+          "next_retry": "2026-08-29T12:00:30Z",
+          "captures": [
+            {
+              "roles": [
+                "latest_attempt"
+              ],
+              "attempt_ordinal": 2,
+              "capture_state": "unavailable",
+              "capture_reason": "projection_error",
+              "record_count": 0,
+              "logical_bytes": 0
+            }
+          ],
+          "has_observation": false,
+          "expires_at": "0001-01-01T00:00:00Z",
+          "renderable": false,
+          "expired": false
+        }
+      ]
+    },
+    "last_aborted_sweep": {
+      "sequence": 3,
+      "started_at": "2026-08-29T12:01:00Z",
+      "aborted_at": "2026-08-29T12:01:01Z",
+      "reason": "canceled",
+      "phase": "target_resolution",
+      "has_active_registration": false,
+      "registration_count": 1,
+      "selected_count": 1
+    }
+  }
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
@@ -55,9 +55,14 @@ var defaultTopologyDiagnosticArchiveLimits = topologyDiagnosticArchiveLimits{
 	maxMapEntries:           topologyDiagnosticArchiveMaxMapEntries,
 }
 
-var topologyDiagnosticArchiveJSONOptions = jsonv2.JoinOptions(
+var topologyDiagnosticArchiveWriterJSONOptions = jsonv2.JoinOptions(
 	jsonv1.DefaultOptionsV1(),
 	jsontext.EscapeForHTML(false),
+)
+
+var topologyDiagnosticArchiveReaderJSONOptions = jsonv2.JoinOptions(
+	jsonv1.DefaultOptionsV1(),
+	jsontext.AllowInvalidUTF8(false),
 )
 
 type topologyDiagnosticArchive struct {
@@ -199,7 +204,7 @@ func writeTopologyDiagnosticArchiveWithProducerVersion(
 	if err != nil {
 		return fmt.Errorf("write SNMP topology diagnostic archive: create zstd encoder: %w", err)
 	}
-	encodeErr := jsonv2.MarshalWrite(encoder, document, topologyDiagnosticArchiveJSONOptions)
+	encodeErr := jsonv2.MarshalWrite(encoder, document, topologyDiagnosticArchiveWriterJSONOptions)
 	closeErr := encoder.Close()
 	if encodeErr != nil {
 		return fmt.Errorf("write SNMP topology diagnostic archive: encode JSON: %w", encodeErr)
@@ -239,7 +244,7 @@ func readTopologyDiagnosticArchiveWithLimits(
 
 	var document topologyDiagnosticArchiveDocumentV1
 	err = consumeTopologyDiagnosticArchiveJSON(compressed, limits, func(decoder *jsontext.Decoder) error {
-		if err := jsonv2.UnmarshalDecode(decoder, &document, topologyDiagnosticArchiveJSONOptions); err != nil {
+		if err := jsonv2.UnmarshalDecode(decoder, &document, topologyDiagnosticArchiveReaderJSONOptions); err != nil {
 			return err
 		}
 		if _, err := decoder.ReadToken(); !errors.Is(err, io.EOF) {
@@ -279,7 +284,7 @@ func consumeTopologyDiagnosticArchiveJSON(
 	defer decoder.Close()
 
 	decoded := &io.LimitedReader{R: decoder, N: limits.maxDecodedBytes + 1}
-	err = consume(jsontext.NewDecoder(decoded, topologyDiagnosticArchiveJSONOptions))
+	err = consume(jsontext.NewDecoder(decoded, topologyDiagnosticArchiveReaderJSONOptions))
 	if decoded.N == 0 {
 		return errTopologyDiagnosticArchiveDecodedLimit
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
@@ -1,0 +1,943 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+const (
+	topologyDiagnosticArchiveFormat  = "netdata.snmp_topology.diagnostics"
+	topologyDiagnosticArchiveVersion = 1
+
+	// The byte bounds include the measured JSON overhead above the live
+	// diagnostic evidence limits without creating another shape policy.
+	topologyDiagnosticArchiveMaxCompressedBytes = 128 << 20
+	topologyDiagnosticArchiveMaxDecodedBytes    = 128 << 20
+	topologyDiagnosticArchiveMaxWindowBytes     = 8 << 20
+)
+
+var (
+	errTopologyDiagnosticArchiveCompressedLimit = errors.New("SNMP topology diagnostic archive compressed-byte limit exceeded")
+	errTopologyDiagnosticArchiveDecodedLimit    = errors.New("SNMP topology diagnostic archive decoded-byte limit exceeded")
+)
+
+type topologyDiagnosticArchiveLimits struct {
+	maxCompressedBytes int64
+	maxDecodedBytes    int64
+	maxWindowBytes     uint64
+}
+
+var defaultTopologyDiagnosticArchiveLimits = topologyDiagnosticArchiveLimits{
+	maxCompressedBytes: topologyDiagnosticArchiveMaxCompressedBytes,
+	maxDecodedBytes:    topologyDiagnosticArchiveMaxDecodedBytes,
+	maxWindowBytes:     topologyDiagnosticArchiveMaxWindowBytes,
+}
+
+type topologyDiagnosticArchive struct {
+	producerVersion string
+	diagnostics     topologyDiagnostics
+}
+
+type topologyDiagnosticArchiveDocumentV1 struct {
+	Format   string                              `json:"format"`
+	Version  uint64                              `json:"version"`
+	Producer topologyDiagnosticArchiveProducerV1 `json:"producer"`
+	Snapshot topologyDiagnosticArchiveSnapshotV1 `json:"snapshot"`
+}
+
+type topologyDiagnosticArchiveProducerV1 struct {
+	AgentVersion string `json:"agent_version"`
+}
+
+type topologyDiagnosticArchiveSnapshotV1 struct {
+	Lifecycle       topologyDiagnosticArchiveLifecycleV1 `json:"job_lifecycle_cut"`
+	ProducerScopeID string                               `json:"producer_scope_id"`
+	Topology        *topologyDiagnosticArchiveSweepV1    `json:"topology_sweep_cut,omitempty"`
+	LastAborted     *topologyDiagnosticArchiveAbortV1    `json:"last_aborted_sweep,omitempty"`
+}
+
+type topologyDiagnosticArchiveLifecycleV1 struct {
+	State  string                                  `json:"capture_state"`
+	Reason string                                  `json:"capture_reason"`
+	Cut    topologyDiagnosticArchiveLifecycleCutV1 `json:"cut"`
+}
+
+type topologyDiagnosticArchiveLifecycleCutV1 struct {
+	Sequence   uint64                                      `json:"sequence"`
+	CapturedAt time.Time                                   `json:"captured_at"`
+	Entries    []topologyDiagnosticArchiveLifecycleEntryV1 `json:"entries,omitempty"`
+}
+
+type topologyDiagnosticArchiveLifecycleEntryV1 struct {
+	RegistrationID uint64                                     `json:"registration_id"`
+	Hostname       string                                     `json:"hostname"`
+	Port           int                                        `json:"port"`
+	SNMPVersion    string                                     `json:"snmp_version"`
+	LastCompleted  topologyDiagnosticArchiveLifecycleStatusV1 `json:"last_completed"`
+	TopologyReady  bool                                       `json:"topology_ready"`
+}
+
+type topologyDiagnosticArchiveLifecycleStatusV1 struct {
+	Phase       string    `json:"phase"`
+	Outcome     string    `json:"outcome"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+type topologyDiagnosticArchiveSweepV1 struct {
+	Sequence      uint64                               `json:"sequence"`
+	StartedAt     time.Time                            `json:"started_at"`
+	PublishedAt   time.Time                            `json:"published_at"`
+	CaptureState  string                               `json:"capture_state"`
+	CaptureReason string                               `json:"capture_reason"`
+	RecordCount   uint64                               `json:"record_count"`
+	LogicalBytes  uint64                               `json:"logical_bytes"`
+	Devices       []topologyDiagnosticArchiveDeviceV1  `json:"devices,omitempty"`
+	Removed       []topologyDiagnosticArchiveRemovedV1 `json:"removed_devices,omitempty"`
+}
+
+type topologyDiagnosticArchiveDeviceV1 struct {
+	RegistrationID  uint64                                  `json:"registration_id"`
+	Selected        bool                                    `json:"selected"`
+	Outcome         string                                  `json:"outcome"`
+	LastAttempt     time.Time                               `json:"last_attempt"`
+	LastSuccess     time.Time                               `json:"last_success"`
+	NextRetry       time.Time                               `json:"next_retry"`
+	RetainedSuccess *topologyDiagnosticArchiveEvidenceRefV1 `json:"retained_success,omitempty"`
+	Captures        []topologyDiagnosticArchiveCaptureV1    `json:"captures,omitempty"`
+	HasObservation  bool                                    `json:"has_observation"`
+	ExpiresAt       time.Time                               `json:"expires_at"`
+	Renderable      bool                                    `json:"renderable"`
+	Expired         bool                                    `json:"expired"`
+}
+
+type topologyDiagnosticArchiveRemovedV1 struct {
+	RegistrationID  uint64                                  `json:"registration_id"`
+	RetainedSuccess *topologyDiagnosticArchiveEvidenceRefV1 `json:"retained_success,omitempty"`
+}
+
+type topologyDiagnosticArchiveEvidenceRefV1 struct {
+	RegistrationID uint64 `json:"registration_id"`
+	Generation     uint64 `json:"generation"`
+}
+
+type topologyDiagnosticArchiveCaptureV1 struct {
+	Roles          []string                                        `json:"roles"`
+	AttemptOrdinal uint64                                          `json:"attempt_ordinal"`
+	State          string                                          `json:"capture_state"`
+	Reason         string                                          `json:"capture_reason"`
+	RecordCount    uint64                                          `json:"record_count"`
+	LogicalBytes   uint64                                          `json:"logical_bytes"`
+	Evidence       *topologyDiagnosticArchiveAcquisitionEvidenceV1 `json:"evidence,omitempty"`
+}
+
+type topologyDiagnosticArchiveAbortV1 struct {
+	Sequence              uint64    `json:"sequence"`
+	StartedAt             time.Time `json:"started_at"`
+	AbortedAt             time.Time `json:"aborted_at"`
+	Reason                string    `json:"reason"`
+	Phase                 string    `json:"phase"`
+	ActiveRegistrationID  uint64    `json:"active_registration_id,omitempty"`
+	HasActiveRegistration bool      `json:"has_active_registration"`
+	RegistrationCount     int       `json:"registration_count"`
+	SelectedCount         int       `json:"selected_count"`
+}
+
+const (
+	topologyDiagnosticArchiveCaptureRoleLatestAttempt   = "latest_attempt"
+	topologyDiagnosticArchiveCaptureRoleRetainedSuccess = "retained_success"
+)
+
+func writeTopologyDiagnosticArchive(w io.Writer, diagnostics topologyDiagnostics) error {
+	return writeTopologyDiagnosticArchiveWithLimits(w, diagnostics, buildinfo.Version, defaultTopologyDiagnosticArchiveLimits)
+}
+
+func writeTopologyDiagnosticArchiveWithLimits(
+	w io.Writer,
+	diagnostics topologyDiagnostics,
+	producerVersion string,
+	limits topologyDiagnosticArchiveLimits,
+) error {
+	if w == nil {
+		return errors.New("write SNMP topology diagnostic archive: nil writer")
+	}
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, producerVersion)
+	if err != nil {
+		return fmt.Errorf("write SNMP topology diagnostic archive: %w", err)
+	}
+	compressed := &topologyDiagnosticArchiveLimitWriter{
+		writer: w,
+		limit:  limits.maxCompressedBytes,
+		err:    errTopologyDiagnosticArchiveCompressedLimit,
+	}
+	encoder, err := zstd.NewWriter(
+		compressed,
+		zstd.WithEncoderLevel(zstd.SpeedDefault),
+		zstd.WithEncoderConcurrency(1),
+		zstd.WithEncoderCRC(true),
+	)
+	if err != nil {
+		return fmt.Errorf("write SNMP topology diagnostic archive: create zstd encoder: %w", err)
+	}
+	decoded := &topologyDiagnosticArchiveLimitWriter{
+		writer: encoder,
+		limit:  limits.maxDecodedBytes,
+		err:    errTopologyDiagnosticArchiveDecodedLimit,
+	}
+	jsonEncoder := json.NewEncoder(decoded)
+	jsonEncoder.SetEscapeHTML(false)
+	encodeErr := jsonEncoder.Encode(document)
+	closeErr := encoder.Close()
+	if encodeErr != nil {
+		return fmt.Errorf("write SNMP topology diagnostic archive: encode JSON: %w", encodeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("write SNMP topology diagnostic archive: close zstd encoder: %w", closeErr)
+	}
+	return nil
+}
+
+func readTopologyDiagnosticArchive(r io.Reader) (topologyDiagnosticArchive, error) {
+	return readTopologyDiagnosticArchiveWithLimits(r, defaultTopologyDiagnosticArchiveLimits)
+}
+
+func readTopologyDiagnosticArchiveWithLimits(
+	r io.Reader,
+	limits topologyDiagnosticArchiveLimits,
+) (topologyDiagnosticArchive, error) {
+	if r == nil {
+		return topologyDiagnosticArchive{}, errors.New("read SNMP topology diagnostic archive: nil reader")
+	}
+	compressed := &io.LimitedReader{R: r, N: limits.maxCompressedBytes + 1}
+	decoder, err := zstd.NewReader(
+		compressed,
+		zstd.WithDecoderConcurrency(1),
+		zstd.WithDecoderMaxMemory(limits.maxWindowBytes),
+		zstd.WithDecoderMaxWindow(limits.maxWindowBytes),
+	)
+	if err != nil {
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: create zstd decoder: %w", err)
+	}
+
+	decoded := &io.LimitedReader{R: decoder, N: limits.maxDecodedBytes + 1}
+	jsonDecoder := json.NewDecoder(decoded)
+	var document topologyDiagnosticArchiveDocumentV1
+	decodeErr := jsonDecoder.Decode(&document)
+	var trailing json.RawMessage
+	if decodeErr == nil {
+		if err := jsonDecoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+			if err == nil {
+				decodeErr = errors.New("trailing JSON value")
+			} else {
+				decodeErr = fmt.Errorf("trailing JSON content: %w", err)
+			}
+		}
+	}
+	decoder.Close()
+	_, drainErr := io.Copy(io.Discard, compressed)
+
+	if compressed.N == 0 {
+		return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveCompressedLimit
+	}
+	if decoded.N == 0 {
+		return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveDecodedLimit
+	}
+	if drainErr != nil {
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: drain compressed input: %w", drainErr)
+	}
+	if decodeErr != nil {
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: decode JSON: %w", decodeErr)
+	}
+	diagnostics, err := document.diagnostics()
+	if err != nil {
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: %w", err)
+	}
+	return topologyDiagnosticArchive{
+		producerVersion: document.Producer.AgentVersion,
+		diagnostics:     diagnostics,
+	}, nil
+}
+
+type topologyDiagnosticArchiveLimitWriter struct {
+	writer  io.Writer
+	limit   int64
+	written int64
+	err     error
+}
+
+func (w *topologyDiagnosticArchiveLimitWriter) Write(p []byte) (int, error) {
+	if w == nil || w.writer == nil {
+		return 0, io.ErrClosedPipe
+	}
+	if int64(len(p)) > w.limit-w.written {
+		return 0, w.err
+	}
+	n, err := w.writer.Write(p)
+	w.written += int64(n)
+	return n, err
+}
+
+func newTopologyDiagnosticArchiveDocumentV1(
+	diagnostics topologyDiagnostics,
+	producerVersion string,
+) (topologyDiagnosticArchiveDocumentV1, error) {
+	snapshot, err := newTopologyDiagnosticArchiveSnapshotV1(diagnostics)
+	if err != nil {
+		return topologyDiagnosticArchiveDocumentV1{}, err
+	}
+	return topologyDiagnosticArchiveDocumentV1{
+		Format:  topologyDiagnosticArchiveFormat,
+		Version: topologyDiagnosticArchiveVersion,
+		Producer: topologyDiagnosticArchiveProducerV1{
+			AgentVersion: producerVersion,
+		},
+		Snapshot: snapshot,
+	}, nil
+}
+
+func newTopologyDiagnosticArchiveSnapshotV1(
+	diagnostics topologyDiagnostics,
+) (topologyDiagnosticArchiveSnapshotV1, error) {
+	lifecycle, err := newTopologyDiagnosticArchiveLifecycleV1(diagnostics.lifecycle)
+	if err != nil {
+		return topologyDiagnosticArchiveSnapshotV1{}, err
+	}
+	result := topologyDiagnosticArchiveSnapshotV1{
+		Lifecycle:       lifecycle,
+		ProducerScopeID: diagnostics.producerScopeID,
+	}
+	if diagnostics.topology != nil {
+		cut, err := newTopologyDiagnosticArchiveSweepV1(diagnostics.topology)
+		if err != nil {
+			return topologyDiagnosticArchiveSnapshotV1{}, err
+		}
+		result.Topology = &cut
+	}
+	if diagnostics.lastAborted != nil {
+		abort, err := newTopologyDiagnosticArchiveAbortV1(diagnostics.lastAborted)
+		if err != nil {
+			return topologyDiagnosticArchiveSnapshotV1{}, err
+		}
+		result.LastAborted = &abort
+	}
+	return result, nil
+}
+
+func newTopologyDiagnosticArchiveLifecycleV1(
+	lifecycle topologyJobLifecycleDiagnosticCut,
+) (topologyDiagnosticArchiveLifecycleV1, error) {
+	state, err := topologyDiagnosticArchiveCaptureStateName(lifecycle.state)
+	if err != nil {
+		return topologyDiagnosticArchiveLifecycleV1{}, fmt.Errorf("job lifecycle capture state: %w", err)
+	}
+	reason, err := topologyDiagnosticArchiveCaptureReasonName(lifecycle.reason)
+	if err != nil {
+		return topologyDiagnosticArchiveLifecycleV1{}, fmt.Errorf("job lifecycle capture reason: %w", err)
+	}
+	result := topologyDiagnosticArchiveLifecycleV1{
+		State:  state,
+		Reason: reason,
+		Cut: topologyDiagnosticArchiveLifecycleCutV1{
+			Sequence:   lifecycle.cut.Sequence,
+			CapturedAt: lifecycle.cut.CapturedAt,
+			Entries:    make([]topologyDiagnosticArchiveLifecycleEntryV1, 0, len(lifecycle.cut.Entries)),
+		},
+	}
+	for _, entry := range lifecycle.cut.Entries {
+		phase, err := topologyDiagnosticArchiveLifecyclePhaseName(entry.LastCompleted.Phase)
+		if err != nil {
+			return topologyDiagnosticArchiveLifecycleV1{}, fmt.Errorf("job lifecycle registration %d phase: %w", entry.RegistrationID, err)
+		}
+		outcome, err := topologyDiagnosticArchiveLifecycleOutcomeName(entry.LastCompleted.Outcome)
+		if err != nil {
+			return topologyDiagnosticArchiveLifecycleV1{}, fmt.Errorf("job lifecycle registration %d outcome: %w", entry.RegistrationID, err)
+		}
+		result.Cut.Entries = append(result.Cut.Entries, topologyDiagnosticArchiveLifecycleEntryV1{
+			RegistrationID: uint64(entry.RegistrationID),
+			Hostname:       entry.Info.Hostname,
+			Port:           entry.Info.Port,
+			SNMPVersion:    entry.Info.SNMPVersion,
+			LastCompleted: topologyDiagnosticArchiveLifecycleStatusV1{
+				Phase:       phase,
+				Outcome:     outcome,
+				CompletedAt: entry.LastCompleted.CompletedAt,
+			},
+			TopologyReady: entry.TopologyReady,
+		})
+	}
+	return result, nil
+}
+
+func newTopologyDiagnosticArchiveSweepV1(cut *topologySweepDiagnosticCut) (topologyDiagnosticArchiveSweepV1, error) {
+	state, err := topologyDiagnosticArchiveCaptureStateName(cut.captureState)
+	if err != nil {
+		return topologyDiagnosticArchiveSweepV1{}, fmt.Errorf("topology sweep capture state: %w", err)
+	}
+	reason, err := topologyDiagnosticArchiveCaptureReasonName(cut.captureReason)
+	if err != nil {
+		return topologyDiagnosticArchiveSweepV1{}, fmt.Errorf("topology sweep capture reason: %w", err)
+	}
+	result := topologyDiagnosticArchiveSweepV1{
+		Sequence:      cut.sequence,
+		StartedAt:     cut.startedAt,
+		PublishedAt:   cut.publishedAt,
+		CaptureState:  state,
+		CaptureReason: reason,
+		RecordCount:   cut.recordCount,
+		LogicalBytes:  cut.logicalBytes,
+		Devices:       make([]topologyDiagnosticArchiveDeviceV1, 0, len(cut.devices)),
+		Removed:       make([]topologyDiagnosticArchiveRemovedV1, 0, len(cut.removed)),
+	}
+	for _, device := range cut.devices {
+		row, err := newTopologyDiagnosticArchiveDeviceV1(device)
+		if err != nil {
+			return topologyDiagnosticArchiveSweepV1{}, err
+		}
+		result.Devices = append(result.Devices, row)
+	}
+	for _, removed := range cut.removed {
+		result.Removed = append(result.Removed, topologyDiagnosticArchiveRemovedV1{
+			RegistrationID:  uint64(removed.registrationID),
+			RetainedSuccess: topologyDiagnosticArchiveEvidenceRef(removed.retainedSuccess, removed.hasRetainedSuccess),
+		})
+	}
+	return result, nil
+}
+
+func newTopologyDiagnosticArchiveDeviceV1(
+	device topologySweepDeviceDiagnostic,
+) (topologyDiagnosticArchiveDeviceV1, error) {
+	outcome, err := topologyDiagnosticArchiveDeviceOutcomeName(device.outcome)
+	if err != nil {
+		return topologyDiagnosticArchiveDeviceV1{}, fmt.Errorf("topology sweep registration %d outcome: %w", device.registrationID, err)
+	}
+	result := topologyDiagnosticArchiveDeviceV1{
+		RegistrationID:  uint64(device.registrationID),
+		Selected:        device.selected,
+		Outcome:         outcome,
+		LastAttempt:     device.lastAttempt,
+		LastSuccess:     device.lastSuccess,
+		NextRetry:       device.nextRetry,
+		RetainedSuccess: topologyDiagnosticArchiveEvidenceRef(device.retainedSuccess, device.hasRetainedSuccess),
+		HasObservation:  device.hasObservation,
+		ExpiresAt:       device.expiresAt,
+		Renderable:      device.renderable,
+		Expired:         device.expired,
+	}
+	if device.acquisition != nil {
+		capture, err := newTopologyDiagnosticArchiveCaptureV1(
+			device.registrationID,
+			device.acquisition,
+			[]string{topologyDiagnosticArchiveCaptureRoleRetainedSuccess},
+		)
+		if err != nil {
+			return topologyDiagnosticArchiveDeviceV1{}, err
+		}
+		result.Captures = append(result.Captures, capture)
+	}
+	if device.latestAttempt != nil {
+		if device.latestAttempt == device.acquisition {
+			result.Captures[0].Roles = append(
+				[]string{topologyDiagnosticArchiveCaptureRoleLatestAttempt},
+				result.Captures[0].Roles...,
+			)
+		} else {
+			capture, err := newTopologyDiagnosticArchiveCaptureV1(
+				device.registrationID,
+				device.latestAttempt,
+				[]string{topologyDiagnosticArchiveCaptureRoleLatestAttempt},
+			)
+			if err != nil {
+				return topologyDiagnosticArchiveDeviceV1{}, err
+			}
+			result.Captures = append(result.Captures, capture)
+		}
+	}
+	return result, nil
+}
+
+func newTopologyDiagnosticArchiveCaptureV1(
+	registrationID ddsnmp.DeviceRegistrationID,
+	capture *topologyAcquisitionCapture,
+	roles []string,
+) (topologyDiagnosticArchiveCaptureV1, error) {
+	state, err := topologyDiagnosticArchiveCaptureStateName(capture.state)
+	if err != nil {
+		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture state: %w", registrationID, err)
+	}
+	reason, err := topologyDiagnosticArchiveCaptureReasonName(capture.reason)
+	if err != nil {
+		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture reason: %w", registrationID, err)
+	}
+	if capture.attemptID.registrationID != registrationID {
+		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf(
+			"topology sweep registration %d capture belongs to registration %d",
+			registrationID,
+			capture.attemptID.registrationID,
+		)
+	}
+	if capture.attemptID.ordinal == 0 {
+		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture attempt ordinal is zero", registrationID)
+	}
+	if capture.state == diagnosticCaptureAvailable && capture.evidence == nil {
+		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d available capture has no evidence", registrationID)
+	}
+	if capture.state != diagnosticCaptureAvailable && capture.evidence != nil {
+		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d unavailable capture has evidence", registrationID)
+	}
+	result := topologyDiagnosticArchiveCaptureV1{
+		Roles:          roles,
+		AttemptOrdinal: capture.attemptID.ordinal,
+		State:          state,
+		Reason:         reason,
+		RecordCount:    capture.recordCount,
+		LogicalBytes:   capture.logicalBytes,
+	}
+	if capture.evidence != nil {
+		if capture.evidence.id != capture.attemptID {
+			return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture/evidence attempt mismatch", registrationID)
+		}
+		evidence, err := newTopologyDiagnosticArchiveAcquisitionEvidenceV1(capture.evidence)
+		if err != nil {
+			return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture evidence: %w", registrationID, err)
+		}
+		result.Evidence = &evidence
+	}
+	return result, nil
+}
+
+func topologyDiagnosticArchiveEvidenceRef(
+	ref topologyEvidenceRef,
+	present bool,
+) *topologyDiagnosticArchiveEvidenceRefV1 {
+	if !present {
+		return nil
+	}
+	return &topologyDiagnosticArchiveEvidenceRefV1{
+		RegistrationID: uint64(ref.registrationID),
+		Generation:     ref.generation,
+	}
+}
+
+func newTopologyDiagnosticArchiveAbortV1(
+	abort *topologyAbortedSweepDiagnostic,
+) (topologyDiagnosticArchiveAbortV1, error) {
+	reason, err := topologyDiagnosticArchiveAbortReasonName(abort.reason)
+	if err != nil {
+		return topologyDiagnosticArchiveAbortV1{}, err
+	}
+	phase, err := topologyDiagnosticArchiveSweepPhaseName(abort.phase)
+	if err != nil {
+		return topologyDiagnosticArchiveAbortV1{}, err
+	}
+	return topologyDiagnosticArchiveAbortV1{
+		Sequence:              abort.sequence,
+		StartedAt:             abort.startedAt,
+		AbortedAt:             abort.abortedAt,
+		Reason:                reason,
+		Phase:                 phase,
+		ActiveRegistrationID:  uint64(abort.activeRegistrationID),
+		HasActiveRegistration: abort.hasActiveRegistration,
+		RegistrationCount:     abort.registrationCount,
+		SelectedCount:         abort.selectedCount,
+	}, nil
+}
+
+func (d topologyDiagnosticArchiveDocumentV1) diagnostics() (topologyDiagnostics, error) {
+	if d.Format != topologyDiagnosticArchiveFormat {
+		return topologyDiagnostics{}, fmt.Errorf("unsupported format %q", d.Format)
+	}
+	if d.Version != topologyDiagnosticArchiveVersion {
+		return topologyDiagnostics{}, fmt.Errorf("unsupported version %d", d.Version)
+	}
+	return d.Snapshot.diagnostics()
+}
+
+func (s topologyDiagnosticArchiveSnapshotV1) diagnostics() (topologyDiagnostics, error) {
+	lifecycle, err := s.Lifecycle.lifecycle()
+	if err != nil {
+		return topologyDiagnostics{}, err
+	}
+	result := topologyDiagnostics{
+		lifecycle:       lifecycle,
+		producerScopeID: s.ProducerScopeID,
+	}
+	if s.Topology != nil {
+		cut, err := s.Topology.sweep()
+		if err != nil {
+			return topologyDiagnostics{}, err
+		}
+		result.topology = cut
+	}
+	if s.LastAborted != nil {
+		abort, err := s.LastAborted.abort()
+		if err != nil {
+			return topologyDiagnostics{}, err
+		}
+		result.lastAborted = abort
+	}
+	return result, nil
+}
+
+func (l topologyDiagnosticArchiveLifecycleV1) lifecycle() (topologyJobLifecycleDiagnosticCut, error) {
+	state, err := topologyDiagnosticArchiveParseCaptureState(l.State)
+	if err != nil {
+		return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("job lifecycle capture state: %w", err)
+	}
+	reason, err := topologyDiagnosticArchiveParseCaptureReason(l.Reason)
+	if err != nil {
+		return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("job lifecycle capture reason: %w", err)
+	}
+	result := topologyJobLifecycleDiagnosticCut{
+		state:  state,
+		reason: reason,
+		cut: ddsnmp.DeviceLifecycleCut{
+			Sequence:   l.Cut.Sequence,
+			CapturedAt: l.Cut.CapturedAt,
+			Entries:    make([]ddsnmp.DeviceLifecycleEntry, 0, len(l.Cut.Entries)),
+		},
+	}
+	seen := make(map[ddsnmp.DeviceRegistrationID]struct{}, len(l.Cut.Entries))
+	for _, entry := range l.Cut.Entries {
+		registrationID := ddsnmp.DeviceRegistrationID(entry.RegistrationID)
+		if registrationID == 0 {
+			return topologyJobLifecycleDiagnosticCut{}, errors.New("job lifecycle registration ID is zero")
+		}
+		if _, ok := seen[registrationID]; ok {
+			return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("duplicate job lifecycle registration ID %d", registrationID)
+		}
+		seen[registrationID] = struct{}{}
+		phase, err := topologyDiagnosticArchiveParseLifecyclePhase(entry.LastCompleted.Phase)
+		if err != nil {
+			return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("job lifecycle registration %d phase: %w", registrationID, err)
+		}
+		outcome, err := topologyDiagnosticArchiveParseLifecycleOutcome(entry.LastCompleted.Outcome)
+		if err != nil {
+			return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("job lifecycle registration %d outcome: %w", registrationID, err)
+		}
+		result.cut.Entries = append(result.cut.Entries, ddsnmp.DeviceLifecycleEntry{
+			RegistrationID: registrationID,
+			Info: ddsnmp.DeviceLifecycleInfo{
+				Hostname:    entry.Hostname,
+				Port:        entry.Port,
+				SNMPVersion: entry.SNMPVersion,
+			},
+			LastCompleted: ddsnmp.DeviceLifecycleStatus{
+				Phase:       phase,
+				Outcome:     outcome,
+				CompletedAt: entry.LastCompleted.CompletedAt,
+			},
+			TopologyReady: entry.TopologyReady,
+		})
+	}
+	return result, nil
+}
+
+func (s topologyDiagnosticArchiveSweepV1) sweep() (*topologySweepDiagnosticCut, error) {
+	state, err := topologyDiagnosticArchiveParseCaptureState(s.CaptureState)
+	if err != nil {
+		return nil, fmt.Errorf("topology sweep capture state: %w", err)
+	}
+	reason, err := topologyDiagnosticArchiveParseCaptureReason(s.CaptureReason)
+	if err != nil {
+		return nil, fmt.Errorf("topology sweep capture reason: %w", err)
+	}
+	result := &topologySweepDiagnosticCut{
+		sequence:      s.Sequence,
+		startedAt:     s.StartedAt,
+		publishedAt:   s.PublishedAt,
+		captureState:  state,
+		captureReason: reason,
+		recordCount:   s.RecordCount,
+		logicalBytes:  s.LogicalBytes,
+		devices:       make([]topologySweepDeviceDiagnostic, 0, len(s.Devices)),
+		removed:       make([]topologyRemovedDeviceDiagnostic, 0, len(s.Removed)),
+	}
+	seen := make(map[ddsnmp.DeviceRegistrationID]struct{}, len(s.Devices)+len(s.Removed))
+	for _, device := range s.Devices {
+		row, err := device.device()
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[row.registrationID]; ok {
+			return nil, fmt.Errorf("duplicate topology sweep registration ID %d", row.registrationID)
+		}
+		seen[row.registrationID] = struct{}{}
+		result.devices = append(result.devices, row)
+	}
+	for _, removed := range s.Removed {
+		registrationID := ddsnmp.DeviceRegistrationID(removed.RegistrationID)
+		if registrationID == 0 {
+			return nil, errors.New("removed topology registration ID is zero")
+		}
+		if _, ok := seen[registrationID]; ok {
+			return nil, fmt.Errorf("duplicate topology sweep registration ID %d", registrationID)
+		}
+		seen[registrationID] = struct{}{}
+		ref, hasRef, err := removed.RetainedSuccess.evidenceRef(registrationID)
+		if err != nil {
+			return nil, fmt.Errorf("removed topology registration %d: %w", registrationID, err)
+		}
+		result.removed = append(result.removed, topologyRemovedDeviceDiagnostic{
+			registrationID:     registrationID,
+			retainedSuccess:    ref,
+			hasRetainedSuccess: hasRef,
+		})
+	}
+	return result, nil
+}
+
+func (d topologyDiagnosticArchiveDeviceV1) device() (topologySweepDeviceDiagnostic, error) {
+	registrationID := ddsnmp.DeviceRegistrationID(d.RegistrationID)
+	if registrationID == 0 {
+		return topologySweepDeviceDiagnostic{}, errors.New("topology sweep registration ID is zero")
+	}
+	outcome, err := topologyDiagnosticArchiveParseDeviceOutcome(d.Outcome)
+	if err != nil {
+		return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d outcome: %w", registrationID, err)
+	}
+	ref, hasRef, err := d.RetainedSuccess.evidenceRef(registrationID)
+	if err != nil {
+		return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d: %w", registrationID, err)
+	}
+	result := topologySweepDeviceDiagnostic{
+		registrationID:     registrationID,
+		selected:           d.Selected,
+		outcome:            outcome,
+		lastAttempt:        d.LastAttempt,
+		lastSuccess:        d.LastSuccess,
+		nextRetry:          d.NextRetry,
+		retainedSuccess:    ref,
+		hasRetainedSuccess: hasRef,
+		hasObservation:     d.HasObservation,
+		expiresAt:          d.ExpiresAt,
+		renderable:         d.Renderable,
+		expired:            d.Expired,
+	}
+	seenRoles := make(map[string]struct{}, 2)
+	for _, archivedCapture := range d.Captures {
+		capture, err := archivedCapture.capture(registrationID)
+		if err != nil {
+			return topologySweepDeviceDiagnostic{}, err
+		}
+		if len(archivedCapture.Roles) == 0 {
+			return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d capture has no role", registrationID)
+		}
+		for _, role := range archivedCapture.Roles {
+			if _, ok := seenRoles[role]; ok {
+				return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d duplicate capture role %q", registrationID, role)
+			}
+			seenRoles[role] = struct{}{}
+			switch role {
+			case topologyDiagnosticArchiveCaptureRoleLatestAttempt:
+				result.latestAttempt = capture
+			case topologyDiagnosticArchiveCaptureRoleRetainedSuccess:
+				result.acquisition = capture
+			default:
+				return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d unknown capture role %q", registrationID, role)
+			}
+		}
+	}
+	if result.acquisition != nil && result.acquisition.state == diagnosticCaptureAvailable {
+		if err := validateTopologyAcquisitionEvidence(result.acquisition.evidence); err != nil {
+			return topologySweepDeviceDiagnostic{}, fmt.Errorf(
+				"topology sweep registration %d retained-success evidence: %w",
+				registrationID,
+				err,
+			)
+		}
+	}
+	return result, nil
+}
+
+func (c topologyDiagnosticArchiveCaptureV1) capture(
+	registrationID ddsnmp.DeviceRegistrationID,
+) (*topologyAcquisitionCapture, error) {
+	state, err := topologyDiagnosticArchiveParseCaptureState(c.State)
+	if err != nil {
+		return nil, fmt.Errorf("topology sweep registration %d capture state: %w", registrationID, err)
+	}
+	reason, err := topologyDiagnosticArchiveParseCaptureReason(c.Reason)
+	if err != nil {
+		return nil, fmt.Errorf("topology sweep registration %d capture reason: %w", registrationID, err)
+	}
+	attemptID := topologyAcquisitionAttemptID{registrationID: registrationID, ordinal: c.AttemptOrdinal}
+	if attemptID.ordinal == 0 {
+		return nil, fmt.Errorf("topology sweep registration %d capture attempt ordinal is zero", registrationID)
+	}
+	result := &topologyAcquisitionCapture{
+		attemptID:    attemptID,
+		state:        state,
+		reason:       reason,
+		recordCount:  c.RecordCount,
+		logicalBytes: c.LogicalBytes,
+	}
+	if c.Evidence != nil {
+		evidence, err := c.Evidence.evidence(attemptID)
+		if err != nil {
+			return nil, fmt.Errorf("topology sweep registration %d capture evidence: %w", registrationID, err)
+		}
+		result.evidence = evidence
+	}
+	if state == diagnosticCaptureAvailable && result.evidence == nil {
+		return nil, fmt.Errorf("topology sweep registration %d available capture has no evidence", registrationID)
+	}
+	if state != diagnosticCaptureAvailable && result.evidence != nil {
+		return nil, fmt.Errorf("topology sweep registration %d unavailable capture has evidence", registrationID)
+	}
+	return result, nil
+}
+
+func (r *topologyDiagnosticArchiveEvidenceRefV1) evidenceRef(
+	owner ddsnmp.DeviceRegistrationID,
+) (topologyEvidenceRef, bool, error) {
+	if r == nil {
+		return topologyEvidenceRef{}, false, nil
+	}
+	registrationID := ddsnmp.DeviceRegistrationID(r.RegistrationID)
+	if registrationID == 0 || registrationID != owner {
+		return topologyEvidenceRef{}, false, fmt.Errorf("retained-success registration reference %d does not match owner %d", registrationID, owner)
+	}
+	if r.Generation == 0 {
+		return topologyEvidenceRef{}, false, errors.New("retained-success generation is zero")
+	}
+	return topologyEvidenceRef{registrationID: registrationID, generation: r.Generation}, true, nil
+}
+
+func (a topologyDiagnosticArchiveAbortV1) abort() (*topologyAbortedSweepDiagnostic, error) {
+	reason, err := topologyDiagnosticArchiveParseAbortReason(a.Reason)
+	if err != nil {
+		return nil, err
+	}
+	phase, err := topologyDiagnosticArchiveParseSweepPhase(a.Phase)
+	if err != nil {
+		return nil, err
+	}
+	registrationID := ddsnmp.DeviceRegistrationID(a.ActiveRegistrationID)
+	if a.HasActiveRegistration && registrationID == 0 {
+		return nil, errors.New("aborted sweep active registration ID is zero")
+	}
+	if !a.HasActiveRegistration && registrationID != 0 {
+		return nil, errors.New("aborted sweep has an inactive registration reference")
+	}
+	if a.RegistrationCount < 0 || a.SelectedCount < 0 || a.SelectedCount > a.RegistrationCount {
+		return nil, errors.New("aborted sweep registration counts are invalid")
+	}
+	return &topologyAbortedSweepDiagnostic{
+		sequence:              a.Sequence,
+		startedAt:             a.StartedAt,
+		abortedAt:             a.AbortedAt,
+		reason:                reason,
+		phase:                 phase,
+		activeRegistrationID:  registrationID,
+		hasActiveRegistration: a.HasActiveRegistration,
+		registrationCount:     a.RegistrationCount,
+		selectedCount:         a.SelectedCount,
+	}, nil
+}
+
+var (
+	topologyDiagnosticArchiveCaptureStateNames = []string{
+		"unknown", "available", "limit_exceeded", "unavailable",
+	}
+	topologyDiagnosticArchiveCaptureReasonNames = []string{
+		"none", "record_limit", "byte_limit", "projection_error", "projection_panic",
+		"global_record_limit", "global_byte_limit",
+	}
+	topologyDiagnosticArchiveLifecyclePhaseNames = []string{
+		"unknown", "init", "check", "collect",
+	}
+	topologyDiagnosticArchiveLifecycleOutcomeNames = []string{
+		"unknown", "success", "failed",
+	}
+	topologyDiagnosticArchiveDeviceOutcomeNames = []string{
+		"unknown", "success", "no_profiles", "failed",
+	}
+	topologyDiagnosticArchiveAbortReasonNames = []string{
+		"unknown", "canceled", "panic",
+	}
+	topologyDiagnosticArchiveSweepPhaseNames = []string{
+		"unknown", "registration_cut", "target_resolution", "device_refresh", "commit",
+	}
+)
+
+func topologyDiagnosticArchiveEnumName[T ~uint8](value T, names []string) (string, error) {
+	index := int(value)
+	if index < 0 || index >= len(names) {
+		return "", fmt.Errorf("unknown value %d", value)
+	}
+	return names[index], nil
+}
+
+func topologyDiagnosticArchiveParseEnum[T ~uint8](value string, names []string) (T, error) {
+	for index, name := range names {
+		if value == name {
+			return T(index), nil
+		}
+	}
+	return 0, fmt.Errorf("unknown value %q", value)
+}
+
+func topologyDiagnosticArchiveCaptureStateName(value diagnosticCaptureState) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveCaptureStateNames)
+}
+
+func topologyDiagnosticArchiveParseCaptureState(value string) (diagnosticCaptureState, error) {
+	return topologyDiagnosticArchiveParseEnum[diagnosticCaptureState](value, topologyDiagnosticArchiveCaptureStateNames)
+}
+
+func topologyDiagnosticArchiveCaptureReasonName(value diagnosticCaptureReason) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveCaptureReasonNames)
+}
+
+func topologyDiagnosticArchiveParseCaptureReason(value string) (diagnosticCaptureReason, error) {
+	return topologyDiagnosticArchiveParseEnum[diagnosticCaptureReason](value, topologyDiagnosticArchiveCaptureReasonNames)
+}
+
+func topologyDiagnosticArchiveLifecyclePhaseName(value ddsnmp.DeviceLifecyclePhase) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveLifecyclePhaseNames)
+}
+
+func topologyDiagnosticArchiveParseLifecyclePhase(value string) (ddsnmp.DeviceLifecyclePhase, error) {
+	return topologyDiagnosticArchiveParseEnum[ddsnmp.DeviceLifecyclePhase](value, topologyDiagnosticArchiveLifecyclePhaseNames)
+}
+
+func topologyDiagnosticArchiveLifecycleOutcomeName(value ddsnmp.DeviceLifecycleOutcome) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveLifecycleOutcomeNames)
+}
+
+func topologyDiagnosticArchiveParseLifecycleOutcome(value string) (ddsnmp.DeviceLifecycleOutcome, error) {
+	return topologyDiagnosticArchiveParseEnum[ddsnmp.DeviceLifecycleOutcome](value, topologyDiagnosticArchiveLifecycleOutcomeNames)
+}
+
+func topologyDiagnosticArchiveDeviceOutcomeName(value deviceRefreshOutcome) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveDeviceOutcomeNames)
+}
+
+func topologyDiagnosticArchiveParseDeviceOutcome(value string) (deviceRefreshOutcome, error) {
+	return topologyDiagnosticArchiveParseEnum[deviceRefreshOutcome](value, topologyDiagnosticArchiveDeviceOutcomeNames)
+}
+
+func topologyDiagnosticArchiveAbortReasonName(value topologyDiagnosticAbortReason) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveAbortReasonNames)
+}
+
+func topologyDiagnosticArchiveParseAbortReason(value string) (topologyDiagnosticAbortReason, error) {
+	return topologyDiagnosticArchiveParseEnum[topologyDiagnosticAbortReason](value, topologyDiagnosticArchiveAbortReasonNames)
+}
+
+func topologyDiagnosticArchiveSweepPhaseName(value topologyDiagnosticSweepPhase) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveSweepPhaseNames)
+}
+
+func topologyDiagnosticArchiveParseSweepPhase(value string) (topologyDiagnosticSweepPhase, error) {
+	return topologyDiagnosticArchiveParseEnum[topologyDiagnosticSweepPhase](value, topologyDiagnosticArchiveSweepPhaseNames)
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
@@ -3,10 +3,14 @@
 package snmptopology
 
 import (
-	"encoding/json"
+	"bytes"
+	jsonv1 "encoding/json"
+	"encoding/json/jsontext"
+	jsonv2 "encoding/json/v2"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -18,29 +22,42 @@ const (
 	topologyDiagnosticArchiveFormat  = "netdata.snmp_topology.diagnostics"
 	topologyDiagnosticArchiveVersion = 1
 
-	// The byte bounds include the measured JSON overhead above the live
-	// diagnostic evidence limits without creating another shape policy.
+	// The reader bounds admit the measured maximum live shapes while containing
+	// independent attachment, decompression, and typed-allocation risks.
 	topologyDiagnosticArchiveMaxCompressedBytes = 128 << 20
-	topologyDiagnosticArchiveMaxDecodedBytes    = 128 << 20
-	topologyDiagnosticArchiveMaxWindowBytes     = 8 << 20
+	topologyDiagnosticArchiveMaxDecodedBytes    = 512 << 20
+	topologyDiagnosticArchiveMaxDecoderMemory   = 8 << 20
+	topologyDiagnosticArchiveMaxArrayElements   = 2 << 20
+	topologyDiagnosticArchiveMaxMapEntries      = 6 << 20
 )
 
 var (
 	errTopologyDiagnosticArchiveCompressedLimit = errors.New("SNMP topology diagnostic archive compressed-byte limit exceeded")
 	errTopologyDiagnosticArchiveDecodedLimit    = errors.New("SNMP topology diagnostic archive decoded-byte limit exceeded")
+	errTopologyDiagnosticArchiveArrayLimit      = errors.New("SNMP topology diagnostic archive array-element limit exceeded")
+	errTopologyDiagnosticArchiveMapLimit        = errors.New("SNMP topology diagnostic archive map-entry limit exceeded")
 )
 
 type topologyDiagnosticArchiveLimits struct {
 	maxCompressedBytes int64
 	maxDecodedBytes    int64
-	maxWindowBytes     uint64
+	maxDecoderMemory   uint64
+	maxArrayElements   uint64
+	maxMapEntries      uint64
 }
 
 var defaultTopologyDiagnosticArchiveLimits = topologyDiagnosticArchiveLimits{
 	maxCompressedBytes: topologyDiagnosticArchiveMaxCompressedBytes,
 	maxDecodedBytes:    topologyDiagnosticArchiveMaxDecodedBytes,
-	maxWindowBytes:     topologyDiagnosticArchiveMaxWindowBytes,
+	maxDecoderMemory:   topologyDiagnosticArchiveMaxDecoderMemory,
+	maxArrayElements:   topologyDiagnosticArchiveMaxArrayElements,
+	maxMapEntries:      topologyDiagnosticArchiveMaxMapEntries,
 }
+
+var topologyDiagnosticArchiveJSONOptions = jsonv2.JoinOptions(
+	jsonv1.DefaultOptionsV1(),
+	jsontext.EscapeForHTML(false),
+)
 
 type topologyDiagnosticArchive struct {
 	producerVersion string
@@ -157,14 +174,13 @@ const (
 )
 
 func writeTopologyDiagnosticArchive(w io.Writer, diagnostics topologyDiagnostics) error {
-	return writeTopologyDiagnosticArchiveWithLimits(w, diagnostics, buildinfo.Version, defaultTopologyDiagnosticArchiveLimits)
+	return writeTopologyDiagnosticArchiveWithProducerVersion(w, diagnostics, buildinfo.Version)
 }
 
-func writeTopologyDiagnosticArchiveWithLimits(
+func writeTopologyDiagnosticArchiveWithProducerVersion(
 	w io.Writer,
 	diagnostics topologyDiagnostics,
 	producerVersion string,
-	limits topologyDiagnosticArchiveLimits,
 ) error {
 	if w == nil {
 		return errors.New("write SNMP topology diagnostic archive: nil writer")
@@ -173,13 +189,8 @@ func writeTopologyDiagnosticArchiveWithLimits(
 	if err != nil {
 		return fmt.Errorf("write SNMP topology diagnostic archive: %w", err)
 	}
-	compressed := &topologyDiagnosticArchiveLimitWriter{
-		writer: w,
-		limit:  limits.maxCompressedBytes,
-		err:    errTopologyDiagnosticArchiveCompressedLimit,
-	}
 	encoder, err := zstd.NewWriter(
-		compressed,
+		w,
 		zstd.WithEncoderLevel(zstd.SpeedDefault),
 		zstd.WithEncoderConcurrency(1),
 		zstd.WithEncoderCRC(true),
@@ -187,14 +198,7 @@ func writeTopologyDiagnosticArchiveWithLimits(
 	if err != nil {
 		return fmt.Errorf("write SNMP topology diagnostic archive: create zstd encoder: %w", err)
 	}
-	decoded := &topologyDiagnosticArchiveLimitWriter{
-		writer: encoder,
-		limit:  limits.maxDecodedBytes,
-		err:    errTopologyDiagnosticArchiveDecodedLimit,
-	}
-	jsonEncoder := json.NewEncoder(decoded)
-	jsonEncoder.SetEscapeHTML(false)
-	encodeErr := jsonEncoder.Encode(document)
+	encodeErr := jsonv2.MarshalWrite(encoder, document, topologyDiagnosticArchiveJSONOptions)
 	closeErr := encoder.Close()
 	if encodeErr != nil {
 		return fmt.Errorf("write SNMP topology diagnostic archive: encode JSON: %w", encodeErr)
@@ -216,45 +220,37 @@ func readTopologyDiagnosticArchiveWithLimits(
 	if r == nil {
 		return topologyDiagnosticArchive{}, errors.New("read SNMP topology diagnostic archive: nil reader")
 	}
-	compressed := &io.LimitedReader{R: r, N: limits.maxCompressedBytes + 1}
-	decoder, err := zstd.NewReader(
-		compressed,
-		zstd.WithDecoderConcurrency(1),
-		zstd.WithDecoderMaxMemory(limits.maxWindowBytes),
-		zstd.WithDecoderMaxWindow(limits.maxWindowBytes),
-	)
+	compressed, err := io.ReadAll(io.LimitReader(r, limits.maxCompressedBytes+1))
 	if err != nil {
-		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: create zstd decoder: %w", err)
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: read compressed input: %w", err)
 	}
-
-	decoded := &io.LimitedReader{R: decoder, N: limits.maxDecodedBytes + 1}
-	jsonDecoder := json.NewDecoder(decoded)
-	var document topologyDiagnosticArchiveDocumentV1
-	decodeErr := jsonDecoder.Decode(&document)
-	var trailing json.RawMessage
-	if decodeErr == nil {
-		if err := jsonDecoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-			if err == nil {
-				decodeErr = errors.New("trailing JSON value")
-			} else {
-				decodeErr = fmt.Errorf("trailing JSON content: %w", err)
-			}
-		}
-	}
-	decoder.Close()
-	_, drainErr := io.Copy(io.Discard, compressed)
-
-	if compressed.N == 0 {
+	if int64(len(compressed)) > limits.maxCompressedBytes {
 		return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveCompressedLimit
 	}
-	if decoded.N == 0 {
-		return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveDecodedLimit
+
+	err = consumeTopologyDiagnosticArchiveJSON(compressed, limits, func(decoder *jsontext.Decoder) error {
+		_, err := preflightTopologyDiagnosticArchiveJSON(decoder, limits)
+		return err
+	})
+	if err != nil {
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: preflight JSON: %w", err)
 	}
-	if drainErr != nil {
-		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: drain compressed input: %w", drainErr)
-	}
-	if decodeErr != nil {
-		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: decode JSON: %w", decodeErr)
+
+	var document topologyDiagnosticArchiveDocumentV1
+	err = consumeTopologyDiagnosticArchiveJSON(compressed, limits, func(decoder *jsontext.Decoder) error {
+		if err := jsonv2.UnmarshalDecode(decoder, &document, topologyDiagnosticArchiveJSONOptions); err != nil {
+			return err
+		}
+		if _, err := decoder.ReadToken(); !errors.Is(err, io.EOF) {
+			if err == nil {
+				return errors.New("trailing JSON value")
+			}
+			return fmt.Errorf("trailing JSON content: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: decode JSON: %w", err)
 	}
 	diagnostics, err := document.diagnostics()
 	if err != nil {
@@ -266,23 +262,137 @@ func readTopologyDiagnosticArchiveWithLimits(
 	}, nil
 }
 
-type topologyDiagnosticArchiveLimitWriter struct {
-	writer  io.Writer
-	limit   int64
-	written int64
-	err     error
+func consumeTopologyDiagnosticArchiveJSON(
+	compressed []byte,
+	limits topologyDiagnosticArchiveLimits,
+	consume func(*jsontext.Decoder) error,
+) error {
+	decoder, err := zstd.NewReader(
+		bytes.NewReader(compressed),
+		zstd.WithDecoderConcurrency(1),
+		zstd.WithDecoderMaxMemory(limits.maxDecoderMemory),
+	)
+	if err != nil {
+		return fmt.Errorf("create zstd decoder: %w", err)
+	}
+	defer decoder.Close()
+
+	decoded := &io.LimitedReader{R: decoder, N: limits.maxDecodedBytes + 1}
+	err = consume(jsontext.NewDecoder(decoded, topologyDiagnosticArchiveJSONOptions))
+	if decoded.N == 0 {
+		return errTopologyDiagnosticArchiveDecodedLimit
+	}
+	return err
 }
 
-func (w *topologyDiagnosticArchiveLimitWriter) Write(p []byte) (int, error) {
-	if w == nil || w.writer == nil {
-		return 0, io.ErrClosedPipe
+type topologyDiagnosticArchiveCollectionCounts struct {
+	arrayElements uint64
+	mapEntries    uint64
+}
+
+type topologyDiagnosticArchiveContainerClass uint8
+
+const (
+	topologyDiagnosticArchiveContainerNone topologyDiagnosticArchiveContainerClass = iota
+	topologyDiagnosticArchiveContainerArray
+	topologyDiagnosticArchiveContainerMap
+)
+
+var topologyDiagnosticArchiveCollectionFields = map[string]topologyDiagnosticArchiveContainerClass{
+	"entries":             topologyDiagnosticArchiveContainerArray,
+	"devices":             topologyDiagnosticArchiveContainerArray,
+	"removed_devices":     topologyDiagnosticArchiveContainerArray,
+	"captures":            topologyDiagnosticArchiveContainerArray,
+	"roles":               topologyDiagnosticArchiveContainerArray,
+	"collection_contexts": topologyDiagnosticArchiveContainerArray,
+	"addresses":           topologyDiagnosticArchiveContainerArray,
+	"profiles":            topologyDiagnosticArchiveContainerArray,
+	"routes":              topologyDiagnosticArchiveContainerArray,
+	"metrics":             topologyDiagnosticArchiveContainerArray,
+	"bgp_rows":            topologyDiagnosticArchiveContainerArray,
+	"vnode_labels":        topologyDiagnosticArchiveContainerMap,
+	"metadata":            topologyDiagnosticArchiveContainerMap,
+	"tags":                topologyDiagnosticArchiveContainerMap,
+}
+
+type topologyDiagnosticArchivePreflightFrame struct {
+	class        topologyDiagnosticArchiveContainerClass
+	pendingClass topologyDiagnosticArchiveContainerClass
+}
+
+func preflightTopologyDiagnosticArchiveJSON(
+	decoder *jsontext.Decoder,
+	limits topologyDiagnosticArchiveLimits,
+) (topologyDiagnosticArchiveCollectionCounts, error) {
+	var counts topologyDiagnosticArchiveCollectionCounts
+	var roots uint64
+	var frames []topologyDiagnosticArchivePreflightFrame
+	for {
+		depth := decoder.StackDepth()
+		next := decoder.PeekKind()
+		var parent jsontext.Kind
+		var index int64
+		if depth == 0 && next != jsontext.KindInvalid {
+			roots++
+			if roots > 1 {
+				return counts, errors.New("trailing JSON value")
+			}
+		} else if depth > 0 {
+			parent, index = decoder.StackIndex(depth)
+			frame := &frames[depth-1]
+			if frame.class == topologyDiagnosticArchiveContainerArray && next != jsontext.KindEndArray {
+				if counts.arrayElements >= limits.maxArrayElements {
+					return counts, errTopologyDiagnosticArchiveArrayLimit
+				}
+				counts.arrayElements++
+			}
+			if frame.class == topologyDiagnosticArchiveContainerMap && index%2 == 0 && next != jsontext.KindEndObject {
+				if counts.mapEntries >= limits.maxMapEntries {
+					return counts, errTopologyDiagnosticArchiveMapLimit
+				}
+				counts.mapEntries++
+			}
+		}
+
+		token, err := decoder.ReadToken()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return counts, nil
+			}
+			return counts, err
+		}
+
+		switch token.Kind() {
+		case jsontext.KindBeginArray, jsontext.KindBeginObject:
+			class := topologyDiagnosticArchiveContainerNone
+			if depth > 0 && parent == jsontext.KindBeginObject && index%2 == 1 {
+				expected := frames[depth-1].pendingClass
+				if (token.Kind() == jsontext.KindBeginArray && expected == topologyDiagnosticArchiveContainerArray) ||
+					(token.Kind() == jsontext.KindBeginObject && expected == topologyDiagnosticArchiveContainerMap) {
+					class = expected
+				}
+			}
+			frames = append(frames, topologyDiagnosticArchivePreflightFrame{class: class})
+		case jsontext.KindEndArray, jsontext.KindEndObject:
+			frames = frames[:len(frames)-1]
+		case jsontext.KindString:
+			if depth > 0 && parent == jsontext.KindBeginObject && index%2 == 0 {
+				frames[depth-1].pendingClass = topologyDiagnosticArchiveCollectionFieldClass(token.String())
+			}
+		}
 	}
-	if int64(len(p)) > w.limit-w.written {
-		return 0, w.err
+}
+
+func topologyDiagnosticArchiveCollectionFieldClass(name string) topologyDiagnosticArchiveContainerClass {
+	if class, ok := topologyDiagnosticArchiveCollectionFields[name]; ok {
+		return class
 	}
-	n, err := w.writer.Write(p)
-	w.written += int64(n)
-	return n, err
+	for field, class := range topologyDiagnosticArchiveCollectionFields {
+		if strings.EqualFold(name, field) {
+			return class
+		}
+	}
+	return topologyDiagnosticArchiveContainerNone
 }
 
 func newTopologyDiagnosticArchiveDocumentV1(
@@ -663,7 +773,7 @@ func (s topologyDiagnosticArchiveSweepV1) sweep() (*topologySweepDiagnosticCut, 
 	}
 	seen := make(map[ddsnmp.DeviceRegistrationID]struct{}, len(s.Devices)+len(s.Removed))
 	for _, device := range s.Devices {
-		row, err := device.device()
+		row, err := device.device(s.Sequence)
 		if err != nil {
 			return nil, err
 		}
@@ -686,6 +796,14 @@ func (s topologyDiagnosticArchiveSweepV1) sweep() (*topologySweepDiagnosticCut, 
 		if err != nil {
 			return nil, fmt.Errorf("removed topology registration %d: %w", registrationID, err)
 		}
+		if hasRef && ref.generation > s.Sequence {
+			return nil, fmt.Errorf(
+				"removed topology registration %d retained-success generation %d exceeds sweep generation %d",
+				registrationID,
+				ref.generation,
+				s.Sequence,
+			)
+		}
 		result.removed = append(result.removed, topologyRemovedDeviceDiagnostic{
 			registrationID:     registrationID,
 			retainedSuccess:    ref,
@@ -695,7 +813,7 @@ func (s topologyDiagnosticArchiveSweepV1) sweep() (*topologySweepDiagnosticCut, 
 	return result, nil
 }
 
-func (d topologyDiagnosticArchiveDeviceV1) device() (topologySweepDeviceDiagnostic, error) {
+func (d topologyDiagnosticArchiveDeviceV1) device(sweepGeneration uint64) (topologySweepDeviceDiagnostic, error) {
 	registrationID := ddsnmp.DeviceRegistrationID(d.RegistrationID)
 	if registrationID == 0 {
 		return topologySweepDeviceDiagnostic{}, errors.New("topology sweep registration ID is zero")
@@ -723,11 +841,20 @@ func (d topologyDiagnosticArchiveDeviceV1) device() (topologySweepDeviceDiagnost
 		expired:            d.Expired,
 	}
 	seenRoles := make(map[string]struct{}, 2)
+	seenAttemptOrdinals := make(map[uint64]struct{}, len(d.Captures))
 	for _, archivedCapture := range d.Captures {
 		capture, err := archivedCapture.capture(registrationID)
 		if err != nil {
 			return topologySweepDeviceDiagnostic{}, err
 		}
+		if _, ok := seenAttemptOrdinals[capture.attemptID.ordinal]; ok {
+			return topologySweepDeviceDiagnostic{}, fmt.Errorf(
+				"topology sweep registration %d duplicate capture attempt ordinal %d",
+				registrationID,
+				capture.attemptID.ordinal,
+			)
+		}
+		seenAttemptOrdinals[capture.attemptID.ordinal] = struct{}{}
 		if len(archivedCapture.Roles) == 0 {
 			return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d capture has no role", registrationID)
 		}
@@ -745,6 +872,20 @@ func (d topologyDiagnosticArchiveDeviceV1) device() (topologySweepDeviceDiagnost
 				return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d unknown capture role %q", registrationID, role)
 			}
 		}
+	}
+	if hasRef != (result.acquisition != nil) {
+		return topologySweepDeviceDiagnostic{}, fmt.Errorf(
+			"topology sweep registration %d retained-success reference and capture role disagree",
+			registrationID,
+		)
+	}
+	if hasRef && ref.generation > sweepGeneration {
+		return topologySweepDeviceDiagnostic{}, fmt.Errorf(
+			"topology sweep registration %d retained-success generation %d exceeds sweep generation %d",
+			registrationID,
+			ref.generation,
+			sweepGeneration,
+		)
 	}
 	if result.acquisition != nil && result.acquisition.state == diagnosticCaptureAvailable {
 		if err := validateTopologyAcquisitionEvidence(result.acquisition.evidence); err != nil {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"time"
 
@@ -24,34 +25,34 @@ const (
 
 	// The reader bounds admit the measured maximum live shapes while containing
 	// independent attachment, decompression, and typed-allocation risks.
-	topologyDiagnosticArchiveMaxCompressedBytes = 128 << 20
-	topologyDiagnosticArchiveMaxDecodedBytes    = 512 << 20
-	topologyDiagnosticArchiveMaxDecoderMemory   = 8 << 20
-	topologyDiagnosticArchiveMaxArrayElements   = 2 << 20
-	topologyDiagnosticArchiveMaxMapEntries      = 6 << 20
+	topologyDiagnosticArchiveMaxCompressedBytes      = 128 << 20
+	topologyDiagnosticArchiveMaxDecodedBytes         = 512 << 20
+	topologyDiagnosticArchiveMaxDecoderMemory        = 8 << 20
+	topologyDiagnosticArchiveMaxArrayAllocationBytes = 128 << 20
+	topologyDiagnosticArchiveMaxMapEntries           = 6 << 20
 )
 
 var (
-	errTopologyDiagnosticArchiveCompressedLimit = errors.New("SNMP topology diagnostic archive compressed-byte limit exceeded")
-	errTopologyDiagnosticArchiveDecodedLimit    = errors.New("SNMP topology diagnostic archive decoded-byte limit exceeded")
-	errTopologyDiagnosticArchiveArrayLimit      = errors.New("SNMP topology diagnostic archive array-element limit exceeded")
-	errTopologyDiagnosticArchiveMapLimit        = errors.New("SNMP topology diagnostic archive map-entry limit exceeded")
+	errTopologyDiagnosticArchiveCompressedLimit      = errors.New("SNMP topology diagnostic archive compressed-byte limit exceeded")
+	errTopologyDiagnosticArchiveDecodedLimit         = errors.New("SNMP topology diagnostic archive decoded-byte limit exceeded")
+	errTopologyDiagnosticArchiveArrayAllocationLimit = errors.New("SNMP topology diagnostic archive array-allocation limit exceeded")
+	errTopologyDiagnosticArchiveMapLimit             = errors.New("SNMP topology diagnostic archive map-entry limit exceeded")
 )
 
 type topologyDiagnosticArchiveLimits struct {
-	maxCompressedBytes int64
-	maxDecodedBytes    int64
-	maxDecoderMemory   uint64
-	maxArrayElements   uint64
-	maxMapEntries      uint64
+	maxCompressedBytes      int64
+	maxDecodedBytes         int64
+	maxDecoderMemory        uint64
+	maxArrayAllocationBytes uint64
+	maxMapEntries           uint64
 }
 
 var defaultTopologyDiagnosticArchiveLimits = topologyDiagnosticArchiveLimits{
-	maxCompressedBytes: topologyDiagnosticArchiveMaxCompressedBytes,
-	maxDecodedBytes:    topologyDiagnosticArchiveMaxDecodedBytes,
-	maxDecoderMemory:   topologyDiagnosticArchiveMaxDecoderMemory,
-	maxArrayElements:   topologyDiagnosticArchiveMaxArrayElements,
-	maxMapEntries:      topologyDiagnosticArchiveMaxMapEntries,
+	maxCompressedBytes:      topologyDiagnosticArchiveMaxCompressedBytes,
+	maxDecodedBytes:         topologyDiagnosticArchiveMaxDecodedBytes,
+	maxDecoderMemory:        topologyDiagnosticArchiveMaxDecoderMemory,
+	maxArrayAllocationBytes: topologyDiagnosticArchiveMaxArrayAllocationBytes,
+	maxMapEntries:           topologyDiagnosticArchiveMaxMapEntries,
 }
 
 var topologyDiagnosticArchiveJSONOptions = jsonv2.JoinOptions(
@@ -286,8 +287,8 @@ func consumeTopologyDiagnosticArchiveJSON(
 }
 
 type topologyDiagnosticArchiveCollectionCounts struct {
-	arrayElements uint64
-	mapEntries    uint64
+	arrayAllocationBytes uint64
+	mapEntries           uint64
 }
 
 type topologyDiagnosticArchiveContainerClass uint8
@@ -298,26 +299,38 @@ const (
 	topologyDiagnosticArchiveContainerMap
 )
 
-var topologyDiagnosticArchiveCollectionFields = map[string]topologyDiagnosticArchiveContainerClass{
-	"entries":             topologyDiagnosticArchiveContainerArray,
-	"devices":             topologyDiagnosticArchiveContainerArray,
-	"removed_devices":     topologyDiagnosticArchiveContainerArray,
-	"captures":            topologyDiagnosticArchiveContainerArray,
-	"roles":               topologyDiagnosticArchiveContainerArray,
-	"collection_contexts": topologyDiagnosticArchiveContainerArray,
-	"addresses":           topologyDiagnosticArchiveContainerArray,
-	"profiles":            topologyDiagnosticArchiveContainerArray,
-	"routes":              topologyDiagnosticArchiveContainerArray,
-	"metrics":             topologyDiagnosticArchiveContainerArray,
-	"bgp_rows":            topologyDiagnosticArchiveContainerArray,
-	"vnode_labels":        topologyDiagnosticArchiveContainerMap,
-	"metadata":            topologyDiagnosticArchiveContainerMap,
-	"tags":                topologyDiagnosticArchiveContainerMap,
+type topologyDiagnosticArchiveCollectionField struct {
+	class             topologyDiagnosticArchiveContainerClass
+	arrayElementBytes uint64
+}
+
+func topologyDiagnosticArchiveArrayField[T any]() topologyDiagnosticArchiveCollectionField {
+	return topologyDiagnosticArchiveCollectionField{
+		class:             topologyDiagnosticArchiveContainerArray,
+		arrayElementBytes: uint64(reflect.TypeFor[T]().Size()),
+	}
+}
+
+var topologyDiagnosticArchiveCollectionFields = map[string]topologyDiagnosticArchiveCollectionField{
+	"entries":             topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveLifecycleEntryV1](),
+	"devices":             topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveDeviceV1](),
+	"removed_devices":     topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveRemovedV1](),
+	"captures":            topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveCaptureV1](),
+	"roles":               topologyDiagnosticArchiveArrayField[string](),
+	"collection_contexts": topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveContextEvidenceV1](),
+	"addresses":           topologyDiagnosticArchiveArrayField[string](),
+	"profiles":            topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveProfileEvidenceV1](),
+	"routes":              topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveRouteV1](),
+	"metrics":             topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveMetricValueV1](),
+	"bgp_rows":            topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveBGPRowValueV1](),
+	"vnode_labels":        {class: topologyDiagnosticArchiveContainerMap},
+	"metadata":            {class: topologyDiagnosticArchiveContainerMap},
+	"tags":                {class: topologyDiagnosticArchiveContainerMap},
 }
 
 type topologyDiagnosticArchivePreflightFrame struct {
-	class        topologyDiagnosticArchiveContainerClass
-	pendingClass topologyDiagnosticArchiveContainerClass
+	field        topologyDiagnosticArchiveCollectionField
+	pendingField topologyDiagnosticArchiveCollectionField
 }
 
 func preflightTopologyDiagnosticArchiveJSON(
@@ -340,13 +353,14 @@ func preflightTopologyDiagnosticArchiveJSON(
 		} else if depth > 0 {
 			parent, index = decoder.StackIndex(depth)
 			frame := &frames[depth-1]
-			if frame.class == topologyDiagnosticArchiveContainerArray && next != jsontext.KindEndArray {
-				if counts.arrayElements >= limits.maxArrayElements {
-					return counts, errTopologyDiagnosticArchiveArrayLimit
+			if frame.field.class == topologyDiagnosticArchiveContainerArray && next != jsontext.KindEndArray {
+				if counts.arrayAllocationBytes > limits.maxArrayAllocationBytes ||
+					frame.field.arrayElementBytes > limits.maxArrayAllocationBytes-counts.arrayAllocationBytes {
+					return counts, errTopologyDiagnosticArchiveArrayAllocationLimit
 				}
-				counts.arrayElements++
+				counts.arrayAllocationBytes += frame.field.arrayElementBytes
 			}
-			if frame.class == topologyDiagnosticArchiveContainerMap && index%2 == 0 && next != jsontext.KindEndObject {
+			if frame.field.class == topologyDiagnosticArchiveContainerMap && index%2 == 0 && next != jsontext.KindEndObject {
 				if counts.mapEntries >= limits.maxMapEntries {
 					return counts, errTopologyDiagnosticArchiveMapLimit
 				}
@@ -364,35 +378,35 @@ func preflightTopologyDiagnosticArchiveJSON(
 
 		switch token.Kind() {
 		case jsontext.KindBeginArray, jsontext.KindBeginObject:
-			class := topologyDiagnosticArchiveContainerNone
+			field := topologyDiagnosticArchiveCollectionField{}
 			if depth > 0 && parent == jsontext.KindBeginObject && index%2 == 1 {
-				expected := frames[depth-1].pendingClass
-				if (token.Kind() == jsontext.KindBeginArray && expected == topologyDiagnosticArchiveContainerArray) ||
-					(token.Kind() == jsontext.KindBeginObject && expected == topologyDiagnosticArchiveContainerMap) {
-					class = expected
+				expected := frames[depth-1].pendingField
+				if (token.Kind() == jsontext.KindBeginArray && expected.class == topologyDiagnosticArchiveContainerArray) ||
+					(token.Kind() == jsontext.KindBeginObject && expected.class == topologyDiagnosticArchiveContainerMap) {
+					field = expected
 				}
 			}
-			frames = append(frames, topologyDiagnosticArchivePreflightFrame{class: class})
+			frames = append(frames, topologyDiagnosticArchivePreflightFrame{field: field})
 		case jsontext.KindEndArray, jsontext.KindEndObject:
 			frames = frames[:len(frames)-1]
 		case jsontext.KindString:
 			if depth > 0 && parent == jsontext.KindBeginObject && index%2 == 0 {
-				frames[depth-1].pendingClass = topologyDiagnosticArchiveCollectionFieldClass(token.String())
+				frames[depth-1].pendingField = topologyDiagnosticArchiveCollectionFieldDefinition(token.String())
 			}
 		}
 	}
 }
 
-func topologyDiagnosticArchiveCollectionFieldClass(name string) topologyDiagnosticArchiveContainerClass {
-	if class, ok := topologyDiagnosticArchiveCollectionFields[name]; ok {
-		return class
+func topologyDiagnosticArchiveCollectionFieldDefinition(fieldName string) topologyDiagnosticArchiveCollectionField {
+	if field, ok := topologyDiagnosticArchiveCollectionFields[fieldName]; ok {
+		return field
 	}
-	for field, class := range topologyDiagnosticArchiveCollectionFields {
-		if strings.EqualFold(name, field) {
-			return class
+	for candidate, field := range topologyDiagnosticArchiveCollectionFields {
+		if strings.EqualFold(fieldName, candidate) {
+			return field
 		}
 	}
-	return topologyDiagnosticArchiveContainerNone
+	return topologyDiagnosticArchiveCollectionField{}
 }
 
 func newTopologyDiagnosticArchiveDocumentV1(

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
@@ -3,15 +3,13 @@
 package snmptopology
 
 import (
-	"bytes"
 	jsonv1 "encoding/json"
 	"encoding/json/jsontext"
 	jsonv2 "encoding/json/v2"
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
-	"strings"
+	"math"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -23,36 +21,26 @@ const (
 	topologyDiagnosticArchiveFormat  = "netdata.snmp_topology.diagnostics"
 	topologyDiagnosticArchiveVersion = 1
 
-	// The reader bounds admit the measured maximum live shapes while containing
-	// independent attachment, decompression, and typed-allocation risks.
-	topologyDiagnosticArchiveMaxCompressedBytes      = 128 << 20
-	topologyDiagnosticArchiveMaxDecodedBytes         = 512 << 20
-	topologyDiagnosticArchiveMaxDecoderMemory        = 8 << 20
-	topologyDiagnosticArchiveMaxArrayAllocationBytes = 128 << 20
-	topologyDiagnosticArchiveMaxMapEntries           = 6 << 20
+	// The defaults leave substantial headroom over the largest measured producer shapes.
+	topologyDiagnosticArchiveDefaultMaxCompressedBytes = 128 << 20
+	topologyDiagnosticArchiveDefaultMaxDecodedBytes    = 512 << 20
 )
 
 var (
-	errTopologyDiagnosticArchiveCompressedLimit      = errors.New("SNMP topology diagnostic archive compressed-byte limit exceeded")
-	errTopologyDiagnosticArchiveDecodedLimit         = errors.New("SNMP topology diagnostic archive decoded-byte limit exceeded")
-	errTopologyDiagnosticArchiveArrayAllocationLimit = errors.New("SNMP topology diagnostic archive array-allocation limit exceeded")
-	errTopologyDiagnosticArchiveMapLimit             = errors.New("SNMP topology diagnostic archive map-entry limit exceeded")
+	errTopologyDiagnosticArchiveCompressedLimit = errors.New("SNMP topology diagnostic archive compressed-byte limit exceeded")
+	errTopologyDiagnosticArchiveDecodedLimit    = errors.New("SNMP topology diagnostic archive decoded-byte limit exceeded")
 )
 
-type topologyDiagnosticArchiveLimits struct {
-	maxCompressedBytes      int64
-	maxDecodedBytes         int64
-	maxDecoderMemory        uint64
-	maxArrayAllocationBytes uint64
-	maxMapEntries           uint64
+type topologyDiagnosticArchiveReadLimits struct {
+	maxCompressedBytes int64
+	maxDecodedBytes    int64
 }
 
-var defaultTopologyDiagnosticArchiveLimits = topologyDiagnosticArchiveLimits{
-	maxCompressedBytes:      topologyDiagnosticArchiveMaxCompressedBytes,
-	maxDecodedBytes:         topologyDiagnosticArchiveMaxDecodedBytes,
-	maxDecoderMemory:        topologyDiagnosticArchiveMaxDecoderMemory,
-	maxArrayAllocationBytes: topologyDiagnosticArchiveMaxArrayAllocationBytes,
-	maxMapEntries:           topologyDiagnosticArchiveMaxMapEntries,
+func defaultTopologyDiagnosticArchiveReadLimits() topologyDiagnosticArchiveReadLimits {
+	return topologyDiagnosticArchiveReadLimits{
+		maxCompressedBytes: topologyDiagnosticArchiveDefaultMaxCompressedBytes,
+		maxDecodedBytes:    topologyDiagnosticArchiveDefaultMaxDecodedBytes,
+	}
 }
 
 var topologyDiagnosticArchiveWriterJSONOptions = jsonv2.JoinOptions(
@@ -215,46 +203,39 @@ func writeTopologyDiagnosticArchiveWithProducerVersion(
 	return nil
 }
 
-func readTopologyDiagnosticArchive(r io.Reader) (topologyDiagnosticArchive, error) {
-	return readTopologyDiagnosticArchiveWithLimits(r, defaultTopologyDiagnosticArchiveLimits)
-}
-
-func readTopologyDiagnosticArchiveWithLimits(
+func readTopologyDiagnosticArchive(
 	r io.Reader,
-	limits topologyDiagnosticArchiveLimits,
+	limits topologyDiagnosticArchiveReadLimits,
 ) (topologyDiagnosticArchive, error) {
 	if r == nil {
 		return topologyDiagnosticArchive{}, errors.New("read SNMP topology diagnostic archive: nil reader")
 	}
-	compressed, err := io.ReadAll(io.LimitReader(r, limits.maxCompressedBytes+1))
-	if err != nil {
-		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: read compressed input: %w", err)
+	if limits.maxCompressedBytes <= 0 || limits.maxCompressedBytes == math.MaxInt64 {
+		return topologyDiagnosticArchive{}, errors.New("read SNMP topology diagnostic archive: invalid compressed-byte limit")
 	}
-	if int64(len(compressed)) > limits.maxCompressedBytes {
+	if limits.maxDecodedBytes <= 0 || limits.maxDecodedBytes == math.MaxInt64 {
+		return topologyDiagnosticArchive{}, errors.New("read SNMP topology diagnostic archive: invalid decoded-byte limit")
+	}
+
+	compressed := &io.LimitedReader{R: r, N: limits.maxCompressedBytes + 1}
+	decoder, err := zstd.NewReader(compressed, zstd.WithDecoderConcurrency(1))
+	if err != nil {
+		if compressed.N == 0 {
+			return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveCompressedLimit
+		}
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: create zstd decoder: %w", err)
+	}
+
+	decoded := &io.LimitedReader{R: decoder, N: limits.maxDecodedBytes + 1}
+	var document topologyDiagnosticArchiveDocumentV1
+	err = jsonv2.UnmarshalRead(decoded, &document, topologyDiagnosticArchiveReaderJSONOptions)
+	decoder.Close()
+	if compressed.N == 0 {
 		return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveCompressedLimit
 	}
-
-	err = consumeTopologyDiagnosticArchiveJSON(compressed, limits, func(decoder *jsontext.Decoder) error {
-		_, err := preflightTopologyDiagnosticArchiveJSON(decoder, limits)
-		return err
-	})
-	if err != nil {
-		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: preflight JSON: %w", err)
+	if decoded.N == 0 {
+		return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveDecodedLimit
 	}
-
-	var document topologyDiagnosticArchiveDocumentV1
-	err = consumeTopologyDiagnosticArchiveJSON(compressed, limits, func(decoder *jsontext.Decoder) error {
-		if err := jsonv2.UnmarshalDecode(decoder, &document, topologyDiagnosticArchiveReaderJSONOptions); err != nil {
-			return err
-		}
-		if _, err := decoder.ReadToken(); !errors.Is(err, io.EOF) {
-			if err == nil {
-				return errors.New("trailing JSON value")
-			}
-			return fmt.Errorf("trailing JSON content: %w", err)
-		}
-		return nil
-	})
 	if err != nil {
 		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: decode JSON: %w", err)
 	}
@@ -266,152 +247,6 @@ func readTopologyDiagnosticArchiveWithLimits(
 		producerVersion: document.Producer.AgentVersion,
 		diagnostics:     diagnostics,
 	}, nil
-}
-
-func consumeTopologyDiagnosticArchiveJSON(
-	compressed []byte,
-	limits topologyDiagnosticArchiveLimits,
-	consume func(*jsontext.Decoder) error,
-) error {
-	decoder, err := zstd.NewReader(
-		bytes.NewReader(compressed),
-		zstd.WithDecoderConcurrency(1),
-		zstd.WithDecoderMaxMemory(limits.maxDecoderMemory),
-	)
-	if err != nil {
-		return fmt.Errorf("create zstd decoder: %w", err)
-	}
-	defer decoder.Close()
-
-	decoded := &io.LimitedReader{R: decoder, N: limits.maxDecodedBytes + 1}
-	err = consume(jsontext.NewDecoder(decoded, topologyDiagnosticArchiveReaderJSONOptions))
-	if decoded.N == 0 {
-		return errTopologyDiagnosticArchiveDecodedLimit
-	}
-	return err
-}
-
-type topologyDiagnosticArchiveCollectionCounts struct {
-	arrayAllocationBytes uint64
-	mapEntries           uint64
-}
-
-type topologyDiagnosticArchiveContainerClass uint8
-
-const (
-	topologyDiagnosticArchiveContainerNone topologyDiagnosticArchiveContainerClass = iota
-	topologyDiagnosticArchiveContainerArray
-	topologyDiagnosticArchiveContainerMap
-)
-
-type topologyDiagnosticArchiveCollectionField struct {
-	class             topologyDiagnosticArchiveContainerClass
-	arrayElementBytes uint64
-}
-
-func topologyDiagnosticArchiveArrayField[T any]() topologyDiagnosticArchiveCollectionField {
-	return topologyDiagnosticArchiveCollectionField{
-		class:             topologyDiagnosticArchiveContainerArray,
-		arrayElementBytes: uint64(reflect.TypeFor[T]().Size()),
-	}
-}
-
-var topologyDiagnosticArchiveCollectionFields = map[string]topologyDiagnosticArchiveCollectionField{
-	"entries":             topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveLifecycleEntryV1](),
-	"devices":             topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveDeviceV1](),
-	"removed_devices":     topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveRemovedV1](),
-	"captures":            topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveCaptureV1](),
-	"roles":               topologyDiagnosticArchiveArrayField[string](),
-	"collection_contexts": topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveContextEvidenceV1](),
-	"addresses":           topologyDiagnosticArchiveArrayField[string](),
-	"profiles":            topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveProfileEvidenceV1](),
-	"routes":              topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveRouteV1](),
-	"metrics":             topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveMetricValueV1](),
-	"bgp_rows":            topologyDiagnosticArchiveArrayField[topologyDiagnosticArchiveBGPRowValueV1](),
-	"vnode_labels":        {class: topologyDiagnosticArchiveContainerMap},
-	"metadata":            {class: topologyDiagnosticArchiveContainerMap},
-	"tags":                {class: topologyDiagnosticArchiveContainerMap},
-}
-
-type topologyDiagnosticArchivePreflightFrame struct {
-	field        topologyDiagnosticArchiveCollectionField
-	pendingField topologyDiagnosticArchiveCollectionField
-}
-
-func preflightTopologyDiagnosticArchiveJSON(
-	decoder *jsontext.Decoder,
-	limits topologyDiagnosticArchiveLimits,
-) (topologyDiagnosticArchiveCollectionCounts, error) {
-	var counts topologyDiagnosticArchiveCollectionCounts
-	var roots uint64
-	var frames []topologyDiagnosticArchivePreflightFrame
-	for {
-		depth := decoder.StackDepth()
-		next := decoder.PeekKind()
-		var parent jsontext.Kind
-		var index int64
-		if depth == 0 && next != jsontext.KindInvalid {
-			roots++
-			if roots > 1 {
-				return counts, errors.New("trailing JSON value")
-			}
-		} else if depth > 0 {
-			parent, index = decoder.StackIndex(depth)
-			frame := &frames[depth-1]
-			if frame.field.class == topologyDiagnosticArchiveContainerArray && next != jsontext.KindEndArray {
-				if counts.arrayAllocationBytes > limits.maxArrayAllocationBytes ||
-					frame.field.arrayElementBytes > limits.maxArrayAllocationBytes-counts.arrayAllocationBytes {
-					return counts, errTopologyDiagnosticArchiveArrayAllocationLimit
-				}
-				counts.arrayAllocationBytes += frame.field.arrayElementBytes
-			}
-			if frame.field.class == topologyDiagnosticArchiveContainerMap && index%2 == 0 && next != jsontext.KindEndObject {
-				if counts.mapEntries >= limits.maxMapEntries {
-					return counts, errTopologyDiagnosticArchiveMapLimit
-				}
-				counts.mapEntries++
-			}
-		}
-
-		token, err := decoder.ReadToken()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return counts, nil
-			}
-			return counts, err
-		}
-
-		switch token.Kind() {
-		case jsontext.KindBeginArray, jsontext.KindBeginObject:
-			field := topologyDiagnosticArchiveCollectionField{}
-			if depth > 0 && parent == jsontext.KindBeginObject && index%2 == 1 {
-				expected := frames[depth-1].pendingField
-				if (token.Kind() == jsontext.KindBeginArray && expected.class == topologyDiagnosticArchiveContainerArray) ||
-					(token.Kind() == jsontext.KindBeginObject && expected.class == topologyDiagnosticArchiveContainerMap) {
-					field = expected
-				}
-			}
-			frames = append(frames, topologyDiagnosticArchivePreflightFrame{field: field})
-		case jsontext.KindEndArray, jsontext.KindEndObject:
-			frames = frames[:len(frames)-1]
-		case jsontext.KindString:
-			if depth > 0 && parent == jsontext.KindBeginObject && index%2 == 0 {
-				frames[depth-1].pendingField = topologyDiagnosticArchiveCollectionFieldDefinition(token.String())
-			}
-		}
-	}
-}
-
-func topologyDiagnosticArchiveCollectionFieldDefinition(fieldName string) topologyDiagnosticArchiveCollectionField {
-	if field, ok := topologyDiagnosticArchiveCollectionFields[fieldName]; ok {
-		return field
-	}
-	for candidate, field := range topologyDiagnosticArchiveCollectionFields {
-		if strings.EqualFold(fieldName, candidate) {
-			return field
-		}
-	}
-	return topologyDiagnosticArchiveCollectionField{}
 }
 
 func newTopologyDiagnosticArchiveDocumentV1(

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_acquisition.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_acquisition.go
@@ -698,9 +698,6 @@ func (v topologyDiagnosticArchiveProfileValuesV1) values(
 			return topologyAcquisitionProfileValues{}, fmt.Errorf("unknown BGP row kind %q", row.Kind)
 		}
 		state := ddprofiledefinition.BGPPeerState(row.State)
-		if !ddprofiledefinition.IsValidBGPPeerState(state) {
-			return topologyAcquisitionProfileValues{}, fmt.Errorf("unknown BGP peer state %q", row.State)
-		}
 		result.bgpRows = append(result.bgpRows, topologyAcquisitionBGPRowValue{
 			routeOrdinal:    row.RouteOrdinal,
 			rowOrdinal:      row.RowOrdinal,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_acquisition.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_acquisition.go
@@ -1,0 +1,896 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/netip"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+)
+
+type topologyDiagnosticArchiveAcquisitionEvidenceV1 struct {
+	Device             topologyDiagnosticArchiveDeviceInputV1       `json:"device"`
+	Target             topologyDiagnosticArchiveTargetV1            `json:"target"`
+	Client             topologyDiagnosticArchivePhaseV1             `json:"client"`
+	Connect            topologyDiagnosticArchivePhaseV1             `json:"connect"`
+	Profiles           topologyDiagnosticArchivePhaseV1             `json:"profiles"`
+	Collection         topologyDiagnosticArchivePhaseV1             `json:"collection"`
+	SysUptime          topologyDiagnosticArchivePhaseV1             `json:"sys_uptime"`
+	VLANProfiles       topologyDiagnosticArchivePhaseV1             `json:"vlan_profiles"`
+	CollectedAt        time.Time                                    `json:"collected_at"`
+	FreshForNanos      int64                                        `json:"fresh_for_ns"`
+	SysUptimeValue     int64                                        `json:"sys_uptime_value"`
+	CollectionContexts []topologyDiagnosticArchiveContextEvidenceV1 `json:"collection_contexts,omitempty"`
+}
+
+type topologyDiagnosticArchiveDeviceInputV1 struct {
+	Hostname    string            `json:"hostname"`
+	SysObjectID string            `json:"sys_object_id"`
+	SysName     string            `json:"sys_name"`
+	SysDescr    string            `json:"sys_descr"`
+	SysContact  string            `json:"sys_contact"`
+	SysLocation string            `json:"sys_location"`
+	Vendor      string            `json:"vendor"`
+	Model       string            `json:"model"`
+	VnodeGUID   string            `json:"vnode_guid"`
+	VnodeLabels map[string]string `json:"vnode_labels,omitempty"`
+}
+
+type topologyDiagnosticArchiveTargetV1 struct {
+	Outcome   string   `json:"outcome"`
+	Addresses []string `json:"addresses,omitempty"`
+}
+
+type topologyDiagnosticArchivePhaseV1 struct {
+	Outcome string `json:"outcome"`
+	Failure string `json:"failure"`
+}
+
+type topologyDiagnosticArchiveContextEvidenceV1 struct {
+	Ordinal    uint32                                       `json:"ordinal"`
+	VLANID     string                                       `json:"vlan_id"`
+	VLANName   string                                       `json:"vlan_name"`
+	Client     topologyDiagnosticArchivePhaseV1             `json:"client"`
+	Connect    topologyDiagnosticArchivePhaseV1             `json:"connect"`
+	Collection topologyDiagnosticArchivePhaseV1             `json:"collection"`
+	Profiles   []topologyDiagnosticArchiveProfileEvidenceV1 `json:"profiles,omitempty"`
+}
+
+type topologyDiagnosticArchiveProfileEvidenceV1 struct {
+	Identity     topologyDiagnosticArchiveProfileIdentityV1 `json:"identity"`
+	Outcome      string                                     `json:"outcome"`
+	FailurePhase string                                     `json:"failure_phase"`
+	Stats        topologyDiagnosticArchiveCollectionStatsV1 `json:"stats"`
+	Routes       []topologyDiagnosticArchiveRouteV1         `json:"routes,omitempty"`
+	Values       topologyDiagnosticArchiveProfileValuesV1   `json:"values"`
+}
+
+type topologyDiagnosticArchiveProfileIdentityV1 struct {
+	Ordinal     uint32 `json:"ordinal"`
+	RouteDigest string `json:"route_digest"`
+}
+
+type topologyDiagnosticArchiveRouteV1 struct {
+	Ordinal      uint32 `json:"ordinal"`
+	Kind         string `json:"kind"`
+	RootOID      string `json:"root_oid"`
+	Source       string `json:"source"`
+	Outcome      string `json:"outcome"`
+	FailureClass string `json:"failure_class"`
+	Rows         uint64 `json:"rows"`
+	Values       uint64 `json:"values"`
+	Missing      uint64 `json:"missing"`
+	Rejected     uint64 `json:"rejected"`
+}
+
+type topologyDiagnosticArchiveProfileValuesV1 struct {
+	Metadata  map[string]topologyDiagnosticArchiveMetaTagV1 `json:"metadata,omitempty"`
+	Tags      map[string]string                             `json:"tags,omitempty"`
+	Metrics   []topologyDiagnosticArchiveMetricValueV1      `json:"metrics,omitempty"`
+	BGPRows   []topologyDiagnosticArchiveBGPRowValueV1      `json:"bgp_rows,omitempty"`
+	BGPFailed bool                                          `json:"bgp_failed"`
+}
+
+type topologyDiagnosticArchiveMetaTagV1 struct {
+	Value        string `json:"value"`
+	IsExactMatch bool   `json:"is_exact_match"`
+}
+
+type topologyDiagnosticArchiveMetricValueV1 struct {
+	RouteOrdinal uint32            `json:"route_ordinal"`
+	RowOrdinal   uint32            `json:"row_ordinal"`
+	ValueOrdinal uint32            `json:"value_ordinal"`
+	Kind         string            `json:"kind"`
+	Tags         map[string]string `json:"tags,omitempty"`
+}
+
+type topologyDiagnosticArchiveBGPRowValueV1 struct {
+	RouteOrdinal uint32 `json:"route_ordinal"`
+	RowOrdinal   uint32 `json:"row_ordinal"`
+	ValueOrdinal uint32 `json:"value_ordinal"`
+
+	OriginProfileID string `json:"origin_profile_id"`
+	Table           string `json:"table"`
+	RowKey          string `json:"row_key"`
+	StructuralID    string `json:"structural_id"`
+	Kind            string `json:"kind"`
+
+	RoutingInstance string `json:"routing_instance"`
+	Neighbor        string `json:"neighbor"`
+	RemoteAS        string `json:"remote_as"`
+	LocalAddress    string `json:"local_address"`
+	LocalAS         string `json:"local_as"`
+	LocalIdentifier string `json:"local_identifier"`
+	PeerIdentifier  string `json:"peer_identifier"`
+	PeerType        string `json:"peer_type"`
+	BGPVersion      string `json:"bgp_version"`
+	Description     string `json:"description"`
+
+	AdminHas       bool              `json:"admin_has"`
+	AdminEnabled   bool              `json:"admin_enabled"`
+	StateHas       bool              `json:"state_has"`
+	State          string            `json:"state"`
+	StateRaw       string            `json:"state_raw"`
+	EstablishedHas bool              `json:"established_has"`
+	Established    int64             `json:"established"`
+	UpdateAgeHas   bool              `json:"update_age_has"`
+	UpdateAge      int64             `json:"update_age"`
+	Tags           map[string]string `json:"tags,omitempty"`
+}
+
+type topologyDiagnosticArchiveCollectionStatsV1 struct {
+	Timing     topologyDiagnosticArchiveTimingStatsV1     `json:"timing"`
+	SNMP       topologyDiagnosticArchiveSNMPStatsV1       `json:"snmp"`
+	Metrics    topologyDiagnosticArchiveMetricStatsV1     `json:"metrics"`
+	TableCache topologyDiagnosticArchiveTableCacheStatsV1 `json:"table_cache"`
+	Errors     topologyDiagnosticArchiveErrorStatsV1      `json:"errors"`
+}
+
+type topologyDiagnosticArchiveTimingStatsV1 struct {
+	ScalarNanos         int64 `json:"scalar_ns"`
+	TableNanos          int64 `json:"table_ns"`
+	LicensingNanos      int64 `json:"licensing_ns"`
+	BGPNanos            int64 `json:"bgp_ns"`
+	VirtualMetricsNanos int64 `json:"virtual_metrics_ns"`
+}
+
+type topologyDiagnosticArchiveSNMPStatsV1 struct {
+	GetRequests  int64 `json:"get_requests"`
+	GetOIDs      int64 `json:"get_oids"`
+	WalkRequests int64 `json:"walk_requests"`
+	WalkPDUs     int64 `json:"walk_pdus"`
+	TablesWalked int64 `json:"tables_walked"`
+	TablesCached int64 `json:"tables_cached"`
+}
+
+type topologyDiagnosticArchiveMetricStatsV1 struct {
+	Scalar    int64 `json:"scalar"`
+	Table     int64 `json:"table"`
+	Virtual   int64 `json:"virtual"`
+	Licensing int64 `json:"licensing"`
+	BGP       int64 `json:"bgp"`
+	Tables    int64 `json:"tables"`
+	Rows      int64 `json:"rows"`
+}
+
+type topologyDiagnosticArchiveTableCacheStatsV1 struct {
+	Hits   int64 `json:"hits"`
+	Misses int64 `json:"misses"`
+}
+
+type topologyDiagnosticArchiveErrorStatsV1 struct {
+	SNMP                int64 `json:"snmp"`
+	ProcessingScalar    int64 `json:"processing_scalar"`
+	ProcessingTable     int64 `json:"processing_table"`
+	ProcessingLicensing int64 `json:"processing_licensing"`
+	ProcessingBGP       int64 `json:"processing_bgp"`
+	MissingOIDs         int64 `json:"missing_oids"`
+}
+
+func newTopologyDiagnosticArchiveAcquisitionEvidenceV1(
+	evidence *topologyAcquisitionAttemptEvidence,
+) (topologyDiagnosticArchiveAcquisitionEvidenceV1, error) {
+	targetOutcome, err := topologyDiagnosticArchiveTargetOutcomeName(evidence.target.outcome)
+	if err != nil {
+		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, err
+	}
+	client, err := newTopologyDiagnosticArchivePhaseV1(evidence.client)
+	if err != nil {
+		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("client phase: %w", err)
+	}
+	connect, err := newTopologyDiagnosticArchivePhaseV1(evidence.connect)
+	if err != nil {
+		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("connect phase: %w", err)
+	}
+	profiles, err := newTopologyDiagnosticArchivePhaseV1(evidence.profiles)
+	if err != nil {
+		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("profiles phase: %w", err)
+	}
+	collection, err := newTopologyDiagnosticArchivePhaseV1(evidence.collection)
+	if err != nil {
+		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("collection phase: %w", err)
+	}
+	sysUptime, err := newTopologyDiagnosticArchivePhaseV1(evidence.sysUptime)
+	if err != nil {
+		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("sys_uptime phase: %w", err)
+	}
+	vlanProfiles, err := newTopologyDiagnosticArchivePhaseV1(evidence.vlanProfiles)
+	if err != nil {
+		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("vlan_profiles phase: %w", err)
+	}
+	result := topologyDiagnosticArchiveAcquisitionEvidenceV1{
+		Device: topologyDiagnosticArchiveDeviceInputV1{
+			Hostname:    evidence.device.hostname,
+			SysObjectID: evidence.device.sysObjectID,
+			SysName:     evidence.device.sysName,
+			SysDescr:    evidence.device.sysDescr,
+			SysContact:  evidence.device.sysContact,
+			SysLocation: evidence.device.sysLocation,
+			Vendor:      evidence.device.vendor,
+			Model:       evidence.device.model,
+			VnodeGUID:   evidence.device.vnodeGUID,
+			VnodeLabels: evidence.device.vnodeLabels,
+		},
+		Target: topologyDiagnosticArchiveTargetV1{
+			Outcome:   targetOutcome,
+			Addresses: make([]string, 0, len(evidence.target.addresses)),
+		},
+		Client:             client,
+		Connect:            connect,
+		Profiles:           profiles,
+		Collection:         collection,
+		SysUptime:          sysUptime,
+		VLANProfiles:       vlanProfiles,
+		CollectedAt:        evidence.collectedAt,
+		FreshForNanos:      int64(evidence.freshFor),
+		SysUptimeValue:     evidence.sysUptimeValue,
+		CollectionContexts: make([]topologyDiagnosticArchiveContextEvidenceV1, 0, len(evidence.collectionContexts)),
+	}
+	for _, address := range evidence.target.addresses {
+		result.Target.Addresses = append(result.Target.Addresses, address.String())
+	}
+	for _, context := range evidence.collectionContexts {
+		archived, err := newTopologyDiagnosticArchiveContextEvidenceV1(context)
+		if err != nil {
+			return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("collection context %d: %w", context.ordinal, err)
+		}
+		result.CollectionContexts = append(result.CollectionContexts, archived)
+	}
+	return result, nil
+}
+
+func newTopologyDiagnosticArchiveContextEvidenceV1(
+	context topologyAcquisitionContextEvidence,
+) (topologyDiagnosticArchiveContextEvidenceV1, error) {
+	client, err := newTopologyDiagnosticArchivePhaseV1(context.client)
+	if err != nil {
+		return topologyDiagnosticArchiveContextEvidenceV1{}, fmt.Errorf("client phase: %w", err)
+	}
+	connect, err := newTopologyDiagnosticArchivePhaseV1(context.connect)
+	if err != nil {
+		return topologyDiagnosticArchiveContextEvidenceV1{}, fmt.Errorf("connect phase: %w", err)
+	}
+	collection, err := newTopologyDiagnosticArchivePhaseV1(context.collection)
+	if err != nil {
+		return topologyDiagnosticArchiveContextEvidenceV1{}, fmt.Errorf("collection phase: %w", err)
+	}
+	result := topologyDiagnosticArchiveContextEvidenceV1{
+		Ordinal:    context.ordinal,
+		VLANID:     context.vlanID,
+		VLANName:   context.vlanName,
+		Client:     client,
+		Connect:    connect,
+		Collection: collection,
+		Profiles:   make([]topologyDiagnosticArchiveProfileEvidenceV1, 0, len(context.profiles)),
+	}
+	for _, profile := range context.profiles {
+		archived, err := newTopologyDiagnosticArchiveProfileEvidenceV1(profile)
+		if err != nil {
+			return topologyDiagnosticArchiveContextEvidenceV1{}, fmt.Errorf("profile %d: %w", profile.identity.Ordinal, err)
+		}
+		result.Profiles = append(result.Profiles, archived)
+	}
+	return result, nil
+}
+
+func newTopologyDiagnosticArchiveProfileEvidenceV1(
+	profile topologyAcquisitionProfileEvidence,
+) (topologyDiagnosticArchiveProfileEvidenceV1, error) {
+	outcome, err := topologyDiagnosticArchiveProfileOutcomeName(profile.outcome)
+	if err != nil {
+		return topologyDiagnosticArchiveProfileEvidenceV1{}, err
+	}
+	failurePhase, err := topologyDiagnosticArchiveProfileFailurePhaseName(profile.failurePhase)
+	if err != nil {
+		return topologyDiagnosticArchiveProfileEvidenceV1{}, err
+	}
+	result := topologyDiagnosticArchiveProfileEvidenceV1{
+		Identity: topologyDiagnosticArchiveProfileIdentityV1{
+			Ordinal:     profile.identity.Ordinal,
+			RouteDigest: hex.EncodeToString(profile.identity.RouteDigest[:]),
+		},
+		Outcome:      outcome,
+		FailurePhase: failurePhase,
+		Stats:        newTopologyDiagnosticArchiveCollectionStatsV1(profile.stats),
+		Routes:       make([]topologyDiagnosticArchiveRouteV1, 0, len(profile.routes)),
+		Values:       newTopologyDiagnosticArchiveProfileValuesV1(profile.values),
+	}
+	for _, route := range profile.routes {
+		archived, err := newTopologyDiagnosticArchiveRouteV1(route)
+		if err != nil {
+			return topologyDiagnosticArchiveProfileEvidenceV1{}, fmt.Errorf("route %d: %w", route.Ordinal, err)
+		}
+		result.Routes = append(result.Routes, archived)
+	}
+	return result, nil
+}
+
+func newTopologyDiagnosticArchiveRouteV1(
+	route ddsnmpcollector.AcquisitionRouteReport,
+) (topologyDiagnosticArchiveRouteV1, error) {
+	kind, err := topologyDiagnosticArchiveRouteKindName(route.Kind)
+	if err != nil {
+		return topologyDiagnosticArchiveRouteV1{}, err
+	}
+	source, err := topologyDiagnosticArchiveRouteSourceName(route.Source)
+	if err != nil {
+		return topologyDiagnosticArchiveRouteV1{}, err
+	}
+	outcome, err := topologyDiagnosticArchiveRouteOutcomeName(route.Outcome)
+	if err != nil {
+		return topologyDiagnosticArchiveRouteV1{}, err
+	}
+	failureClass, err := topologyDiagnosticArchiveRouteFailureClassName(route.FailureClass)
+	if err != nil {
+		return topologyDiagnosticArchiveRouteV1{}, err
+	}
+	return topologyDiagnosticArchiveRouteV1{
+		Ordinal:      route.Ordinal,
+		Kind:         kind,
+		RootOID:      route.RootOID,
+		Source:       source,
+		Outcome:      outcome,
+		FailureClass: failureClass,
+		Rows:         route.Rows,
+		Values:       route.Values,
+		Missing:      route.Missing,
+		Rejected:     route.Rejected,
+	}, nil
+}
+
+func newTopologyDiagnosticArchiveProfileValuesV1(
+	values topologyAcquisitionProfileValues,
+) topologyDiagnosticArchiveProfileValuesV1 {
+	result := topologyDiagnosticArchiveProfileValuesV1{
+		Tags:      values.tags,
+		Metrics:   make([]topologyDiagnosticArchiveMetricValueV1, 0, len(values.metrics)),
+		BGPRows:   make([]topologyDiagnosticArchiveBGPRowValueV1, 0, len(values.bgpRows)),
+		BGPFailed: values.bgpFailed,
+	}
+	if values.metadata != nil {
+		result.Metadata = make(map[string]topologyDiagnosticArchiveMetaTagV1, len(values.metadata))
+		for key, value := range values.metadata {
+			result.Metadata[key] = topologyDiagnosticArchiveMetaTagV1{
+				Value:        value.Value,
+				IsExactMatch: value.IsExactMatch,
+			}
+		}
+	}
+	for _, metric := range values.metrics {
+		result.Metrics = append(result.Metrics, topologyDiagnosticArchiveMetricValueV1{
+			RouteOrdinal: metric.routeOrdinal,
+			RowOrdinal:   metric.rowOrdinal,
+			ValueOrdinal: metric.valueOrdinal,
+			Kind:         string(metric.kind),
+			Tags:         metric.tags,
+		})
+	}
+	for _, row := range values.bgpRows {
+		result.BGPRows = append(result.BGPRows, topologyDiagnosticArchiveBGPRowValueV1{
+			RouteOrdinal:    row.routeOrdinal,
+			RowOrdinal:      row.rowOrdinal,
+			ValueOrdinal:    row.valueOrdinal,
+			OriginProfileID: row.originProfileID,
+			Table:           row.table,
+			RowKey:          row.rowKey,
+			StructuralID:    row.structuralID,
+			Kind:            string(row.kind),
+			RoutingInstance: row.routingInstance,
+			Neighbor:        row.neighbor,
+			RemoteAS:        row.remoteAS,
+			LocalAddress:    row.localAddress,
+			LocalAS:         row.localAS,
+			LocalIdentifier: row.localIdentifier,
+			PeerIdentifier:  row.peerIdentifier,
+			PeerType:        row.peerType,
+			BGPVersion:      row.bgpVersion,
+			Description:     row.description,
+			AdminHas:        row.adminHas,
+			AdminEnabled:    row.adminEnabled,
+			StateHas:        row.stateHas,
+			State:           string(row.state),
+			StateRaw:        row.stateRaw,
+			EstablishedHas:  row.establishedHas,
+			Established:     row.established,
+			UpdateAgeHas:    row.updateAgeHas,
+			UpdateAge:       row.updateAge,
+			Tags:            row.tags,
+		})
+	}
+	return result
+}
+
+func newTopologyDiagnosticArchiveCollectionStatsV1(
+	stats ddsnmp.CollectionStats,
+) topologyDiagnosticArchiveCollectionStatsV1 {
+	return topologyDiagnosticArchiveCollectionStatsV1{
+		Timing: topologyDiagnosticArchiveTimingStatsV1{
+			ScalarNanos:         int64(stats.Timing.Scalar),
+			TableNanos:          int64(stats.Timing.Table),
+			LicensingNanos:      int64(stats.Timing.Licensing),
+			BGPNanos:            int64(stats.Timing.BGP),
+			VirtualMetricsNanos: int64(stats.Timing.VirtualMetrics),
+		},
+		SNMP: topologyDiagnosticArchiveSNMPStatsV1{
+			GetRequests:  stats.SNMP.GetRequests,
+			GetOIDs:      stats.SNMP.GetOIDs,
+			WalkRequests: stats.SNMP.WalkRequests,
+			WalkPDUs:     stats.SNMP.WalkPDUs,
+			TablesWalked: stats.SNMP.TablesWalked,
+			TablesCached: stats.SNMP.TablesCached,
+		},
+		Metrics: topologyDiagnosticArchiveMetricStatsV1{
+			Scalar:    stats.Metrics.Scalar,
+			Table:     stats.Metrics.Table,
+			Virtual:   stats.Metrics.Virtual,
+			Licensing: stats.Metrics.Licensing,
+			BGP:       stats.Metrics.BGP,
+			Tables:    stats.Metrics.Tables,
+			Rows:      stats.Metrics.Rows,
+		},
+		TableCache: topologyDiagnosticArchiveTableCacheStatsV1{
+			Hits:   stats.TableCache.Hits,
+			Misses: stats.TableCache.Misses,
+		},
+		Errors: topologyDiagnosticArchiveErrorStatsV1{
+			SNMP:                stats.Errors.SNMP,
+			ProcessingScalar:    stats.Errors.Processing.Scalar,
+			ProcessingTable:     stats.Errors.Processing.Table,
+			ProcessingLicensing: stats.Errors.Processing.Licensing,
+			ProcessingBGP:       stats.Errors.Processing.BGP,
+			MissingOIDs:         stats.Errors.MissingOIDs,
+		},
+	}
+}
+
+func (e topologyDiagnosticArchiveAcquisitionEvidenceV1) evidence(
+	id topologyAcquisitionAttemptID,
+) (*topologyAcquisitionAttemptEvidence, error) {
+	targetOutcome, err := topologyDiagnosticArchiveParseTargetOutcome(e.Target.Outcome)
+	if err != nil {
+		return nil, err
+	}
+	var addresses []netip.Addr
+	if len(e.Target.Addresses) > 0 {
+		addresses = make([]netip.Addr, 0, len(e.Target.Addresses))
+	}
+	for _, raw := range e.Target.Addresses {
+		address, err := netip.ParseAddr(raw)
+		if err != nil {
+			return nil, fmt.Errorf("target address %q: %w", raw, err)
+		}
+		addresses = append(addresses, address)
+	}
+	client, err := e.Client.phase()
+	if err != nil {
+		return nil, fmt.Errorf("client phase: %w", err)
+	}
+	connect, err := e.Connect.phase()
+	if err != nil {
+		return nil, fmt.Errorf("connect phase: %w", err)
+	}
+	profiles, err := e.Profiles.phase()
+	if err != nil {
+		return nil, fmt.Errorf("profiles phase: %w", err)
+	}
+	collection, err := e.Collection.phase()
+	if err != nil {
+		return nil, fmt.Errorf("collection phase: %w", err)
+	}
+	sysUptime, err := e.SysUptime.phase()
+	if err != nil {
+		return nil, fmt.Errorf("sys_uptime phase: %w", err)
+	}
+	vlanProfiles, err := e.VLANProfiles.phase()
+	if err != nil {
+		return nil, fmt.Errorf("vlan_profiles phase: %w", err)
+	}
+	result := &topologyAcquisitionAttemptEvidence{
+		id: id,
+		device: topologySemanticDeviceInput{
+			hostname:    e.Device.Hostname,
+			sysObjectID: e.Device.SysObjectID,
+			sysName:     e.Device.SysName,
+			sysDescr:    e.Device.SysDescr,
+			sysContact:  e.Device.SysContact,
+			sysLocation: e.Device.SysLocation,
+			vendor:      e.Device.Vendor,
+			model:       e.Device.Model,
+			vnodeGUID:   e.Device.VnodeGUID,
+			vnodeLabels: e.Device.VnodeLabels,
+		},
+		target: topologyTargetResolutionEvidence{
+			outcome:   targetOutcome,
+			addresses: addresses,
+		},
+		client:             client,
+		connect:            connect,
+		profiles:           profiles,
+		collection:         collection,
+		sysUptime:          sysUptime,
+		vlanProfiles:       vlanProfiles,
+		collectedAt:        e.CollectedAt,
+		freshFor:           time.Duration(e.FreshForNanos),
+		sysUptimeValue:     e.SysUptimeValue,
+		collectionContexts: make([]topologyAcquisitionContextEvidence, 0, len(e.CollectionContexts)),
+	}
+	for _, context := range e.CollectionContexts {
+		reconstructed, err := context.context()
+		if err != nil {
+			return nil, fmt.Errorf("collection context %d: %w", context.Ordinal, err)
+		}
+		result.collectionContexts = append(result.collectionContexts, reconstructed)
+	}
+	return result, nil
+}
+
+func (c topologyDiagnosticArchiveContextEvidenceV1) context() (topologyAcquisitionContextEvidence, error) {
+	client, err := c.Client.phase()
+	if err != nil {
+		return topologyAcquisitionContextEvidence{}, fmt.Errorf("client phase: %w", err)
+	}
+	connect, err := c.Connect.phase()
+	if err != nil {
+		return topologyAcquisitionContextEvidence{}, fmt.Errorf("connect phase: %w", err)
+	}
+	collection, err := c.Collection.phase()
+	if err != nil {
+		return topologyAcquisitionContextEvidence{}, fmt.Errorf("collection phase: %w", err)
+	}
+	result := topologyAcquisitionContextEvidence{
+		ordinal:    c.Ordinal,
+		vlanID:     c.VLANID,
+		vlanName:   c.VLANName,
+		client:     client,
+		connect:    connect,
+		collection: collection,
+		profiles:   make([]topologyAcquisitionProfileEvidence, 0, len(c.Profiles)),
+	}
+	for _, profile := range c.Profiles {
+		reconstructed, err := profile.profile()
+		if err != nil {
+			return topologyAcquisitionContextEvidence{}, fmt.Errorf("profile %d: %w", profile.Identity.Ordinal, err)
+		}
+		result.profiles = append(result.profiles, reconstructed)
+	}
+	return result, nil
+}
+
+func (p topologyDiagnosticArchiveProfileEvidenceV1) profile() (topologyAcquisitionProfileEvidence, error) {
+	digest, err := hex.DecodeString(p.Identity.RouteDigest)
+	if err != nil || len(digest) != 32 {
+		return topologyAcquisitionProfileEvidence{}, errors.New("route digest must be 32 bytes of hexadecimal")
+	}
+	var routeDigest [32]byte
+	copy(routeDigest[:], digest)
+	outcome, err := topologyDiagnosticArchiveParseProfileOutcome(p.Outcome)
+	if err != nil {
+		return topologyAcquisitionProfileEvidence{}, err
+	}
+	failurePhase, err := topologyDiagnosticArchiveParseProfileFailurePhase(p.FailurePhase)
+	if err != nil {
+		return topologyAcquisitionProfileEvidence{}, err
+	}
+	result := topologyAcquisitionProfileEvidence{
+		identity: ddsnmpcollector.AcquisitionProfileIdentity{
+			Ordinal:     p.Identity.Ordinal,
+			RouteDigest: routeDigest,
+		},
+		outcome:      outcome,
+		failurePhase: failurePhase,
+		stats:        p.Stats.stats(),
+		routes:       make([]ddsnmpcollector.AcquisitionRouteReport, 0, len(p.Routes)),
+	}
+	routeOrdinals := make(map[uint32]struct{}, len(p.Routes))
+	for _, route := range p.Routes {
+		if _, ok := routeOrdinals[route.Ordinal]; ok {
+			return topologyAcquisitionProfileEvidence{}, fmt.Errorf("duplicate route ordinal %d", route.Ordinal)
+		}
+		reconstructed, err := route.route()
+		if err != nil {
+			return topologyAcquisitionProfileEvidence{}, fmt.Errorf("route %d: %w", route.Ordinal, err)
+		}
+		routeOrdinals[route.Ordinal] = struct{}{}
+		result.routes = append(result.routes, reconstructed)
+	}
+	values, err := p.Values.values(routeOrdinals)
+	if err != nil {
+		return topologyAcquisitionProfileEvidence{}, err
+	}
+	result.values = values
+	return result, nil
+}
+
+func (r topologyDiagnosticArchiveRouteV1) route() (ddsnmpcollector.AcquisitionRouteReport, error) {
+	kind, err := topologyDiagnosticArchiveParseRouteKind(r.Kind)
+	if err != nil {
+		return ddsnmpcollector.AcquisitionRouteReport{}, err
+	}
+	source, err := topologyDiagnosticArchiveParseRouteSource(r.Source)
+	if err != nil {
+		return ddsnmpcollector.AcquisitionRouteReport{}, err
+	}
+	outcome, err := topologyDiagnosticArchiveParseRouteOutcome(r.Outcome)
+	if err != nil {
+		return ddsnmpcollector.AcquisitionRouteReport{}, err
+	}
+	failureClass, err := topologyDiagnosticArchiveParseRouteFailureClass(r.FailureClass)
+	if err != nil {
+		return ddsnmpcollector.AcquisitionRouteReport{}, err
+	}
+	return ddsnmpcollector.AcquisitionRouteReport{
+		Ordinal:      r.Ordinal,
+		Kind:         kind,
+		RootOID:      r.RootOID,
+		Source:       source,
+		Outcome:      outcome,
+		FailureClass: failureClass,
+		Rows:         r.Rows,
+		Values:       r.Values,
+		Missing:      r.Missing,
+		Rejected:     r.Rejected,
+	}, nil
+}
+
+func (v topologyDiagnosticArchiveProfileValuesV1) values(
+	routeOrdinals map[uint32]struct{},
+) (topologyAcquisitionProfileValues, error) {
+	result := topologyAcquisitionProfileValues{
+		tags:      v.Tags,
+		metrics:   make([]topologyAcquisitionMetricValue, 0, len(v.Metrics)),
+		bgpRows:   make([]topologyAcquisitionBGPRowValue, 0, len(v.BGPRows)),
+		bgpFailed: v.BGPFailed,
+	}
+	if v.Metadata != nil {
+		result.metadata = make(map[string]ddsnmp.MetaTag, len(v.Metadata))
+		for key, value := range v.Metadata {
+			result.metadata[key] = ddsnmp.MetaTag{Value: value.Value, IsExactMatch: value.IsExactMatch}
+		}
+	}
+	for _, metric := range v.Metrics {
+		if _, ok := routeOrdinals[metric.RouteOrdinal]; !ok {
+			return topologyAcquisitionProfileValues{}, fmt.Errorf("metric references unknown route ordinal %d", metric.RouteOrdinal)
+		}
+		kind := ddsnmp.TopologyKind(metric.Kind)
+		if !ddprofiledefinition.IsValidTopologyKind(kind) {
+			return topologyAcquisitionProfileValues{}, fmt.Errorf("unknown topology kind %q", metric.Kind)
+		}
+		result.metrics = append(result.metrics, topologyAcquisitionMetricValue{
+			routeOrdinal: metric.RouteOrdinal,
+			rowOrdinal:   metric.RowOrdinal,
+			valueOrdinal: metric.ValueOrdinal,
+			kind:         kind,
+			tags:         metric.Tags,
+		})
+	}
+	for _, row := range v.BGPRows {
+		if _, ok := routeOrdinals[row.RouteOrdinal]; !ok {
+			return topologyAcquisitionProfileValues{}, fmt.Errorf("BGP row references unknown route ordinal %d", row.RouteOrdinal)
+		}
+		kind := ddprofiledefinition.BGPRowKind(row.Kind)
+		if !ddprofiledefinition.IsValidBGPRowKind(kind) {
+			return topologyAcquisitionProfileValues{}, fmt.Errorf("unknown BGP row kind %q", row.Kind)
+		}
+		state := ddprofiledefinition.BGPPeerState(row.State)
+		if !ddprofiledefinition.IsValidBGPPeerState(state) {
+			return topologyAcquisitionProfileValues{}, fmt.Errorf("unknown BGP peer state %q", row.State)
+		}
+		result.bgpRows = append(result.bgpRows, topologyAcquisitionBGPRowValue{
+			routeOrdinal:    row.RouteOrdinal,
+			rowOrdinal:      row.RowOrdinal,
+			valueOrdinal:    row.ValueOrdinal,
+			originProfileID: row.OriginProfileID,
+			table:           row.Table,
+			rowKey:          row.RowKey,
+			structuralID:    row.StructuralID,
+			kind:            kind,
+			routingInstance: row.RoutingInstance,
+			neighbor:        row.Neighbor,
+			remoteAS:        row.RemoteAS,
+			localAddress:    row.LocalAddress,
+			localAS:         row.LocalAS,
+			localIdentifier: row.LocalIdentifier,
+			peerIdentifier:  row.PeerIdentifier,
+			peerType:        row.PeerType,
+			bgpVersion:      row.BGPVersion,
+			description:     row.Description,
+			adminHas:        row.AdminHas,
+			adminEnabled:    row.AdminEnabled,
+			stateHas:        row.StateHas,
+			state:           state,
+			stateRaw:        row.StateRaw,
+			establishedHas:  row.EstablishedHas,
+			established:     row.Established,
+			updateAgeHas:    row.UpdateAgeHas,
+			updateAge:       row.UpdateAge,
+			tags:            row.Tags,
+		})
+	}
+	return result, nil
+}
+
+func (s topologyDiagnosticArchiveCollectionStatsV1) stats() ddsnmp.CollectionStats {
+	var result ddsnmp.CollectionStats
+	result.Timing.Scalar = time.Duration(s.Timing.ScalarNanos)
+	result.Timing.Table = time.Duration(s.Timing.TableNanos)
+	result.Timing.Licensing = time.Duration(s.Timing.LicensingNanos)
+	result.Timing.BGP = time.Duration(s.Timing.BGPNanos)
+	result.Timing.VirtualMetrics = time.Duration(s.Timing.VirtualMetricsNanos)
+	result.SNMP.GetRequests = s.SNMP.GetRequests
+	result.SNMP.GetOIDs = s.SNMP.GetOIDs
+	result.SNMP.WalkRequests = s.SNMP.WalkRequests
+	result.SNMP.WalkPDUs = s.SNMP.WalkPDUs
+	result.SNMP.TablesWalked = s.SNMP.TablesWalked
+	result.SNMP.TablesCached = s.SNMP.TablesCached
+	result.Metrics.Scalar = s.Metrics.Scalar
+	result.Metrics.Table = s.Metrics.Table
+	result.Metrics.Virtual = s.Metrics.Virtual
+	result.Metrics.Licensing = s.Metrics.Licensing
+	result.Metrics.BGP = s.Metrics.BGP
+	result.Metrics.Tables = s.Metrics.Tables
+	result.Metrics.Rows = s.Metrics.Rows
+	result.TableCache.Hits = s.TableCache.Hits
+	result.TableCache.Misses = s.TableCache.Misses
+	result.Errors.SNMP = s.Errors.SNMP
+	result.Errors.Processing.Scalar = s.Errors.ProcessingScalar
+	result.Errors.Processing.Table = s.Errors.ProcessingTable
+	result.Errors.Processing.Licensing = s.Errors.ProcessingLicensing
+	result.Errors.Processing.BGP = s.Errors.ProcessingBGP
+	result.Errors.MissingOIDs = s.Errors.MissingOIDs
+	return result
+}
+
+func newTopologyDiagnosticArchivePhaseV1(
+	phase topologyAcquisitionPhaseEvidence,
+) (topologyDiagnosticArchivePhaseV1, error) {
+	outcome, err := topologyDiagnosticArchivePhaseOutcomeName(phase.outcome)
+	if err != nil {
+		return topologyDiagnosticArchivePhaseV1{}, err
+	}
+	failure, err := topologyDiagnosticArchivePhaseFailureName(phase.failure)
+	if err != nil {
+		return topologyDiagnosticArchivePhaseV1{}, err
+	}
+	return topologyDiagnosticArchivePhaseV1{Outcome: outcome, Failure: failure}, nil
+}
+
+func (p topologyDiagnosticArchivePhaseV1) phase() (topologyAcquisitionPhaseEvidence, error) {
+	outcome, err := topologyDiagnosticArchiveParsePhaseOutcome(p.Outcome)
+	if err != nil {
+		return topologyAcquisitionPhaseEvidence{}, err
+	}
+	failure, err := topologyDiagnosticArchiveParsePhaseFailure(p.Failure)
+	if err != nil {
+		return topologyAcquisitionPhaseEvidence{}, err
+	}
+	return topologyAcquisitionPhaseEvidence{outcome: outcome, failure: failure}, nil
+}
+
+var (
+	topologyDiagnosticArchiveTargetOutcomeNames = []string{
+		"unknown", "literal", "resolved", "empty", "unavailable", "failed",
+	}
+	topologyDiagnosticArchivePhaseOutcomeNames = []string{
+		"unknown", "success", "empty", "failed", "not_observed",
+	}
+	topologyDiagnosticArchivePhaseFailureNames = []string{
+		"none", "client_configuration", "connect", "collection", "sys_uptime", "vlan_identifier",
+	}
+	topologyDiagnosticArchiveProfileOutcomeNames = []string{
+		"unknown", "success", "partial", "failed",
+	}
+	topologyDiagnosticArchiveProfileFailurePhaseNames = []string{
+		"none", "prepare", "tables",
+	}
+	topologyDiagnosticArchiveRouteKindNames = []string{
+		"unknown", "profile_tag_scalar", "metadata_scalar", "topology_scalar", "topology_table",
+		"bgp_scalar", "bgp_table",
+	}
+	topologyDiagnosticArchiveRouteSourceNames = []string{
+		"none", "get", "walk", "cache",
+	}
+	topologyDiagnosticArchiveRouteOutcomeNames = []string{
+		"not_observed", "missing", "failed", "empty", "values", "rejected", "partial",
+	}
+	topologyDiagnosticArchiveRouteFailureClassNames = []string{
+		"none", "transport", "processing", "dependency",
+	}
+)
+
+func topologyDiagnosticArchiveTargetOutcomeName(value topologyTargetResolutionOutcome) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveTargetOutcomeNames)
+}
+
+func topologyDiagnosticArchiveParseTargetOutcome(value string) (topologyTargetResolutionOutcome, error) {
+	return topologyDiagnosticArchiveParseEnum[topologyTargetResolutionOutcome](value, topologyDiagnosticArchiveTargetOutcomeNames)
+}
+
+func topologyDiagnosticArchivePhaseOutcomeName(value topologyAcquisitionPhaseOutcome) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchivePhaseOutcomeNames)
+}
+
+func topologyDiagnosticArchiveParsePhaseOutcome(value string) (topologyAcquisitionPhaseOutcome, error) {
+	return topologyDiagnosticArchiveParseEnum[topologyAcquisitionPhaseOutcome](value, topologyDiagnosticArchivePhaseOutcomeNames)
+}
+
+func topologyDiagnosticArchivePhaseFailureName(value topologyAcquisitionFailureClass) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchivePhaseFailureNames)
+}
+
+func topologyDiagnosticArchiveParsePhaseFailure(value string) (topologyAcquisitionFailureClass, error) {
+	return topologyDiagnosticArchiveParseEnum[topologyAcquisitionFailureClass](value, topologyDiagnosticArchivePhaseFailureNames)
+}
+
+func topologyDiagnosticArchiveProfileOutcomeName(value ddsnmpcollector.AcquisitionProfileOutcome) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveProfileOutcomeNames)
+}
+
+func topologyDiagnosticArchiveParseProfileOutcome(value string) (ddsnmpcollector.AcquisitionProfileOutcome, error) {
+	return topologyDiagnosticArchiveParseEnum[ddsnmpcollector.AcquisitionProfileOutcome](value, topologyDiagnosticArchiveProfileOutcomeNames)
+}
+
+func topologyDiagnosticArchiveProfileFailurePhaseName(value ddsnmpcollector.AcquisitionFailurePhase) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveProfileFailurePhaseNames)
+}
+
+func topologyDiagnosticArchiveParseProfileFailurePhase(value string) (ddsnmpcollector.AcquisitionFailurePhase, error) {
+	return topologyDiagnosticArchiveParseEnum[ddsnmpcollector.AcquisitionFailurePhase](value, topologyDiagnosticArchiveProfileFailurePhaseNames)
+}
+
+func topologyDiagnosticArchiveRouteKindName(value ddsnmpcollector.AcquisitionRouteKind) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveRouteKindNames)
+}
+
+func topologyDiagnosticArchiveParseRouteKind(value string) (ddsnmpcollector.AcquisitionRouteKind, error) {
+	return topologyDiagnosticArchiveParseEnum[ddsnmpcollector.AcquisitionRouteKind](value, topologyDiagnosticArchiveRouteKindNames)
+}
+
+func topologyDiagnosticArchiveRouteSourceName(value ddsnmpcollector.AcquisitionRouteSource) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveRouteSourceNames)
+}
+
+func topologyDiagnosticArchiveParseRouteSource(value string) (ddsnmpcollector.AcquisitionRouteSource, error) {
+	return topologyDiagnosticArchiveParseEnum[ddsnmpcollector.AcquisitionRouteSource](value, topologyDiagnosticArchiveRouteSourceNames)
+}
+
+func topologyDiagnosticArchiveRouteOutcomeName(value ddsnmpcollector.AcquisitionRouteOutcome) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveRouteOutcomeNames)
+}
+
+func topologyDiagnosticArchiveParseRouteOutcome(value string) (ddsnmpcollector.AcquisitionRouteOutcome, error) {
+	return topologyDiagnosticArchiveParseEnum[ddsnmpcollector.AcquisitionRouteOutcome](value, topologyDiagnosticArchiveRouteOutcomeNames)
+}
+
+func topologyDiagnosticArchiveRouteFailureClassName(value ddsnmpcollector.AcquisitionFailureClass) (string, error) {
+	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveRouteFailureClassNames)
+}
+
+func topologyDiagnosticArchiveParseRouteFailureClass(value string) (ddsnmpcollector.AcquisitionFailureClass, error) {
+	return topologyDiagnosticArchiveParseEnum[ddsnmpcollector.AcquisitionFailureClass](value, topologyDiagnosticArchiveRouteFailureClassNames)
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
@@ -116,7 +116,7 @@ func BenchmarkSNMPTopologyDiagnosticArchiveEncoderLevel(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					if err := jsonv2.MarshalWrite(encoder, document, topologyDiagnosticArchiveJSONOptions); err != nil {
+					if err := jsonv2.MarshalWrite(encoder, document, topologyDiagnosticArchiveWriterJSONOptions); err != nil {
 						b.Fatal(err)
 					}
 					if err := encoder.Close(); err != nil {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
@@ -4,11 +4,9 @@ package snmptopology
 
 import (
 	"bytes"
-	"encoding/json/jsontext"
 	jsonv2 "encoding/json/v2"
 	"fmt"
 	"io"
-	"math"
 	"runtime"
 	"strings"
 	"testing"
@@ -29,14 +27,8 @@ func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
 		"maximum_records": func(tb testing.TB) topologyDiagnostics {
 			return benchmarkTopologyArchiveDiagnostics(tb, 3, 83_000, 8)
 		},
-		"maximum_array_allocation": func(tb testing.TB) topologyDiagnostics {
-			return benchmarkTopologyArchiveArrayAllocation(tb, 249_999)
-		},
 		"maximum_combined": func(tb testing.TB) topologyDiagnostics {
 			return benchmarkTopologyArchiveDiagnostics(tb, 3, 83_000, 215)
-		},
-		"maximum_map_entries": func(tb testing.TB) topologyDiagnostics {
-			return benchmarkTopologyArchiveMapCardinality(tb)
 		},
 		"maximum_logical_bytes": func(tb testing.TB) topologyDiagnostics {
 			return benchmarkTopologyArchiveDiagnostics(tb, 2, 7_500, 4_000)
@@ -58,7 +50,6 @@ func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
 			}
 			compressedBytes := encoded.Len()
 			decodedBytes := decodedTopologyDiagnosticArchiveSize(b, encoded.Bytes())
-			collectionCounts := topologyDiagnosticArchiveCollectionCountsForBenchmark(b, encoded.Bytes())
 			runtime.GC()
 			b.Run("write", func(b *testing.B) {
 				b.ReportAllocs()
@@ -72,16 +63,19 @@ func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
 						b.Fatal(err)
 					}
 				}
-				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes, collectionCounts)
+				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes)
 			})
 			b.Run("read", func(b *testing.B) {
 				b.ReportAllocs()
 				for b.Loop() {
-					if _, err := readTopologyDiagnosticArchive(bytes.NewReader(encoded.Bytes())); err != nil {
+					if _, err := readTopologyDiagnosticArchive(
+						bytes.NewReader(encoded.Bytes()),
+						defaultTopologyDiagnosticArchiveReadLimits(),
+					); err != nil {
 						b.Fatal(err)
 					}
 				}
-				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes, collectionCounts)
+				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes)
 			})
 		})
 	}
@@ -144,37 +138,14 @@ func decodedTopologyDiagnosticArchiveSize(tb testing.TB, encoded []byte) int {
 	return int(n)
 }
 
-func topologyDiagnosticArchiveCollectionCountsForBenchmark(
-	tb testing.TB,
-	encoded []byte,
-) topologyDiagnosticArchiveCollectionCounts {
-	tb.Helper()
-	var counts topologyDiagnosticArchiveCollectionCounts
-	limits := defaultTopologyDiagnosticArchiveLimits
-	limits.maxArrayAllocationBytes = math.MaxUint64
-	limits.maxMapEntries = math.MaxUint64
-	err := consumeTopologyDiagnosticArchiveJSON(encoded, limits, func(decoder *jsontext.Decoder) error {
-		var err error
-		counts, err = preflightTopologyDiagnosticArchiveJSON(decoder, limits)
-		return err
-	})
-	if err != nil {
-		tb.Fatal(err)
-	}
-	return counts
-}
-
 func reportTopologyDiagnosticArchiveSize(
 	b *testing.B,
 	decodedBytes int,
 	compressedBytes int,
-	counts topologyDiagnosticArchiveCollectionCounts,
 ) {
 	b.ReportMetric(float64(decodedBytes), "decoded_B")
 	b.ReportMetric(float64(compressedBytes), "compressed_B")
 	b.ReportMetric(float64(decodedBytes)/float64(compressedBytes), "compression_ratio")
-	b.ReportMetric(float64(counts.arrayAllocationBytes), "array_allocation_B")
-	b.ReportMetric(float64(counts.mapEntries), "map_entries")
 }
 
 func benchmarkTopologyArchiveDiagnostics(
@@ -311,96 +282,5 @@ func benchmarkTopologyArchiveDiagnosticsWithMetric(
 		},
 		producerScopeID: "benchmark-scope",
 		topology:        cut,
-	}
-}
-
-func benchmarkTopologyArchiveMapCardinality(tb testing.TB) topologyDiagnostics {
-	tb.Helper()
-	tags := map[string]string{
-		tagCdpIfIndex:               "",
-		tagCdpIfName:                "",
-		tagCdpDeviceIndex:           "",
-		tagCdpDeviceID:              "",
-		tagCdpAddressType:           "",
-		tagCdpDevicePort:            "",
-		tagCdpVersion:               "",
-		tagCdpPlatform:              "",
-		tagCdpCaps:                  "",
-		tagCdpAddress:               "",
-		tagCdpVTPDomain:             "",
-		tagCdpNativeVLAN:            "",
-		tagCdpDuplex:                "",
-		tagCdpPower:                 "",
-		tagCdpMTU:                   "",
-		tagCdpSysName:               "",
-		tagCdpSysObjectID:           "",
-		tagCdpPrimaryMgmtAddrType:   "",
-		tagCdpPrimaryMgmtAddr:       "",
-		tagCdpSecondaryMgmtAddrType: "",
-		tagCdpSecondaryMgmtAddr:     "",
-		tagCdpPhysicalLocation:      "",
-		tagCdpLastChange:            "",
-	}
-	logicalBytesPerMetric := uint64(len(ddsnmp.KindCdpCache)) + topologySemanticFilteredStringMapBytes(
-		tags,
-		func(key string) bool { return topologySemanticMetricTagAllowed(ddsnmp.KindCdpCache, key) },
-	)
-	perDeviceBudget := (defaultTopologyDiagnosticGlobalLimits.maxLogicalBytes-topologyDiagnosticCutLogicalBytes-
-		2*topologyDiagnosticRowLogicalBytes)/2 - 1_024
-	metricsPerDevice := min(
-		int(perDeviceBudget/logicalBytesPerMetric),
-		int(defaultTopologyAcquisitionLimits.maxRecords-4),
-	)
-	return benchmarkTopologyArchiveDiagnosticsWithMetric(
-		tb,
-		2,
-		metricsPerDevice,
-		ddsnmp.KindCdpCache,
-		func(int) map[string]string { return tags },
-	)
-}
-
-func benchmarkTopologyArchiveArrayAllocation(tb testing.TB, deviceCount int) topologyDiagnostics {
-	tb.Helper()
-	const sequence = uint64(1)
-	devices := make([]topologySweepDeviceDiagnostic, 0, deviceCount)
-	for index := range deviceCount {
-		registrationID := ddsnmp.DeviceRegistrationID(index + 1)
-		retained := &topologyAcquisitionCapture{
-			attemptID: topologyAcquisitionAttemptID{registrationID: registrationID, ordinal: 1},
-			state:     diagnosticCaptureUnavailable,
-			reason:    diagnosticCaptureReasonProjectionError,
-		}
-		latest := &topologyAcquisitionCapture{
-			attemptID: topologyAcquisitionAttemptID{registrationID: registrationID, ordinal: 2},
-			state:     diagnosticCaptureUnavailable,
-			reason:    diagnosticCaptureReasonProjectionError,
-		}
-		devices = append(devices, topologySweepDeviceDiagnostic{
-			registrationID: registrationID,
-			outcome:        deviceRefreshOutcomeFailed,
-			retainedSuccess: topologyEvidenceRef{
-				registrationID: registrationID,
-				generation:     sequence,
-			},
-			hasRetainedSuccess: true,
-			acquisition:        retained,
-			latestAttempt:      latest,
-		})
-	}
-	return topologyDiagnostics{
-		lifecycle: topologyJobLifecycleDiagnosticCut{
-			state:  diagnosticCaptureLimitExceeded,
-			reason: diagnosticCaptureReasonGlobalRecordLimit,
-		},
-		producerScopeID: "benchmark-scope",
-		topology: &topologySweepDiagnosticCut{
-			sequence:      sequence,
-			captureState:  diagnosticCaptureAvailable,
-			captureReason: diagnosticCaptureReasonNone,
-			recordCount:   uint64(deviceCount + 1),
-			logicalBytes:  topologyDiagnosticCutLogicalBytes + uint64(deviceCount)*topologyDiagnosticRowLogicalBytes,
-			devices:       devices,
-		},
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
@@ -4,9 +4,11 @@ package snmptopology
 
 import (
 	"bytes"
-	"encoding/json"
+	"encoding/json/jsontext"
+	jsonv2 "encoding/json/v2"
 	"fmt"
 	"io"
+	"math"
 	"runtime"
 	"strings"
 	"testing"
@@ -27,42 +29,50 @@ func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
 		"maximum_records": func(tb testing.TB) topologyDiagnostics {
 			return benchmarkTopologyArchiveDiagnostics(tb, 3, 83_000, 8)
 		},
+		"maximum_array_elements": func(tb testing.TB) topologyDiagnostics {
+			return benchmarkTopologyArchiveArrayCardinality(tb, 249_999)
+		},
 		"maximum_combined": func(tb testing.TB) topologyDiagnostics {
 			return benchmarkTopologyArchiveDiagnostics(tb, 3, 83_000, 215)
 		},
+		"maximum_map_entries": func(tb testing.TB) topologyDiagnostics {
+			return benchmarkTopologyArchiveMapCardinality(tb)
+		},
 		"maximum_logical_bytes": func(tb testing.TB) topologyDiagnostics {
 			return benchmarkTopologyArchiveDiagnostics(tb, 2, 7_500, 4_000)
+		},
+		"maximum_escaping": func(tb testing.TB) topologyDiagnostics {
+			return benchmarkTopologyArchiveDiagnosticsWithValue(tb, 2, 7_500, strings.Repeat("\x00", 4_000))
 		},
 	}
 	for name, build := range cases {
 		b.Run(name, func(b *testing.B) {
 			diagnostics := build(b)
 			var encoded bytes.Buffer
-			if err := writeTopologyDiagnosticArchiveWithLimits(
+			if err := writeTopologyDiagnosticArchiveWithProducerVersion(
 				&encoded,
 				diagnostics,
 				"v-benchmark",
-				defaultTopologyDiagnosticArchiveLimits,
 			); err != nil {
 				b.Fatal(err)
 			}
 			compressedBytes := encoded.Len()
 			decodedBytes := decodedTopologyDiagnosticArchiveSize(b, encoded.Bytes())
+			collectionCounts := topologyDiagnosticArchiveCollectionCountsForBenchmark(b, encoded.Bytes())
 			runtime.GC()
 			b.Run("write", func(b *testing.B) {
 				b.ReportAllocs()
 				for b.Loop() {
 					var target bytes.Buffer
-					if err := writeTopologyDiagnosticArchiveWithLimits(
+					if err := writeTopologyDiagnosticArchiveWithProducerVersion(
 						&target,
 						diagnostics,
 						"v-benchmark",
-						defaultTopologyDiagnosticArchiveLimits,
 					); err != nil {
 						b.Fatal(err)
 					}
 				}
-				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes)
+				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes, collectionCounts)
 			})
 			b.Run("read", func(b *testing.B) {
 				b.ReportAllocs()
@@ -71,7 +81,7 @@ func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
 						b.Fatal(err)
 					}
 				}
-				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes)
+				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes, collectionCounts)
 			})
 		})
 	}
@@ -106,9 +116,7 @@ func BenchmarkSNMPTopologyDiagnosticArchiveEncoderLevel(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					jsonEncoder := json.NewEncoder(encoder)
-					jsonEncoder.SetEscapeHTML(false)
-					if err := jsonEncoder.Encode(document); err != nil {
+					if err := jsonv2.MarshalWrite(encoder, document, topologyDiagnosticArchiveJSONOptions); err != nil {
 						b.Fatal(err)
 					}
 					if err := encoder.Close(); err != nil {
@@ -136,10 +144,37 @@ func decodedTopologyDiagnosticArchiveSize(tb testing.TB, encoded []byte) int {
 	return int(n)
 }
 
-func reportTopologyDiagnosticArchiveSize(b *testing.B, decodedBytes, compressedBytes int) {
+func topologyDiagnosticArchiveCollectionCountsForBenchmark(
+	tb testing.TB,
+	encoded []byte,
+) topologyDiagnosticArchiveCollectionCounts {
+	tb.Helper()
+	var counts topologyDiagnosticArchiveCollectionCounts
+	limits := defaultTopologyDiagnosticArchiveLimits
+	limits.maxArrayElements = math.MaxUint64
+	limits.maxMapEntries = math.MaxUint64
+	err := consumeTopologyDiagnosticArchiveJSON(encoded, limits, func(decoder *jsontext.Decoder) error {
+		var err error
+		counts, err = preflightTopologyDiagnosticArchiveJSON(decoder, limits)
+		return err
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return counts
+}
+
+func reportTopologyDiagnosticArchiveSize(
+	b *testing.B,
+	decodedBytes int,
+	compressedBytes int,
+	counts topologyDiagnosticArchiveCollectionCounts,
+) {
 	b.ReportMetric(float64(decodedBytes), "decoded_B")
 	b.ReportMetric(float64(compressedBytes), "compressed_B")
 	b.ReportMetric(float64(decodedBytes)/float64(compressedBytes), "compression_ratio")
+	b.ReportMetric(float64(counts.arrayElements), "array_elements")
+	b.ReportMetric(float64(counts.mapEntries), "map_entries")
 }
 
 func benchmarkTopologyArchiveDiagnostics(
@@ -149,14 +184,44 @@ func benchmarkTopologyArchiveDiagnostics(
 	tagValueBytes int,
 ) topologyDiagnostics {
 	tb.Helper()
+	return benchmarkTopologyArchiveDiagnosticsWithValue(tb, deviceCount, metricsPerDevice, strings.Repeat("x", tagValueBytes))
+}
+
+func benchmarkTopologyArchiveDiagnosticsWithValue(
+	tb testing.TB,
+	deviceCount int,
+	metricsPerDevice int,
+	value string,
+) topologyDiagnostics {
+	tb.Helper()
+	return benchmarkTopologyArchiveDiagnosticsWithMetric(
+		tb,
+		deviceCount,
+		metricsPerDevice,
+		ddsnmp.KindIfName,
+		func(index int) map[string]string {
+			return map[string]string{
+				tagTopoIfIndex: fmt.Sprintf("%d", index+1),
+				tagTopoIfName:  value,
+			}
+		},
+	)
+}
+
+func benchmarkTopologyArchiveDiagnosticsWithMetric(
+	tb testing.TB,
+	deviceCount int,
+	metricsPerDevice int,
+	kind ddsnmp.TopologyKind,
+	metricTags func(int) map[string]string,
+) topologyDiagnostics {
+	tb.Helper()
 	const sequence = uint64(1)
 	publishedAt := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
 	entries := make([]ddsnmp.DeviceEntry, 0, deviceCount)
 	states := make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState, deviceCount)
 	selected := make(map[ddsnmp.DeviceRegistrationID]bool, deviceCount)
 	seen := make(map[ddsnmp.DeviceRegistrationID]bool, deviceCount)
-	value := strings.Repeat("x", tagValueBytes)
-
 	for deviceIndex := range deviceCount {
 		registrationID := ddsnmp.DeviceRegistrationID(deviceIndex + 1)
 		hostname := fmt.Sprintf("192.0.2.%d", registrationID)
@@ -165,11 +230,8 @@ func benchmarkTopologyArchiveDiagnostics(
 		references := make([]ddsnmpcollector.AcquisitionValueReference, 0, metricsPerDevice)
 		for metricIndex := range metricsPerDevice {
 			metrics = append(metrics, ddsnmp.Metric{
-				TopologyKind: ddsnmp.KindIfName,
-				Tags: map[string]string{
-					tagTopoIfIndex: fmt.Sprintf("%d", metricIndex+1),
-					tagTopoIfName:  value,
-				},
+				TopologyKind: kind,
+				Tags:         metricTags(metricIndex),
 			})
 			references = append(references, ddsnmpcollector.AcquisitionValueReference{
 				RouteOrdinal: 0,
@@ -249,5 +311,96 @@ func benchmarkTopologyArchiveDiagnostics(
 		},
 		producerScopeID: "benchmark-scope",
 		topology:        cut,
+	}
+}
+
+func benchmarkTopologyArchiveMapCardinality(tb testing.TB) topologyDiagnostics {
+	tb.Helper()
+	tags := map[string]string{
+		tagCdpIfIndex:               "",
+		tagCdpIfName:                "",
+		tagCdpDeviceIndex:           "",
+		tagCdpDeviceID:              "",
+		tagCdpAddressType:           "",
+		tagCdpDevicePort:            "",
+		tagCdpVersion:               "",
+		tagCdpPlatform:              "",
+		tagCdpCaps:                  "",
+		tagCdpAddress:               "",
+		tagCdpVTPDomain:             "",
+		tagCdpNativeVLAN:            "",
+		tagCdpDuplex:                "",
+		tagCdpPower:                 "",
+		tagCdpMTU:                   "",
+		tagCdpSysName:               "",
+		tagCdpSysObjectID:           "",
+		tagCdpPrimaryMgmtAddrType:   "",
+		tagCdpPrimaryMgmtAddr:       "",
+		tagCdpSecondaryMgmtAddrType: "",
+		tagCdpSecondaryMgmtAddr:     "",
+		tagCdpPhysicalLocation:      "",
+		tagCdpLastChange:            "",
+	}
+	logicalBytesPerMetric := uint64(len(ddsnmp.KindCdpCache)) + topologySemanticFilteredStringMapBytes(
+		tags,
+		func(key string) bool { return topologySemanticMetricTagAllowed(ddsnmp.KindCdpCache, key) },
+	)
+	perDeviceBudget := (defaultTopologyDiagnosticGlobalLimits.maxLogicalBytes-topologyDiagnosticCutLogicalBytes-
+		2*topologyDiagnosticRowLogicalBytes)/2 - 1_024
+	metricsPerDevice := min(
+		int(perDeviceBudget/logicalBytesPerMetric),
+		int(defaultTopologyAcquisitionLimits.maxRecords-4),
+	)
+	return benchmarkTopologyArchiveDiagnosticsWithMetric(
+		tb,
+		2,
+		metricsPerDevice,
+		ddsnmp.KindCdpCache,
+		func(int) map[string]string { return tags },
+	)
+}
+
+func benchmarkTopologyArchiveArrayCardinality(tb testing.TB, deviceCount int) topologyDiagnostics {
+	tb.Helper()
+	const sequence = uint64(1)
+	devices := make([]topologySweepDeviceDiagnostic, 0, deviceCount)
+	for index := range deviceCount {
+		registrationID := ddsnmp.DeviceRegistrationID(index + 1)
+		retained := &topologyAcquisitionCapture{
+			attemptID: topologyAcquisitionAttemptID{registrationID: registrationID, ordinal: 1},
+			state:     diagnosticCaptureUnavailable,
+			reason:    diagnosticCaptureReasonProjectionError,
+		}
+		latest := &topologyAcquisitionCapture{
+			attemptID: topologyAcquisitionAttemptID{registrationID: registrationID, ordinal: 2},
+			state:     diagnosticCaptureUnavailable,
+			reason:    diagnosticCaptureReasonProjectionError,
+		}
+		devices = append(devices, topologySweepDeviceDiagnostic{
+			registrationID: registrationID,
+			outcome:        deviceRefreshOutcomeFailed,
+			retainedSuccess: topologyEvidenceRef{
+				registrationID: registrationID,
+				generation:     sequence,
+			},
+			hasRetainedSuccess: true,
+			acquisition:        retained,
+			latestAttempt:      latest,
+		})
+	}
+	return topologyDiagnostics{
+		lifecycle: topologyJobLifecycleDiagnosticCut{
+			state:  diagnosticCaptureLimitExceeded,
+			reason: diagnosticCaptureReasonGlobalRecordLimit,
+		},
+		producerScopeID: "benchmark-scope",
+		topology: &topologySweepDiagnosticCut{
+			sequence:      sequence,
+			captureState:  diagnosticCaptureAvailable,
+			captureReason: diagnosticCaptureReasonNone,
+			recordCount:   uint64(deviceCount + 1),
+			logicalBytes:  topologyDiagnosticCutLogicalBytes + uint64(deviceCount)*topologyDiagnosticRowLogicalBytes,
+			devices:       devices,
+		},
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+)
+
+func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
+	cases := map[string]func(testing.TB) topologyDiagnostics{
+		"representative": func(tb testing.TB) topologyDiagnostics {
+			_, diagnostics := newTopologyScenarioReplayFixture(tb, newMixedL2L3ControlScenario())
+			completeTopologyDiagnosticArchiveFixture(&diagnostics)
+			return diagnostics
+		},
+		"maximum_records": func(tb testing.TB) topologyDiagnostics {
+			return benchmarkTopologyArchiveDiagnostics(tb, 3, 83_000, 8)
+		},
+		"maximum_combined": func(tb testing.TB) topologyDiagnostics {
+			return benchmarkTopologyArchiveDiagnostics(tb, 3, 83_000, 215)
+		},
+		"maximum_logical_bytes": func(tb testing.TB) topologyDiagnostics {
+			return benchmarkTopologyArchiveDiagnostics(tb, 2, 7_500, 4_000)
+		},
+	}
+	for name, build := range cases {
+		b.Run(name, func(b *testing.B) {
+			diagnostics := build(b)
+			var encoded bytes.Buffer
+			if err := writeTopologyDiagnosticArchiveWithLimits(
+				&encoded,
+				diagnostics,
+				"v-benchmark",
+				defaultTopologyDiagnosticArchiveLimits,
+			); err != nil {
+				b.Fatal(err)
+			}
+			compressedBytes := encoded.Len()
+			decodedBytes := decodedTopologyDiagnosticArchiveSize(b, encoded.Bytes())
+			runtime.GC()
+			b.Run("write", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					var target bytes.Buffer
+					if err := writeTopologyDiagnosticArchiveWithLimits(
+						&target,
+						diagnostics,
+						"v-benchmark",
+						defaultTopologyDiagnosticArchiveLimits,
+					); err != nil {
+						b.Fatal(err)
+					}
+				}
+				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes)
+			})
+			b.Run("read", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, err := readTopologyDiagnosticArchive(bytes.NewReader(encoded.Bytes())); err != nil {
+						b.Fatal(err)
+					}
+				}
+				reportTopologyDiagnosticArchiveSize(b, decodedBytes, compressedBytes)
+			})
+		})
+	}
+}
+
+func BenchmarkSNMPTopologyDiagnosticArchiveEncoderLevel(b *testing.B) {
+	cases := map[string]topologyDiagnostics{}
+	_, cases["representative"] = newTopologyScenarioReplayFixture(b, newMixedL2L3ControlScenario())
+	cases["maximum_combined"] = benchmarkTopologyArchiveDiagnostics(b, 3, 83_000, 215)
+	levels := map[string]zstd.EncoderLevel{
+		"fastest": zstd.SpeedFastest,
+		"default": zstd.SpeedDefault,
+		"better":  zstd.SpeedBetterCompression,
+	}
+	for shape, diagnostics := range cases {
+		document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-benchmark")
+		if err != nil {
+			b.Fatal(err)
+		}
+		for name, level := range levels {
+			b.Run(shape+"/"+name, func(b *testing.B) {
+				var compressedBytes int
+				b.ReportAllocs()
+				for b.Loop() {
+					var target bytes.Buffer
+					encoder, err := zstd.NewWriter(
+						&target,
+						zstd.WithEncoderLevel(level),
+						zstd.WithEncoderConcurrency(1),
+						zstd.WithEncoderCRC(true),
+					)
+					if err != nil {
+						b.Fatal(err)
+					}
+					jsonEncoder := json.NewEncoder(encoder)
+					jsonEncoder.SetEscapeHTML(false)
+					if err := jsonEncoder.Encode(document); err != nil {
+						b.Fatal(err)
+					}
+					if err := encoder.Close(); err != nil {
+						b.Fatal(err)
+					}
+					compressedBytes = target.Len()
+				}
+				b.ReportMetric(float64(compressedBytes), "compressed_B")
+			})
+		}
+	}
+}
+
+func decodedTopologyDiagnosticArchiveSize(tb testing.TB, encoded []byte) int {
+	tb.Helper()
+	decoder, err := zstd.NewReader(bytes.NewReader(encoded), zstd.WithDecoderConcurrency(1))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	n, err := io.Copy(io.Discard, decoder)
+	decoder.Close()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return int(n)
+}
+
+func reportTopologyDiagnosticArchiveSize(b *testing.B, decodedBytes, compressedBytes int) {
+	b.ReportMetric(float64(decodedBytes), "decoded_B")
+	b.ReportMetric(float64(compressedBytes), "compressed_B")
+	b.ReportMetric(float64(decodedBytes)/float64(compressedBytes), "compression_ratio")
+}
+
+func benchmarkTopologyArchiveDiagnostics(
+	tb testing.TB,
+	deviceCount int,
+	metricsPerDevice int,
+	tagValueBytes int,
+) topologyDiagnostics {
+	tb.Helper()
+	const sequence = uint64(1)
+	publishedAt := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	entries := make([]ddsnmp.DeviceEntry, 0, deviceCount)
+	states := make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState, deviceCount)
+	selected := make(map[ddsnmp.DeviceRegistrationID]bool, deviceCount)
+	seen := make(map[ddsnmp.DeviceRegistrationID]bool, deviceCount)
+	value := strings.Repeat("x", tagValueBytes)
+
+	for deviceIndex := range deviceCount {
+		registrationID := ddsnmp.DeviceRegistrationID(deviceIndex + 1)
+		hostname := fmt.Sprintf("192.0.2.%d", registrationID)
+		info := ddsnmp.DeviceConnectionInfo{Hostname: hostname, SysName: fmt.Sprintf("switch-%d", registrationID)}
+		metrics := make([]ddsnmp.Metric, 0, metricsPerDevice)
+		references := make([]ddsnmpcollector.AcquisitionValueReference, 0, metricsPerDevice)
+		for metricIndex := range metricsPerDevice {
+			metrics = append(metrics, ddsnmp.Metric{
+				TopologyKind: ddsnmp.KindIfName,
+				Tags: map[string]string{
+					tagTopoIfIndex: fmt.Sprintf("%d", metricIndex+1),
+					tagTopoIfName:  value,
+				},
+			})
+			references = append(references, ddsnmpcollector.AcquisitionValueReference{
+				RouteOrdinal: 0,
+				RowOrdinal:   uint32(metricIndex),
+			})
+		}
+		profileMetrics := &ddsnmp.ProfileMetrics{TopologyMetrics: metrics}
+		recorder := newTopologyAcquisitionRecorder(
+			topologyAcquisitionAttemptID{registrationID: registrationID, ordinal: 1},
+			topologySemanticDeviceInputFromConnection(info),
+			topologyTargetResolutionEvidence{outcome: topologyTargetResolutionEmpty},
+			defaultTopologyAcquisitionLimits,
+		)
+		observer := recorder.beginContext(0, "", "")
+		observer.ObserveProfile(ddsnmpcollector.AcquisitionProfileReport{
+			Identity: ddsnmpcollector.AcquisitionProfileIdentity{Ordinal: 0},
+			Outcome:  ddsnmpcollector.AcquisitionProfileOutcomeSuccess,
+			Routes: []ddsnmpcollector.AcquisitionRouteReport{{
+				Ordinal: 0,
+				Kind:    ddsnmpcollector.AcquisitionRouteKindTopologyTable,
+				Source:  ddsnmpcollector.AcquisitionRouteSourceWalk,
+				Outcome: ddsnmpcollector.AcquisitionRouteOutcomeValues,
+				Rows:    uint64(metricsPerDevice),
+				Values:  uint64(metricsPerDevice),
+			}},
+			TopologyValueReferences: references,
+		}, profileMetrics)
+		recorder.completeContext(0, successfulAcquisitionPhase())
+		recorder.setCollectedShape(publishedAt, time.Hour, 3600)
+		capture := recorder.finish()
+		if capture.state != diagnosticCaptureAvailable {
+			tb.Fatalf("benchmark capture %d is unavailable: state=%d reason=%d records=%d bytes=%d",
+				registrationID, capture.state, capture.reason, capture.recordCount, capture.logicalBytes)
+		}
+		snapshot := &topologyDeviceSnapshot{
+			collectedAt: publishedAt,
+			freshFor:    time.Hour,
+			acquisition: capture,
+		}
+		generation := activateTopologyDeviceSnapshot(registrationID, sequence, publishedAt, snapshot)
+		states[registrationID] = deviceRefreshState{
+			generation:    generation,
+			latestAttempt: capture,
+			lastAttempt:   publishedAt,
+			lastSuccess:   publishedAt,
+			outcome:       deviceRefreshOutcomeSuccess,
+		}
+		entries = append(entries, ddsnmp.DeviceEntry{RegistrationID: registrationID, Info: info})
+		selected[registrationID] = true
+		seen[registrationID] = true
+	}
+	cut, err := projectTopologyDiagnosticCut(topologyDiagnosticCutInput{
+		sequence:    sequence,
+		startedAt:   publishedAt.Add(-time.Minute),
+		publishedAt: publishedAt,
+		entries:     entries,
+		selected:    selected,
+		seen:        seen,
+		states:      states,
+		limits:      defaultTopologyDiagnosticGlobalLimits,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if cut.captureState != diagnosticCaptureAvailable {
+		tb.Fatalf("benchmark cut is unavailable: state=%d reason=%d records=%d bytes=%d",
+			cut.captureState, cut.captureReason, cut.recordCount, cut.logicalBytes)
+	}
+	return topologyDiagnostics{
+		lifecycle: topologyJobLifecycleDiagnosticCut{
+			state:  diagnosticCaptureAvailable,
+			reason: diagnosticCaptureReasonNone,
+			cut: ddsnmp.DeviceLifecycleCut{
+				Sequence:   1,
+				CapturedAt: publishedAt,
+			},
+		},
+		producerScopeID: "benchmark-scope",
+		topology:        cut,
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
@@ -29,8 +29,8 @@ func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
 		"maximum_records": func(tb testing.TB) topologyDiagnostics {
 			return benchmarkTopologyArchiveDiagnostics(tb, 3, 83_000, 8)
 		},
-		"maximum_array_elements": func(tb testing.TB) topologyDiagnostics {
-			return benchmarkTopologyArchiveArrayCardinality(tb, 249_999)
+		"maximum_array_allocation": func(tb testing.TB) topologyDiagnostics {
+			return benchmarkTopologyArchiveArrayAllocation(tb, 249_999)
 		},
 		"maximum_combined": func(tb testing.TB) topologyDiagnostics {
 			return benchmarkTopologyArchiveDiagnostics(tb, 3, 83_000, 215)
@@ -151,7 +151,7 @@ func topologyDiagnosticArchiveCollectionCountsForBenchmark(
 	tb.Helper()
 	var counts topologyDiagnosticArchiveCollectionCounts
 	limits := defaultTopologyDiagnosticArchiveLimits
-	limits.maxArrayElements = math.MaxUint64
+	limits.maxArrayAllocationBytes = math.MaxUint64
 	limits.maxMapEntries = math.MaxUint64
 	err := consumeTopologyDiagnosticArchiveJSON(encoded, limits, func(decoder *jsontext.Decoder) error {
 		var err error
@@ -173,7 +173,7 @@ func reportTopologyDiagnosticArchiveSize(
 	b.ReportMetric(float64(decodedBytes), "decoded_B")
 	b.ReportMetric(float64(compressedBytes), "compressed_B")
 	b.ReportMetric(float64(decodedBytes)/float64(compressedBytes), "compression_ratio")
-	b.ReportMetric(float64(counts.arrayElements), "array_elements")
+	b.ReportMetric(float64(counts.arrayAllocationBytes), "array_allocation_B")
 	b.ReportMetric(float64(counts.mapEntries), "map_entries")
 }
 
@@ -360,7 +360,7 @@ func benchmarkTopologyArchiveMapCardinality(tb testing.TB) topologyDiagnostics {
 	)
 }
 
-func benchmarkTopologyArchiveArrayCardinality(tb testing.TB, deviceCount int) topologyDiagnostics {
+func benchmarkTopologyArchiveArrayAllocation(tb testing.TB, deviceCount int) topologyDiagnostics {
 	tb.Helper()
 	const sequence = uint64(1)
 	devices := make([]topologySweepDeviceDiagnostic, 0, deviceCount)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
@@ -5,7 +5,9 @@ package snmptopology
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/json/jsontext"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"reflect"
@@ -241,10 +243,33 @@ func TestTopologyDiagnosticArchiveRejectsCompactArrayBeforeTypedDecode(t *testin
 		}
 	}`
 	limits := defaultTopologyDiagnosticArchiveLimits
-	limits.maxArrayElements = 64
+	limits.maxArrayAllocationBytes = 64 * uint64(reflect.TypeFor[topologyDiagnosticArchiveLifecycleEntryV1]().Size())
 
 	_, err := readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(compressArchiveJSON(t, raw)), limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayLimit)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayAllocationLimit)
+}
+
+func TestTopologyDiagnosticArchiveRejectsCompactWideArrayBeforeTypedDecode(t *testing.T) {
+	rowBytes := topologyDiagnosticArchiveCollectionFields["bgp_rows"].arrayElementBytes
+	require.NotZero(t, rowBytes)
+	rowCount := int(defaultTopologyDiagnosticArchiveLimits.maxArrayAllocationBytes/rowBytes) + 1
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newMixedL2L3ControlScenario())
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+	row := firstTopologyDiagnosticArchiveBGPRow(t, &document)
+	entry := fmt.Sprintf(`{"route_ordinal":%d,"kind":%q}`, row.RouteOrdinal, row.Kind)
+	raw := archiveDocumentJSON(t, document)
+	marker := `"bgp_rows":[`
+	start := strings.Index(raw, marker)
+	require.NotEqual(t, -1, start)
+	start += len(marker)
+	endOffset := strings.IndexByte(raw[start:], ']')
+	require.NotEqual(t, -1, endOffset)
+	rows := strings.Repeat(entry+",", rowCount)
+	raw = raw[:start] + rows[:len(rows)-1] + raw[start+endOffset:]
+
+	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, raw)))
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayAllocationLimit)
 }
 
 func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.T) {
@@ -292,9 +317,9 @@ func TestTopologyDiagnosticArchiveEnforcesOnlyTheFourReaderResourceBounds(t *tes
 	require.Contains(t, strings.ToLower(err.Error()), "window")
 
 	limits = defaultTopologyDiagnosticArchiveLimits
-	limits.maxArrayElements = 1
+	limits.maxArrayAllocationBytes = 1
 	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(encoded), limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayLimit)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayAllocationLimit)
 
 	require.NotNil(t, document.Snapshot.Topology)
 	require.NotEmpty(t, document.Snapshot.Topology.Devices)
@@ -359,7 +384,7 @@ func TestTopologyDiagnosticArchiveWriterPreservesV1StringSemantics(t *testing.T)
 
 func TestTopologyDiagnosticArchiveCollectionClassifierCoversDTO(t *testing.T) {
 	root := reflect.TypeFor[topologyDiagnosticArchiveDocumentV1]()
-	discovered := make(map[string]topologyDiagnosticArchiveContainerClass)
+	discovered := make(map[string]topologyDiagnosticArchiveCollectionField)
 	visited := make(map[reflect.Type]bool)
 	var arrays int
 	var maps int
@@ -379,15 +404,20 @@ func TestTopologyDiagnosticArchiveCollectionClassifierCoversDTO(t *testing.T) {
 			switch field.Type.Kind() {
 			case reflect.Slice:
 				arrays++
-				require.Equal(t, topologyDiagnosticArchiveContainerArray,
-					topologyDiagnosticArchiveCollectionFieldClass(name), "%s.%s", value, field.Name)
-				discovered[name] = topologyDiagnosticArchiveContainerArray
+				expected := topologyDiagnosticArchiveCollectionField{
+					class:             topologyDiagnosticArchiveContainerArray,
+					arrayElementBytes: uint64(field.Type.Elem().Size()),
+				}
+				require.Equal(t, expected,
+					topologyDiagnosticArchiveCollectionFieldDefinition(name), "%s.%s", value, field.Name)
+				discovered[name] = expected
 				visit(field.Type.Elem())
 			case reflect.Map:
 				maps++
-				require.Equal(t, topologyDiagnosticArchiveContainerMap,
-					topologyDiagnosticArchiveCollectionFieldClass(name), "%s.%s", value, field.Name)
-				discovered[name] = topologyDiagnosticArchiveContainerMap
+				expected := topologyDiagnosticArchiveCollectionField{class: topologyDiagnosticArchiveContainerMap}
+				require.Equal(t, expected,
+					topologyDiagnosticArchiveCollectionFieldDefinition(name), "%s.%s", value, field.Name)
+				discovered[name] = expected
 				visit(field.Type.Elem())
 			default:
 				visit(field.Type)
@@ -399,8 +429,23 @@ func TestTopologyDiagnosticArchiveCollectionClassifierCoversDTO(t *testing.T) {
 	require.Equal(t, 11, arrays)
 	require.Equal(t, 5, maps)
 	require.Equal(t, topologyDiagnosticArchiveCollectionFields, discovered)
-	require.Equal(t, topologyDiagnosticArchiveContainerArray,
-		topologyDiagnosticArchiveCollectionFieldClass("EnTrIeS"))
+	require.Equal(t, topologyDiagnosticArchiveCollectionFields["entries"],
+		topologyDiagnosticArchiveCollectionFieldDefinition("EnTrIeS"))
+}
+
+func TestTopologyDiagnosticArchivePreflightCountsAllocationClassesTogether(t *testing.T) {
+	const raw = `{"entries":[{},{}],"tags":{"site":"lab","zone":"a"}}`
+	limits := defaultTopologyDiagnosticArchiveLimits
+	counts, err := preflightTopologyDiagnosticArchiveJSON(
+		jsontext.NewDecoder(strings.NewReader(raw), topologyDiagnosticArchiveJSONOptions),
+		limits,
+	)
+	require.NoError(t, err)
+	require.Equal(t,
+		2*uint64(reflect.TypeFor[topologyDiagnosticArchiveLifecycleEntryV1]().Size()),
+		counts.arrayAllocationBytes,
+	)
+	require.Equal(t, uint64(2), counts.mapEntries)
 }
 
 func TestTopologyDiagnosticArchiveEnumTablesAreCompleteAndRoundTrip(t *testing.T) {
@@ -459,11 +504,11 @@ func FuzzReadTopologyDiagnosticArchive(f *testing.F) {
 	f.Add(seed)
 	f.Fuzz(func(t *testing.T, input []byte) {
 		limits := topologyDiagnosticArchiveLimits{
-			maxCompressedBytes: 1 << 20,
-			maxDecodedBytes:    4 << 20,
-			maxDecoderMemory:   1 << 20,
-			maxArrayElements:   1 << 20,
-			maxMapEntries:      1 << 20,
+			maxCompressedBytes:      1 << 20,
+			maxDecodedBytes:         4 << 20,
+			maxDecoderMemory:        1 << 20,
+			maxArrayAllocationBytes: 1 << 20,
+			maxMapEntries:           1 << 20,
 		}
 		_, _ = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(input), limits)
 	})

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
@@ -5,12 +5,9 @@ package snmptopology
 import (
 	"bytes"
 	"encoding/json"
-	"encoding/json/jsontext"
 	"errors"
-	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -33,7 +30,10 @@ func TestTopologyDiagnosticArchiveRoundTripPreservesReplayAndInspection(t *testi
 		diagnostics,
 		"v-test",
 	))
-	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(encoded.Bytes()))
+	archive, err := readTopologyDiagnosticArchive(
+		bytes.NewReader(encoded.Bytes()),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.NoError(t, err)
 	require.Equal(t, "v-test", archive.producerVersion)
 
@@ -81,7 +81,10 @@ func TestTopologyDiagnosticArchiveV1GoldenDocument(t *testing.T) {
 	raw, err := os.ReadFile("testdata/topology-diagnostic-archive-v1.json")
 	require.NoError(t, err)
 
-	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, string(raw))))
+	archive, err := readTopologyDiagnosticArchive(
+		bytes.NewReader(compressArchiveJSON(t, string(raw))),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.NoError(t, err)
 	require.Equal(t, "v1.2.3", archive.producerVersion)
 
@@ -143,7 +146,10 @@ func TestTopologyDiagnosticArchiveRejectsMalformedAndUnsupportedInput(t *testing
 			require.NoError(t, json.Unmarshal(encoded, &mutated))
 			tc.mutate(&mutated)
 
-			_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, mutated))))
+			_, err = readTopologyDiagnosticArchive(
+				bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, mutated))),
+				defaultTopologyDiagnosticArchiveReadLimits(),
+			)
 			require.ErrorContains(t, err, tc.want)
 		})
 	}
@@ -159,7 +165,10 @@ func TestTopologyDiagnosticArchivePreservesOpenBGPPeerState(t *testing.T) {
 	row.StateHas = true
 	row.State = state
 
-	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, document))))
+	archive, err := readTopologyDiagnosticArchive(
+		bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, document))),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.NoError(t, err)
 	restored, err := newTopologyDiagnosticArchiveDocumentV1(archive.diagnostics, archive.producerVersion)
 	require.NoError(t, err)
@@ -207,7 +216,10 @@ func TestTopologyDiagnosticArchiveRejectsRetainedReferenceCaptureMismatch(t *tes
 			device := &mutated.Snapshot.Topology.Devices[1]
 			mutate.mutate(device, mutated.Snapshot.Topology.Sequence)
 
-			_, err := readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, mutated))))
+			_, err := readTopologyDiagnosticArchive(
+				bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, mutated))),
+				defaultTopologyDiagnosticArchiveReadLimits(),
+			)
 			require.ErrorContains(t, err, mutate.want)
 		})
 	}
@@ -222,54 +234,11 @@ func TestTopologyDiagnosticArchiveRejectsDuplicateCaptureAttemptOrdinal(t *testi
 	require.Len(t, device.Captures, 2)
 	device.Captures[1].AttemptOrdinal = device.Captures[0].AttemptOrdinal
 
-	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, document))))
+	_, err = readTopologyDiagnosticArchive(
+		bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, document))),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.ErrorContains(t, err, "duplicate capture attempt ordinal")
-}
-
-func TestTopologyDiagnosticArchiveRejectsCompactArrayBeforeTypedDecode(t *testing.T) {
-	const entryCount = 129
-	raw := `{
-		"format":"netdata.snmp_topology.diagnostics",
-		"version":1,
-		"producer":{"agent_version":"v-test"},
-		"snapshot":{
-			"job_lifecycle_cut":{
-				"capture_state":"available",
-				"capture_reason":"none",
-				"cut":{"sequence":1,"captured_at":"2026-08-29T00:00:00Z","entries":[` +
-		strings.Repeat("{},", entryCount-1) + `{}` + `]}
-			},
-			"producer_scope_id":"scope"
-		}
-	}`
-	limits := defaultTopologyDiagnosticArchiveLimits
-	limits.maxArrayAllocationBytes = 64 * uint64(reflect.TypeFor[topologyDiagnosticArchiveLifecycleEntryV1]().Size())
-
-	_, err := readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(compressArchiveJSON(t, raw)), limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayAllocationLimit)
-}
-
-func TestTopologyDiagnosticArchiveRejectsCompactWideArrayBeforeTypedDecode(t *testing.T) {
-	rowBytes := topologyDiagnosticArchiveCollectionFields["bgp_rows"].arrayElementBytes
-	require.NotZero(t, rowBytes)
-	rowCount := int(defaultTopologyDiagnosticArchiveLimits.maxArrayAllocationBytes/rowBytes) + 1
-	_, diagnostics := newTopologyScenarioReplayFixture(t, newMixedL2L3ControlScenario())
-	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
-	require.NoError(t, err)
-	row := firstTopologyDiagnosticArchiveBGPRow(t, &document)
-	entry := fmt.Sprintf(`{"route_ordinal":%d,"kind":%q}`, row.RouteOrdinal, row.Kind)
-	raw := archiveDocumentJSON(t, document)
-	marker := `"bgp_rows":[`
-	start := strings.Index(raw, marker)
-	require.NotEqual(t, -1, start)
-	start += len(marker)
-	endOffset := strings.IndexByte(raw[start:], ']')
-	require.NotEqual(t, -1, endOffset)
-	rows := strings.Repeat(entry+",", rowCount)
-	raw = raw[:start] + rows[:len(rows)-1] + raw[start+endOffset:]
-
-	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, raw)))
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayAllocationLimit)
 }
 
 func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.T) {
@@ -278,62 +247,53 @@ func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.
 	require.NoError(t, err)
 	validJSON := archiveDocumentJSON(t, document)
 
-	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, validJSON+"{}")))
-	require.ErrorContains(t, err, "trailing JSON value")
+	_, err = readTopologyDiagnosticArchive(
+		bytes.NewReader(compressArchiveJSON(t, validJSON+"{}")),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
+	require.Error(t, err)
 
 	encoded := compressArchiveJSON(t, validJSON)
 	require.Greater(t, len(encoded), 8)
-	_, err = readTopologyDiagnosticArchive(bytes.NewReader(encoded[:len(encoded)-4]))
+	_, err = readTopologyDiagnosticArchive(
+		bytes.NewReader(encoded[:len(encoded)-4]),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.Error(t, err)
 
 	corrupt := append([]byte(nil), encoded...)
 	corrupt[len(corrupt)-1] ^= 0xff
-	_, err = readTopologyDiagnosticArchive(bytes.NewReader(corrupt))
+	_, err = readTopologyDiagnosticArchive(
+		bytes.NewReader(corrupt),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.Error(t, err)
 }
 
-func TestTopologyDiagnosticArchiveEnforcesOnlyTheFourReaderResourceBounds(t *testing.T) {
+func TestTopologyDiagnosticArchiveReadLimitsHaveGenerousDefaults(t *testing.T) {
+	limits := defaultTopologyDiagnosticArchiveReadLimits()
+	require.Equal(t, int64(128<<20), limits.maxCompressedBytes)
+	require.Equal(t, int64(512<<20), limits.maxDecodedBytes)
+}
+
+func TestTopologyDiagnosticArchiveEnforcesCallerByteLimits(t *testing.T) {
 	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
 	completeTopologyDiagnosticArchiveFixture(&diagnostics)
 	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
 	require.NoError(t, err)
 	encoded := compressArchiveJSON(t, archiveDocumentJSON(t, document))
 
-	limits := defaultTopologyDiagnosticArchiveLimits
-	limits.maxCompressedBytes = int64(len(encoded) - 1)
-	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(encoded), limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveCompressedLimit)
-
-	limits = defaultTopologyDiagnosticArchiveLimits
-	limits.maxDecodedBytes = 64
-	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(encoded), limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveDecodedLimit)
-
-	windowed := compressArchiveJSONWithWindow(t, strings.Repeat(" ", 8<<10)+archiveDocumentJSON(t, document), 8<<10)
-	limits = defaultTopologyDiagnosticArchiveLimits
-	limits.maxDecoderMemory = 1 << 10
-	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(windowed), limits)
-	require.Error(t, err)
-	require.Contains(t, strings.ToLower(err.Error()), "window")
-
-	limits = defaultTopologyDiagnosticArchiveLimits
-	limits.maxArrayAllocationBytes = 1
-	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(encoded), limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayAllocationLimit)
-
-	require.NotNil(t, document.Snapshot.Topology)
-	require.NotEmpty(t, document.Snapshot.Topology.Devices)
-	require.NotEmpty(t, document.Snapshot.Topology.Devices[0].Captures)
-	require.NotNil(t, document.Snapshot.Topology.Devices[0].Captures[0].Evidence)
-	document.Snapshot.Topology.Devices[0].Captures[0].Evidence.Device.VnodeLabels = map[string]string{
-		"site": "lab",
-		"zone": "a",
+	for _, limit := range []int64{1, int64(len(encoded) - 1)} {
+		limits := defaultTopologyDiagnosticArchiveReadLimits()
+		limits.maxCompressedBytes = limit
+		_, err = readTopologyDiagnosticArchive(bytes.NewReader(encoded), limits)
+		require.ErrorIs(t, err, errTopologyDiagnosticArchiveCompressedLimit)
 	}
-	mapEncoded := compressArchiveJSON(t, archiveDocumentJSON(t, document))
-	limits = defaultTopologyDiagnosticArchiveLimits
-	limits.maxMapEntries = 1
-	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(mapEncoded), limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveMapLimit)
+
+	limits := defaultTopologyDiagnosticArchiveReadLimits()
+	limits.maxDecodedBytes = 64
+	_, err = readTopologyDiagnosticArchive(bytes.NewReader(encoded), limits)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveDecodedLimit)
 }
 
 func TestTopologyDiagnosticArchiveWriterPropagatesDestinationFailure(t *testing.T) {
@@ -357,7 +317,10 @@ func TestTopologyDiagnosticArchiveUsesStandardJSONFieldSemantics(t *testing.T) {
 	raw = strings.Replace(raw, `"version":1`, `"version":99,"version":1`, 1)
 	raw = strings.Replace(raw, `"format":`, `"FoRmAt":`, 1)
 
-	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, raw)))
+	_, err = readTopologyDiagnosticArchive(
+		bytes.NewReader(compressArchiveJSON(t, raw)),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.NoError(t, err)
 }
 
@@ -368,7 +331,10 @@ func TestTopologyDiagnosticArchiveRejectsInvalidWireUTF8(t *testing.T) {
 	raw := archiveDocumentJSON(t, document)
 
 	invalidUTF8 := strings.Replace(raw, `"v-test"`, `"`+string([]byte{0xff})+`"`, 1)
-	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, invalidUTF8)))
+	_, err = readTopologyDiagnosticArchive(
+		bytes.NewReader(compressArchiveJSON(t, invalidUTF8)),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.ErrorContains(t, err, "invalid UTF-8")
 }
 
@@ -383,75 +349,12 @@ func TestTopologyDiagnosticArchiveWriterPreservesV1StringSemantics(t *testing.T)
 	require.NotContains(t, raw, `\u003c`)
 	require.NotContains(t, raw, `\u003e`)
 	require.NotContains(t, raw, `\u0026`)
-	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(encoded.Bytes()))
+	archive, err := readTopologyDiagnosticArchive(
+		bytes.NewReader(encoded.Bytes()),
+		defaultTopologyDiagnosticArchiveReadLimits(),
+	)
 	require.NoError(t, err)
 	require.Equal(t, "v<&>\ufffd", archive.producerVersion)
-}
-
-func TestTopologyDiagnosticArchiveCollectionClassifierCoversDTO(t *testing.T) {
-	root := reflect.TypeFor[topologyDiagnosticArchiveDocumentV1]()
-	discovered := make(map[string]topologyDiagnosticArchiveCollectionField)
-	visited := make(map[reflect.Type]bool)
-	var arrays int
-	var maps int
-
-	var visit func(reflect.Type)
-	visit = func(value reflect.Type) {
-		for value.Kind() == reflect.Pointer {
-			value = value.Elem()
-		}
-		if value.Kind() != reflect.Struct || value.PkgPath() != root.PkgPath() || visited[value] {
-			return
-		}
-		visited[value] = true
-		for index := range value.NumField() {
-			field := value.Field(index)
-			name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
-			switch field.Type.Kind() {
-			case reflect.Slice:
-				arrays++
-				expected := topologyDiagnosticArchiveCollectionField{
-					class:             topologyDiagnosticArchiveContainerArray,
-					arrayElementBytes: uint64(field.Type.Elem().Size()),
-				}
-				require.Equal(t, expected,
-					topologyDiagnosticArchiveCollectionFieldDefinition(name), "%s.%s", value, field.Name)
-				discovered[name] = expected
-				visit(field.Type.Elem())
-			case reflect.Map:
-				maps++
-				expected := topologyDiagnosticArchiveCollectionField{class: topologyDiagnosticArchiveContainerMap}
-				require.Equal(t, expected,
-					topologyDiagnosticArchiveCollectionFieldDefinition(name), "%s.%s", value, field.Name)
-				discovered[name] = expected
-				visit(field.Type.Elem())
-			default:
-				visit(field.Type)
-			}
-		}
-	}
-	visit(root)
-
-	require.Equal(t, 11, arrays)
-	require.Equal(t, 5, maps)
-	require.Equal(t, topologyDiagnosticArchiveCollectionFields, discovered)
-	require.Equal(t, topologyDiagnosticArchiveCollectionFields["entries"],
-		topologyDiagnosticArchiveCollectionFieldDefinition("EnTrIeS"))
-}
-
-func TestTopologyDiagnosticArchivePreflightCountsAllocationClassesTogether(t *testing.T) {
-	const raw = `{"entries":[{},{}],"tags":{"site":"lab","zone":"a"}}`
-	limits := defaultTopologyDiagnosticArchiveLimits
-	counts, err := preflightTopologyDiagnosticArchiveJSON(
-		jsontext.NewDecoder(strings.NewReader(raw), topologyDiagnosticArchiveReaderJSONOptions),
-		limits,
-	)
-	require.NoError(t, err)
-	require.Equal(t,
-		2*uint64(reflect.TypeFor[topologyDiagnosticArchiveLifecycleEntryV1]().Size()),
-		counts.arrayAllocationBytes,
-	)
-	require.Equal(t, uint64(2), counts.mapEntries)
 }
 
 func TestTopologyDiagnosticArchiveEnumTablesAreCompleteAndRoundTrip(t *testing.T) {
@@ -509,14 +412,11 @@ func FuzzReadTopologyDiagnosticArchive(f *testing.F) {
 	}`)
 	f.Add(seed)
 	f.Fuzz(func(t *testing.T, input []byte) {
-		limits := topologyDiagnosticArchiveLimits{
-			maxCompressedBytes:      1 << 20,
-			maxDecodedBytes:         4 << 20,
-			maxDecoderMemory:        1 << 20,
-			maxArrayAllocationBytes: 1 << 20,
-			maxMapEntries:           1 << 20,
+		limits := topologyDiagnosticArchiveReadLimits{
+			maxCompressedBytes: 1 << 20,
+			maxDecodedBytes:    4 << 20,
 		}
-		_, _ = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(input), limits)
+		_, _ = readTopologyDiagnosticArchive(bytes.NewReader(input), limits)
 	})
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
@@ -5,8 +5,10 @@ package snmptopology
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -24,11 +26,10 @@ func TestTopologyDiagnosticArchiveRoundTripPreservesReplayAndInspection(t *testi
 	completeTopologyDiagnosticArchiveFixture(&diagnostics)
 
 	var encoded bytes.Buffer
-	require.NoError(t, writeTopologyDiagnosticArchiveWithLimits(
+	require.NoError(t, writeTopologyDiagnosticArchiveWithProducerVersion(
 		&encoded,
 		diagnostics,
 		"v-test",
-		defaultTopologyDiagnosticArchiveLimits,
 	))
 	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(encoded.Bytes()))
 	require.NoError(t, err)
@@ -146,6 +147,106 @@ func TestTopologyDiagnosticArchiveRejectsMalformedAndUnsupportedInput(t *testing
 	}
 }
 
+func TestTopologyDiagnosticArchivePreservesOpenBGPPeerState(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newMixedL2L3ControlScenario())
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+
+	const state = "vendor-specific"
+	row := firstTopologyDiagnosticArchiveBGPRow(t, &document)
+	row.StateHas = true
+	row.State = state
+
+	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, document))))
+	require.NoError(t, err)
+	restored, err := newTopologyDiagnosticArchiveDocumentV1(archive.diagnostics, archive.producerVersion)
+	require.NoError(t, err)
+	require.Equal(t, state, firstTopologyDiagnosticArchiveBGPRow(t, &restored).State)
+}
+
+func TestTopologyDiagnosticArchiveRejectsRetainedReferenceCaptureMismatch(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newMixedL2L3ControlScenario())
+	completeTopologyDiagnosticArchiveFixture(&diagnostics)
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(document.Snapshot.Topology.Devices), 2)
+
+	tests := map[string]struct {
+		mutate func(*topologyDiagnosticArchiveDeviceV1, uint64)
+		want   string
+	}{
+		"reference without role": {
+			mutate: func(device *topologyDiagnosticArchiveDeviceV1, _ uint64) {
+				require.NotNil(t, device.RetainedSuccess)
+				require.Len(t, device.Captures, 1)
+				device.Captures[0].Roles = []string{topologyDiagnosticArchiveCaptureRoleLatestAttempt}
+			},
+			want: "retained-success reference and capture role disagree",
+		},
+		"role without reference": {
+			mutate: func(device *topologyDiagnosticArchiveDeviceV1, _ uint64) {
+				require.NotNil(t, device.RetainedSuccess)
+				device.RetainedSuccess = nil
+			},
+			want: "retained-success reference and capture role disagree",
+		},
+		"generation newer than sweep": {
+			mutate: func(device *topologyDiagnosticArchiveDeviceV1, sequence uint64) {
+				require.NotNil(t, device.RetainedSuccess)
+				device.RetainedSuccess.Generation = sequence + 1
+			},
+			want: "retained-success generation",
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			mutated := document
+			mutated.Snapshot.Topology = cloneTopologyDiagnosticArchiveSweepV1(t, document.Snapshot.Topology)
+			device := &mutated.Snapshot.Topology.Devices[1]
+			mutate.mutate(device, mutated.Snapshot.Topology.Sequence)
+
+			_, err := readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, mutated))))
+			require.ErrorContains(t, err, mutate.want)
+		})
+	}
+}
+
+func TestTopologyDiagnosticArchiveRejectsDuplicateCaptureAttemptOrdinal(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newMixedL2L3ControlScenario())
+	completeTopologyDiagnosticArchiveFixture(&diagnostics)
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+	device := &document.Snapshot.Topology.Devices[0]
+	require.Len(t, device.Captures, 2)
+	device.Captures[1].AttemptOrdinal = device.Captures[0].AttemptOrdinal
+
+	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, document))))
+	require.ErrorContains(t, err, "duplicate capture attempt ordinal")
+}
+
+func TestTopologyDiagnosticArchiveRejectsCompactArrayBeforeTypedDecode(t *testing.T) {
+	const entryCount = 129
+	raw := `{
+		"format":"netdata.snmp_topology.diagnostics",
+		"version":1,
+		"producer":{"agent_version":"v-test"},
+		"snapshot":{
+			"job_lifecycle_cut":{
+				"capture_state":"available",
+				"capture_reason":"none",
+				"cut":{"sequence":1,"captured_at":"2026-08-29T00:00:00Z","entries":[` +
+		strings.Repeat("{},", entryCount-1) + `{}` + `]}
+			},
+			"producer_scope_id":"scope"
+		}
+	}`
+	limits := defaultTopologyDiagnosticArchiveLimits
+	limits.maxArrayElements = 64
+
+	_, err := readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(compressArchiveJSON(t, raw)), limits)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayLimit)
+}
+
 func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.T) {
 	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
 	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
@@ -166,8 +267,9 @@ func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.
 	require.Error(t, err)
 }
 
-func TestTopologyDiagnosticArchiveEnforcesOnlyTheThreeResourceBounds(t *testing.T) {
+func TestTopologyDiagnosticArchiveEnforcesOnlyTheFourReaderResourceBounds(t *testing.T) {
 	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	completeTopologyDiagnosticArchiveFixture(&diagnostics)
 	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
 	require.NoError(t, err)
 	encoded := compressArchiveJSON(t, archiveDocumentJSON(t, document))
@@ -184,24 +286,41 @@ func TestTopologyDiagnosticArchiveEnforcesOnlyTheThreeResourceBounds(t *testing.
 
 	windowed := compressArchiveJSONWithWindow(t, strings.Repeat(" ", 8<<10)+archiveDocumentJSON(t, document), 8<<10)
 	limits = defaultTopologyDiagnosticArchiveLimits
-	limits.maxWindowBytes = 1 << 10
+	limits.maxDecoderMemory = 1 << 10
 	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(windowed), limits)
 	require.Error(t, err)
 	require.Contains(t, strings.ToLower(err.Error()), "window")
-}
-
-func TestTopologyDiagnosticArchiveWriterEnforcesEncodedAndDecodedBounds(t *testing.T) {
-	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
-
-	limits := defaultTopologyDiagnosticArchiveLimits
-	limits.maxDecodedBytes = 64
-	err := writeTopologyDiagnosticArchiveWithLimits(io.Discard, diagnostics, "v-test", limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveDecodedLimit)
 
 	limits = defaultTopologyDiagnosticArchiveLimits
-	limits.maxCompressedBytes = 16
-	err = writeTopologyDiagnosticArchiveWithLimits(io.Discard, diagnostics, "v-test", limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveCompressedLimit)
+	limits.maxArrayElements = 1
+	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(encoded), limits)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveArrayLimit)
+
+	require.NotNil(t, document.Snapshot.Topology)
+	require.NotEmpty(t, document.Snapshot.Topology.Devices)
+	require.NotEmpty(t, document.Snapshot.Topology.Devices[0].Captures)
+	require.NotNil(t, document.Snapshot.Topology.Devices[0].Captures[0].Evidence)
+	document.Snapshot.Topology.Devices[0].Captures[0].Evidence.Device.VnodeLabels = map[string]string{
+		"site": "lab",
+		"zone": "a",
+	}
+	mapEncoded := compressArchiveJSON(t, archiveDocumentJSON(t, document))
+	limits = defaultTopologyDiagnosticArchiveLimits
+	limits.maxMapEntries = 1
+	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(mapEncoded), limits)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveMapLimit)
+}
+
+func TestTopologyDiagnosticArchiveWriterPropagatesDestinationFailure(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	destinationErr := errors.New("destination failure")
+
+	err := writeTopologyDiagnosticArchiveWithProducerVersion(
+		topologyDiagnosticArchiveErrorWriter{err: destinationErr},
+		diagnostics,
+		"v-test",
+	)
+	require.ErrorIs(t, err, destinationErr)
 }
 
 func TestTopologyDiagnosticArchiveUsesStandardJSONFieldSemantics(t *testing.T) {
@@ -211,9 +330,77 @@ func TestTopologyDiagnosticArchiveUsesStandardJSONFieldSemantics(t *testing.T) {
 	raw := archiveDocumentJSON(t, document)
 	raw = strings.Replace(raw, `"version":1`, `"ignored":true,"version":1`, 1)
 	raw = strings.Replace(raw, `"version":1`, `"version":99,"version":1`, 1)
+	raw = strings.Replace(raw, `"format":`, `"FoRmAt":`, 1)
 
 	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, raw)))
 	require.NoError(t, err)
+
+	invalidUTF8 := strings.Replace(raw, `"v-test"`, `"`+string([]byte{0xff})+`"`, 1)
+	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, invalidUTF8)))
+	require.NoError(t, err)
+	require.Equal(t, "\ufffd", archive.producerVersion)
+}
+
+func TestTopologyDiagnosticArchiveWriterPreservesV1StringSemantics(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	producerVersion := "v<&>" + string([]byte{0xff})
+	var encoded bytes.Buffer
+	require.NoError(t, writeTopologyDiagnosticArchiveWithProducerVersion(&encoded, diagnostics, producerVersion))
+
+	raw := decompressArchiveJSON(t, encoded.Bytes())
+	require.Contains(t, raw, `"agent_version":"v<&>`)
+	require.NotContains(t, raw, `\u003c`)
+	require.NotContains(t, raw, `\u003e`)
+	require.NotContains(t, raw, `\u0026`)
+	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(encoded.Bytes()))
+	require.NoError(t, err)
+	require.Equal(t, "v<&>\ufffd", archive.producerVersion)
+}
+
+func TestTopologyDiagnosticArchiveCollectionClassifierCoversDTO(t *testing.T) {
+	root := reflect.TypeFor[topologyDiagnosticArchiveDocumentV1]()
+	discovered := make(map[string]topologyDiagnosticArchiveContainerClass)
+	visited := make(map[reflect.Type]bool)
+	var arrays int
+	var maps int
+
+	var visit func(reflect.Type)
+	visit = func(value reflect.Type) {
+		for value.Kind() == reflect.Pointer {
+			value = value.Elem()
+		}
+		if value.Kind() != reflect.Struct || value.PkgPath() != root.PkgPath() || visited[value] {
+			return
+		}
+		visited[value] = true
+		for index := range value.NumField() {
+			field := value.Field(index)
+			name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+			switch field.Type.Kind() {
+			case reflect.Slice:
+				arrays++
+				require.Equal(t, topologyDiagnosticArchiveContainerArray,
+					topologyDiagnosticArchiveCollectionFieldClass(name), "%s.%s", value, field.Name)
+				discovered[name] = topologyDiagnosticArchiveContainerArray
+				visit(field.Type.Elem())
+			case reflect.Map:
+				maps++
+				require.Equal(t, topologyDiagnosticArchiveContainerMap,
+					topologyDiagnosticArchiveCollectionFieldClass(name), "%s.%s", value, field.Name)
+				discovered[name] = topologyDiagnosticArchiveContainerMap
+				visit(field.Type.Elem())
+			default:
+				visit(field.Type)
+			}
+		}
+	}
+	visit(root)
+
+	require.Equal(t, 11, arrays)
+	require.Equal(t, 5, maps)
+	require.Equal(t, topologyDiagnosticArchiveCollectionFields, discovered)
+	require.Equal(t, topologyDiagnosticArchiveContainerArray,
+		topologyDiagnosticArchiveCollectionFieldClass("EnTrIeS"))
 }
 
 func TestTopologyDiagnosticArchiveEnumTablesAreCompleteAndRoundTrip(t *testing.T) {
@@ -274,7 +461,9 @@ func FuzzReadTopologyDiagnosticArchive(f *testing.F) {
 		limits := topologyDiagnosticArchiveLimits{
 			maxCompressedBytes: 1 << 20,
 			maxDecodedBytes:    4 << 20,
-			maxWindowBytes:     1 << 20,
+			maxDecoderMemory:   1 << 20,
+			maxArrayElements:   1 << 20,
+			maxMapEntries:      1 << 20,
 		}
 		_, _ = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(input), limits)
 	})
@@ -360,4 +549,64 @@ func compressArchiveJSONWithWindow(t testing.TB, value string, window int) []byt
 	require.NoError(t, err)
 	require.NoError(t, encoder.Close())
 	return encoded.Bytes()
+}
+
+func decompressArchiveJSON(t testing.TB, encoded []byte) string {
+	t.Helper()
+	decoder, err := zstd.NewReader(bytes.NewReader(encoded), zstd.WithDecoderConcurrency(1))
+	require.NoError(t, err)
+	decompressed, err := io.ReadAll(decoder)
+	decoder.Close()
+	require.NoError(t, err)
+	return string(decompressed)
+}
+
+func firstTopologyDiagnosticArchiveBGPRow(
+	t testing.TB,
+	document *topologyDiagnosticArchiveDocumentV1,
+) *topologyDiagnosticArchiveBGPRowValueV1 {
+	t.Helper()
+	require.NotNil(t, document)
+	require.NotNil(t, document.Snapshot.Topology)
+	for deviceIndex := range document.Snapshot.Topology.Devices {
+		device := &document.Snapshot.Topology.Devices[deviceIndex]
+		for captureIndex := range device.Captures {
+			capture := &device.Captures[captureIndex]
+			if capture.Evidence == nil {
+				continue
+			}
+			for contextIndex := range capture.Evidence.CollectionContexts {
+				context := &capture.Evidence.CollectionContexts[contextIndex]
+				for profileIndex := range context.Profiles {
+					profile := &context.Profiles[profileIndex]
+					if len(profile.Values.BGPRows) > 0 {
+						return &profile.Values.BGPRows[0]
+					}
+				}
+			}
+		}
+	}
+	t.Fatal("archive fixture has no BGP row")
+	return nil
+}
+
+func cloneTopologyDiagnosticArchiveSweepV1(
+	t testing.TB,
+	sweep *topologyDiagnosticArchiveSweepV1,
+) *topologyDiagnosticArchiveSweepV1 {
+	t.Helper()
+	require.NotNil(t, sweep)
+	raw, err := json.Marshal(sweep)
+	require.NoError(t, err)
+	var cloned topologyDiagnosticArchiveSweepV1
+	require.NoError(t, json.Unmarshal(raw, &cloned))
+	return &cloned
+}
+
+type topologyDiagnosticArchiveErrorWriter struct {
+	err error
+}
+
+func (w topologyDiagnosticArchiveErrorWriter) Write([]byte) (int, error) {
+	return 0, w.err
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
@@ -359,11 +359,17 @@ func TestTopologyDiagnosticArchiveUsesStandardJSONFieldSemantics(t *testing.T) {
 
 	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, raw)))
 	require.NoError(t, err)
+}
+
+func TestTopologyDiagnosticArchiveRejectsInvalidWireUTF8(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+	raw := archiveDocumentJSON(t, document)
 
 	invalidUTF8 := strings.Replace(raw, `"v-test"`, `"`+string([]byte{0xff})+`"`, 1)
-	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, invalidUTF8)))
-	require.NoError(t, err)
-	require.Equal(t, "\ufffd", archive.producerVersion)
+	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, invalidUTF8)))
+	require.ErrorContains(t, err, "invalid UTF-8")
 }
 
 func TestTopologyDiagnosticArchiveWriterPreservesV1StringSemantics(t *testing.T) {
@@ -437,7 +443,7 @@ func TestTopologyDiagnosticArchivePreflightCountsAllocationClassesTogether(t *te
 	const raw = `{"entries":[{},{}],"tags":{"site":"lab","zone":"a"}}`
 	limits := defaultTopologyDiagnosticArchiveLimits
 	counts, err := preflightTopologyDiagnosticArchiveJSON(
-		jsontext.NewDecoder(strings.NewReader(raw), topologyDiagnosticArchiveJSONOptions),
+		jsontext.NewDecoder(strings.NewReader(raw), topologyDiagnosticArchiveReaderJSONOptions),
 		limits,
 	)
 	require.NoError(t, err)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyv1test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopologyDiagnosticArchiveRoundTripPreservesReplayAndInspection(t *testing.T) {
+	scenario := newMixedL2L3ControlScenario()
+	registry, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
+	completeTopologyDiagnosticArchiveFixture(&diagnostics)
+
+	var encoded bytes.Buffer
+	require.NoError(t, writeTopologyDiagnosticArchiveWithLimits(
+		&encoded,
+		diagnostics,
+		"v-test",
+		defaultTopologyDiagnosticArchiveLimits,
+	))
+	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(encoded.Bytes()))
+	require.NoError(t, err)
+	require.Equal(t, "v-test", archive.producerVersion)
+
+	beforeDocument, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+	afterDocument, err := newTopologyDiagnosticArchiveDocumentV1(archive.diagnostics, "v-test")
+	require.NoError(t, err)
+	require.JSONEq(t, archiveDocumentJSON(t, beforeDocument), archiveDocumentJSON(t, afterDocument))
+
+	require.NotSame(t,
+		archive.diagnostics.topology.devices[0].latestAttempt,
+		archive.diagnostics.topology.devices[0].acquisition,
+	)
+	require.Same(t,
+		archive.diagnostics.topology.devices[1].latestAttempt,
+		archive.diagnostics.topology.devices[1].acquisition,
+	)
+
+	live, ok, err := (funcDepsAdapter{registry: registry}).Snapshot(scenario.opts)
+	require.NoError(t, err)
+	require.True(t, ok)
+	replayed, ok, err := replayTopologyDiagnostics(archive.diagnostics, scenario.opts)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, topologyv1test.NormalizeData(t, live), topologyv1test.NormalizeData(t, replayed))
+
+	beforeDevice, err := inspectTopologyDevice(diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	afterDevice, err := inspectTopologyDevice(archive.diagnostics, scenario.opts, 1)
+	require.NoError(t, err)
+	require.Equal(t, beforeDevice, afterDevice)
+
+	stages := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
+	require.NotEmpty(t, stages.data.Links)
+	subject, ok := topologyInspectionSubjectFromLink(stages.data, 0)
+	require.True(t, ok)
+	beforeLink, err := inspectTopologyLink(diagnostics, scenario.opts, subject)
+	require.NoError(t, err)
+	afterLink, err := inspectTopologyLink(archive.diagnostics, scenario.opts, subject)
+	require.NoError(t, err)
+	require.Equal(t, beforeLink, afterLink)
+}
+
+func TestTopologyDiagnosticArchiveV1GoldenDocument(t *testing.T) {
+	raw, err := os.ReadFile("testdata/topology-diagnostic-archive-v1.json")
+	require.NoError(t, err)
+
+	archive, err := readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, string(raw))))
+	require.NoError(t, err)
+	require.Equal(t, "v1.2.3", archive.producerVersion)
+
+	document, err := newTopologyDiagnosticArchiveDocumentV1(archive.diagnostics, archive.producerVersion)
+	require.NoError(t, err)
+	require.JSONEq(t, string(raw), archiveDocumentJSON(t, document))
+}
+
+func TestTopologyDiagnosticArchiveRejectsMalformedAndUnsupportedInput(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	completeTopologyDiagnosticArchiveFixture(&diagnostics)
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		mutate func(*topologyDiagnosticArchiveDocumentV1)
+		want   string
+	}{
+		"format": {
+			mutate: func(document *topologyDiagnosticArchiveDocumentV1) { document.Format = "other" },
+			want:   "unsupported format",
+		},
+		"version": {
+			mutate: func(document *topologyDiagnosticArchiveDocumentV1) { document.Version++ },
+			want:   "unsupported version",
+		},
+		"retained reference": {
+			mutate: func(document *topologyDiagnosticArchiveDocumentV1) {
+				document.Snapshot.Topology.Devices[0].RetainedSuccess.RegistrationID++
+			},
+			want: "does not match owner",
+		},
+		"capture role": {
+			mutate: func(document *topologyDiagnosticArchiveDocumentV1) {
+				document.Snapshot.Topology.Devices[0].Captures[0].Roles[0] = "other"
+			},
+			want: "unknown capture role",
+		},
+		"route reference": {
+			mutate: func(document *topologyDiagnosticArchiveDocumentV1) {
+				profile := &document.Snapshot.Topology.Devices[0].Captures[0].Evidence.CollectionContexts[0].Profiles[0]
+				require.NotEmpty(t, profile.Values.Metrics)
+				profile.Values.Metrics[0].RouteOrdinal = ^uint32(0)
+			},
+			want: "references unknown route ordinal",
+		},
+		"target address": {
+			mutate: func(document *topologyDiagnosticArchiveDocumentV1) {
+				document.Snapshot.Topology.Devices[0].Captures[0].Evidence.Target.Addresses = []string{"not-an-address"}
+			},
+			want: "target address",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := json.Marshal(document)
+			require.NoError(t, err)
+			var mutated topologyDiagnosticArchiveDocumentV1
+			require.NoError(t, json.Unmarshal(encoded, &mutated))
+			tc.mutate(&mutated)
+
+			_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, mutated))))
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+	validJSON := archiveDocumentJSON(t, document)
+
+	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, validJSON+"{}")))
+	require.ErrorContains(t, err, "trailing JSON value")
+
+	encoded := compressArchiveJSON(t, validJSON)
+	require.Greater(t, len(encoded), 8)
+	_, err = readTopologyDiagnosticArchive(bytes.NewReader(encoded[:len(encoded)-4]))
+	require.Error(t, err)
+
+	corrupt := append([]byte(nil), encoded...)
+	corrupt[len(corrupt)-1] ^= 0xff
+	_, err = readTopologyDiagnosticArchive(bytes.NewReader(corrupt))
+	require.Error(t, err)
+}
+
+func TestTopologyDiagnosticArchiveEnforcesOnlyTheThreeResourceBounds(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+	encoded := compressArchiveJSON(t, archiveDocumentJSON(t, document))
+
+	limits := defaultTopologyDiagnosticArchiveLimits
+	limits.maxCompressedBytes = int64(len(encoded) - 1)
+	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(encoded), limits)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveCompressedLimit)
+
+	limits = defaultTopologyDiagnosticArchiveLimits
+	limits.maxDecodedBytes = 64
+	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(encoded), limits)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveDecodedLimit)
+
+	windowed := compressArchiveJSONWithWindow(t, strings.Repeat(" ", 8<<10)+archiveDocumentJSON(t, document), 8<<10)
+	limits = defaultTopologyDiagnosticArchiveLimits
+	limits.maxWindowBytes = 1 << 10
+	_, err = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(windowed), limits)
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "window")
+}
+
+func TestTopologyDiagnosticArchiveWriterEnforcesEncodedAndDecodedBounds(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+
+	limits := defaultTopologyDiagnosticArchiveLimits
+	limits.maxDecodedBytes = 64
+	err := writeTopologyDiagnosticArchiveWithLimits(io.Discard, diagnostics, "v-test", limits)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveDecodedLimit)
+
+	limits = defaultTopologyDiagnosticArchiveLimits
+	limits.maxCompressedBytes = 16
+	err = writeTopologyDiagnosticArchiveWithLimits(io.Discard, diagnostics, "v-test", limits)
+	require.ErrorIs(t, err, errTopologyDiagnosticArchiveCompressedLimit)
+}
+
+func TestTopologyDiagnosticArchiveUsesStandardJSONFieldSemantics(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, "v-test")
+	require.NoError(t, err)
+	raw := archiveDocumentJSON(t, document)
+	raw = strings.Replace(raw, `"version":1`, `"ignored":true,"version":1`, 1)
+	raw = strings.Replace(raw, `"version":1`, `"version":99,"version":1`, 1)
+
+	_, err = readTopologyDiagnosticArchive(bytes.NewReader(compressArchiveJSON(t, raw)))
+	require.NoError(t, err)
+}
+
+func TestTopologyDiagnosticArchiveEnumTablesAreCompleteAndRoundTrip(t *testing.T) {
+	tables := []struct {
+		name  string
+		names []string
+		last  uint8
+	}{
+		{"capture state", topologyDiagnosticArchiveCaptureStateNames, uint8(diagnosticCaptureUnavailable)},
+		{"capture reason", topologyDiagnosticArchiveCaptureReasonNames, uint8(diagnosticCaptureReasonGlobalByteLimit)},
+		{"lifecycle phase", topologyDiagnosticArchiveLifecyclePhaseNames, uint8(ddsnmp.DeviceLifecyclePhaseCollect)},
+		{"lifecycle outcome", topologyDiagnosticArchiveLifecycleOutcomeNames, uint8(ddsnmp.DeviceLifecycleOutcomeFailed)},
+		{"device outcome", topologyDiagnosticArchiveDeviceOutcomeNames, uint8(deviceRefreshOutcomeFailed)},
+		{"abort reason", topologyDiagnosticArchiveAbortReasonNames, uint8(topologyDiagnosticAbortPanic)},
+		{"sweep phase", topologyDiagnosticArchiveSweepPhaseNames, uint8(topologyDiagnosticSweepPhaseCommit)},
+		{"target outcome", topologyDiagnosticArchiveTargetOutcomeNames, uint8(topologyTargetResolutionFailed)},
+		{"phase outcome", topologyDiagnosticArchivePhaseOutcomeNames, uint8(topologyAcquisitionPhaseNotObserved)},
+		{"phase failure", topologyDiagnosticArchivePhaseFailureNames, uint8(topologyAcquisitionFailureVLANIdentifier)},
+		{"profile outcome", topologyDiagnosticArchiveProfileOutcomeNames, uint8(ddsnmpcollector.AcquisitionProfileOutcomeFailed)},
+		{"profile failure", topologyDiagnosticArchiveProfileFailurePhaseNames, uint8(ddsnmpcollector.AcquisitionFailurePhaseTables)},
+		{"route kind", topologyDiagnosticArchiveRouteKindNames, uint8(ddsnmpcollector.AcquisitionRouteKindBGPTable)},
+		{"route source", topologyDiagnosticArchiveRouteSourceNames, uint8(ddsnmpcollector.AcquisitionRouteSourceCache)},
+		{"route outcome", topologyDiagnosticArchiveRouteOutcomeNames, uint8(ddsnmpcollector.AcquisitionRouteOutcomePartial)},
+		{"route failure", topologyDiagnosticArchiveRouteFailureClassNames, uint8(ddsnmpcollector.AcquisitionFailureClassDependency)},
+	}
+	for _, table := range tables {
+		t.Run(table.name, func(t *testing.T) {
+			require.Len(t, table.names, int(table.last)+1)
+			seen := make(map[string]struct{}, len(table.names))
+			for index, name := range table.names {
+				require.NotEmpty(t, name)
+				_, duplicate := seen[name]
+				require.False(t, duplicate)
+				seen[name] = struct{}{}
+				encoded, err := topologyDiagnosticArchiveEnumName(uint8(index), table.names)
+				require.NoError(t, err)
+				require.Equal(t, name, encoded)
+				decoded, err := topologyDiagnosticArchiveParseEnum[uint8](encoded, table.names)
+				require.NoError(t, err)
+				require.Equal(t, uint8(index), decoded)
+			}
+		})
+	}
+}
+
+func FuzzReadTopologyDiagnosticArchive(f *testing.F) {
+	seed := compressArchiveJSON(f, `{
+		"format":"netdata.snmp_topology.diagnostics",
+		"version":1,
+		"producer":{"agent_version":"v-test"},
+		"snapshot":{
+			"job_lifecycle_cut":{"capture_state":"available","capture_reason":"none","cut":{"sequence":1,"captured_at":"2026-08-29T00:00:00Z"}},
+			"producer_scope_id":"scope"
+		}
+	}`)
+	f.Add(seed)
+	f.Fuzz(func(t *testing.T, input []byte) {
+		limits := topologyDiagnosticArchiveLimits{
+			maxCompressedBytes: 1 << 20,
+			maxDecodedBytes:    4 << 20,
+			maxWindowBytes:     1 << 20,
+		}
+		_, _ = readTopologyDiagnosticArchiveWithLimits(bytes.NewReader(input), limits)
+	})
+}
+
+func completeTopologyDiagnosticArchiveFixture(diagnostics *topologyDiagnostics) {
+	if diagnostics == nil || diagnostics.topology == nil {
+		return
+	}
+	capturedAt := diagnostics.topology.publishedAt.Add(time.Second)
+	diagnostics.lifecycle = topologyJobLifecycleDiagnosticCut{
+		state:  diagnosticCaptureAvailable,
+		reason: diagnosticCaptureReasonNone,
+		cut: ddsnmp.DeviceLifecycleCut{
+			Sequence:   7,
+			CapturedAt: capturedAt,
+			Entries:    make([]ddsnmp.DeviceLifecycleEntry, 0, len(diagnostics.topology.devices)),
+		},
+	}
+	for _, device := range diagnostics.topology.devices {
+		diagnostics.lifecycle.cut.Entries = append(diagnostics.lifecycle.cut.Entries, ddsnmp.DeviceLifecycleEntry{
+			RegistrationID: device.registrationID,
+			Info: ddsnmp.DeviceLifecycleInfo{
+				Hostname:    "192.0.2." + device.registrationID.String(),
+				Port:        161,
+				SNMPVersion: "2c",
+			},
+			LastCompleted: ddsnmp.DeviceLifecycleStatus{
+				Phase:       ddsnmp.DeviceLifecyclePhaseCollect,
+				Outcome:     ddsnmp.DeviceLifecycleOutcomeSuccess,
+				CompletedAt: capturedAt.Add(-time.Second),
+			},
+			TopologyReady: true,
+		})
+	}
+	if len(diagnostics.topology.devices) > 0 {
+		device := &diagnostics.topology.devices[0]
+		device.latestAttempt = &topologyAcquisitionCapture{
+			attemptID: topologyAcquisitionAttemptID{
+				registrationID: device.registrationID,
+				ordinal:        device.acquisition.attemptID.ordinal + 1,
+			},
+			state:  diagnosticCaptureUnavailable,
+			reason: diagnosticCaptureReasonProjectionError,
+		}
+	}
+	diagnostics.lastAborted = &topologyAbortedSweepDiagnostic{
+		sequence:              3,
+		startedAt:             capturedAt.Add(time.Minute),
+		abortedAt:             capturedAt.Add(time.Minute + time.Second),
+		reason:                topologyDiagnosticAbortCanceled,
+		phase:                 topologyDiagnosticSweepPhaseDeviceRefresh,
+		activeRegistrationID:  diagnostics.topology.devices[0].registrationID,
+		hasActiveRegistration: true,
+		registrationCount:     len(diagnostics.topology.devices),
+		selectedCount:         len(diagnostics.topology.devices),
+	}
+}
+
+func archiveDocumentJSON(t testing.TB, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func compressArchiveJSON(t testing.TB, value string) []byte {
+	t.Helper()
+	return compressArchiveJSONWithWindow(t, value, 1<<20)
+}
+
+func compressArchiveJSONWithWindow(t testing.TB, value string, window int) []byte {
+	t.Helper()
+	var encoded bytes.Buffer
+	encoder, err := zstd.NewWriter(
+		&encoded,
+		zstd.WithEncoderConcurrency(1),
+		zstd.WithWindowSize(window),
+		zstd.WithEncoderCRC(true),
+	)
+	require.NoError(t, err)
+	_, err = encoder.Write([]byte(value))
+	require.NoError(t, err)
+	require.NoError(t, encoder.Close())
+	return encoded.Bytes()
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_link_detail_guard_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_link_detail_guard_test.go
@@ -266,9 +266,6 @@ func forbiddenLinkMapCarrierKeyValueError(
 	if name == "" {
 		return nil
 	}
-	if isAllowedLinkMapCarrierUse(path, name, node) {
-		return nil
-	}
 	return forbiddenLinkMapCarrierUseError(path, fset, node, name, "composite field", forbidden)
 }
 
@@ -294,6 +291,9 @@ func forbiddenLinkMapCarrierUseError(
 	kind string,
 	forbidden map[string]struct{},
 ) error {
+	if isAllowedLinkMapCarrierUse(path, name, node) {
+		return nil
+	}
 	if _, ok := forbidden[name]; !ok {
 		return nil
 	}
@@ -302,6 +302,9 @@ func forbiddenLinkMapCarrierUseError(
 }
 
 func isAllowedLinkMapCarrierUse(path, name string, node ast.Node) bool {
+	if strings.HasPrefix(filepath.Base(path), "topology_diagnostic_archive") && name == "Metrics" {
+		return true
+	}
 	if filepath.Base(path) != "presentation.go" || name != "Metrics" {
 		return false
 	}


### PR DESCRIPTION
##### Summary

Adds a portable, compressed snapshot of SNMP topology diagnostics that can be saved and inspected outside the running Agent.

Topology issues such as missing devices or links are difficult to diagnose from screenshots and descriptions alone. The archive preserves the relevant diagnostic state so maintainers can reproduce and investigate the reported topology without repeated information-gathering from users.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a portable, compressed snapshot of SNMP topology diagnostics so maintainers can reproduce missing-device and missing-link reports from a saved file instead of repeated information-gathering from users.

**Diagnostic archive**
- Serializes job lifecycle, topology sweep, and per-device acquisition evidence into versioned JSON and compresses it with zstd.
- The reader caps compressed size, decoded size, decoder memory, and weighted array and map allocations and rejects invalid UTF-8 so untrusted archives can't exhaust memory.
- Round-trip tests confirm an archive replays to the same topology and inspection output.
- Relaxes a link-map guard test so the new archive files may carry the `Metrics` carrier field.

<sup>Written for commit a6988b978ee3a70c36cc252f4c56a67c9e30a05f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portable, versioned diagnostic archives for SNMP topology data.
  * Archives preserve job state, topology sweeps, device captures, and aborted-sweep details.
  * Added compressed streaming archive handling with validation and corruption detection.

* **Documentation**
  * Documented archive structure, replay behavior, security considerations, and limitations.

* **Bug Fixes**
  * Improved validation of allowed topology diagnostic data paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->