### PR TITLE
Publish nightly build artifacts to a Cloudflare R2 bucket.

### DIFF
--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -91,7 +91,7 @@ echo "::group::Preparing R2 versioned release artifacts"
 mkdir -p "artifacts/r2/${VERSION}"
 cd "artifacts/r2/${VERSION}"
 copy_source_tarball "${VERSION}"
-copy_static_builds "${VERSION}" latest
+copy_static_builds "${VERSION}"
 copy_msi_packages "${VERSION}"
 echo "${VERSION}" > Version
 create_manifest

--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -73,8 +73,8 @@ create_manifest() {
 }
 
 echo "::group::Preparing GitHub release artifacts"
-mkdir -p github
-cd github
+mkdir -p artifacts/github
+cd artifacts/github
 copy_source_tarball "" "${VERSION}" latest
 copy_static_builds versioned latest
 copy_msi_packages "" "${VERSION}" latest
@@ -86,8 +86,8 @@ cd "${TOP}"
 echo "::endgroup::"
 
 echo "::group::Preparing R2 versioned release artifacts"
-mkdir -p "r2/${VERSION}"
-cd "r2/${VERSION}"
+mkdir -p "artifacts/r2/${VERSION}"
+cd "artifacts/r2/${VERSION}"
 copy_source_tarball "${VERSION}"
 copy_static_builds versioned
 copy_msi_packages "${VERSION}"
@@ -98,8 +98,8 @@ cd ../..
 echo "::endgroup::"
 
 echo "::group::Preparing R2 latest release artifacts"
-mkdir -p r2/latest
-cd r2/latest
+mkdir -p artifacts/r2/latest
+cd artifacts/r2/latest
 copy_source_tarball latest
 copy_static_builds latest
 copy_msi_packages latest

--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -27,7 +27,7 @@ copy_static_builds() {
 
 copy_source_tarball() {
     for ext in ${DISTFILE_EXTENSIONS} ; do
-        distfile="$(shopt -s nullglob; set -- "${artifacts}"/netdata-*.tar."${ext}"; echo "$1")"
+        distfile="$(shopt -s nullglob; set -- "${artifacts}"/netdata-*.tar."${ext}"; echo "${1:-}")"
         if [ -z "${distfile}" ]; then
             echo "::warning title=No ${ext} distfile matched::Failed to match any source tarball with a ${ext} extension when preparing artifacts."
             return 1
@@ -94,7 +94,7 @@ copy_msi_packages "${VERSION}"
 echo "${VERSION}" > Version
 create_manifest
 cat Manifest
-cd ../..
+cd "${TOP}"
 echo "::endgroup::"
 
 echo "::group::Preparing R2 latest release artifacts"
@@ -106,5 +106,5 @@ copy_msi_packages latest
 echo "${VERSION}" > Version
 create_manifest
 cat Manifest
-cd ../..
+cd "${TOP}"
 echo "::endgroup::"

--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -16,10 +16,7 @@ copy_static_builds() {
     for ext in ${STATIC_EXTENSIONS}; do
         for arch in ${STATIC_ARCHES}; do
             for tag in "${@}"; do
-                case "${tag}" in
-                    latest) cp -v "${artifacts}/netdata-${arch}-latest.${ext}.run" .  ;;
-                    versioned) cp -v "${artifacts}/netdata-${arch}-latest.${ext}.run" "./netdata-${arch}-${VERSION}.${ext}.run" ;;
-                esac
+                cp -v "${artifacts}/netdata-${arch}-latest.${ext}.run" "./netdata-${arch}-${tag}.${ext}.run"
             done
         done
     done
@@ -81,7 +78,7 @@ echo "::group::Preparing GitHub release artifacts"
 mkdir -p artifacts/github
 cd artifacts/github
 copy_source_tarball "" "${VERSION}" latest
-copy_static_builds versioned latest
+copy_static_builds "${VERSION}" latest
 copy_msi_packages "" "${VERSION}" latest
 create_legacy_compat_files
 echo "${VERSION}" > Version
@@ -94,7 +91,7 @@ echo "::group::Preparing R2 versioned release artifacts"
 mkdir -p "artifacts/r2/${VERSION}"
 cd "artifacts/r2/${VERSION}"
 copy_source_tarball "${VERSION}"
-copy_static_builds versioned
+copy_static_builds "${VERSION}" latest
 copy_msi_packages "${VERSION}"
 echo "${VERSION}" > Version
 create_manifest

--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -72,6 +72,11 @@ create_manifest() {
     fi
 }
 
+echo "Using ${artifacts} as source directory for artifacts"
+echo "::group::Files currently in ${artifacts}"
+ls -l "${artifacts}"
+echo "::endgroup::"
+
 echo "::group::Preparing GitHub release artifacts"
 mkdir -p artifacts/github
 cd artifacts/github

--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+artifacts="$(realpath "${1}")"
+signing_key="${2:-}"
+
+TOP="$(pwd)"
+DISTFILE_EXTENSIONS="gz"
+MSI_ARCHES="x64"
+STATIC_ARCHES="x86_64 aarch64 armv6l armv7l"
+STATIC_EXTENSIONS="gz"
+VERSION="$(cat packaging/version)"
+
+copy_static_builds() {
+    for ext in ${STATIC_EXTENSIONS}; do
+        for arch in ${STATIC_ARCHES}; do
+            for tag in "${@}"; do
+                case "${tag}" in
+                    latest) cp -v "${artifacts}/netdata-${arch}-latest.${ext}.run" .  ;;
+                    versioned) cp -v "${artifacts}/netdata-${arch}-latest.${ext}.run" "./netdata-${arch}-${VERSION}.${ext}.run" ;;
+                esac
+            done
+        done
+    done
+}
+
+copy_source_tarball() {
+    for ext in ${DISTFILE_EXTENSIONS} ; do
+        distfile="$(shopt -s nullglob; set -- "${artifacts}"/netdata-*.tar."${ext}"; echo "$1")"
+        if [ -z "${distfile}" ]; then
+            echo "::warning title=No ${ext} distfile matched::Failed to match any source tarball with a ${ext} extension when preparing artifacts."
+            return 1
+        fi
+
+        for tag in "${@}"; do
+            case "${tag}" in
+                '') cp -v "${distfile}" . ;;
+                *) cp -v "${distfile}" "./netdata-${tag}.tar.${ext}" ;;
+            esac
+        done
+    done
+}
+
+copy_msi_packages() {
+    for arch in ${MSI_ARCHES} ; do
+        for tag in "${@}" ; do
+            case "${tag}" in
+                '') cp -v "${artifacts}/netdata-${arch}.msi" . ;;
+                *) cp -v "${artifacts}/netdata-${arch}.msi" "./netdata-${tag}-${arch}.msi" ;;
+            esac
+        done
+    done
+}
+
+create_legacy_compat_files() {
+    ln -s ./netdata-x86_64-latest.gz.run netdata-latest.gz.run
+    ln -s "./netdata-x86_64-${VERSION}.gz.run" "netdata-${VERSION}.gz.run"
+    echo "${VERSION}" > latest-version.txt
+    sha256sum -b ./* > sha256sums.txt
+}
+
+create_manifest() {
+    for f in * ; do
+        [ -f "${f}" ] || continue
+        sha256="$(sha256sum -b "$f" | awk '{print $1}')"
+        size="$(wc -c < "$f" | awk '{print $1}')"
+        printf '%s %s %s\n' "${f}" "${size}" "${sha256}" >> Manifest
+    done
+    if [ -n "${signing_key}" ]; then
+        gpg -u "${signing_key}" --detach-sign Manifest
+    fi
+}
+
+echo "::group::Preparing GitHub release artifacts"
+mkdir -p github
+cd github
+copy_source_tarball "" "${VERSION}" latest
+copy_static_builds versioned latest
+copy_msi_packages "" "${VERSION}" latest
+create_legacy_compat_files
+echo "${VERSION}" > Version
+create_manifest
+cat Manifest
+cd "${TOP}"
+echo "::endgroup::"
+
+echo "::group::Preparing R2 versioned release artifacts"
+mkdir -p "r2/${VERSION}"
+cd "r2/${VERSION}"
+copy_source_tarball "${VERSION}"
+copy_static_builds versioned
+copy_msi_packages "${VERSION}"
+echo "${VERSION}" > Version
+create_manifest
+cat Manifest
+cd ../..
+echo "::endgroup::"
+
+echo "::group::Preparing R2 latest release artifacts"
+mkdir -p r2/latest
+cd r2/latest
+copy_source_tarball latest
+copy_static_builds latest
+copy_msi_packages latest
+echo "${VERSION}" > Version
+create_manifest
+cat Manifest
+cd ../..
+echo "::endgroup::"

--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -58,6 +58,7 @@ create_legacy_compat_files() {
 }
 
 create_manifest() {
+    rm -f Manifest Manifest.sig
     for f in * ; do
         [ -f "${f}" ] || continue
         sha256="$(sha256sum -b "$f" | awk '{print $1}')"

--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -24,7 +24,7 @@ copy_static_builds() {
 
 copy_source_tarball() {
     for ext in ${DISTFILE_EXTENSIONS} ; do
-        distfile="$(shopt -s nullglob; set -- "${artifacts}"/netdata-*.tar."${ext}"; echo "${1:-}")"
+        distfile="$(shopt -s nullglob; for candidate in "${artifacts}"/netdata-*.tar."${ext}"; do if [[ -f "${candidate}" && -r "${candidate}" ]]; then printf '%s' "${candidate}"; break; fi; done)"
         if [ -z "${distfile}" ]; then
             echo "::warning title=No ${ext} distfile matched::Failed to match any source tarball with a ${ext} extension when preparing artifacts."
             return 1

--- a/.github/scripts/prepare-artifacts.sh
+++ b/.github/scripts/prepare-artifacts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eou pipefail
+set -euo pipefail
 
 artifacts="$(realpath "${1}")"
 signing_key="${2:-}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -992,7 +992,7 @@ jobs:
         with:
           allowUpdates: false
           artifactErrorsFailBuild: true
-          artifacts: 'final-artifacts/sha256sums.txt,final-artifacts/netdata-*.tar.gz,final-artifacts/netdata-*.gz.run,final-artifacts/netdata-*.msi'
+          artifacts: 'final-artifacts/*'
           owner: netdata
           repo: netdata-nightlies
           body: Netdata nightly build for ${{ steps.version.outputs.date }}.
@@ -1172,7 +1172,7 @@ jobs:
         with:
           allowUpdates: false
           artifactErrorsFailBuild: true
-          artifacts: 'final-artifacts/sha256sums.txt,final-artifacts/netdata-*.tar.gz,final-artifacts/netdata-*.gz.run,final-artifacts/netdata-*.msi'
+          artifacts: 'final-artifacts/*'
           draft: true
           tag: ${{ needs.normalize-tag.outputs.tag }}
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -702,7 +702,7 @@ jobs:
       - name: Prepare Artifacts
         id: consolidate
         if: needs.file-check.outputs.run == 'true'
-        run: .github/scripts/prepare-artifacts.sh artifacts/dist-artifacts ${{ steps.import-keys.outputs.fingerprint }}
+        run: .github/scripts/prepare-artifacts.sh dist-artifacts ${{ steps.import-keys.outputs.fingerprint }}
       - name: Store GitHub Artifacts
         id: store-github
         if: needs.file-check.outputs.run == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1056,6 +1056,114 @@ jobs:
             && github.event_name == 'workflow_dispatch'
           }}
 
+  publish-nightly-artifacts:
+    name: Publish Nightly Release Artifacts
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'nightly' && github.repository == 'netdata/netdata'
+    needs:
+      - prepare-upload
+      - windows-test
+      - artifact-verification-dist
+      - artifact-verification-static
+    steps:
+      - name: Install RClone
+        id: install-rclone
+        run: |
+          apt-get update || exit 1
+          apt-get install -y rclone || exit 1
+      - name: Retrieve Artifacts
+        id: fetch
+        use: actions/download-artifact@v4
+        with:
+          name: final-artifacts
+          path: final-artifacts
+      - name: Import GPG Keys
+        id: import-keys
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.NETDATABOT_PACKAGE_SIGNING_KEY }}
+      - name: Prepare Data For Upload
+        id: prepare
+        run: |
+          mv final-artifacts/latest-version.txt . || exit 1
+          version=$(cat latest-version.txt)
+          mkdir -p upload || exit 1
+          cd upload || exit 1
+          mkdir -p latest || exit 1
+          cd latest || exit 1
+          cp -va ../final-artifacts/* . || exit 1
+          rm -f netdata-latest.*.run netdata-v*-g*.tar.* netdata-*${version}*.run sha256sums.txt || exit 1
+          sha256sum -b ./* | tee sha256sums.txt || exit 1
+          for f in * ; do
+            [ -f "${f}" ] || continue
+            sha256="$(sha256sum "$f" | awk '{print $1}')"
+            size="$(wc -c < "$f" | awk '{print $1}')"
+            printf '%s %s %s\n' "$sha256" "$size" "$f" >> manifest.txt || exit 1
+          done
+          gpg -u ${{ steps.import-keys.outputs.fingerprint }} --detach-sign manifest.txt || exit 1
+          cd .. || exit 1
+          mkdir -p ${version} || exit 1
+          cd ${version} || exit 1
+          cp -va ../final-artifacts/* . || exit 1
+          rm -f netdata*latest*.run netdata-latest.tar.* sha256sums.txt || exit 1
+          for f in netdata-*.tar.* ; do
+            ext=${f##*.}
+            mv -v ${f} netdata-${version}.tar.${ext} || exit 1
+          done
+          sha256sum -b ./* | tee sha256sums.txt || exit 1
+          for f in * ; do
+            [ -f "${f}" ] || continue
+            sha256="$(sha256sum "$f" | awk '{print $1}')"
+            size="$(wc -c < "$f" | awk '{print $1}')"
+            printf '%s %s %s\n' "$sha256" "$size" "$f" >> manifest.txt || exit 1
+          done
+          gpg -u ${{ steps.import-keys.outputs.fingerprint }} --detach-sign manifest.txt || exit 1
+          cd ../.. || exit 1
+      - name: Upload Versioned Artifacts
+        id: upload-versioned
+        env:
+          RCLONE_CONFIG_S3_TYPE: "s3"
+          RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
+          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.S3_RELEASE_ACCESS_KEY }}"
+          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.S3_RELEASE_SECRET_KEY }}"
+          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.S3_RELEASE_ENDPOINT }}"
+          RCLONE_CONFIG_S3_REGION: "auto"
+        run: |
+          rclone copy --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./$(cat latest-version.txt) s3:${{ secrets.S3_NIGHTLY_BUCKET }}/nightlies
+      - name: Upload Latest Artifacts
+        id: upload-latest
+        env:
+          RCLONE_CONFIG_S3_TYPE: "s3"
+          RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
+          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.S3_RELEASE_ACCESS_KEY }}"
+          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.S3_RELEASE_SECRET_KEY }}"
+          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.S3_RELEASE_ENDPOINT }}"
+          RCLONE_CONFIG_S3_REGION: "auto"
+        run: |
+          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./latest s3:${{ secrets.S3_NIGHTLY_BUCKET }}/nightlies/latest
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER: ''
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Failed to upload nightly artifacts:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: |-
+              ${{ github.repository }}: Failed to upload nightly build artifacts.
+              Install RClone: ${{ steps.install-rclone.outcome }}
+              Fetch artifacts: ${{ steps.fetch.outcome }}
+              Import GPG keys: ${{ steps.import-keys.outcome }}
+              Prepare data for upload: ${{ steps.prepare.outcome }}
+              Upload versioned artifacts: ${{ steps.upload-versioned.outcome }}
+              Upload latest artifacts: ${{ steps.upload-latest.outcome }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && github.event_name == 'workflow_dispatch'
+          }}
+
   normalize-tag: # Fix the release tag if needed
     name: Normalize Release Tag
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,23 +693,31 @@ jobs:
           pattern: windows-*-installer
           path: dist-artifacts
           merge-multiple: true
+      - name: Import GPG Keys
+        id: import-keys
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.NETDATABOT_PACKAGE_SIGNING_KEY }}
       - name: Prepare Artifacts
         id: consolidate
         if: needs.file-check.outputs.run == 'true'
-        working-directory: ./artifacts/
-        run: |
-          mv ../dist-artifacts/* . || exit 1
-          ln -s ${{ needs.build-dist.outputs.distfile }} netdata-latest.tar.gz || exit 1
-          cp ../packaging/version ./latest-version.txt || exit 1
-          sha256sum -b ./* > sha256sums.txt || exit 1
-          cat sha256sums.txt
-      - name: Store Artifacts
-        id: store
+        run: .github/scripts/prepare-artifacts.sh artifacts/dist-artifacts ${{ steps.import-keys.outputs.fingerprint }}
+      - name: Store GitHub Artifacts
+        id: store-github
         if: needs.file-check.outputs.run == 'true'
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: final-artifacts
-          path: artifacts/*
+          name: github-artifacts
+          path: artifacts/github/*
+          compression-level: 0
+          retention-days: 30
+      - name: Store R2 Artifacts
+        id: store-r2
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: r2-artifacts
+          path: artifacts/r2/*
           compression-level: 0
           retention-days: 30
       - name: Failure Notification
@@ -727,7 +735,8 @@ jobs:
               Fetch dist artifacts: ${{ steps.fetch-dist.outcome }}
               Fetch Windows installers: ${{ steps.fetch-windows.outcome }}
               Consolidate artifacts: ${{ steps.consolidate.outcome }}
-              Store: ${{ steps.store.outcome }}
+              Store Github: ${{ steps.store-github.outcome }}
+              Store R2: ${{ steps.store-r2.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: >-
           ${{
@@ -765,7 +774,7 @@ jobs:
         if: needs.file-check.outputs.run == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: final-artifacts
+          name: github-artifacts
           path: artifacts
       - name: Prepare artifacts directory
         id: prepare
@@ -832,7 +841,7 @@ jobs:
         if: needs.file-check.outputs.run == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: final-artifacts
+          name: github-artifacts
           path: artifacts
       - name: Prepare artifacts directory
         id: prepare
@@ -899,7 +908,7 @@ jobs:
         if: needs.file-check.outputs.run == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: final-artifacts
+          name: github-artifacts
           path: artifacts
       - name: Prepare artifacts directory
         id: prepare
@@ -967,7 +976,7 @@ jobs:
         id: fetch
         uses: actions/download-artifact@v4
         with:
-          name: final-artifacts
+          name: github-artifacts
           path: final-artifacts
       - name: Prepare version info
         id: version
@@ -1075,52 +1084,10 @@ jobs:
         id: fetch
         use: actions/download-artifact@v4
         with:
-          name: final-artifacts
-          path: final-artifacts
-      - name: Import GPG Keys
-        id: import-keys
-        uses: crazy-max/ghaction-import-gpg@v7
-        with:
-          gpg_private_key: ${{ secrets.NETDATABOT_PACKAGE_SIGNING_KEY }}
-      - name: Prepare Data For Upload
-        id: prepare
-        run: |
-          mv final-artifacts/latest-version.txt . || exit 1
-          version=$(cat latest-version.txt)
-          mkdir -p upload || exit 1
-          cd upload || exit 1
-          mkdir -p latest || exit 1
-          cd latest || exit 1
-          cp -va ../final-artifacts/* . || exit 1
-          rm -f netdata-latest.*.run netdata-v*-g*.tar.* netdata-*${version}*.run sha256sums.txt || exit 1
-          sha256sum -b ./* | tee sha256sums.txt || exit 1
-          for f in * ; do
-            [ -f "${f}" ] || continue
-            sha256="$(sha256sum "$f" | awk '{print $1}')"
-            size="$(wc -c < "$f" | awk '{print $1}')"
-            printf '%s %s %s\n' "$sha256" "$size" "$f" >> manifest.txt || exit 1
-          done
-          gpg -u ${{ steps.import-keys.outputs.fingerprint }} --detach-sign manifest.txt || exit 1
-          cd .. || exit 1
-          mkdir -p ${version} || exit 1
-          cd ${version} || exit 1
-          cp -va ../final-artifacts/* . || exit 1
-          rm -f netdata*latest*.run netdata-latest.tar.* sha256sums.txt || exit 1
-          for f in netdata-*.tar.* ; do
-            ext=${f##*.}
-            mv -v ${f} netdata-${version}.tar.${ext} || exit 1
-          done
-          sha256sum -b ./* | tee sha256sums.txt || exit 1
-          for f in * ; do
-            [ -f "${f}" ] || continue
-            sha256="$(sha256sum "$f" | awk '{print $1}')"
-            size="$(wc -c < "$f" | awk '{print $1}')"
-            printf '%s %s %s\n' "$sha256" "$size" "$f" >> manifest.txt || exit 1
-          done
-          gpg -u ${{ steps.import-keys.outputs.fingerprint }} --detach-sign manifest.txt || exit 1
-          cd ../.. || exit 1
-      - name: Upload Versioned Artifacts
-        id: upload-versioned
+          name: r2-artifacts
+          path: artifacts
+      - name: Upload Artifacts
+        id: upload
         env:
           RCLONE_CONFIG_S3_TYPE: "s3"
           RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
@@ -1128,19 +1095,9 @@ jobs:
           RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.CLOUDFLARE_R2_SECRET_KEY }}"
           RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.CLOUDFLARE_R2_RELEASE_ENDPOINT }}"
           RCLONE_CONFIG_S3_REGION: "auto"
+        working-directory: artifacts
         run: |
-          rclone copy --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./$(cat latest-version.txt) s3:netdata-agent-artifacts/nightlies
-      - name: Upload Latest Artifacts
-        id: upload-latest
-        env:
-          RCLONE_CONFIG_S3_TYPE: "s3"
-          RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
-          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.CLOUDFLARE_R2_ACCESS_KEY }}"
-          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.CLOUDFLARE_R2_SECRET_KEY }}"
-          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.CLOUDFLARE_R2_RELEASE_ENDPOINT }}"
-          RCLONE_CONFIG_S3_REGION: "auto"
-        run: |
-          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./latest s3:netdata-agent-artifacts/nightlies/latest
+          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./ s3:netdata-agent-artifacts/nightlies
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -1153,10 +1110,7 @@ jobs:
               ${{ github.repository }}: Failed to upload nightly build artifacts.
               Install RClone: ${{ steps.install-rclone.outcome }}
               Fetch artifacts: ${{ steps.fetch.outcome }}
-              Import GPG keys: ${{ steps.import-keys.outcome }}
-              Prepare data for upload: ${{ steps.prepare.outcome }}
-              Upload versioned artifacts: ${{ steps.upload-versioned.outcome }}
-              Upload latest artifacts: ${{ steps.upload-latest.outcome }}
+              Upload artifacts: ${{ steps.upload.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: >-
           ${{
@@ -1197,7 +1151,7 @@ jobs:
         id: fetch
         uses: actions/download-artifact@v4
         with:
-          name: final-artifacts
+          name: github-artifacts
           path: final-artifacts
       - name: Create Release
         id: create-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1124,23 +1124,23 @@ jobs:
         env:
           RCLONE_CONFIG_S3_TYPE: "s3"
           RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
-          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.S3_RELEASE_ACCESS_KEY }}"
-          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.S3_RELEASE_SECRET_KEY }}"
-          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.S3_RELEASE_ENDPOINT }}"
+          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.CLOUDFLARE_R2_ACCESS_KEY }}"
+          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.CLOUDFLARE_R2_SECRET_KEY }}"
+          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.CLOUDFLARE_R2_RELEASE_ENDPOINT }}"
           RCLONE_CONFIG_S3_REGION: "auto"
         run: |
-          rclone copy --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./$(cat latest-version.txt) s3:${{ secrets.S3_NIGHTLY_BUCKET }}/nightlies
+          rclone copy --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./$(cat latest-version.txt) s3:netdata-agent-artifacts/nightlies
       - name: Upload Latest Artifacts
         id: upload-latest
         env:
           RCLONE_CONFIG_S3_TYPE: "s3"
           RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
-          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.S3_RELEASE_ACCESS_KEY }}"
-          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.S3_RELEASE_SECRET_KEY }}"
-          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.S3_RELEASE_ENDPOINT }}"
+          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.CLOUDFLARE_R2_ACCESS_KEY }}"
+          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.CLOUDFLARE_R2_SECRET_KEY }}"
+          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.CLOUDFLARE_R2_RELEASE_ENDPOINT }}"
           RCLONE_CONFIG_S3_REGION: "auto"
         run: |
-          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./latest s3:${{ secrets.S3_NIGHTLY_BUCKET }}/nightlies/latest
+          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./latest s3:netdata-agent-artifacts/nightlies/latest
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -695,6 +695,7 @@ jobs:
           merge-multiple: true
       - name: Import GPG Keys
         id: import-keys
+        if: needs.file-check.outputs.run == 'true' && github.event_name != 'pull_request'
         uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.NETDATABOT_PACKAGE_SIGNING_KEY }}
@@ -1078,16 +1079,16 @@ jobs:
       - name: Install RClone
         id: install-rclone
         run: |
-          apt-get update || exit 1
-          apt-get install -y rclone || exit 1
+          sudo apt-get update || exit 1
+          sudo apt-get install -y rclone || exit 1
       - name: Retrieve Artifacts
         id: fetch
-        use: actions/download-artifact@v4
+        uses: actions/download-artifact@v4
         with:
           name: r2-artifacts
           path: artifacts
-      - name: Upload Artifacts
-        id: upload
+      - name: Upload Versioned Artifacts
+        id: upload-versioned
         env:
           RCLONE_CONFIG_S3_TYPE: "s3"
           RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
@@ -1097,7 +1098,19 @@ jobs:
           RCLONE_CONFIG_S3_REGION: "auto"
         working-directory: artifacts
         run: |
-          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./ s3:netdata-agent-artifacts/nightlies
+          rclone copy --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./v* s3:netdata-agent-artifacts/nightlies
+      - name: Upload Latest Artifacts
+        id: upload-latest
+        env:
+          RCLONE_CONFIG_S3_TYPE: "s3"
+          RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
+          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.CLOUDFLARE_R2_ACCESS_KEY }}"
+          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.CLOUDFLARE_R2_SECRET_KEY }}"
+          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.CLOUDFLARE_R2_RELEASE_ENDPOINT }}"
+          RCLONE_CONFIG_S3_REGION: "auto"
+        working-directory: artifacts
+        run: |
+          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./latest/ s3:netdata-agent-artifacts/nightlies/latest/
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1098,7 +1098,8 @@ jobs:
           RCLONE_CONFIG_S3_REGION: "auto"
         working-directory: artifacts
         run: |
-          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./ s3:netdata-agent-artifacts/nightlies/
+          rclone copy --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./ s3:netdata-agent-artifacts/nightlies/
+          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./latest/ s3:netdata-agent-artifacts/nightlies/latest/
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1087,8 +1087,8 @@ jobs:
         with:
           name: r2-artifacts
           path: artifacts
-      - name: Upload Versioned Artifacts
-        id: upload-versioned
+      - name: Upload Artifacts
+        id: upload
         env:
           RCLONE_CONFIG_S3_TYPE: "s3"
           RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
@@ -1098,19 +1098,7 @@ jobs:
           RCLONE_CONFIG_S3_REGION: "auto"
         working-directory: artifacts
         run: |
-          rclone copy --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./v* s3:netdata-agent-artifacts/nightlies
-      - name: Upload Latest Artifacts
-        id: upload-latest
-        env:
-          RCLONE_CONFIG_S3_TYPE: "s3"
-          RCLONE_CONFIG_S3_PROVIDER: "Cloudflare"
-          RCLONE_CONFIG_S3_ACCESS_KEY_ID: "${{ secrets.CLOUDFLARE_R2_ACCESS_KEY }}"
-          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "${{ secrets.CLOUDFLARE_R2_SECRET_KEY }}"
-          RCLONE_CONFIG_S3_ENDPOINT: "${{ secrets.CLOUDFLARE_R2_RELEASE_ENDPOINT }}"
-          RCLONE_CONFIG_S3_REGION: "auto"
-        working-directory: artifacts
-        run: |
-          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./latest/ s3:netdata-agent-artifacts/nightlies/latest/
+          rclone sync --fast-list --use-server-modtime --metadata --header-upload "Cache-Control: no-transform" ./ s3:netdata-agent-artifacts/nightlies/
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
##### Summary

This is preliminary work for migrating build artifact hosting off of GitHub. This migration will allow us to significantly simplify our installer and updater code, allow for easier implementation of a prerelease channel, and also make life easier for users who need IPv6 access for installation/update purposes.

Alongside the new hosting, this makes a handful of changes to the structure of the published artifacts:

- Each version will have its own directory, with a `latest` directory containing the most recent version.
- Versioned file names will now use consistent versions for all files.
- The `latest` directory will use `latest` for the version in file names.
- Checksums are provided only for the files in each directory.
- A new manifest file including not just SHA-256 checksums but also file sizes.
- A detached GPG signature created using our regular release signing key will be provided for the new manifest file.

The new manifest and detached GPG signature will be used in the future to provide more rigorous verification of build artifacts being fetched for installs/updates.

##### Test Plan

n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Nightly builds now publish artifacts to Cloudflare R2 alongside GitHub, supporting the migration away from GitHub-hosted downloads. A shared preparation script creates consistent layouts and verification metadata for both destinations.

- Stores each release under its version and mirrors the newest release under `latest`, while preserving legacy GitHub filenames.
- Adds per-directory manifests with SHA-256 checksums and file sizes, plus detached GPG signatures for release builds.
- Uploads versioned and `latest` artifacts through a dedicated workflow job and sends a Slack notification when publishing fails.
- GitHub releases now include every artifact in the prepared directory instead of a fixed file pattern.

<sup>Written for commit c11c90c11ca12ac3af18d3c5ea433f51abc08d28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Distribution**
  - Release downloads now use consistent versioned and “latest” filenames.
  - Added manifests and checksums to help verify downloaded files.
  - Release manifests can be digitally signed for authenticity.
  - Release files are organized for both GitHub downloads and the downloadable artifact store.
  - Added compatibility links for legacy x86_64 download paths.

- **Nightly Builds**
  - Nightly artifacts are now published automatically to the downloadable artifact store.
  - Nightly releases include version information and verification files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->