### PR TITLE
health: remove unused health_log_detail indexes

### DIFF
--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -86,8 +86,6 @@ const char *database_config[] = {
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_3 ON health_log_detail (transition_id)",
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_9 ON health_log_detail (unique_id DESC, health_log_id)",
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_6 on health_log_detail (health_log_id, when_key)",
-    "CREATE INDEX IF NOT EXISTS health_log_d_ind_7 on health_log_detail (alarm_id)",
-    "CREATE INDEX IF NOT EXISTS health_log_d_ind_8 on health_log_detail (new_status, updated_by_id)",
 
     "CREATE TABLE IF NOT EXISTS agent_event_log (id INTEGER PRIMARY KEY, version TEXT, event_type INT, value, date_created INT)",
     "CREATE INDEX IF NOT EXISTS idx_agent_event_log1 on agent_event_log (event_type)",
@@ -126,6 +124,21 @@ const char *database_cleanup[] = {
     "DROP INDEX IF EXISTS health_log_d_ind_4",
     "DROP INDEX IF EXISTS health_log_d_ind_1",
     "DROP INDEX IF EXISTS health_log_d_ind_5",
+    // health_log_d_ind_7 (alarm_id) and health_log_d_ind_8 (new_status, updated_by_id) are
+    // dropped because nothing can drive a lookup through them. alarm_id is only ever filtered
+    // alongside a far more selective column (transition_id, ~1 row/value, or health_log_id,
+    // ~81), so once the database has statistics the planner prefers those - and on the
+    // databases that have none yet it picks health_log_d_ind_7, which is the worse choice on a
+    // parent, where one alarm_id spans every child's rows. new_status only appears as
+    // "(new_status > 2 OR old_status > 2)" - a range OR'd with an unindexed column, which
+    // cannot drive an index - and updated_by_id only as "<> 0", which never constrains one.
+    // On a large parent they cost ~800MB and 2 of 7 b-tree updates on every insert and delete.
+    //
+    // A conditional drop is enough - this list runs on every startup, after the migrations and
+    // after database_config[], so it covers both new and existing databases and is a no-op once
+    // they are gone. No version bump.
+    "DROP INDEX IF EXISTS health_log_d_ind_7",
+    "DROP INDEX IF EXISTS health_log_d_ind_8",
     "DELETE FROM alert_hash_cloud WHERE hash_id NOT IN (SELECT hash_id FROM alert_hash)",
     NULL
 };


### PR DESCRIPTION
##### Summary
- Remove unused alarm_id and (new_status, updated_by_id) indexes.
- Drop existing indexes during startup cleanup without a database version bump.
- Reduce parent database storage and B-tree maintenance overhead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Removed two unused database indexes that did not improve lookup performance.
  * Added cleanup handling to safely remove these indexes from existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->