### PR TITLE
dbengine: detect and trace PGD double frees

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -221,6 +221,7 @@ int https_client_timeout_unittest(void);
 int mqtt_wss_client_timeout_unittest(void);
 int pgc_unittest(void);
 int mrg_unittest(void);
+int pgd_unittest(void);
 int pluginsd_parser_unittest(void);
 int websocket_compression_unittest(void);
 void replication_initialize(void);
@@ -548,6 +549,7 @@ int netdata_main(int argc, char **argv) {
                             if (uuidmap_unittest()) return 1;
 #ifdef ENABLE_DBENGINE
                             if (mrg_unittest()) return 1;
+                            if (pgd_unittest()) return 1;
 #endif
                             if (paths_unittest()) return 1;
 #ifdef HAVE_LIBBACKTRACE
@@ -720,6 +722,10 @@ int netdata_main(int argc, char **argv) {
                         else if(strcmp(optarg, "mrgtest") == 0) {
                             unittest_running = true;
                             return mrg_unittest();
+                        }
+                        else if(strcmp(optarg, "pgdtest") == 0) {
+                            unittest_running = true;
+                            return pgd_unittest();
                         }
                         else if(strcmp(optarg, "mrgretentionbench") == 0) {
                             unittest_running = true;

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -1412,9 +1412,10 @@ int pgd_unittest(void) {
     // This runs unconditionally. The PGD-level checks further down depend on winning an
     // allocation race for two co-located slots and may be skipped; this one never is.
     {
-        struct aral_statistics selftest_stats = { 0 };
+        // stats = NULL so the aral allocates and owns them, and aral_destroy() frees them.
+        // Passing a local would store a pointer to this frame inside a heap object.
         ARAL *ar = aral_create("pgd-lifetime-selftest", sizeof(PGD), 0, 0,
-                               &selftest_stats, NULL, NULL, false, false, true);
+                               NULL, NULL, NULL, false, false, true);
         if(!ar) {
             fprintf(stderr, "PGD: cannot create the selftest aral\n");
             errors++;
@@ -1452,6 +1453,11 @@ int pgd_unittest(void) {
 
             aral_freez(ar, keep);
         }
+
+        // both elements are back, so no page is in use - tear the aral down rather than
+        // leaking it and its page on every invocation
+        if(ar)
+            aral_destroy(ar);
     }
 
     // This test deliberately reads `pg` back AFTER freeing it, so its page must not be

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -1404,15 +1404,16 @@ int pgd_unittest(void) {
     // after test_dbengine() has exercised these same arals, so "there is only one page"
     // does NOT hold here - it only holds for a standalone -W pgdtest.
     //
-    // pgd_alloc() picks its aral by gettid_cached() % partitions, so two allocations on this
-    // thread come from the same aral, and aral fills a page's slots consecutively. Keeping
-    // `pin` alive therefore keeps that page's used_elements > 0 for as long as we read `pg`,
-    // which makes the page undeletable rather than merely unlikely to be deleted.
+    // pgd_alloc() picks its aral by gettid_cached() % partitions, so both allocations on this
+    // thread come from the same aral. But same aral does NOT mean same page: if `pin` takes
+    // the last free slot of the current page, the next allocation starts a fresh one, and a
+    // pin on a different page holds nothing. So the pin is not sufficient on its own - it is
+    // verified below, and the read-back is skipped when it cannot be proven.
     //
     // Worth being precise about the hazard: these arals are created with mmap=false
-    // (page.c:518), so a deleted page is freez()'d, not nd_munmap()'d - the stale read would
-    // be a heap use-after-free, not a fault. Still UB, and invisible here because ASAN skips
-    // this test, which is exactly why the pin is structural instead of probabilistic.
+    // (page.c:518), so a deleted page is freez()'d, not nd_munmap()'d - a stale read would be
+    // a heap use-after-free, not a fault. Still UB, and invisible here because ASAN skips
+    // this test - which is why it is proven rather than assumed.
     PGD *pin = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 16);
 
     PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 16);
@@ -1429,24 +1430,42 @@ int pgd_unittest(void) {
         errors++;
     }
 
+    // Prove `pin` shares pg's page before trusting it. aral hands out consecutive slots
+    // within a page, so if the two elements are exactly one slot apart they are on the same
+    // page - and `pin` then keeps that page's used_elements > 0, which is what makes it
+    // undeletable (the delete at aral.c:1265 requires used_elements == 0). Distinct pages are
+    // separate mallocs with their own headers, so they cannot be exactly one slot apart.
+    size_t slot = aral_actual_element_size(pgd_alloc_globals.aral_pgd[pg->partition]);
+    uintptr_t a = (uintptr_t)pg, b = (uintptr_t)pin;
+    bool pinned = (a > b ? a - b : b - a) == (uintptr_t)slot;
+
     pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 
-    // Reading pg back is deliberate, and safe only because `pin` above holds the page.
-    // Everything below 2*sizeof(void*) now belongs to aral's free-list header.
-    //
-    // This is the detector's own contract: a second free must see the FIRST freer's site.
-    // We exercise the exact claim the fatal path reads, rather than calling pgd_free()
-    // again - that would fatal and take this process down with it.
-    uint16_t previous = pgd_claim_freed(pg, PGD_FREE_SITE_CREATE_BAD_TYPE);
-    if(!pgd_mark_is_freed(previous)) {
-        fprintf(stderr, "PGD: a freed PGD does not carry the freed mark - the guard is disarmed\n");
-        errors++;
+    if(!pinned) {
+        // Rare: pin landed on the previous page's last slot. Reading pg back would be a
+        // genuine use-after-free, so skip it rather than commit the UB this test exists to
+        // reason about. Not an error - the coverage is simply unavailable this run.
+        fprintf(stderr, "PGD: skipping the freed-slot read-back - the pin is on another aral "
+                        "page, so the freed page could be deleted under us\n");
     }
-    else if((PGD_FREE_SITE)(previous & 0xFFU) != PGD_FREE_SITE_UNITTEST) {
-        fprintf(stderr, "PGD: the freed mark reports the wrong first-free site (%s) - "
-                        "the site is the whole point of the mark\n",
-                pgd_free_site_name((PGD_FREE_SITE)(previous & 0xFFU)));
-        errors++;
+    else {
+        // Reading pg back is deliberate, and safe because `pin` provably holds the page.
+        // Everything below 2*sizeof(void*) now belongs to aral's free-list header.
+        //
+        // This is the detector's own contract: a second free must see the FIRST freer's site.
+        // We exercise the exact claim the fatal path reads, rather than calling pgd_free()
+        // again - that would fatal and take this process down with it.
+        uint16_t previous = pgd_claim_freed(pg, PGD_FREE_SITE_CREATE_BAD_TYPE);
+        if(!pgd_mark_is_freed(previous)) {
+            fprintf(stderr, "PGD: a freed PGD does not carry the freed mark - the guard is disarmed\n");
+            errors++;
+        }
+        else if((PGD_FREE_SITE)(previous & 0xFFU) != PGD_FREE_SITE_UNITTEST) {
+            fprintf(stderr, "PGD: the freed mark reports the wrong first-free site (%s) - "
+                            "the site is the whole point of the mark\n",
+                    pgd_free_site_name((PGD_FREE_SITE)(previous & 0xFFU)));
+            errors++;
+        }
     }
 
     // The use-after-free guard reads the SAME mark the double-free guard writes, and the
@@ -1462,32 +1481,36 @@ int pgd_unittest(void) {
     pgd_check_alive(NULL, "unittest: NULL must be accepted");
     pgd_check_alive(PGD_EMPTY, "unittest: PGD_EMPTY must be accepted");
 
-    // pgd_alloc() must clear the mark, or every FIRST free of a recycled slot would be
-    // misreported as a double free, AND every first USE of it as a use-after-free. Test the
-    // clear directly - which slot aral hands back next is not ours to predict.
-    pgd_clear_freed(pg);
+    // Everything below reads or writes the freed `pg`, so it runs only while the pin
+    // provably holds its page.
+    if(pinned) {
+        // pgd_alloc() must clear the mark, or every FIRST free of a recycled slot would be
+        // misreported as a double free, AND every first USE of it as a use-after-free. Test
+        // the clear directly - which slot aral hands back next is not ours to predict.
+        pgd_clear_freed(pg);
 
-    // a cleared mark must make the use guard quiet again
-    pgd_check_alive(pg, "unittest: a cleared mark must read as live");
-    if(pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
-        fprintf(stderr, "PGD: clearing the freed mark did not clear it\n");
-        errors++;
-    }
+        // a cleared mark must make the use guard quiet again
+        pgd_check_alive(pg, "unittest: a cleared mark must read as live");
+        if(pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
+            fprintf(stderr, "PGD: clearing the freed mark did not clear it\n");
+            errors++;
+        }
 
 #if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
-    // Pin the LP64 mechanism this guard exists to describe: aral's 16-byte free-list header
-    // makes a freed PGD read back as ARRAY_32BIT in partition 0, which is what lets a
-    // second pgd_free() misroute silently. The guard is correct either way, but if this
-    // stops holding, the comments in this file and the fatal's wording are stale.
-    if(pg->type != RRDENG_PAGE_TYPE_ARRAY_32BIT || pg->partition != 0) {
-        fprintf(stderr,
-                "PGD: aral's free-list header no longer makes a freed PGD read back as "
-                "ARRAY_32BIT/partition 0 (type %u, partition %u) - re-check ARAL_FREE in "
-                "aral.c against struct pgd\n",
-                (unsigned)pg->type, (unsigned)pg->partition);
-        errors++;
-    }
+        // Pin the LP64 mechanism this guard exists to describe: aral's 16-byte free-list
+        // header makes a freed PGD read back as ARRAY_32BIT in partition 0, which is what
+        // lets a second pgd_free() misroute silently. The guard is correct either way, but
+        // if this stops holding, the comments in this file and the fatal's wording are stale.
+        if(pg->type != RRDENG_PAGE_TYPE_ARRAY_32BIT || pg->partition != 0) {
+            fprintf(stderr,
+                    "PGD: aral's free-list header no longer makes a freed PGD read back as "
+                    "ARRAY_32BIT/partition 0 (type %u, partition %u) - re-check ARAL_FREE in "
+                    "aral.c against struct pgd\n",
+                    (unsigned)pg->type, (unsigned)pg->partition);
+            errors++;
+        }
 #endif
+    }
 
     // every read of the freed `pg` is done - the page may be released now
     pgd_free(pin, PGD_FREE_SITE_UNITTEST);

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -23,7 +23,7 @@ typedef struct {
     uint16_t freed_mark;        // PGD lifetime guard - see below
 } page_raw_t;
 
-typedef struct xxx {
+typedef struct {
     gorilla_writer_t *writer;
     uint16_t num_buffers;
     uint16_t freed_mark;        // PGD lifetime guard - same offset as page_raw_t's
@@ -1397,59 +1397,85 @@ int pgd_unittest(void) {
     if(!pgd_alloc_globals.partitions)
         pgd_init_arals();
 
-    // Pin the aral page before allocating the PGD under test. This test deliberately reads
-    // `pg` back AFTER freeing it, and aral_freez_internal() deletes a page that has become
-    // FULLY free whenever another page still has free items (aral.c:1265; the delete is
-    // gated on used_elements == 0). pgd_unittest() runs at position 33 of -W unittest, well
-    // after test_dbengine() has exercised these same arals, so "there is only one page"
-    // does NOT hold here - it only holds for a standalone -W pgdtest.
+    // This test deliberately reads `pg` back AFTER freeing it, so its page must not be
+    // deletable: aral_freez_internal() deletes a page that has become FULLY free whenever
+    // another page still has free items (aral.c:1265; the delete is gated on
+    // used_elements == 0). Keeping a live element ON THE SAME PAGE prevents that.
     //
-    // pgd_alloc() picks its aral by gettid_cached() % partitions, so both allocations on this
-    // thread come from the same aral. But same aral does NOT mean same page: if `pin` takes
-    // the last free slot of the current page, the next allocation starts a fresh one, and a
-    // pin on a different page holds nothing. So the pin is not sufficient on its own - it is
-    // verified below, and the read-back is skipped when it cannot be proven.
+    // "Same aral" is not enough. pgd_alloc() picks its aral by gettid_cached() % partitions,
+    // so every allocation here shares one aral, but aral serves recycled free-list slots
+    // before fresh ones and those are scattered across pages - and a fresh page starts as
+    // soon as the current one is exhausted. So co-location has to be PROVEN, not assumed:
+    // two elements exactly one slot apart are necessarily on the same page, because distinct
+    // pages are separate mallocs each carrying its own ARAL_PAGE header.
     //
-    // Worth being precise about the hazard: these arals are created with mmap=false
-    // (page.c:518), so a deleted page is freez()'d, not nd_munmap()'d - a stale read would be
-    // a heap use-after-free, not a fault. Still UB, and invisible here because ASAN skips
-    // this test - which is why it is proven rather than assumed.
-    PGD *pin = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 16);
+    // Probe until such a pair appears. Recycled slots are scattered, but the free list is
+    // finite: once it is drained, aral hands out consecutive slots from a page's tail, so a
+    // bounded probe finds an adjacent pair. All probes stay allocated until the end, which
+    // also keeps every page they touch alive.
+    //
+    // pgd_unittest() runs at position 33 of -W unittest, well after test_dbengine() has
+    // exercised these arals, so this is the realistic case - not the standalone -W pgdtest
+    // one, where the aral is fresh and any two allocations are trivially adjacent. Note CI
+    // only ever runs -W unittest.
+    //
+    // The hazard if this were wrong: these arals are created with mmap=false (page.c:518),
+    // so a deleted page is freez()'d, not nd_munmap()'d - a stale read would be a heap
+    // use-after-free rather than a fault. Silent, and invisible to ASAN because this whole
+    // test is skipped there. That is why it is proven rather than assumed.
+    PGD *probe[64];
+    size_t probes = 0;
+    PGD *pg = NULL;          // the one under test: proven to share a page with another probe
+    size_t slot = 0;
 
-    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 16);
-    if(!pg || pg == PGD_EMPTY || !pin || pin == PGD_EMPTY) {
+    while(probes < _countof(probe)) {
+        PGD *p = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 16);
+        if(!p || p == PGD_EMPTY)
+            break;
+
+        if(!slot)
+            slot = aral_actual_element_size(pgd_alloc_globals.aral_pgd[p->partition]);
+
+        // is this one adjacent to any probe already taken?
+        for(size_t i = 0; i < probes ;i++) {
+            uintptr_t a = (uintptr_t)p, b = (uintptr_t)probe[i];
+            if((a > b ? a - b : b - a) == (uintptr_t)slot) {
+                // probe[i] is on p's page and stays allocated until the end of the test,
+                // which is what keeps that page's used_elements > 0 while we read p back
+                pg = p;
+                break;
+            }
+        }
+
+        probe[probes++] = p;
+
+        if(pg)
+            break;
+    }
+
+    if(!probes) {
         fprintf(stderr, "PGD: cannot create a page to test with\n");
-        if(pin && pin != PGD_EMPTY) pgd_free(pin, PGD_FREE_SITE_UNITTEST);
-        if(pg && pg != PGD_EMPTY) pgd_free(pg, PGD_FREE_SITE_UNITTEST);
         return 1;
     }
 
-    // a live PGD must never look freed
-    if(pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
-        fprintf(stderr, "PGD: a freshly created PGD is already marked as freed\n");
+    if(!pg) {
+        // Never observed: it would mean 64 consecutive allocations from one aral produced no
+        // two elements on a common page. Fail loudly rather than silently skip - a silent
+        // skip would report PASSED while verifying nothing, every run, forever.
+        fprintf(stderr, "PGD: could not obtain two PGDs on one aral page in %zu probes - "
+                        "the lifetime guard is NOT being verified\n", probes);
         errors++;
     }
-
-    // Prove `pin` shares pg's page before trusting it. aral hands out consecutive slots
-    // within a page, so if the two elements are exactly one slot apart they are on the same
-    // page - and `pin` then keeps that page's used_elements > 0, which is what makes it
-    // undeletable (the delete at aral.c:1265 requires used_elements == 0). Distinct pages are
-    // separate mallocs with their own headers, so they cannot be exactly one slot apart.
-    size_t slot = aral_actual_element_size(pgd_alloc_globals.aral_pgd[pg->partition]);
-    uintptr_t a = (uintptr_t)pg, b = (uintptr_t)pin;
-    bool pinned = (a > b ? a - b : b - a) == (uintptr_t)slot;
-
-    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
-
-    if(!pinned) {
-        // Rare: pin landed on the previous page's last slot. Reading pg back would be a
-        // genuine use-after-free, so skip it rather than commit the UB this test exists to
-        // reason about. Not an error - the coverage is simply unavailable this run.
-        fprintf(stderr, "PGD: skipping the freed-slot read-back - the pin is on another aral "
-                        "page, so the freed page could be deleted under us\n");
-    }
     else {
-        // Reading pg back is deliberate, and safe because `pin` provably holds the page.
+        // a live PGD must never look freed
+        if(pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
+            fprintf(stderr, "PGD: a freshly created PGD is already marked as freed\n");
+            errors++;
+        }
+
+        pgd_free(pg, PGD_FREE_SITE_UNITTEST);
+
+        // Reading pg back is deliberate, and safe because a probe provably holds its page.
         // Everything below 2*sizeof(void*) now belongs to aral's free-list header.
         //
         // This is the detector's own contract: a second free must see the FIRST freer's site.
@@ -1481,9 +1507,9 @@ int pgd_unittest(void) {
     pgd_check_alive(NULL, "unittest: NULL must be accepted");
     pgd_check_alive(PGD_EMPTY, "unittest: PGD_EMPTY must be accepted");
 
-    // Everything below reads or writes the freed `pg`, so it runs only while the pin
-    // provably holds its page.
-    if(pinned) {
+    // Everything below reads or writes the freed `pg`, so it runs only when a co-located
+    // probe was proven above (pg is NULL otherwise, and that already counted an error).
+    if(pg) {
         // pgd_alloc() must clear the mark, or every FIRST free of a recycled slot would be
         // misreported as a double free, AND every first USE of it as a use-after-free. Test
         // the clear directly - which slot aral hands back next is not ours to predict.
@@ -1512,8 +1538,12 @@ int pgd_unittest(void) {
 #endif
     }
 
-    // every read of the freed `pg` is done - the page may be released now
-    pgd_free(pin, PGD_FREE_SITE_UNITTEST);
+    // every read of the freed `pg` is done - the probes may go back to the aral now.
+    // pg was freed by the test itself, so skip it here and never free it twice.
+    for(size_t i = 0; i < probes ;i++) {
+        if(probe[i] != pg)
+            pgd_free(probe[i], PGD_FREE_SITE_UNITTEST);
+    }
 
     if(errors)
         fprintf(stderr, "PGD: lifetime-guard test FAILED with %d error(s)\n", errors);

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -132,6 +132,7 @@ static const char *pgd_free_site_name(PGD_FREE_SITE site) {
         case PGD_FREE_SITE_EXTENT_INSERT_LOST:   return "extent population, lost the main cache insert race";
         case PGD_FREE_SITE_DISK_GORILLA_INVALID: return "invalid gorilla chain loaded from disk";
         case PGD_FREE_SITE_CREATE_BAD_TYPE:      return "unknown page type while creating";
+        case PGD_FREE_SITE_UNITTEST:             return "unit test teardown";
         default:                                 return "unknown";
     }
 }
@@ -667,7 +668,13 @@ void pgd_free_with_trace(PGD *pg, PGD_FREE_SITE site, const char *func) {
     // below offset 2*sizeof(void*) has been overwritten by ARAL's free-list header, and on
     // LP64 the values it leaves behind (type 0 == ARRAY_32BIT, partition 0) are precisely
     // the ones that make the rest of this function proceed as if nothing were wrong.
-    uint16_t previous = pgd_claim_freed(pg, site);
+    // Read before claiming. On the path this guard exists for - a PGD that is already
+    // freed - we then fatal without writing to it at all. The exchange still happens on
+    // the normal path, so two threads racing to free one live PGD cannot both win.
+    uint16_t previous = __atomic_load_n(&pg->raw.freed_mark, __ATOMIC_ACQUIRE);
+    if (likely(!pgd_mark_is_freed(previous)))
+        previous = pgd_claim_freed(pg, site);
+
     if (unlikely(pgd_mark_is_freed(previous))) {
         fatal("DBENGINE: PGD double free - pgd %p was first freed by: %s; "
               "it is now being freed again by: %s (in '%s'). "
@@ -1287,7 +1294,7 @@ int pgd_unittest(void) {
         errors++;
     }
 
-    pgd_free(pg, PGD_FREE_SITE_MAIN_CACHE_EVICT);
+    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 
     // Reading pg back is deliberate: the aral page is still mapped. Everything below
     // 2*sizeof(void*) now belongs to aral's free-list header.
@@ -1295,12 +1302,12 @@ int pgd_unittest(void) {
     // This is the detector's own contract: a second free must see the FIRST freer's site.
     // We exercise the exact claim the fatal path reads, rather than calling pgd_free()
     // again - that would fatal and take this process down with it.
-    uint16_t previous = pgd_claim_freed(pg, PGD_FREE_SITE_EXTENT_INSERT_LOST);
+    uint16_t previous = pgd_claim_freed(pg, PGD_FREE_SITE_CREATE_BAD_TYPE);
     if(!pgd_mark_is_freed(previous)) {
         fprintf(stderr, "PGD: a freed PGD does not carry the freed mark - the guard is disarmed\n");
         errors++;
     }
-    else if((PGD_FREE_SITE)(previous & 0xFFU) != PGD_FREE_SITE_MAIN_CACHE_EVICT) {
+    else if((PGD_FREE_SITE)(previous & 0xFFU) != PGD_FREE_SITE_UNITTEST) {
         fprintf(stderr, "PGD: the freed mark reports the wrong first-free site (%s) - "
                         "the site is the whole point of the mark\n",
                 pgd_free_site_name((PGD_FREE_SITE)(previous & 0xFFU)));

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -137,6 +137,56 @@ static const char *pgd_free_site_name(PGD_FREE_SITE site) {
     }
 }
 
+// ----------------------------------------------------------------------------
+// PGD use-after-free guard
+//
+// The double-free check above only fires on the SECOND pgd_free(). It says nothing about
+// the far more common shape in the fleet: a PGD that is freed once, and then USED - by a
+// collector still appending points to it, or by the flush path still reading it. That is
+// what produces 21 of the 25 pgd_fatal events / 30 days, and it produces them with the
+// wrong story, because every field pgd_fatal prints has already been overwritten by ARAL's
+// free-list header:
+//
+//     collection on page not created from a collector - pgd: { type: ARRAY_32BIT, used: 0,
+//     slots: 0, partition: 0, state: 0, options: 0 }
+//
+// Nothing in that line is this PGD's. `state: 0` is why the "not created from a collector"
+// check tripped, and `type/used/slots/partition` are ARAL_FREE{size_t,pointer}. Reading it
+// as a page-state bug sends the investigation to the collector, not to the freer.
+//
+// So: check the mark on ENTRY to every PGD entry point, BEFORE reading any other field,
+// and name the site that freed it. Same mark, same cost as the double-free check - one
+// 16-bit relaxed load on a cacheline the caller is about to touch anyway.
+//
+// Unlike `states`, the mark cannot be a benign shutdown race: nothing but pgd_free() ever
+// writes it. That is why this check does NOT honour exit_initiated_get() the way its
+// neighbours in pgd_append_point() do - those tolerate a state mismatch during exit
+// because a state mismatch can be a race; writing into freed memory cannot.
+
+static void pgd_fatal_use_after_free(const PGD *pg, uint16_t mark, const char *what, const char *func) {
+    fatal("DBENGINE: PGD use after free - %s on pgd %p in '%s', but that PGD was already "
+          "freed by: %s. Do not trust any other field of it: its first %zu bytes now hold "
+          "ARAL's free-list header, which is why it reports type %u, partition %u, used %u, "
+          "slots %u, states %u.",
+          what, (const void *)pg, func ? func : "(unknown)",
+          pgd_free_site_name((PGD_FREE_SITE)(mark & 0xFFU)),
+          (size_t)(2 * sizeof(void *)),
+          (unsigned)pg->type, (unsigned)pg->partition,
+          (unsigned)pg->used, (unsigned)pg->slots, (unsigned)pg->states);
+}
+
+// Fatals if pg has already been freed; returns normally otherwise. NULL and PGD_EMPTY are
+// neither freed nor dereferenceable, so callers that already tolerate them keep doing so.
+#define pgd_check_alive(pg, what) pgd_check_alive_with_trace(pg, what, __FUNCTION__)
+static ALWAYS_INLINE void pgd_check_alive_with_trace(const PGD *pg, const char *what, const char *func) {
+    if(!pg || pg == PGD_EMPTY)
+        return;
+
+    uint16_t mark = __atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED);
+    if(unlikely(pgd_mark_is_freed(mark)))
+        pgd_fatal_use_after_free(pg, mark, what, func);
+}
+
 // Claim the PGD for freeing, and return what was there before.
 //
 // This is an exchange, taken on ENTRY to pgd_free(), not a store on the way out. Two
@@ -251,6 +301,18 @@ static PRINTFLIKE(2, 3) void pgd_fatal(const PGD *pg, const char *fmt, ...) {
             int options = pg->options;
             buffer_sprintf(wb, "%d", options);
         }
+    }
+
+    {
+        // The lifetime verdict has to come last and be unmissable: if this PGD is already
+        // freed, every field printed above belongs to ARAL's free-list header, not to it.
+        uint16_t mark = __atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED);
+        if(unlikely(pgd_mark_is_freed(mark)))
+            buffer_sprintf(wb, ", lifetime: ALREADY FREED BY '%s' - IGNORE EVERY FIELD "
+                               "ABOVE, they are ARAL's free-list header",
+                           pgd_free_site_name((PGD_FREE_SITE)(mark & 0xFFU)));
+        else
+            buffer_strcat(wb, ", lifetime: live");
     }
 
     buffer_strcat(wb, " }");
@@ -893,6 +955,8 @@ ALWAYS_INLINE uint32_t pgd_memory_footprint(PGD *pg)
 // return the nominal buffer size depending on the page type - used by the PGC histogram
 uint32_t pgd_buffer_memory_footprint(PGD *pg)
 {
+    pgd_check_alive(pg, "buffer memory footprint");
+
     if (!pg)
         return 0;
 
@@ -926,6 +990,10 @@ uint32_t pgd_buffer_memory_footprint(PGD *pg)
 
 uint32_t pgd_disk_footprint(PGD *pg)
 {
+    // before pgd_aral_unmark() below dereferences pg->gorilla.writer, which sits at
+    // offset 0 and is therefore clobbered on every freed PGD, on every ABI
+    pgd_check_alive(pg, "disk footprint (flush)");
+
     if (!pgd_slots_used(pg))
         return 0;
 
@@ -986,6 +1054,9 @@ uint32_t pgd_disk_footprint(PGD *pg)
 
 void pgd_copy_to_extent(PGD *pg, uint8_t *dst, uint32_t dst_size)
 {
+    // a freed PGD here would serialize ARAL's free-list header into the extent
+    pgd_check_alive(pg, "copy to extent (flush)");
+
     internal_fatal(pgd_disk_footprint(pg) != dst_size, "Wrong disk footprint size requested (need %u, available %u)",
                    pgd_disk_footprint(pg), dst_size);
 
@@ -1037,6 +1108,9 @@ size_t pgd_append_point(
     SN_FLAGS flags,
     uint32_t expected_slot)
 {
+    // before pg->states, which a freed PGD no longer owns
+    pgd_check_alive(pg, "data collection");
+
     if (pg->states & PGD_STATE_SCHEDULED_FOR_FLUSHING) {
         if(exit_initiated_get() == EXIT_REASON_NONE)
             pgd_fatal(pg, "Data collection on page already scheduled for flushing");
@@ -1172,6 +1246,7 @@ static void pgdc_seek(PGDC *pgdc, uint32_t position)
 void pgdc_reset(PGDC *pgdc, PGD *pgd, uint32_t position)
 {
     // pgd might be null and position equal to UINT32_MAX
+    pgd_check_alive(pgd, "query cursor reset");
 
     pgdc->pgd = pgd;
     pgdc->position = position;
@@ -1314,10 +1389,30 @@ int pgd_unittest(void) {
         errors++;
     }
 
+    // The use-after-free guard reads the SAME mark the double-free guard writes, so what
+    // has to be pinned here is that it agrees with it on a freed PGD, and stays quiet on
+    // the two sentinels every PGD entry point already tolerates. Calling a real entry
+    // point (pgd_append_point() etc.) is not an option - it would fatal by design and take
+    // this process down; so drive the predicate the guard is built on.
+    if(!pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
+        fprintf(stderr, "PGD: the use-after-free guard cannot see the freed mark that "
+                        "pgd_free() left - the use paths are unguarded\n");
+        errors++;
+    }
+
+    // NULL and PGD_EMPTY must never be reported as freed: pgd_check_alive() returns early
+    // for both, and callers rely on that. If this ever regressed it would fatal on every
+    // empty page in the fleet, so it is worth a test even though it looks trivial.
+    pgd_check_alive(NULL, "unittest: NULL must be accepted");
+    pgd_check_alive(PGD_EMPTY, "unittest: PGD_EMPTY must be accepted");
+
     // pgd_alloc() must clear the mark, or every FIRST free of a recycled slot would be
-    // misreported as a double free. Test the clear directly - which slot aral hands back
-    // next is not ours to predict.
+    // misreported as a double free, AND every first USE of it as a use-after-free. Test the
+    // clear directly - which slot aral hands back next is not ours to predict.
     pgd_clear_freed(pg);
+
+    // a cleared mark must make the use guard quiet again
+    pgd_check_alive(pg, "unittest: a cleared mark must read as live");
     if(pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
         fprintf(stderr, "PGD: clearing the freed mark did not clear it\n");
         errors++;

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -20,11 +20,13 @@ typedef enum __attribute__((packed)) {
 typedef struct {
     uint8_t *data;
     uint16_t size;
+    uint16_t freed_mark;        // PGD lifetime guard - see below
 } page_raw_t;
 
-typedef struct {
+typedef struct xxx {
     gorilla_writer_t *writer;
     uint16_t num_buffers;
+    uint16_t freed_mark;        // PGD lifetime guard - same offset as page_raw_t's
 } page_gorilla_t;
 
 struct pgd {
@@ -50,6 +52,108 @@ struct pgd {
         page_gorilla_t gorilla;
     };
 };
+
+// ----------------------------------------------------------------------------
+// PGD lifetime guard
+//
+// aral_freez() writes ARAL_FREE { size_t size; struct aral_free *next; } over the FIRST
+// 16 BYTES of the element it frees (src/libnetdata/aral/aral.c). On a 24-byte PGD that
+// clobbers used, slots, type, partition, options, states and raw.data, and leaves bytes
+// 16..23 untouched. The clobbered values are not random: type reads back as 0, which is
+// RRDENG_PAGE_TYPE_ARRAY_32BIT, and partition reads back as 0.
+//
+// So a second pgd_free() on an already freed PGD passes every check it has, takes the
+// ARRAY branch even when the PGD was a GORILLA page, and calls
+//
+//     aral_freez(pgd-<stale raw.size>-0, <the free-list 'next' pointer>)
+//
+// which either fatals inside ARAL naming an arena and a pointer that have nothing to do
+// with the bug, or - when 'next' happens to be NULL - corrupts state silently, because
+// aral_freez(ar, NULL) is a no-op.
+//
+// We therefore mark a PGD as freed in the 8 bytes ARAL provably cannot reach, and check
+// that mark on entry. Same approach as SPINLOCK_TRACKED: record the actor inline in the
+// object's own memory, in production, on one narrowly scoped hot object.
+//
+// Under FSANITIZE_ADDRESS the pool is bypassed (aral_freez() delegates to freez()), so
+// the mark is never read back and ASAN catches the double free directly.
+
+// The guard has to survive what aral_freez() writes into a freed element:
+// ARAL_FREE { size_t size; struct aral_free *next; } - two pointer-sized words at offset
+// 0, on every ABI. The asserts below are what actually enforce that.
+//
+// freed_mark is a declared member of BOTH union arms at the same offset, not punned
+// padding, and it is a uint16 so it fits in padding those arms already had - so
+// sizeof(struct pgd) is unchanged on LP64 (24) and on ILP32 (16), and PGD does not move
+// aral size class on either. A member appended after the union instead would have cost
+// +8 bytes per PGD on LP64, because sizeof(page_raw_t) is already pointer-padded to 16.
+//
+// The ABIs differ, and it matters:
+//
+//   LP64  ARAL_FREE is 16 bytes and covers used/slots/type/partition/options/states AND
+//         raw.data. type reads back as 0 == RRDENG_PAGE_TYPE_ARRAY_32BIT and partition as
+//         0, so a second pgd_free() takes the ARRAY branch even for a GORILLA page and
+//         frees the free-list `next` pointer into the arena picked by the stale raw.size.
+//   ILP32 ARAL_FREE is 8 bytes and covers only used/slots/type/partition/options/states.
+//         raw.data SURVIVES, so a second pgd_free() frees the real data buffer again, and
+//         partition is a byte of the `next` pointer - i.e. an out-of-range index into
+//         aral_pgd[] once internal_fatal() is compiled out.
+//
+// Either way the resulting fatal describes the wrong thing, which is why this guard exists.
+// 8 bits of magic is enough: freed_mark is a declared member that nothing but this guard
+// ever writes, so it only has to tell "cleared by pgd_alloc()" from "freed". The low byte
+// carries the PGD_FREE_SITE.
+#define PGD_FREED_MAGIC      0x9D00U
+#define PGD_FREED_MAGIC_MASK 0xFF00U
+
+_Static_assert(offsetof(struct pgd, raw.freed_mark) >= 2 * sizeof(void *),
+               "freed_mark must sit past ARAL_FREE{size_t,pointer}, which aral_freez() "
+               "writes over the start of every freed element");
+_Static_assert(offsetof(struct pgd, raw.freed_mark) == offsetof(struct pgd, gorilla.freed_mark),
+               "both union arms must place freed_mark at the same offset");
+_Static_assert(offsetof(struct pgd, raw.freed_mark) >= offsetof(struct pgd, raw.size) + sizeof(((page_raw_t *)0)->size),
+               "freed_mark must not overlay page_raw_t.size");
+_Static_assert(offsetof(struct pgd, gorilla.freed_mark) >= offsetof(struct pgd, gorilla.num_buffers) + sizeof(((page_gorilla_t *)0)->num_buffers),
+               "freed_mark must not overlay page_gorilla_t.num_buffers");
+
+#if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+// The guard must stay free on the platform that carries the fleet: it has to fit in
+// padding struct pgd already had, so PGD does not change aral size class.
+_Static_assert(sizeof(PGD) == 24, "struct pgd grew on LP64 - the freed mark is no longer free");
+#endif
+
+static ALWAYS_INLINE bool pgd_mark_is_freed(uint16_t mark) {
+    return (mark & PGD_FREED_MAGIC_MASK) == PGD_FREED_MAGIC;
+}
+
+static const char *pgd_free_site_name(PGD_FREE_SITE site) {
+    switch(site) {
+        case PGD_FREE_SITE_MAIN_CACHE_EVICT:     return "main cache eviction (main_cache_free_clean_page_callback)";
+        case PGD_FREE_SITE_EXTENT_INSERT_LOST:   return "extent population, lost the main cache insert race";
+        case PGD_FREE_SITE_DISK_GORILLA_INVALID: return "invalid gorilla chain loaded from disk";
+        case PGD_FREE_SITE_CREATE_BAD_TYPE:      return "unknown page type while creating";
+        default:                                 return "unknown";
+    }
+}
+
+// Claim the PGD for freeing, and return what was there before.
+//
+// This is an exchange, taken on ENTRY to pgd_free(), not a store on the way out. Two
+// threads racing to free the same PGD would both pass a check-then-set guard and both run
+// the teardown; with an exchange exactly one wins, and the loser gets the winner's mark
+// back and reports it.
+static ALWAYS_INLINE uint16_t pgd_claim_freed(PGD *pg, PGD_FREE_SITE site) {
+    return __atomic_exchange_n(&pg->raw.freed_mark,
+                               (uint16_t)(PGD_FREED_MAGIC | ((uint16_t)site & 0xFFU)),
+                               __ATOMIC_ACQ_REL);
+}
+
+// aral does not zero recycled slots, so a PGD handed back out still carries the mark of
+// its previous life. Clearing it on allocation is what keeps the guard free of false
+// positives.
+static ALWAYS_INLINE void pgd_clear_freed(PGD *pg) {
+    __atomic_store_n(&pg->raw.freed_mark, 0, __ATOMIC_RELAXED);
+}
 
 static PRINTFLIKE(2, 3) void pgd_fatal(const PGD *pg, const char *fmt, ...) {
     BUFFER *wb = buffer_create(0, NULL);
@@ -382,6 +486,10 @@ static ALWAYS_INLINE PGD *pgd_alloc(bool for_collector) {
         pgd = aral_mallocz(pgd_alloc_globals.aral_pgd[partition]);
 
     pgd->partition = partition;
+
+    // the slot may be recycled from a previously freed PGD, which still carries its mark
+    pgd_clear_freed(pgd);
+
     return pgd;
 }
 
@@ -485,6 +593,7 @@ ALWAYS_INLINE PGD *pgd_create(uint8_t type, uint32_t slots) {
 
         default:
             netdata_log_error("%s() - Unknown page type: %uc", __FUNCTION__, type);
+            pgd_claim_freed(pg, PGD_FREE_SITE_CREATE_BAD_TYPE);
             aral_freez(pgd_alloc_globals.aral_pgd[pg->partition], pg);
             pg = PGD_EMPTY;
             break;
@@ -521,7 +630,7 @@ ALWAYS_INLINE PGD *pgd_create_from_disk_data(uint8_t type, void *base, uint32_t 
                                               size / RRDENG_GORILLA_32BIT_BUFFER_SIZE,
                                               &total_entries))) {
                 netdata_log_error("DBENGINE: invalid gorilla disk page chain.");
-                pgd_free(pg);
+                pgd_free(pg, PGD_FREE_SITE_DISK_GORILLA_INVALID);
                 pg = PGD_EMPTY;
                 break;
             }
@@ -541,6 +650,7 @@ ALWAYS_INLINE PGD *pgd_create_from_disk_data(uint8_t type, void *base, uint32_t 
 
         default:
             netdata_log_error("%s() - Unknown page type: %uc", __FUNCTION__, type);
+            pgd_claim_freed(pg, PGD_FREE_SITE_CREATE_BAD_TYPE);
             aral_freez(pgd_alloc_globals.aral_pgd[pg->partition], pg);
             pg = PGD_EMPTY;
             break;
@@ -549,9 +659,28 @@ ALWAYS_INLINE PGD *pgd_create_from_disk_data(uint8_t type, void *base, uint32_t 
     return pg;
 }
 
-void pgd_free(PGD *pg) {
+void pgd_free_with_trace(PGD *pg, PGD_FREE_SITE site, const char *func) {
     if (!pg || pg == PGD_EMPTY)
         return;
+
+    // Claim the PGD before trusting ANY field of it. On an already freed PGD every field
+    // below offset 2*sizeof(void*) has been overwritten by ARAL's free-list header, and on
+    // LP64 the values it leaves behind (type 0 == ARRAY_32BIT, partition 0) are precisely
+    // the ones that make the rest of this function proceed as if nothing were wrong.
+    uint16_t previous = pgd_claim_freed(pg, site);
+    if (unlikely(pgd_mark_is_freed(previous))) {
+        fatal("DBENGINE: PGD double free - pgd %p was first freed by: %s; "
+              "it is now being freed again by: %s (in '%s'). "
+              "Its first %zu bytes now hold ARAL's free-list header, so the values it "
+              "reports (type %u, partition %u, used %u, slots %u, data %p) belong to that "
+              "header, not to this PGD.",
+              (void *)pg,
+              pgd_free_site_name((PGD_FREE_SITE)(previous & 0xFFU)),
+              pgd_free_site_name(site), func ? func : "(unknown)",
+              (size_t)(2 * sizeof(void *)),
+              (unsigned)pg->type, (unsigned)pg->partition,
+              (unsigned)pg->used, (unsigned)pg->slots, pg->raw.data);
+    }
 
     internal_fatal(pg->partition >= pgd_alloc_globals.partitions,
                    "PGD partition is invalid %u", pg->partition);
@@ -565,9 +694,6 @@ void pgd_free(PGD *pg) {
 
                 pgd_data_free(pg->raw.data, pg->raw.size, pg->partition);
                 timing_dbengine_evict_step(TIMING_STEP_DBENGINE_EVICT_FREE_MAIN_PGD_ARAL);
-
-                pg->raw.data = NULL;
-                pg->raw.size = 0;
             }
             else if ((pg->states & PGD_STATE_CREATED_FROM_COLLECTOR) ||
                      (pg->states & PGD_STATE_SCHEDULED_FOR_FLUSHING) ||
@@ -1122,4 +1248,94 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             return false;
         }
     }
+}
+
+// ----------------------------------------------------------------------------
+// unittest
+
+// The PGD lifetime guard rests on an assumption that lives in ANOTHER module: that
+// aral_freez() overwrites exactly the first 16 bytes of the element with
+// ARAL_FREE { size_t size; struct aral_free *next; }, leaving bytes 16..23 - where we put
+// the freed mark - alone. This test pins that assumption, so a future change to ARAL's
+// free-list layout fails here loudly instead of silently disarming the guard in
+// production.
+//
+// Skipped under FSANITIZE_ADDRESS: there aral_freez() delegates to freez(), so reading a
+// freed PGD back is a genuine use-after-free that ASAN traps first, and ASAN already
+// catches PGD double frees directly.
+int pgd_unittest(void) {
+#if defined(FSANITIZE_ADDRESS)
+    fprintf(stderr, "PGD: skipping lifetime-guard test under ASAN (aral bypasses its pool)\n");
+    return 0;
+#else
+    int errors = 0;
+
+    // pgd_init_arals() sorts and de-duplicates the static aral_sizes[] table in place, so
+    // it is not idempotent. Only initialise if nothing has yet.
+    if(!pgd_alloc_globals.partitions)
+        pgd_init_arals();
+
+    PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 16);
+    if(!pg || pg == PGD_EMPTY) {
+        fprintf(stderr, "PGD: cannot create a page to test with\n");
+        return 1;
+    }
+
+    // a live PGD must never look freed
+    if(pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
+        fprintf(stderr, "PGD: a freshly created PGD is already marked as freed\n");
+        errors++;
+    }
+
+    pgd_free(pg, PGD_FREE_SITE_MAIN_CACHE_EVICT);
+
+    // Reading pg back is deliberate: the aral page is still mapped. Everything below
+    // 2*sizeof(void*) now belongs to aral's free-list header.
+    //
+    // This is the detector's own contract: a second free must see the FIRST freer's site.
+    // We exercise the exact claim the fatal path reads, rather than calling pgd_free()
+    // again - that would fatal and take this process down with it.
+    uint16_t previous = pgd_claim_freed(pg, PGD_FREE_SITE_EXTENT_INSERT_LOST);
+    if(!pgd_mark_is_freed(previous)) {
+        fprintf(stderr, "PGD: a freed PGD does not carry the freed mark - the guard is disarmed\n");
+        errors++;
+    }
+    else if((PGD_FREE_SITE)(previous & 0xFFU) != PGD_FREE_SITE_MAIN_CACHE_EVICT) {
+        fprintf(stderr, "PGD: the freed mark reports the wrong first-free site (%s) - "
+                        "the site is the whole point of the mark\n",
+                pgd_free_site_name((PGD_FREE_SITE)(previous & 0xFFU)));
+        errors++;
+    }
+
+    // pgd_alloc() must clear the mark, or every FIRST free of a recycled slot would be
+    // misreported as a double free. Test the clear directly - which slot aral hands back
+    // next is not ours to predict.
+    pgd_clear_freed(pg);
+    if(pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
+        fprintf(stderr, "PGD: clearing the freed mark did not clear it\n");
+        errors++;
+    }
+
+#if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+    // Pin the LP64 mechanism this guard exists to describe: aral's 16-byte free-list header
+    // makes a freed PGD read back as ARRAY_32BIT in partition 0, which is what lets a
+    // second pgd_free() misroute silently. The guard is correct either way, but if this
+    // stops holding, the comments in this file and the fatal's wording are stale.
+    if(pg->type != RRDENG_PAGE_TYPE_ARRAY_32BIT || pg->partition != 0) {
+        fprintf(stderr,
+                "PGD: aral's free-list header no longer makes a freed PGD read back as "
+                "ARRAY_32BIT/partition 0 (type %u, partition %u) - re-check ARAL_FREE in "
+                "aral.c against struct pgd\n",
+                (unsigned)pg->type, (unsigned)pg->partition);
+        errors++;
+    }
+#endif
+
+    if(errors)
+        fprintf(stderr, "PGD: lifetime-guard test FAILED with %d error(s)\n", errors);
+    else
+        fprintf(stderr, "PGD: lifetime-guard test PASSED\n");
+
+    return errors;
+#endif
 }

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -1397,9 +1397,29 @@ int pgd_unittest(void) {
     if(!pgd_alloc_globals.partitions)
         pgd_init_arals();
 
+    // Pin the aral page before allocating the PGD under test. This test deliberately reads
+    // `pg` back AFTER freeing it, and aral_freez_internal() deletes a page that has become
+    // FULLY free whenever another page still has free items (aral.c:1265; the delete is
+    // gated on used_elements == 0). pgd_unittest() runs at position 33 of -W unittest, well
+    // after test_dbengine() has exercised these same arals, so "there is only one page"
+    // does NOT hold here - it only holds for a standalone -W pgdtest.
+    //
+    // pgd_alloc() picks its aral by gettid_cached() % partitions, so two allocations on this
+    // thread come from the same aral, and aral fills a page's slots consecutively. Keeping
+    // `pin` alive therefore keeps that page's used_elements > 0 for as long as we read `pg`,
+    // which makes the page undeletable rather than merely unlikely to be deleted.
+    //
+    // Worth being precise about the hazard: these arals are created with mmap=false
+    // (page.c:518), so a deleted page is freez()'d, not nd_munmap()'d - the stale read would
+    // be a heap use-after-free, not a fault. Still UB, and invisible here because ASAN skips
+    // this test, which is exactly why the pin is structural instead of probabilistic.
+    PGD *pin = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 16);
+
     PGD *pg = pgd_create(RRDENG_PAGE_TYPE_ARRAY_TIER1, 16);
-    if(!pg || pg == PGD_EMPTY) {
+    if(!pg || pg == PGD_EMPTY || !pin || pin == PGD_EMPTY) {
         fprintf(stderr, "PGD: cannot create a page to test with\n");
+        if(pin && pin != PGD_EMPTY) pgd_free(pin, PGD_FREE_SITE_UNITTEST);
+        if(pg && pg != PGD_EMPTY) pgd_free(pg, PGD_FREE_SITE_UNITTEST);
         return 1;
     }
 
@@ -1411,11 +1431,8 @@ int pgd_unittest(void) {
 
     pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 
-    // Reading pg back is deliberate. It is safe HERE - not in general - because this aral
-    // has a single page and aral_freez_internal() keeps the last page with free items
-    // (aral.c:1275) instead of unmapping it. In production a fully-freed page CAN be
-    // unmapped; see the "Unmapping" boundary noted with the guard above. Everything below
-    // 2*sizeof(void*) now belongs to aral's free-list header.
+    // Reading pg back is deliberate, and safe only because `pin` above holds the page.
+    // Everything below 2*sizeof(void*) now belongs to aral's free-list header.
     //
     // This is the detector's own contract: a second free must see the FIRST freer's site.
     // We exercise the exact claim the fatal path reads, rather than calling pgd_free()
@@ -1471,6 +1488,9 @@ int pgd_unittest(void) {
         errors++;
     }
 #endif
+
+    // every read of the freed `pg` is done - the page may be released now
+    pgd_free(pin, PGD_FREE_SITE_UNITTEST);
 
     if(errors)
         fprintf(stderr, "PGD: lifetime-guard test FAILED with %d error(s)\n", errors);

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -120,6 +120,10 @@ _Static_assert(offsetof(struct pgd, gorilla.freed_mark) >= offsetof(struct pgd, 
 // The guard must stay free on the platform that carries the fleet: it has to fit in
 // padding struct pgd already had, so PGD does not change aral size class.
 _Static_assert(sizeof(PGD) == 24, "struct pgd grew on LP64 - the freed mark is no longer free");
+#elif UINTPTR_MAX == 0xFFFFFFFFu
+// Same requirement on ILP32, where the comments above claim 16 - assert it instead of
+// only documenting it, so a layout change cannot move PGD's aral size class unnoticed.
+_Static_assert(sizeof(PGD) == 16, "struct pgd grew on ILP32 - the freed mark is no longer free");
 #endif
 
 static ALWAYS_INLINE bool pgd_mark_is_freed(uint16_t mark) {
@@ -154,14 +158,48 @@ static const char *pgd_free_site_name(PGD_FREE_SITE site) {
 // check tripped, and `type/used/slots/partition` are ARAL_FREE{size_t,pointer}. Reading it
 // as a page-state bug sends the investigation to the collector, not to the freer.
 //
-// So: check the mark on ENTRY to every PGD entry point, BEFORE reading any other field,
-// and name the site that freed it. Same mark, same cost as the double-free check - one
-// 16-bit relaxed load on a cacheline the caller is about to touch anyway.
+// So: check the mark BEFORE any other field is read, and name the site that freed it. Same
+// mark, same cost as the double-free check - one 16-bit relaxed load on a cacheline the
+// caller is about to touch anyway.
 //
-// Unlike `states`, the mark cannot be a benign shutdown race: nothing but pgd_free() ever
-// writes it. That is why this check does NOT honour exit_initiated_get() the way its
-// neighbours in pgd_append_point() do - those tolerate a state mismatch during exit
-// because a state mismatch can be a race; writing into freed memory cannot.
+// Guarded: pgd_append_point(), pgd_disk_footprint(), pgd_buffer_memory_footprint(),
+// pgd_copy_to_extent(), pgdc_reset(). pgd_fatal() reports the verdict for everything else.
+// NOT guarded, deliberately: pgd_type(), pgd_is_empty(), pgd_slots_used(), pgd_capacity(),
+// pgd_memory_footprint() and pgdc_get_next_point(). The first five only read scalars that
+// pgd_fatal() already labels; the last is per-point in the query hot path, and pgdc_reset()
+// guards the cursor at setup. A freed PGD reaching pgdc_get_next_point() still derefs
+// raw.data (== ARAL's free-list `next` on LP64) and SIGSEGVs without a story - a known gap,
+// not a regression: nothing here removes a check that existed before.
+//
+// Two more boundaries this detector cannot cross, both inherent to an in-object mark:
+//
+//   Recycling (ABA). pgd_alloc() clears the mark, so once ARAL hands the slot to a new PGD
+//   a stale pointer to the old one reads as live and the operation silently proceeds
+//   against the new page. The mark catches a use-after-free only while the slot is still
+//   free; it cannot catch one after reuse.
+//
+//   Unmapping. aral_freez_internal() deletes a fully-freed ARAL page at runtime when
+//   another page still has free slots (aral.c:1265 -> aral_del_page___no_lock_needed() ->
+//   nd_munmap()/freez()). If that happens between the free and the guarded use, the mark
+//   load itself faults. Strictly no worse than before - the old code dereferenced the same
+//   unmapped page - but "fatal with a story" is best-effort, not a guarantee.
+//
+// On exit: this check does NOT honour exit_initiated_get(), unlike its neighbours in
+// pgd_append_point(). Be precise about what that trades, because it differs by ABI. `states`
+// sits at offset 7 of struct pgd, and ARAL_FREE{size_t,pointer} covers bytes 0..15 on LP64
+// and 0..7 on ILP32:
+//
+//   LP64  offset 7 is the TOP byte of ARAL_FREE.size, so it always reads 0 for any real
+//         element size. The old code therefore always reached the
+//         !(states & CREATED_FROM_COLLECTOR) check below and returned 0 during exit - it
+//         never wrote into the freed PGD. Here we trade a clean shutdown for detection.
+//   ILP32 offset 7 is the TOP byte of ARAL_FREE.next, which is not reliably 0. The old code
+//         could pass the state checks and write into freed memory. Here we prevent that.
+//
+// So the honest claim is narrower than "writing into freed memory cannot be a race": on the
+// ABI that carries the fleet this converts a silent, harmless exit into a reported fatal.
+// That is the intended trade - a latent eviction/collector lifetime race is worth a crash
+// event - but it is a deliberate behaviour change, not a free win.
 
 static void pgd_fatal_use_after_free(const PGD *pg, uint16_t mark, const char *what, const char *func) {
     fatal("DBENGINE: PGD use after free - %s on pgd %p in '%s', but that PGD was already "
@@ -990,8 +1028,10 @@ uint32_t pgd_buffer_memory_footprint(PGD *pg)
 
 uint32_t pgd_disk_footprint(PGD *pg)
 {
-    // before pgd_aral_unmark() below dereferences pg->gorilla.writer, which sits at
-    // offset 0 and is therefore clobbered on every freed PGD, on every ABI
+    // before pgd_aral_unmark() below dereferences pg->gorilla.writer, which sits at offset 8
+    // and is therefore clobbered on a freed PGD on LP64 (ARAL_FREE covers bytes 0..15). On
+    // ILP32 it covers only 0..7, so writer survives there and the deref hits the real, freed
+    // gorilla writer instead - equally fatal, differently shaped.
     pgd_check_alive(pg, "disk footprint (flush)");
 
     if (!pgd_slots_used(pg))
@@ -1371,7 +1411,10 @@ int pgd_unittest(void) {
 
     pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 
-    // Reading pg back is deliberate: the aral page is still mapped. Everything below
+    // Reading pg back is deliberate. It is safe HERE - not in general - because this aral
+    // has a single page and aral_freez_internal() keeps the last page with free items
+    // (aral.c:1275) instead of unmapping it. In production a fully-freed page CAN be
+    // unmapped; see the "Unmapping" boundary noted with the guard above. Everything below
     // 2*sizeof(void*) now belongs to aral's free-list header.
     //
     // This is the detector's own contract: a second free must see the FIRST freer's site.
@@ -1389,17 +1432,13 @@ int pgd_unittest(void) {
         errors++;
     }
 
-    // The use-after-free guard reads the SAME mark the double-free guard writes, so what
-    // has to be pinned here is that it agrees with it on a freed PGD, and stays quiet on
-    // the two sentinels every PGD entry point already tolerates. Calling a real entry
-    // point (pgd_append_point() etc.) is not an option - it would fatal by design and take
-    // this process down; so drive the predicate the guard is built on.
-    if(!pgd_mark_is_freed(__atomic_load_n(&pg->raw.freed_mark, __ATOMIC_RELAXED))) {
-        fprintf(stderr, "PGD: the use-after-free guard cannot see the freed mark that "
-                        "pgd_free() left - the use paths are unguarded\n");
-        errors++;
-    }
-
+    // The use-after-free guard reads the SAME mark the double-free guard writes, and the
+    // exchange above already proved pgd_free() left it set with the right site - so there is
+    // nothing further to assert about a freed PGD here. What is left to pin is the guard's
+    // behaviour on the inputs it must NOT flag. Calling a real entry point
+    // (pgd_append_point() etc.) is not an option - it would fatal by design and take this
+    // process down.
+    //
     // NULL and PGD_EMPTY must never be reported as freed: pgd_check_alive() returns early
     // for both, and callers rely on that. If this ever regressed it would fatal on every
     // empty page in the fleet, so it is worth a test even though it looks trivial.

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -1397,6 +1397,63 @@ int pgd_unittest(void) {
     if(!pgd_alloc_globals.partitions)
         pgd_init_arals();
 
+    // ------------------------------------------------------------------------------------
+    // The cross-module assumption, checked deterministically.
+    //
+    // What can silently disarm the production guard is ARAL changing where it writes its
+    // free-list header: freed_mark must stay outside it. That claim is about ARAL, not about
+    // PGD, so it does not need a real PGD - and checking it on a PRIVATE aral makes it
+    // immune to whatever state the shared pgd arals are in. A fresh aral has exactly one
+    // page, and aral_freez_internal() keeps the last page with free items (aral.c:1275)
+    // instead of deleting it, so reading the element back is safe by construction. The
+    // second allocation keeps used_elements > 0 as well, so the page cannot even become a
+    // deletion candidate.
+    //
+    // This runs unconditionally. The PGD-level checks further down depend on winning an
+    // allocation race for two co-located slots and may be skipped; this one never is.
+    {
+        struct aral_statistics selftest_stats = { 0 };
+        ARAL *ar = aral_create("pgd-lifetime-selftest", sizeof(PGD), 0, 0,
+                               &selftest_stats, NULL, NULL, false, false, true);
+        if(!ar) {
+            fprintf(stderr, "PGD: cannot create the selftest aral\n");
+            errors++;
+        }
+        else {
+            void *keep = aral_mallocz(ar);      // holds the page, never freed before the read
+            void *e = aral_mallocz(ar);
+
+            const size_t mark_off = offsetof(struct pgd, raw.freed_mark);
+            uint16_t *mark = (uint16_t *)((uint8_t *)e + mark_off);
+            uint8_t *head = (uint8_t *)e;
+
+            *mark = PGD_FREED_MAGIC | 0x5AU;
+            memset(head, 0, 2 * sizeof(void *));
+
+            aral_freez(ar, e);
+
+            // ARAL must have written its free-list header over the head of the element...
+            bool header_written = false;
+            for(size_t i = 0; i < 2 * sizeof(void *) ;i++)
+                if(head[i]) { header_written = true; break; }
+
+            if(!header_written) {
+                fprintf(stderr, "PGD: aral_freez() no longer writes a free-list header over the "
+                                "start of a freed element - re-check ARAL_FREE in aral.c\n");
+                errors++;
+            }
+
+            // ...and it must NOT have reached the freed mark.
+            if(*mark != (uint16_t)(PGD_FREED_MAGIC | 0x5AU)) {
+                fprintf(stderr, "PGD: aral_freez() now overwrites offset %zu, where the freed "
+                                "mark lives - the lifetime guard is SILENTLY DISARMED\n", mark_off);
+                errors++;
+            }
+
+            aral_freez(ar, keep);
+        }
+    }
+
     // This test deliberately reads `pg` back AFTER freeing it, so its page must not be
     // deletable: aral_freez_internal() deletes a page that has become FULLY free whenever
     // another page still has free items (aral.c:1265; the delete is gated on
@@ -1459,12 +1516,18 @@ int pgd_unittest(void) {
     }
 
     if(!pg) {
-        // Never observed: it would mean 64 consecutive allocations from one aral produced no
-        // two elements on a common page. Fail loudly rather than silently skip - a silent
-        // skip would report PASSED while verifying nothing, every run, forever.
-        fprintf(stderr, "PGD: could not obtain two PGDs on one aral page in %zu probes - "
-                        "the lifetime guard is NOT being verified\n", probes);
-        errors++;
+        // The probe bound is a heuristic, not a proof: aral serves a page's virgin slots
+        // sequentially (the elements_segmented fast path) and only then falls back to the
+        // recycled list, so how many allocations it takes to see two co-located slots depends
+        // on how scattered that list is. A long enough scattered list would exhaust the probe.
+        //
+        // That must NOT fail the build - it would be a false failure on a healthy tree. It is
+        // safe to skip because the assumption that can silently disarm the guard was already
+        // verified above, deterministically, on a private aral. What is lost here is only the
+        // end-to-end check that pgd_free() stamps the mark on a real PGD.
+        fprintf(stderr, "PGD: no two PGDs landed on one aral page in %zu probes - skipping the "
+                        "freed-PGD read-back (the ARAL layout assumption was still verified)\n",
+                probes);
     }
     else {
         // a live PGD must never look freed

--- a/src/database/engine/page.h
+++ b/src/database/engine/page.h
@@ -42,6 +42,7 @@ typedef enum {
     PGD_FREE_SITE_EXTENT_INSERT_LOST,    // pdc.c: lost the main cache insert race
     PGD_FREE_SITE_DISK_GORILLA_INVALID,  // page.c: invalid gorilla chain loaded from disk
     PGD_FREE_SITE_CREATE_BAD_TYPE,       // page.c: unknown page type while creating
+    PGD_FREE_SITE_UNITTEST,              // test teardown - never reached in a running agent
 } PGD_FREE_SITE;
 
 void pgd_free_with_trace(PGD *pg, PGD_FREE_SITE site, const char *func);

--- a/src/database/engine/page.h
+++ b/src/database/engine/page.h
@@ -24,10 +24,28 @@ typedef struct pgd PGD;
 #define PGD_EMPTY (PGD *)(-1)
 
 void pgd_init_arals(void);
+int pgd_unittest(void);
 
 PGD *pgd_create(uint8_t type, uint32_t slots);
 PGD *pgd_create_from_disk_data(uint8_t type, void *base, uint32_t size);
-void pgd_free(PGD *pg);
+// Every place a PGD can be freed, enumerated. The freed PGD records which one freed it,
+// so a double free names BOTH sites - and those tell apart three different bugs:
+//
+//   MAIN_CACHE_EVICT   twice -> the PGC evicted one page twice (a PGC_PAGE double delete)
+//   EXTENT_INSERT_LOST       -> pgc_page_add() reported !added but consumed the PGD anyway
+//   DISK_GORILLA_INVALID     -> a PGD freed on the from-disk error path was still published
+//
+// See the PGD lifetime guard in page.c.
+typedef enum {
+    PGD_FREE_SITE_UNKNOWN = 0,
+    PGD_FREE_SITE_MAIN_CACHE_EVICT,      // pagecache.c: main_cache_free_clean_page_callback()
+    PGD_FREE_SITE_EXTENT_INSERT_LOST,    // pdc.c: lost the main cache insert race
+    PGD_FREE_SITE_DISK_GORILLA_INVALID,  // page.c: invalid gorilla chain loaded from disk
+    PGD_FREE_SITE_CREATE_BAD_TYPE,       // page.c: unknown page type while creating
+} PGD_FREE_SITE;
+
+void pgd_free_with_trace(PGD *pg, PGD_FREE_SITE site, const char *func);
+#define pgd_free(pg, site) pgd_free_with_trace(pg, site, __FUNCTION__)
 
 uint32_t pgd_type(PGD *pg);
 bool pgd_is_empty(PGD *pg);

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -61,7 +61,7 @@ TEST(PGD, EmptyOrNull) {
     pgdc_reset(&cursor, pg, 0);
     EXPECT_FALSE(pgdc_get_next_point(&cursor, 0, &sp));
 
-    pgd_free(pg);
+    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 
     pg = PGD_EMPTY;
 
@@ -74,7 +74,7 @@ TEST(PGD, EmptyOrNull) {
     pgdc_reset(&cursor, pg, 0);
     EXPECT_FALSE(pgdc_get_next_point(&cursor, 0, &sp));
 
-    pgd_free(pg);
+    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, Create) {
@@ -96,7 +96,7 @@ TEST(PGD, Create) {
         ".*"
     );
 
-    pgd_free(pg);
+    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, CursorFullPage) {
@@ -151,7 +151,7 @@ TEST(PGD, CursorFullPage) {
         EXPECT_FALSE(pgdc_get_next_point(&cursor, 2 * slots, &sp));
     }
 
-    pgd_free(pg);
+    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, CursorHalfPage) {
@@ -191,7 +191,7 @@ TEST(PGD, CursorHalfPage) {
 
     EXPECT_FALSE(pgdc_get_next_point(&cursor, slots, &sp));
 
-    pgd_free(pg);
+    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, MemoryFootprint) {
@@ -267,7 +267,7 @@ TEST(PGD, DiskFootprint) {
     }
     EXPECT_EQ(pgd_disk_footprint(pg), footprint);
 
-    pgd_free(pg);
+    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 
     pg = pgd_create(page_type, slots);
 
@@ -290,7 +290,7 @@ TEST(PGD, DiskFootprint) {
     }
     EXPECT_EQ(pgd_disk_footprint(pg), footprint);
 
-    pgd_free(pg);
+    pgd_free(pg, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, CopyToExtent) {
@@ -323,7 +323,7 @@ TEST(PGD, CopyToExtent) {
     for (size_t i = 5; i != size_in_words; i++)
         EXPECT_EQ(disk_buffer[i], 0);
 
-    pgd_free(pg_collector);
+    pgd_free(pg_collector, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, Roundtrip) {
@@ -373,8 +373,8 @@ TEST(PGD, Roundtrip) {
         EXPECT_FALSE(pgdc_get_next_point(&cursor_disk, slots, &sp_disk));
     }
 
-    pgd_free(pg_disk);
-    pgd_free(pg_collector);
+    pgd_free(pg_disk, PGD_FREE_SITE_UNITTEST);
+    pgd_free(pg_collector, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, RejectCorruptGorillaDiskChain) {
@@ -396,7 +396,7 @@ TEST(PGD, RejectCorruptGorillaDiskChain) {
     PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
     EXPECT_EQ(pg_disk, PGD_EMPTY);
 
-    pgd_free(pg_collector);
+    pgd_free(pg_collector, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, StopCorruptGorillaDiskEntriesAtEncodedBits) {
@@ -425,8 +425,8 @@ TEST(PGD, StopCorruptGorillaDiskEntriesAtEncodedBits) {
     EXPECT_EQ(value, static_cast<uint32_t>(sp.min));
     EXPECT_FALSE(pgdc_get_next_point(&cursor, 1, &sp));
 
-    pgd_free(pg_disk);
-    pgd_free(pg_collector);
+    pgd_free(pg_disk, PGD_FREE_SITE_UNITTEST);
+    pgd_free(pg_collector, PGD_FREE_SITE_UNITTEST);
 }
 
 TEST(PGD, RejectCorruptGorillaDiskNbits) {
@@ -446,7 +446,7 @@ TEST(PGD, RejectCorruptGorillaDiskNbits) {
     PGD *pg_disk = pgd_create_from_disk_data(page_type, &disk_buffer[0], size_in_bytes);
     EXPECT_EQ(pg_disk, PGD_EMPTY);
 
-    pgd_free(pg_collector);
+    pgd_free(pg_collector, PGD_FREE_SITE_UNITTEST);
 }
 
 int pgd_test(int argc, char *argv[])

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -11,7 +11,7 @@ struct rrdeng_cache_efficiency_stats rrdeng_cache_efficiency_stats = {};
 static void main_cache_free_clean_page_callback(PGC *cache __maybe_unused, PGC_ENTRY entry __maybe_unused)
 {
     // Release storage associated with the page
-    pgd_free(entry.data);
+    pgd_free(entry.data, PGD_FREE_SITE_MAIN_CACHE_EVICT);
 }
 
 static void main_cache_flush_dirty_page_init_callback(PGC *cache __maybe_unused, Word_t section) {

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -1285,7 +1285,7 @@ static bool epdl_populate_pages_from_extent_data(
         bool added = true;
         PGC_PAGE *page = pgc_page_add_and_acquire(main_cache, page_entry, &added);
         if (false == added) {
-            pgd_free(pgd);
+            pgd_free(pgd, PGD_FREE_SITE_EXTENT_INSERT_LOST);
             pgd = pgc_page_data(page);
             stats_cache_hit_while_inserting++;
             stats_data_from_main_cache++;


### PR DESCRIPTION
##### Summary
- Add an atomic PGD lifetime guard that detects double frees at the real call site, records both free locations, protects against stale ARAL metadata, and adds pgdtest coverage across all PGD release paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against double-free errors in page storage, with diagnostics identifying where conflicting releases occurred.
  * Improved cleanup handling across page-cache eviction, extent insertion, and invalid page-data scenarios.

* **Tests**
  * Added page-storage unit tests, including coverage for lifetime and double-free protection.
  * Integrated these tests into the standard test suite and added a standalone command-line test option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->