### PR TITLE
fix(go.d/snmp_topology): validate LLDP management address size

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -1428,7 +1428,8 @@ Examples:
   `lldpRemManAddrIfSubtype`; derive subtype with `index: 4`, retain the declared
   address length with `index: 5`, and derive address bytes with
   `index_transform: [{start: 5}]` plus `format: hex`. The topology consumer
-  rejects a row when the declared length does not match the encoded byte count.
+  rejects a row when the declared length is outside the MIB's `1..31` range or
+  does not match the encoded byte count.
 
 Audit recipe:
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lldp.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lldp.go
@@ -11,6 +11,8 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
+const lldpManagementAddressMaxLength = 31
+
 func init() {
 	registerTopologyMetricHandler(ddsnmp.KindLldpLocPort, (*topologyBuilder).updateLldpLocPort)
 	registerTopologyMetricHandler(ddsnmp.KindLldpLocManAddr, (*topologyBuilder).updateLldpLocManAddr)
@@ -172,7 +174,7 @@ func validLLDPManagementAddressLength(addrHex, declaredLength string) bool {
 	}
 
 	length, err := strconv.Atoi(declaredLength)
-	if err != nil || length <= 0 {
+	if err != nil || length <= 0 || length > lldpManagementAddressMaxLength {
 		return false
 	}
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -535,23 +535,36 @@ func TestTopologyCache_LLDPExplicitNonIPFamilyIsRejectedAcrossIngresses(t *testi
 
 func TestTopologyCache_LLDPRemoteManagementAddressValidatesDeclaredLength(t *testing.T) {
 	tests := map[string]struct {
-		length string
-		want   string
+		addrHex string
+		length  string
+		subtype string
+		want    string
 	}{
-		"matching length":   {length: "4", want: "192.0.2.2"},
-		"mismatched length": {length: "3"},
-		"invalid length":    {length: "invalid"},
-		"missing length":    {want: "192.0.2.2"},
+		"matching length":     {length: "4", want: "192.0.2.2"},
+		"mismatched length":   {length: "3"},
+		"invalid length":      {length: "invalid"},
+		"missing length":      {want: "192.0.2.2"},
+		"maximum MIB length":  {addrHex: strings.Repeat("00", 31), length: "31", subtype: "16", want: strings.Repeat("00", 31)},
+		"exceeds MIB maximum": {addrHex: strings.Repeat("00", 32), length: "32", subtype: "16"},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			addrHex := tc.addrHex
+			if addrHex == "" {
+				addrHex = "c0000202"
+			}
+			subtype := tc.subtype
+			if subtype == "" {
+				subtype = "1"
+			}
+
 			cache := newTopologyBuilder()
 			cache.updateLldpRemManAddr(map[string]string{
 				tagLldpLocPortNum:         "1",
 				tagLldpRemIndex:           "1",
-				tagLldpRemMgmtAddrSubtype: "1",
-				tagLldpRemMgmtAddr:        "c0000202",
+				tagLldpRemMgmtAddrSubtype: subtype,
+				tagLldpRemMgmtAddr:        addrHex,
 				tagLldpRemMgmtAddrLen:     tc.length,
 			})
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
@@ -167,11 +165,12 @@ func TestTopologyProductionPath_LLDPRemoteManagementAddressProfiles(t *testing.T
 		fixture        string
 		profile        string
 		sysObjectID    string
+		sysDescr       string
 		managementAddr string
 	}{
 		"standards readable anchor": {
 			fixture:        "arubaos-cx_10.10.snmprec",
-			profile:        "_std-topology-lldp-mib",
+			profile:        "aruba-cx-switch",
 			sysObjectID:    "1.3.6.1.4.1.47196.4.1.1.1.1",
 			managementAddr: "192.0.2.1",
 		},
@@ -179,6 +178,7 @@ func TestTopologyProductionPath_LLDPRemoteManagementAddressProfiles(t *testing.T
 			fixture:        "routeros_rb750gr3.snmprec",
 			profile:        "topology-role-mikrotik-rb750gr3",
 			sysObjectID:    "1.3.6.1.4.1.14988.1",
+			sysDescr:       "RouterOS RB750Gr3",
 			managementAddr: "fdfd:0:2:1::1",
 		},
 	}
@@ -186,25 +186,19 @@ func TestTopologyProductionPath_LLDPRemoteManagementAddressProfiles(t *testing.T
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			fixture := loadTopologySNMPRecHandler(t, filepath.Join("../../../../testdata/snmp/snmprec", tc.fixture))
-			profile, err := ddsnmp.LoadProfileByName(tc.profile)
-			require.NoError(t, err)
-
-			profile.Definition.Metadata = nil
-			profile.Definition.SysobjectIDMetadata = nil
-			profile.Definition.MetricTags = nil
-			profile.Definition.StaticTags = nil
-			profile.Definition.Metrics = nil
-			profile.Definition.VirtualMetrics = nil
-			profile.Definition.Licensing = nil
-			profile.Definition.BGP = nil
-			profile.Definition.Topology = slices.DeleteFunc(profile.Definition.Topology, func(row ddprofiledefinition.TopologyConfig) bool {
-				return row.Table.Name != "lldpRemManAddrTable"
-			})
-			require.Len(t, profile.Definition.Topology, 1)
+			profiles := ddsnmp.DefaultCatalog().Resolve(ddsnmp.ResolveRequest{
+				SysObjectID: tc.sysObjectID,
+				SysDescr:    tc.sysDescr,
+			}).Project(ddsnmp.ConsumerTopology).FilterByKind(map[ddsnmp.TopologyKind]bool{
+				ddsnmp.KindLldpRemManAddr: true,
+			}).Profiles()
+			require.Len(t, profiles, 1)
+			profileName := strings.TrimSuffix(filepath.Base(profiles[0].SourceFile), filepath.Ext(profiles[0].SourceFile))
+			require.Equal(t, tc.profile, profileName)
 
 			profileMetrics, err := ddsnmpcollector.New(ddsnmpcollector.Config{
 				SnmpClient:  fixture,
-				Profiles:    []*ddsnmp.Profile{profile},
+				Profiles:    profiles,
 				Log:         newTestSNMPTopologyCollector().Logger,
 				SysObjectID: tc.sysObjectID,
 			}).Collect()

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/topology-role-mikrotik-rb750gr3.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/topology-role-mikrotik-rb750gr3.yaml
@@ -1,6 +1,8 @@
 # RouterOS RB750Gr3 fixture evidence shows a device deviation: the standard
 # readable lldpRemManAddrIfSubtype row anchor (.3) is absent, while the
-# nominally not-accessible INDEX objects (.1/.2) are readable.
+# nominally not-accessible INDEX objects (.1/.2) are readable. Its row suffix
+# stops before the address subtype, length, and octets, so index-only decoding
+# cannot reconstruct the management address.
 
 selector:
   - sysobjectid:


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates LLDP management address length against the MIB's `1..31` range; rows with declared length outside that range are now rejected (previously only lengths `<= 0` were rejected). Updates the production-path test to resolve profiles through the real catalog instead of mutating a loaded profile.

<sup>Written for commit f7d9f17343a75ea401c11b80140eaaf62d71dd44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LLDP topology validation to reject management addresses exceeding the MIB-defined 31-byte limit.
  - Continued validating that declared address lengths match the encoded address data.
  - Updated LLDP fixture handling to correctly resolve device-specific topology profiles.

- **Documentation**
  - Clarified RouterOS LLDP management-address limitations in the SNMP profile documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->