### PR TITLE
Fix dbengine empty flush batch counter leak

### DIFF
--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -1970,7 +1970,20 @@ static bool flush_pages(PGC *cache, size_t max_flushes, Word_t section, bool wai
             continue;
         }
 
-        if(cache->config.pgc_save_init_cb)
+        // Only for a non-empty batch. The gate above is
+        // `all_of_them || pages_added == optimal_flush_size`, so on the all_of_them path
+        // (datafile rotation, shutdown) pages_added can be 0 - the loop above only adds pages
+        // that win page_acquire() and page_transition_trylock().
+        //
+        // The init callback is what tells the user "a flush is starting", and main_cache pairs
+        // it with ctx->atomic.extents_currently_being_flushed, which is only ever decremented
+        // per COMPLETED extent write. Its save callback returns immediately for an empty batch
+        // and cannot rebalance the counter itself, because it recovers ctx from
+        // entries_array[0].section. The increment would leak, and datafile rotation
+        // (datafile.c) and shutdown (rrdengine.c) both wait on that counter forever.
+        //
+        // A batch of zero pages is not a flush.
+        if(cache->config.pgc_save_init_cb && pages_added)
             cache->config.pgc_save_init_cb(cache, last_section);
 
         pgc_queue_unlock(cache, &cache->dirty);

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -1972,15 +1972,17 @@ static bool flush_pages(PGC *cache, size_t max_flushes, Word_t section, bool wai
 
         // Only for a non-empty batch. The gate above is
         // `all_of_them || pages_added == optimal_flush_size`, so on the all_of_them path
-        // (datafile rotation, shutdown) pages_added can be 0 - the loop above only adds pages
-        // that win page_acquire() and page_transition_trylock().
+        // (flush-all, quiesce, shutdown) pages_added can be 0 - the loop above only adds pages
+        // that win page_acquire() and page_transition_trylock(), and during shutdown concurrent
+        // flushers hold transition locks on exactly those pages.
         //
         // The init callback is what tells the user "a flush is starting", and main_cache pairs
-        // it with ctx->atomic.extents_currently_being_flushed, which is only ever decremented
-        // per COMPLETED extent write. Its save callback returns immediately for an empty batch
-        // and cannot rebalance the counter itself, because it recovers ctx from
-        // entries_array[0].section. The increment would leak, and datafile rotation
-        // (datafile.c) and shutdown (rrdengine.c) both wait on that counter forever.
+        // it with ctx->atomic.extents_currently_being_flushed, which is decremented once per
+        // extent write enqueued by the save callback. That callback returns immediately for an
+        // empty batch, so nothing is enqueued, and it cannot rebalance the counter itself
+        // because it recovers ctx from entries_array[0].section. The increment would leak, and
+        // shutdown waits on that counter forever - ctx_shutdown_tp_worker() (rrdengine.c) and
+        // finalize_data_files() (datafile.c).
         //
         // A batch of zero pages is not a flush.
         if(cache->config.pgc_save_init_cb && pages_added)

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -942,7 +942,10 @@ datafile_extent_build(struct rrdengine_instance *ctx, struct page_descr_with_dat
     }
 
     if (!count) {
-        __atomic_sub_fetch(&ctx->atomic.extents_currently_being_flushed, 1, __ATOMIC_RELAXED);
+        // No decrement here. The only caller does `if (!xt_io_descr) goto done;` and `done:`
+        // decrements extents_currently_being_flushed, so decrementing here too would take the
+        // unsigned counter below zero and wrap it - and both waiters on it (datafile.c for
+        // rotation, rrdengine.c for shutdown) would then spin forever.
         return NULL;
     }
 

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -944,8 +944,10 @@ datafile_extent_build(struct rrdengine_instance *ctx, struct page_descr_with_dat
     if (!count) {
         // No decrement here. The only caller does `if (!xt_io_descr) goto done;` and `done:`
         // decrements extents_currently_being_flushed, so decrementing here too would take the
-        // unsigned counter below zero and wrap it - and both waiters on it (datafile.c for
-        // rotation, rrdengine.c for shutdown) would then spin forever.
+        // unsigned counter below zero and wrap it, and both waiters on it - shutdown's
+        // ctx_shutdown_tp_worker() (rrdengine.c) and finalize_data_files() (datafile.c) - would
+        // spin forever. Not reachable today (the only EXTENT_WRITE producer returns early on an
+        // empty batch), but the accounting must not depend on that.
         return NULL;
     }
 


### PR DESCRIPTION
##### Summary
- Skip the flush-init callback when a batch contains no pages.
- Prevent extents_currently_being_flushed from being incremented without a matching extent write.
- Avoid shutdown hanging after empty flush batches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when flushing pages during datafile rotation, quiescing, and shutdown.
  - Fixed an issue where empty flush batches could leave shutdown or datafile finalization waiting indefinitely.
  - Corrected flush-progress tracking to prevent shutdown delays and ensure clean completion of background data operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->