### PR TITLE
fix(streaming): cap the receiver line buffer to the protocol limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3182,6 +3182,10 @@ add_executable(stream-receiver-hops-test EXCLUDE_FROM_ALL
         src/streaming/tests/stream-handshake-hops-test.c)
 target_link_libraries(stream-receiver-hops-test libnetdata)
 
+add_executable(stream-receiver-line-cap-test EXCLUDE_FROM_ALL
+        src/streaming/tests/stream-receiver-line-cap-test.c)
+target_link_libraries(stream-receiver-line-cap-test libnetdata)
+
 add_executable(stream-replay-endpoints-test EXCLUDE_FROM_ALL
         src/streaming/tests/stream-replay-endpoints-test.c)
 target_link_libraries(stream-replay-endpoints-test libnetdata)

--- a/src/streaming/stream-receiver-internals.h
+++ b/src/streaming/stream-receiver-internals.h
@@ -34,6 +34,14 @@ static inline bool stream_receiver_parse_hops(const char *value, int16_t *hops) 
     return true;
 }
 
+// The receiver accumulates input into line_buffer across reads until a newline
+// shows up, so its length is attacker-controlled. A single protocol line can
+// never exceed PLUGINSD_LINE_MAX bytes: beyond that the sender is misbehaving
+// and the connection has to be dropped before memory grows without bound.
+static inline bool stream_receiver_line_buffer_overflow(const BUFFER *line_buffer) {
+    return line_buffer->len > PLUGINSD_LINE_MAX;
+}
+
 struct parser;
 
 struct receiver_state {

--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -857,6 +857,18 @@ stream_receive_and_process(struct stream_thread *sth, struct receiver_state *rpt
             *removed = true;
             return -1;
         }
+
+        if(unlikely(stream_receiver_line_buffer_overflow(rpt->thread.line_buffer))) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "STREAM RCV[%zu] '%s' [from [%s]:%s]: received %zu bytes without a newline (max %zu). "
+                   "Disconnecting the sender.",
+                   sth->id, rrdhost_hostname(rpt->host), rpt->remote_ip, rpt->remote_port,
+                   rpt->thread.line_buffer->len, (size_t)PLUGINSD_LINE_MAX);
+
+            stream_receiver_remove(sth, rpt, STREAM_HANDSHAKE_DISCONNECT_BUFFER_OVERFLOW);
+            *removed = true;
+            return -1;
+        }
     }
     else {
         rc = receiver_read_uncompressed(rpt);
@@ -872,6 +884,18 @@ stream_receive_and_process(struct stream_thread *sth, struct receiver_state *rpt
 
             rpt->thread.line_buffer->len = 0;
             rpt->thread.line_buffer->buffer[0] = '\0';
+        }
+
+        if(unlikely(stream_receiver_line_buffer_overflow(rpt->thread.line_buffer))) {
+            nd_log(NDLS_DAEMON, NDLP_ERR,
+                   "STREAM RCV[%zu] '%s' [from [%s]:%s]: received %zu bytes without a newline (max %zu). "
+                   "Disconnecting the sender.",
+                   sth->id, rrdhost_hostname(rpt->host), rpt->remote_ip, rpt->remote_port,
+                   rpt->thread.line_buffer->len, (size_t)PLUGINSD_LINE_MAX);
+
+            stream_receiver_remove(sth, rpt, STREAM_HANDSHAKE_DISCONNECT_BUFFER_OVERFLOW);
+            *removed = true;
+            return -1;
         }
     }
 

--- a/src/streaming/tests/stream-receiver-line-cap-test.c
+++ b/src/streaming/tests/stream-receiver-line-cap-test.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "libnetdata/libnetdata.h"
+#include "streaming/stream-receiver-internals.h"
+
+// The receiver loop feeds buffered_reader_next_line() from a 15KB-ish read
+// buffer; without a newline everything accumulates into the line buffer.
+// This test drives the real primitive the same way and checks the threshold
+// the receiver acts on.
+
+static size_t feed_no_newline(struct buffered_reader *reader, BUFFER *line_buffer, size_t chunks) {
+    char chunk[4096];
+    memset(chunk, 'A', sizeof(chunk));
+
+    size_t fed = 0;
+    for(size_t i = 0; i < chunks; i++) {
+        memcpy(reader->read_buffer, chunk, sizeof(chunk));
+        reader->read_len = sizeof(chunk);
+        reader->pos = 0;
+
+        while(buffered_reader_next_line(reader, line_buffer))
+            ; // complete lines are consumed by the parser in the real receiver
+
+        fed += sizeof(chunk);
+    }
+    return fed;
+}
+
+int main(void) {
+    int failed = 0;
+
+    // 1. no newline: the line buffer accumulates without bound and the
+    //    overflow condition fires as soon as it passes PLUGINSD_LINE_MAX
+    {
+        struct buffered_reader reader;
+        buffered_reader_init(&reader);
+        BUFFER *lb = buffer_create(16, NULL);
+
+        size_t fed = feed_no_newline(&reader, lb, 2); // 8KB, still under the cap
+        if(lb->len != fed || stream_receiver_line_buffer_overflow(lb)) {
+            fprintf(stderr, "unexpected state after %zu bytes (len %zu), cap is %d\n",
+                    fed, lb->len, PLUGINSD_LINE_MAX);
+            failed++;
+        }
+
+        feed_no_newline(&reader, lb, 5); // +20KB, past the cap
+        if(lb->len != 7 * 4096 || !stream_receiver_line_buffer_overflow(lb)) {
+            fprintf(stderr, "overflow not reported after %zu bytes without a newline (cap %d)\n",
+                    lb->len, PLUGINSD_LINE_MAX);
+            failed++;
+        }
+
+        // the accumulation is unbounded: doubling the input doubles the buffer
+        size_t len_before = lb->len;
+        feed_no_newline(&reader, lb, 14);
+        if(lb->len <= len_before) {
+            fprintf(stderr, "line buffer did not keep accumulating (%zu -> %zu)\n", len_before, lb->len);
+            failed++;
+        }
+
+        buffer_free(lb);
+    }
+
+    // 2. boundary: exactly PLUGINSD_LINE_MAX is accepted, one byte more is not
+    {
+        BUFFER *lb = buffer_create(16, NULL);
+
+        lb->len = PLUGINSD_LINE_MAX;
+        if(stream_receiver_line_buffer_overflow(lb)) {
+            fprintf(stderr, "overflow reported at exactly the cap (%d)\n", PLUGINSD_LINE_MAX);
+            failed++;
+        }
+
+        lb->len = PLUGINSD_LINE_MAX + 1;
+        if(!stream_receiver_line_buffer_overflow(lb)) {
+            fprintf(stderr, "overflow not reported at cap + 1\n");
+            failed++;
+        }
+
+        buffer_free(lb);
+    }
+
+    // 3. complete lines keep the line buffer empty, so normal senders never
+    //    reach the cap
+    {
+        struct buffered_reader reader;
+        buffered_reader_init(&reader);
+        BUFFER *lb = buffer_create(16, NULL);
+
+        char data[4096];
+        memset(data, 'B', sizeof(data) - 1);
+        data[sizeof(data) - 1] = '\n';
+
+        for(size_t i = 0; i < 64; i++) { // 256KB of complete lines in 4KB chunks
+            memcpy(reader.read_buffer, data, sizeof(data));
+            reader.read_len = sizeof(data);
+            reader.pos = 0;
+
+            size_t lines = 0;
+            while(buffered_reader_next_line(&reader, lb)) {
+                // the parser consumes the line and resets the buffer, like
+                // stream_receive_and_process() does
+                lb->len = 0;
+                lb->buffer[0] = '\0';
+                lines++;
+            }
+
+            if(lines != 1 || lb->len != 0) {
+                fprintf(stderr, "expected 1 complete line at round %zu, got %zu (len %zu)\n",
+                        i, lines, lb->len);
+                failed++;
+                break;
+            }
+            if(stream_receiver_line_buffer_overflow(lb)) {
+                fprintf(stderr, "false overflow with complete lines\n");
+                failed++;
+                break;
+            }
+        }
+
+        buffer_free(lb);
+    }
+
+    if(failed) {
+        fprintf(stderr, "stream-receiver-line-cap-test: %d failures\n", failed);
+        return 1;
+    }
+
+    fprintf(stderr, "stream-receiver-line-cap-test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
##### Summary

The streaming receiver keeps input in a line buffer until a newline shows up, and nothing ever bounded how large that buffer can get. The buffer is grown with `buffer_need_bytes()` on every read that does not contain a newline, so a child that simply streams bytes without `\n` makes the parent allocate memory 1:1 with the input. In testing, ~96MB of such input added ~98MB to the parent's RSS. A child that talks the protocol normally sends lines well below the limit, so a connection running away like this means the sender is broken or hostile.

A single protocol line can never exceed `PLUGINSD_LINE_MAX` bytes. This caps the receiver line buffer there and drops the connection (with a log message) when a sender keeps the buffer past the limit.

Adds `stream_receiver_line_buffer_overflow()` in `stream-receiver-internals.h` and a standalone test (built as `stream-receiver-line-cap-test`) that drives the real line primitive directly and covers the accumulation behavior, the exact cap boundary and complete lines.

##### Test Plan

- `stream-receiver-line-cap-test`: OK (no-newline accumulation hits the cap, boundary at `PLUGINSD_LINE_MAX` / `+1`, complete lines never trip it)
- `netdata -c netdata.conf -W unittest`: all tests pass
- Manual: parent on the loopback, child sends newline-free data → connection dropped once the buffer passes the limit, RSS stays flat; normal line-based streaming keeps working

##### Additional Information

Noticed while going through the streaming receiver. The other deferred buffers in the same codebase (e.g. `PLUGINSD_MAX_DEFERRED_SIZE`) already have caps; this path was the odd one out.

<details> <summary>For users: How does this change affect me?</summary>
Parents drop streaming connections that send data without any newline once the accumulated bytes pass the protocol line limit, instead of letting memory grow until the process dies. Normal children are not affected.
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the streaming receiver's line buffer at `PLUGINSD_LINE_MAX` bytes so a sender that streams data without newlines no longer makes the parent's memory grow 1:1 with input until OOM. The connection is dropped with a log message once the buffer passes the limit. The cap is checked before the parser consumes a line, so an overlong line that arrives with a newline is caught too, in both compressed and uncompressed streams; normal line-based streaming is unaffected.

**Bug Fixes**
- Adds `stream_receiver_line_buffer_overflow()` and a shared `stream_receiver_overlong_line()` disconnect path for both compressed and uncompressed streams.
- Added `stream-receiver-line-cap-test` covering buffer accumulation, the exact cap boundary, overlong complete lines, and normal lines.

<sup>Written for commit 99c1190e0237202cff66c0772ad9efd0720fb6d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented streaming connections from consuming unbounded memory when incoming protocol lines exceed the allowed size.
  * Oversized lines are now detected during both compressed and uncompressed stream processing.
  * Affected connections are logged and disconnected safely when protocol lines exceed the limit.
  * Lines exactly at the permitted size continue to be accepted.

* **Tests**
  * Added coverage for line-length limits, boundary conditions, partial data, oversized terminated lines, and repeated valid messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->