### PR TITLE
fix(go.d/snmp_topology): inspect links by replay index

### DIFF
--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -660,15 +660,21 @@ identity representation of the retained observation after shaping; it is not
 claimed to be the registration itself or proof that one registration caused a
 collapsed actor.
 
-Link inspection resolves both endpoints through exact normalized actor identity
-keys, then matches the existing link family, protocol, and direction. These
-fields define a candidate subject rather than a unique link identity; the full
-matching graph rows retain interface, subnet, adjacency, routing-instance, and
-other parallel-link details. Endpoint reversal is accepted for bidirectional
-links and unordered direct L3/OSPF/BGP adjacencies; ordered STP and
-subnet-membership roles remain exact. Zero matches is `absent` only after the
-relevant stage completed, one is `present`, and multiple actor or link matches
-is `undetermined` with every candidate returned.
+Link inspection has two selectors with distinct purposes. Exact inspection
+selects one existing graph link by its zero-based replay index, derives its
+ordinary subject and family-wide source context, and maps the same index to the
+typed link row. The index belongs to one archive and query option set; it is not
+a persistent link identity.
+
+Candidate inspection resolves both endpoints through exact normalized actor
+identity keys, then matches the existing link family, protocol, and direction.
+These fields can describe a link that is absent but do not define a unique link
+identity; the full matching graph rows retain interface, subnet, adjacency,
+routing-instance, and other parallel-link details. Endpoint reversal is
+accepted for bidirectional links and unordered direct L3/OSPF/BGP adjacencies;
+ordered STP and subnet-membership roles remain exact. Zero matches is `absent`
+only after the relevant stage completed, one is `present`, and multiple actor
+or link matches is `undetermined` with every candidate returned.
 
 Every link report also carries the committed diagnostic cut's capture state,
 reason, sequence, and timestamps. A cut rejected by projection or diagnostic
@@ -762,7 +768,7 @@ operation:
 - `summary` reports cut state/counts and an ordered registration inventory;
 - `replay` returns the unchanged production topology-v1 payload; and
 - `inspect-device` and `inspect-link` return typed positive-allowlist projections of the existing offline inspection
-  reports.
+  reports; link inspection accepts either an existing replay index or the candidate identity selector.
 
 The collector's diagnostic facade owns the command request/report DTOs beside the adapter that constructs them from
 private topology state. The command depends only on that facade; it does not own a second archive model, replay engine,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api.go
@@ -132,6 +132,26 @@ func (a *DiagnosticArchive) InspectLink(
 	return newDiagnosticLinkInspection(report)
 }
 
+// InspectLinkAt inspects one existing link by its zero-based index in the
+// replay produced by the supplied query options.
+func (a *DiagnosticArchive) InspectLinkAt(
+	options DiagnosticQueryOptions,
+	index int,
+) (DiagnosticLinkInspection, error) {
+	if a == nil {
+		return DiagnosticLinkInspection{}, errors.New("inspect SNMP topology link: nil archive")
+	}
+	query, err := diagnosticQueryOptionsToInternal(options)
+	if err != nil {
+		return DiagnosticLinkInspection{}, err
+	}
+	report, err := inspectTopologyLinkAt(a.archive.diagnostics, query, index)
+	if err != nil {
+		return DiagnosticLinkInspection{}, err
+	}
+	return newDiagnosticLinkInspection(report)
+}
+
 func diagnosticQueryOptionsFromInternal(options topologyoptions.QueryOptions) DiagnosticQueryOptions {
 	depth := strconv.Itoa(options.Depth)
 	if options.Depth == topologyoptions.DepthAllInternal {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api_test.go
@@ -81,6 +81,32 @@ func TestDiagnosticArchiveAPIReusesArchiveReplayAndInspection(t *testing.T) {
 	require.Equal(t, 1, link.TypedLink.Membership.Candidates)
 	require.NotEmpty(t, link.Source.Contexts)
 	require.Equal(t, wantReplay.Stats, link.Stats)
+
+	linkAt, err := archive.InspectLinkAt(query, 0)
+	require.NoError(t, err)
+	directLinkAtReport, err := inspectTopologyLinkAt(diagnostics, scenario.opts, 0)
+	require.NoError(t, err)
+	directLinkAt, err := newDiagnosticLinkInspection(directLinkAtReport)
+	require.NoError(t, err)
+	require.Equal(t, directLinkAt, linkAt)
+	require.Equal(t, 0, linkAt.GraphLink.SelectedIndex)
+	require.Equal(t, 0, linkAt.TypedLink.Row)
+}
+
+func TestDiagnosticArchiveAPIRejectsInvalidExactLinkIndexes(t *testing.T) {
+	_, diagnostics := newTopologyScenarioReplayFixture(t, newLLDPDirectScenario())
+	completeTopologyDiagnosticArchiveFixture(&diagnostics)
+
+	var encoded bytes.Buffer
+	require.NoError(t, writeTopologyDiagnosticArchive(&encoded, diagnostics))
+	archive, err := ReadDiagnosticArchive(bytes.NewReader(encoded.Bytes()), DefaultDiagnosticArchiveReadLimits())
+	require.NoError(t, err)
+
+	query := diagnosticQueryOptionsFromInternal(newLLDPDirectScenario().opts)
+	for _, index := range []int{-1, 1_000_000} {
+		_, err := archive.InspectLinkAt(query, index)
+		require.ErrorContains(t, err, "link index")
+	}
 }
 
 func TestDiagnosticArchiveAPIRejectsInvalidExternalSelectors(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection.go
@@ -218,7 +218,57 @@ func inspectTopologyLink(
 	subject topologyInspectionLinkSubject,
 ) (topologyLinkInspection, error) {
 	subject = normalizeTopologyInspectionLinkSubject(subject)
-	report := topologyLinkInspection{
+	report := newTopologyLinkInspection(diagnostics, options, subject)
+	if subject.srcIdentity == "" || subject.dstIdentity == "" || subject.family == "" {
+		return report, fmt.Errorf("topology inspection link subject is incomplete")
+	}
+
+	replay := replayTopologyDiagnosticStages(diagnostics, options)
+	if replay.graph.state != topologyInspectionPresent {
+		report.source = inspectTopologyLinkSourceContext(replay.devices, subject.family)
+		return report, nil
+	}
+	return completeTopologyLinkInspection(report, replay, inspectTopologyGraphLink(replay.data, subject)), nil
+}
+
+func inspectTopologyLinkAt(
+	diagnostics topologyDiagnostics,
+	options topologyoptions.QueryOptions,
+	index int,
+) (topologyLinkInspection, error) {
+	report := newTopologyLinkInspection(diagnostics, options, topologyInspectionLinkSubject{})
+	if index < 0 {
+		return report, fmt.Errorf("topology inspection link index must be zero or greater: %d", index)
+	}
+
+	replay := replayTopologyDiagnosticStages(diagnostics, options)
+	if replay.graph.state != topologyInspectionPresent {
+		if replay.err != nil {
+			return report, fmt.Errorf("topology inspection link index %d: replay graph: %w", index, replay.err)
+		}
+		return report, fmt.Errorf("topology inspection link index %d out of range [0,0)", index)
+	}
+	if index >= len(replay.data.Links) {
+		return report, fmt.Errorf(
+			"topology inspection link index %d out of range [0,%d)",
+			index,
+			len(replay.data.Links),
+		)
+	}
+	subject, ok := topologyInspectionSubjectFromLink(replay.data, index)
+	if !ok {
+		return report, fmt.Errorf("topology inspection link index %d has no usable endpoint identity", index)
+	}
+	report.subject = subject
+	return completeTopologyLinkInspection(report, replay, inspectTopologyGraphLinkAt(replay.data, index)), nil
+}
+
+func newTopologyLinkInspection(
+	diagnostics topologyDiagnostics,
+	options topologyoptions.QueryOptions,
+	subject topologyInspectionLinkSubject,
+) topologyLinkInspection {
+	return topologyLinkInspection{
 		subject:       subject,
 		options:       topologyoptions.NormalizeQueryOptions(options),
 		diagnosticCut: inspectTopologyDiagnosticCut(diagnostics.topology),
@@ -226,23 +276,22 @@ func inspectTopologyLink(
 		typedLink:     topologyInspectionRowResult{row: -1},
 		lastAborted:   diagnostics.lastAborted,
 	}
-	if subject.srcIdentity == "" || subject.dstIdentity == "" || subject.family == "" {
-		return report, fmt.Errorf("topology inspection link subject is incomplete")
-	}
+}
 
-	replay := replayTopologyDiagnosticStages(diagnostics, options)
-	report.source = inspectTopologyLinkSourceContext(replay.devices, subject.family)
-	if replay.graph.state != topologyInspectionPresent {
-		return report, nil
-	}
+func completeTopologyLinkInspection(
+	report topologyLinkInspection,
+	replay topologyDiagnosticReplayStages,
+	graphLink topologyInspectionGraphLinkResult,
+) topologyLinkInspection {
+	report.source = inspectTopologyLinkSourceContext(replay.devices, report.subject.family)
 	report.graphStats.state = topologyInspectionPresent
 	report.stats = replay.data.Stats
-	report.graphLink = inspectTopologyGraphLink(replay.data, subject)
+	report.graphLink = graphLink
 	report.typedLink = topologyInspectionRenderedRow(
 		replay.typed.state,
 		report.graphLink.membership,
 		report.graphLink.index,
 		replay.payload.Links.Rows,
 	)
-	return report, nil
+	return report
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_link.go
@@ -83,6 +83,33 @@ func inspectTopologyGraphLink(
 	return result
 }
 
+func inspectTopologyGraphLinkAt(
+	data topologymodel.Data,
+	index int,
+) topologyInspectionGraphLinkResult {
+	link := data.Links[index]
+	return topologyInspectionGraphLinkResult{
+		membership: topologyInspectionStage{state: topologyInspectionPresent, candidates: 1},
+		srcActors:  inspectTopologyActorHandle(data, link.SrcActorHandle),
+		dstActors:  inspectTopologyActorHandle(data, link.DstActorHandle),
+		links:      []topologymodel.Link{link},
+		index:      index,
+	}
+}
+
+func inspectTopologyActorHandle(
+	data topologymodel.Data,
+	handle topologymodel.ActorHandle,
+) topologyInspectionActorResult {
+	indexes := make([]int, 0, 1)
+	for i := range data.Actors {
+		if data.Actors[i].ActorHandle == handle {
+			indexes = append(indexes, i)
+		}
+	}
+	return topologyInspectionActorsAt(data, indexes)
+}
+
 func topologyInspectionLinkMatches(
 	link topologymodel.Link,
 	srcHandles map[topologymodel.ActorHandle]struct{},

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_inspection_test.go
@@ -521,6 +521,42 @@ func TestInspectTopologyGraphLinkReturnsDuplicateCandidates(t *testing.T) {
 	require.Equal(t, -1, match.index)
 }
 
+func TestInspectTopologyGraphLinkAtSelectsNULIdentity(t *testing.T) {
+	data := topologymodel.Data{Actors: []topologymodel.Actor{
+		{
+			ActorID: "segment-a",
+			Match:   topologymodel.Match{Hostnames: []string{"segment:bridge\x00device\x00port"}},
+		},
+		{
+			ActorID: "device-b",
+			Match:   topologymodel.Match{IPAddresses: []string{"192.0.2.2"}},
+		},
+	}}
+	allocator := graph.NewActorHandleAllocator()
+	for i := range data.Actors {
+		data.Actors[i].ActorHandle = allocator.Next()
+	}
+	data.Links = []topologymodel.Link{{
+		LinkType:       "bridge",
+		Protocol:       "fdb",
+		Direction:      "observed",
+		SrcActorHandle: data.Actors[0].ActorHandle,
+		DstActorHandle: data.Actors[1].ActorHandle,
+	}}
+
+	subject, ok := topologyInspectionSubjectFromLink(data, 0)
+	require.True(t, ok)
+	require.Contains(t, subject.srcIdentity, "\x00")
+
+	match := inspectTopologyGraphLinkAt(data, 0)
+	require.Equal(t, topologyInspectionPresent, match.membership.state)
+	require.Equal(t, 1, match.membership.candidates)
+	require.Equal(t, 0, match.index)
+	require.Equal(t, data.Links, match.links)
+	require.Equal(t, topologyInspectionPresent, match.srcActors.membership.state)
+	require.Equal(t, topologyInspectionPresent, match.dstActors.membership.state)
+}
+
 func TestTopologyInspectionLinkSubjectReturnsParallelBGPRoutingInstancesAsCandidates(t *testing.T) {
 	scenario := newTopologyScenario("inspection-parallel-bgp")
 	left := scenario.Router("router-left", "192.0.2.61", "02:00:00:00:61:01", "192.0.2.61", "65001")
@@ -532,6 +568,7 @@ func TestTopologyInspectionLinkSubjectReturnsParallelBGPRoutingInstancesAsCandid
 	_, diagnostics := newTopologyScenarioReplayFixture(t, scenario)
 	replay := replayTopologyDiagnosticStages(diagnostics, scenario.opts)
 
+	var indexes []int
 	var subjects []topologyInspectionLinkSubject
 	for i, link := range replay.data.Links {
 		if topologyInspectionLinkFamily(link) != topologymodel.BGPAdjacencyLinkType {
@@ -539,8 +576,10 @@ func TestTopologyInspectionLinkSubjectReturnsParallelBGPRoutingInstancesAsCandid
 		}
 		subject, ok := topologyInspectionSubjectFromLink(replay.data, i)
 		require.True(t, ok)
+		indexes = append(indexes, i)
 		subjects = append(subjects, subject)
 	}
+	require.Len(t, indexes, 2)
 	require.Len(t, subjects, 2)
 	require.Equal(t, subjects[0], subjects[1])
 	match := inspectTopologyGraphLink(replay.data, subjects[0])
@@ -553,6 +592,18 @@ func TestTopologyInspectionLinkSubjectReturnsParallelBGPRoutingInstancesAsCandid
 		routingInstances[link.Detail.BGP.RoutingInstance] = true
 	}
 	require.Equal(t, map[string]bool{"blue": true, "red": true}, routingInstances)
+
+	for _, index := range indexes {
+		report, err := inspectTopologyLinkAt(diagnostics, scenario.opts, index)
+		require.NoError(t, err)
+		require.Equal(t, topologyInspectionPresent, report.graphLink.membership.state)
+		require.Equal(t, 1, report.graphLink.membership.candidates)
+		require.Equal(t, index, report.graphLink.index)
+		require.Equal(t, []topologymodel.Link{replay.data.Links[index]}, report.graphLink.links)
+		require.Equal(t, topologyInspectionPresent, report.typedLink.state)
+		require.Equal(t, index, report.typedLink.row)
+		require.Equal(t, subjects[0], report.subject)
+	}
 }
 
 func setTopologyInspectionLifecycleCut(diagnostics *topologyDiagnostics, registrationIDs ...ddsnmp.DeviceRegistrationID) {

--- a/src/go/tools/snmp-topology-diagnostics/README.md
+++ b/src/go/tools/snmp-topology-diagnostics/README.md
@@ -15,6 +15,7 @@ go run ./tools/snmp-topology-diagnostics validate --archive /path/to/archive.zst
 go run ./tools/snmp-topology-diagnostics summary --archive /path/to/archive.zst
 go run ./tools/snmp-topology-diagnostics replay --archive /path/to/archive.zst
 go run ./tools/snmp-topology-diagnostics inspect-device --archive /path/to/archive.zst --registration-id 7
+go run ./tools/snmp-topology-diagnostics inspect-link --archive /path/to/archive.zst --link-index 12
 go run ./tools/snmp-topology-diagnostics inspect-link --archive /path/to/archive.zst \
   --source-identity ip:192.0.2.10 \
   --destination-identity ip:192.0.2.20 \
@@ -28,10 +29,16 @@ production topology-v1 payload. The inspection operations report one device or l
 rendered topology stages. Link reports also include family-wide source context; that context is not causal provenance for
 the inspected link.
 
-Use `summary` to find a device registration ID. A device inspection reports its graph identity keys; one of those keys can
-be supplied as a link endpoint identity. Link families are `lldp`, `cdp`, `bridge`, `fdb`, `stp`, `arp`, `l3_subnet`,
-`l3_subnet_membership`, `ospf_adjacency`, and `bgp_adjacency`. Link direction is required and accepts `observed`,
-`unidirectional`, or `bidirectional`.
+Use `summary` to find a device registration ID. Use `--link-index` to inspect one existing link by its zero-based row in
+the `links` table emitted by `replay`. The index belongs to that archive and query option set; do not reuse it with a
+different archive or query. Exact selection also works when an actor identity cannot be carried in a command-line
+argument or when the identity selector would match multiple parallel links.
+
+The identity-based link selector remains useful for investigating a link that may be absent. A device inspection reports
+its graph identity keys; one of those keys can be supplied as a link endpoint identity. The exact and identity-based
+selector modes cannot be combined. Link families are `lldp`, `cdp`, `bridge`, `fdb`, `stp`, `arp`, `l3_subnet`,
+`l3_subnet_membership`, `ospf_adjacency`, and `bgp_adjacency`. Link direction is required for identity selection and
+accepts `observed`, `unidirectional`, or `bidirectional`.
 
 Replay and inspection accept the production scalar query options:
 

--- a/src/go/tools/snmp-topology-diagnostics/main.go
+++ b/src/go/tools/snmp-topology-diagnostics/main.go
@@ -33,6 +33,7 @@ type diagnosticArchive interface {
 		snmptopology.DiagnosticQueryOptions,
 		snmptopology.DiagnosticLinkSubject,
 	) (snmptopology.DiagnosticLinkInspection, error)
+	InspectLinkAt(snmptopology.DiagnosticQueryOptions, int) (snmptopology.DiagnosticLinkInspection, error)
 }
 
 type archiveOpener func(io.Reader, snmptopology.DiagnosticReadLimits) (diagnosticArchive, error)
@@ -44,6 +45,8 @@ type commandOptions struct {
 	query             snmptopology.DiagnosticQueryOptions
 	registrationID    uint64
 	link              snmptopology.DiagnosticLinkSubject
+	linkIndex         int
+	linkIndexSet      bool
 }
 
 func main() {
@@ -142,6 +145,7 @@ func parseCommandOptions(operation string, arguments []string, stderr io.Writer)
 	case "inspect-device":
 		flags.Uint64Var(&options.registrationID, "registration-id", 0, "device registration ID")
 	case "inspect-link":
+		flags.IntVar(&options.linkIndex, "link-index", -1, "zero-based link index in this archive and query replay")
 		flags.StringVar(&options.link.SourceIdentity, "source-identity", "", "source actor identity key")
 		flags.StringVar(&options.link.DestinationIdentity, "destination-identity", "", "destination actor identity key")
 		flags.StringVar(&options.link.Family, "family", "", "link family")
@@ -154,6 +158,11 @@ func parseCommandOptions(operation string, arguments []string, stderr io.Writer)
 		}
 		return commandOptions{}, 2
 	}
+	flags.Visit(func(value *flag.Flag) {
+		if value.Name == "link-index" {
+			options.linkIndexSet = true
+		}
+	})
 	if flags.NArg() != 0 {
 		fmt.Fprintf(stderr, "error: unexpected arguments: %v\n", flags.Args())
 		return commandOptions{}, 2
@@ -166,14 +175,27 @@ func parseCommandOptions(operation string, arguments []string, stderr io.Writer)
 		fmt.Fprintln(stderr, "error: --registration-id must be greater than zero")
 		return commandOptions{}, 2
 	}
-	if operation == "inspect-link" &&
-		(options.link.SourceIdentity == "" || options.link.DestinationIdentity == "" ||
-			options.link.Family == "" || options.link.Direction == "") {
-		fmt.Fprintln(
-			stderr,
-			"error: --source-identity, --destination-identity, --family, and --direction are required",
-		)
-		return commandOptions{}, 2
+	if operation == "inspect-link" {
+		hasCompositeSelector := options.link.SourceIdentity != "" || options.link.DestinationIdentity != "" ||
+			options.link.Family != "" || options.link.Protocol != "" || options.link.Direction != ""
+		if options.linkIndexSet && hasCompositeSelector {
+			fmt.Fprintln(stderr, "error: --link-index and identity-based link selectors are mutually exclusive")
+			return commandOptions{}, 2
+		}
+		if options.linkIndexSet {
+			if options.linkIndex < 0 {
+				fmt.Fprintln(stderr, "error: --link-index must be zero or greater")
+				return commandOptions{}, 2
+			}
+		} else if options.link.SourceIdentity == "" || options.link.DestinationIdentity == "" ||
+			options.link.Family == "" || options.link.Direction == "" {
+			fmt.Fprintln(
+				stderr,
+				"error: a link selector is required: use --link-index or --source-identity, "+
+					"--destination-identity, --family, and --direction",
+			)
+			return commandOptions{}, 2
+		}
 	}
 	return options, -1
 }
@@ -218,6 +240,9 @@ func executeOperation(operation string, archive diagnosticArchive, options comma
 	case "inspect-device":
 		return archive.InspectDevice(options.query, options.registrationID)
 	case "inspect-link":
+		if options.linkIndexSet {
+			return archive.InspectLinkAt(options.query, options.linkIndex)
+		}
 		return archive.InspectLink(options.query, options.link)
 	default:
 		return nil, fmt.Errorf("unknown operation %q", operation)

--- a/src/go/tools/snmp-topology-diagnostics/main_test.go
+++ b/src/go/tools/snmp-topology-diagnostics/main_test.go
@@ -97,6 +97,11 @@ func TestRunDispatchesReplayAndInspectionOnce(t *testing.T) {
 			operation: "inspect-link",
 			want:      `"family": "lldp"`,
 		},
+		"inspect link by index": {
+			args:      []string{"inspect-link", "--archive", path, "--link-index", "3"},
+			operation: "inspect-link-at",
+			want:      `"selected_index": 0`,
+		},
 	}
 
 	for name, tc := range tests {
@@ -132,11 +137,14 @@ func TestRunDispatchesReplayAndInspectionOnce(t *testing.T) {
 					t.Fatalf("explicit boolean query options were not forwarded: %+v", fake.query)
 				}
 			}
-			if tc.operation == "inspect-device" || tc.operation == "inspect-link" {
+			if tc.operation == "inspect-device" || strings.HasPrefix(tc.operation, "inspect-link") {
 				if !fake.query.CollapseActorsByIP || !fake.query.EliminateNonIPInferred ||
 					fake.query.MapType != "managed_fabric" || fake.query.Depth != "all" {
 					t.Fatalf("default query options were not forwarded: %+v", fake.query)
 				}
+			}
+			if tc.operation == "inspect-link-at" && fake.linkIndex != 3 {
+				t.Fatalf("link index=%d, want 3", fake.linkIndex)
 			}
 			if !strings.Contains(stdout.String(), tc.want) {
 				t.Fatalf("stdout missing %q:\n%s", tc.want, stdout.String())
@@ -188,6 +196,12 @@ func TestRunRealArchiveMatchesDirectOperations(t *testing.T) {
 			},
 			direct: func(archive *snmptopology.DiagnosticArchive) (any, error) {
 				return archive.InspectLink(query, link)
+			},
+		},
+		"inspect link by index": {
+			args: []string{"inspect-link", "--archive", archivePath, "--link-index", "0"},
+			direct: func(archive *snmptopology.DiagnosticArchive) (any, error) {
+				return archive.InspectLinkAt(query, 0)
 			},
 		},
 	}
@@ -313,6 +327,30 @@ func TestRunRejectsUsageArchiveAndSelectors(t *testing.T) {
 			code: 1,
 			want: "link direction",
 		},
+		"missing link selector": {
+			args: []string{"inspect-link", "--archive", validArchive},
+			code: 2,
+			want: "link selector",
+		},
+		"negative link index": {
+			args: []string{"inspect-link", "--archive", validArchive, "--link-index", "-1"},
+			code: 2,
+			want: "--link-index must be zero or greater",
+		},
+		"mixed link selectors": {
+			args: []string{
+				"inspect-link", "--archive", validArchive, "--link-index", "0",
+				"--source-identity", "actor:a", "--destination-identity", "actor:b",
+				"--family", "lldp", "--direction", "bidirectional",
+			},
+			code: 2,
+			want: "mutually exclusive",
+		},
+		"link index out of range": {
+			args: []string{"inspect-link", "--archive", validArchive, "--link-index", "1000000"},
+			code: 1,
+			want: "link index",
+		},
 	}
 
 	for name, tc := range tests {
@@ -333,6 +371,7 @@ type fakeDiagnosticArchive struct {
 	operationCalls int
 	limits         snmptopology.DiagnosticReadLimits
 	query          snmptopology.DiagnosticQueryOptions
+	linkIndex      int
 }
 
 func (a *fakeDiagnosticArchive) Identity() snmptopology.DiagnosticArchiveIdentity {
@@ -372,6 +411,17 @@ func (a *fakeDiagnosticArchive) InspectLink(
 	a.operationCalls++
 	a.query = options
 	return snmptopology.DiagnosticLinkInspection{Subject: subject}, nil
+}
+
+func (a *fakeDiagnosticArchive) InspectLinkAt(
+	options snmptopology.DiagnosticQueryOptions,
+	index int,
+) (snmptopology.DiagnosticLinkInspection, error) {
+	a.operation = "inspect-link-at"
+	a.operationCalls++
+	a.query = options
+	a.linkIndex = index
+	return snmptopology.DiagnosticLinkInspection{}, nil
 }
 
 func writeGoldenDiagnosticArchive(t testing.TB) string {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds exact link selection to the `snmp-topology-diagnostics` tool so `inspect-link` can inspect one existing link by its zero-based replay index instead of requiring endpoint identities.

- `--link-index` and the identity-based selectors are mutually exclusive; one selector is now always required.
- The index belongs to one archive and query option set, not a persistent link identity.
- Exact selection works when an actor identity can't be passed on the command line, such as keys containing NUL bytes, and when identity matching would return multiple parallel links.

<sup>Written for commit 50e64967d9392822aff77cbceb000d79c20d9dca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exact link inspection by zero-based link index.
  * Updated diagnostic tooling to support `--link-index` selection.
  * Preserved identity-based inspection for investigating potentially absent links.
  * Added clear handling for invalid, conflicting, missing, and ambiguous link selectors.
* **Documentation**
  * Expanded architecture and command-line guidance for link selection, matching behavior, and inspection results.
* **Bug Fixes**
  * Improved link and actor resolution, including links with complex identities and parallel routing instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->