### PR TITLE
Add permanent SNMP troubleshooting data workflow

### DIFF
--- a/.github/workflows/snmp-topology-tests.yml
+++ b/.github/workflows/snmp-topology-tests.yml
@@ -9,6 +9,7 @@ on:
       - 'src/go/plugin/go.d/collector/snmp/**'
       - 'src/go/plugin/go.d/collector/snmp_topology/**'
       - 'src/go/plugin/go.d/config/go.d/snmp.profiles/**'
+      - 'docs/npm/device-metrics/collect-snmp-troubleshooting-data.md'
       - 'src/go/pkg/topology/**'
       - 'src/go/pkg/l2topology/**'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'src/go/plugin/go.d/collector/snmp/**'
       - 'src/go/plugin/go.d/collector/snmp_topology/**'
       - 'src/go/plugin/go.d/config/go.d/snmp.profiles/**'
+      - 'docs/npm/device-metrics/collect-snmp-troubleshooting-data.md'
       - 'src/go/pkg/topology/**'
       - 'src/go/pkg/l2topology/**'
 
@@ -46,15 +48,16 @@ jobs:
           set -euo pipefail
           mkdir -p /tmp/snmpsim-data
           cp src/go/testdata/snmp/snmprec/arubaos-cx_10.10.snmprec /tmp/snmpsim-data/lldp1.snmprec
+          cp src/go/testdata/snmp/snmprec/arubaos-cx_10.10.snmprec /tmp/snmpsim-data/public.snmprec
           cp src/go/testdata/snmp/snmprec/aos6.snmprec /tmp/snmpsim-data/lldp2.snmprec
           cp src/go/testdata/snmp/snmprec/ciscosb_sg350x-24p.snmprec /tmp/snmpsim-data/cdp1.snmprec
 
-      - name: Start snmpsim
+      - name: Install test tools and start snmpsim
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y snmp
+          sudo apt-get install -y python3-yaml snmp
 
           docker run -d --name snmpsim-v2 -p 1161:161/udp -v /tmp/snmpsim-data:/usr/local/snmpsim/data tandrup/snmpsim:v0.4@sha256:a080b493042d91c4cec9282a83403e334660ed1c2c71e7e3afa920c3f1c42d7e
           docker run -d --name snmpsim-v3 -p 1162:161/udp -e EXTRA_FLAGS='--v3-only --v3-user=testuser --v3-auth-key=authpass1 --v3-auth-proto=MD5 --v3-priv-key=privpass1 --v3-priv-proto=AES' -v /tmp/snmpsim-data:/usr/local/snmpsim/data tandrup/snmpsim:v0.4@sha256:a080b493042d91c4cec9282a83403e334660ed1c2c71e7e3afa920c3f1c42d7e
@@ -80,6 +83,140 @@ jobs:
 
           wait_for_simulator snmpsim-v3 \
             snmpget -v3 -l authPriv -u testuser -a MD5 -A authpass1 -x AES -X privpass1 -n lldp1 127.0.0.1:1162 1.3.6.1.2.1.1.1.0
+
+      - name: Test SNMP troubleshooting data collector
+        run: python3 src/go/plugin/go.d/collector/snmp/tools/test_collect_snmp_troubleshooting_data.py -v
+
+      - name: Test troubleshooting collector on Python 3.6
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --volume "${PWD}:/workspace:ro" \
+            --workdir /workspace \
+            python:3.6-slim@sha256:2cfebc27956e6a55f78606864d91fe527696f9e32a724e6f9702b5f9602d0474 \
+            sh -c 'pip install --disable-pip-version-check PyYAML==5.3.1 && python src/go/plugin/go.d/collector/snmp/tools/test_collect_snmp_troubleshooting_data.py -v'
+
+      - name: Verify documented collector checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import hashlib
+          import re
+
+          script_path = 'src/go/plugin/go.d/collector/snmp/tools/collect-snmp-troubleshooting-data.py'
+          docs_path = 'docs/npm/device-metrics/collect-snmp-troubleshooting-data.md'
+          with open(script_path, 'rb') as handle:
+              actual = hashlib.sha256(handle.read()).hexdigest()
+          with open(docs_path, 'r') as handle:
+              match = re.search(r"SNMP_DIAG_SHA256='([0-9a-f]{64})'", handle.read())
+          if match is None:
+              raise SystemExit('documented SNMP_DIAG_SHA256 was not found')
+          if match.group(1) != actual:
+              raise SystemExit('documented SNMP collector checksum does not match the script')
+          PY
+
+      - name: Exercise collector against SNMPv2c and SNMPv3 fixtures
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_root="$(mktemp -d "${RUNNER_TEMP}/snmp-diagnostic.XXXXXX")"
+          mkdir -p "${test_root}/output" "${test_root}/extracted"
+          cat > "${test_root}/snmp.conf" <<'EOF'
+          jobs:
+            - name: fixture-v2c
+              hostname: 127.0.0.1
+              community: public
+              options:
+                version: 2c
+                port: 1161
+                timeout: 1
+                retries: 0
+            - name: fixture-v3
+              hostname: 127.0.0.1
+              options:
+                version: 3
+                port: 1162
+                timeout: 1
+                retries: 0
+              user:
+                name: testuser
+                level: authPriv
+                auth_proto: md5
+                auth_key: authpass1
+                priv_proto: aes
+                priv_key: privpass1
+                context_name: lldp1
+          EOF
+
+          set +e
+          python3 src/go/plugin/go.d/collector/snmp/tools/collect-snmp-troubleshooting-data.py \
+            --netdata-snmp-config "${test_root}/snmp.conf" \
+            --all-configured \
+            --yes \
+            --command-timeout 20 \
+            --output-dir "${test_root}/output"
+          collector_status=$?
+          set -e
+          test "${collector_status}" -eq 0 || test "${collector_status}" -eq 2
+
+          mapfile -t archives < <(find "${test_root}/output" -maxdepth 1 -type f -name '*.tar.gz' -print)
+          test "${#archives[@]}" -eq 1
+          tar -xzf "${archives[0]}" -C "${test_root}/extracted"
+          (
+            cd "${test_root}/extracted"
+            sha256sum --check manifest.sha256
+          )
+          awk -F '\t' '
+            NR == 1 { next }
+            $1 == "fixture-v2c" && $3 == "system" && $4 == "success" { v2c++ }
+            $1 == "fixture-v3" && $3 == "system" && $4 == "success" { v3++ }
+            END { exit !(v2c == 1 && v3 == 1) }
+          ' "${test_root}/extracted/collection-status.tsv"
+          if grep -R -F -e 'authpass1' -e 'privpass1' "${test_root}/extracted"; then
+            echo 'SNMP credentials were included in the support archive' >&2
+            exit 1
+          fi
+
+          mkdir -p "${test_root}/discovery-output" "${test_root}/discovery-extracted"
+          cat > "${test_root}/sd-snmp.conf" <<'EOF'
+          disabled: false
+          discoverer:
+            snmp:
+              credentials:
+                - name: fixture-v2c
+                  version: 2c
+                  community: public
+              networks:
+                - subnet: 127.0.0.1/32
+                  credential: fixture-v2c
+          services: []
+          EOF
+
+          set +e
+          python3 src/go/plugin/go.d/collector/snmp/tools/collect-snmp-troubleshooting-data.py \
+            --netdata-snmp-config "${test_root}/sd-snmp.conf" \
+            --node 127.0.0.1 \
+            --port 1161 \
+            --timeout 1 \
+            --retries 0 \
+            --yes \
+            --command-timeout 20 \
+            --output-dir "${test_root}/discovery-output"
+          discovery_status=$?
+          set -e
+          test "${discovery_status}" -eq 0 || test "${discovery_status}" -eq 2
+
+          mapfile -t discovery_archives < <(find "${test_root}/discovery-output" -maxdepth 1 -type f -name '*.tar.gz' -print)
+          test "${#discovery_archives[@]}" -eq 1
+          tar -xzf "${discovery_archives[0]}" -C "${test_root}/discovery-extracted"
+          awk -F '\t' '$3 == "system" && $4 == "success" { found = 1 } END { exit !found }' \
+            "${test_root}/discovery-extracted/collection-status.tsv"
+          if grep -R -F 'public' "${test_root}/discovery-extracted"; then
+            echo 'SNMP discovery credential was included in the support archive' >&2
+            exit 1
+          fi
 
       - name: Run topology fixture tests
         env:

--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -609,6 +609,10 @@ sidebar:
               edit_url: https://github.com/netdata/netdata/edit/master/docs/npm/device-metrics/troubleshooting.md
               description: Timeouts, missing metrics, SNMPv3 auth, gaps, and phantom spikes.
           - meta:
+              label: Collect Troubleshooting Data
+              edit_url: https://github.com/netdata/netdata/edit/master/docs/npm/device-metrics/collect-snmp-troubleshooting-data.md
+              description: Collect raw SNMP data without credentials for Netdata Support to investigate metrics and topology issues.
+          - meta:
               label: Anti-patterns
               edit_url: https://github.com/netdata/netdata/edit/master/docs/npm/device-metrics/anti-patterns.md
               description: The common SNMP polling mistakes and how to avoid them.

--- a/docs/npm/device-metrics/collect-snmp-troubleshooting-data.md
+++ b/docs/npm/device-metrics/collect-snmp-troubleshooting-data.md
@@ -1,0 +1,233 @@
+<!--startmeta
+custom_edit_url: "https://github.com/netdata/netdata/edit/master/docs/npm/device-metrics/collect-snmp-troubleshooting-data.md"
+sidebar_label: "Collect Troubleshooting Data"
+learn_status: "Published"
+learn_rel_path: "Network Performance Monitoring/Device Metrics"
+keywords: ['snmp', 'troubleshooting', 'topology', 'support', 'diagnostics', 'freshdesk']
+endmeta-->
+
+<!-- markdownlint-disable-file -->
+
+# Collect SNMP troubleshooting data
+
+Use this collector when Netdata Support needs the raw SNMP data returned by one or more network devices. It is useful for
+investigating missing metrics, incomplete topology, profile matching, authentication failures, timeouts, and unsupported OIDs.
+
+The collector is a standalone troubleshooting tool. It does not inspect a running Netdata Agent, reproduce Netdata topology,
+scan networks, or change any device or Netdata configuration.
+
+## What the collector does
+
+The collector follows a simple, visible workflow:
+
+1. You select the affected nodes manually, from an existing Netdata `go.d/snmp.conf`, or both.
+2. It asks for any required settings or credentials that are not available from the configuration.
+3. It prints the exact nodes, SNMP versions, and protocol data it will request. No SNMP requests have been sent yet.
+4. It waits for approval.
+5. It prints progress while collecting bounded raw SNMP walks.
+6. It creates one private `.tar.gz` archive.
+7. It reports successful, partial, and failed protocol collections.
+
+The raw walks cover system identity, interfaces, bridge/STP/FDB, LLDP, LLDPv2, CDP, IP addresses and neighbors, OSPF,
+standard BGP, and common vendor BGP tables.
+
+SNMP credentials are stored in a private temporary Net-SNMP configuration, not in command-line arguments or the final archive.
+The temporary data is removed when the collector finishes or is interrupted.
+
+## Requirements
+
+Run the collector on a Linux system that can reach the affected devices. It requires:
+
+- Python 3.6 or later;
+- PyYAML when using a Netdata configuration file;
+- `snmpwalk` from the Net-SNMP command-line tools;
+- `curl` and `sha256sum` only when using the download procedure below.
+
+For example, the required packages are commonly named `python3-yaml` and `snmp` on Debian/Ubuntu, or `python3-pyyaml` and
+`net-snmp-utils` on RHEL-compatible systems.
+
+## Download the collector
+
+Download the reviewed collector into a private temporary directory and verify it before running it:
+
+```bash
+SNMP_DIAG_DIR="$(mktemp -d)"
+(
+  set -euo pipefail
+  chmod 700 "$SNMP_DIAG_DIR"
+  SNMP_DIAG_SHA256='d022249eefbcf4c65cd4433dc115d65343efa76a1317d9ac9388f5adb16b009f'
+  curl --fail --location --proto '=https' --tlsv1.2 \
+    --output "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" \
+    'https://raw.githubusercontent.com/netdata/netdata/master/src/go/plugin/go.d/collector/snmp/tools/collect-snmp-troubleshooting-data.py'
+  printf '%s  %s\n' "$SNMP_DIAG_SHA256" "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" | sha256sum --check -
+  chmod 700 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py"
+  python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" --help
+)
+```
+
+If checksum verification fails, do not run the file. Report the failure in the support ticket.
+
+Running the collector with `--help`, `-h`, or no parameters prints its complete usage without contacting any device:
+
+```bash
+python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py"
+```
+
+## Select nodes from Netdata configuration
+
+The collector checks these Netdata configuration roots in order:
+
+1. `/etc/netdata`
+2. `/opt/netdata/etc/netdata`
+
+The first root containing Netdata SNMP configuration wins. Within that root, the collector reads the standard static jobs file
+`go.d/snmp.conf` and SNMP service-discovery file `go.d/sd/snmp.conf` when they exist.
+
+List the available static jobs and discovery credential scopes without exposing credentials:
+
+```bash
+sudo python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" --list-configured
+```
+
+Select only the affected jobs by repeating `--node`:
+
+```bash
+sudo python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" \
+  --node 'core-switch' \
+  --node 'edge-router'
+```
+
+You can also select a configured job by its exact address. If the same address belongs to multiple static jobs, use the job name
+so the collector knows which credentials to use.
+
+For SNMP service discovery, select the exact affected IP address. The collector reuses the credential assigned to the single
+configured range containing that address:
+
+```bash
+sudo python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" \
+  --node '192.0.2.10'
+```
+
+The collector does not read the discovery cache, enumerate a range, or scan a subnet. If an address belongs to multiple
+credential scopes, use manual configuration so the intended credentials are explicit.
+
+Use a different static-jobs or SNMP-discovery configuration file when needed. An explicit path always wins and the collector
+stops if that file does not exist:
+
+```bash
+sudo python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" \
+  --netdata-snmp-config '/private/path/snmp.conf' \
+  --node 'core-switch'
+```
+
+Use `sudo` when the Netdata configuration or its credentials are protected. Alternatively, copy the configuration to a private,
+restricted location and provide its path explicitly.
+
+`--all-configured` selects every enabled static job in the chosen configuration. It never expands discovery ranges. Use it only
+when all static jobs are relevant:
+
+```bash
+sudo python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" --all-configured
+```
+
+## Configure nodes manually
+
+A Netdata configuration is optional. Select a manual SNMPv1 or SNMPv2c node by address and assign a useful name with
+`NAME=ADDRESS`:
+
+```bash
+python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" \
+  --node 'access-switch=192.0.2.10' \
+  --snmp-version 2c \
+  --port 161 \
+  --timeout 5 \
+  --retries 1
+```
+
+The collector requests the community with a hidden prompt. It never accepts communities or passphrases as command-line
+arguments, where other local users could see them.
+
+For SNMPv3, provide the non-secret protocol settings and enter the passphrases at the hidden prompts:
+
+```bash
+python3 "$SNMP_DIAG_DIR/collect-snmp-troubleshooting-data.py" \
+  --node 'edge-router=192.0.2.20' \
+  --snmp-version 3 \
+  --v3-user 'operator' \
+  --v3-level authPriv \
+  --v3-auth-proto sha256 \
+  --v3-priv-proto aes256 \
+  --v3-context 'routing-instance'
+```
+
+Omit `--v3-context` when the device uses the default SNMPv3 context.
+
+`NAME=ADDRESS` explicitly requests manual settings even when the address belongs to a configured discovery scope. Repeat
+`--node` to select several manual nodes that use the same command-line protocol settings. Run separate collections when manual
+nodes require different settings, or describe them as separate jobs in a private Netdata-format configuration file.
+
+When every selected node uses `NAME=ADDRESS`, the collector does not load automatically detected Netdata configuration. An
+explicit `--netdata-snmp-config` path is still loaded and validated.
+
+If a Netdata configuration value contains a canonical `${env:VARIABLE}` reference available to the collector, it is resolved
+using Netdata's trimmed-value behavior. Text such as `${TOKEN}` without a resolver scheme remains literal. For other unresolved
+active references, such as protected `${file:/path}` secrets, the collector prompts for the effective value instead of trying to
+reproduce Netdata's secret-resolution machinery.
+
+## Review and approve the plan
+
+Before sending any SNMP request, the collector prints:
+
+- each selected node name and address;
+- the SNMP port and version;
+- whether the settings came from manual input or a Netdata configuration;
+- every protocol data group it will collect.
+
+Review the plan and answer `y` or `yes` to proceed. Any other answer cancels collection without contacting a device.
+
+`--yes` accepts the printed plan non-interactively. Use it only after the same command and scope have already been reviewed.
+
+## Read and submit the result
+
+The collector prints every SNMP command before running it, followed by progress and a result for each node and protocol group.
+One of these statuses is recorded for each group:
+
+- `success`: every walk in the group completed;
+- `partial`: some data was collected, but a walk failed or its bounded output was truncated;
+- `failed`: no walk in the group completed.
+
+The final archive is named `netdata-snmp-data-<UTC timestamp>.tar.gz`. It contains:
+
+- `plan.txt`: the approved collection scope;
+- `collection-status.tsv`: per-node and per-protocol results;
+- `summary.txt`: successful, partial, and failed totals;
+- `devices/`: bounded raw SNMP output;
+- `manifest.sha256`: integrity hashes for the files in the archive;
+- `README.txt`: handling guidance.
+
+The process exit code is `0` when every protocol group succeeds, `2` when the archive contains partial or failed collections,
+`1` for a fatal setup error, `130` for Ctrl-C, `129` for `SIGHUP`, and `143` for `SIGTERM`. An exit code of `2` still produces
+useful diagnostic evidence.
+
+Attach the single `.tar.gz` archive to a restricted ticket in the
+[Netdata Support portal](https://support.netdata.cloud/support/home). Include what is missing or incorrect, when the problem was
+visible, and whether device configuration or firmware changed recently.
+
+Raw SNMP data can contain private hostnames, addresses, MAC addresses, interface descriptions, device identifiers, and other
+network inventory. Do not upload the archive to Slack, GitHub, email, a public ticket, or another public location.
+
+## If collection fails
+
+- **A required command is missing:** install the package named in the error and rerun the same command.
+- **The Netdata configuration is unreadable:** rerun with `sudo`, or pass a private readable copy with
+  `--netdata-snmp-config`.
+- **A configured secret reference cannot be resolved:** enter the effective value at the hidden prompt.
+- **Some walks fail or time out:** submit the archive. Failures are useful evidence and do not stop the remaining probes.
+- **Collection is interrupted:** rerun it. The collector removes private temporary data and does not keep an incomplete archive.
+
+## Related documentation
+
+- [Troubleshooting SNMP device metrics](/docs/npm/device-metrics/troubleshooting.md)
+- [SNMP device configuration](/docs/npm/device-metrics/configuration.md)
+- [SNMP topology discovery methods](/docs/npm/topology/discovery-methods.md)
+- [Secrets Management](/src/collectors/SECRETS.md)

--- a/docs/npm/device-metrics/troubleshooting.md
+++ b/docs/npm/device-metrics/troubleshooting.md
@@ -70,6 +70,8 @@ The problems below are the ones that actually come up when polling network devic
 
 ## What's next
 
+- [Collect Troubleshooting Data](/docs/npm/device-metrics/collect-snmp-troubleshooting-data.md) — collect raw SNMP data without
+  including credentials when Netdata Support investigates metrics or topology.
 - [Configuration](/docs/npm/device-metrics/configuration.md) — the options referenced above.
 - [Sizing and Scaling](/docs/npm/device-metrics/sizing-and-scaling.md) — fixing hub-side overload for good.
 - [Anti-patterns](/docs/npm/device-metrics/anti-patterns.md) — the mistakes that cause these problems in the first place.

--- a/integrations/gen_npm_catalog.py
+++ b/integrations/gen_npm_catalog.py
@@ -558,7 +558,20 @@ SNMP_TRAPS_SETUP = setup_block(
     }],
 )
 
-TROUBLESHOOTING = {'problems': {'list': []}}
+TROUBLESHOOTING = {
+    'problems': {
+        'list': [{
+            'name': 'Collect Live Data for Netdata Support',
+            'description':
+                'For missing SNMP metrics or incomplete SNMP-derived topology, follow '
+                "[Collect SNMP troubleshooting data](/docs/npm/device-metrics/collect-snmp-troubleshooting-data.md) "
+                "to create "
+                'a raw SNMP data archive that omits credentials and attach it to a '
+                'restricted Freshdesk ticket.',
+        }],
+    },
+}
+EMPTY_TROUBLESHOOTING = {'problems': {'list': []}}
 METRICS = {'folding': {'title': 'Metrics', 'enabled': False}, 'description': '', 'availability': [], 'scopes': []}
 
 
@@ -579,7 +592,7 @@ def make_entry(name, link, categories, icon, keywords, ov, plugin_name=PLUGIN_GO
         },
         'overview': ov,
         'setup': setup if setup is not None else SETUP,
-        'troubleshooting': TROUBLESHOOTING,
+        'troubleshooting': TROUBLESHOOTING if module_name in ('snmp', 'snmp_topology') else EMPTY_TROUBLESHOOTING,
         'alerts': [],
         'metrics': metrics if metrics is not None else METRICS,
     }

--- a/integrations/tests/test_descriptions.py
+++ b/integrations/tests/test_descriptions.py
@@ -51,6 +51,7 @@ from gen_npm_catalog import (  # noqa: E402
     build_device_modules,
     is_device_catalog_profile,
     load_profiles,
+    make_entry,
 )
 
 
@@ -81,6 +82,26 @@ class NPMCatalogProfileVisibilityTest(unittest.TestCase):
             for module in modules
         ]
         self.assertFalse(any("topology-role-" in value for value in method_descriptions))
+
+    def test_snmp_support_collection_is_not_attached_to_unrelated_catalog_entries(self):
+        common = {
+            "name": "Test",
+            "link": "",
+            "categories": ["data-collection.networking"],
+            "icon": "netdata.png",
+            "keywords": ["test"],
+            "ov": {},
+        }
+        snmp = make_entry(**common)
+        topology = make_entry(**common, module_name="snmp_topology")
+        traps = make_entry(**common, module_name="snmp_traps")
+        non_snmp = make_entry(**common, plugin_name="netdata", module_name="streaming")
+
+        self.assertTrue(snmp["troubleshooting"]["problems"]["list"])
+        self.assertTrue(topology["troubleshooting"]["problems"]["list"])
+        self.assertFalse(traps["troubleshooting"]["problems"]["list"])
+        self.assertFalse(non_snmp["troubleshooting"]["problems"]["list"])
+
 
 MARKDOWN_SPECIAL_CHARACTERS = "*_[]<>#`~"
 yaml = YAML(typ="safe")

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -1242,6 +1242,9 @@ modules:
     troubleshooting:
       problems:
         list:
+          - name: Collect Live Data for Netdata Support
+            description: |
+              For missing SNMP metrics or incomplete SNMP-derived topology, follow [Collect SNMP troubleshooting data](/docs/npm/device-metrics/collect-snmp-troubleshooting-data.md) to create a raw SNMP data archive that omits credentials and attach it to a restricted Freshdesk ticket.
           - name: Debugging Gaps on Charts
             description: |
               If your SNMP charts show gaps, it means the collector could not finish metric collection before the next scheduled run. This usually happens when SNMP tables take longer to collect than your configured `update_every`.

--- a/src/go/plugin/go.d/collector/snmp/tools/collect-snmp-troubleshooting-data.py
+++ b/src/go/plugin/go.d/collector/snmp/tools/collect-snmp-troubleshooting-data.py
@@ -1,0 +1,1369 @@
+#!/usr/bin/env python3
+"""Collect bounded raw SNMP data for Netdata troubleshooting."""
+
+from __future__ import print_function
+
+import argparse
+import errno
+import fcntl
+import getpass
+import hashlib
+import ipaddress
+import os
+import re
+import select
+import shlex
+import shutil
+import signal
+import stat
+# Required for shell-free snmpwalk execution.
+import subprocess  # nosec B404
+import sys
+import tarfile
+import tempfile
+import time
+from contextlib import contextmanager
+
+
+VERSION = "1.0"
+DEFAULT_CONFIG_ROOTS = (
+    "/etc/netdata",
+    "/opt/netdata/etc/netdata",
+)
+SNMPWALK_PATHS = ("/usr/bin/snmpwalk", "/usr/local/bin/snmpwalk")
+SNMP_CONFIG_FILENAME = "snmp.conf"
+MAX_COMMAND_OUTPUT = 4 * 1024 * 1024
+
+# These are raw MIB subtrees used to understand device identity, interfaces,
+# neighbors, and the routing data from which network topology is derived.
+PROBE_GROUPS = (
+    ("system", (".1.3.6.1.2.1.1",)),
+    ("interfaces", (".1.3.6.1.2.1.2.2.1", ".1.3.6.1.2.1.31.1.1.1")),
+    ("bridge-stp-fdb", (".1.3.6.1.2.1.17",)),
+    ("lldp", (".1.0.8802.1.1.2",)),
+    ("lldpv2", (".1.3.111.2.802.1.1.13",)),
+    ("cdp", (".1.3.6.1.4.1.9.9.23",)),
+    (
+        "ip-addresses-neighbors",
+        (
+            ".1.3.6.1.2.1.4.20",
+            ".1.3.6.1.2.1.4.22",
+            ".1.3.6.1.2.1.4.34.1",
+            ".1.3.6.1.2.1.4.35.1",
+        ),
+    ),
+    ("ospf", (".1.3.6.1.2.1.14",)),
+    ("bgp", (".1.3.6.1.2.1.15",)),
+    (
+        "vendor-bgp",
+        (
+            ".1.3.6.1.4.1.9.9.187",        # Cisco BGP4-MIB
+            ".1.3.6.1.4.1.2636.5.1.1",    # Juniper BGP4-V2-MIB
+            ".1.3.6.1.4.1.2011.5.25.177",  # Huawei BGP4-V2-MIB
+            ".1.3.6.1.4.1.30065.4.1",     # Arista BGP4-V2-MIB
+            ".1.3.6.1.4.1.6527.3.1.2.14",  # Nokia TIMETRA-BGP-MIB
+            ".1.3.6.1.4.1.6027.3.26",     # Dell FORCE10-BGP4-V2-MIB
+        ),
+    ),
+)
+
+
+class CollectionError(Exception):
+    """A user-actionable collection error."""
+
+
+class CollectionInterrupted(BaseException):
+    """A termination signal that per-probe Exception handling must not swallow."""
+
+    def __init__(self, signum):
+        """Record the signal that initiated interruption cleanup."""
+        super(CollectionInterrupted, self).__init__(signum)
+        self.signum = signum
+
+
+_TERMINATION_DEFER_DEPTH = 0
+_PENDING_TERMINATION_SIGNAL = None
+_TERMINATION_IN_PROGRESS = False
+
+
+class Node(object):
+    def __init__(
+        self,
+        name,
+        hostname,
+        version="2c",
+        port=161,
+        timeout=5,
+        retries=1,
+        source="manual",
+        community=None,
+        username=None,
+        level=None,
+        auth_proto=None,
+        auth_key=None,
+        priv_proto=None,
+        priv_key=None,
+        context_name="",
+    ):
+        """Validate and store one SNMP node configuration."""
+        self.name = str(name)
+        self.hostname = str(hostname)
+        self.version = normalize_version(version)
+        self.port = positive_int(port, "SNMP port")
+        self.timeout = positive_int(timeout, "SNMP timeout")
+        self.retries = nonnegative_int(retries, "SNMP retries")
+        self.source = source
+        self.community = scalar(community)
+        self.username = scalar(username)
+        self.level = normalize_level(level)
+        self.auth_proto = normalize_auth_proto(auth_proto)
+        self.auth_key = scalar(auth_key)
+        self.priv_proto = normalize_priv_proto(priv_proto)
+        self.priv_key = scalar(priv_key)
+        self.context_name = scalar(context_name) or ""
+
+
+class CommandResult(object):
+    def __init__(self, returncode, timed_out, truncated, bytes_written):
+        """Store the bounded subprocess outcome."""
+        self.returncode = returncode
+        self.timed_out = timed_out
+        self.truncated = truncated
+        self.bytes_written = bytes_written
+
+
+class DiscoveryScope(object):
+    def __init__(self, subnet, address_range, credential, source):
+        """Store one discovery range and its referenced credential."""
+        self.subnet = subnet
+        self.address_range = address_range
+        self.credential = credential
+        self.source = source
+
+    def contains(self, address):
+        version, start, end = self.address_range
+        return address.version == version and start <= int(address) <= end
+
+
+def scalar(value):
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def positive_int(value, label):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise CollectionError("{} must be an integer".format(label))
+    if parsed < 1:
+        raise CollectionError("{} must be at least 1".format(label))
+    return parsed
+
+
+def nonnegative_int(value, label):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise CollectionError("{} must be an integer".format(label))
+    if parsed < 0:
+        raise CollectionError("{} must not be negative".format(label))
+    return parsed
+
+
+def normalize_version(value):
+    mapping = {"0": "1", "1": "1", "2": "2c", "2c": "2c", "3": "3"}
+    version = mapping.get(str(value).lower())
+    if version is None:
+        raise CollectionError("unsupported SNMP version {!r}; use 1, 2c, or 3".format(value))
+    return version
+
+
+def normalize_level(value):
+    mapping = {
+        None: "noAuthNoPriv",
+        "": "noAuthNoPriv",
+        "1": "noAuthNoPriv",
+        "none": "noAuthNoPriv",
+        "noauthnopriv": "noAuthNoPriv",
+        "2": "authNoPriv",
+        "authnopriv": "authNoPriv",
+        "3": "authPriv",
+        "authpriv": "authPriv",
+    }
+    level = mapping.get(None if value is None else str(value).lower())
+    if level is None:
+        raise CollectionError(
+            "unsupported SNMPv3 security level {!r}; use none, authNoPriv, or authPriv".format(value)
+        )
+    return level
+
+
+def normalize_auth_proto(value):
+    mapping = {
+        None: "NONE",
+        "": "NONE",
+        "1": "NONE",
+        "none": "NONE",
+        "2": "MD5",
+        "md5": "MD5",
+        "3": "SHA",
+        "sha": "SHA",
+        "4": "SHA-224",
+        "sha224": "SHA-224",
+        "5": "SHA-256",
+        "sha256": "SHA-256",
+        "6": "SHA-384",
+        "sha384": "SHA-384",
+        "7": "SHA-512",
+        "sha512": "SHA-512",
+    }
+    protocol = mapping.get(None if value is None else str(value).lower())
+    if protocol is None:
+        raise CollectionError("unsupported SNMPv3 authentication protocol {!r}".format(value))
+    return protocol
+
+
+def normalize_priv_proto(value):
+    mapping = {
+        None: "NONE",
+        "": "NONE",
+        "1": "NONE",
+        "none": "NONE",
+        "2": "DES",
+        "des": "DES",
+        "3": "AES",
+        "aes": "AES",
+        "4": "AES-192",
+        "aes192": "AES-192",
+        "5": "AES-256",
+        "aes256": "AES-256",
+        "6": "AES-192-C",
+        "aes192c": "AES-192-C",
+        "7": "AES-256-C",
+        "aes256c": "AES-256-C",
+    }
+    protocol = mapping.get(None if value is None else str(value).lower())
+    if protocol is None:
+        raise CollectionError("unsupported SNMPv3 privacy protocol {!r}".format(value))
+    return protocol
+
+
+def load_yaml_module():
+    try:
+        import yaml
+    except ImportError:
+        raise CollectionError(
+            "PyYAML is required to read Netdata configuration; install python3-yaml "
+            "or run with only manual --node targets"
+        )
+    return yaml
+
+
+def select_netdata_configs(explicit_path, default_roots=DEFAULT_CONFIG_ROOTS):
+    if explicit_path is not None:
+        if not explicit_path:
+            raise CollectionError("--netdata-snmp-config requires a non-empty FILE")
+        path = os.path.abspath(explicit_path)
+        if not os.path.isfile(path):
+            raise CollectionError("--netdata-snmp-config does not exist or is not a file: {}".format(path))
+        return [path]
+    for root in default_roots:
+        paths = (
+            os.path.join(root, "go.d", SNMP_CONFIG_FILENAME),
+            os.path.join(root, "go.d", "sd", SNMP_CONFIG_FILENAME),
+        )
+        existing = [path for path in paths if os.path.isfile(path)]
+        if existing:
+            return existing
+    return []
+
+
+def read_yaml_document(path):
+    yaml = load_yaml_module()
+    try:
+        with open(path, "r") as handle:
+            data = yaml.safe_load(handle)
+    except PermissionError:
+        raise CollectionError(
+            "cannot read {}. Run this command with sudo, or copy the file to a private readable path "
+            "and pass --netdata-snmp-config".format(path)
+        )
+    except OSError as error:
+        raise CollectionError("cannot read {}: {}".format(path, error))
+    except yaml.YAMLError as error:
+        raise CollectionError("cannot parse {} as YAML: {}".format(path, error))
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise CollectionError("{} must contain a top-level YAML mapping".format(path))
+    return data
+
+
+def parse_static_job(job, index, path):
+    if not isinstance(job, dict):
+        raise CollectionError("{}: jobs[{}] must be a mapping".format(path, index))
+    if job.get("enabled") is False or job.get("disabled") is True:
+        return None
+    name = scalar(job.get("name"))
+    hostname = scalar(job.get("hostname"))
+    if not name or not hostname:
+        raise CollectionError("{}: jobs[{}] requires name and hostname".format(path, index))
+    options = job.get("options") or {}
+    user = job.get("user") or {}
+    if not isinstance(options, dict) or not isinstance(user, dict):
+        raise CollectionError("{}: job {!r} has invalid options or user settings".format(path, name))
+    return Node(
+        name=name,
+        hostname=hostname,
+        version=options.get("version", "2c"),
+        port=options.get("port", 161),
+        timeout=options.get("timeout", 5),
+        retries=options.get("retries", 1),
+        source="Netdata config: {}".format(path),
+        community=job.get("community", "public"),
+        username=user.get("name"),
+        level=user.get("level", "authPriv"),
+        auth_proto=user.get("auth_proto", "sha512"),
+        auth_key=user.get("auth_key"),
+        priv_proto=user.get("priv_proto", "aes192c"),
+        priv_key=user.get("priv_key"),
+        context_name=user.get("context_name", ""),
+    )
+
+
+def parse_static_jobs(data, path):
+    jobs = data.get("jobs")
+    if "jobs" not in data or jobs is None:
+        return []
+    if not isinstance(jobs, list):
+        raise CollectionError("{}: 'jobs' must be a list or null".format(path))
+
+    nodes = []
+    seen_names = set()
+    for index, job in enumerate(jobs, 1):
+        node = parse_static_job(job, index, path)
+        if node is None:
+            continue
+        if node.name in seen_names:
+            raise CollectionError("{} contains duplicate job name {!r}".format(path, node.name))
+        seen_names.add(node.name)
+        nodes.append(node)
+    return nodes
+
+
+def parse_address_range(value, path):
+    text = scalar(value)
+    if not text:
+        raise CollectionError("{}: discovery network requires a subnet".format(path))
+    try:
+        if "-" in text:
+            first, last = text.split("-", 1)
+            start = ipaddress.ip_address(first.strip())
+            end = ipaddress.ip_address(last.strip())
+            if start.version != end.version or int(start) > int(end):
+                raise ValueError("invalid address range")
+            return start.version, int(start), int(end)
+        if "/" in text:
+            network = ipaddress.ip_network(text, strict=False)
+            start = int(network.network_address)
+            end = int(network.broadcast_address)
+            if (network.version == 4 and network.prefixlen < 31) or (
+                network.version == 6 and network.prefixlen < 127
+            ):
+                start += 1
+                end -= 1
+            return network.version, start, end
+        address = ipaddress.ip_address(text)
+        return address.version, int(address), int(address)
+    except ValueError as error:
+        raise CollectionError(
+            "{}: unsupported discovery subnet {!r}: {}".format(path, text, error)
+        )
+
+
+def index_discovery_credentials(credentials, path):
+    by_name = {}
+    for index, credential in enumerate(credentials, 1):
+        if not isinstance(credential, dict):
+            raise CollectionError("{}: discovery credential {} must be a mapping".format(path, index))
+        name = scalar(credential.get("name"))
+        if not name:
+            raise CollectionError("{}: discovery credential {} requires a name".format(path, index))
+        if name in by_name:
+            raise CollectionError("{} contains duplicate discovery credential {!r}".format(path, name))
+        by_name[name] = credential
+    return by_name
+
+
+def build_discovery_scopes(networks, credentials, path):
+    scopes = []
+    for index, network in enumerate(networks, 1):
+        if not isinstance(network, dict):
+            raise CollectionError("{}: discovery network {} must be a mapping".format(path, index))
+        subnet = scalar(network.get("subnet"))
+        credential_name = scalar(network.get("credential"))
+        if credential_name not in credentials:
+            raise CollectionError(
+                "{}: discovery network {!r} references unknown credential {!r}".format(
+                    path, subnet, credential_name
+                )
+            )
+        scopes.append(
+            DiscoveryScope(
+                subnet,
+                parse_address_range(subnet, path),
+                credentials[credential_name],
+                path,
+            )
+        )
+    return scopes
+
+
+def parse_discovery_scopes(data, path):
+    discoverer = data.get("discoverer")
+    if not isinstance(discoverer, dict) or "snmp" not in discoverer or data.get("disabled") is True:
+        return []
+    snmp = discoverer.get("snmp") or {}
+    if not isinstance(snmp, dict):
+        raise CollectionError("{}: discoverer.snmp must be a mapping".format(path))
+    credentials = snmp.get("credentials") or []
+    networks = snmp.get("networks") or []
+    if not isinstance(credentials, list) or not isinstance(networks, list):
+        raise CollectionError("{}: discovery credentials and networks must be lists".format(path))
+    return build_discovery_scopes(networks, index_discovery_credentials(credentials, path), path)
+
+
+def read_netdata_configuration(paths, skip_empty=False):
+    nodes = []
+    scopes = []
+    seen_names = set()
+    for path in paths:
+        data = read_yaml_document(path)
+        if not data and skip_empty:
+            continue
+        if "jobs" not in data and not (
+            isinstance(data.get("discoverer"), dict) and "snmp" in data["discoverer"]
+        ):
+            raise CollectionError(
+                "{} is neither a go.d SNMP jobs file nor an SNMP discovery file".format(path)
+            )
+        for node in parse_static_jobs(data, path):
+            if node.name in seen_names:
+                raise CollectionError("Netdata configuration contains duplicate job name {!r}".format(node.name))
+            seen_names.add(node.name)
+            nodes.append(node)
+        scopes.extend(parse_discovery_scopes(data, path))
+    return nodes, scopes
+
+
+def read_netdata_jobs(path):
+    nodes, _scopes = read_netdata_configuration([path])
+    return nodes
+
+
+def parse_manual_selector(selector):
+    if "=" in selector:
+        name, hostname = selector.split("=", 1)
+        name = name.strip()
+        hostname = hostname.strip()
+        if not name or not hostname:
+            raise CollectionError("manual --node NAME=ADDRESS requires both values")
+        return name, hostname
+    value = selector.strip()
+    if not value:
+        raise CollectionError("--node must not be empty")
+    return value, value
+
+
+def node_from_discovery(name, hostname, scope, args):
+    credential = scope.credential
+    return Node(
+        name=name,
+        hostname=hostname,
+        version=credential.get("version", "2c"),
+        port=args.port,
+        timeout=args.timeout,
+        retries=args.retries,
+        source="Netdata discovery config: {} ({})".format(scope.source, scope.subnet),
+        community=credential.get("community"),
+        username=credential.get("username"),
+        level=credential.get("security_level"),
+        auth_proto=credential.get("auth_protocol"),
+        auth_key=credential.get("auth_password"),
+        priv_proto=credential.get("priv_protocol"),
+        priv_key=credential.get("priv_password"),
+        context_name=credential.get("context_name", ""),
+    )
+
+
+def node_identity(node):
+    return (
+        node.hostname,
+        node.version,
+        node.port,
+        node.timeout,
+        node.retries,
+        node.community,
+        node.username,
+        node.level,
+        node.auth_proto,
+        node.auth_key,
+        node.priv_proto,
+        node.priv_key,
+        node.context_name,
+    )
+
+
+def add_selected_node(selected, selected_by_name, node):
+    existing = selected_by_name.get(node.name)
+    if existing is not None:
+        if node_identity(existing) != node_identity(node):
+            raise CollectionError(
+                "node name {!r} selects conflicting addresses or SNMP settings; "
+                "use a unique NAME for each target".format(node.name)
+            )
+        return
+    selected_by_name[node.name] = node
+    selected.append(node)
+
+
+def configured_node_for_selector(selector, by_name, by_hostname):
+    if "=" in selector:
+        return None
+    if selector in by_name:
+        return by_name[selector]
+    matches = by_hostname.get(selector, [])
+    if len(matches) > 1:
+        names = ", ".join(sorted(node.name for node in matches))
+        raise CollectionError(
+            "configured address {!r} belongs to multiple jobs ({}); select a job name".format(
+                selector, names
+            )
+        )
+    return matches[0] if matches else None
+
+
+def discovery_node_for_selector(name, hostname, selector, discovery_scopes, args):
+    if "=" in selector:
+        return None
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        return None
+    matches = [scope for scope in discovery_scopes if scope.contains(address)]
+    if len(matches) > 1:
+        raise CollectionError(
+            "address {!r} matches multiple discovery credential scopes; use "
+            "--node NAME=ADDRESS to provide manual settings".format(hostname)
+        )
+    return node_from_discovery(name, hostname, matches[0], args) if matches else None
+
+
+def manual_node(name, hostname, args):
+    return Node(
+        name=name,
+        hostname=hostname,
+        version=args.snmp_version,
+        port=args.port,
+        timeout=args.timeout,
+        retries=args.retries,
+        username=args.v3_user,
+        level=args.v3_level,
+        auth_proto=args.v3_auth_proto,
+        priv_proto=args.v3_priv_proto,
+        context_name=args.v3_context,
+    )
+
+
+def select_nodes(configured, discovery_scopes, selectors, all_configured, args):
+    selected = []
+    selected_by_name = {}
+
+    if all_configured:
+        if not configured:
+            raise CollectionError(
+                "--all-configured requires static SNMP jobs. Discovery networks are never scanned; "
+                "select exact addresses with --node"
+            )
+        for node in configured:
+            add_selected_node(selected, selected_by_name, node)
+
+    by_name = {node.name: node for node in configured}
+    by_hostname = {}
+    for node in configured:
+        by_hostname.setdefault(node.hostname, []).append(node)
+
+    for selector in selectors:
+        node = configured_node_for_selector(selector, by_name, by_hostname)
+        if node is not None:
+            add_selected_node(selected, selected_by_name, node)
+            continue
+        name, hostname = parse_manual_selector(selector)
+        node = discovery_node_for_selector(name, hostname, selector, discovery_scopes, args)
+        add_selected_node(
+            selected,
+            selected_by_name,
+            node if node is not None else manual_node(name, hostname, args),
+        )
+
+    if not selected:
+        raise CollectionError("select at least one node with --node, or use --all-configured")
+    return selected
+
+
+_NETDATA_ENV_REFERENCE = re.compile(r"\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}")
+_ACTIVE_REFERENCE = re.compile(r"\$\{[^{}:]*:[^{}]*\}")
+
+
+def resolve_config_value(value, prompt, secret=False, default=None):
+    value = scalar(value)
+    if value is not None:
+        def replace_netdata_env(match):
+            value = os.environ.get(match.group(1))
+            return match.group(0) if value is None else value.strip()
+
+        value = _NETDATA_ENV_REFERENCE.sub(replace_netdata_env, value)
+        # Netdata supports additional ${...} resolvers that a standalone tool
+        # cannot reproduce safely. Prompt instead of using an unresolved token.
+        if not _ACTIVE_REFERENCE.search(value):
+            return value
+    if default is not None and value is None:
+        return default
+    try:
+        answer = getpass.getpass(prompt + ": ") if secret else input(prompt + ": ")
+    except EOFError:
+        raise CollectionError(
+            "{} is not available from configuration or the environment, and input is not interactive".format(
+                prompt
+            )
+        )
+    if not answer:
+        raise CollectionError("{} is required".format(prompt))
+    return answer
+
+
+def prepare_nodes(nodes):
+    for node in nodes:
+        node.hostname = resolve_config_value(node.hostname, "Address for {}".format(node.name))
+        validate_hostname(node.hostname)
+        if node.version in ("1", "2c"):
+            node.community = resolve_config_value(
+                node.community, "SNMP community for {}".format(node.name), secret=True
+            )
+            validate_secret(node.community, "SNMP community")
+            continue
+
+        node.username = resolve_config_value(node.username, "SNMPv3 username for {}".format(node.name))
+        validate_secret(node.username, "SNMPv3 username")
+        if node.level in ("authNoPriv", "authPriv"):
+            node.auth_key = resolve_config_value(
+                node.auth_key, "SNMPv3 authentication passphrase for {}".format(node.name), secret=True
+            )
+            validate_secret(node.auth_key, "SNMPv3 authentication passphrase")
+        if node.level == "authPriv":
+            node.priv_key = resolve_config_value(
+                node.priv_key, "SNMPv3 privacy passphrase for {}".format(node.name), secret=True
+            )
+            validate_secret(node.priv_key, "SNMPv3 privacy passphrase")
+        if node.context_name:
+            node.context_name = resolve_config_value(
+                node.context_name, "SNMPv3 context for {}".format(node.name)
+            )
+            validate_secret(node.context_name, "SNMPv3 context")
+
+
+def validate_secret(value, label):
+    if value is None or value == "":
+        raise CollectionError("{} must not be empty".format(label))
+    if any(character in value for character in "\x00\r\n"):
+        raise CollectionError("{} contains an unsupported control character".format(label))
+
+
+def validate_hostname(hostname):
+    if any(character in hostname for character in "\x00\r\n\t "):
+        raise CollectionError("SNMP address {!r} contains whitespace or a control character".format(hostname))
+    try:
+        ipaddress.ip_address(hostname)
+        return
+    except ValueError:
+        pass
+    if len(hostname) > 253 or not re.match(r"^[A-Za-z0-9][A-Za-z0-9._-]*$", hostname):
+        raise CollectionError("SNMP address {!r} is not a valid IP address or hostname".format(hostname))
+
+
+def find_snmpwalk(paths=SNMPWALK_PATHS):
+    for path in paths:
+        if not os.path.isfile(path) or not os.access(path, os.X_OK):
+            continue
+        info = os.stat(path)
+        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            continue
+        if os.geteuid() == 0 and info.st_uid != 0:
+            continue
+        return path
+    raise CollectionError(
+        "snmpwalk was not found at {}. Install the Net-SNMP command-line tools and try again".format(
+            " or ".join(paths)
+        )
+    )
+
+
+def format_plan(nodes):
+    protocols = ", ".join(name for name, _oids in PROBE_GROUPS)
+    lines = [
+        "SNMP data collection plan",
+        "=========================",
+        "No SNMP requests have been sent.",
+        "",
+    ]
+    for index, node in enumerate(nodes, 1):
+        lines.extend(
+            (
+                "{}. {}".format(index, node.name),
+                "   Address: {}:{}".format(node.hostname, node.port),
+                "   SNMP version: {}".format(node.version),
+                "   Source: {}".format(node.source),
+                "   Protocol data: {}".format(protocols),
+                "",
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def approve_plan(assume_yes):
+    if assume_yes:
+        print("Approval: accepted by --yes")
+        return True
+    try:
+        answer = input("Proceed with this collection? [y/N]: ").strip().lower()
+    except EOFError:
+        return False
+    return answer in ("y", "yes")
+
+
+def net_snmp_quote(value):
+    validate_secret(value, "SNMP configuration value")
+    return '"{}"'.format(value.replace("\\", "\\\\").replace('"', '\\"'))
+
+
+def write_private_snmp_config(directory, node):
+    lines = ["dontLoadHostConfig true", "defVersion {}".format(node.version)]
+    if node.version in ("1", "2c"):
+        lines.append("defCommunity {}".format(net_snmp_quote(node.community)))
+    else:
+        lines.append("defSecurityName {}".format(net_snmp_quote(node.username)))
+        lines.append("defSecurityLevel {}".format(node.level))
+        if node.level in ("authNoPriv", "authPriv"):
+            lines.append("defAuthType {}".format(node.auth_proto))
+            lines.append("defAuthPassphrase {}".format(net_snmp_quote(node.auth_key)))
+        if node.level == "authPriv":
+            lines.append("defPrivType {}".format(node.priv_proto))
+            lines.append("defPrivPassphrase {}".format(net_snmp_quote(node.priv_key)))
+        if node.context_name:
+            lines.append("defContext {}".format(net_snmp_quote(node.context_name)))
+    path = os.path.join(directory, SNMP_CONFIG_FILENAME)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        payload = ("\n".join(lines) + "\n").encode("utf-8")
+        offset = 0
+        while offset < len(payload):
+            offset += os.write(descriptor, payload[offset:])
+    finally:
+        os.close(descriptor)
+    return path
+
+
+def net_snmp_target(hostname, port):
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        address = None
+    if address is not None and address.version == 6:
+        return "udp6:[{}]:{}".format(hostname, port)
+    return "udp:{}:{}".format(hostname, port)
+
+
+def terminate_process_group(process):
+    with defer_termination_signals():
+        if process.poll() is not None:
+            return
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        try:
+            process.wait(timeout=1)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+
+
+def handle_termination_signal(signum, _frame):
+    global _PENDING_TERMINATION_SIGNAL
+    global _TERMINATION_IN_PROGRESS
+    if _TERMINATION_IN_PROGRESS:
+        return
+    if _TERMINATION_DEFER_DEPTH:
+        if _PENDING_TERMINATION_SIGNAL is None:
+            _PENDING_TERMINATION_SIGNAL = signum
+        return
+    _TERMINATION_IN_PROGRESS = True
+    raise CollectionInterrupted(signum)
+
+
+@contextmanager
+def defer_termination_signals():
+    global _PENDING_TERMINATION_SIGNAL
+    global _TERMINATION_DEFER_DEPTH
+    global _TERMINATION_IN_PROGRESS
+    _TERMINATION_DEFER_DEPTH += 1
+    try:
+        yield
+    finally:
+        _TERMINATION_DEFER_DEPTH -= 1
+        if _TERMINATION_DEFER_DEPTH == 0 and _PENDING_TERMINATION_SIGNAL is not None:
+            signum = _PENDING_TERMINATION_SIGNAL
+            _PENDING_TERMINATION_SIGNAL = None
+            _TERMINATION_IN_PROGRESS = True
+            raise CollectionInterrupted(signum)
+
+
+def install_termination_handlers():
+    global _PENDING_TERMINATION_SIGNAL
+    global _TERMINATION_DEFER_DEPTH
+    global _TERMINATION_IN_PROGRESS
+    _PENDING_TERMINATION_SIGNAL = None
+    _TERMINATION_DEFER_DEPTH = 0
+    _TERMINATION_IN_PROGRESS = False
+    previous = {}
+    for signum in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+        previous[signum] = signal.signal(signum, handle_termination_signal)
+    return previous
+
+
+def restore_signal_handlers(previous):
+    global _PENDING_TERMINATION_SIGNAL
+    global _TERMINATION_DEFER_DEPTH
+    global _TERMINATION_IN_PROGRESS
+    for signum, handler in previous.items():
+        signal.signal(signum, handler)
+    _PENDING_TERMINATION_SIGNAL = None
+    _TERMINATION_DEFER_DEPTH = 0
+    _TERMINATION_IN_PROGRESS = False
+
+
+def command_output_state(process, descriptor, deadline):
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return "timeout"
+    readable, _writable, _exceptional = select.select(
+        [descriptor], [], [], min(0.2, remaining)
+    )
+    if readable:
+        return "read"
+    if process.poll() is None:
+        return "wait"
+    readable, _writable, _exceptional = select.select([descriptor], [], [], 0)
+    return "read" if readable else "done"
+
+
+def read_nonblocking(descriptor):
+    try:
+        return os.read(descriptor, 65536)
+    except OSError as error:
+        if error.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+            return None
+        raise
+
+
+def write_bounded_chunk(output, chunk, written, limit):
+    kept = chunk[:max(0, limit - written)]
+    if kept:
+        output.write(kept)
+    return written + len(kept), len(kept) != len(chunk)
+
+
+def drain_bounded_output(process, descriptor, output, deadline, limit):
+    written = 0
+    truncated = False
+    timed_out = False
+    while True:
+        state = command_output_state(process, descriptor, deadline)
+        if state == "timeout":
+            terminate_process_group(process)
+            timed_out = True
+            break
+        if state == "wait":
+            continue
+        if state == "done":
+            break
+        chunk = read_nonblocking(descriptor)
+        if chunk is None:
+            continue
+        if not chunk:
+            break
+        written, chunk_truncated = write_bounded_chunk(output, chunk, written, limit)
+        truncated = truncated or chunk_truncated
+    return timed_out, truncated, written
+
+
+def finish_process(process, deadline):
+    if process.poll() is not None:
+        return False
+    try:
+        process.wait(timeout=max(0, deadline - time.monotonic()))
+        return False
+    except subprocess.TimeoutExpired:
+        terminate_process_group(process)
+        return True
+
+
+def run_bounded(command, environment, output, timeout, limit=MAX_COMMAND_OUTPUT):
+    process = None
+    try:
+        with defer_termination_signals():
+            # The executable and argument list are validated; no shell is used.
+            process = subprocess.Popen(  # nosec B603
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=environment,
+                start_new_session=True,
+            )
+        descriptor = process.stdout.fileno()
+        flags = fcntl.fcntl(descriptor, fcntl.F_GETFL)
+        fcntl.fcntl(descriptor, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        deadline = time.monotonic() + timeout
+        timed_out, truncated, written = drain_bounded_output(
+            process, descriptor, output, deadline, limit
+        )
+        timed_out = finish_process(process, deadline) or timed_out
+    except BaseException:
+        with defer_termination_signals():
+            if process is not None:
+                terminate_process_group(process)
+        raise
+    finally:
+        with defer_termination_signals():
+            if process is not None and process.stdout is not None:
+                process.stdout.close()
+    return CommandResult(process.returncode, timed_out, truncated, written)
+
+
+def safe_name(value):
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._-")
+    return cleaned[:80] or "node"
+
+
+def write_text(path, text):
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        payload = text.encode("utf-8")
+        offset = 0
+        while offset < len(payload):
+            offset += os.write(descriptor, payload[offset:])
+    finally:
+        os.close(descriptor)
+
+
+def collect_probe(snmpwalk, node, oids, config_dir, output_path, command_timeout):
+    environment = os.environ.copy()
+    environment["SNMPCONFPATH"] = config_dir
+    successes = 0
+    failures = 0
+    truncated = False
+    details = []
+    with open(output_path, "wb") as output:
+        for oid in oids:
+            command = [
+                snmpwalk,
+                "-On",
+                "-t",
+                str(node.timeout),
+                "-r",
+                str(node.retries),
+                net_snmp_target(node.hostname, node.port),
+                oid,
+            ]
+            visible = "SNMPCONFPATH={} {}".format(
+                shlex.quote(config_dir), " ".join(shlex.quote(item) for item in command)
+            )
+            print("    $ {}".format(visible))
+            output.write(("\n### OID {}\n$ {}\n".format(oid, visible)).encode("utf-8"))
+            result = run_bounded(command, environment, output, command_timeout)
+            output.write(b"\n")
+            if result.timed_out:
+                failures += 1
+                details.append("{} timed out".format(oid))
+            elif result.returncode != 0:
+                failures += 1
+                details.append("{} exited {}".format(oid, result.returncode))
+            else:
+                successes += 1
+            if result.truncated:
+                truncated = True
+                details.append("{} output truncated".format(oid))
+
+    if failures == 0 and not truncated:
+        status_value = "success"
+    elif successes > 0:
+        status_value = "partial"
+    else:
+        status_value = "failed"
+    return status_value, "; ".join(details) or "collected"
+
+
+def build_manifest(root):
+    lines = []
+    for directory, _subdirectories, filenames in os.walk(root):
+        for filename in sorted(filenames):
+            path = os.path.join(directory, filename)
+            relative = os.path.relpath(path, root)
+            digest = hashlib.sha256()
+            with open(path, "rb") as handle:
+                while True:
+                    chunk = handle.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+            lines.append("{}  {}".format(digest.hexdigest(), relative))
+    write_text(os.path.join(root, "manifest.sha256"), "\n".join(lines) + "\n")
+
+
+def create_archive(root, output_dir):
+    if not os.path.isdir(output_dir):
+        raise CollectionError("output directory does not exist: {}".format(output_dir))
+    timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    archive_path = os.path.abspath(
+        os.path.join(output_dir, "netdata-snmp-data-{}.tar.gz".format(timestamp))
+    )
+    suffix = 1
+    while os.path.exists(archive_path):
+        archive_path = os.path.abspath(
+            os.path.join(output_dir, "netdata-snmp-data-{}-{}.tar.gz".format(timestamp, suffix))
+        )
+        suffix += 1
+    descriptor = -1
+    archive_created = False
+    try:
+        with defer_termination_signals():
+            descriptor = os.open(archive_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            archive_created = True
+        with os.fdopen(descriptor, "wb") as archive_file:
+            descriptor = -1
+            with tarfile.open(fileobj=archive_file, mode="w:gz") as archive:
+                for name in sorted(os.listdir(root)):
+                    archive.add(os.path.join(root, name), arcname=name, recursive=True)
+    except BaseException:
+        with defer_termination_signals():
+            if descriptor >= 0:
+                os.close(descriptor)
+            if archive_created:
+                try:
+                    os.unlink(archive_path)
+                except OSError:
+                    pass
+        raise
+    if os.geteuid() == 0 and os.environ.get("SUDO_UID") and os.environ.get("SUDO_GID"):
+        try:
+            os.chown(archive_path, int(os.environ["SUDO_UID"]), int(os.environ["SUDO_GID"]))
+        except (OSError, ValueError) as error:
+            print("WARNING: could not return archive ownership to the sudo user: {}".format(error), file=sys.stderr)
+    return archive_path
+
+
+def collect(nodes, plan, snmpwalk, output_dir, command_timeout):
+    private_root = None
+    try:
+        with defer_termination_signals():
+            private_root = tempfile.mkdtemp(prefix="netdata-snmp-", dir=output_dir)
+        os.chmod(private_root, 0o700)
+        data_root = os.path.join(private_root, "archive")
+        secrets_root = os.path.join(private_root, "credentials")
+        os.mkdir(data_root, 0o700)
+        os.mkdir(secrets_root, 0o700)
+        os.mkdir(os.path.join(data_root, "devices"), 0o700)
+        rows = []
+        write_text(os.path.join(data_root, "plan.txt"), plan)
+        write_text(
+            os.path.join(data_root, "README.txt"),
+            "This archive contains raw SNMP responses collected for Netdata troubleshooting.\n"
+            "SNMP credentials are not included. Raw responses can contain sensitive network,\n"
+            "inventory, addressing, and device configuration information. Share the archive\n"
+            "only through the restricted support ticket requested by Netdata.\n",
+        )
+        total = len(nodes) * len(PROBE_GROUPS)
+        current = 0
+        for node_index, node in enumerate(nodes, 1):
+            node_dir = os.path.join(
+                data_root,
+                "devices",
+                "{:03d}-{}".format(node_index, safe_name(node.name)),
+            )
+            credential_dir = os.path.join(secrets_root, "{:03d}".format(node_index))
+            os.mkdir(node_dir, 0o700)
+            os.mkdir(credential_dir, 0o700)
+            write_private_snmp_config(credential_dir, node)
+            for group_name, oids in PROBE_GROUPS:
+                current += 1
+                print("[{}/{}] {}: {}".format(current, total, node.name, group_name))
+                output_path = os.path.join(node_dir, group_name + ".txt")
+                try:
+                    status_value, detail = collect_probe(
+                        snmpwalk,
+                        node,
+                        oids,
+                        credential_dir,
+                        output_path,
+                        command_timeout,
+                    )
+                except Exception as error:
+                    status_value = "failed"
+                    detail = "collector error: {}".format(error)
+                    write_text(output_path, detail + "\n")
+                rows.append((node.name, node.hostname, group_name, status_value, detail))
+                print("    Result: {}{}".format(status_value, " ({})".format(detail) if detail != "collected" else ""))
+
+        header = "node\taddress\tprotocol\tstatus\tdetails\n"
+        status_text = header + "".join(
+            "{}\t{}\t{}\t{}\t{}\n".format(
+                clean_tsv(name), clean_tsv(address), clean_tsv(protocol), status_value, clean_tsv(detail)
+            )
+            for name, address, protocol, status_value, detail in rows
+        )
+        write_text(os.path.join(data_root, "collection-status.tsv"), status_text)
+        summary = summarize(rows)
+        write_text(os.path.join(data_root, "summary.txt"), summary)
+        build_manifest(data_root)
+        archive_path = create_archive(data_root, output_dir)
+        return rows, summary, archive_path
+    finally:
+        with defer_termination_signals():
+            if private_root is not None:
+                shutil.rmtree(private_root, ignore_errors=True)
+
+
+def clean_tsv(value):
+    return str(value).replace("\t", " ").replace("\r", " ").replace("\n", " ")
+
+
+def summarize(rows):
+    counts = {"success": 0, "partial": 0, "failed": 0}
+    for _name, _address, _protocol, status_value, _detail in rows:
+        counts[status_value] += 1
+    return (
+        "SNMP collection summary\n"
+        "=======================\n"
+        "Successful protocol collections: {success}\n"
+        "Partial protocol collections: {partial}\n"
+        "Failed protocol collections: {failed}\n".format(**counts)
+    )
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Collect raw SNMP data for Netdata troubleshooting.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  %(prog)s --node 192.0.2.10\n"
+            "  %(prog)s --node core-switch=192.0.2.10 --snmp-version 3 --v3-user operator\n"
+            "  %(prog)s --node core-switch\n"
+            "  %(prog)s --all-configured\n"
+            "  %(prog)s --netdata-snmp-config /private/snmp.conf --list-configured\n\n"
+            "With no explicit configuration path, the standard SNMP jobs and discovery files under\n"
+            "/etc/netdata are used first, then those under /opt/netdata/etc/netdata. A configured\n"
+            "job name or address reuses that job. An exact IP inside one discovery credential scope\n"
+            "reuses that credential without scanning. Other --node values are manual targets."
+        ),
+    )
+    parser.add_argument("--version", action="version", version="%(prog)s " + VERSION)
+    parser.add_argument(
+        "--node",
+        action="append",
+        default=[],
+        metavar="[NAME=]ADDRESS_OR_JOB",
+        help="node to collect; repeat for multiple nodes",
+    )
+    parser.add_argument(
+        "--all-configured",
+        action="store_true",
+        help="collect every job from the selected Netdata SNMP config",
+    )
+    parser.add_argument(
+        "--list-configured",
+        action="store_true",
+        help="list jobs and discovery credential scopes from Netdata config and exit",
+    )
+    parser.add_argument(
+        "--netdata-snmp-config",
+        metavar="FILE",
+        help="use this Netdata go.d SNMP configuration file",
+    )
+    parser.add_argument(
+        "--snmp-version",
+        default="2c",
+        choices=("1", "2", "2c", "3"),
+        help="SNMP version for manual nodes (default: 2c)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=161, help="SNMP port for manual nodes (default: 161)"
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=5,
+        help="SNMP request timeout for manual nodes (default: 5 seconds)",
+    )
+    parser.add_argument(
+        "--retries", type=int, default=1, help="SNMP retries for manual nodes (default: 1)"
+    )
+    parser.add_argument(
+        "--v3-user", help="SNMPv3 username for manual nodes; prompted when omitted"
+    )
+    parser.add_argument(
+        "--v3-level",
+        default="authPriv",
+        choices=("none", "authNoPriv", "authPriv"),
+        help="SNMPv3 security level for manual nodes (default: authPriv)",
+    )
+    parser.add_argument(
+        "--v3-auth-proto",
+        default="sha512",
+        choices=("md5", "sha", "sha224", "sha256", "sha384", "sha512"),
+        help="SNMPv3 authentication protocol for manual nodes (default: sha512)",
+    )
+    parser.add_argument(
+        "--v3-priv-proto",
+        default="aes",
+        choices=("des", "aes", "aes192", "aes256", "aes192c", "aes256c"),
+        help="SNMPv3 privacy protocol for manual nodes (default: aes)",
+    )
+    parser.add_argument(
+        "--v3-context",
+        default="",
+        help="SNMPv3 context name for manual nodes (default: empty)",
+    )
+    parser.add_argument(
+        "--command-timeout",
+        type=int,
+        default=120,
+        help="maximum time for each SNMP walk (default: 120 seconds)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        metavar="DIRECTORY",
+        help="directory for the final tar.gz (default: current directory)",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="accept the printed plan without an interactive confirmation",
+    )
+    return parser
+
+
+def list_configured_jobs(nodes, scopes, paths):
+    print("Netdata SNMP configuration from {}:".format(", ".join(paths)))
+    for node in nodes:
+        print("  job  {}  {}:{}  SNMP {}".format(node.name, node.hostname, node.port, node.version))
+    for scope in scopes:
+        print(
+            "  discovery scope  {}  SNMP {}  (select an exact address with --node)".format(
+                scope.subnet, normalize_version(scope.credential.get("version", "2c"))
+            )
+        )
+    if not nodes and not scopes:
+        print("  (no enabled jobs or discovery credential scopes)")
+
+
+def run(args):
+    try:
+        args.port = positive_int(args.port, "--port")
+        args.timeout = positive_int(args.timeout, "--timeout")
+        args.retries = nonnegative_int(args.retries, "--retries")
+        args.command_timeout = positive_int(args.command_timeout, "--command-timeout")
+        manual_only = (
+            bool(args.node)
+            and all("=" in selector for selector in args.node)
+            and args.netdata_snmp_config is None
+            and not args.list_configured
+            and not args.all_configured
+        )
+        if manual_only:
+            config_paths = []
+            configured, discovery_scopes = [], []
+        else:
+            config_paths = select_netdata_configs(args.netdata_snmp_config)
+            configured, discovery_scopes = read_netdata_configuration(
+                config_paths, skip_empty=args.netdata_snmp_config is None
+            )
+        if args.list_configured:
+            if not config_paths:
+                raise CollectionError(
+                    "no Netdata SNMP config was found; use --netdata-snmp-config FILE"
+                )
+            list_configured_jobs(configured, discovery_scopes, config_paths)
+            return 0
+        nodes = select_nodes(
+            configured, discovery_scopes, args.node, args.all_configured, args
+        )
+        prepare_nodes(nodes)
+        snmpwalk = find_snmpwalk()
+        output_dir = os.path.abspath(args.output_dir)
+        if not os.path.isdir(output_dir):
+            raise CollectionError("output directory does not exist: {}".format(output_dir))
+        plan = format_plan(nodes)
+        print(plan)
+        if not approve_plan(args.yes):
+            print("Collection cancelled. No SNMP requests were sent.")
+            return 0
+        rows, summary, archive_path = collect(
+            nodes, plan, snmpwalk, output_dir, args.command_timeout
+        )
+        print("\n" + summary)
+        print("Archive: {}".format(archive_path))
+        print("Next step: attach this tar.gz to a restricted Freshdesk support ticket.")
+        return 0 if all(row[3] == "success" for row in rows) else 2
+    except CollectionError as error:
+        print("ERROR: {}".format(error), file=sys.stderr)
+        return 1
+    except CollectionInterrupted as interruption:
+        signal_name = signal.Signals(interruption.signum).name
+        print(
+            "\nCollection interrupted by {}. No incomplete archive was kept.".format(signal_name),
+            file=sys.stderr,
+        )
+        return 128 + interruption.signum
+
+
+def main(argv=None):
+    direct_cli = argv is None
+    argv = sys.argv[1:] if argv is None else argv
+    parser = build_parser()
+    if not argv:
+        parser.print_help()
+        return 0
+    args = parser.parse_args(argv)
+    previous_handlers = install_termination_handlers()
+    try:
+        result = run(args)
+    except BaseException:
+        restore_signal_handlers(previous_handlers)
+        raise
+    if not (direct_cli and _TERMINATION_IN_PROGRESS):
+        restore_signal_handlers(previous_handlers)
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/go/plugin/go.d/collector/snmp/tools/test_collect_snmp_troubleshooting_data.py
+++ b/src/go/plugin/go.d/collector/snmp/tools/test_collect_snmp_troubleshooting_data.py
@@ -1,0 +1,1003 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+
+import importlib.util
+import ipaddress
+import io
+import os
+import signal
+import stat
+# Signal cleanup tests spawn controlled helper scripts.
+import subprocess  # nosec B404
+import sys
+import tarfile
+import tempfile
+import time
+import types
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "collect-snmp-troubleshooting-data.py")
+SPEC = importlib.util.spec_from_file_location("snmp_collector", SCRIPT_PATH)
+collector = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(collector)
+
+
+def arguments(**overrides):
+    values = {
+        "snmp_version": "2c",
+        "port": 161,
+        "timeout": 5,
+        "retries": 1,
+        "v3_user": None,
+        "v3_level": "authPriv",
+        "v3_auth_proto": "sha512",
+        "v3_priv_proto": "aes",
+        "v3_context": "",
+    }
+    values.update(overrides)
+    return types.SimpleNamespace(**values)
+
+
+class TemporaryDirectoryTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def path(self, name):
+        return os.path.join(self.temporary.name, name)
+
+    def write(self, name, content):
+        path = self.path(name)
+        with open(path, "w") as handle:
+            handle.write(content)
+        return path
+
+
+class ConfigurationTests(TemporaryDirectoryTest):
+    def test_explicit_config_wins(self):
+        explicit = self.write("explicit.conf", "jobs: []\n")
+        first = self.path("first")
+        self.assertEqual(collector.select_netdata_configs(explicit, (first,)), [explicit])
+
+    def test_missing_explicit_config_is_an_error(self):
+        missing = self.path("missing.conf")
+        with self.assertRaisesRegex(collector.CollectionError, "does not exist"):
+            collector.select_netdata_configs(missing, ())
+
+    def test_empty_explicit_config_path_is_an_error(self):
+        with self.assertRaisesRegex(collector.CollectionError, "non-empty FILE"):
+            collector.select_netdata_configs("", ())
+
+    def test_first_default_config_wins(self):
+        first = self.path("first-root")
+        second = self.path("second-root")
+        os.makedirs(os.path.join(first, "go.d", "sd"))
+        os.makedirs(os.path.join(second, "go.d", "sd"))
+        first_static = os.path.join(first, "go.d", "snmp.conf")
+        first_discovery = os.path.join(first, "go.d", "sd", "snmp.conf")
+        second_static = os.path.join(second, "go.d", "snmp.conf")
+        for path in (first_static, first_discovery, second_static):
+            with open(path, "w") as handle:
+                handle.write("jobs: []\n")
+        self.assertEqual(
+            collector.select_netdata_configs(None, (first, second)),
+            [first_static, first_discovery],
+        )
+
+    def test_no_config_is_allowed(self):
+        self.assertEqual(
+            collector.select_netdata_configs(None, (self.path("one"), self.path("two"))), []
+        )
+
+    def test_reads_v2c_and_v3_jobs_and_skips_disabled_jobs(self):
+        path = self.write(
+            "snmp.conf",
+            """
+jobs:
+  - name: access-switch
+    hostname: 192.0.2.10
+    community: private
+    options:
+      version: 2
+      port: 1161
+      timeout: 7
+      retries: 2
+  - name: core-router
+    hostname: 2001:db8::10
+    options:
+      version: 3
+    user:
+      name: operator
+      level: authNoPriv
+      auth_proto: sha256
+      auth_key: secret
+  - name: disabled
+    hostname: 192.0.2.20
+    enabled: false
+""",
+        )
+        nodes = collector.read_netdata_jobs(path)
+        self.assertEqual([node.name for node in nodes], ["access-switch", "core-router"])
+        self.assertEqual(nodes[0].version, "2c")
+        self.assertEqual(nodes[0].port, 1161)
+        self.assertEqual(nodes[0].timeout, 7)
+        self.assertEqual(nodes[0].retries, 2)
+        self.assertEqual(nodes[1].version, "3")
+        self.assertEqual(nodes[1].level, "authNoPriv")
+        self.assertEqual(nodes[1].auth_proto, "SHA-256")
+
+    def test_reads_numeric_v3_aliases_from_static_job(self):
+        path = self.write(
+            "numeric-v3.conf",
+            """
+jobs:
+  - name: numeric-v3
+    hostname: 192.0.2.10
+    options:
+      version: 3
+    user:
+      name: operator
+      level: 3
+      auth_proto: 5
+      auth_key: auth-secret
+      priv_proto: 3
+      priv_key: priv-secret
+""",
+        )
+        node = collector.read_netdata_jobs(path)[0]
+        self.assertEqual(node.level, "authPriv")
+        self.assertEqual(node.auth_proto, "SHA-256")
+        self.assertEqual(node.priv_proto, "AES")
+
+    def test_missing_jobs_list_is_an_error(self):
+        path = self.write("snmp.conf", "not_jobs: []\n")
+        with self.assertRaisesRegex(collector.CollectionError, "neither a go.d SNMP jobs file"):
+            collector.read_netdata_jobs(path)
+
+    def test_null_jobs_list_is_empty(self):
+        path = self.write("snmp.conf", "jobs: null\n")
+        self.assertEqual(collector.read_netdata_jobs(path), [])
+
+    def test_automatic_config_skips_empty_file_and_reads_discovery(self):
+        static_path = self.write("snmp.conf", "# Use stock defaults.\n")
+        discovery_path = self.write(
+            "sd-snmp.conf",
+            """
+discoverer:
+  snmp:
+    credentials:
+      - name: public
+        version: 2c
+        community: public
+    networks:
+      - subnet: 192.0.2.0/24
+        credential: public
+""",
+        )
+        nodes, scopes = collector.read_netdata_configuration(
+            [static_path, discovery_path], skip_empty=True
+        )
+        self.assertEqual(nodes, [])
+        self.assertEqual(len(scopes), 1)
+
+    def test_explicit_empty_config_is_an_error(self):
+        path = self.write("snmp.conf", "# Use stock defaults.\n")
+        with self.assertRaisesRegex(collector.CollectionError, "neither"):
+            collector.read_netdata_configuration([path])
+
+    def test_reads_discovery_credentials_and_networks_without_creating_nodes(self):
+        path = self.write(
+            "sd-snmp.conf",
+            """
+disabled: false
+discoverer:
+  snmp:
+    credentials:
+      - name: lan-v3
+        version: 3
+        username: operator
+        security_level: authNoPriv
+        auth_protocol: sha256
+        auth_password: secret
+    networks:
+      - subnet: 192.0.2.0/24
+        credential: lan-v3
+services: []
+""",
+        )
+        nodes, scopes = collector.read_netdata_configuration([path])
+        self.assertEqual(nodes, [])
+        self.assertEqual(len(scopes), 1)
+        self.assertEqual(scopes[0].subnet, "192.0.2.0/24")
+        self.assertTrue(scopes[0].contains(ipaddress.ip_address("192.0.2.10")))
+        self.assertFalse(scopes[0].contains(ipaddress.ip_address("192.0.3.10")))
+
+    def test_disabled_discovery_file_has_no_credential_scopes(self):
+        path = self.write(
+            "sd-snmp.conf",
+            "disabled: true\ndiscoverer:\n  snmp:\n    credentials: []\n    networks: []\n",
+        )
+        _nodes, scopes = collector.read_netdata_configuration([path])
+        self.assertEqual(scopes, [])
+
+    def test_discovery_range_formats_match_exact_addresses(self):
+        for subnet, inside, outside in (
+            ("192.0.2.10-192.0.2.20", "192.0.2.15", "192.0.2.21"),
+            ("192.0.2.0/255.255.255.0", "192.0.2.10", "192.0.3.10"),
+            ("2001:db8::/126", "2001:db8::1", "2001:db8::8"),
+        ):
+            scope = collector.DiscoveryScope(
+                subnet,
+                collector.parse_address_range(subnet, "test"),
+                {},
+                "test",
+            )
+            self.assertTrue(scope.contains(ipaddress.ip_address(inside)))
+            self.assertFalse(scope.contains(ipaddress.ip_address(outside)))
+
+    def test_duplicate_job_names_are_an_error(self):
+        path = self.write(
+            "snmp.conf",
+            "jobs:\n  - {name: same, hostname: 192.0.2.1}\n"
+            "  - {name: same, hostname: 192.0.2.2}\n",
+        )
+        with self.assertRaisesRegex(collector.CollectionError, "duplicate job name"):
+            collector.read_netdata_jobs(path)
+
+    def test_unreadable_config_explains_sudo(self):
+        path = self.write("snmp.conf", "jobs: []\n")
+        with mock.patch("builtins.open", side_effect=PermissionError("denied")):
+            with self.assertRaisesRegex(collector.CollectionError, "sudo"):
+                collector.read_netdata_jobs(path)
+
+
+class SelectionTests(unittest.TestCase):
+    def setUp(self):
+        self.configured = [
+            collector.Node("switch-a", "192.0.2.10", community="one", source="config"),
+            collector.Node("switch-b", "192.0.2.11", community="two", source="config"),
+        ]
+
+    def test_job_name_reuses_configured_settings(self):
+        nodes = collector.select_nodes(self.configured, [], ["switch-a"], False, arguments())
+        self.assertEqual(len(nodes), 1)
+        self.assertIs(nodes[0], self.configured[0])
+
+    def test_configured_address_reuses_configured_settings(self):
+        nodes = collector.select_nodes(self.configured, [], ["192.0.2.11"], False, arguments())
+        self.assertIs(nodes[0], self.configured[1])
+
+    def test_unmatched_selector_becomes_manual_node(self):
+        nodes = collector.select_nodes(
+            self.configured,
+            [],
+            ["edge=192.0.2.30"],
+            False,
+            arguments(snmp_version="1", port=1161),
+        )
+        self.assertEqual(nodes[0].name, "edge")
+        self.assertEqual(nodes[0].hostname, "192.0.2.30")
+        self.assertEqual(nodes[0].version, "1")
+        self.assertEqual(nodes[0].port, 1161)
+        self.assertEqual(nodes[0].source, "manual")
+
+    def test_all_configured_selects_all_jobs(self):
+        nodes = collector.select_nodes(self.configured, [], [], True, arguments())
+        self.assertEqual(nodes, self.configured)
+
+    def test_no_selection_is_an_error(self):
+        args = arguments()
+        with self.assertRaisesRegex(collector.CollectionError, "select at least one"):
+            collector.select_nodes([], [], [], False, args)
+
+    def test_all_configured_requires_jobs(self):
+        args = arguments()
+        with self.assertRaisesRegex(collector.CollectionError, "requires static SNMP jobs"):
+            collector.select_nodes([], [], [], True, args)
+
+    def test_ambiguous_configured_address_requires_job_name(self):
+        configured = self.configured + [
+            collector.Node("switch-c", "192.0.2.10", community="three", source="config")
+        ]
+        args = arguments()
+        with self.assertRaisesRegex(collector.CollectionError, "select a job name"):
+            collector.select_nodes(configured, [], ["192.0.2.10"], False, args)
+
+    def test_exact_discovery_address_reuses_matching_credential(self):
+        scope = collector.DiscoveryScope(
+            "192.0.2.0/24",
+            collector.parse_address_range("192.0.2.0/24", "test"),
+            {"name": "lan", "version": "2c", "community": "private"},
+            "/private/sd/snmp.conf",
+        )
+        nodes = collector.select_nodes([], [scope], ["192.0.2.10"], False, arguments())
+        self.assertEqual(nodes[0].community, "private")
+        self.assertIn("discovery config", nodes[0].source)
+
+    def test_discovery_v3_omitted_security_uses_go_discoverer_defaults(self):
+        scope = collector.DiscoveryScope(
+            "192.0.2.0/24",
+            collector.parse_address_range("192.0.2.0/24", "test"),
+            {"name": "v3", "version": "3", "username": "operator"},
+            "discovery.conf",
+        )
+        nodes = collector.select_nodes(
+            [], [scope], ["192.0.2.10"], False, arguments()
+        )
+        self.assertEqual(nodes[0].level, "noAuthNoPriv")
+        self.assertEqual(nodes[0].auth_proto, "NONE")
+        self.assertEqual(nodes[0].priv_proto, "NONE")
+
+    def test_discovery_v3_accepts_numeric_security_aliases(self):
+        # Fixed synthetic values make protocol-alias behavior deterministic; they are not real credentials.
+        scope = collector.DiscoveryScope(
+            "192.0.2.0/24",
+            collector.parse_address_range("192.0.2.0/24", "test"),
+            {
+                "name": "v3",
+                "version": "3",
+                "username": "operator",
+                "security_level": 3,
+                "auth_protocol": 5,
+                "auth_password": "auth-secret",  # nosec B105
+                "priv_protocol": 3,
+                "priv_password": "priv-secret",  # nosec B105
+            },
+            "discovery.conf",
+        )
+        node = collector.select_nodes(
+            [], [scope], ["192.0.2.10"], False, arguments()
+        )[0]
+        self.assertEqual(node.level, "authPriv")
+        self.assertEqual(node.auth_proto, "SHA-256")
+        self.assertEqual(node.priv_proto, "AES")
+
+    def test_manual_v3_uses_portable_aes_default(self):
+        args = collector.build_parser().parse_args(
+            ["--node", "switch=192.0.2.10", "--snmp-version", "3"]
+        )
+        nodes = collector.select_nodes([], [], args.node, False, args)
+        self.assertEqual(nodes[0].priv_proto, "AES")
+
+    def test_name_equals_address_forces_manual_settings(self):
+        scope = collector.DiscoveryScope(
+            "192.0.2.0/24",
+            collector.parse_address_range("192.0.2.0/24", "test"),
+            {"name": "lan", "version": "2c", "community": "private"},
+            "/private/sd/snmp.conf",
+        )
+        nodes = collector.select_nodes(
+            [], [scope], ["manual=192.0.2.10"], False, arguments(snmp_version="1")
+        )
+        self.assertEqual(nodes[0].version, "1")
+        self.assertIsNone(nodes[0].community)
+
+    def test_overlapping_discovery_scopes_require_manual_settings(self):
+        scopes = [
+            collector.DiscoveryScope(
+                subnet,
+                collector.parse_address_range(subnet, "test"),
+                {"name": subnet, "version": "2c", "community": subnet},
+                "/private/sd/snmp.conf",
+            )
+            for subnet in ("192.0.2.0/24", "192.0.2.0/25")
+        ]
+        args = arguments()
+        with self.assertRaisesRegex(collector.CollectionError, "multiple discovery"):
+            collector.select_nodes([], scopes, ["192.0.2.10"], False, args)
+
+    def test_identical_repeated_selector_is_collected_once(self):
+        nodes = collector.select_nodes(
+            self.configured, [], ["switch-a", "switch-a"], False, arguments()
+        )
+        self.assertEqual(nodes, [self.configured[0]])
+
+    def test_same_name_with_different_targets_is_an_error(self):
+        args = arguments()
+        with self.assertRaisesRegex(collector.CollectionError, "conflicting addresses"):
+            collector.select_nodes(
+                [],
+                [],
+                ["router=192.0.2.10", "router=192.0.2.11"],
+                False,
+                args,
+            )
+
+
+class CredentialTests(TemporaryDirectoryTest):
+    def test_manual_v2c_community_is_prompted(self):
+        node = collector.Node("switch", "192.0.2.10")
+        with mock.patch("getpass.getpass", return_value="private") as prompt:
+            collector.prepare_nodes([node])
+        self.assertEqual(node.community, "private")
+        prompt.assert_called_once()
+
+    def test_manual_v3_credentials_are_prompted(self):
+        node = collector.Node(
+            "router",
+            "192.0.2.20",
+            version="3",
+            username="operator",
+            level="authPriv",
+            auth_proto="sha256",
+            priv_proto="aes256",
+        )
+        with mock.patch("getpass.getpass", side_effect=["auth-secret", "priv-secret"]):
+            collector.prepare_nodes([node])
+        self.assertEqual(node.auth_key, "auth-secret")
+        self.assertEqual(node.priv_key, "priv-secret")
+
+    def test_no_colon_reference_is_literal_when_environment_variable_exists(self):
+        node = collector.Node("switch", "192.0.2.10", community="prefix${SNMP_TEST_SECRET}suffix")
+        # Synthetic values verify resolver behavior and are not credentials.
+        with mock.patch.dict(os.environ, {"SNMP_TEST_SECRET": "replacement"}):  # nosec B105
+            collector.prepare_nodes([node])
+        self.assertEqual(node.community, "prefix${SNMP_TEST_SECRET}suffix")
+
+    def test_netdata_environment_reference_is_resolved(self):
+        node = collector.Node("switch", "192.0.2.10", community="${env:SNMP_TEST_SECRET}")
+        with mock.patch.dict(os.environ, {"SNMP_TEST_SECRET": "  resolved  "}):  # nosec B105
+            collector.prepare_nodes([node])
+        self.assertEqual(node.community, "resolved")
+
+    def test_whitespace_only_netdata_environment_reference_is_empty(self):
+        node = collector.Node("switch", "192.0.2.10", community="${env:SNMP_TEST_SECRET}")
+        with mock.patch.dict(os.environ, {"SNMP_TEST_SECRET": " \t\n "}):  # nosec B105
+            with self.assertRaisesRegex(collector.CollectionError, "must not be empty"):
+                collector.prepare_nodes([node])
+
+    def test_dollar_characters_in_credentials_are_not_treated_as_resolvers(self):
+        nodes = [
+            collector.Node("raw", "192.0.2.10", community="value$with$dollars"),
+            collector.Node("environment", "192.0.2.11", community="${env:SNMP_TEST_SECRET}"),
+        ]
+        with mock.patch.dict(os.environ, {"SNMP_TEST_SECRET": "another$value"}):  # nosec B105
+            collector.prepare_nodes(nodes)
+        self.assertEqual(nodes[0].community, "value$with$dollars")
+        self.assertEqual(nodes[1].community, "another$value")
+
+    def test_no_colon_reference_is_literal_when_environment_variable_is_absent(self):
+        node = collector.Node("switch", "192.0.2.10", community="${NOT_DEFINED}")
+        with mock.patch.dict(os.environ, {}, clear=True):
+            collector.prepare_nodes([node])
+        self.assertEqual(node.community, "${NOT_DEFINED}")
+
+    def test_netdata_secret_resolver_is_prompted(self):
+        node = collector.Node("switch", "192.0.2.10", community="${file:/private/community}")
+        with mock.patch("getpass.getpass", return_value="entered"):
+            collector.prepare_nodes([node])
+        self.assertEqual(node.community, "entered")
+
+    def test_missing_secret_without_interactive_input_is_a_clear_error(self):
+        node = collector.Node("switch", "192.0.2.10", community="${env:NOT_DEFINED}")
+        with mock.patch("getpass.getpass", side_effect=EOFError):
+            with self.assertRaisesRegex(collector.CollectionError, "input is not interactive"):
+                collector.prepare_nodes([node])
+
+    def test_private_config_contains_credentials_but_command_does_not(self):
+        node = collector.Node("switch", "192.0.2.10", community="very-secret")
+        config_dir = self.path("credentials")
+        os.mkdir(config_dir, 0o700)
+        config_path = collector.write_private_snmp_config(config_dir, node)
+        with open(config_path, "r") as handle:
+            self.assertIn("very-secret", handle.read())
+        self.assertEqual(stat.S_IMODE(os.stat(config_path).st_mode), 0o600)
+
+        output_path = self.path("output.txt")
+        captured = {}
+
+        def fake_run(command, environment, output, timeout):
+            captured["command"] = command
+            captured["environment"] = environment
+            output.write(b"raw data\n")
+            return collector.CommandResult(0, False, False, 9)
+
+        with mock.patch.object(collector, "run_bounded", side_effect=fake_run):
+            with redirect_stdout(io.StringIO()):
+                collector.collect_probe(
+                    "/usr/bin/snmpwalk",
+                    node,
+                    (".1.3.6.1.2.1.1",),
+                    config_dir,
+                    output_path,
+                    5,
+                )
+        self.assertNotIn("very-secret", " ".join(captured["command"]))
+        self.assertEqual(captured["environment"]["SNMPCONFPATH"], config_dir)
+
+
+class PlanTests(unittest.TestCase):
+    def test_plan_lists_nodes_versions_and_protocols_without_estimates(self):
+        nodes = [
+            collector.Node("switch", "192.0.2.10", version="2c", community="private"),
+            collector.Node("router", "2001:db8::1", version="3", username="operator"),
+        ]
+        plan = collector.format_plan(nodes)
+        self.assertIn("No SNMP requests have been sent", plan)
+        self.assertIn("switch", plan)
+        self.assertIn("192.0.2.10:161", plan)
+        self.assertIn("SNMP version: 3", plan)
+        for name, _oids in collector.PROBE_GROUPS:
+            self.assertIn(name, plan)
+        self.assertNotIn("ETA", plan)
+        self.assertNotIn("estimated", plan.lower())
+        self.assertNotIn("very-secret", plan)
+
+    def test_default_confirmation_is_rejection(self):
+        with mock.patch("builtins.input", return_value=""):
+            self.assertFalse(collector.approve_plan(False))
+
+    def test_yes_confirmation_is_acceptance(self):
+        with mock.patch("builtins.input", return_value="yes"):
+            self.assertTrue(collector.approve_plan(False))
+
+
+class CommandTests(TemporaryDirectoryTest):
+    def test_ipv4_hostname_and_ipv6_targets(self):
+        self.assertEqual(collector.net_snmp_target("192.0.2.1", 161), "udp:192.0.2.1:161")
+        self.assertEqual(collector.net_snmp_target("switch.example", 1161), "udp:switch.example:1161")
+        self.assertEqual(collector.net_snmp_target("2001:db8::1", 161), "udp6:[2001:db8::1]:161")
+
+    def test_output_is_hard_bounded(self):
+        output_path = self.path("bounded.bin")
+        command = [sys.executable, "-c", "import sys; sys.stdout.write('x' * (8 * 1024 * 1024))"]
+        with open(output_path, "wb") as output:
+            result = collector.run_bounded(command, os.environ.copy(), output, 10, limit=1024)
+        self.assertEqual(result.returncode, 0)
+        self.assertTrue(result.truncated)
+        self.assertEqual(os.path.getsize(output_path), 1024)
+
+    def test_timeout_stops_the_started_process(self):
+        output_path = self.path("timeout.bin")
+        command = [sys.executable, "-c", "import time; time.sleep(10)"]
+        with open(output_path, "wb") as output:
+            result = collector.run_bounded(command, os.environ.copy(), output, 0.1)
+        self.assertTrue(result.timed_out)
+        self.assertIsNotNone(result.returncode)
+
+    def test_timeout_stops_a_process_that_closed_its_output(self):
+        output_path = self.path("closed-output.bin")
+        command = [sys.executable, "-c", "import os,time; os.close(1); time.sleep(10)"]
+        with open(output_path, "wb") as output:
+            result = collector.run_bounded(command, os.environ.copy(), output, 0.1)
+        self.assertTrue(result.timed_out)
+        self.assertIsNotNone(result.returncode)
+
+    def test_group_writable_snmpwalk_is_rejected(self):
+        path = self.path("snmpwalk")
+        with open(path, "w") as handle:
+            handle.write("#!/bin/sh\n")
+        # The unsafe mode is intentional: the collector must reject this fixture.
+        os.chmod(path, 0o770)  # nosec B103
+        with self.assertRaisesRegex(collector.CollectionError, "snmpwalk was not found"):
+            collector.find_snmpwalk((path,))
+
+
+class SignalCleanupTests(TemporaryDirectoryTest):
+    def wait_for_child_pid(self, path, process):
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                with open(path, "r") as handle:
+                    content = handle.read().strip()
+            except FileNotFoundError:
+                content = ""
+            if content:
+                try:
+                    return int(content)
+                except ValueError:
+                    pass
+            if process.poll() is not None:
+                break
+            time.sleep(0.05)
+        self.fail("the test SNMP process did not start")
+
+    def test_signal_during_process_spawn_terminates_the_acquired_child(self):
+        real_popen = subprocess.Popen
+        for signum in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+            with self.subTest(signal=signum):
+                output_path = self.path("spawn-window-{}.bin".format(signum))
+                spawned = []
+
+                def spawn_then_signal(*args, **kwargs):
+                    process = real_popen(*args, **kwargs)
+                    spawned.append(process)
+                    os.kill(os.getpid(), signum)
+                    return process
+
+                command = [sys.executable, "-c", "import time; time.sleep(60)"]
+                environment = os.environ.copy()
+                previous = collector.install_termination_handlers()
+                try:
+                    with mock.patch.object(collector.subprocess, "Popen", side_effect=spawn_then_signal):
+                        with open(output_path, "wb") as output:
+                            with self.assertRaises(collector.CollectionInterrupted):
+                                collector.run_bounded(command, environment, output, 120)
+                finally:
+                    collector.restore_signal_handlers(previous)
+                self.assertEqual(len(spawned), 1)
+                self.assertIsNotNone(spawned[0].poll())
+
+    def test_signal_during_archive_open_removes_the_acquired_file(self):
+        archive_root = self.path("archive-source")
+        os.mkdir(archive_root)
+        collector.write_text(os.path.join(archive_root, "data.txt"), "raw data\n")
+        real_open = os.open
+        for signum in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+            with self.subTest(signal=signum):
+                output_dir = self.path("archive-output-{}".format(signum))
+                os.mkdir(output_dir)
+
+                def open_then_signal(path, flags, mode=0o777):
+                    descriptor = real_open(path, flags, mode)
+                    if path.endswith(".tar.gz"):
+                        os.kill(os.getpid(), signum)
+                    return descriptor
+
+                previous = collector.install_termination_handlers()
+                try:
+                    with mock.patch.object(collector.os, "open", side_effect=open_then_signal):
+                        with self.assertRaises(collector.CollectionInterrupted):
+                            collector.create_archive(archive_root, output_dir)
+                finally:
+                    collector.restore_signal_handlers(previous)
+                self.assertEqual(os.listdir(output_dir), [])
+
+    def test_signal_during_temporary_tree_creation_removes_the_tree(self):
+        real_mkdtemp = tempfile.mkdtemp
+        for signum in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+            with self.subTest(signal=signum):
+                output_dir = self.path("temporary-output-{}".format(signum))
+                os.mkdir(output_dir)
+
+                def create_then_signal(*args, **kwargs):
+                    path = real_mkdtemp(*args, **kwargs)
+                    os.kill(os.getpid(), signum)
+                    return path
+
+                previous = collector.install_termination_handlers()
+                try:
+                    with mock.patch.object(collector.tempfile, "mkdtemp", side_effect=create_then_signal):
+                        with self.assertRaises(collector.CollectionInterrupted):
+                            collector.collect([], "plan", "/usr/bin/snmpwalk", output_dir, 5)
+                finally:
+                    collector.restore_signal_handlers(previous)
+                self.assertEqual(os.listdir(output_dir), [])
+
+    def run_signal_case(self, signum, second_signal=None, second_signal_phase=None):
+        output_dir = self.path("output-{}".format(signum))
+        os.mkdir(output_dir)
+        child_pid_path = self.path("child-{}.pid".format(signum))
+        cleanup_marker_path = self.path("cleanup-{}-{}".format(signum, second_signal_phase))
+        child_signal_handler = ""
+        if second_signal_phase == "child":
+            child_signal_handler = (
+                "import signal\n"
+                "def handle_term(_signum, _frame):\n"
+                "    with open(os.environ['SNMP_TEST_CLEANUP_MARKER'], 'w') as handle:\n"
+                "        handle.write('terminating')\n"
+                "signal.signal(signal.SIGTERM, handle_term)\n"
+            )
+        fake_snmpwalk = self.write(
+            "snmpwalk-{}.py".format(signum),
+            "#!{}\n"
+            "import os\n"
+            "import time\n"
+            "{}"
+            "with open(os.environ['SNMP_TEST_CHILD_PID'], 'w') as handle:\n"
+            "    handle.write(str(os.getpid()))\n"
+            "time.sleep(60)\n".format(sys.executable, child_signal_handler),
+        )
+        os.chmod(fake_snmpwalk, 0o700)
+        slow_tree_cleanup = ""
+        if second_signal_phase == "tree":
+            slow_tree_cleanup = (
+                "real_rmtree = collector.shutil.rmtree\n"
+                "def slow_rmtree(*args, **kwargs):\n"
+                "    with open({!r}, 'w') as handle:\n"
+                "        handle.write('removing')\n"
+                "    time.sleep(1)\n"
+                "    return real_rmtree(*args, **kwargs)\n"
+                "collector.shutil.rmtree = slow_rmtree\n".format(cleanup_marker_path)
+            )
+        driver = self.write(
+            "driver-{}.py".format(signum),
+            "import importlib.util\n"
+            "import sys\n"
+            "import time\n"
+            "spec = importlib.util.spec_from_file_location('collector', {!r})\n"
+            "collector = importlib.util.module_from_spec(spec)\n"
+            "spec.loader.exec_module(collector)\n"
+            "collector.PROBE_GROUPS = (('system', ('.1',)),)\n"
+            "{}"
+            "previous = collector.install_termination_handlers()\n"
+            "try:\n"
+            "    node = collector.Node('switch', '192.0.2.10', community='private')\n"
+            "    collector.collect([node], collector.format_plan([node]), {!r}, {!r}, 120)\n"
+            "except collector.CollectionInterrupted as interruption:\n"
+            "    sys.exit(128 + interruption.signum)\n"
+            "finally:\n"
+            "    collector.restore_signal_handlers(previous)\n".format(
+                SCRIPT_PATH, slow_tree_cleanup, fake_snmpwalk, output_dir
+            ),
+        )
+        environment = os.environ.copy()
+        environment["SNMP_TEST_CHILD_PID"] = child_pid_path
+        environment["SNMP_TEST_CLEANUP_MARKER"] = cleanup_marker_path
+        # The generated driver path and arguments are controlled by this test.
+        process = subprocess.Popen(  # nosec B603
+            [sys.executable, driver],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+        )
+        child_pid = None
+        try:
+            child_pid = self.wait_for_child_pid(child_pid_path, process)
+
+            os.kill(process.pid, signum)
+            if second_signal is not None:
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline and not os.path.exists(cleanup_marker_path):
+                    if process.poll() is not None:
+                        break
+                    time.sleep(0.05)
+                self.assertTrue(
+                    os.path.exists(cleanup_marker_path),
+                    "cleanup did not reach the requested second-signal window",
+                )
+                os.kill(process.pid, second_signal)
+            stdout, stderr = process.communicate(timeout=10)
+            self.assertEqual(
+                process.returncode,
+                128 + signum,
+                "driver output:\n{}\n{}".format(
+                    stdout.decode("utf-8", "replace"), stderr.decode("utf-8", "replace")
+                ),
+            )
+            with self.assertRaises(ProcessLookupError):
+                os.kill(child_pid, 0)
+            leftovers = [name for name in os.listdir(output_dir) if name.startswith("netdata-snmp-")]
+            self.assertEqual(leftovers, [])
+        finally:
+            if process.poll() is None:
+                os.kill(process.pid, signal.SIGKILL)
+                process.wait()
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, 0)
+                except ProcessLookupError:
+                    pass
+                else:
+                    os.kill(child_pid, signal.SIGKILL)
+
+    def test_sighup_cleans_child_and_credentials(self):
+        self.run_signal_case(signal.SIGHUP)
+
+    def test_sigterm_cleans_child_and_credentials(self):
+        self.run_signal_case(signal.SIGTERM)
+
+    def test_sigint_cleans_child_and_credentials(self):
+        self.run_signal_case(signal.SIGINT)
+
+    def test_second_signal_during_resistant_child_cleanup_is_ignored(self):
+        self.run_signal_case(signal.SIGTERM, signal.SIGHUP, "child")
+
+    def test_second_signal_during_credential_tree_cleanup_is_ignored(self):
+        self.run_signal_case(signal.SIGHUP, signal.SIGTERM, "tree")
+
+    def test_second_signal_after_interrupted_cli_main_preserves_first_exit(self):
+        output_dir = self.path("cli-exit-output")
+        os.mkdir(output_dir)
+        child_pid_path = self.path("cli-exit-child.pid")
+        exit_marker_path = self.path("cli-exit.marker")
+        fake_snmpwalk = self.write(
+            "cli-exit-snmpwalk.py",
+            "#!{}\n"
+            "import os\n"
+            "import time\n"
+            "with open(os.environ['SNMP_TEST_CHILD_PID'], 'w') as handle:\n"
+            "    handle.write(str(os.getpid()))\n"
+            "time.sleep(60)\n".format(sys.executable),
+        )
+        os.chmod(fake_snmpwalk, 0o700)
+        driver = self.write(
+            "cli-exit-driver.py",
+            "import importlib.util\n"
+            "import sys\n"
+            "import time\n"
+            "spec = importlib.util.spec_from_file_location('collector', {!r})\n"
+            "collector = importlib.util.module_from_spec(spec)\n"
+            "spec.loader.exec_module(collector)\n"
+            "collector.PROBE_GROUPS = (('system', ('.1',)),)\n"
+            "collector.find_snmpwalk = lambda: {!r}\n"
+            "collector.getpass.getpass = lambda _prompt: 'private'\n"
+            "sys.argv = ['collector', '--node', 'switch=192.0.2.10', '--yes', "
+            "'--output-dir', {!r}]\n"
+            "result = collector.main()\n"
+            "with open({!r}, 'w') as handle:\n"
+            "    handle.write(str(result))\n"
+            "time.sleep(1)\n"
+            "sys.exit(result)\n".format(
+                SCRIPT_PATH, fake_snmpwalk, output_dir, exit_marker_path
+            ),
+        )
+        environment = os.environ.copy()
+        environment["SNMP_TEST_CHILD_PID"] = child_pid_path
+        # The generated driver path and arguments are controlled by this test.
+        process = subprocess.Popen(  # nosec B603
+            [sys.executable, driver],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+        )
+        child_pid = None
+        try:
+            child_pid = self.wait_for_child_pid(child_pid_path, process)
+
+            os.kill(process.pid, signal.SIGINT)
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline and not os.path.exists(exit_marker_path):
+                if process.poll() is not None:
+                    break
+                time.sleep(0.05)
+            self.assertTrue(os.path.exists(exit_marker_path), "main did not reach its interrupted return")
+            with open(exit_marker_path, "r") as handle:
+                self.assertEqual(handle.read(), "130")
+
+            os.kill(process.pid, signal.SIGHUP)
+            stdout, stderr = process.communicate(timeout=10)
+            self.assertEqual(
+                process.returncode,
+                130,
+                "driver output:\n{}\n{}".format(
+                    stdout.decode("utf-8", "replace"), stderr.decode("utf-8", "replace")
+                ),
+            )
+            with self.assertRaises(ProcessLookupError):
+                os.kill(child_pid, 0)
+            leftovers = [name for name in os.listdir(output_dir) if name.startswith("netdata-snmp-")]
+            self.assertEqual(leftovers, [])
+        finally:
+            if process.poll() is None:
+                os.kill(process.pid, signal.SIGKILL)
+                process.wait()
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, 0)
+                except ProcessLookupError:
+                    pass
+                else:
+                    os.kill(child_pid, signal.SIGKILL)
+
+
+class ArchiveTests(TemporaryDirectoryTest):
+    def test_collection_continues_and_archive_excludes_credentials(self):
+        node = collector.Node("switch", "192.0.2.10", community="archive-secret")
+
+        def fake_probe(_tool, _node, oids, _config, output_path, _timeout):
+            group_name = "failed-protocol" if oids == (".2",) else "successful-protocol"
+            collector.write_text(output_path, "raw {}\n".format(group_name))
+            if group_name == "failed-protocol":
+                return "failed", "test failure"
+            return "success", "collected"
+
+        groups = (("successful-protocol", (".1",)), ("failed-protocol", (".2",)))
+        with mock.patch.object(collector, "PROBE_GROUPS", groups):
+            with mock.patch.object(collector, "collect_probe", side_effect=fake_probe):
+                with redirect_stdout(io.StringIO()):
+                    rows, summary, archive_path = collector.collect(
+                        [node], collector.format_plan([node]), "/usr/bin/snmpwalk", self.temporary.name, 5
+                    )
+
+        self.assertEqual([row[3] for row in rows], ["success", "failed"])
+        self.assertIn("Successful protocol collections: 1", summary)
+        self.assertIn("Failed protocol collections: 1", summary)
+        self.assertEqual(stat.S_IMODE(os.stat(archive_path).st_mode), 0o600)
+
+        with tarfile.open(archive_path, "r:gz") as archive:
+            names = archive.getnames()
+            self.assertIn("plan.txt", names)
+            self.assertIn("collection-status.tsv", names)
+            self.assertIn("summary.txt", names)
+            self.assertIn("README.txt", names)
+            self.assertIn("manifest.sha256", names)
+            self.assertFalse(any("credential" in name or name.endswith("snmp.conf") for name in names))
+            for member in archive.getmembers():
+                if member.isfile():
+                    self.assertNotIn(b"archive-secret", archive.extractfile(member).read())
+
+
+class MainTests(TemporaryDirectoryTest):
+    def test_no_arguments_prints_help(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(collector.main([]), 0)
+        self.assertIn("--node", output.getvalue())
+        self.assertIn("--netdata-snmp-config", output.getvalue())
+
+    def test_missing_explicit_config_fails_even_with_manual_node(self):
+        error = io.StringIO()
+        with redirect_stderr(error):
+            code = collector.main(
+                [
+                    "--node",
+                    "192.0.2.10",
+                    "--netdata-snmp-config",
+                    self.path("missing.conf"),
+                ]
+            )
+        self.assertEqual(code, 1)
+        self.assertIn("does not exist", error.getvalue())
+
+    def test_empty_explicit_config_fails_before_manual_plan(self):
+        output = io.StringIO()
+        error = io.StringIO()
+        with redirect_stdout(output), redirect_stderr(error):
+            code = collector.main(
+                [
+                    "--node",
+                    "manual=192.0.2.10",
+                    "--netdata-snmp-config",
+                    "",
+                ]
+            )
+        self.assertEqual(code, 1)
+        self.assertNotIn("SNMP data collection plan", output.getvalue())
+        self.assertIn("non-empty FILE", error.getvalue())
+
+    def test_manual_only_selection_bypasses_unusable_automatic_config(self):
+        for failure in ("unreadable automatic config", "malformed automatic config"):
+            with self.subTest(failure=failure):
+                with mock.patch.object(
+                    collector, "select_netdata_configs", side_effect=collector.CollectionError(failure)
+                ) as select_config:
+                    with mock.patch.object(collector, "prepare_nodes"):
+                        with mock.patch.object(
+                            collector, "find_snmpwalk", return_value="/usr/bin/snmpwalk"
+                        ):
+                            with mock.patch.object(collector, "approve_plan", return_value=False):
+                                with redirect_stdout(io.StringIO()):
+                                    code = collector.main(["--node", "manual=192.0.2.10"])
+                self.assertEqual(code, 0)
+                select_config.assert_not_called()
+
+    def test_rejected_plan_never_collects(self):
+        node = collector.Node("switch", "192.0.2.10", community="private")
+        with mock.patch.object(collector, "select_netdata_configs", return_value=[]):
+            with mock.patch.object(collector, "select_nodes", return_value=[node]):
+                with mock.patch.object(collector, "prepare_nodes"):
+                    with mock.patch.object(collector, "find_snmpwalk", return_value="/usr/bin/snmpwalk"):
+                        with mock.patch.object(collector, "approve_plan", return_value=False):
+                            with mock.patch.object(collector, "collect") as collect_mock:
+                                with redirect_stdout(io.StringIO()):
+                                    code = collector.main(["--node", "192.0.2.10"])
+        self.assertEqual(code, 0)
+        collect_mock.assert_not_called()
+
+    def test_partial_collection_returns_two_and_prints_archive(self):
+        node = collector.Node("switch", "192.0.2.10", community="private")
+        rows = [("switch", "192.0.2.10", "system", "failed", "timeout")]
+        summary = collector.summarize(rows)
+        archive_path = self.path("result.tar.gz")
+        with mock.patch.object(collector, "select_netdata_configs", return_value=[]):
+            with mock.patch.object(collector, "select_nodes", return_value=[node]):
+                with mock.patch.object(collector, "prepare_nodes"):
+                    with mock.patch.object(collector, "find_snmpwalk", return_value="/usr/bin/snmpwalk"):
+                        with mock.patch.object(collector, "collect", return_value=(rows, summary, archive_path)):
+                            output = io.StringIO()
+                            with redirect_stdout(output):
+                                code = collector.main(["--node", "192.0.2.10", "--yes"])
+        self.assertEqual(code, 2)
+        self.assertIn("Archive: {}".format(archive_path), output.getvalue())
+        self.assertIn("Freshdesk", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Summary

Provide a permanent, operator-facing way to collect raw SNMP evidence for missing metrics and incomplete SNMP-derived topology.

- Accept explicit `[NAME=]ADDRESS` nodes without requiring prior Netdata configuration.
- Use an explicit Netdata SNMP configuration file, or the first standard installation under `/etc/netdata` or
  `/opt/netdata/etc/netdata`, only as a shortcut for node settings and credentials.
- Reuse static SNMP jobs and map an explicitly selected exact IP to one discovery credential scope without scanning or expanding
  configured networks.
- Print the complete node, SNMP-version, and protocol plan before contact; require approval; show command progress; and summarize
  successful, partial, and failed protocol collections.
- Capture bounded raw system, interface, bridge/STP/FDB, LLDP, LLDPv2, CDP, IP/neighbor, OSPF, and BGP walks in one private
  `tar.gz` archive.
- Keep credentials out of command arguments and the archive through per-node private Net-SNMP configuration removed on success,
  error, Ctrl-C, `SIGHUP`, or `SIGTERM`.
- Add a Learn procedure under **Network Performance Monitoring -> Device Metrics -> Collect SNMP Troubleshooting Data** and link
  it from SNMP integration metadata and NPM catalog descriptions.
- Add Python 3.6-compatible tests, checksum binding, and SNMPv2c/SNMPv3 simulator CI coverage.

The collector does not inspect Agent processes, runtime APIs, logs, caches, or generated topology. It only captures raw SNMP data
from operator-selected nodes after approval.

##### Compatibility

- Requires Python 3.6 or newer, PyYAML, and Net-SNMP `snmpwalk` at a trusted standard path.
- Protected Netdata configuration may require `sudo`; manual configuration works without Netdata configuration.
- Existing collector and topology runtime behavior is unchanged. This PR adds a support tool, documentation, metadata links, and
  CI only.

##### Validation

- 65 focused tests pass on the workstation runtime and pinned Python 3.6/PyYAML 5.3.1.
- 45 integration-description tests pass.
- Pinned simulators collected all ten protocol groups over both SNMPv2c and authenticated/private SNMPv3, including numeric
  SNMPv3 configuration aliases. Archive manifest, credential exclusion, mode `0600`, and exit-zero checks passed.
- The collector reused the workstation's installed discovery configuration for six explicitly selected active devices. All six
  responded; unsupported MIB groups were reported transparently with the documented partial exit status.
- Flake8, actionlint, YAML validation, documented-checksum binding, complexity checks, Bandit, D107, `git diff --check`, and SOW
  audit pass.
- An independent adversarial review of immutable commit `ed78608c14e0b8bdf6c029bf580a11473441460a` reproduced the real-signal,
  bounded-I/O, config/default, archive, credential, Python 3.6, documentation, and no-scan checks and returned PASS with no P1,
  P2, or P3 finding.

<details>
<summary>For users: How does this change affect me?</summary>

Operators working with Netdata Support can follow one Learn page, select only the affected devices, review the planned SNMP
requests, collect raw evidence, and attach the resulting private archive to a restricted support ticket.

The tool performs read-only SNMP walks. It does not change Netdata or device configuration.

</details>





