### PR TITLE
chore(go.d/snmp): diagnose missing profile identity

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -95,18 +95,14 @@ func (c *Collector) ensureInitialized() error {
 		return errors.New("snmp client not initialized")
 	}
 
-	if c.sysInfo != nil {
+	if c.initialized {
 		return nil
 	}
 
-	si, err := snmputils.GetSysInfo(c.snmpClient)
-	if err != nil {
+	if err := c.ensureDeviceProfile(); err != nil {
 		return err
 	}
-
-	if c.snmpProfiles == nil {
-		c.snmpProfiles = c.setupProfiles(si)
-	}
+	si := c.sysInfo
 
 	if c.ddSnmpColl == nil && len(c.snmpProfiles) > 0 {
 		c.ddSnmpColl = c.newDdSnmpColl(ddsnmpcollector.Config{
@@ -116,10 +112,6 @@ func (c *Collector) ensureInitialized() error {
 			SysObjectID:     si.SysObjectID,
 			DisableBulkWalk: c.disableBulkWalk,
 		})
-	}
-
-	if c.ddSnmpColl == nil && !c.PingOnly && !c.Ping.Enabled {
-		return errors.New("no profiles found and ping disabled")
 	}
 
 	if c.CreateVnode {
@@ -134,13 +126,12 @@ func (c *Collector) ensureInitialized() error {
 		}
 	}
 
-	c.sysInfo = si
-
 	if c.PingOnly || c.Ping.Enabled {
 		c.addPingCharts()
 	}
 
 	c.registerDeviceState(si, nil)
+	c.initialized = true
 
 	return nil
 }

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -144,6 +144,7 @@ type (
 
 		sysInfo              *snmputils.SysInfo
 		snmpProfiles         []*ddsnmp.Profile
+		initialized          bool
 		deviceMetadataSynced bool
 
 		adjMaxRepetitions uint32
@@ -212,7 +213,7 @@ func (c *Collector) Check(ctx context.Context) (err error) {
 		c.snmpClient = snmpClient
 	}
 
-	if _, err := snmputils.GetSysInfo(c.snmpClient); err != nil {
+	if err := c.ensureDeviceProfile(); err != nil {
 		return err
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -741,7 +741,9 @@ func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
 			pdus: []gosnmp.SnmpPDU{
 				{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.2.1.999"},
 			},
-			wantErr: "no SNMP metric profiles available for sysObjectID \"1.3.6.1.2.1.999\"",
+			manualProfiles: []string{"generic-device"},
+			wantErr:        "no SNMP metric profiles available for sysObjectID \"1.3.6.1.2.1.999\"",
+			wantAbsent:     []string{"manual_profiles"},
 		},
 		"invalid manual profile": {
 			manualProfiles: []string{"profile-that-does-not-exist"},

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -716,6 +716,137 @@ func TestCollector_Check(t *testing.T) {
 	}
 }
 
+func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
+	tests := map[string]struct {
+		pdus           []gosnmp.SnmpPDU
+		pingEnabled    bool
+		pingOnly       bool
+		manualProfiles []string
+		wantErr        string
+		wantAbsent     []string
+	}{
+		"empty system walk": {
+			wantErr: "system subtree walk returned no PDUs",
+		},
+		"partial system walk with ordinary ping enabled": {
+			pdus: []gosnmp.SnmpPDU{
+				{Name: snmputils.OidSysDescr, Type: gosnmp.OctetString, Value: []byte("private description")},
+				{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("private hostname")},
+			},
+			pingEnabled: true,
+			wantErr:     "without sysObjectID",
+			wantAbsent:  []string{"private description", "private hostname"},
+		},
+		"unmatched system object": {
+			pdus: []gosnmp.SnmpPDU{
+				{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.2.1.999"},
+			},
+			wantErr: "no SNMP metric profiles available for sysObjectID \"1.3.6.1.2.1.999\"",
+		},
+		"invalid manual profile": {
+			manualProfiles: []string{"profile-that-does-not-exist"},
+			wantErr:        "system subtree walk returned no PDUs",
+		},
+		"topology-only manual profile": {
+			manualProfiles: []string{"topology-role-qbridge"},
+			wantErr:        "system subtree walk returned no PDUs",
+		},
+		"applicable manual metric profile": {
+			manualProfiles: []string{"generic-device"},
+		},
+		"reported Cisco ASR identity": {
+			pdus: []gosnmp.SnmpPDU{
+				{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.9.1.1166"},
+			},
+		},
+		"explicit ping only": {
+			pingOnly: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			client := snmpmock.NewMockHandler(ctrl)
+			client.EXPECT().WalkAll(snmputils.RootOidMibSystem).Return(tc.pdus, nil)
+
+			collr := newTestSNMPCollector()
+			collr.Config = prepareV2Config()
+			collr.CreateVnode = false
+			collr.Ping.Enabled = tc.pingEnabled
+			collr.PingOnly = tc.pingOnly
+			collr.ManualProfiles = tc.manualProfiles
+			collr.snmpClient = client
+
+			err := collr.Check(context.Background())
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			for _, value := range tc.wantAbsent {
+				assert.NotContains(t, err.Error(), value)
+			}
+		})
+	}
+}
+
+func TestCollector_CheckRetainsIdentityForInitialization(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().WalkAll(snmputils.RootOidMibSystem).Return([]gosnmp.SnmpPDU{
+		{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.14988.1"},
+	}, nil).Times(1)
+
+	collr := newTestSNMPCollector()
+	collr.Config = prepareV2Config()
+	collr.CreateVnode = false
+	collr.Ping.Enabled = false
+	collr.snmpClient = client
+	collr.snmpProfiles = []*ddsnmp.Profile{{}}
+	collr.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector { return &mockDdSnmpCollector{} }
+
+	require.NoError(t, collr.Check(context.Background()))
+	require.NoError(t, collr.ensureInitialized())
+	assert.Equal(t, "1.3.6.1.4.1.14988.1", collr.sysInfo.SysObjectID)
+}
+
+func TestSysInfoDiagnosticOmitsRawSystemValues(t *testing.T) {
+	si := &snmputils.SysInfo{
+		SysObjectID: "1.3.6.1.4.1.9.1.1166",
+		Descr:       "private description",
+		Contact:     "private contact",
+		Name:        "private hostname",
+		Location:    "private location",
+		Vendor:      "Cisco",
+		Category:    "Router",
+		Model:       "ASR 1000",
+		Probe: snmputils.SysInfoProbe{
+			PDUCount:        5,
+			FirstOID:        snmputils.OidSysDescr,
+			LastOID:         snmputils.OidSysLocation,
+			SeenSysDescr:    true,
+			SeenSysObjectID: true,
+			SeenSysContact:  true,
+			SeenSysName:     true,
+			SeenSysLocation: true,
+		},
+	}
+
+	diagnostic := formatSysInfoDiagnostic(si)
+	assert.Contains(t, diagnostic, si.SysObjectID)
+	assert.Contains(t, diagnostic, "pdu_count=5")
+	assert.Contains(t, diagnostic, "sys_object_id=true")
+	for _, raw := range []string{si.Descr, si.Contact, si.Name, si.Location} {
+		assert.NotContains(t, diagnostic, raw)
+	}
+}
+
 func TestCollector_CheckPingOnlyUsesReadOnlyProbing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -225,7 +225,7 @@
             "title": "Enable ping",
             "type": "boolean",
             "default": true,
-            "description": "Collect ICMP round-trip time using pro-bing alongside SNMP."
+            "description": "Collect ICMP round-trip time alongside SNMP profile metrics. This option does not enable profile-less operation; use ping_only for that."
           },
           "network": {
             "title": "Network",

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -429,7 +429,7 @@ modules:
               required: false
             - name: ping.enabled
               group: Ping
-              description: Enable ICMP round-trip measurements (runs alongside SNMP). When disabled, no ping metrics are collected.
+              description: Enable ICMP round-trip measurements alongside SNMP profile metrics. This option does not enable profile-less operation; use `ping_only` for that. When disabled, no ping metrics are collected.
               default_value: true
               required: false
             - name: ping.privileged

--- a/src/go/plugin/go.d/collector/snmp/profile_sets.go
+++ b/src/go/plugin/go.d/collector/snmp/profile_sets.go
@@ -31,7 +31,78 @@ func (c *Collector) setupProfiles(si *snmputils.SysInfo) []*ddsnmp.Profile {
 	return profiles
 }
 
+func (c *Collector) ensureDeviceProfile() error {
+	if c.sysInfo != nil {
+		return nil
+	}
+
+	si, err := snmputils.GetSysInfo(c.snmpClient)
+	if err != nil {
+		return err
+	}
+	c.Debugf("SNMP system identity: %s", formatSysInfoDiagnostic(si))
+
+	profiles := c.snmpProfiles
+	if profiles == nil {
+		profiles = c.setupProfiles(si)
+	}
+
+	if len(profiles) == 0 && !c.PingOnly {
+		return noMetricProfilesError(si)
+	}
+
+	c.sysInfo = si
+	c.snmpProfiles = profiles
+	return nil
+}
+
+func noMetricProfilesError(si *snmputils.SysInfo) error {
+	const remediation = "configure an applicable manual_profiles entry or set ping_only: true"
+
+	switch {
+	case si == nil || si.Probe.PDUCount == 0:
+		return fmt.Errorf("no SNMP metric profiles available: system subtree walk returned no PDUs; %s", remediation)
+	case si.SysObjectID == "":
+		return fmt.Errorf(
+			"no SNMP metric profiles available: system subtree walk returned %d PDU(s) without sysObjectID (%s); %s",
+			si.Probe.PDUCount,
+			formatSysInfoDiagnostic(si),
+			remediation,
+		)
+	default:
+		return fmt.Errorf("no SNMP metric profiles available for sysObjectID %q; %s", si.SysObjectID, remediation)
+	}
+}
+
+func formatSysInfoDiagnostic(si *snmputils.SysInfo) string {
+	if si == nil {
+		return "unavailable"
+	}
+
+	p := si.Probe
+	return fmt.Sprintf(
+		"sys_object_id=%q vendor=%q category=%q model=%q probe={pdu_count=%d first_oid=%q last_oid=%q "+
+			"sys_descr=%t sys_object_id=%t sys_contact=%t sys_name=%t sys_location=%t}",
+		si.SysObjectID,
+		si.Vendor,
+		si.Category,
+		si.Model,
+		p.PDUCount,
+		p.FirstOID,
+		p.LastOID,
+		p.SeenSysDescr,
+		p.SeenSysObjectID,
+		p.SeenSysContact,
+		p.SeenSysName,
+		p.SeenSysLocation,
+	)
+}
+
 func (c *Collector) logMatchedProfiles(profiles []*ddsnmp.Profile, sysObjectID string) {
+	if len(profiles) == 0 {
+		return
+	}
+
 	var profInfo []string
 
 	for _, prof := range profiles {
@@ -44,9 +115,5 @@ func (c *Collector) logMatchedProfiles(profiles []*ddsnmp.Profile, sysObjectID s
 	}
 
 	msg := fmt.Sprintf("device matched %d profile(s): %s (sysObjectID: '%s')", len(profiles), strings.Join(profInfo, ", "), sysObjectID)
-	if len(profiles) == 0 {
-		c.Warning(msg)
-	} else {
-		c.Info(msg)
-	}
+	c.Info(msg)
 }

--- a/src/go/plugin/go.d/collector/snmp/profile_sets.go
+++ b/src/go/plugin/go.d/collector/snmp/profile_sets.go
@@ -57,20 +57,24 @@ func (c *Collector) ensureDeviceProfile() error {
 }
 
 func noMetricProfilesError(si *snmputils.SysInfo) error {
-	const remediation = "configure an applicable manual_profiles entry or set ping_only: true"
+	const missingIdentityRemediation = "configure an applicable metric profile in manual_profiles or set ping_only: true"
 
 	switch {
 	case si == nil || si.Probe.PDUCount == 0:
-		return fmt.Errorf("no SNMP metric profiles available: system subtree walk returned no PDUs; %s", remediation)
+		return fmt.Errorf("no SNMP metric profiles available: system subtree walk returned no PDUs; %s", missingIdentityRemediation)
 	case si.SysObjectID == "":
 		return fmt.Errorf(
 			"no SNMP metric profiles available: system subtree walk returned %d PDU(s) without sysObjectID (%s); %s",
 			si.Probe.PDUCount,
 			formatSysInfoDiagnostic(si),
-			remediation,
+			missingIdentityRemediation,
 		)
 	default:
-		return fmt.Errorf("no SNMP metric profiles available for sysObjectID %q; %s", si.SysObjectID, remediation)
+		return fmt.Errorf(
+			"no SNMP metric profiles available for sysObjectID %q; add or update a profile whose selector matches this sysObjectID, "+
+				"or set ping_only: true",
+			si.SysObjectID,
+		)
 	}
 }
 

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/discoverer_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/discoverer_test.go
@@ -279,5 +279,15 @@ func prepareNewTarget(sub subnet, ip string) *target {
 		Organization: "net-snmp",
 		Category:     "Server",
 		Model:        "Linux",
+		Probe: snmputils.SysInfoProbe{
+			PDUCount:        5,
+			FirstOID:        snmputils.OidSysDescr,
+			LastOID:         snmputils.OidSysLocation,
+			SeenSysDescr:    true,
+			SeenSysObjectID: true,
+			SeenSysContact:  true,
+			SeenSysName:     true,
+			SeenSysLocation: true,
+		},
 	})
 }

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -84,6 +84,10 @@ func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 			si.Descr = valueSanitizer.Replace(si.Descr)
 		case OidSysObject:
 			si.Probe.SeenSysObjectID = true
+			if pdu.Type != gosnmp.ObjectIdentifier {
+				err = fmt.Errorf("expected ObjectIdentifier, got %v", pdu.Type)
+				break
+			}
 			var sysObj string
 			if sysObj, err = PduToString(pdu); err == nil {
 				si.SysObjectID = sysObj

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -31,7 +31,8 @@ const (
 )
 
 type SysInfo struct {
-	SysObjectID string `json:"-"`
+	SysObjectID string       `json:"-"`
+	Probe       SysInfoProbe `json:"-" yaml:"-"`
 
 	Descr    string `json:"description"`
 	Contact  string `json:"contact"`
@@ -44,10 +45,21 @@ type SysInfo struct {
 	Model        string `json:"model"`
 }
 
+type SysInfoProbe struct {
+	PDUCount        int
+	FirstOID        string
+	LastOID         string
+	SeenSysDescr    bool
+	SeenSysObjectID bool
+	SeenSysContact  bool
+	SeenSysName     bool
+	SeenSysLocation bool
+}
+
 func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 	pdus, err := client.WalkAll(RootOidMibSystem)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("walk SNMP system subtree %q: %w", RootOidMibSystem, err)
 	}
 
 	si := &SysInfo{
@@ -59,28 +71,38 @@ func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 
 	for _, pdu := range pdus {
 		oid := strings.TrimPrefix(pdu.Name, ".")
+		si.Probe.PDUCount++
+		if si.Probe.PDUCount == 1 {
+			si.Probe.FirstOID = oid
+		}
+		si.Probe.LastOID = oid
 
 		switch oid {
 		case OidSysDescr:
+			si.Probe.SeenSysDescr = true
 			si.Descr, err = PduToString(pdu)
 			si.Descr = valueSanitizer.Replace(si.Descr)
 		case OidSysObject:
+			si.Probe.SeenSysObjectID = true
 			var sysObj string
 			if sysObj, err = PduToString(pdu); err == nil {
 				si.SysObjectID = sysObj
 			}
 		case OidSysContact:
+			si.Probe.SeenSysContact = true
 			si.Contact, err = PduToString(pdu)
 			si.Contact = valueSanitizer.Replace(si.Contact)
 		case OidSysName:
+			si.Probe.SeenSysName = true
 			si.Name, err = PduToString(pdu)
 			si.Name = valueSanitizer.Replace(si.Name)
 		case OidSysLocation:
+			si.Probe.SeenSysLocation = true
 			si.Location, err = PduToString(pdu)
 			si.Location = valueSanitizer.Replace(si.Location)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("OID '%s': %v", pdu.Name, err)
+			return nil, fmt.Errorf("OID %q: %w", pdu.Name, err)
 		}
 	}
 

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmputils
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gosnmp/gosnmp"
+	snmpmock "github.com/gosnmp/gosnmp/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSysInfoRecordsProbeDiagnostics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pdus := []gosnmp.SnmpPDU{
+		{Name: "." + OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
+		{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
+		{Name: OidSysContact, Type: gosnmp.OctetString, Value: []byte("operations")},
+		{Name: "1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(123)},
+		{Name: "." + OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
+		{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
+	}
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().WalkAll(RootOidMibSystem).Return(pdus, nil)
+
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Equal(t, "1.3.6.1.4.1.9.1.1166", si.SysObjectID)
+	assert.Equal(t, SysInfoProbe{
+		PDUCount:        len(pdus),
+		FirstOID:        OidSysDescr,
+		LastOID:         OidSysLocation,
+		SeenSysDescr:    true,
+		SeenSysObjectID: true,
+		SeenSysContact:  true,
+		SeenSysName:     true,
+		SeenSysLocation: true,
+	}, si.Probe)
+}
+
+func TestGetSysInfoReturnsPartialProbeWithoutIdentityError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().WalkAll(RootOidMibSystem).Return([]gosnmp.SnmpPDU{
+		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
+		{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
+	}, nil)
+
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Empty(t, si.SysObjectID)
+	assert.Equal(t, SysInfoProbe{
+		PDUCount:     2,
+		FirstOID:     OidSysDescr,
+		LastOID:      OidSysName,
+		SeenSysDescr: true,
+		SeenSysName:  true,
+	}, si.Probe)
+}
+
+func TestGetSysInfoReturnsEmptyProbeWithoutIdentityError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().WalkAll(RootOidMibSystem).Return(nil, nil)
+
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Empty(t, si.SysObjectID)
+	assert.Equal(t, SysInfoProbe{}, si.Probe)
+}
+
+func TestGetSysInfoWrapsWalkErrorWithSystemRoot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	walkErr := errors.New("timeout")
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().WalkAll(RootOidMibSystem).Return(nil, walkErr)
+
+	si, err := GetSysInfo(client)
+	require.Error(t, err)
+	assert.Nil(t, si)
+	assert.ErrorIs(t, err, walkErr)
+	assert.Contains(t, err.Error(), RootOidMibSystem)
+}
+
+func TestSysInfoProbeIsNotSerialized(t *testing.T) {
+	si := SysInfo{
+		SysObjectID: "1.3.6.1.4.1.9.1.1166",
+		Probe: SysInfoProbe{
+			PDUCount:        2,
+			FirstOID:        OidSysDescr,
+			LastOID:         OidSysObject,
+			SeenSysDescr:    true,
+			SeenSysObjectID: true,
+		},
+	}
+
+	got, err := json.Marshal(si)
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), "Probe")
+	assert.NotContains(t, string(got), "probe")
+	assert.NotContains(t, string(got), OidSysDescr)
+}

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
@@ -98,6 +98,23 @@ func TestGetSysInfoWrapsWalkErrorWithSystemRoot(t *testing.T) {
 	assert.Contains(t, err.Error(), RootOidMibSystem)
 }
 
+func TestGetSysInfoRejectsWrongTypedSysObjectWithoutEchoingValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const rawValue = "private device identifier"
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().WalkAll(RootOidMibSystem).Return([]gosnmp.SnmpPDU{
+		{Name: OidSysObject, Type: gosnmp.OctetString, Value: []byte(rawValue)},
+	}, nil)
+
+	si, err := GetSysInfo(client)
+	require.Error(t, err)
+	assert.Nil(t, si)
+	assert.Contains(t, err.Error(), "expected ObjectIdentifier")
+	assert.NotContains(t, err.Error(), rawValue)
+}
+
 func TestSysInfoProbeIsNotSerialized(t *testing.T) {
 	si := SysInfo{
 		SysObjectID: "1.3.6.1.4.1.9.1.1166",


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails SNMP collection with a clear diagnostic when no metric profile matches a device, instead of silently collecting only ping charts.

**Behavior**
- Collection now errors when no metric profiles match unless `ping_only` is set; previously `ping.enabled` alone allowed profile-less operation.
- `ping.enabled` documentation now clarifies it only collects ICMP alongside profile metrics.
- Caches system identity after first collection so `Check` and `ensureInitialized` reuse it.

**Diagnostics**
- Error message distinguishes an empty system walk, a missing `sysObjectID`, or an unmatched `sysObjectID`, and recommends `manual_profiles` or `ping_only`.
- New probe metadata records PDU count, first/last OID, and which system OIDs were seen, without logging raw system values.

<sup>Written for commit 455ad9248f89fbffae33e1ac11bc6f15119274fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SNMP device identification and metric-profile matching, including partial or incomplete system responses.
  - Devices without applicable metric profiles now receive clearer diagnostics, while ping-only monitoring continues to work as intended.
  - Improved handling and reporting of SNMP walk failures and invalid system identity data.
  - Prevented sensitive raw system values from appearing in diagnostic output.

- **Documentation**
  - Clarified that enabling ping adds ICMP latency metrics but does not enable profile-less monitoring; use ping-only mode for that scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->