### PR TITLE
fix(jobmgr): preserve shutdown errors through redaction

### DIFF
--- a/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/secret_flow_test.go
@@ -171,7 +171,7 @@ func TestProcessCoreSecretUpdateDuringInitialCandidateRetriesLatestStoreGenerati
 	testProcessCoreSecretMutationDependentRestart(t, "update", nil, true, false)
 }
 
-func TestProcessCoreShutdownDuringPendingSecretCandidatePromotionQuiesces(t *testing.T) {
+func TestProcessCoreShutdownAfterSecretReplacementInitializationQuiesces(t *testing.T) {
 	testProcessCoreSecretMutationDependentRestart(t, "update", nil, true, true)
 }
 

--- a/src/go/plugin/agent/jobmgr/joboutput/config_factory_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/config_factory_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
@@ -316,6 +317,15 @@ func (sensitiveCodedRetryableError) Error() string         { return "resolved-se
 func (sensitiveCodedRetryableError) DyncfgCode() int       { return 429 }
 func (sensitiveCodedRetryableError) DyncfgRetryable() bool { return true }
 
+type sensitiveCodedProcessControlError struct {
+	cause error
+}
+
+func (err *sensitiveCodedProcessControlError) Error() string         { return "resolved-sensitive-control" }
+func (err *sensitiveCodedProcessControlError) Unwrap() error         { return err.cause }
+func (err *sensitiveCodedProcessControlError) DyncfgCode() int       { return 429 }
+func (err *sensitiveCodedProcessControlError) DyncfgRetryable() bool { return true }
+
 func TestResolvedLifecycleRedactionPreservesControlClassifications(t *testing.T) {
 	err := lifecycle.RetainOwnership(errors.Join(
 		lifecycle.ErrTaskPanic,
@@ -329,6 +339,85 @@ func TestResolvedLifecycleRedactionPreservesControlClassifications(t *testing.T)
 	require.Contains(t, redacted.Error(), "redacted")
 	require.ErrorIs(t, redacted, lifecycle.ErrTaskPanic)
 	require.ErrorIs(t, redacted, context.Canceled)
+	require.True(t, lifecycle.OwnershipRetained(redacted))
+	require.True(t, dyncfg.IsRetryableError(redacted))
+	coded, ok := errors.AsType[dyncfg.CodedError](redacted)
+	require.True(t, ok)
+	require.Equal(t, 429, coded.DyncfgCode())
+}
+
+func TestResolvedLifecycleRedactionPreservesPureProcessControlTrees(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want []error
+	}{
+		"retired": {
+			err:  fmt.Errorf("resolved-sensitive-retired: %w", jobmgr.ErrProcessAttemptRetired),
+			want: []error{jobmgr.ErrProcessAttemptRetired},
+		},
+		"stopped": {
+			err:  fmt.Errorf("resolved-sensitive-stopped: %w", jobmgr.ErrProcessAttemptStopped),
+			want: []error{jobmgr.ErrProcessAttemptStopped},
+		},
+		"joined": {
+			err: errors.Join(
+				fmt.Errorf("resolved-sensitive-retired: %w", jobmgr.ErrProcessAttemptRetired),
+				fmt.Errorf("resolved-sensitive-stopped: %w", jobmgr.ErrProcessAttemptStopped),
+			),
+			want: []error{jobmgr.ErrProcessAttemptRetired, jobmgr.ErrProcessAttemptStopped},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			redacted := redactResolvedLifecycleError(test.err)
+
+			require.Contains(t, redacted.Error(), "redacted")
+			require.NotContains(t, redacted.Error(), "resolved-sensitive")
+			for _, want := range test.want {
+				require.ErrorIs(t, redacted, want)
+			}
+			require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+				redacted,
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			))
+		})
+	}
+}
+
+func TestResolvedLifecycleRedactionRejectsMixedProcessControlTree(t *testing.T) {
+	err := errors.Join(
+		fmt.Errorf("resolved-sensitive-stopped: %w", jobmgr.ErrProcessAttemptStopped),
+		errors.New("resolved-sensitive-operational"),
+	)
+
+	redacted := redactResolvedLifecycleError(err)
+
+	require.Contains(t, redacted.Error(), "redacted")
+	require.NotContains(t, redacted.Error(), "resolved-sensitive")
+	require.NotErrorIs(t, redacted, jobmgr.ErrProcessAttemptStopped)
+	require.False(t, jobmgr.ContainsOnlyErrorLeaves(
+		redacted,
+		jobmgr.ErrProcessAttemptRetired,
+		jobmgr.ErrProcessAttemptStopped,
+	))
+}
+
+func TestResolvedLifecycleRedactionComposesProcessControlMetadata(t *testing.T) {
+	err := lifecycle.RetainOwnership(&sensitiveCodedProcessControlError{
+		cause: jobmgr.ErrProcessAttemptStopped,
+	})
+
+	redacted := redactResolvedLifecycleError(err)
+
+	require.Contains(t, redacted.Error(), "redacted")
+	require.NotContains(t, redacted.Error(), "resolved-sensitive")
+	require.ErrorIs(t, redacted, jobmgr.ErrProcessAttemptStopped)
+	require.True(t, jobmgr.ContainsOnlyErrorLeaves(
+		redacted,
+		jobmgr.ErrProcessAttemptRetired,
+		jobmgr.ErrProcessAttemptStopped,
+	))
 	require.True(t, lifecycle.OwnershipRetained(redacted))
 	require.True(t, dyncfg.IsRetryableError(redacted))
 	coded, ok := errors.AsType[dyncfg.CodedError](redacted)

--- a/src/go/plugin/agent/jobmgr/joboutput/secret_redaction.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/secret_redaction.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
@@ -14,6 +15,18 @@ import (
 var errResolvedLifecycleRedacted = errors.New(
 	"job output: collector lifecycle failed; resolved configuration details redacted",
 )
+
+type redactedResolvedProcessControlError struct {
+	cause error
+}
+
+func (err *redactedResolvedProcessControlError) Error() string {
+	return errResolvedLifecycleRedacted.Error()
+}
+
+func (err *redactedResolvedProcessControlError) Unwrap() error {
+	return err.cause
+}
 
 type redactedResolvedCodedError struct {
 	cause     error
@@ -39,6 +52,29 @@ func redactResolvedLifecycleError(err error) error {
 		return nil
 	}
 	safe := error(errResolvedLifecycleRedacted)
+	if jobmgr.ContainsOnlyErrorLeaves(
+		err,
+		jobmgr.ErrProcessAttemptRetired,
+		jobmgr.ErrProcessAttemptStopped,
+	) {
+		retired := errors.Is(err, jobmgr.ErrProcessAttemptRetired)
+		stopped := errors.Is(err, jobmgr.ErrProcessAttemptStopped)
+		var cause error
+		switch {
+		case retired && stopped:
+			cause = errors.Join(
+				jobmgr.ErrProcessAttemptRetired,
+				jobmgr.ErrProcessAttemptStopped,
+			)
+		case retired:
+			cause = jobmgr.ErrProcessAttemptRetired
+		case stopped:
+			cause = jobmgr.ErrProcessAttemptStopped
+		}
+		if cause != nil {
+			safe = &redactedResolvedProcessControlError{cause: cause}
+		}
+	}
 	if errors.Is(err, context.Canceled) {
 		safe = errors.Join(safe, context.Canceled)
 	}


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves process control errors (`ErrProcessAttemptRetired` and `ErrProcessAttemptStopped`) through secret redaction, so shutdown conditions survive redaction instead of being collapsed into a generic redacted error.

- Adds a wrapper error that preserves only these sentinel errors when the error tree contains exclusively process control leaves.
- Retains `context.Canceled` and dyncfg metadata on the redacted error.
- Renames a test to reflect the actual shutdown scenario and adds coverage for pure, mixed, and composed error trees.

<sup>Written for commit 10ed164db518fbf79acb06ca88e2b38962ab1bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for secret-related job lifecycle events while preserving safe redaction.
  * Retained actionable process-attempt status details when resolving lifecycle errors.
  * Improved classification of retryable and coded errors when multiple underlying causes are present.
* **Tests**
  * Added coverage for process-control error handling, mixed error trees, and shutdown behavior after secret replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->