### PR TITLE
perf(ml): reduce memory usage with lazy model allocation

### DIFF
--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -884,6 +884,13 @@ static bool ml_dimension_update_models(ml_worker_t *worker, ml_dimension_t *dim,
         dim->has_received_downstream_model = true;
 
     if (dim->km_contexts.size() < Cfg.num_models_to_use) {
+        // First install: reserve exactly the final capacity, so a dimension
+        // that never gets a model never pays for the model array, and one that
+        // does still allocates only once (push_back growth would otherwise
+        // realloc its way up to 32 slots).
+        if (dim->km_contexts.empty())
+            dim->km_contexts.reserve(Cfg.num_models_to_use);
+
         dim->km_contexts.emplace_back(dim->kmeans);
     } else {
         bool can_drop_middle_km = false;

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -428,7 +428,12 @@ void ml_dimension_new(RRDDIM *rd)
 
     spinlock_init(&dim->slock);
 
-    dim->km_contexts.reserve(Cfg.num_models_to_use);
+    // km_contexts is intentionally NOT reserved here. Reserving
+    // num_models_to_use entries at creation costs 2304 bytes (18 x 128) for
+    // every dimension, including the ones that never train and never receive a
+    // model. The exact reservation is made on the first install instead, in
+    // ml_dimension_update_models(); the model-load path reserves its own local
+    // vector and swaps it in (ml.cc).
 
     rd->ml_dimension = (rrd_ml_dimension_t *) dim;
 


### PR DESCRIPTION
##### Summary
- Lazily allocate each dimension’s model array only when its first model is installed, avoiding 2.3 KB of unused memory per dimension and preventing intermediate vector reallocations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved model context setup by deferring memory allocation until models are installed.
  * Preserved capacity planning when adding the first model, helping reduce unnecessary resource usage during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->