### PR TITLE
feat(go.d/snmp_topology): add IpAddressTable support

### DIFF
--- a/.agents/skills/project-snmp-profiles-authoring/SKILL.md
+++ b/.agents/skills/project-snmp-profiles-authoring/SKILL.md
@@ -54,10 +54,11 @@ Use this skill before editing files under:
    indexes such as `InetAddress`.
 15. To constrain a topology table to a fixed structural index prefix, use one
     readable anchor symbol and set `table.OID` to `<anchor-column>.<prefix>`.
-    Simple same-index cross-table dependencies inherit that prefix and are
-    anchor-gated. Do not rely on propagation for ordinary metrics, multiple
-    anchors, `lookup_symbol`, `index_transform`, or conflicting dependency
-    scopes.
+    A simple same-index cross-table dependency inherits that prefix and is
+    anchor-gated only when its target table has no symbol-bearing producer.
+    A target route with a real symbol owner remains eager. Do not rely on
+    propagation for ordinary metrics, multiple anchors, `lookup_symbol`,
+    `index_transform`, or conflicting dependency scopes.
 
 ## Device-Scoped MIB Deviations
 
@@ -152,7 +153,7 @@ rg -n -C 4 'OBJECT-TYPE|MAX-ACCESS[[:space:]]+not-accessible|ACCESS[[:space:]]+n
 For known topology-sensitive symbols, scan profile YAMLs before committing:
 
 ```bash
-rg -n 'name:[[:space:]]*(dot1qTpFdbAddress|ipNetToPhysicalIfIndex|ipNetToPhysicalNetAddressType|ipNetToPhysicalNetAddress|lldpLocManAddrSubtype|lldpLocManAddr|lldpRemManAddrSubtype|lldpRemManAddr)\b' src/go/plugin/go.d/config/go.d/snmp.profiles
+rg -n 'name:[[:space:]]*(dot1qTpFdbAddress|ipAddressAddr|ipNetToPhysicalIfIndex|ipNetToPhysicalNetAddressType|ipNetToPhysicalNetAddress|lldpLocManAddrSubtype|lldpLocManAddr|lldpRemManAddrSubtype|lldpRemManAddr)\b' src/go/plugin/go.d/config/go.d/snmp.profiles
 ```
 
 Any hit must be reviewed. It is valid only when the tag is index-derived without a `symbol.OID`, or when it satisfies every

--- a/.agents/skills/project-snmp-profiles-authoring/SKILL.md
+++ b/.agents/skills/project-snmp-profiles-authoring/SKILL.md
@@ -125,8 +125,10 @@ metric_tags:
 The table root anchors on readable `ipAddressIfIndex` and appends index prefix
 `1.4` for IPv4 type and its required four-octet length. The address is the
 not-accessible `ipAddressAddr` index component; `start: 2` skips address type
-and length. Keep the transformed octets raw so malformed trailing components
-cannot be normalized as another address family.
+and length. Keep the transformed components raw and require the topology
+consumer to decode exactly four decimal octets in `0..255`; structural walk
+scope alone does not validate the remaining instance suffix. A malformed
+descendant can activate dependency walks, but it MUST NOT emit topology.
 
 LLDP-MIB local management address:
 

--- a/.agents/skills/project-snmp-profiles-authoring/SKILL.md
+++ b/.agents/skills/project-snmp-profiles-authoring/SKILL.md
@@ -52,6 +52,11 @@ Use this skill before editing files under:
    row-index selector: `index`, `index_from_end`, or `index_transform`. Use
    `index_from_end` for trailing AFI/SAFI-like components after variable-length
    indexes such as `InetAddress`.
+15. To constrain a topology table to a fixed structural index prefix, use one
+    readable anchor symbol and set `table.OID` to `<anchor-column>.<prefix>`.
+    Simple same-index cross-table dependencies inherit that prefix and are
+    anchor-gated. Do not rely on propagation for multiple anchors,
+    `lookup_symbol`, or conflicting dependency scopes.
 
 ## Device-Scoped MIB Deviations
 
@@ -100,6 +105,25 @@ IP-MIB `ipNetToPhysicalTable` address:
 ```
 
 The `start: 3` skips `ifIndex`, address type, and the InetAddress length byte.
+
+IP-MIB `ipAddressTable` IPv4 address:
+
+```yaml
+table:
+  OID: 1.3.6.1.2.1.4.34.1.3.1
+symbols:
+  - OID: 1.3.6.1.2.1.4.34.1.3
+metric_tags:
+  - tag: topo_ip_addr
+    symbol:
+      format: ip_address
+    index_transform:
+      - start: 2
+```
+
+The table root anchors on readable `ipAddressIfIndex` and appends index prefix
+`1` for IPv4. The address is the not-accessible `ipAddressAddr` index component;
+`start: 2` skips address type and length.
 
 LLDP-MIB local management address:
 

--- a/.agents/skills/project-snmp-profiles-authoring/SKILL.md
+++ b/.agents/skills/project-snmp-profiles-authoring/SKILL.md
@@ -113,11 +113,14 @@ IP-MIB `ipAddressTable` IPv4 address:
 ```yaml
 table:
   OID: 1.3.6.1.2.1.4.34.1.3.1.4
+  name: ipAddressTableIPv4
 symbols:
   - OID: 1.3.6.1.2.1.4.34.1.3
+    name: ip_if_index
 metric_tags:
   - tag: topo_ip_addr
     symbol:
+      name: ipAddressAddr
     index_transform:
       - start: 2
 ```
@@ -125,7 +128,9 @@ metric_tags:
 The table root anchors on readable `ipAddressIfIndex` and appends index prefix
 `1.4` for IPv4 type and its required four-octet length. The address is the
 not-accessible `ipAddressAddr` index component; `start: 2` skips address type
-and length. Keep the transformed components raw and require the topology
+and length. The open-ended slice is intentional: a fixed `end` would hide
+malformed trailing components instead of letting the strict consumer reject
+the row. Keep the transformed components raw and require the topology
 consumer to decode exactly four decimal octets in `0..255`; structural walk
 scope alone does not validate the remaining instance suffix. A malformed
 descendant can activate dependency walks, but it MUST NOT emit topology.

--- a/.agents/skills/project-snmp-profiles-authoring/SKILL.md
+++ b/.agents/skills/project-snmp-profiles-authoring/SKILL.md
@@ -55,8 +55,9 @@ Use this skill before editing files under:
 15. To constrain a topology table to a fixed structural index prefix, use one
     readable anchor symbol and set `table.OID` to `<anchor-column>.<prefix>`.
     Simple same-index cross-table dependencies inherit that prefix and are
-    anchor-gated. Do not rely on propagation for multiple anchors,
-    `lookup_symbol`, or conflicting dependency scopes.
+    anchor-gated. Do not rely on propagation for ordinary metrics, multiple
+    anchors, `lookup_symbol`, `index_transform`, or conflicting dependency
+    scopes.
 
 ## Device-Scoped MIB Deviations
 

--- a/.agents/skills/project-snmp-profiles-authoring/SKILL.md
+++ b/.agents/skills/project-snmp-profiles-authoring/SKILL.md
@@ -112,20 +112,21 @@ IP-MIB `ipAddressTable` IPv4 address:
 
 ```yaml
 table:
-  OID: 1.3.6.1.2.1.4.34.1.3.1
+  OID: 1.3.6.1.2.1.4.34.1.3.1.4
 symbols:
   - OID: 1.3.6.1.2.1.4.34.1.3
 metric_tags:
   - tag: topo_ip_addr
     symbol:
-      format: ip_address
     index_transform:
       - start: 2
 ```
 
 The table root anchors on readable `ipAddressIfIndex` and appends index prefix
-`1` for IPv4. The address is the not-accessible `ipAddressAddr` index component;
-`start: 2` skips address type and length.
+`1.4` for IPv4 type and its required four-octet length. The address is the
+not-accessible `ipAddressAddr` index component; `start: 2` skips address type
+and length. Keep the transformed octets raw so malformed trailing components
+cannot be normalized as another address family.
 
 LLDP-MIB local management address:
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report_test.go
@@ -410,6 +410,54 @@ func TestCollector_AcquisitionObserverReportsSyntheticDependencyVarbindCounts(t 
 	assert.Equal(t, uint64(4), routes[dependency.Table.OID].Values)
 }
 
+func TestCollector_AcquisitionObserverLeavesDormantDependencyUnobserved(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	dependency, source := crossTableDependencyTestConfigs("1.3.6.1.4.1.99999.57")
+	profile := &ddsnmp.Profile{
+		SourceFile: "dormant-topology-dependency.yaml",
+		Definition: &ddprofiledefinition.ProfileDefinition{Topology: []ddprofiledefinition.TopologyConfig{{
+			Kind:          ddsnmp.KindArpEntry,
+			MetricsConfig: source,
+		}}},
+	}
+	ddsnmp.HandleCrossTableTagsWithoutMetrics(profile)
+	var dependencyRoot string
+	for _, cfg := range profile.Definition.Topology {
+		if cfg.Table.Name == dependency.Table.Name && len(cfg.Symbols) == 0 {
+			dependencyRoot = cfg.Table.OID
+			break
+		}
+	}
+	require.NotEmpty(t, dependencyRoot)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, source.Table.OID, nil)
+
+	var report AcquisitionProfileReport
+	collector := New(Config{
+		SnmpClient: mockHandler,
+		Profiles:   []*ddsnmp.Profile{profile},
+		Log:        logger.New(),
+		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+			report = value
+		}),
+	})
+	_, err := collector.Collect()
+	require.NoError(t, err)
+
+	require.Len(t, report.Routes, 2)
+	routes := make(map[string]AcquisitionRouteReport, len(report.Routes))
+	for _, route := range report.Routes {
+		routes[route.RootOID] = route
+	}
+	assert.Equal(t, AcquisitionRouteSourceWalk, routes[source.Table.OID].Source)
+	assert.Equal(t, AcquisitionRouteOutcomeEmpty, routes[source.Table.OID].Outcome)
+	dependencyRoute, ok := routes[dependencyRoot]
+	require.True(t, ok)
+	assert.Equal(t, AcquisitionRouteSourceNone, dependencyRoute.Source)
+	assert.Equal(t, AcquisitionRouteOutcomeNotObserved, dependencyRoute.Outcome)
+}
+
 func TestCollector_AcquisitionObserverFiltersSharedWalkToSyntheticDependencyRoot(t *testing.T) {
 	ctrl, mockHandler := setupMockHandler(t)
 	defer ctrl.Finish()

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
@@ -19,6 +19,7 @@ type tableRouteState uint8
 
 const (
 	tableRoutePending tableRouteState = iota
+	tableRouteDormant
 	tableRouteNeedsFresh
 	tableRouteCached
 	tableRouteFresh
@@ -202,6 +203,8 @@ func (s *tableCollectionSession) resolve() {
 		if trigger := s.stageCached(route); trigger != nil {
 			s.requireFresh(route, trigger, &freshQueue)
 			s.resolveFreshQueue(&freshQueue)
+		} else if s.isDependencyOnlyTopologyRoute(route) {
+			route.state = tableRouteDormant
 		} else {
 			route.state = tableRouteCached
 		}
@@ -529,6 +532,9 @@ func (s *tableCollectionSession) collectScope(scope *tableCollectionScope) ([]dd
 		}
 
 		switch req.route.state {
+		case tableRouteDormant:
+			// The owner had no eligible rows, so this dependency was never observed.
+			continue
 		case tableRouteCached:
 			tablesSeen[req.route.oid] = true
 			if acquisition != nil {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
@@ -102,6 +102,10 @@ func (g *tableRouteGraph) dependencies(req *tableCollectionRequest) []*tableColl
 	return g.dependenciesByRequest[req]
 }
 
+func (g *tableRouteGraph) hasDependents(route *tableCollectionRoute) bool {
+	return len(g.dependentsByRoute[route]) > 0
+}
+
 func (g *tableRouteGraph) dependents(route *tableCollectionRoute) []*tableCollectionRoute {
 	byOID := g.dependentsByRoute[route]
 	if len(byOID) == 0 {
@@ -335,7 +339,7 @@ func (s *tableCollectionSession) routeNeedsFresh(route *tableCollectionRoute) bo
 }
 
 func (s *tableCollectionSession) isDependencyOnlyTopologyRoute(route *tableCollectionRoute) bool {
-	if len(s.graph.dependents(route)) == 0 {
+	if !s.graph.hasDependents(route) {
 		return false
 	}
 	for _, req := range route.requests {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
@@ -190,7 +190,7 @@ func (s *tableCollectionSession) resolve() {
 	routes := s.sortedRoutes()
 	var freshQueue []freshRouteWork
 	for _, route := range routes {
-		if routeNeedsFresh(route) {
+		if s.routeNeedsFresh(route) {
 			s.requireFresh(route, freshTriggerForRoute(route), &freshQueue)
 		}
 	}
@@ -322,6 +322,25 @@ func routeNeedsFresh(route *tableCollectionRoute) bool {
 		}
 	}
 	return !hasCacheOwner
+}
+
+func (s *tableCollectionSession) routeNeedsFresh(route *tableCollectionRoute) bool {
+	if s.isDependencyOnlyTopologyRoute(route) {
+		return false
+	}
+	return routeNeedsFresh(route)
+}
+
+func (s *tableCollectionSession) isDependencyOnlyTopologyRoute(route *tableCollectionRoute) bool {
+	if len(s.graph.dependents(route)) == 0 {
+		return false
+	}
+	for _, req := range route.requests {
+		if req.scope.mode != tableSymbolModePresence || len(req.config.Symbols) != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func freshTriggerForRoute(route *tableCollectionRoute) *tableCollectionRequest {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_topology_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_topology_test.go
@@ -144,3 +144,99 @@ func TestCollector_CollectTopologyMetrics_TableSymbolUsesPDUPresenceWithoutStruc
 	require.Zero(t, secondWalkStats.TableCache.Hits)
 	require.Zero(t, secondWalkStats.TableCache.Misses)
 }
+
+func TestCollector_CollectTopologyMetrics_DependencyOnlyRouteWaitsForAnchorRows(t *testing.T) {
+	const (
+		anchorTableOID      = "1.3.6.1.4.1.99999.1"
+		anchorColumnOID     = anchorTableOID + ".1"
+		dependencyColumnOID = "1.3.6.1.4.1.99999.2.1"
+	)
+
+	profile := &ddsnmp.Profile{
+		SourceFile: "topology-lazy-dependency.yaml",
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Topology: []ddprofiledefinition.TopologyConfig{{
+				Kind: ddsnmp.KindIpIfIndex,
+				MetricsConfig: ddprofiledefinition.MetricsConfig{
+					Table:   ddprofiledefinition.SymbolConfig{OID: anchorTableOID, Name: "anchorTable"},
+					Symbols: []ddprofiledefinition.SymbolConfig{{OID: anchorColumnOID, Name: "ip_if_index"}},
+					MetricTags: []ddprofiledefinition.MetricTagConfig{{
+						Tag:    "dependency_value",
+						Table:  "dependencyTable",
+						Symbol: ddprofiledefinition.SymbolConfigCompat{OID: dependencyColumnOID, Name: "dependencyValue"},
+					}},
+				},
+			}},
+		},
+	}
+	ddsnmp.HandleCrossTableTagsWithoutMetrics(profile)
+
+	device := newStatefulSNMPDevice()
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+	device.install(mockHandler)
+	collector := New(Config{
+		SnmpClient: mockHandler,
+		Profiles:   []*ddsnmp.Profile{profile},
+		Log:        logger.New(),
+	})
+
+	results, err := collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].TopologyMetrics)
+	assert.Equal(t, 1, device.walkCount[anchorTableOID])
+	assert.Zero(t, device.walkCount[dependencyColumnOID])
+}
+
+func TestCollector_CollectTopologyMetrics_DependencyWithSymbolOwnerRemainsEager(t *testing.T) {
+	const (
+		anchorTableOID      = "1.3.6.1.4.1.99999.1"
+		anchorColumnOID     = anchorTableOID + ".1"
+		dependencyColumnOID = "1.3.6.1.4.1.99999.2.1"
+	)
+
+	profile := &ddsnmp.Profile{
+		SourceFile: "topology-owned-dependency.yaml",
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Topology: []ddprofiledefinition.TopologyConfig{
+				{
+					Kind: ddsnmp.KindIpIfIndex,
+					MetricsConfig: ddprofiledefinition.MetricsConfig{
+						Table:   ddprofiledefinition.SymbolConfig{OID: anchorTableOID, Name: "anchorTable"},
+						Symbols: []ddprofiledefinition.SymbolConfig{{OID: anchorColumnOID, Name: "anchor"}},
+						MetricTags: []ddprofiledefinition.MetricTagConfig{{
+							Tag:    "dependency_value",
+							Table:  "dependencyTable",
+							Symbol: ddprofiledefinition.SymbolConfigCompat{OID: dependencyColumnOID, Name: "dependencyValue"},
+						}},
+					},
+				},
+				{
+					Kind: ddsnmp.KindIpIfIndex,
+					MetricsConfig: ddprofiledefinition.MetricsConfig{
+						Table:   ddprofiledefinition.SymbolConfig{OID: dependencyColumnOID, Name: "dependencyTable"},
+						Symbols: []ddprofiledefinition.SymbolConfig{{OID: dependencyColumnOID, Name: "dependencyValue"}},
+					},
+				},
+			},
+		},
+	}
+
+	device := newStatefulSNMPDevice()
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+	device.install(mockHandler)
+	collector := New(Config{
+		SnmpClient: mockHandler,
+		Profiles:   []*ddsnmp.Profile{profile},
+		Log:        logger.New(),
+	})
+
+	results, err := collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].TopologyMetrics)
+	assert.Equal(t, 1, device.walkCount[anchorTableOID])
+	assert.Equal(t, 1, device.walkCount[dependencyColumnOID])
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/topology_profile_index_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/topology_profile_index_test.go
@@ -125,49 +125,6 @@ func TestTopologyProfile_IPAddressUsesTableIndex(t *testing.T) {
 	}}, actual)
 }
 
-func TestTopologyProfile_ModernIPAddressUsesFiveIPv4ColumnRoots(t *testing.T) {
-	ctrl, mockHandler := setupMockHandler(t)
-	defer ctrl.Finish()
-
-	const index = "1.4.192.0.2.17"
-	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.20", nil)
-	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.3.1", []gosnmp.SnmpPDU{
-		createIntegerPDU("1.3.6.1.2.1.4.34.1.3."+index, 7),
-	})
-	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.4.1", []gosnmp.SnmpPDU{
-		createIntegerPDU("1.3.6.1.2.1.4.34.1.4."+index, 1),
-	})
-	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.5.1", []gosnmp.SnmpPDU{
-		createPDU("1.3.6.1.2.1.4.34.1.5."+index, gosnmp.ObjectIdentifier, "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28"),
-	})
-	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.7.1", []gosnmp.SnmpPDU{
-		createIntegerPDU("1.3.6.1.2.1.4.34.1.7."+index, 1),
-	})
-	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.10.1", []gosnmp.SnmpPDU{
-		createIntegerPDU("1.3.6.1.2.1.4.34.1.10."+index, 1),
-	})
-
-	actual := collectTopologyProfileTables(t, mockHandler, "_std-topology-ip-mib")
-
-	assertTableMetricsEqual(t, []ddsnmp.Metric{{
-		Name:       "ip_if_index",
-		StaticTags: map[string]string{"topo_ip_source": "modern"},
-		Tags: map[string]string{
-			"topo_ip_addr":           "192.0.2.17",
-			"topo_if_index":          "7",
-			"topo_ip_source":         "modern",
-			"topo_ip_type":           "unicast",
-			"topo_ip_prefix_pointer": "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28",
-			"topo_ip_status":         "preferred",
-			"topo_ip_row_status":     "active",
-		},
-		MetricType:   "gauge",
-		IsTable:      true,
-		Table:        "ipAddressTableIPv4",
-		TopologyKind: ddsnmp.KindIpIfIndex,
-	}}, actual)
-}
-
 func TestTopologyProfile_CiscoVTPUsesVLANIndexComponent(t *testing.T) {
 	ctrl, mockHandler := setupMockHandler(t)
 	defer ctrl.Finish()

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/topology_profile_index_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/topology_profile_index_test.go
@@ -109,7 +109,7 @@ func TestTopologyProfile_IPAddressUsesTableIndex(t *testing.T) {
 		createIntegerPDU("1.3.6.1.2.1.4.20.1.2.192.0.2.17", 7),
 		createPDU("1.3.6.1.2.1.4.20.1.3.192.0.2.17", gosnmp.IPAddress, "255.255.255.248"),
 	})
-	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.3.1", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.3.1.4", nil)
 
 	actual := collectTopologyProfileTables(t, mockHandler, "_std-topology-ip-mib")
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/topology_profile_index_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/topology_profile_index_test.go
@@ -109,16 +109,61 @@ func TestTopologyProfile_IPAddressUsesTableIndex(t *testing.T) {
 		createIntegerPDU("1.3.6.1.2.1.4.20.1.2.192.0.2.17", 7),
 		createPDU("1.3.6.1.2.1.4.20.1.3.192.0.2.17", gosnmp.IPAddress, "255.255.255.248"),
 	})
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.3.1", nil)
 
 	actual := collectTopologyProfileTables(t, mockHandler, "_std-topology-ip-mib")
 
 	assertTableMetricsEqual(t, []ddsnmp.Metric{{
 		Name:         "ip_if_index",
 		Value:        0,
-		Tags:         map[string]string{"topo_ip_addr": "192.0.2.17", "topo_if_index": "7", "topo_ip_netmask": "255.255.255.248"},
+		StaticTags:   map[string]string{"topo_ip_source": "legacy"},
+		Tags:         map[string]string{"topo_ip_addr": "192.0.2.17", "topo_if_index": "7", "topo_ip_netmask": "255.255.255.248", "topo_ip_source": "legacy"},
 		MetricType:   "gauge",
 		IsTable:      true,
 		Table:        "ipAddrTable",
+		TopologyKind: ddsnmp.KindIpIfIndex,
+	}}, actual)
+}
+
+func TestTopologyProfile_ModernIPAddressUsesFiveIPv4ColumnRoots(t *testing.T) {
+	ctrl, mockHandler := setupMockHandler(t)
+	defer ctrl.Finish()
+
+	const index = "1.4.192.0.2.17"
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.20", nil)
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.3.1", []gosnmp.SnmpPDU{
+		createIntegerPDU("1.3.6.1.2.1.4.34.1.3."+index, 7),
+	})
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.4.1", []gosnmp.SnmpPDU{
+		createIntegerPDU("1.3.6.1.2.1.4.34.1.4."+index, 1),
+	})
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.5.1", []gosnmp.SnmpPDU{
+		createPDU("1.3.6.1.2.1.4.34.1.5."+index, gosnmp.ObjectIdentifier, "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28"),
+	})
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.7.1", []gosnmp.SnmpPDU{
+		createIntegerPDU("1.3.6.1.2.1.4.34.1.7."+index, 1),
+	})
+	expectSNMPWalk(mockHandler, gosnmp.Version2c, "1.3.6.1.2.1.4.34.1.10.1", []gosnmp.SnmpPDU{
+		createIntegerPDU("1.3.6.1.2.1.4.34.1.10."+index, 1),
+	})
+
+	actual := collectTopologyProfileTables(t, mockHandler, "_std-topology-ip-mib")
+
+	assertTableMetricsEqual(t, []ddsnmp.Metric{{
+		Name:       "ip_if_index",
+		StaticTags: map[string]string{"topo_ip_source": "modern"},
+		Tags: map[string]string{
+			"topo_ip_addr":           "192.0.2.17",
+			"topo_if_index":          "7",
+			"topo_ip_source":         "modern",
+			"topo_ip_type":           "unicast",
+			"topo_ip_prefix_pointer": "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28",
+			"topo_ip_status":         "preferred",
+			"topo_ip_row_status":     "active",
+		},
+		MetricType:   "gauge",
+		IsTable:      true,
+		Table:        "ipAddressTableIPv4",
 		TopologyKind: ddsnmp.KindIpIfIndex,
 	}}, actual)
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare.go
@@ -93,6 +93,8 @@ func (d *crossTableDependency) add(tag ddprofiledefinition.MetricTagConfig, inde
 	scopedWalkOID := ""
 	if indexScope != "" && tag.Index == 0 && len(tag.IndexTransform) == 0 &&
 		tag.Symbol.OID != "" && tag.LookupSymbol.OID == "" {
+		// A direct cross-table join already requires the dependency to use the
+		// anchor's unchanged row-index suffix. Narrowing only preserves its fixed prefix.
 		scopedWalkOID = trimProfileOID(tag.Symbol.OID) + "." + indexScope
 	}
 	if d.seen && d.scopedWalkOID != scopedWalkOID {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare.go
@@ -4,6 +4,7 @@ package ddsnmp
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
@@ -39,8 +40,9 @@ func handleCrossTableTagsWithoutMetricsForRows(metrics *[]ddprofiledefinition.Me
 		seenTableNames[m.Table.Name] = true
 	}
 
-	tagCrossTableOnlyOIDs := crossTableOnlyTagOIDs(*metrics, seenTableNames)
-	for tableName, dependency := range tagCrossTableOnlyOIDs {
+	tagCrossTableOnlyOIDs := crossTableOnlyTagOIDs(*metrics, seenTableNames, false)
+	for _, tableName := range sortedDependencyNames(tagCrossTableOnlyOIDs) {
+		dependency := tagCrossTableOnlyOIDs[tableName]
 		*metrics = append(*metrics, syntheticCrossTableMetric(tableName, dependency.walkOID()))
 	}
 }
@@ -51,16 +53,25 @@ func handleCrossTableTagsWithoutMetricsForTopologyRows(topology *[]ddprofiledefi
 		seenTableNames[topo.Table.Name] = true
 	}
 
-	for i := range *topology {
-		topo := &(*topology)[i]
-		tagCrossTableOnlyOIDs := crossTableOnlyTagOIDs([]ddprofiledefinition.MetricsConfig{topo.MetricsConfig}, seenTableNames)
-		for tableName, dependency := range tagCrossTableOnlyOIDs {
-			*topology = append(*topology, ddprofiledefinition.TopologyConfig{
-				Kind:          topo.Kind,
-				MetricsConfig: syntheticCrossTableMetric(tableName, dependency.walkOID()),
-			})
-			seenTableNames[tableName] = true
+	metrics := make([]ddprofiledefinition.MetricsConfig, 0, len(*topology))
+	dependencyKinds := make(map[string]ddprofiledefinition.TopologyKind)
+	for _, topo := range *topology {
+		metrics = append(metrics, topo.MetricsConfig)
+		for _, tag := range topo.MetricTags {
+			if tag.Table != "" && !seenTableNames[tag.Table] {
+				if _, ok := dependencyKinds[tag.Table]; !ok {
+					dependencyKinds[tag.Table] = topo.Kind
+				}
+			}
 		}
+	}
+
+	tagCrossTableOnlyOIDs := crossTableOnlyTagOIDs(metrics, seenTableNames, true)
+	for _, tableName := range sortedDependencyNames(tagCrossTableOnlyOIDs) {
+		*topology = append(*topology, ddprofiledefinition.TopologyConfig{
+			Kind:          dependencyKinds[tableName],
+			MetricsConfig: syntheticCrossTableMetric(tableName, tagCrossTableOnlyOIDs[tableName].walkOID()),
+		})
 	}
 }
 
@@ -80,7 +91,8 @@ func (d *crossTableDependency) add(tag ddprofiledefinition.MetricTagConfig, inde
 	}
 
 	scopedWalkOID := ""
-	if indexScope != "" && tag.Symbol.OID != "" && tag.LookupSymbol.OID == "" {
+	if indexScope != "" && tag.Index == 0 && len(tag.IndexTransform) == 0 &&
+		tag.Symbol.OID != "" && tag.LookupSymbol.OID == "" {
 		scopedWalkOID = trimProfileOID(tag.Symbol.OID) + "." + indexScope
 	}
 	if d.seen && d.scopedWalkOID != scopedWalkOID {
@@ -97,13 +109,20 @@ func (d crossTableDependency) walkOID() string {
 	return longestCommonPrefix(d.oids)
 }
 
-func crossTableOnlyTagOIDs(metrics []ddprofiledefinition.MetricsConfig, seenTableNames map[string]bool) map[string]*crossTableDependency {
+func crossTableOnlyTagOIDs(
+	metrics []ddprofiledefinition.MetricsConfig,
+	seenTableNames map[string]bool,
+	propagateIndexScope bool,
+) map[string]*crossTableDependency {
 	tagCrossTableOnlyOIDs := make(map[string]*crossTableDependency)
 	for _, m := range metrics {
 		if m.IsScalar() {
 			continue
 		}
-		indexScope := tableIndexScope(m)
+		indexScope := ""
+		if propagateIndexScope {
+			indexScope = tableIndexScope(m)
+		}
 		for _, tag := range m.MetricTags {
 			if tag.Table == "" || seenTableNames[tag.Table] {
 				continue
@@ -117,6 +136,15 @@ func crossTableOnlyTagOIDs(metrics []ddprofiledefinition.MetricsConfig, seenTabl
 		}
 	}
 	return tagCrossTableOnlyOIDs
+}
+
+func sortedDependencyNames(dependencies map[string]*crossTableDependency) []string {
+	names := make([]string, 0, len(dependencies))
+	for name := range dependencies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func syntheticCrossTableMetric(tableName, walkOID string) ddprofiledefinition.MetricsConfig {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare.go
@@ -4,7 +4,6 @@ package ddsnmp
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
@@ -21,8 +20,10 @@ func HandleCrossTableTagsWithoutMetrics(prof *Profile) {
 // are still walked during collection. Without this, if a table like ifXTable is used
 // only for cross-table tags (e.g., getting interface names) but has no metrics defined,
 // it won't be walked and the tags will be missing. This creates synthetic metric entries
-// for such tables using the longest common OID prefix of the referenced columns, including
-// lookup columns used by value-based joins.
+// for such tables. The walk root is normally the longest common OID prefix of the
+// referenced columns, including lookup columns used by value-based joins. A fixed
+// structural index prefix on a single readable anchor is also propagated to simple
+// same-index dependency columns so both sides retain the same narrowed row scope.
 func handleCrossTableTagsWithoutMetrics(prof *Profile) {
 	if prof.Definition == nil {
 		return
@@ -39,8 +40,8 @@ func handleCrossTableTagsWithoutMetricsForRows(metrics *[]ddprofiledefinition.Me
 	}
 
 	tagCrossTableOnlyOIDs := crossTableOnlyTagOIDs(*metrics, seenTableNames)
-	for tableName, oids := range tagCrossTableOnlyOIDs {
-		*metrics = append(*metrics, syntheticCrossTableMetric(tableName, oids))
+	for tableName, dependency := range tagCrossTableOnlyOIDs {
+		*metrics = append(*metrics, syntheticCrossTableMetric(tableName, dependency.walkOID()))
 	}
 }
 
@@ -53,48 +54,96 @@ func handleCrossTableTagsWithoutMetricsForTopologyRows(topology *[]ddprofiledefi
 	for i := range *topology {
 		topo := &(*topology)[i]
 		tagCrossTableOnlyOIDs := crossTableOnlyTagOIDs([]ddprofiledefinition.MetricsConfig{topo.MetricsConfig}, seenTableNames)
-		for tableName, oids := range tagCrossTableOnlyOIDs {
+		for tableName, dependency := range tagCrossTableOnlyOIDs {
 			*topology = append(*topology, ddprofiledefinition.TopologyConfig{
 				Kind:          topo.Kind,
-				MetricsConfig: syntheticCrossTableMetric(tableName, oids),
+				MetricsConfig: syntheticCrossTableMetric(tableName, dependency.walkOID()),
 			})
 			seenTableNames[tableName] = true
 		}
 	}
 }
 
-func crossTableOnlyTagOIDs(metrics []ddprofiledefinition.MetricsConfig, seenTableNames map[string]bool) map[string][]string {
-	tagCrossTableOnlyOIDs := make(map[string][]string)
+type crossTableDependency struct {
+	oids          []string
+	scopedWalkOID string
+	scopeConflict bool
+	seen          bool
+}
+
+func (d *crossTableDependency) add(tag ddprofiledefinition.MetricTagConfig, indexScope string) {
+	if tag.Symbol.OID != "" {
+		d.oids = append(d.oids, tag.Symbol.OID)
+	}
+	if tag.LookupSymbol.OID != "" {
+		d.oids = append(d.oids, tag.LookupSymbol.OID)
+	}
+
+	scopedWalkOID := ""
+	if indexScope != "" && tag.Symbol.OID != "" && tag.LookupSymbol.OID == "" {
+		scopedWalkOID = trimProfileOID(tag.Symbol.OID) + "." + indexScope
+	}
+	if d.seen && d.scopedWalkOID != scopedWalkOID {
+		d.scopeConflict = true
+	}
+	d.seen = true
+	d.scopedWalkOID = scopedWalkOID
+}
+
+func (d crossTableDependency) walkOID() string {
+	if !d.scopeConflict && d.scopedWalkOID != "" {
+		return d.scopedWalkOID
+	}
+	return longestCommonPrefix(d.oids)
+}
+
+func crossTableOnlyTagOIDs(metrics []ddprofiledefinition.MetricsConfig, seenTableNames map[string]bool) map[string]*crossTableDependency {
+	tagCrossTableOnlyOIDs := make(map[string]*crossTableDependency)
 	for _, m := range metrics {
 		if m.IsScalar() {
 			continue
 		}
+		indexScope := tableIndexScope(m)
 		for _, tag := range m.MetricTags {
 			if tag.Table == "" || seenTableNames[tag.Table] {
 				continue
 			}
-			if tag.Symbol.OID != "" {
-				tagCrossTableOnlyOIDs[tag.Table] = append(tagCrossTableOnlyOIDs[tag.Table], tag.Symbol.OID)
+			dependency := tagCrossTableOnlyOIDs[tag.Table]
+			if dependency == nil {
+				dependency = &crossTableDependency{}
+				tagCrossTableOnlyOIDs[tag.Table] = dependency
 			}
-			if tag.LookupSymbol.OID != "" {
-				tagCrossTableOnlyOIDs[tag.Table] = append(tagCrossTableOnlyOIDs[tag.Table], tag.LookupSymbol.OID)
-			}
+			dependency.add(tag, indexScope)
 		}
 	}
 	return tagCrossTableOnlyOIDs
 }
 
-func syntheticCrossTableMetric(tableName string, oids []string) ddprofiledefinition.MetricsConfig {
-	slices.Sort(oids)
-	oids = slices.Compact(oids)
-
+func syntheticCrossTableMetric(tableName, walkOID string) ddprofiledefinition.MetricsConfig {
 	return ddprofiledefinition.MetricsConfig{
 		MIB: fmt.Sprintf("synthetic-%s-MIB", tableName),
 		Table: ddprofiledefinition.SymbolConfig{
-			OID:  longestCommonPrefix(oids),
+			OID:  walkOID,
 			Name: tableName,
 		},
 	}
+}
+
+func tableIndexScope(metric ddprofiledefinition.MetricsConfig) string {
+	if len(metric.Symbols) != 1 {
+		return ""
+	}
+	tableOID := trimProfileOID(metric.Table.OID)
+	columnOID := trimProfileOID(metric.Symbols[0].OID)
+	scope, ok := strings.CutPrefix(tableOID, columnOID+".")
+	if !ok {
+		return ""
+	}
+	return scope
+}
+
+func trimProfileOID(oid string) string {
+	return strings.Trim(oid, ".")
 }
 
 func longestCommonPrefix(oids []string) string {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare_test.go
@@ -133,6 +133,122 @@ func TestHandleCrossTableTagsWithoutMetrics_PropagatesNarrowAnchorIndexScope(t *
 	assert.Equal(t, dependencyColumnOID+".1", profile.Definition.Topology[1].Table.OID)
 }
 
+func TestHandleCrossTableTagsWithoutMetrics_DoesNotScopeOrdinaryMetrics(t *testing.T) {
+	const (
+		anchorColumnOID     = "1.3.6.1.2.1.4.34.1.3"
+		dependencyColumnOID = "1.3.6.1.2.1.4.34.1.4"
+	)
+	profile := &Profile{Definition: &ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{{
+			Table:   ddprofiledefinition.SymbolConfig{OID: anchorColumnOID + ".1", Name: "scopedMetricTable"},
+			Symbols: []ddprofiledefinition.SymbolConfig{{OID: anchorColumnOID, Name: "value"}},
+			MetricTags: []ddprofiledefinition.MetricTagConfig{{
+				Tag:    "dependency_value",
+				Table:  "dependencyTable",
+				Symbol: ddprofiledefinition.SymbolConfigCompat{OID: dependencyColumnOID, Name: "dependencyValue"},
+			}},
+		}},
+	}}
+
+	handleCrossTableTagsWithoutMetrics(profile)
+
+	require.Len(t, profile.Definition.Metrics, 2)
+	assert.Equal(t, dependencyColumnOID, profile.Definition.Metrics[1].Table.OID)
+}
+
+func TestHandleCrossTableTagsWithoutMetrics_DoesNotScopeTransformedTopologyJoin(t *testing.T) {
+	const (
+		anchorColumnOID     = "1.3.6.1.2.1.4.34.1.3"
+		dependencyColumnOID = "1.3.6.1.2.1.4.34.1.4"
+	)
+	profile := &Profile{Definition: &ddprofiledefinition.ProfileDefinition{
+		Topology: []ddprofiledefinition.TopologyConfig{{
+			Kind: ddprofiledefinition.KindIpIfIndex,
+			MetricsConfig: ddprofiledefinition.MetricsConfig{
+				Table:   ddprofiledefinition.SymbolConfig{OID: anchorColumnOID + ".1", Name: "scopedTopologyTable"},
+				Symbols: []ddprofiledefinition.SymbolConfig{{OID: anchorColumnOID, Name: "ip_if_index"}},
+				MetricTags: []ddprofiledefinition.MetricTagConfig{{
+					Tag:            "dependency_value",
+					Table:          "dependencyTable",
+					Symbol:         ddprofiledefinition.SymbolConfigCompat{OID: dependencyColumnOID, Name: "dependencyValue"},
+					IndexTransform: []ddprofiledefinition.MetricIndexTransform{{Start: 1}},
+				}},
+			},
+		}},
+	}}
+
+	handleCrossTableTagsWithoutMetrics(profile)
+
+	require.Len(t, profile.Definition.Topology, 2)
+	assert.Equal(t, dependencyColumnOID, profile.Definition.Topology[1].Table.OID)
+}
+
+func TestHandleCrossTableTagsWithoutMetrics_ConflictingTopologyScopesUseFullDependencyColumn(t *testing.T) {
+	const (
+		anchorColumnOID     = "1.3.6.1.2.1.4.34.1.3"
+		dependencyColumnOID = "1.3.6.1.2.1.4.34.1.4"
+	)
+	row := func(scope string) ddprofiledefinition.TopologyConfig {
+		return ddprofiledefinition.TopologyConfig{
+			Kind: ddprofiledefinition.KindIpIfIndex,
+			MetricsConfig: ddprofiledefinition.MetricsConfig{
+				Table:   ddprofiledefinition.SymbolConfig{OID: anchorColumnOID + "." + scope, Name: "anchor" + scope},
+				Symbols: []ddprofiledefinition.SymbolConfig{{OID: anchorColumnOID, Name: "ip_if_index"}},
+				MetricTags: []ddprofiledefinition.MetricTagConfig{{
+					Tag:    "dependency_value",
+					Table:  "dependencyTable",
+					Symbol: ddprofiledefinition.SymbolConfigCompat{OID: dependencyColumnOID, Name: "dependencyValue"},
+				}},
+			},
+		}
+	}
+
+	for _, scopes := range [][]string{{"1", "2"}, {"2", "1"}} {
+		t.Run(scopes[0]+"_then_"+scopes[1], func(t *testing.T) {
+			profile := &Profile{Definition: &ddprofiledefinition.ProfileDefinition{
+				Topology: []ddprofiledefinition.TopologyConfig{row(scopes[0]), row(scopes[1])},
+			}}
+
+			handleCrossTableTagsWithoutMetrics(profile)
+
+			require.Len(t, profile.Definition.Topology, 3)
+			assert.Equal(t, "dependencyTable", profile.Definition.Topology[2].Table.Name)
+			assert.Equal(t, dependencyColumnOID, profile.Definition.Topology[2].Table.OID)
+		})
+	}
+}
+
+func TestHandleCrossTableTagsWithoutMetrics_AppendsDependenciesDeterministically(t *testing.T) {
+	const anchorOID = "1.3.6.1.4.1.99999.1"
+	wantNames := []string{"alphaTable", "middleTable", "zuluTable"}
+	for range 32 {
+		profile := &Profile{Definition: &ddprofiledefinition.ProfileDefinition{
+			Topology: []ddprofiledefinition.TopologyConfig{{
+				Kind: ddprofiledefinition.KindIpIfIndex,
+				MetricsConfig: ddprofiledefinition.MetricsConfig{
+					Table:   ddprofiledefinition.SymbolConfig{OID: anchorOID, Name: "anchorTable"},
+					Symbols: []ddprofiledefinition.SymbolConfig{{OID: anchorOID + ".1", Name: "value"}},
+					MetricTags: []ddprofiledefinition.MetricTagConfig{
+						{Tag: "zulu", Table: "zuluTable", Symbol: ddprofiledefinition.SymbolConfigCompat{OID: "1.3.6.1.4.1.99999.4.1"}},
+						{Tag: "alpha", Table: "alphaTable", Symbol: ddprofiledefinition.SymbolConfigCompat{OID: "1.3.6.1.4.1.99999.2.1"}},
+						{Tag: "middle", Table: "middleTable", Symbol: ddprofiledefinition.SymbolConfigCompat{OID: "1.3.6.1.4.1.99999.3.1"}},
+					},
+				},
+			}},
+		}}
+
+		handleCrossTableTagsWithoutMetrics(profile)
+
+		require.Len(t, profile.Definition.Topology, 4)
+		gotNames := []string{
+			profile.Definition.Topology[1].Table.Name,
+			profile.Definition.Topology[2].Table.Name,
+			profile.Definition.Topology[3].Table.Name,
+		}
+		assert.Equal(t, wantNames, gotNames)
+	}
+}
+
 func TestPrepareLoadedProfile_EnrichesTopologyMappingRefs(t *testing.T) {
 	profile := &Profile{
 		Definition: &ddprofiledefinition.ProfileDefinition{

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_prepare_test.go
@@ -101,6 +101,38 @@ func TestHandleCrossTableTagsWithoutMetrics(t *testing.T) {
 	assert.Equal(t, "1.3.6.1.2.1.17.1.4.1.2", profile.Definition.Topology[1].Table.OID)
 }
 
+func TestHandleCrossTableTagsWithoutMetrics_PropagatesNarrowAnchorIndexScope(t *testing.T) {
+	const (
+		anchorColumnOID     = "1.3.6.1.2.1.4.34.1.3"
+		dependencyColumnOID = "1.3.6.1.2.1.4.34.1.4"
+	)
+	profile := &Profile{
+		Definition: &ddprofiledefinition.ProfileDefinition{
+			Topology: []ddprofiledefinition.TopologyConfig{{
+				Kind: ddprofiledefinition.KindIpIfIndex,
+				MetricsConfig: ddprofiledefinition.MetricsConfig{
+					Table:   ddprofiledefinition.SymbolConfig{OID: anchorColumnOID + ".1", Name: "ipAddressIfIndexIPv4"},
+					Symbols: []ddprofiledefinition.SymbolConfig{{OID: anchorColumnOID, Name: "ip_if_index"}},
+					MetricTags: []ddprofiledefinition.MetricTagConfig{{
+						Tag:   "ip_address_type",
+						Table: "ipAddressTypeIPv4",
+						Symbol: ddprofiledefinition.SymbolConfigCompat{
+							OID:  dependencyColumnOID,
+							Name: "ipAddressType",
+						},
+					}},
+				},
+			}},
+		},
+	}
+
+	handleCrossTableTagsWithoutMetrics(profile)
+
+	require.Len(t, profile.Definition.Topology, 2)
+	assert.Equal(t, "ipAddressTypeIPv4", profile.Definition.Topology[1].Table.Name)
+	assert.Equal(t, dependencyColumnOID+".1", profile.Definition.Topology[1].Table.OID)
+}
+
 func TestPrepareLoadedProfile_EnrichesTopologyMappingRefs(t *testing.T) {
 	profile := &Profile{
 		Definition: &ddprofiledefinition.ProfileDefinition{

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -441,8 +441,10 @@ topology:
   is the symbol column plus a fixed structural index prefix, simple same-index
   cross-table dependencies inherit that prefix. For example, an anchor root
   `<column>.1` constrains dependency column walks to `<dependency-column>.1`.
-  Dependencies using `lookup_symbol`, multiple anchors, or conflicting scopes
-  use their ordinary common-prefix route instead.
+  Dependencies using `lookup_symbol`, `index_transform`, multiple anchors, or
+  conflicting scopes use their ordinary common-prefix route instead. This
+  structural prefix propagation is topology-only; ordinary metric-table
+  dependencies retain their existing common-prefix collection roots.
 - `systemUptime` stays under `metrics:` for regular SNMP collection. It is not a
   topology kind and should not be declared under `topology:`.
 
@@ -480,8 +482,12 @@ Stock profiles compose topology capabilities independently:
 - `_std-topology-ip-mib.yaml` provides IPv4 address, interface-index, and
   netmask facts used for L3 subnet topology. `generic-device.yaml` and
   `generic-ups.yaml` extend it as their baseline. The legacy `ipAddrTable`
-  address is derived from the row index, so the readable ifIndex and netmask
-  columns are sufficient.
+  address is derived from the row index. RFC 4293 `ipAddressTable` IPv4 rows
+  anchor on the readable `ipAddressIfIndex` column and derive the address from
+  the variable-length index. Their type, prefix pointer, address status, and
+  row status dependency columns are IPv4-scoped and remain dormant when the
+  anchor is empty. Both sources resolve into one legacy-preferred per-IP fact;
+  a valid modern prefix fills only a missing legacy mask on the same ifIndex.
 - `_std-topology-interface-mib.yaml` provides interface identity and status.
 - `_std-topology-bridge-base-mib.yaml`, `_std-topology-fdb-mib.yaml`,
   `_std-topology-q-bridge-mib.yaml`, `_std-topology-stp-mib.yaml`, and

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -484,11 +484,13 @@ Stock profiles compose topology capabilities independently:
   `generic-ups.yaml` extend it as their baseline. The legacy `ipAddrTable`
   address is derived from the row index. RFC 4293 `ipAddressTable` IPv4 rows
   anchor on the readable `ipAddressIfIndex` column with the exact IPv4
-  type-and-four-octet-length index prefix, then derive the raw four address
-  octets from the index. Their type, prefix pointer, address status, and row
-  status dependency columns share that scope and remain dormant when the
-  anchor is empty. Both sources resolve into one legacy-preferred per-IP fact;
-  a valid modern prefix fills only a missing legacy mask on the same ifIndex.
+  type-and-four-octet-length index prefix, then derive the raw address suffix
+  from the index. The topology consumer accepts only exactly four decimal
+  octets in `0..255`. Their type, prefix pointer, address status, and row status
+  dependency columns share that scope and remain dormant when the anchor is
+  empty; a malformed descendant can activate them but cannot emit topology.
+  Both sources resolve into one legacy-preferred per-IP fact; a valid modern
+  prefix fills only a missing legacy mask on the same ifIndex.
 - `_std-topology-interface-mib.yaml` provides interface identity and status.
 - `_std-topology-bridge-base-mib.yaml`, `_std-topology-fdb-mib.yaml`,
   `_std-topology-q-bridge-mib.yaml`, `_std-topology-stp-mib.yaml`, and
@@ -1437,8 +1439,9 @@ Examples:
   `ipNetToPhysicalPhysAddress`, is readable and can stay as a column symbol.
 - `IP-MIB::ipAddressAddr` is a `not-accessible` `ipAddressTable` index
   component. For IPv4, constrain the readable `ipAddressIfIndex` anchor to the
-  exact type-and-length prefix `1.4` and keep the four transformed address
-  octets raw so malformed widths or trailing components fail IPv4 parsing.
+  type-and-length prefix `1.4` and keep the transformed suffix raw. The
+  consumer MUST require exactly four decimal octets in `0..255`; the walk root
+  alone cannot reject extra suffix components.
   `ipAddressType`, `ipAddressPrefix`, `ipAddressStatus`, and
   `ipAddressRowStatus` are readable tag sources.
 - `LLDP-MIB::lldpLocManAddrSubtype` and `LLDP-MIB::lldpLocManAddr` are

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -483,9 +483,10 @@ Stock profiles compose topology capabilities independently:
   netmask facts used for L3 subnet topology. `generic-device.yaml` and
   `generic-ups.yaml` extend it as their baseline. The legacy `ipAddrTable`
   address is derived from the row index. RFC 4293 `ipAddressTable` IPv4 rows
-  anchor on the readable `ipAddressIfIndex` column and derive the address from
-  the variable-length index. Their type, prefix pointer, address status, and
-  row status dependency columns are IPv4-scoped and remain dormant when the
+  anchor on the readable `ipAddressIfIndex` column with the exact IPv4
+  type-and-four-octet-length index prefix, then derive the raw four address
+  octets from the index. Their type, prefix pointer, address status, and row
+  status dependency columns share that scope and remain dormant when the
   anchor is empty. Both sources resolve into one legacy-preferred per-IP fact;
   a valid modern prefix fills only a missing legacy mask on the same ifIndex.
 - `_std-topology-interface-mib.yaml` provides interface identity and status.
@@ -1435,9 +1436,11 @@ Examples:
   Derive them from the row index. The physical MAC value,
   `ipNetToPhysicalPhysAddress`, is readable and can stay as a column symbol.
 - `IP-MIB::ipAddressAddr` is a `not-accessible` `ipAddressTable` index
-  component. Derive its address from the row index. Use a readable column such
-  as `ipAddressIfIndex` as the row anchor; `ipAddressType`, `ipAddressPrefix`,
-  `ipAddressStatus`, and `ipAddressRowStatus` are readable tag sources.
+  component. For IPv4, constrain the readable `ipAddressIfIndex` anchor to the
+  exact type-and-length prefix `1.4` and keep the four transformed address
+  octets raw so malformed widths or trailing components fail IPv4 parsing.
+  `ipAddressType`, `ipAddressPrefix`, `ipAddressStatus`, and
+  `ipAddressRowStatus` are readable tag sources.
 - `LLDP-MIB::lldpLocManAddrSubtype` and `LLDP-MIB::lldpLocManAddr` are
   `not-accessible` index components. Anchor the row on a readable column such as
   `lldpLocManAddrLen`, then derive subtype and address from the row index. Use

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -1455,7 +1455,7 @@ Audit recipe:
 
 ```bash
 rg -n -C 4 'OBJECT-TYPE|MAX-ACCESS[[:space:]]+not-accessible|ACCESS[[:space:]]+not-accessible' path/to/MIB
-rg -n 'name:[[:space:]]*(dot1qTpFdbAddress|ipNetToPhysicalIfIndex|ipNetToPhysicalNetAddressType|ipNetToPhysicalNetAddress|lldpLocManAddrSubtype|lldpLocManAddr|lldpRemManAddrSubtype|lldpRemManAddr)\b' src/go/plugin/go.d/config/go.d/snmp.profiles
+rg -n 'name:[[:space:]]*(dot1qTpFdbAddress|ipAddressAddr|ipNetToPhysicalIfIndex|ipNetToPhysicalNetAddressType|ipNetToPhysicalNetAddress|lldpLocManAddrSubtype|lldpLocManAddr|lldpRemManAddrSubtype|lldpRemManAddr)\b' src/go/plugin/go.d/config/go.d/snmp.profiles
 ```
 
 Any profile hit for a `not-accessible` object is valid only when the tag is

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -433,6 +433,16 @@ topology:
   symbols and for `metric_tags`.
 - `metric_tags` inside a topology row work like table metric tags and identify
   or enrich the topology row.
+- A cross-table tag whose target table has no row producer creates an internal
+  dependency-only collection route. For topology rows, that route is walked
+  only after its owning row produces at least one anchor PDU. A target table
+  with its own symbol-bearing row remains an independent eager producer.
+- When a topology row has exactly one readable anchor symbol and its `table.OID`
+  is the symbol column plus a fixed structural index prefix, simple same-index
+  cross-table dependencies inherit that prefix. For example, an anchor root
+  `<column>.1` constrains dependency column walks to `<dependency-column>.1`.
+  Dependencies using `lookup_symbol`, multiple anchors, or conflicting scopes
+  use their ordinary common-prefix route instead.
 - `systemUptime` stays under `metrics:` for regular SNMP collection. It is not a
   topology kind and should not be declared under `topology:`.
 
@@ -1418,6 +1428,10 @@ Examples:
   `IP-MIB::ipNetToPhysicalNetAddress` are `not-accessible` index components.
   Derive them from the row index. The physical MAC value,
   `ipNetToPhysicalPhysAddress`, is readable and can stay as a column symbol.
+- `IP-MIB::ipAddressAddr` is a `not-accessible` `ipAddressTable` index
+  component. Derive its address from the row index. Use a readable column such
+  as `ipAddressIfIndex` as the row anchor; `ipAddressType`, `ipAddressPrefix`,
+  `ipAddressStatus`, and `ipAddressRowStatus` are readable tag sources.
 - `LLDP-MIB::lldpLocManAddrSubtype` and `LLDP-MIB::lldpLocManAddr` are
   `not-accessible` index components. Anchor the row on a readable column such as
   `lldpLocManAddrLen`, then derive subtype and address from the row index. Use

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -302,6 +302,7 @@ Ingestion is split by source area:
 - `topology_cache_cdp.go`
 - `topology_cache_fdb.go`
 - `topology_cache_interfaces.go`
+- `topology_ip_addresses.go`
 - `topology_cache_stp_arp.go`
 - `topology_l3_interfaces.go`
 - `topology_ospf_neighbors.go`

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -235,15 +235,17 @@ The standard capabilities have separate owners:
 - `generic-device.yaml` and `generic-ups.yaml` extend
   `_std-topology-ip-mib.yaml`. This baseline keeps the legacy `ipAddrTable` and
   also collects RFC 4293 `ipAddressTable` IPv4 rows. The modern anchor is the
-  readable `ipAddressIfIndex` column constrained by the IPv4 address-type index;
-  its type, prefix pointer, address status, and row status columns are walked
-  only when the anchor returns rows. Unsupported and IPv6-only agents therefore
-  pay for one empty modern logical anchor walk, while supported IPv4 agents use
-  five IPv4-scoped logical walks and return at most five required varbinds per
-  address. A logical walk can require multiple SNMP request/response exchanges
+  readable `ipAddressIfIndex` column constrained by the IPv4 address-type and
+  four-octet-length indexes; its type, prefix pointer, address status, and row
+  status columns are walked only when the anchor returns rows. Unsupported,
+  IPv6-only, and malformed-width agents therefore pay for one empty modern
+  logical anchor walk, while supported IPv4 agents use five IPv4-scoped logical
+  walks and return at most five required varbinds per address. A logical walk
+  can require multiple SNMP request/response exchanges
   for pagination, termination, or transport fallback; the bound here is on
   selected roots and returned row data, not a claim of one wire packet. The
-  address itself is derived from the not-accessible row index.
+  address itself is derived as exactly four raw octets from the not-accessible
+  row index, so trailing components cannot be normalized as another family.
 - Both IP-MIB sources feed one canonical per-IP record. Valid legacy facts take
   precedence; a valid modern prefix may fill a missing legacy mask only when
   the interface index agrees. Modern rows must be active unicast addresses in

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -237,15 +237,19 @@ The standard capabilities have separate owners:
   also collects RFC 4293 `ipAddressTable` IPv4 rows. The modern anchor is the
   readable `ipAddressIfIndex` column constrained by the IPv4 address-type and
   four-octet-length indexes; its type, prefix pointer, address status, and row
-  status columns are walked only when the anchor returns rows. Unsupported,
-  IPv6-only, and malformed-width agents therefore pay for one empty modern
-  logical anchor walk, while supported IPv4 agents use five IPv4-scoped logical
-  walks and return at most five required varbinds per address. A logical walk
-  can require multiple SNMP request/response exchanges
+  status columns are walked only when the anchor returns a descendant.
+  Unsupported and IPv6-only agents therefore pay for one empty modern logical
+  anchor walk, while a non-empty structurally scoped anchor activates five
+  IPv4-scoped logical walks and returns at most five required varbinds per row.
+  A malformed descendant under `.1.4` can activate those dependency walks, but
+  the topology consumer rejects it unless its remaining suffix is exactly four
+  decimal octets in `0..255`. A logical walk can require multiple SNMP
+  request/response exchanges
   for pagination, termination, or transport fallback; the bound here is on
   selected roots and returned row data, not a claim of one wire packet. The
-  address itself is derived as exactly four raw octets from the not-accessible
-  row index, so trailing components cannot be normalized as another family.
+  address itself is derived from the not-accessible row index without using the
+  general SNMP hex/IP parser, so malformed components cannot alias to another
+  IPv4 identity.
 - Both IP-MIB sources feed one canonical per-IP record. Valid legacy facts take
   precedence; a valid modern prefix may fill a missing legacy mask only when
   the interface index agrees. Modern rows must be active unicast addresses in

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -232,10 +232,21 @@ their configured root as values.
 The standard capabilities have separate owners:
 
 - `generic-device.yaml` and `generic-ups.yaml` extend
-  `_std-topology-ip-mib.yaml`. This baseline walks the legacy IPv4
-  `ipAddrTable` and provides address, interface-index, and netmask facts for L3
-  subnet enrichment. The address comes from the indexed row suffix; the `.2`
-  ifIndex and `.3` netmask columns are the required readable PDUs.
+  `_std-topology-ip-mib.yaml`. This baseline keeps the legacy `ipAddrTable` and
+  also collects RFC 4293 `ipAddressTable` IPv4 rows. The modern anchor is the
+  readable `ipAddressIfIndex` column constrained by the IPv4 address-type index;
+  its type, prefix pointer, address status, and row status columns are walked
+  only when the anchor returns rows. Unsupported and IPv6-only agents therefore
+  pay for one empty modern anchor walk, while supported IPv4 agents return at
+  most five required varbinds per address. The address itself is derived from
+  the not-accessible row index.
+- Both IP-MIB sources feed one canonical per-IP record. Valid legacy facts take
+  precedence; a valid modern prefix may fill a missing legacy mask only when
+  the interface index agrees. Modern rows must be active unicast addresses in
+  preferred or deprecated state. A valid `ipAddressPrefix` RowPointer is decoded
+  only when it targets the exact `ipAddressPrefixOrigin` row for the same
+  interface and containing IPv4 prefix; a missing, `0.0`, or malformed pointer
+  retains address/interface inventory without a netmask.
 - `_std-topology-interface-mib.yaml` owns interface identity and state.
 - `_std-topology-bridge-base-mib.yaml` owns bridge identity and bridge-port to
   ifIndex mapping.

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -227,7 +227,8 @@ every configured identity, descriptor, signal, tag source, and cross-table depen
 OIDs already classified unavailable by collector state. Table rows without required identity/signals are rejected.
 Optional absent descriptors are not missing; cross-table failures that reject a row or tag use the dependency class.
 Synthetic table-dependency units have no semantic rows, so they report zero rows and count only received varbinds below
-their configured root as values.
+their configured root as values. A dependency left dormant because its anchor had no eligible rows keeps source `none`
+and outcome `not_observed`; it is not reported as an empty cache result.
 
 The standard capabilities have separate owners:
 
@@ -237,9 +238,12 @@ The standard capabilities have separate owners:
   readable `ipAddressIfIndex` column constrained by the IPv4 address-type index;
   its type, prefix pointer, address status, and row status columns are walked
   only when the anchor returns rows. Unsupported and IPv6-only agents therefore
-  pay for one empty modern anchor walk, while supported IPv4 agents return at
-  most five required varbinds per address. The address itself is derived from
-  the not-accessible row index.
+  pay for one empty modern logical anchor walk, while supported IPv4 agents use
+  five IPv4-scoped logical walks and return at most five required varbinds per
+  address. A logical walk can require multiple SNMP request/response exchanges
+  for pagination, termination, or transport fallback; the bound here is on
+  selected roots and returned row data, not a claim of one wire packet. The
+  address itself is derived from the not-accessible row index.
 - Both IP-MIB sources feed one canonical per-IP record. Valid legacy facts take
   precedence; a valid modern prefix may fill a missing legacy mask only when
   the interface index agrees. Modern rows must be active unicast addresses in

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -1537,9 +1537,10 @@ func TestCollectorRefreshPrefersResolvedTargetManagementIP(t *testing.T) {
 			return []*ddsnmp.ProfileMetrics{{TopologyMetrics: []ddsnmp.Metric{{
 				TopologyKind: ddsnmp.KindIpIfIndex,
 				Tags: map[string]string{
-					tagTopoIfIndex: "1",
-					tagTopoIPAddr:  "10.0.0.1",
-					tagTopoIPMask:  "255.255.255.0",
+					tagTopoIPSource: topoIPSourceLegacy,
+					tagTopoIfIndex:  "1",
+					tagTopoIPAddr:   "10.0.0.1",
+					tagTopoIPMask:   "255.255.255.0",
 				},
 			}}}}, nil
 		})
@@ -1583,9 +1584,10 @@ func TestCollectorRefreshSelectsNextDNSTargetAfterMaskRejection(t *testing.T) {
 			return []*ddsnmp.ProfileMetrics{{TopologyMetrics: []ddsnmp.Metric{{
 				TopologyKind: ddsnmp.KindIpIfIndex,
 				Tags: map[string]string{
-					tagTopoIfIndex: "1",
-					tagTopoIPAddr:  "192.0.2.0",
-					tagTopoIPMask:  "255.255.255.0",
+					tagTopoIPSource: topoIPSourceLegacy,
+					tagTopoIfIndex:  "1",
+					tagTopoIPAddr:   "192.0.2.0",
+					tagTopoIPMask:   "255.255.255.0",
 				},
 			}}}}, nil
 		})

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/observations.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologymodel/observations.go
@@ -112,12 +112,12 @@ type L3Subnet struct {
 }
 
 func L3SubnetForInterface(row L3Interface) (L3Subnet, bool) {
-	ip, err := netip.ParseAddr(topologyutil.NormalizeIPAddress(row.IP))
-	if err != nil || !ip.Is4() {
+	ip, ok := topologyutil.ParseIPAddress(row.IP)
+	if !ok || !ip.Is4() {
 		return L3Subnet{}, false
 	}
-	netmask, err := netip.ParseAddr(topologyutil.NormalizeIPAddress(row.Netmask))
-	if err != nil || !netmask.Is4() {
+	netmask, ok := topologyutil.ParseIPAddress(row.Netmask)
+	if !ok || !netmask.Is4() {
 		return L3Subnet{}, false
 	}
 	network, ok := netaddr.NetworkAddress(ip, netmask)

--- a/src/go/plugin/go.d/collector/snmp_topology/profile_filter_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/profile_filter_test.go
@@ -3,8 +3,6 @@
 package snmptopology
 
 import (
-	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,19 +14,16 @@ import (
 
 func TestFindTopologyProfiles_IPBaselineBoundaries(t *testing.T) {
 	tests := map[string]struct {
-		device       ddsnmp.DeviceConnectionInfo
-		wantProfiles []string
-		wantIPKinds  int
+		device         ddsnmp.DeviceConnectionInfo
+		wantIPBaseline bool
 	}{
 		"Palo Alto inherits generic device": {
-			device:       ddsnmp.DeviceConnectionInfo{SysObjectID: "1.3.6.1.4.1.25461.2.3.33"},
-			wantProfiles: []string{"generic-device.yaml", "palo-alto.yaml"},
-			wantIPKinds:  1,
+			device:         ddsnmp.DeviceConnectionInfo{SysObjectID: "1.3.6.1.4.1.25461.2.3.33"},
+			wantIPBaseline: true,
 		},
 		"generic UPS owns its baseline": {
-			device:       ddsnmp.DeviceConnectionInfo{SysObjectID: "1.3.6.1.2.1.33"},
-			wantProfiles: []string{"generic-ups.yaml"},
-			wantIPKinds:  1,
+			device:         ddsnmp.DeviceConnectionInfo{SysObjectID: "1.3.6.1.2.1.33"},
+			wantIPBaseline: true,
 		},
 		"manual composition keeps explicit generic topology owner": {
 			device: ddsnmp.DeviceConnectionInfo{
@@ -36,34 +31,27 @@ func TestFindTopologyProfiles_IPBaselineBoundaries(t *testing.T) {
 			},
 			// The generic profile owns the deduplicated IP/OSPF baseline. The vendor
 			// metrics profile does not become a topology owner through composition.
-			wantProfiles: []string{"generic-device.yaml"},
-			wantIPKinds:  1,
+			wantIPBaseline: true,
 		},
 		"manual vendor alone does not inject baseline": {
 			device: ddsnmp.DeviceConnectionInfo{
 				ManualProfiles: []string{"palo-alto"},
 			},
-			wantProfiles: []string{"palo-alto.yaml"},
-			wantIPKinds:  0,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			profiles := (&Collector{}).findTopologyProfiles(tc.device)
-			var profileNames []string
-			ipKinds := 0
+			hasIPBaseline := false
 			for _, profile := range profiles {
-				profileNames = append(profileNames, filepath.Base(profile.SourceFile))
 				for _, topology := range profile.Definition.Topology {
 					if topology.Kind == ddprofiledefinition.KindIpIfIndex {
-						ipKinds++
+						hasIPBaseline = true
 					}
 				}
 			}
-			sort.Strings(profileNames)
-			assert.Equal(t, tc.wantProfiles, profileNames)
-			assert.Equal(t, tc.wantIPKinds, ipKinds, "unexpected projected IP topology owner count")
+			assert.Equal(t, tc.wantIPBaseline, hasIPBaseline)
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/profile_filter_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/profile_filter_test.go
@@ -43,6 +43,7 @@ func TestFindTopologyProfiles_IPBaselineBoundaries(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			profiles := (&Collector{}).findTopologyProfiles(tc.device)
+			require.NotEmpty(t, profiles)
 			ipSources := make(map[string]int)
 			for _, profile := range profiles {
 				for _, topology := range profile.Definition.Topology {

--- a/src/go/plugin/go.d/collector/snmp_topology/profile_filter_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/profile_filter_test.go
@@ -43,15 +43,30 @@ func TestFindTopologyProfiles_IPBaselineBoundaries(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			profiles := (&Collector{}).findTopologyProfiles(tc.device)
-			hasIPBaseline := false
+			ipSources := make(map[string]int)
 			for _, profile := range profiles {
 				for _, topology := range profile.Definition.Topology {
-					if topology.Kind == ddprofiledefinition.KindIpIfIndex {
-						hasIPBaseline = true
+					if topology.Kind != ddprofiledefinition.KindIpIfIndex {
+						continue
 					}
+					source := ""
+					for _, tag := range topology.StaticTags {
+						if tag.Tag == tagTopoIPSource {
+							source = tag.Value
+						}
+					}
+					if source == "" {
+						continue
+					}
+					ipSources[source]++
 				}
 			}
-			assert.Equal(t, tc.wantIPBaseline, hasIPBaseline)
+			want := map[string]int{}
+			if tc.wantIPBaseline {
+				want[topoIPSourceLegacy] = 1
+				want[topoIPSourceModern] = 1
+			}
+			assert.Equal(t, want, ipSources)
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
@@ -31,13 +31,12 @@ type topologyBuilder struct {
 	lldpRemotes  map[string]*lldpRemote
 	cdpRemotes   map[string]*cdpRemote
 
-	ifNamesByIndex      map[string]string
-	ifStatusByIndex     map[string]ifStatus
-	// ipAddressesByIP is the build-only source of truth for legacy/modern reconciliation.
-	ipAddressesByIP     map[string]ipAddressCandidates
-	ifIndexByIP         map[string]string
-	ifNetmaskByIP       map[string]string
-	l3InterfacesByIP    map[string]topologymodel.L3Interface
+	ifNamesByIndex  map[string]string
+	ifStatusByIndex map[string]ifStatus
+	// ipAddressCandidatesByIP is build-only provenance state and is released at finalization.
+	ipAddressCandidatesByIP map[string]ipAddressCandidates
+	// ipAddressesByIP is the single resolved interface-address inventory.
+	ipAddressesByIP     map[string]resolvedIPAddress
 	trapMatchMethodByIP map[string]string
 	bridgePortToIf      map[string]string
 	fdbEntries          map[string]*fdbEntry

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache.go
@@ -21,7 +21,7 @@ type topologyBuilder struct {
 
 	agentID     string
 	localDevice topologymodel.Device
-	// localManagementAddressKeys deduplicates high-cardinality IP-MIB rows during collection.
+	// localManagementAddressKeys deduplicates local management observations while the builder is mutable.
 	// It is build-only state and is released when the builder is finalized.
 	localManagementAddressKeys map[managementAddressKey]struct{}
 	// targetManagementIPs is private pre-finalization selection evidence.
@@ -33,6 +33,8 @@ type topologyBuilder struct {
 
 	ifNamesByIndex      map[string]string
 	ifStatusByIndex     map[string]ifStatus
+	// ipAddressesByIP is the build-only source of truth for legacy/modern reconciliation.
+	ipAddressesByIP     map[string]ipAddressCandidates
 	ifIndexByIP         map[string]string
 	ifNetmaskByIP       map[string]string
 	l3InterfacesByIP    map[string]topologymodel.L3Interface

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_interfaces.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
@@ -79,33 +78,7 @@ func (c *topologyBuilder) updateIfNameByIndex(tags map[string]string) {
 }
 
 func (c *topologyBuilder) updateIfIndexByIP(tags map[string]string) {
-	ifIndex := strings.TrimSpace(tags[tagTopoIfIndex])
-	if ifIndex == "" {
-		return
-	}
-
-	ip := topologyutil.NormalizeIPAddress(tags[tagTopoIPAddr])
-	if ip == "" {
-		return
-	}
-
-	c.ifIndexByIP[ip] = ifIndex
-	mask := topologyutil.NormalizeIPAddress(tags[tagTopoIPMask])
-	if mask != "" {
-		c.ifNetmaskByIP[ip] = mask
-		c.l3InterfacesByIP[ip] = topologymodel.L3Interface{
-			IP:      ip,
-			Netmask: mask,
-			IfIndex: ifIndex,
-		}
-	}
-	if isEligibleManagementInterfaceAddress(ip, mask) {
-		c.appendLocalManagementAddress(topologymodel.ManagementAddress{
-			Address:     ip,
-			AddressType: managementAddressTypeFromIP(ip),
-			Source:      "ip_mib",
-		})
-	}
+	c.updateIPAddressCandidate(tags)
 }
 
 func (c *topologyBuilder) updateBridgePortMap(tags map[string]string) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -16,9 +16,7 @@ func newTopologyBuilder() *topologyBuilder {
 		cdpRemotes:         make(map[string]*cdpRemote),
 		ifNamesByIndex:     make(map[string]string),
 		ifStatusByIndex:    make(map[string]ifStatus),
-		ifIndexByIP:        make(map[string]string),
-		ifNetmaskByIP:      make(map[string]string),
-		l3InterfacesByIP:   make(map[string]topologymodel.L3Interface),
+		ipAddressesByIP:    make(map[string]resolvedIPAddress),
 		bridgePortToIf:     make(map[string]string),
 		fdbEntries:         make(map[string]*fdbEntry),
 		vlanByFDBID:        make(map[string]fdbVLANMapping),
@@ -54,7 +52,7 @@ func (c *topologyBuilder) finalize() topologyBuilderFinalizeStats {
 	}
 
 	c.finalizeIPAddresses()
-	finalizeLocalManagementAddresses(&c.localDevice, c.targetManagementIPs, c.ifNetmaskByIP)
+	finalizeLocalManagementAddressesWithLookup(&c.localDevice, c.targetManagementIPs, c.ipNetmask)
 	c.localManagementAddressKeys = nil
 	c.rebuildTrapSourceMatchMethods()
 	c.finalizeFDBVLANs()
@@ -72,8 +70,8 @@ func (c *topologyBuilder) finalize() topologyBuilderFinalizeStats {
 }
 
 func (c *topologyBuilder) rebuildTrapSourceMatchMethods() {
-	methods := make(map[string]string, len(c.ifIndexByIP)+len(c.localDevice.ManagementAddresses)+1)
-	for value := range c.ifIndexByIP {
+	methods := make(map[string]string, len(c.ipAddressesByIP)+len(c.localDevice.ManagementAddresses)+1)
+	for value := range c.ipAddressesByIP {
 		if addr, ok := topologyutil.ParseIPAddress(value); ok {
 			methods[addr.String()] = "local_interface_ip"
 		}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_lifecycle.go
@@ -53,6 +53,7 @@ func (c *topologyBuilder) finalize() topologyBuilderFinalizeStats {
 		return topologyBuilderFinalizeStats{}
 	}
 
+	c.finalizeIPAddresses()
 	finalizeLocalManagementAddresses(&c.localDevice, c.targetManagementIPs, c.ifNetmaskByIP)
 	c.localManagementAddressKeys = nil
 	c.rebuildTrapSourceMatchMethods()

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_tags.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_tags.go
@@ -80,6 +80,11 @@ const (
 	tagTopoIfDuplex = "topo_if_duplex"
 	tagTopoIPAddr   = "topo_ip_addr"
 	tagTopoIPMask   = "topo_ip_netmask"
+	tagTopoIPSource = "topo_ip_source"
+	tagTopoIPType   = "topo_ip_type"
+	tagTopoIPPrefix = "topo_ip_prefix_pointer"
+	tagTopoIPStatus = "topo_ip_status"
+	tagTopoIPRow    = "topo_ip_row_status"
 
 	tagBridgeBasePort = "bridge_base_port"
 	tagBridgeIfIndex  = "bridge_if_index"

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -315,29 +315,34 @@ func TestTopologyCache_UpdateIfIndexByIP_PreservesInventoryAndFiltersManagementC
 		tagTopoIPAddr:   "10.20.4.1",
 		tagTopoIPMask:   "255.255.255.0",
 	})
+	cache.finalize()
 
-	require.Equal(t, "1", cache.ifIndexByIP["10.20.4.1"])
-	require.Equal(t, "2", cache.ifIndexByIP["2001:db8::1"])
+	require.Equal(t, "1", cache.ipIfIndex("10.20.4.1"))
+	require.Equal(t, "2", cache.ipIfIndex("2001:db8::1"))
 	for _, row := range rows[2:] {
-		require.Equal(t, row[tagTopoIfIndex], cache.ifIndexByIP[row[tagTopoIPAddr]])
+		require.Equal(t, row[tagTopoIfIndex], cache.ipIfIndex(row[tagTopoIPAddr]))
 	}
-	require.Equal(t, "255.255.255.0", cache.ifNetmaskByIP["10.20.4.1"])
-	require.Empty(t, cache.ifNetmaskByIP["2001:db8::1"])
+	require.Equal(t, "255.255.255.0", cache.ipNetmask("10.20.4.1"))
+	require.Empty(t, cache.ipNetmask("2001:db8::1"))
+	l3, ok := cache.ipL3Interface("10.20.4.1")
+	require.True(t, ok)
 	require.Equal(t, topologymodel.L3Interface{
 		IP:      "10.20.4.1",
 		Netmask: "255.255.255.0",
 		IfIndex: "1",
-	}, cache.l3InterfacesByIP["10.20.4.1"])
-	require.NotContains(t, cache.l3InterfacesByIP, "2001:db8::1")
+	}, l3)
+	_, ok = cache.ipL3Interface("2001:db8::1")
+	require.False(t, ok)
 	for _, row := range rows[2:] {
+		l3, ok := cache.ipL3Interface(row[tagTopoIPAddr])
+		require.True(t, ok)
 		require.Equal(t, topologymodel.L3Interface{
 			IP:      row[tagTopoIPAddr],
 			Netmask: row[tagTopoIPMask],
 			IfIndex: row[tagTopoIfIndex],
-		}, cache.l3InterfacesByIP[row[tagTopoIPAddr]])
+		}, l3)
 	}
 
-	cache.finalize()
 	addrs := cache.localDevice.ManagementAddresses
 	require.Len(t, addrs, 3)
 	require.Contains(t, addrs, topologymodel.ManagementAddress{
@@ -399,8 +404,9 @@ func TestTopologyCache_FinalizeRejectsMaskProvenManagementAddressesAcrossSources
 			}
 			cache.finalize()
 
-			require.Equal(t, "1", cache.ifIndexByIP["192.0.2.0"])
-			require.Contains(t, cache.l3InterfacesByIP, "192.0.2.0")
+			require.Equal(t, "1", cache.ipIfIndex("192.0.2.0"))
+			_, ok := cache.ipL3Interface("192.0.2.0")
+			require.True(t, ok)
 			require.Equal(t, "192.0.2.10", cache.localDevice.ManagementIP)
 			require.Equal(t, []topologymodel.ManagementAddress{{
 				Address:     "192.0.2.10",

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -275,8 +275,9 @@ func TestTopologyCache_BuildEngineObservation_DerivesBaseBridgeMACFromInterfaceP
 	}
 
 	cache.updateIfIndexByIP(map[string]string{
-		tagTopoIPAddr:  "10.20.4.2",
-		tagTopoIfIndex: "1",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIPAddr:   "10.20.4.2",
+		tagTopoIfIndex:  "1",
 	})
 	cache.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "1",
@@ -293,25 +294,26 @@ func TestTopologyCache_UpdateIfIndexByIP_PreservesInventoryAndFiltersManagementC
 	cache := newTopologyBuilder()
 
 	rows := []map[string]string{
-		{tagTopoIfIndex: "1", tagTopoIPAddr: "10.20.4.1", tagTopoIPMask: "255.255.255.0"},
-		{tagTopoIfIndex: "2", tagTopoIPAddr: "2001:db8::1"},
-		{tagTopoIfIndex: "3", tagTopoIPAddr: "127.0.0.1", tagTopoIPMask: "255.0.0.0"},
-		{tagTopoIfIndex: "4", tagTopoIPAddr: "169.254.1.1", tagTopoIPMask: "255.255.0.0"},
-		{tagTopoIfIndex: "5", tagTopoIPAddr: "0.0.0.0", tagTopoIPMask: "0.0.0.0"},
-		{tagTopoIfIndex: "6", tagTopoIPAddr: "224.0.0.1", tagTopoIPMask: "240.0.0.0"},
-		{tagTopoIfIndex: "7", tagTopoIPAddr: "255.255.255.255", tagTopoIPMask: "255.255.255.255"},
-		{tagTopoIfIndex: "8", tagTopoIPAddr: "192.0.2.0", tagTopoIPMask: "255.255.255.0"},
-		{tagTopoIfIndex: "9", tagTopoIPAddr: "192.0.2.255", tagTopoIPMask: "255.255.255.0"},
-		{tagTopoIfIndex: "10", tagTopoIPAddr: "192.0.2.10", tagTopoIPMask: "255.255.255.254"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "1", tagTopoIPAddr: "10.20.4.1", tagTopoIPMask: "255.255.255.0"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "2", tagTopoIPAddr: "2001:db8::1"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "3", tagTopoIPAddr: "127.0.0.1", tagTopoIPMask: "255.0.0.0"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "4", tagTopoIPAddr: "169.254.1.1", tagTopoIPMask: "255.255.0.0"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "5", tagTopoIPAddr: "0.0.0.0", tagTopoIPMask: "0.0.0.0"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "6", tagTopoIPAddr: "224.0.0.1", tagTopoIPMask: "240.0.0.0"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "7", tagTopoIPAddr: "255.255.255.255", tagTopoIPMask: "255.255.255.255"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "8", tagTopoIPAddr: "192.0.2.0", tagTopoIPMask: "255.255.255.0"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "9", tagTopoIPAddr: "192.0.2.255", tagTopoIPMask: "255.255.255.0"},
+		{tagTopoIPSource: topoIPSourceLegacy, tagTopoIfIndex: "10", tagTopoIPAddr: "192.0.2.10", tagTopoIPMask: "255.255.255.254"},
 	}
 	for _, row := range rows {
 		cache.updateIfIndexByIP(row)
 	}
 	// Duplicate row should not duplicate management address entries.
 	cache.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "1",
-		tagTopoIPAddr:  "10.20.4.1",
-		tagTopoIPMask:  "255.255.255.0",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "1",
+		tagTopoIPAddr:   "10.20.4.1",
+		tagTopoIPMask:   "255.255.255.0",
 	})
 
 	require.Equal(t, "1", cache.ifIndexByIP["10.20.4.1"])
@@ -335,6 +337,7 @@ func TestTopologyCache_UpdateIfIndexByIP_PreservesInventoryAndFiltersManagementC
 		}, cache.l3InterfacesByIP[row[tagTopoIPAddr]])
 	}
 
+	cache.finalize()
 	addrs := cache.localDevice.ManagementAddresses
 	require.Len(t, addrs, 3)
 	require.Contains(t, addrs, topologymodel.ManagementAddress{
@@ -374,14 +377,16 @@ func TestTopologyCache_FinalizeRejectsMaskProvenManagementAddressesAcrossSources
 			}
 			addIPMIB := func() {
 				cache.updateIfIndexByIP(map[string]string{
-					tagTopoIfIndex: "1",
-					tagTopoIPAddr:  "192.0.2.0",
-					tagTopoIPMask:  "255.255.255.0",
+					tagTopoIPSource: topoIPSourceLegacy,
+					tagTopoIfIndex:  "1",
+					tagTopoIPAddr:   "192.0.2.0",
+					tagTopoIPMask:   "255.255.255.0",
 				})
 				cache.updateIfIndexByIP(map[string]string{
-					tagTopoIfIndex: "2",
-					tagTopoIPAddr:  "192.0.2.10",
-					tagTopoIPMask:  "255.255.255.0",
+					tagTopoIPSource: topoIPSourceLegacy,
+					tagTopoIfIndex:  "2",
+					tagTopoIPAddr:   "192.0.2.10",
+					tagTopoIPMask:   "255.255.255.0",
 				})
 			}
 
@@ -417,9 +422,10 @@ func TestTopologyCache_LLDPExplicitNonIPFamilyDoesNotBecomeManagementIP(t *testi
 		ChassisIDType: "macAddress",
 	}
 	cache.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "1",
-		tagTopoIPAddr:  "192.0.2.10",
-		tagTopoIPMask:  "255.255.255.0",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "1",
+		tagTopoIPAddr:   "192.0.2.10",
+		tagTopoIPMask:   "255.255.255.0",
 	})
 	cache.updateLldpLocManAddr(map[string]string{
 		tagLldpLocMgmtAddrSubtype: "16",
@@ -456,9 +462,10 @@ func TestTopologyCacheFinalizePreparesStableObservationSnapshot(t *testing.T) {
 		tagTopoIfOper:  "up",
 	})
 	cache.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "7",
-		tagTopoIPAddr:  "192.0.2.1",
-		tagTopoIPMask:  "255.255.255.255",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "7",
+		tagTopoIPAddr:   "192.0.2.1",
+		tagTopoIPMask:   "255.255.255.255",
 	})
 	cache.finalize()
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_cache_test.go
@@ -277,13 +277,19 @@ func TestTopologyCache_BuildEngineObservation_DerivesBaseBridgeMACFromInterfaceP
 	cache.updateIfIndexByIP(map[string]string{
 		tagTopoIPSource: topoIPSourceLegacy,
 		tagTopoIPAddr:   "10.20.4.2",
-		tagTopoIfIndex:  "1",
+		tagTopoIfIndex:  "2",
 	})
 	cache.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "1",
+		tagTopoIfName:  "UnrelatedPort",
+		tagTopoIfPhys:  "02:00:00:00:00:01",
+	})
+	cache.updateIfNameByIndex(map[string]string{
+		tagTopoIfIndex: "2",
 		tagTopoIfName:  "Port1",
 		tagTopoIfPhys:  "\"18 FD 74 33 1A 9C \"",
 	})
+	cache.finalize()
 
 	obs := cache.buildEngineObservation(cache.localDevice)
 	require.Equal(t, "18:fd:74:33:1a:9c", obs.BaseBridgeAddress)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
@@ -26,6 +26,7 @@ import (
 func TestTopologyProductionPath_CatalogFixtureReconcilesLegacyAndModernIPRows(t *testing.T) {
 	fixture := loadTopologySNMPRecHandler(t, filepath.Join("../../../../testdata/snmp/snmprec", "iosxe_c9800.snmprec"))
 	dev, profileMetrics := collectCatalogFixtureTopology(t, fixture)
+	requireModernIPAddressWalkEnvelope(t, fixture.walkRoots)
 
 	type sourceRows struct {
 		legacy map[string]string
@@ -78,6 +79,23 @@ func TestTopologyProductionPath_CatalogFixtureReconcilesLegacyAndModernIPRows(t 
 		Address: ip, AddressType: "ipv4", Source: "ip_mib",
 	})
 	require.Equal(t, "management_address", cache.trapMatchMethodByIP[ip])
+}
+
+func requireModernIPAddressWalkEnvelope(t testing.TB, walkRoots []string) {
+	t.Helper()
+	const entryOID = "1.3.6.1.2.1.4.34.1"
+	var modernRoots []string
+	for _, root := range walkRoots {
+		if root == entryOID || strings.HasPrefix(root, entryOID+".") {
+			modernRoots = append(modernRoots, root)
+		}
+	}
+	require.Len(t, modernRoots, 5, "modern IPv4 inventory must stay within the five-field wire envelope")
+	for _, root := range modernRoots {
+		parts := strings.Split(strings.TrimPrefix(root, entryOID+"."), ".")
+		require.Len(t, parts, 2, "modern route must be a narrow column root with a structural address-family suffix: %s", root)
+		require.Equal(t, "1", parts[1], "modern route must be constrained to the IPv4 InetAddressType index: %s", root)
+	}
 }
 
 func TestTopologyProductionPath_CatalogFixtureKeepsModernInventoryWithoutPrefix(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
@@ -93,8 +93,9 @@ func requireModernIPAddressWalkEnvelope(t testing.TB, walkRoots []string) {
 	require.Len(t, modernRoots, 5, "modern IPv4 inventory must stay within the five-field wire envelope")
 	for _, root := range modernRoots {
 		parts := strings.Split(strings.TrimPrefix(root, entryOID+"."), ".")
-		require.Len(t, parts, 2, "modern route must be a narrow column root with a structural address-family suffix: %s", root)
+		require.Len(t, parts, 3, "modern route must be a narrow column root with structural family and length suffixes: %s", root)
 		require.Equal(t, "1", parts[1], "modern route must be constrained to the IPv4 InetAddressType index: %s", root)
+		require.Equal(t, "4", parts[2], "modern route must require the four-octet IPv4 InetAddress length: %s", root)
 	}
 }
 
@@ -132,6 +133,35 @@ func TestTopologyProductionPath_CatalogFixtureKeepsModernInventoryWithoutPrefix(
 		Address: ip, AddressType: "ipv4", Source: "ip_mib",
 	})
 	require.Equal(t, "management_address", cache.trapMatchMethodByIP[ip])
+}
+
+func TestTopologyProductionPath_CatalogFixtureRejectsMalformedModernIPv4Indexes(t *testing.T) {
+	fixture := loadTopologySNMPRecHandler(t, filepath.Join("../../../../testdata/snmp/snmprec", "iosxe_c9800.snmprec"))
+	addMalformedModernIPv4FixtureRow(fixture, "1.16.0.0.0.0.0.0.0.0.0.0.255.255.203.0.113.241", 7)
+	addMalformedModernIPv4FixtureRow(fixture, "1.4.0.0.0.0.0.0.0.0.0.0.255.255.203.0.113.242", 8)
+
+	dev, profileMetrics := collectCatalogFixtureTopology(t, fixture)
+	cache := newTestTopologyCache(dev)
+	cache.ingestTopologyProfileMetrics(profileMetrics)
+	cache.finalize()
+
+	require.Empty(t, cache.ipIfIndex("203.0.113.241"), "IPv4 type with a 16-octet declared address must be rejected")
+	require.Empty(t, cache.ipIfIndex("203.0.113.242"), "IPv4 length with trailing mapped payload must be rejected")
+}
+
+func addMalformedModernIPv4FixtureRow(fixture *topologySNMPRecHandler, index string, ifIndex int) {
+	const entryOID = "1.3.6.1.2.1.4.34.1"
+	fixture.addEntries(
+		gosnmp.SnmpPDU{Name: entryOID + ".3." + index, Type: gosnmp.Integer, Value: ifIndex},
+		gosnmp.SnmpPDU{Name: entryOID + ".4." + index, Type: gosnmp.Integer, Value: 1},
+		gosnmp.SnmpPDU{
+			Name:  entryOID + ".5." + index,
+			Type:  gosnmp.ObjectIdentifier,
+			Value: fmt.Sprintf("1.3.6.1.2.1.4.32.1.5.%d.1.4.203.0.113.0.24", ifIndex),
+		},
+		gosnmp.SnmpPDU{Name: entryOID + ".7." + index, Type: gosnmp.Integer, Value: 1},
+		gosnmp.SnmpPDU{Name: entryOID + ".10." + index, Type: gosnmp.Integer, Value: 1},
+	)
 }
 
 func collectCatalogFixtureTopology(

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
@@ -19,8 +19,135 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 )
+
+func TestTopologyProductionPath_CatalogFixtureReconcilesLegacyAndModernIPRows(t *testing.T) {
+	fixture := loadTopologySNMPRecHandler(t, filepath.Join("../../../../testdata/snmp/snmprec", "iosxe_c9800.snmprec"))
+	dev, profileMetrics := collectCatalogFixtureTopology(t, fixture)
+
+	type sourceRows struct {
+		legacy map[string]string
+		modern map[string]string
+	}
+	rowsByIP := make(map[string]*sourceRows)
+	for _, pm := range profileMetrics {
+		for _, metric := range pm.TopologyMetrics {
+			if metric.TopologyKind != ddsnmp.KindIpIfIndex {
+				continue
+			}
+			ip := metric.Tags[tagTopoIPAddr]
+			if ip == "" {
+				continue
+			}
+			rows := rowsByIP[ip]
+			if rows == nil {
+				rows = &sourceRows{}
+				rowsByIP[ip] = rows
+			}
+			switch metric.Tags[tagTopoIPSource] {
+			case topoIPSourceLegacy:
+				rows.legacy = metric.Tags
+			case topoIPSourceModern:
+				rows.modern = metric.Tags
+			}
+		}
+	}
+
+	var ip string
+	var rows *sourceRows
+	for candidateIP, candidateRows := range rowsByIP {
+		if candidateRows.legacy != nil && candidateRows.modern != nil &&
+			candidateRows.legacy[tagTopoIfIndex] == candidateRows.modern[tagTopoIfIndex] {
+			ip, rows = candidateIP, candidateRows
+			break
+		}
+	}
+	require.NotEmpty(t, ip, "fixture should contain one address represented by both IP-MIB generations")
+
+	cache := newTestTopologyCache(dev)
+	cache.ingestTopologyProfileMetrics(profileMetrics)
+	cache.finalize()
+
+	require.Equal(t, rows.legacy[tagTopoIfIndex], cache.ipIfIndex(ip))
+	require.Equal(t, rows.legacy[tagTopoIPMask], cache.ipNetmask(ip))
+	_, hasL3 := cache.ipL3Interface(ip)
+	require.True(t, hasL3)
+	require.Contains(t, cache.localDevice.ManagementAddresses, topologymodel.ManagementAddress{
+		Address: ip, AddressType: "ipv4", Source: "ip_mib",
+	})
+	require.Equal(t, "management_address", cache.trapMatchMethodByIP[ip])
+}
+
+func TestTopologyProductionPath_CatalogFixtureKeepsModernInventoryWithoutPrefix(t *testing.T) {
+	fixture := loadTopologySNMPRecHandler(t, filepath.Join("../../../../testdata/snmp/snmprec", "gam.snmprec"))
+	dev, profileMetrics := collectCatalogFixtureTopology(t, fixture)
+
+	var modernTags map[string]string
+	for _, pm := range profileMetrics {
+		for _, metric := range pm.TopologyMetrics {
+			if metric.TopologyKind == ddsnmp.KindIpIfIndex &&
+				metric.Tags[tagTopoIPSource] == topoIPSourceModern &&
+				metric.Tags[tagTopoIPPrefix] == "0.0" {
+				modernTags = metric.Tags
+				break
+			}
+		}
+		if modernTags != nil {
+			break
+		}
+	}
+	require.NotNil(t, modernTags, "fixture should expose an RFC 4293 IPv4 row without a prefix row")
+	ip := modernTags[tagTopoIPAddr]
+	require.NotEmpty(t, ip)
+
+	cache := newTestTopologyCache(dev)
+	cache.ingestTopologyProfileMetrics(profileMetrics)
+	cache.finalize()
+
+	require.Equal(t, modernTags[tagTopoIfIndex], cache.ipIfIndex(ip))
+	require.Empty(t, cache.ipNetmask(ip))
+	_, hasL3 := cache.ipL3Interface(ip)
+	require.False(t, hasL3)
+	require.Contains(t, cache.localDevice.ManagementAddresses, topologymodel.ManagementAddress{
+		Address: ip, AddressType: "ipv4", Source: "ip_mib",
+	})
+	require.Equal(t, "management_address", cache.trapMatchMethodByIP[ip])
+}
+
+func collectCatalogFixtureTopology(
+	t testing.TB,
+	fixture *topologySNMPRecHandler,
+) (ddsnmp.DeviceConnectionInfo, []*ddsnmp.ProfileMetrics) {
+	t.Helper()
+	sysObjectPDU, ok := fixture.byOID["1.3.6.1.2.1.1.2.0"]
+	require.True(t, ok, "fixture should contain sysObjectID")
+	sysObjectID, ok := sysObjectPDU.Value.(string)
+	require.True(t, ok)
+
+	dev := ddsnmp.DeviceConnectionInfo{
+		Hostname:       "192.0.2.10",
+		Port:           161,
+		SNMPVersion:    gosnmp.Version2c.String(),
+		SysObjectID:    sysObjectID,
+		SysName:        "catalog-fixture",
+		MaxOIDs:        60,
+		MaxRepetitions: 25,
+	}
+	profiles := (&Collector{}).findTopologyProfiles(dev)
+	require.NotEmpty(t, profiles, "stock catalog should resolve topology profiles")
+
+	profileMetrics, err := ddsnmpcollector.New(ddsnmpcollector.Config{
+		SnmpClient:  fixture,
+		Profiles:    profiles,
+		Log:         newTestSNMPTopologyCollector().Logger,
+		SysObjectID: dev.SysObjectID,
+	}).Collect()
+	require.NoError(t, err)
+	require.NotEmpty(t, profileMetrics)
+	return dev, profileMetrics
+}
 
 func TestTopologyProductionPath_StockIOSXEFixture(t *testing.T) {
 	fixture := loadTopologySNMPRecHandler(t, filepath.Join("../../../../testdata/snmp/snmprec", "iosxe_ie32008t2s-ios17-12.snmprec"))
@@ -191,6 +318,7 @@ func TestTopologySNMPRecPDURejectsMalformedValues(t *testing.T) {
 	}{
 		"integer":    {typeCode: "2", raw: "invalid"},
 		"octets":     {typeCode: "4x", raw: "not-hex"},
+		"ip-address": {typeCode: "64x", raw: "not-hex"},
 		"counter32":  {typeCode: "65", raw: "4294967296"},
 		"gauge32":    {typeCode: "66", raw: "4294967296"},
 		"time-ticks": {typeCode: "67", raw: "4294967296"},
@@ -245,6 +373,19 @@ func topologySNMPRecPDU(name, typeCode, raw string) (gosnmp.SnmpPDU, error) {
 			Name:  name,
 			Type:  gosnmp.IPAddress,
 			Value: raw,
+		}, nil
+	case "64x":
+		value, err := hex.DecodeString(raw)
+		if err != nil {
+			return gosnmp.SnmpPDU{}, err
+		}
+		if len(value) != 4 && len(value) != 16 {
+			return gosnmp.SnmpPDU{}, fmt.Errorf("unsupported 64x length %d", len(value))
+		}
+		return gosnmp.SnmpPDU{
+			Name:  name,
+			Type:  gosnmp.IPAddress,
+			Value: value,
 		}, nil
 	case "65":
 		value, err := strconv.ParseUint(raw, 10, 32)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ddsnmp_fixture_test.go
@@ -137,8 +137,11 @@ func TestTopologyProductionPath_CatalogFixtureKeepsModernInventoryWithoutPrefix(
 
 func TestTopologyProductionPath_CatalogFixtureRejectsMalformedModernIPv4Indexes(t *testing.T) {
 	fixture := loadTopologySNMPRecHandler(t, filepath.Join("../../../../testdata/snmp/snmprec", "iosxe_c9800.snmprec"))
-	addMalformedModernIPv4FixtureRow(fixture, "1.16.0.0.0.0.0.0.0.0.0.0.255.255.203.0.113.241", 7)
-	addMalformedModernIPv4FixtureRow(fixture, "1.4.0.0.0.0.0.0.0.0.0.0.255.255.203.0.113.242", 8)
+	addMalformedModernIPv4FixtureRow(fixture, "1.16.0.0.0.0.0.0.0.0.0.0.255.255.203.0.113.241", 7001)
+	addMalformedModernIPv4FixtureRow(fixture, "1.4.0.0.0.0.0.0.0.0.0.0.255.255.203.0.113.242", 7002)
+	addMalformedModernIPv4FixtureRow(fixture, "1.4.1.2.3.4.5.6.7.8", 7003)
+	addMalformedModernIPv4FixtureRow(fixture, "1.4.192.0.2.256", 7004)
+	addMalformedModernIPv4FixtureRow(fixture, "1.4.123.45.67", 7005)
 
 	dev, profileMetrics := collectCatalogFixtureTopology(t, fixture)
 	cache := newTestTopologyCache(dev)
@@ -147,6 +150,12 @@ func TestTopologyProductionPath_CatalogFixtureRejectsMalformedModernIPv4Indexes(
 
 	require.Empty(t, cache.ipIfIndex("203.0.113.241"), "IPv4 type with a 16-octet declared address must be rejected")
 	require.Empty(t, cache.ipIfIndex("203.0.113.242"), "IPv4 length with trailing mapped payload must be rejected")
+	for _, aliasedAddress := range []string{"18.52.86.120", "25.32.34.86", "1.35.69.103"} {
+		require.Empty(t, cache.ipIfIndex(aliasedAddress), "malformed index must not alias to %s", aliasedAddress)
+	}
+	for _, address := range cache.ipAddressesByIP {
+		require.NotContains(t, []string{"7001", "7002", "7003", "7004", "7005"}, address.ifIndex)
+	}
 }
 
 func addMalformedModernIPv4FixtureRow(fixture *topologySNMPRecHandler, index string, ifIndex int) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses.go
@@ -102,14 +102,13 @@ func ipAddressCandidateFromTags(source string, tags map[string]string) (ipAddres
 	if topologyutil.ParsePositiveInt64(ifIndex) == 0 {
 		return ipAddressCandidate{}, "", false
 	}
-	addr, ok := topologyutil.ParseIPAddress(tags[tagTopoIPAddr])
-	if !ok {
-		return ipAddressCandidate{}, "", false
-	}
-	ip := addr.String()
 
 	switch source {
 	case topoIPSourceLegacy:
+		addr, ok := topologyutil.ParseIPAddress(tags[tagTopoIPAddr])
+		if !ok {
+			return ipAddressCandidate{}, "", false
+		}
 		var prefixLength uint8
 		var hasPrefix bool
 		if addr.Is4() {
@@ -119,16 +118,48 @@ func ipAddressCandidateFromTags(source string, tags map[string]string) (ipAddres
 			ifIndex:      ifIndex,
 			prefixLength: prefixLength,
 			hasPrefix:    hasPrefix,
-		}, ip, true
+		}, addr.String(), true
 	case topoIPSourceModern:
-		if !addr.Is4() || !modernIPAddressEligible(tags) {
+		addr, ok := parseModernIPv4IndexAddress(tags[tagTopoIPAddr])
+		if !ok || !modernIPAddressEligible(tags) {
 			return ipAddressCandidate{}, "", false
 		}
 		prefixLength, hasPrefix := ipv4PrefixLengthFromPointer(addr, ifIndex, tags[tagTopoIPPrefix])
-		return ipAddressCandidate{ifIndex: ifIndex, prefixLength: prefixLength, hasPrefix: hasPrefix}, ip, true
+		return ipAddressCandidate{ifIndex: ifIndex, prefixLength: prefixLength, hasPrefix: hasPrefix}, addr.String(), true
 	default:
 		return ipAddressCandidate{}, "", false
 	}
+}
+
+func parseModernIPv4IndexAddress(value string) (netip.Addr, bool) {
+	value = strings.TrimSpace(value)
+	var octets [4]byte
+	for i := range octets {
+		part := value
+		if i < len(octets)-1 {
+			var found bool
+			part, value, found = strings.Cut(value, ".")
+			if !found {
+				return netip.Addr{}, false
+			}
+		} else if strings.Contains(value, ".") {
+			return netip.Addr{}, false
+		}
+		if part == "" {
+			return netip.Addr{}, false
+		}
+		for _, char := range part {
+			if char < '0' || char > '9' {
+				return netip.Addr{}, false
+			}
+		}
+		octet, err := strconv.ParseUint(part, 10, 8)
+		if err != nil {
+			return netip.Addr{}, false
+		}
+		octets[i] = byte(octet)
+	}
+	return netip.AddrFrom4(octets), true
 }
 
 func modernIPAddressEligible(tags map[string]string) bool {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses.go
@@ -21,15 +21,17 @@ const (
 )
 
 type ipAddressCandidate struct {
-	ifIndex string
-	mask    string
+	ifIndex      string
+	prefixLength uint8
+	hasPrefix    bool
 }
 
 type ipAddressCandidateSet struct {
 	ifIndex         string
 	ifIndexConflict bool
-	mask            string
-	maskConflict    bool
+	prefixLength    uint8
+	hasPrefix       bool
+	prefixConflict  bool
 }
 
 type ipAddressCandidates struct {
@@ -37,17 +39,23 @@ type ipAddressCandidates struct {
 	modern ipAddressCandidateSet
 }
 
+type resolvedIPAddress struct {
+	ifIndex string
+	netmask string
+}
+
 func (s *ipAddressCandidateSet) add(candidate ipAddressCandidate) {
 	if s.ifIndex == "" {
 		s.ifIndex = candidate.ifIndex
-	} else if s.ifIndex != candidate.ifIndex {
+	} else if topologyutil.ParsePositiveInt64(s.ifIndex) != topologyutil.ParsePositiveInt64(candidate.ifIndex) {
 		s.ifIndexConflict = true
 	}
-	if candidate.mask != "" {
-		if s.mask == "" {
-			s.mask = candidate.mask
-		} else if s.mask != candidate.mask {
-			s.maskConflict = true
+	if candidate.hasPrefix {
+		if !s.hasPrefix {
+			s.prefixLength = candidate.prefixLength
+			s.hasPrefix = true
+		} else if s.prefixLength != candidate.prefixLength {
+			s.prefixConflict = true
 		}
 	}
 }
@@ -57,8 +65,9 @@ func (s ipAddressCandidateSet) resolve() (ipAddressCandidate, bool) {
 		return ipAddressCandidate{}, false
 	}
 	candidate := ipAddressCandidate{ifIndex: s.ifIndex}
-	if !s.maskConflict {
-		candidate.mask = s.mask
+	if !s.prefixConflict && s.hasPrefix {
+		candidate.prefixLength = s.prefixLength
+		candidate.hasPrefix = true
 	}
 	return candidate, true
 }
@@ -73,10 +82,10 @@ func (c *topologyBuilder) updateIPAddressCandidate(tags map[string]string) {
 	if !ok {
 		return
 	}
-	if c.ipAddressesByIP == nil {
-		c.ipAddressesByIP = make(map[string]ipAddressCandidates)
+	if c.ipAddressCandidatesByIP == nil {
+		c.ipAddressCandidatesByIP = make(map[string]ipAddressCandidates)
 	}
-	record := c.ipAddressesByIP[ip]
+	record := c.ipAddressCandidatesByIP[ip]
 	switch source {
 	case topoIPSourceLegacy:
 		record.legacy.add(candidate)
@@ -85,8 +94,7 @@ func (c *topologyBuilder) updateIPAddressCandidate(tags map[string]string) {
 	default:
 		return
 	}
-	c.ipAddressesByIP[ip] = record
-	c.materializeIPAddress(ip, record)
+	c.ipAddressCandidatesByIP[ip] = record
 }
 
 func ipAddressCandidateFromTags(source string, tags map[string]string) (ipAddressCandidate, string, bool) {
@@ -102,19 +110,22 @@ func ipAddressCandidateFromTags(source string, tags map[string]string) (ipAddres
 
 	switch source {
 	case topoIPSourceLegacy:
-		mask := ""
+		var prefixLength uint8
+		var hasPrefix bool
 		if addr.Is4() {
-			mask = normalizeIPv4Mask(tags[tagTopoIPMask])
+			prefixLength, hasPrefix = ipv4PrefixLengthFromMask(tags[tagTopoIPMask])
 		}
-		return ipAddressCandidate{ifIndex: ifIndex, mask: mask}, ip, true
+		return ipAddressCandidate{
+			ifIndex:      ifIndex,
+			prefixLength: prefixLength,
+			hasPrefix:    hasPrefix,
+		}, ip, true
 	case topoIPSourceModern:
 		if !addr.Is4() || !modernIPAddressEligible(tags) {
 			return ipAddressCandidate{}, "", false
 		}
-		return ipAddressCandidate{
-			ifIndex: ifIndex,
-			mask:    ipv4MaskFromPrefixPointer(addr, ifIndex, tags[tagTopoIPPrefix]),
-		}, ip, true
+		prefixLength, hasPrefix := ipv4PrefixLengthFromPointer(addr, ifIndex, tags[tagTopoIPPrefix])
+		return ipAddressCandidate{ifIndex: ifIndex, prefixLength: prefixLength, hasPrefix: hasPrefix}, ip, true
 	default:
 		return ipAddressCandidate{}, "", false
 	}
@@ -132,110 +143,109 @@ func modernIPAddressEligible(tags map[string]string) bool {
 	return strings.TrimSpace(tags[tagTopoIPRow]) == "active"
 }
 
-func normalizeIPv4Mask(value string) string {
+func ipv4PrefixLengthFromMask(value string) (uint8, bool) {
 	maskAddr, ok := topologyutil.ParseIPAddress(value)
 	if !ok || !maskAddr.Is4() {
-		return ""
+		return 0, false
 	}
 	mask := net.IPMask(maskAddr.AsSlice())
-	if _, bits := mask.Size(); bits != 32 {
-		return ""
+	ones, bits := mask.Size()
+	if bits != 32 {
+		return 0, false
 	}
-	return maskAddr.String()
+	return uint8(ones), true
 }
 
-func ipv4MaskFromPrefixPointer(address netip.Addr, ifIndex, value string) string {
+func ipv4PrefixLengthFromPointer(address netip.Addr, ifIndex string, value string) (uint8, bool) {
 	value = strings.TrimPrefix(strings.TrimSpace(value), ".")
 	suffix, ok := strings.CutPrefix(value, ipAddressPrefixOriginOID+".")
 	if !ok {
-		return ""
+		return 0, false
 	}
 	var parts [8]string
 	for i := 0; i < len(parts)-1; i++ {
 		var found bool
 		parts[i], suffix, found = strings.Cut(suffix, ".")
 		if !found {
-			return ""
+			return 0, false
 		}
 	}
 	parts[len(parts)-1] = suffix
 	pointerIfIndex, err := strconv.ParseInt(parts[0], 10, 64)
 	if err != nil || pointerIfIndex <= 0 || pointerIfIndex != topologyutil.ParsePositiveInt64(ifIndex) {
-		return ""
+		return 0, false
 	}
 	if parts[1] != "1" || parts[2] != "4" {
-		return ""
+		return 0, false
 	}
 
 	var prefixBytes [4]byte
 	for i := range prefixBytes {
 		value, err := strconv.Atoi(parts[i+3])
 		if err != nil || value < 0 || value > 255 {
-			return ""
+			return 0, false
 		}
 		prefixBytes[i] = byte(value)
 	}
 	prefixLength, err := strconv.Atoi(parts[7])
 	if err != nil || prefixLength < 0 || prefixLength > 32 {
-		return ""
+		return 0, false
 	}
 	prefixAddress := netip.AddrFrom4(prefixBytes)
 	prefix := netip.PrefixFrom(prefixAddress, prefixLength)
 	if prefix.Masked().Addr() != prefixAddress || !prefix.Contains(address) {
-		return ""
+		return 0, false
 	}
-	return net.IP(net.CIDRMask(prefixLength, 32)).String()
+	return uint8(prefixLength), true
 }
 
 func (c *topologyBuilder) materializeIPAddress(ip string, record ipAddressCandidates) {
-	delete(c.ifIndexByIP, ip)
-	delete(c.ifNetmaskByIP, ip)
-	delete(c.l3InterfacesByIP, ip)
-
 	candidate, ok := resolveIPAddressCandidates(record)
 	if !ok {
 		return
 	}
-	c.ifIndexByIP[ip] = candidate.ifIndex
-	if candidate.mask == "" {
+	resolved := resolvedIPAddress{ifIndex: candidate.ifIndex}
+	if !candidate.hasPrefix {
+		c.ipAddressesByIP[ip] = resolved
 		return
 	}
-	c.ifNetmaskByIP[ip] = candidate.mask
-	c.l3InterfacesByIP[ip] = topologymodel.L3Interface{
-		IP:      ip,
-		Netmask: candidate.mask,
-		IfIndex: candidate.ifIndex,
-	}
+	resolved.netmask = net.IP(net.CIDRMask(int(candidate.prefixLength), 32)).String()
+	c.ipAddressesByIP[ip] = resolved
 }
 
 func resolveIPAddressCandidates(record ipAddressCandidates) (ipAddressCandidate, bool) {
+	if record.legacy.ifIndexConflict {
+		return ipAddressCandidate{}, false
+	}
 	legacy, hasLegacy := record.legacy.resolve()
 	modern, hasModern := record.modern.resolve()
 	if !hasLegacy {
 		return modern, hasModern
 	}
-	if legacy.mask == "" && hasModern && modern.ifIndex == legacy.ifIndex {
-		legacy.mask = modern.mask
+	if !legacy.hasPrefix && !record.legacy.prefixConflict && hasModern && modern.ifIndex == legacy.ifIndex {
+		legacy.prefixLength = modern.prefixLength
+		legacy.hasPrefix = modern.hasPrefix
 	}
 	return legacy, true
 }
 
 func (c *topologyBuilder) finalizeIPAddresses() {
-	if c == nil || len(c.ipAddressesByIP) == 0 {
+	if c == nil || len(c.ipAddressCandidatesByIP) == 0 {
 		return
 	}
-	ips := make([]string, 0, len(c.ipAddressesByIP))
-	for ip := range c.ipAddressesByIP {
+	c.ipAddressesByIP = make(map[string]resolvedIPAddress, len(c.ipAddressCandidatesByIP))
+	ips := make([]string, 0, len(c.ipAddressCandidatesByIP))
+	for ip := range c.ipAddressCandidatesByIP {
 		ips = append(ips, ip)
 	}
 	slices.Sort(ips)
 	for _, ip := range ips {
-		ifIndex := c.ifIndexByIP[ip]
-		if ifIndex == "" {
+		c.materializeIPAddress(ip, c.ipAddressCandidatesByIP[ip])
+		resolved, ok := c.ipAddressesByIP[ip]
+		if !ok {
 			continue
 		}
-		mask := c.ifNetmaskByIP[ip]
-		if !isEligibleManagementInterfaceAddress(ip, mask) {
+		if !isEligibleManagementInterfaceAddress(ip, resolved.netmask) {
 			continue
 		}
 		c.appendLocalManagementAddress(topologymodel.ManagementAddress{
@@ -244,5 +254,30 @@ func (c *topologyBuilder) finalizeIPAddresses() {
 			Source:      "ip_mib",
 		})
 	}
-	c.ipAddressesByIP = nil
+	c.ipAddressCandidatesByIP = nil
+}
+
+func (c *topologyBuilder) ipIfIndex(ip string) string {
+	if c == nil {
+		return ""
+	}
+	return c.ipAddressesByIP[ip].ifIndex
+}
+
+func (c *topologyBuilder) ipNetmask(ip string) string {
+	if c == nil {
+		return ""
+	}
+	return c.ipAddressesByIP[ip].netmask
+}
+
+func (c *topologyBuilder) ipL3Interface(ip string) (topologymodel.L3Interface, bool) {
+	if c == nil {
+		return topologymodel.L3Interface{}, false
+	}
+	resolved, ok := c.ipAddressesByIP[ip]
+	if !ok || resolved.ifIndex == "" || resolved.netmask == "" {
+		return topologymodel.L3Interface{}, false
+	}
+	return topologymodel.L3Interface{IP: ip, Netmask: resolved.netmask, IfIndex: resolved.ifIndex}, true
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"net"
+	"net/netip"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
+)
+
+const (
+	topoIPSourceLegacy = "legacy"
+	topoIPSourceModern = "modern"
+
+	ipAddressPrefixOriginOID = "1.3.6.1.2.1.4.32.1.5"
+)
+
+type ipAddressCandidate struct {
+	ifIndex string
+	mask    string
+}
+
+type ipAddressCandidateSet struct {
+	ifIndex         string
+	ifIndexConflict bool
+	mask            string
+	maskConflict    bool
+}
+
+type ipAddressCandidates struct {
+	legacy ipAddressCandidateSet
+	modern ipAddressCandidateSet
+}
+
+func (s *ipAddressCandidateSet) add(candidate ipAddressCandidate) {
+	if s.ifIndex == "" {
+		s.ifIndex = candidate.ifIndex
+	} else if s.ifIndex != candidate.ifIndex {
+		s.ifIndexConflict = true
+	}
+	if candidate.mask != "" {
+		if s.mask == "" {
+			s.mask = candidate.mask
+		} else if s.mask != candidate.mask {
+			s.maskConflict = true
+		}
+	}
+}
+
+func (s ipAddressCandidateSet) resolve() (ipAddressCandidate, bool) {
+	if s.ifIndex == "" || s.ifIndexConflict {
+		return ipAddressCandidate{}, false
+	}
+	candidate := ipAddressCandidate{ifIndex: s.ifIndex}
+	if !s.maskConflict {
+		candidate.mask = s.mask
+	}
+	return candidate, true
+}
+
+func (c *topologyBuilder) updateIPAddressCandidate(tags map[string]string) {
+	if c == nil {
+		return
+	}
+
+	source := strings.TrimSpace(tags[tagTopoIPSource])
+	candidate, ip, ok := ipAddressCandidateFromTags(source, tags)
+	if !ok {
+		return
+	}
+	if c.ipAddressesByIP == nil {
+		c.ipAddressesByIP = make(map[string]ipAddressCandidates)
+	}
+	record := c.ipAddressesByIP[ip]
+	switch source {
+	case topoIPSourceLegacy:
+		record.legacy.add(candidate)
+	case topoIPSourceModern:
+		record.modern.add(candidate)
+	default:
+		return
+	}
+	c.ipAddressesByIP[ip] = record
+	c.materializeIPAddress(ip, record)
+}
+
+func ipAddressCandidateFromTags(source string, tags map[string]string) (ipAddressCandidate, string, bool) {
+	ifIndex := strings.TrimSpace(tags[tagTopoIfIndex])
+	if topologyutil.ParsePositiveInt64(ifIndex) == 0 {
+		return ipAddressCandidate{}, "", false
+	}
+	addr, ok := topologyutil.ParseIPAddress(tags[tagTopoIPAddr])
+	if !ok {
+		return ipAddressCandidate{}, "", false
+	}
+	ip := addr.String()
+
+	switch source {
+	case topoIPSourceLegacy:
+		mask := ""
+		if addr.Is4() {
+			mask = normalizeIPv4Mask(tags[tagTopoIPMask])
+		}
+		return ipAddressCandidate{ifIndex: ifIndex, mask: mask}, ip, true
+	case topoIPSourceModern:
+		if !addr.Is4() || !modernIPAddressEligible(tags) {
+			return ipAddressCandidate{}, "", false
+		}
+		return ipAddressCandidate{
+			ifIndex: ifIndex,
+			mask:    ipv4MaskFromPrefixPointer(addr, ifIndex, tags[tagTopoIPPrefix]),
+		}, ip, true
+	default:
+		return ipAddressCandidate{}, "", false
+	}
+}
+
+func modernIPAddressEligible(tags map[string]string) bool {
+	if strings.TrimSpace(tags[tagTopoIPType]) != "unicast" {
+		return false
+	}
+	switch strings.TrimSpace(tags[tagTopoIPStatus]) {
+	case "preferred", "deprecated":
+	default:
+		return false
+	}
+	return strings.TrimSpace(tags[tagTopoIPRow]) == "active"
+}
+
+func normalizeIPv4Mask(value string) string {
+	maskAddr, ok := topologyutil.ParseIPAddress(value)
+	if !ok || !maskAddr.Is4() {
+		return ""
+	}
+	mask := net.IPMask(maskAddr.AsSlice())
+	if _, bits := mask.Size(); bits != 32 {
+		return ""
+	}
+	return maskAddr.String()
+}
+
+func ipv4MaskFromPrefixPointer(address netip.Addr, ifIndex, value string) string {
+	value = strings.TrimPrefix(strings.TrimSpace(value), ".")
+	suffix, ok := strings.CutPrefix(value, ipAddressPrefixOriginOID+".")
+	if !ok {
+		return ""
+	}
+	var parts [8]string
+	for i := 0; i < len(parts)-1; i++ {
+		var found bool
+		parts[i], suffix, found = strings.Cut(suffix, ".")
+		if !found {
+			return ""
+		}
+	}
+	parts[len(parts)-1] = suffix
+	pointerIfIndex, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || pointerIfIndex <= 0 || pointerIfIndex != topologyutil.ParsePositiveInt64(ifIndex) {
+		return ""
+	}
+	if parts[1] != "1" || parts[2] != "4" {
+		return ""
+	}
+
+	var prefixBytes [4]byte
+	for i := range prefixBytes {
+		value, err := strconv.Atoi(parts[i+3])
+		if err != nil || value < 0 || value > 255 {
+			return ""
+		}
+		prefixBytes[i] = byte(value)
+	}
+	prefixLength, err := strconv.Atoi(parts[7])
+	if err != nil || prefixLength < 0 || prefixLength > 32 {
+		return ""
+	}
+	prefixAddress := netip.AddrFrom4(prefixBytes)
+	prefix := netip.PrefixFrom(prefixAddress, prefixLength)
+	if prefix.Masked().Addr() != prefixAddress || !prefix.Contains(address) {
+		return ""
+	}
+	return net.IP(net.CIDRMask(prefixLength, 32)).String()
+}
+
+func (c *topologyBuilder) materializeIPAddress(ip string, record ipAddressCandidates) {
+	delete(c.ifIndexByIP, ip)
+	delete(c.ifNetmaskByIP, ip)
+	delete(c.l3InterfacesByIP, ip)
+
+	candidate, ok := resolveIPAddressCandidates(record)
+	if !ok {
+		return
+	}
+	c.ifIndexByIP[ip] = candidate.ifIndex
+	if candidate.mask == "" {
+		return
+	}
+	c.ifNetmaskByIP[ip] = candidate.mask
+	c.l3InterfacesByIP[ip] = topologymodel.L3Interface{
+		IP:      ip,
+		Netmask: candidate.mask,
+		IfIndex: candidate.ifIndex,
+	}
+}
+
+func resolveIPAddressCandidates(record ipAddressCandidates) (ipAddressCandidate, bool) {
+	legacy, hasLegacy := record.legacy.resolve()
+	modern, hasModern := record.modern.resolve()
+	if !hasLegacy {
+		return modern, hasModern
+	}
+	if legacy.mask == "" && hasModern && modern.ifIndex == legacy.ifIndex {
+		legacy.mask = modern.mask
+	}
+	return legacy, true
+}
+
+func (c *topologyBuilder) finalizeIPAddresses() {
+	if c == nil || len(c.ipAddressesByIP) == 0 {
+		return
+	}
+	ips := make([]string, 0, len(c.ipAddressesByIP))
+	for ip := range c.ipAddressesByIP {
+		ips = append(ips, ip)
+	}
+	slices.Sort(ips)
+	for _, ip := range ips {
+		ifIndex := c.ifIndexByIP[ip]
+		if ifIndex == "" {
+			continue
+		}
+		mask := c.ifNetmaskByIP[ip]
+		if !isEligibleManagementInterfaceAddress(ip, mask) {
+			continue
+		}
+		c.appendLocalManagementAddress(topologymodel.ManagementAddress{
+			Address:     ip,
+			AddressType: managementAddressTypeFromIP(ip),
+			Source:      "ip_mib",
+		})
+	}
+	c.ipAddressesByIP = nil
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses_test.go
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopologyCache_ModernIPAddressEligibilityAndPrefix(t *testing.T) {
+	tests := map[string]struct {
+		mutate      func(map[string]string)
+		wantAddress bool
+		wantNetmask string
+	}{
+		"preferred unicast active": {
+			wantAddress: true,
+			wantNetmask: "255.255.255.240",
+		},
+		"deprecated remains usable": {
+			mutate:      func(tags map[string]string) { tags[tagTopoIPStatus] = "deprecated" },
+			wantAddress: true,
+			wantNetmask: "255.255.255.240",
+		},
+		"zero pointer keeps inventory": {
+			mutate:      func(tags map[string]string) { tags[tagTopoIPPrefix] = "0.0" },
+			wantAddress: true,
+		},
+		"missing pointer keeps inventory": {
+			mutate:      func(tags map[string]string) { delete(tags, tagTopoIPPrefix) },
+			wantAddress: true,
+		},
+		"wrong pointer target keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.4.7.1.4.192.0.2.16.28"
+			},
+			wantAddress: true,
+		},
+		"pointer interface mismatch keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.8.1.4.192.0.2.16.28"
+			},
+			wantAddress: true,
+		},
+		"pointer address type mismatch keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.2.4.192.0.2.16.28"
+			},
+			wantAddress: true,
+		},
+		"pointer address length mismatch keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.1.16.192.0.2.16.28"
+			},
+			wantAddress: true,
+		},
+		"pointer with truncated index keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.28"
+			},
+			wantAddress: true,
+		},
+		"pointer with invalid octet keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.256.16.28"
+			},
+			wantAddress: true,
+		},
+		"non-network prefix keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.17.28"
+			},
+			wantAddress: true,
+		},
+		"prefix outside address keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.1.4.198.51.100.0.24"
+			},
+			wantAddress: true,
+		},
+		"invalid prefix length keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.33"
+			},
+			wantAddress: true,
+		},
+		"anycast is not a device-unique identity": {
+			mutate: func(tags map[string]string) { tags[tagTopoIPType] = "anycast" },
+		},
+		"invalid address is unusable": {
+			mutate: func(tags map[string]string) { tags[tagTopoIPStatus] = "invalid" },
+		},
+		"inactive conceptual row is unusable": {
+			mutate: func(tags map[string]string) { tags[tagTopoIPRow] = "notInService" },
+		},
+		"missing type fails closed": {
+			mutate: func(tags map[string]string) { delete(tags, tagTopoIPType) },
+		},
+		"missing status fails closed": {
+			mutate: func(tags map[string]string) { delete(tags, tagTopoIPStatus) },
+		},
+		"missing row status fails closed": {
+			mutate: func(tags map[string]string) { delete(tags, tagTopoIPRow) },
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := newTopologyBuilder()
+			tags := modernIPv4Tags("192.0.2.17", "7", "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28")
+			if test.mutate != nil {
+				test.mutate(tags)
+			}
+
+			cache.updateIfIndexByIP(tags)
+			cache.finalize()
+
+			if !test.wantAddress {
+				assert.NotContains(t, cache.ifIndexByIP, "192.0.2.17")
+				assert.NotContains(t, cache.ifNetmaskByIP, "192.0.2.17")
+				assert.NotContains(t, cache.l3InterfacesByIP, "192.0.2.17")
+				return
+			}
+			assert.Equal(t, "7", cache.ifIndexByIP["192.0.2.17"])
+			assert.Equal(t, test.wantNetmask, cache.ifNetmaskByIP["192.0.2.17"])
+			if test.wantNetmask == "" {
+				assert.NotContains(t, cache.l3InterfacesByIP, "192.0.2.17")
+			} else {
+				assert.Contains(t, cache.l3InterfacesByIP, "192.0.2.17")
+			}
+		})
+	}
+}
+
+func TestTopologyCache_ModernIPAddressRejectsIPv6(t *testing.T) {
+	cache := newTopologyBuilder()
+	cache.updateIfIndexByIP(modernIPv4Tags(
+		"2001:db8::17",
+		"7",
+		"1.3.6.1.2.1.4.32.1.5.7.2.16.32.1.13.184.0.0.0.0.0.0.0.0.0.0.0.16.64",
+	))
+	cache.finalize()
+
+	assert.Empty(t, cache.ifIndexByIP)
+	assert.Empty(t, cache.ifNetmaskByIP)
+	assert.Empty(t, cache.l3InterfacesByIP)
+}
+
+func TestTopologyCache_IPAddressMergeIsOrderIndependent(t *testing.T) {
+	tests := map[string]struct {
+		legacy      map[string]string
+		modern      map[string]string
+		wantIfIndex string
+		wantMask    string
+	}{
+		"legacy mask wins": {
+			legacy:      legacyIPv4Tags("192.0.2.17", "7", "255.255.255.0"),
+			modern:      modernIPv4Tags("192.0.2.17", "7", "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28"),
+			wantIfIndex: "7",
+			wantMask:    "255.255.255.0",
+		},
+		"modern fills missing legacy mask": {
+			legacy:      legacyIPv4Tags("192.0.2.17", "7", ""),
+			modern:      modernIPv4Tags("192.0.2.17", "7", "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28"),
+			wantIfIndex: "7",
+			wantMask:    "255.255.255.240",
+		},
+		"modern fills invalid legacy mask": {
+			legacy:      legacyIPv4Tags("192.0.2.17", "7", "255.0.255.0"),
+			modern:      modernIPv4Tags("192.0.2.17", "7", "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28"),
+			wantIfIndex: "7",
+			wantMask:    "255.255.255.240",
+		},
+		"conflicting modern interface cannot supply mask": {
+			legacy:      legacyIPv4Tags("192.0.2.17", "7", ""),
+			modern:      modernIPv4Tags("192.0.2.17", "8", "1.3.6.1.2.1.4.32.1.5.8.1.4.192.0.2.16.28"),
+			wantIfIndex: "7",
+		},
+	}
+
+	for name, test := range tests {
+		for _, modernFirst := range []bool{false, true} {
+			order := "legacy first"
+			if modernFirst {
+				order = "modern first"
+			}
+			t.Run(name+"/"+order, func(t *testing.T) {
+				cache := newTopologyBuilder()
+				if modernFirst {
+					cache.updateIfIndexByIP(test.modern)
+					cache.updateIfIndexByIP(test.legacy)
+				} else {
+					cache.updateIfIndexByIP(test.legacy)
+					cache.updateIfIndexByIP(test.modern)
+				}
+				cache.finalize()
+
+				assert.Equal(t, test.wantIfIndex, cache.ifIndexByIP["192.0.2.17"])
+				assert.Equal(t, test.wantMask, cache.ifNetmaskByIP["192.0.2.17"])
+				require.Len(t, cache.localDevice.ManagementAddresses, 1)
+			})
+		}
+	}
+}
+
+func TestTopologyCache_IPAddressUnknownSourceCannotOverride(t *testing.T) {
+	cache := newTopologyBuilder()
+	cache.updateIfIndexByIP(legacyIPv4Tags("192.0.2.17", "7", "255.255.255.0"))
+	cache.updateIfIndexByIP(map[string]string{
+		tagTopoIPAddr:  "192.0.2.17",
+		tagTopoIfIndex: "99",
+		tagTopoIPMask:  "255.255.0.0",
+	})
+	cache.finalize()
+
+	assert.Equal(t, "7", cache.ifIndexByIP["192.0.2.17"])
+	assert.Equal(t, "255.255.255.0", cache.ifNetmaskByIP["192.0.2.17"])
+}
+
+func TestTopologyCache_IPAddressSameSourceCandidateResolution(t *testing.T) {
+	tests := map[string]struct {
+		rows        []map[string]string
+		wantIfIndex string
+		wantMask    string
+	}{
+		"exact duplicate collapses": {
+			rows: []map[string]string{
+				legacyIPv4Tags("192.0.2.17", "7", "255.255.255.0"),
+				legacyIPv4Tags("192.0.2.17", "7", "255.255.255.0"),
+			},
+			wantIfIndex: "7",
+			wantMask:    "255.255.255.0",
+		},
+		"conflicting interface indexes fail closed": {
+			rows: []map[string]string{
+				modernIPv4Tags("192.0.2.17", "7", "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28"),
+				modernIPv4Tags("192.0.2.17", "8", "1.3.6.1.2.1.4.32.1.5.8.1.4.192.0.2.16.28"),
+			},
+		},
+		"conflicting masks retain interface inventory": {
+			rows: []map[string]string{
+				legacyIPv4Tags("192.0.2.17", "7", "255.255.255.0"),
+				legacyIPv4Tags("192.0.2.17", "7", "255.255.255.128"),
+			},
+			wantIfIndex: "7",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := newTopologyBuilder()
+			for _, row := range test.rows {
+				cache.updateIfIndexByIP(row)
+			}
+			cache.finalize()
+
+			assert.Equal(t, test.wantIfIndex, cache.ifIndexByIP["192.0.2.17"])
+			assert.Equal(t, test.wantMask, cache.ifNetmaskByIP["192.0.2.17"])
+			if test.wantMask == "" {
+				assert.NotContains(t, cache.l3InterfacesByIP, "192.0.2.17")
+			}
+		})
+	}
+}
+
+func modernIPv4Tags(ip, ifIndex, prefixPointer string) map[string]string {
+	return map[string]string{
+		tagTopoIPAddr:   ip,
+		tagTopoIfIndex:  ifIndex,
+		tagTopoIPSource: topoIPSourceModern,
+		tagTopoIPType:   "unicast",
+		tagTopoIPPrefix: prefixPointer,
+		tagTopoIPStatus: "preferred",
+		tagTopoIPRow:    "active",
+	}
+}
+
+func legacyIPv4Tags(ip, ifIndex, mask string) map[string]string {
+	return map[string]string{
+		tagTopoIPAddr:   ip,
+		tagTopoIfIndex:  ifIndex,
+		tagTopoIPMask:   mask,
+		tagTopoIPSource: topoIPSourceLegacy,
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses_test.go
@@ -157,6 +157,24 @@ func TestTopologyCache_ModernIPAddressRejectsIPv6(t *testing.T) {
 	assert.Empty(t, cache.ipAddressesByIP)
 }
 
+func TestTopologyCache_ModernIPAddressRejectsMalformedIndexAddress(t *testing.T) {
+	for name, address := range map[string]string{
+		"extra components": "1.2.3.4.5.6.7.8",
+		"invalid octet":    "192.0.2.256",
+		"truncated":        "123.45.67",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cache := newTopologyBuilder()
+			cache.updateIfIndexByIP(modernIPv4Tags(address, "7", "0.0"))
+			cache.finalize()
+
+			assert.Empty(t, cache.ipAddressesByIP)
+			assert.Empty(t, cache.localDevice.ManagementAddresses)
+			assert.Empty(t, cache.trapMatchMethodByIP)
+		})
+	}
+}
+
 func TestTopologyCache_IPAddressMergeIsOrderIndependent(t *testing.T) {
 	tests := map[string]struct {
 		legacy      map[string]string

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ip_addresses_test.go
@@ -62,6 +62,12 @@ func TestTopologyCache_ModernIPAddressEligibilityAndPrefix(t *testing.T) {
 			},
 			wantAddress: true,
 		},
+		"pointer with trailing index components keeps inventory": {
+			mutate: func(tags map[string]string) {
+				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28.99"
+			},
+			wantAddress: true,
+		},
 		"pointer with invalid octet keeps inventory": {
 			mutate: func(tags map[string]string) {
 				tags[tagTopoIPPrefix] = "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.256.16.28"
@@ -89,8 +95,14 @@ func TestTopologyCache_ModernIPAddressEligibilityAndPrefix(t *testing.T) {
 		"anycast is not a device-unique identity": {
 			mutate: func(tags map[string]string) { tags[tagTopoIPType] = "anycast" },
 		},
+		"broadcast is not a device-unique identity": {
+			mutate: func(tags map[string]string) { tags[tagTopoIPType] = "broadcast" },
+		},
 		"invalid address is unusable": {
 			mutate: func(tags map[string]string) { tags[tagTopoIPStatus] = "invalid" },
+		},
+		"optimistic address is not yet usable": {
+			mutate: func(tags map[string]string) { tags[tagTopoIPStatus] = "optimistic" },
 		},
 		"inactive conceptual row is unusable": {
 			mutate: func(tags map[string]string) { tags[tagTopoIPRow] = "notInService" },
@@ -118,17 +130,16 @@ func TestTopologyCache_ModernIPAddressEligibilityAndPrefix(t *testing.T) {
 			cache.finalize()
 
 			if !test.wantAddress {
-				assert.NotContains(t, cache.ifIndexByIP, "192.0.2.17")
-				assert.NotContains(t, cache.ifNetmaskByIP, "192.0.2.17")
-				assert.NotContains(t, cache.l3InterfacesByIP, "192.0.2.17")
+				assert.NotContains(t, cache.ipAddressesByIP, "192.0.2.17")
 				return
 			}
-			assert.Equal(t, "7", cache.ifIndexByIP["192.0.2.17"])
-			assert.Equal(t, test.wantNetmask, cache.ifNetmaskByIP["192.0.2.17"])
+			assert.Equal(t, "7", cache.ipIfIndex("192.0.2.17"))
+			assert.Equal(t, test.wantNetmask, cache.ipNetmask("192.0.2.17"))
+			_, hasL3 := cache.ipL3Interface("192.0.2.17")
 			if test.wantNetmask == "" {
-				assert.NotContains(t, cache.l3InterfacesByIP, "192.0.2.17")
+				assert.False(t, hasL3)
 			} else {
-				assert.Contains(t, cache.l3InterfacesByIP, "192.0.2.17")
+				assert.True(t, hasL3)
 			}
 		})
 	}
@@ -143,9 +154,7 @@ func TestTopologyCache_ModernIPAddressRejectsIPv6(t *testing.T) {
 	))
 	cache.finalize()
 
-	assert.Empty(t, cache.ifIndexByIP)
-	assert.Empty(t, cache.ifNetmaskByIP)
-	assert.Empty(t, cache.l3InterfacesByIP)
+	assert.Empty(t, cache.ipAddressesByIP)
 }
 
 func TestTopologyCache_IPAddressMergeIsOrderIndependent(t *testing.T) {
@@ -197,8 +206,8 @@ func TestTopologyCache_IPAddressMergeIsOrderIndependent(t *testing.T) {
 				}
 				cache.finalize()
 
-				assert.Equal(t, test.wantIfIndex, cache.ifIndexByIP["192.0.2.17"])
-				assert.Equal(t, test.wantMask, cache.ifNetmaskByIP["192.0.2.17"])
+				assert.Equal(t, test.wantIfIndex, cache.ipIfIndex("192.0.2.17"))
+				assert.Equal(t, test.wantMask, cache.ipNetmask("192.0.2.17"))
 				require.Len(t, cache.localDevice.ManagementAddresses, 1)
 			})
 		}
@@ -215,8 +224,8 @@ func TestTopologyCache_IPAddressUnknownSourceCannotOverride(t *testing.T) {
 	})
 	cache.finalize()
 
-	assert.Equal(t, "7", cache.ifIndexByIP["192.0.2.17"])
-	assert.Equal(t, "255.255.255.0", cache.ifNetmaskByIP["192.0.2.17"])
+	assert.Equal(t, "7", cache.ipIfIndex("192.0.2.17"))
+	assert.Equal(t, "255.255.255.0", cache.ipNetmask("192.0.2.17"))
 }
 
 func TestTopologyCache_IPAddressSameSourceCandidateResolution(t *testing.T) {
@@ -256,12 +265,66 @@ func TestTopologyCache_IPAddressSameSourceCandidateResolution(t *testing.T) {
 			}
 			cache.finalize()
 
-			assert.Equal(t, test.wantIfIndex, cache.ifIndexByIP["192.0.2.17"])
-			assert.Equal(t, test.wantMask, cache.ifNetmaskByIP["192.0.2.17"])
+			assert.Equal(t, test.wantIfIndex, cache.ipIfIndex("192.0.2.17"))
+			assert.Equal(t, test.wantMask, cache.ipNetmask("192.0.2.17"))
 			if test.wantMask == "" {
-				assert.NotContains(t, cache.l3InterfacesByIP, "192.0.2.17")
+				_, hasL3 := cache.ipL3Interface("192.0.2.17")
+				assert.False(t, hasL3)
 			}
 		})
+	}
+}
+
+func TestTopologyCache_LegacyAmbiguityDoesNotFallBackToModern(t *testing.T) {
+	tests := map[string]struct {
+		legacyRows  []map[string]string
+		wantIfIndex string
+	}{
+		"conflicting legacy interfaces suppress the address": {
+			legacyRows: []map[string]string{
+				legacyIPv4Tags("192.0.2.17", "7", "255.255.255.0"),
+				legacyIPv4Tags("192.0.2.17", "8", "255.255.255.0"),
+			},
+		},
+		"conflicting legacy masks retain inventory without modern prefix": {
+			legacyRows: []map[string]string{
+				legacyIPv4Tags("192.0.2.17", "7", "255.255.255.0"),
+				legacyIPv4Tags("192.0.2.17", "7", "255.255.255.128"),
+			},
+			wantIfIndex: "7",
+		},
+	}
+
+	for name, test := range tests {
+		for _, modernFirst := range []bool{false, true} {
+			order := "legacy_first"
+			if modernFirst {
+				order = "modern_first"
+			}
+			t.Run(name+"/"+order, func(t *testing.T) {
+				cache := newTopologyBuilder()
+				modern := modernIPv4Tags(
+					"192.0.2.17",
+					"7",
+					"1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.16.28",
+				)
+				if modernFirst {
+					cache.updateIfIndexByIP(modern)
+				}
+				for _, row := range test.legacyRows {
+					cache.updateIfIndexByIP(row)
+				}
+				if !modernFirst {
+					cache.updateIfIndexByIP(modern)
+				}
+				cache.finalize()
+
+				assert.Equal(t, test.wantIfIndex, cache.ipIfIndex("192.0.2.17"))
+				assert.Empty(t, cache.ipNetmask("192.0.2.17"))
+				_, hasL3 := cache.ipL3Interface("192.0.2.17")
+				assert.False(t, hasL3)
+			})
+		}
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
@@ -15,7 +15,17 @@ func (c *topologyBuilder) snapshotL3Interfaces(localDeviceID string) []topologym
 		return nil
 	}
 
-	ips := make([]string, 0, len(c.ipAddressesByIP))
+	count := 0
+	for _, resolved := range c.ipAddressesByIP {
+		if resolved.netmask != "" {
+			count++
+		}
+	}
+	if count == 0 {
+		return nil
+	}
+
+	ips := make([]string, 0, count)
 	for ip, resolved := range c.ipAddressesByIP {
 		if resolved.netmask != "" {
 			ips = append(ips, ip)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_l3_interfaces.go
@@ -11,19 +11,24 @@ import (
 )
 
 func (c *topologyBuilder) snapshotL3Interfaces(localDeviceID string) []topologymodel.L3Interface {
-	if c == nil || len(c.l3InterfacesByIP) == 0 {
+	if c == nil || len(c.ipAddressesByIP) == 0 {
 		return nil
 	}
 
-	ips := make([]string, 0, len(c.l3InterfacesByIP))
-	for ip := range c.l3InterfacesByIP {
-		ips = append(ips, ip)
+	ips := make([]string, 0, len(c.ipAddressesByIP))
+	for ip, resolved := range c.ipAddressesByIP {
+		if resolved.netmask != "" {
+			ips = append(ips, ip)
+		}
 	}
 	sort.Strings(ips)
 
 	rows := make([]topologymodel.L3Interface, 0, len(ips))
 	for _, ip := range ips {
-		row := c.l3InterfacesByIP[ip]
+		row, ok := c.ipL3Interface(ip)
+		if !ok {
+			continue
+		}
 		row.DeviceID = strings.TrimSpace(localDeviceID)
 		row.IfIndex = strings.TrimSpace(row.IfIndex)
 		row.IP = topologyutil.NormalizeIPAddress(row.IP)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_management_address.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_management_address.go
@@ -281,14 +281,27 @@ func finalizeLocalManagementAddresses(
 	targets []netip.Addr,
 	netmasks map[string]string,
 ) {
+	finalizeLocalManagementAddressesWithLookup(device, targets, func(ip string) string {
+		return netmasks[ip]
+	})
+}
+
+func finalizeLocalManagementAddressesWithLookup(
+	device *topologymodel.Device,
+	targets []netip.Addr,
+	netmask func(string) string,
+) {
 	if device == nil {
 		return
+	}
+	if netmask == nil {
+		netmask = func(string) string { return "" }
 	}
 
 	var selector managementIPSelector
 	addTarget := func(addr netip.Addr) {
 		addr = addr.Unmap()
-		if isEligibleManagementInterfaceAddress(addr.String(), netmasks[addr.String()]) {
+		if isEligibleManagementInterfaceAddress(addr.String(), netmask(addr.String())) {
 			selector.add(addr, managementAddressSourceCollectorTarget)
 		}
 	}
@@ -303,7 +316,7 @@ func finalizeLocalManagementAddresses(
 	filtered := addrs[:0]
 	for _, addr := range addrs {
 		ip, ok := managementAddressIP(addr)
-		if ok && !isEligibleManagementInterfaceAddress(ip.String(), netmasks[ip.String()]) {
+		if ok && !isEligibleManagementInterfaceAddress(ip.String(), netmask(ip.String())) {
 			continue
 		}
 		filtered = append(filtered, addr)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_management_address_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_management_address_test.go
@@ -156,19 +156,21 @@ func TestAppendManagementAddressFiltersUnusableIPsAndKeepsNonIPFamilies(t *testi
 	}, addrs)
 }
 
-func TestTopologyCacheManagementAddressIngestionPreservesOrderSourceAndDedup(t *testing.T) {
+func TestTopologyCacheManagementAddressIngestionRejectsAmbiguousIPMIBCandidate(t *testing.T) {
 	cache := newTopologyBuilder()
 	cache.updateTime = time.Now()
 	cache.ingestTopologyProfileMetrics([]*ddsnmp.ProfileMetrics{{TopologyMetrics: []ddsnmp.Metric{
 		{TopologyKind: ddsnmp.KindIpIfIndex, Tags: map[string]string{
-			tagTopoIfIndex: "7",
-			tagTopoIPAddr:  "192.0.2.10",
-			tagTopoIPMask:  "255.255.255.0",
+			tagTopoIPSource: topoIPSourceLegacy,
+			tagTopoIfIndex:  "7",
+			tagTopoIPAddr:   "192.0.2.10",
+			tagTopoIPMask:   "255.255.255.0",
 		}},
 		{TopologyKind: ddsnmp.KindIpIfIndex, Tags: map[string]string{
-			tagTopoIfIndex: "8",
-			tagTopoIPAddr:  "::ffff:192.0.2.10",
-			tagTopoIPMask:  "255.255.255.0",
+			tagTopoIPSource: topoIPSourceLegacy,
+			tagTopoIfIndex:  "8",
+			tagTopoIPAddr:   "::ffff:192.0.2.10",
+			tagTopoIPMask:   "255.255.255.0",
 		}},
 		{TopologyKind: ddsnmp.KindLldpLocManAddr, Tags: map[string]string{
 			tagLldpLocMgmtAddr:          "c000020a",
@@ -185,14 +187,15 @@ func TestTopologyCacheManagementAddressIngestionPreservesOrderSourceAndDedup(t *
 			tagLldpLocMgmtAddrOID:       "1.3.6.1.2.1.2.2.1.1.99",
 		}},
 		{TopologyKind: ddsnmp.KindIpIfIndex, Tags: map[string]string{
-			tagTopoIfIndex: "9",
-			tagTopoIPAddr:  "198.51.100.20",
-			tagTopoIPMask:  "255.255.255.0",
+			tagTopoIPSource: topoIPSourceLegacy,
+			tagTopoIfIndex:  "9",
+			tagTopoIPAddr:   "198.51.100.20",
+			tagTopoIPMask:   "255.255.255.0",
 		}},
 	}}})
+	cache.finalize()
 
 	require.Equal(t, []topologymodel.ManagementAddress{
-		{Address: "192.0.2.10", AddressType: "ipv4", Source: "ip_mib"},
 		{
 			Address:     "192.0.2.10",
 			AddressType: "ipv4",
@@ -204,22 +207,50 @@ func TestTopologyCacheManagementAddressIngestionPreservesOrderSourceAndDedup(t *
 		{Address: "198.51.100.20", AddressType: "ipv4", Source: "ip_mib"},
 	}, cache.localDevice.ManagementAddresses)
 
-	cache.finalize()
 	require.Nil(t, cache.localManagementAddressKeys)
 }
 
 func BenchmarkTopologyCacheIPManagementAddressIngest(b *testing.B) {
-	for _, rows := range []int{256, 1024, 4096} {
+	for _, rows := range []int{256, 1024, 4096, 65536} {
 		b.Run(fmt.Sprintf("rows=%d", rows), func(b *testing.B) {
 			metrics := make([]ddsnmp.Metric, rows)
 			for i := range metrics {
 				metrics[i] = ddsnmp.Metric{
 					TopologyKind: ddsnmp.KindIpIfIndex,
 					Tags: map[string]string{
-						tagTopoIfIndex: fmt.Sprintf("%d", i+1),
-						tagTopoIPAddr:  fmt.Sprintf("10.%d.%d.%d", (i>>16)&255, (i>>8)&255, i&255),
-						tagTopoIPMask:  "255.255.255.255",
+						tagTopoIPSource: topoIPSourceLegacy,
+						tagTopoIfIndex:  fmt.Sprintf("%d", i+1),
+						tagTopoIPAddr:   fmt.Sprintf("10.%d.%d.%d", (i>>16)&255, (i>>8)&255, i&255),
+						tagTopoIPMask:   "255.255.255.255",
 					},
+				}
+			}
+			pms := []*ddsnmp.ProfileMetrics{{TopologyMetrics: metrics}}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				cache := newTopologyBuilder()
+				cache.ingestTopologyProfileMetrics(pms)
+				runtime.KeepAlive(cache)
+			}
+		})
+	}
+}
+
+func BenchmarkTopologyCacheModernIPAddressIngest(b *testing.B) {
+	for _, rows := range []int{256, 1024, 4096, 65536} {
+		b.Run(fmt.Sprintf("rows=%d", rows), func(b *testing.B) {
+			metrics := make([]ddsnmp.Metric, rows)
+			for i := range metrics {
+				ip := fmt.Sprintf("10.%d.%d.%d", (i>>16)&255, (i>>8)&255, i&255)
+				ifIndex := fmt.Sprintf("%d", i+1)
+				metrics[i] = ddsnmp.Metric{
+					TopologyKind: ddsnmp.KindIpIfIndex,
+					Tags: modernIPv4Tags(
+						ip,
+						ifIndex,
+						fmt.Sprintf("%s.%s.1.4.%s.32", ipAddressPrefixOriginOID, ifIndex, ip),
+					),
 				}
 			}
 			pms := []*ddsnmp.ProfileMetrics{{TopologyMetrics: metrics}}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_management_address_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_management_address_test.go
@@ -210,7 +210,7 @@ func TestTopologyCacheManagementAddressIngestionRejectsAmbiguousIPMIBCandidate(t
 	require.Nil(t, cache.localManagementAddressKeys)
 }
 
-func BenchmarkTopologyCacheIPManagementAddressIngest(b *testing.B) {
+func BenchmarkTopologyCacheIPManagementAddressLifecycle(b *testing.B) {
 	for _, rows := range []int{256, 1024, 4096, 65536} {
 		b.Run(fmt.Sprintf("rows=%d", rows), func(b *testing.B) {
 			metrics := make([]ddsnmp.Metric, rows)
@@ -231,13 +231,14 @@ func BenchmarkTopologyCacheIPManagementAddressIngest(b *testing.B) {
 			for range b.N {
 				cache := newTopologyBuilder()
 				cache.ingestTopologyProfileMetrics(pms)
+				cache.finalize()
 				runtime.KeepAlive(cache)
 			}
 		})
 	}
 }
 
-func BenchmarkTopologyCacheModernIPAddressIngest(b *testing.B) {
+func BenchmarkTopologyCacheModernIPAddressLifecycle(b *testing.B) {
 	for _, rows := range []int{256, 1024, 4096, 65536} {
 		b.Run(fmt.Sprintf("rows=%d", rows), func(b *testing.B) {
 			metrics := make([]ddsnmp.Metric, rows)
@@ -259,6 +260,7 @@ func BenchmarkTopologyCacheModernIPAddressIngest(b *testing.B) {
 			for range b.N {
 				cache := newTopologyBuilder()
 				cache.ingestTopologyProfileMetrics(pms)
+				cache.finalize()
 				runtime.KeepAlive(cache)
 			}
 		})

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_identity.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_observation_local_identity.go
@@ -53,7 +53,7 @@ func (c *topologyBuilder) deriveLocalBridgeMACFromInterfacePhysAddress(localMana
 
 	localManagementIP = topologyutil.NormalizeIPAddress(localManagementIP)
 	if localManagementIP != "" {
-		ifIndex := strings.TrimSpace(c.ifIndexByIP[localManagementIP])
+		ifIndex := strings.TrimSpace(c.ipIfIndex(localManagementIP))
 		if ifIndex != "" {
 			if status, ok := c.ifStatusByIndex[ifIndex]; ok {
 				if mac := topologyutil.NormalizeMAC(status.mac); mac != "" && mac != "00:00:00:00:00:00" {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
@@ -49,7 +49,8 @@ func (c *topologyBuilder) snapshotOSPFNeighbors(
 		return nil
 	}
 
-	localInterfaces := newTopologyOSPFLocalInterfaceIndex(l3Interfaces)
+	var localInterfaces topologyOSPFLocalInterfaceIndex
+	localInterfacesBuilt := false
 	keys := topologyutil.SortedMapKeys(c.ospfNeighborsByKey)
 	rows := make([]topologymodel.OSPFNeighbor, 0, len(keys))
 	for _, key := range keys {
@@ -58,12 +59,18 @@ func (c *topologyBuilder) snapshotOSPFNeighbors(
 		if row.LocalRouterID == "" {
 			row.LocalRouterID = topologyutil.NormalizeTopologyRouterID(c.localDevice.OSPFRouterID)
 		}
-		if iface, ok := localInterfaces.match(row.NeighborIP); ok {
-			row.LocalIP = iface.IP
-			row.Network = iface.Network
-			row.Netmask = iface.Netmask
-			row.Subnet = iface.Subnet
-			row.Prefix = iface.Prefix
+		if neighbor, matchable := parseOSPFNeighborIPv4(row.NeighborIP); matchable {
+			if !localInterfacesBuilt {
+				localInterfaces = newTopologyOSPFLocalInterfaceIndex(l3Interfaces)
+				localInterfacesBuilt = true
+			}
+			if iface, ok := localInterfaces.matchAddress(neighbor); ok {
+				row.LocalIP = iface.IP
+				row.Network = iface.Network
+				row.Netmask = iface.Netmask
+				row.Subnet = iface.Subnet
+				row.Prefix = iface.Prefix
+			}
 		}
 		if row.DeviceID == "" || (row.NeighborRouterID == "" && row.NeighborIP == "") {
 			continue
@@ -115,17 +122,22 @@ func newTopologyOSPFLocalInterfaceIndex(l3Interfaces []topologymodel.L3Interface
 }
 
 func (index topologyOSPFLocalInterfaceIndex) match(neighborIP string) (topologyOSPFLocalInterfaceMatch, bool) {
+	neighbor, ok := parseOSPFNeighborIPv4(neighborIP)
+	if !ok {
+		return topologyOSPFLocalInterfaceMatch{}, false
+	}
+	return index.matchAddress(neighbor)
+}
+
+func parseOSPFNeighborIPv4(value string) (netip.Addr, bool) {
+	neighbor, ok := topologyutil.ParseIPAddress(value)
+	return neighbor, ok && neighbor.Is4() && !neighbor.IsUnspecified()
+}
+
+func (index topologyOSPFLocalInterfaceIndex) matchAddress(neighbor netip.Addr) (topologyOSPFLocalInterfaceMatch, bool) {
 	if len(index) == 0 {
 		return topologyOSPFLocalInterfaceMatch{}, false
 	}
-	neighbor, ok := topologyutil.ParseIPAddress(neighborIP)
-	if !ok || !neighbor.Is4() {
-		return topologyOSPFLocalInterfaceMatch{}, false
-	}
-	if neighbor.IsUnspecified() {
-		return topologyOSPFLocalInterfaceMatch{}, false
-	}
-
 	for bits := 32; bits >= 0; bits-- {
 		entry, found := index[netip.PrefixFrom(neighbor, bits).Masked()]
 		if found {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
@@ -4,7 +4,6 @@ package snmptopology
 
 import (
 	"net/netip"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -42,7 +41,10 @@ func (c *topologyBuilder) updateOSPFNeighbor(tags map[string]string) {
 	c.ospfNeighborsByKey[topologyOSPFNeighborCacheKey(row)] = row
 }
 
-func (c *topologyBuilder) snapshotOSPFNeighbors(localDeviceID string) []topologymodel.OSPFNeighbor {
+func (c *topologyBuilder) snapshotOSPFNeighbors(
+	localDeviceID string,
+	l3Interfaces []topologymodel.L3Interface,
+) []topologymodel.OSPFNeighbor {
 	if c == nil || len(c.ospfNeighborsByKey) == 0 {
 		return nil
 	}
@@ -55,7 +57,7 @@ func (c *topologyBuilder) snapshotOSPFNeighbors(localDeviceID string) []topology
 		if row.LocalRouterID == "" {
 			row.LocalRouterID = topologyutil.NormalizeTopologyRouterID(c.localDevice.OSPFRouterID)
 		}
-		if iface, ok := c.matchOSPFNeighborLocalInterface(row.NeighborIP); ok {
+		if iface, ok := matchOSPFNeighborLocalInterface(row.NeighborIP, l3Interfaces); ok {
 			row.LocalIP = iface.IP
 			row.Network = iface.Network
 			row.Netmask = iface.Netmask
@@ -78,31 +80,21 @@ type topologyOSPFLocalInterfaceMatch struct {
 	Prefix  int
 }
 
-func (c *topologyBuilder) matchOSPFNeighborLocalInterface(neighborIP string) (topologyOSPFLocalInterfaceMatch, bool) {
-	neighbor, err := netip.ParseAddr(topologyutil.NormalizeIPAddress(neighborIP))
-	if err != nil || !neighbor.Is4() {
+func matchOSPFNeighborLocalInterface(
+	neighborIP string,
+	l3Interfaces []topologymodel.L3Interface,
+) (topologyOSPFLocalInterfaceMatch, bool) {
+	neighbor, ok := topologyutil.ParseIPAddress(neighborIP)
+	if !ok || !neighbor.Is4() {
 		return topologyOSPFLocalInterfaceMatch{}, false
 	}
 	if neighbor.IsUnspecified() {
 		return topologyOSPFLocalInterfaceMatch{}, false
 	}
 
-	ips := make([]string, 0, len(c.ipAddressesByIP))
-	for ip, resolved := range c.ipAddressesByIP {
-		if resolved.netmask != "" {
-			ips = append(ips, ip)
-		}
-	}
-	sort.Strings(ips)
-
 	var best topologyOSPFLocalInterfaceMatch
 	found := false
-	for _, ip := range ips {
-		row, ok := c.ipL3Interface(ip)
-		if !ok {
-			continue
-		}
-		row.DeviceID = "local"
+	for _, row := range l3Interfaces {
 		subnet, ok := topologymodel.L3SubnetForInterface(row)
 		if !ok {
 			continue

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
@@ -49,6 +49,7 @@ func (c *topologyBuilder) snapshotOSPFNeighbors(
 		return nil
 	}
 
+	localInterfaces := newTopologyOSPFLocalInterfaceIndex(l3Interfaces)
 	keys := topologyutil.SortedMapKeys(c.ospfNeighborsByKey)
 	rows := make([]topologymodel.OSPFNeighbor, 0, len(keys))
 	for _, key := range keys {
@@ -57,7 +58,7 @@ func (c *topologyBuilder) snapshotOSPFNeighbors(
 		if row.LocalRouterID == "" {
 			row.LocalRouterID = topologyutil.NormalizeTopologyRouterID(c.localDevice.OSPFRouterID)
 		}
-		if iface, ok := matchOSPFNeighborLocalInterface(row.NeighborIP, l3Interfaces); ok {
+		if iface, ok := localInterfaces.match(row.NeighborIP); ok {
 			row.LocalIP = iface.IP
 			row.Network = iface.Network
 			row.Netmask = iface.Netmask
@@ -80,10 +81,43 @@ type topologyOSPFLocalInterfaceMatch struct {
 	Prefix  int
 }
 
-func matchOSPFNeighborLocalInterface(
-	neighborIP string,
-	l3Interfaces []topologymodel.L3Interface,
-) (topologyOSPFLocalInterfaceMatch, bool) {
+type topologyOSPFLocalInterfaceEntry struct {
+	ip      string
+	network netip.Addr
+	netmask string
+	prefix  int
+}
+
+type topologyOSPFLocalInterfaceIndex map[netip.Prefix]topologyOSPFLocalInterfaceEntry
+
+func newTopologyOSPFLocalInterfaceIndex(l3Interfaces []topologymodel.L3Interface) topologyOSPFLocalInterfaceIndex {
+	var index topologyOSPFLocalInterfaceIndex
+	for _, row := range l3Interfaces {
+		subnet, ok := topologymodel.L3SubnetForInterface(row)
+		if !ok {
+			continue
+		}
+		prefix := netip.PrefixFrom(subnet.Network, subnet.Prefix).Masked()
+		if _, exists := index[prefix]; exists {
+			continue
+		}
+		if index == nil {
+			index = make(topologyOSPFLocalInterfaceIndex)
+		}
+		index[prefix] = topologyOSPFLocalInterfaceEntry{
+			ip:      row.IP,
+			network: subnet.Network,
+			netmask: row.Netmask,
+			prefix:  subnet.Prefix,
+		}
+	}
+	return index
+}
+
+func (index topologyOSPFLocalInterfaceIndex) match(neighborIP string) (topologyOSPFLocalInterfaceMatch, bool) {
+	if len(index) == 0 {
+		return topologyOSPFLocalInterfaceMatch{}, false
+	}
 	neighbor, ok := topologyutil.ParseIPAddress(neighborIP)
 	if !ok || !neighbor.Is4() {
 		return topologyOSPFLocalInterfaceMatch{}, false
@@ -92,31 +126,20 @@ func matchOSPFNeighborLocalInterface(
 		return topologyOSPFLocalInterfaceMatch{}, false
 	}
 
-	var best topologyOSPFLocalInterfaceMatch
-	found := false
-	for _, row := range l3Interfaces {
-		subnet, ok := topologymodel.L3SubnetForInterface(row)
-		if !ok {
-			continue
-		}
-		prefix := netip.PrefixFrom(subnet.Network, subnet.Prefix)
-		if !prefix.Contains(neighbor) {
-			continue
-		}
-		candidate := topologyOSPFLocalInterfaceMatch{
-			IP:      topologyutil.NormalizeIPAddress(row.IP),
-			Network: subnet.Network.String(),
-			Netmask: subnet.Netmask.String(),
-			Subnet:  subnet.Network.String() + "/" + strconv.Itoa(subnet.Prefix),
-			Prefix:  subnet.Prefix,
-		}
-		if !found || candidate.Prefix > best.Prefix {
-			best = candidate
-			found = true
+	for bits := 32; bits >= 0; bits-- {
+		entry, found := index[netip.PrefixFrom(neighbor, bits).Masked()]
+		if found {
+			network := entry.network.String()
+			return topologyOSPFLocalInterfaceMatch{
+				IP:      entry.ip,
+				Network: network,
+				Netmask: entry.netmask,
+				Subnet:  network + "/" + strconv.Itoa(entry.prefix),
+				Prefix:  entry.prefix,
+			}, true
 		}
 	}
-
-	return best, found
+	return topologyOSPFLocalInterfaceMatch{}, false
 }
 
 func topologyOSPFNeighborCacheKey(row topologymodel.OSPFNeighbor) string {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors.go
@@ -87,16 +87,21 @@ func (c *topologyBuilder) matchOSPFNeighborLocalInterface(neighborIP string) (to
 		return topologyOSPFLocalInterfaceMatch{}, false
 	}
 
-	ips := make([]string, 0, len(c.l3InterfacesByIP))
-	for ip := range c.l3InterfacesByIP {
-		ips = append(ips, ip)
+	ips := make([]string, 0, len(c.ipAddressesByIP))
+	for ip, resolved := range c.ipAddressesByIP {
+		if resolved.netmask != "" {
+			ips = append(ips, ip)
+		}
 	}
 	sort.Strings(ips)
 
 	var best topologyOSPFLocalInterfaceMatch
 	found := false
 	for _, ip := range ips {
-		row := c.l3InterfacesByIP[ip]
+		row, ok := c.ipL3Interface(ip)
+		if !ok {
+			continue
+		}
 		row.DeviceID = "local"
 		subnet, ok := topologymodel.L3SubnetForInterface(row)
 		if !ok {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
@@ -22,33 +22,6 @@ func TestTopologyCache_OSPFNeighborDropsUnspecifiedOnlyNeighborIdentity(t *testi
 	require.Empty(t, cache.ospfNeighborsByKey)
 }
 
-func TestTopologyCache_OSPFMatchingReusesCompactL3Projection(t *testing.T) {
-	cache := newTopologyBuilder()
-	for i := range 256 {
-		cache.updateIfIndexByIP(modernIPv4Tags(
-			fmt.Sprintf("10.0.%d.%d", i/256, i%256),
-			fmt.Sprintf("%d", i+1),
-			"0.0",
-		))
-	}
-	cache.finalize()
-	localInterfaces := newTopologyOSPFLocalInterfaceIndex(cache.snapshotL3Interfaces("local"))
-
-	allocsForMatches := func(matches int) float64 {
-		return testing.AllocsPerRun(10, func() {
-			for range matches {
-				match, ok := localInterfaces.match("192.0.2.1")
-				runtime.KeepAlive(match)
-				runtime.KeepAlive(ok)
-			}
-		})
-	}
-
-	one := allocsForMatches(1)
-	many := allocsForMatches(32)
-	require.LessOrEqual(t, many, one+4, "matching must not rebuild the full address projection per neighbor")
-}
-
 func TestTopologyCache_OSPFSnapshotAllocationsDoNotScaleWithPrefixNeighborCrossProduct(t *testing.T) {
 	allocsForNeighbors := func(neighbors int) float64 {
 		cache := newTopologyBuilder()

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
@@ -32,12 +32,12 @@ func TestTopologyCache_OSPFMatchingReusesCompactL3Projection(t *testing.T) {
 		))
 	}
 	cache.finalize()
-	l3Interfaces := cache.snapshotL3Interfaces("local")
+	localInterfaces := newTopologyOSPFLocalInterfaceIndex(cache.snapshotL3Interfaces("local"))
 
 	allocsForMatches := func(matches int) float64 {
 		return testing.AllocsPerRun(10, func() {
 			for range matches {
-				match, ok := matchOSPFNeighborLocalInterface("192.0.2.1", l3Interfaces)
+				match, ok := localInterfaces.match("192.0.2.1")
 				runtime.KeepAlive(match)
 				runtime.KeepAlive(ok)
 			}
@@ -49,6 +49,42 @@ func TestTopologyCache_OSPFMatchingReusesCompactL3Projection(t *testing.T) {
 	require.LessOrEqual(t, many, one+4, "matching must not rebuild the full address projection per neighbor")
 }
 
+func TestTopologyCache_OSPFSnapshotAllocationsDoNotScaleWithPrefixNeighborCrossProduct(t *testing.T) {
+	allocsForNeighbors := func(neighbors int) float64 {
+		cache := newTopologyBuilder()
+		cache.localDevice.ChassisID = "02:00:00:00:00:01"
+		cache.localDevice.ChassisIDType = "macAddress"
+		cache.localDevice.SysName = "allocation-router"
+		for i := range 256 {
+			ip := fmt.Sprintf("10.0.%d.%d", i>>8, i&255)
+			ifIndex := fmt.Sprintf("%d", i+1)
+			cache.updateIfIndexByIP(modernIPv4Tags(
+				ip,
+				ifIndex,
+				fmt.Sprintf("%s.%s.1.4.%s.32", ipAddressPrefixOriginOID, ifIndex, ip),
+			))
+		}
+		for i := range neighbors {
+			cache.updateOSPFNeighbor(map[string]string{
+				tagOSPFNeighborRouterID: fmt.Sprintf("192.0.2.%d", i+1),
+				tagOSPFNeighborIP:       fmt.Sprintf("198.51.100.%d", i+1),
+				tagOSPFNeighborState:    "full",
+			})
+		}
+		cache.finalize()
+
+		return testing.AllocsPerRun(10, func() {
+			snapshot, ok := cache.buildObservationSnapshot()
+			runtime.KeepAlive(snapshot)
+			runtime.KeepAlive(ok)
+		})
+	}
+
+	one := allocsForNeighbors(1)
+	many := allocsForNeighbors(32)
+	require.LessOrEqual(t, many, one+512, "prefix matching must not reparse every interface for every neighbor")
+}
+
 func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testing.T) {
 	cache := newTopologyBuilder()
 	cache.ipAddressesByIP = map[string]resolvedIPAddress{
@@ -56,7 +92,7 @@ func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testi
 		"10.0.1.1": {ifIndex: "2", netmask: "255.255.255.252"},
 	}
 
-	match, ok := matchOSPFNeighborLocalInterface("10.0.1.2", cache.snapshotL3Interfaces("local"))
+	match, ok := newTopologyOSPFLocalInterfaceIndex(cache.snapshotL3Interfaces("local")).match("10.0.1.2")
 
 	require.True(t, ok)
 	require.Equal(t, "10.0.1.1", match.IP)
@@ -64,6 +100,19 @@ func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testi
 	require.Equal(t, "255.255.255.252", match.Netmask)
 	require.Equal(t, "10.0.1.0/30", match.Subnet)
 	require.Equal(t, 30, match.Prefix)
+}
+
+func TestTopologyCache_MatchOSPFNeighborLocalInterfaceKeepsFirstSortedEqualPrefix(t *testing.T) {
+	cache := newTopologyBuilder()
+	cache.ipAddressesByIP = map[string]resolvedIPAddress{
+		"10.0.1.2": {ifIndex: "2", netmask: "255.255.255.0"},
+		"10.0.1.1": {ifIndex: "1", netmask: "255.255.255.0"},
+	}
+
+	match, ok := newTopologyOSPFLocalInterfaceIndex(cache.snapshotL3Interfaces("local")).match("10.0.1.99")
+
+	require.True(t, ok)
+	require.Equal(t, "10.0.1.1", match.IP)
 }
 
 func BenchmarkTopologyCacheOSPFSnapshotWithoutPrefixes(b *testing.B) {
@@ -78,6 +127,42 @@ func BenchmarkTopologyCacheOSPFSnapshotWithoutPrefixes(b *testing.B) {
 					fmt.Sprintf("169.254.%d.%d", (i>>8)&255, i&255),
 					fmt.Sprintf("%d", i+1),
 					"0.0",
+				))
+			}
+			for i := range 100 {
+				cache.updateOSPFNeighbor(map[string]string{
+					tagOSPFNeighborRouterID: fmt.Sprintf("192.0.2.%d", i+1),
+					tagOSPFNeighborIP:       fmt.Sprintf("198.51.100.%d", i+1),
+					tagOSPFNeighborState:    "full",
+				})
+			}
+			cache.finalize()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				snapshot, ok := cache.buildObservationSnapshot()
+				runtime.KeepAlive(snapshot)
+				runtime.KeepAlive(ok)
+			}
+		})
+	}
+}
+
+func BenchmarkTopologyCacheOSPFSnapshotWithPrefixes(b *testing.B) {
+	for _, addressRows := range []int{4096, 65536} {
+		b.Run(fmt.Sprintf("addresses=%d/neighbors=100", addressRows), func(b *testing.B) {
+			cache := newTopologyBuilder()
+			cache.localDevice.ChassisID = "02:00:00:00:00:01"
+			cache.localDevice.ChassisIDType = "macAddress"
+			cache.localDevice.SysName = "benchmark-router"
+			for i := range addressRows {
+				ip := fmt.Sprintf("10.%d.%d.%d", (i>>16)&255, (i>>8)&255, i&255)
+				ifIndex := fmt.Sprintf("%d", i+1)
+				cache.updateIfIndexByIP(modernIPv4Tags(
+					ip,
+					ifIndex,
+					fmt.Sprintf("%s.%s.1.4.%s.32", ipAddressPrefixOriginOID, ifIndex, ip),
 				))
 			}
 			for i := range 100 {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
@@ -3,6 +3,8 @@
 package snmptopology
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,6 +22,33 @@ func TestTopologyCache_OSPFNeighborDropsUnspecifiedOnlyNeighborIdentity(t *testi
 	require.Empty(t, cache.ospfNeighborsByKey)
 }
 
+func TestTopologyCache_OSPFMatchingReusesCompactL3Projection(t *testing.T) {
+	cache := newTopologyBuilder()
+	for i := range 256 {
+		cache.updateIfIndexByIP(modernIPv4Tags(
+			fmt.Sprintf("10.0.%d.%d", i/256, i%256),
+			fmt.Sprintf("%d", i+1),
+			"0.0",
+		))
+	}
+	cache.finalize()
+	l3Interfaces := cache.snapshotL3Interfaces("local")
+
+	allocsForMatches := func(matches int) float64 {
+		return testing.AllocsPerRun(10, func() {
+			for range matches {
+				match, ok := matchOSPFNeighborLocalInterface("192.0.2.1", l3Interfaces)
+				runtime.KeepAlive(match)
+				runtime.KeepAlive(ok)
+			}
+		})
+	}
+
+	one := allocsForMatches(1)
+	many := allocsForMatches(32)
+	require.LessOrEqual(t, many, one+4, "matching must not rebuild the full address projection per neighbor")
+}
+
 func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testing.T) {
 	cache := newTopologyBuilder()
 	cache.ipAddressesByIP = map[string]resolvedIPAddress{
@@ -27,7 +56,7 @@ func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testi
 		"10.0.1.1": {ifIndex: "2", netmask: "255.255.255.252"},
 	}
 
-	match, ok := cache.matchOSPFNeighborLocalInterface("10.0.1.2")
+	match, ok := matchOSPFNeighborLocalInterface("10.0.1.2", cache.snapshotL3Interfaces("local"))
 
 	require.True(t, ok)
 	require.Equal(t, "10.0.1.1", match.IP)
@@ -35,4 +64,38 @@ func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testi
 	require.Equal(t, "255.255.255.252", match.Netmask)
 	require.Equal(t, "10.0.1.0/30", match.Subnet)
 	require.Equal(t, 30, match.Prefix)
+}
+
+func BenchmarkTopologyCacheOSPFSnapshotWithoutPrefixes(b *testing.B) {
+	for _, addressRows := range []int{4096, 65536} {
+		b.Run(fmt.Sprintf("addresses=%d/neighbors=100", addressRows), func(b *testing.B) {
+			cache := newTopologyBuilder()
+			cache.localDevice.ChassisID = "02:00:00:00:00:01"
+			cache.localDevice.ChassisIDType = "macAddress"
+			cache.localDevice.SysName = "benchmark-router"
+			for i := range addressRows {
+				cache.updateIfIndexByIP(modernIPv4Tags(
+					fmt.Sprintf("169.254.%d.%d", (i>>8)&255, i&255),
+					fmt.Sprintf("%d", i+1),
+					"0.0",
+				))
+			}
+			for i := range 100 {
+				cache.updateOSPFNeighbor(map[string]string{
+					tagOSPFNeighborRouterID: fmt.Sprintf("192.0.2.%d", i+1),
+					tagOSPFNeighborIP:       fmt.Sprintf("198.51.100.%d", i+1),
+					tagOSPFNeighborState:    "full",
+				})
+			}
+			cache.finalize()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				snapshot, ok := cache.buildObservationSnapshot()
+				runtime.KeepAlive(snapshot)
+				runtime.KeepAlive(ok)
+			}
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
@@ -5,8 +5,6 @@ package snmptopology
 import (
 	"testing"
 
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,17 +22,9 @@ func TestTopologyCache_OSPFNeighborDropsUnspecifiedOnlyNeighborIdentity(t *testi
 
 func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testing.T) {
 	cache := newTopologyBuilder()
-	cache.l3InterfacesByIP = map[string]topologymodel.L3Interface{
-		"10.0.0.1": {
-			IP:      "10.0.0.1",
-			Netmask: "255.255.0.0",
-			IfIndex: "1",
-		},
-		"10.0.1.1": {
-			IP:      "10.0.1.1",
-			Netmask: "255.255.255.252",
-			IfIndex: "2",
-		},
+	cache.ipAddressesByIP = map[string]resolvedIPAddress{
+		"10.0.0.1": {ifIndex: "1", netmask: "255.255.0.0"},
+		"10.0.1.1": {ifIndex: "2", netmask: "255.255.255.252"},
 	}
 
 	match, ok := cache.matchOSPFNeighborLocalInterface("10.0.1.2")

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_ospf_neighbors_test.go
@@ -85,6 +85,43 @@ func TestTopologyCache_OSPFSnapshotAllocationsDoNotScaleWithPrefixNeighborCrossP
 	require.LessOrEqual(t, many, one+512, "prefix matching must not reparse every interface for every neighbor")
 }
 
+func TestTopologyCache_AddresslessOSPFSnapshotDoesNotBuildPrefixIndex(t *testing.T) {
+	allocsForNeighbors := func(neighbors int) float64 {
+		cache := newTopologyBuilder()
+		cache.localDevice.ChassisID = "02:00:00:00:00:01"
+		cache.localDevice.ChassisIDType = "macAddress"
+		cache.localDevice.SysName = "addressless-router"
+		for i := range 256 {
+			ip := fmt.Sprintf("10.0.%d.%d", i>>8, i&255)
+			ifIndex := fmt.Sprintf("%d", i+1)
+			cache.updateIfIndexByIP(modernIPv4Tags(
+				ip,
+				ifIndex,
+				fmt.Sprintf("%s.%s.1.4.%s.32", ipAddressPrefixOriginOID, ifIndex, ip),
+			))
+		}
+		for i := range neighbors {
+			cache.updateOSPFNeighbor(map[string]string{
+				tagOSPFNeighborRouterID: fmt.Sprintf("192.0.2.%d", i+1),
+				tagOSPFNeighborIP:       "0.0.0.0",
+				tagOSPFNeighborState:    "full",
+			})
+		}
+		cache.finalize()
+
+		return testing.AllocsPerRun(10, func() {
+			snapshot, ok := cache.buildObservationSnapshot()
+			runtime.KeepAlive(snapshot)
+			runtime.KeepAlive(ok)
+		})
+	}
+
+	withoutNeighbors := allocsForNeighbors(0)
+	addresslessNeighbors := allocsForNeighbors(32)
+	require.LessOrEqual(t, addresslessNeighbors, withoutNeighbors+512,
+		"addressless neighbors must not trigger prefix-index construction")
+}
+
 func TestTopologyCache_MatchOSPFNeighborLocalInterfaceUsesLongestPrefix(t *testing.T) {
 	cache := newTopologyBuilder()
 	cache.ipAddressesByIP = map[string]resolvedIPAddress{
@@ -118,33 +155,7 @@ func TestTopologyCache_MatchOSPFNeighborLocalInterfaceKeepsFirstSortedEqualPrefi
 func BenchmarkTopologyCacheOSPFSnapshotWithoutPrefixes(b *testing.B) {
 	for _, addressRows := range []int{4096, 65536} {
 		b.Run(fmt.Sprintf("addresses=%d/neighbors=100", addressRows), func(b *testing.B) {
-			cache := newTopologyBuilder()
-			cache.localDevice.ChassisID = "02:00:00:00:00:01"
-			cache.localDevice.ChassisIDType = "macAddress"
-			cache.localDevice.SysName = "benchmark-router"
-			for i := range addressRows {
-				cache.updateIfIndexByIP(modernIPv4Tags(
-					fmt.Sprintf("169.254.%d.%d", (i>>8)&255, i&255),
-					fmt.Sprintf("%d", i+1),
-					"0.0",
-				))
-			}
-			for i := range 100 {
-				cache.updateOSPFNeighbor(map[string]string{
-					tagOSPFNeighborRouterID: fmt.Sprintf("192.0.2.%d", i+1),
-					tagOSPFNeighborIP:       fmt.Sprintf("198.51.100.%d", i+1),
-					tagOSPFNeighborState:    "full",
-				})
-			}
-			cache.finalize()
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for b.Loop() {
-				snapshot, ok := cache.buildObservationSnapshot()
-				runtime.KeepAlive(snapshot)
-				runtime.KeepAlive(ok)
-			}
+			benchmarkTopologyCacheOSPFSnapshot(b, addressRows, false, false)
 		})
 	}
 }
@@ -152,35 +163,54 @@ func BenchmarkTopologyCacheOSPFSnapshotWithoutPrefixes(b *testing.B) {
 func BenchmarkTopologyCacheOSPFSnapshotWithPrefixes(b *testing.B) {
 	for _, addressRows := range []int{4096, 65536} {
 		b.Run(fmt.Sprintf("addresses=%d/neighbors=100", addressRows), func(b *testing.B) {
-			cache := newTopologyBuilder()
-			cache.localDevice.ChassisID = "02:00:00:00:00:01"
-			cache.localDevice.ChassisIDType = "macAddress"
-			cache.localDevice.SysName = "benchmark-router"
-			for i := range addressRows {
-				ip := fmt.Sprintf("10.%d.%d.%d", (i>>16)&255, (i>>8)&255, i&255)
-				ifIndex := fmt.Sprintf("%d", i+1)
-				cache.updateIfIndexByIP(modernIPv4Tags(
-					ip,
-					ifIndex,
-					fmt.Sprintf("%s.%s.1.4.%s.32", ipAddressPrefixOriginOID, ifIndex, ip),
-				))
-			}
-			for i := range 100 {
-				cache.updateOSPFNeighbor(map[string]string{
-					tagOSPFNeighborRouterID: fmt.Sprintf("192.0.2.%d", i+1),
-					tagOSPFNeighborIP:       fmt.Sprintf("198.51.100.%d", i+1),
-					tagOSPFNeighborState:    "full",
-				})
-			}
-			cache.finalize()
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for b.Loop() {
-				snapshot, ok := cache.buildObservationSnapshot()
-				runtime.KeepAlive(snapshot)
-				runtime.KeepAlive(ok)
-			}
+			benchmarkTopologyCacheOSPFSnapshot(b, addressRows, true, false)
 		})
+	}
+}
+
+func BenchmarkTopologyCacheOSPFSnapshotAddresslessNeighbors(b *testing.B) {
+	for _, addressRows := range []int{4096, 65536} {
+		b.Run(fmt.Sprintf("addresses=%d/neighbors=100", addressRows), func(b *testing.B) {
+			benchmarkTopologyCacheOSPFSnapshot(b, addressRows, true, true)
+		})
+	}
+}
+
+func benchmarkTopologyCacheOSPFSnapshot(b *testing.B, addressRows int, withPrefixes, addressless bool) {
+	cache := newTopologyBuilder()
+	cache.localDevice.ChassisID = "02:00:00:00:00:01"
+	cache.localDevice.ChassisIDType = "macAddress"
+	cache.localDevice.SysName = "benchmark-router"
+	for i := range addressRows {
+		ip := fmt.Sprintf("10.%d.%d.%d", (i>>16)&255, (i>>8)&255, i&255)
+		if !withPrefixes {
+			ip = fmt.Sprintf("169.254.%d.%d", (i>>8)&255, i&255)
+		}
+		ifIndex := fmt.Sprintf("%d", i+1)
+		pointer := "0.0"
+		if withPrefixes {
+			pointer = fmt.Sprintf("%s.%s.1.4.%s.32", ipAddressPrefixOriginOID, ifIndex, ip)
+		}
+		cache.updateIfIndexByIP(modernIPv4Tags(ip, ifIndex, pointer))
+	}
+	for i := range 100 {
+		neighborIP := fmt.Sprintf("198.51.100.%d", i+1)
+		if addressless {
+			neighborIP = "0.0.0.0"
+		}
+		cache.updateOSPFNeighbor(map[string]string{
+			tagOSPFNeighborRouterID: fmt.Sprintf("192.0.2.%d", i+1),
+			tagOSPFNeighborIP:       neighborIP,
+			tagOSPFNeighborState:    "full",
+		})
+	}
+	cache.finalize()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		snapshot, ok := cache.buildObservationSnapshot()
+		runtime.KeepAlive(snapshot)
+		runtime.KeepAlive(ok)
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_benchmark_test.go
@@ -470,10 +470,9 @@ func BenchmarkTopologyGenerationAliasSnapshotRead(b *testing.B) {
 					AddressType: "ipv4",
 					Source:      "ip_mib",
 				})
-				cache.l3InterfacesByIP[ip] = topologymodel.L3Interface{
-					IP:      ip,
-					Netmask: "255.255.255.0",
-					IfIndex: fmt.Sprintf("%d", i+1),
+				cache.ipAddressesByIP[ip] = resolvedIPAddress{
+					ifIndex: fmt.Sprintf("%d", i+1),
+					netmask: "255.255.255.0",
 				}
 			}
 			generation := freezeTestTopologyBuilder(1, cache)
@@ -858,11 +857,7 @@ func benchmarkAliasRichTopologyRegistry(deviceCount, aliasCount int, sharedPrima
 
 	for deviceIndex, cache := range caches {
 		ip := fmt.Sprintf("203.0.113.%d", deviceIndex+1)
-		cache.l3InterfacesByIP[ip] = topologymodel.L3Interface{
-			IP:      ip,
-			Netmask: "255.255.255.0",
-			IfIndex: "100",
-		}
+		cache.ipAddressesByIP[ip] = resolvedIPAddress{ifIndex: "100", netmask: "255.255.255.0"}
 	}
 
 	logicalPeerCount = min(logicalPeerCount, len(caches)-1)
@@ -870,15 +865,13 @@ func benchmarkAliasRichTopologyRegistry(deviceCount, aliasCount int, sharedPrima
 		networkOffset := (peerIndex - 1) * 4
 		localIP := fmt.Sprintf("198.51.100.%d", networkOffset+1)
 		remoteIP := fmt.Sprintf("198.51.100.%d", networkOffset+2)
-		caches[0].l3InterfacesByIP[localIP] = topologymodel.L3Interface{
-			IP:      localIP,
-			Netmask: "255.255.255.252",
-			IfIndex: fmt.Sprintf("%d", peerIndex),
+		caches[0].ipAddressesByIP[localIP] = resolvedIPAddress{
+			ifIndex: fmt.Sprintf("%d", peerIndex),
+			netmask: "255.255.255.252",
 		}
-		caches[peerIndex].l3InterfacesByIP[remoteIP] = topologymodel.L3Interface{
-			IP:      remoteIP,
-			Netmask: "255.255.255.252",
-			IfIndex: "1",
+		caches[peerIndex].ipAddressesByIP[remoteIP] = resolvedIPAddress{
+			ifIndex: "1",
+			netmask: "255.255.255.252",
 		}
 		caches[0].ospfNeighborsByKey[fmt.Sprintf("benchmark-neighbor-%d", peerIndex)] = topologymodel.OSPFNeighbor{
 			LocalRouterID: caches[0].localDevice.OSPFRouterID,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_snapshot.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_snapshot.go
@@ -27,11 +27,12 @@ func (c *topologyBuilder) buildObservationSnapshot() (topologymodel.ObservationS
 			local.ChassisIDType = "macAddress"
 		}
 	}
+	l3Interfaces := c.snapshotL3Interfaces(localObservation.DeviceID)
 
 	return topologymodel.ObservationSnapshot{
 		L2Observations: []topologyengine.L2Observation{localObservation},
-		L3Interfaces:   c.snapshotL3Interfaces(localObservation.DeviceID),
-		OSPFNeighbors:  c.snapshotOSPFNeighbors(localObservation.DeviceID),
+		L3Interfaces:   l3Interfaces,
+		OSPFNeighbors:  c.snapshotOSPFNeighbors(localObservation.DeviceID, l3Interfaces),
 		BGPPeers:       c.snapshotBGPPeers(localObservation.DeviceID),
 		LocalDevice:    local,
 		LocalDeviceID:  localObservation.DeviceID,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_registry_test.go
@@ -441,9 +441,10 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetForManagedRoutersWithoutLLDP(t 
 		ManagementIP:  "10.0.0.1",
 	}
 	cacheA.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "2",
-		tagTopoIPAddr:  "198.51.100.1",
-		tagTopoIPMask:  "255.255.255.252",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "2",
+		tagTopoIPAddr:   "198.51.100.1",
+		tagTopoIPMask:   "255.255.255.252",
 	})
 	cacheA.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "2",
@@ -461,9 +462,10 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetForManagedRoutersWithoutLLDP(t 
 		ManagementIP:  "10.0.0.2",
 	}
 	cacheB.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "7",
-		tagTopoIPAddr:  "198.51.100.2",
-		tagTopoIPMask:  "255.255.255.252",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "7",
+		tagTopoIPAddr:   "198.51.100.2",
+		tagTopoIPMask:   "255.255.255.252",
 	})
 	cacheB.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "7",
@@ -500,9 +502,10 @@ func TestTopologyRegistry_WeakDevicesUseSelectedManagementIPIdentity(t *testing.
 		cache := newTopologyBuilder()
 		cache.updateTime = time.Now().Add(time.Duration(i) * time.Millisecond)
 		cache.updateIfIndexByIP(map[string]string{
-			tagTopoIfIndex: "1",
-			tagTopoIPAddr:  ip,
-			tagTopoIPMask:  "255.255.255.0",
+			tagTopoIPSource: topoIPSourceLegacy,
+			tagTopoIfIndex:  "1",
+			tagTopoIPAddr:   ip,
+			tagTopoIPMask:   "255.255.255.0",
 		})
 		cache.finalize()
 		publishTestTopologyBuilder(registry, cache)
@@ -539,9 +542,10 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *tes
 		ManagementIP:  "10.0.0.1",
 	}
 	cacheA.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "2",
-		tagTopoIPAddr:  "203.0.113.1",
-		tagTopoIPMask:  "255.255.255.0",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "2",
+		tagTopoIPAddr:   "203.0.113.1",
+		tagTopoIPMask:   "255.255.255.0",
 	})
 	cacheA.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "2",
@@ -559,9 +563,10 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *tes
 		ManagementIP:  "10.0.0.2",
 	}
 	cacheB.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "7",
-		tagTopoIPAddr:  "203.0.113.2",
-		tagTopoIPMask:  "255.255.255.0",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "7",
+		tagTopoIPAddr:   "203.0.113.2",
+		tagTopoIPMask:   "255.255.255.0",
 	})
 	cacheB.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "7",
@@ -579,9 +584,10 @@ func TestTopologyRegistry_DefaultMapEmitsL3SubnetSegmentForManagedRouters(t *tes
 		ManagementIP:  "10.0.0.3",
 	}
 	cacheC.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "9",
-		tagTopoIPAddr:  "203.0.113.3",
-		tagTopoIPMask:  "255.255.255.0",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "9",
+		tagTopoIPAddr:   "203.0.113.3",
+		tagTopoIPMask:   "255.255.255.0",
 	})
 	cacheC.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "9",
@@ -662,9 +668,10 @@ func TestTopologyRegistry_OSPFSnapshotEnrichesSubnetAfterNeighborIngest(t *testi
 		},
 	})
 	cacheA.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "2",
-		tagTopoIPAddr:  "198.51.100.1",
-		tagTopoIPMask:  "255.255.255.252",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "2",
+		tagTopoIPAddr:   "198.51.100.1",
+		tagTopoIPMask:   "255.255.255.252",
 	})
 
 	cacheB := newTopologyBuilder()
@@ -683,9 +690,10 @@ func TestTopologyRegistry_OSPFSnapshotEnrichesSubnetAfterNeighborIngest(t *testi
 		},
 	}})
 	cacheB.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "7",
-		tagTopoIPAddr:  "198.51.100.2",
-		tagTopoIPMask:  "255.255.255.252",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "7",
+		tagTopoIPAddr:   "198.51.100.2",
+		tagTopoIPMask:   "255.255.255.252",
 	})
 
 	publishTestTopologyBuilder(registry, cacheA)
@@ -1044,9 +1052,10 @@ func TestTopologyRegistry_ManagedFocusUsesOnlyReconciledManagementAddresses(t *t
 		ManagementIP:  "192.0.2.10",
 	}
 	cacheA.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "1",
-		tagTopoIPAddr:  "192.0.2.20",
-		tagTopoIPMask:  "255.255.255.0",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "1",
+		tagTopoIPAddr:   "192.0.2.20",
+		tagTopoIPMask:   "255.255.255.0",
 	})
 
 	cacheB := newTopologyBuilder()
@@ -1096,9 +1105,10 @@ func TestTopologyRegistry_ManagedFocusRetainsUniqueReconciledLocalAlias(t *testi
 		ManagementIP:  "192.0.2.10",
 	}
 	cacheA.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "1",
-		tagTopoIPAddr:  "192.0.2.11",
-		tagTopoIPMask:  "255.255.255.0",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "1",
+		tagTopoIPAddr:   "192.0.2.11",
+		tagTopoIPMask:   "255.255.255.0",
 	})
 
 	cacheB := newTopologyBuilder()
@@ -1186,9 +1196,10 @@ func TestTopologyCache_SnapshotEngineObservationsIncludesL3Interfaces(t *testing
 		ManagementIP:  "10.0.0.1",
 	}
 	cache.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "2",
-		tagTopoIPAddr:  "198.51.100.1",
-		tagTopoIPMask:  "255.255.255.252",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "2",
+		tagTopoIPAddr:   "198.51.100.1",
+		tagTopoIPMask:   "255.255.255.252",
 	})
 	cache.updateIfNameByIndex(map[string]string{
 		tagTopoIfIndex: "2",
@@ -1196,8 +1207,9 @@ func TestTopologyCache_SnapshotEngineObservationsIncludesL3Interfaces(t *testing
 		tagTopoIfDescr: "Uplink",
 	})
 	cache.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: "3",
-		tagTopoIPAddr:  "2001:db8::1",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  "3",
+		tagTopoIPAddr:   "2001:db8::1",
 	})
 
 	snapshot, ok := snapshotTestTopologyBuilder(cache)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_builder_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_builder_test.go
@@ -65,6 +65,9 @@ type topologyScenarioPort struct {
 	mac        string
 	ip         string
 	netmask    string
+	modernIPv4 bool
+	prefixIP   string
+	prefixLen  int
 }
 
 type topologyScenarioPortPair struct {
@@ -161,6 +164,18 @@ func (p *topologyScenarioPort) IPv4(cidr string) *topologyScenarioPort {
 	ip, netmask := topologyScenarioIPv4CIDR(cidr)
 	p.ip = ip
 	p.netmask = netmask
+	return p
+}
+
+func (p *topologyScenarioPort) ModernIPv4(cidr string) *topologyScenarioPort {
+	p.IPv4(cidr)
+	_, prefix, err := net.ParseCIDR(strings.TrimSpace(cidr))
+	if err != nil || prefix.IP.To4() == nil {
+		return p
+	}
+	p.modernIPv4 = true
+	p.prefixIP = prefix.IP.String()
+	p.prefixLen, _ = prefix.Mask.Size()
 	return p
 }
 
@@ -311,12 +326,25 @@ func (s *topologyScenario) topologyMetricsForDevice(dev *topologyScenarioDevice)
 			}),
 		)
 		if port.ip != "" && port.netmask != "" {
-			metrics = append(metrics, topologyScenarioMetric(ddsnmp.KindIpIfIndex, map[string]string{
-				tagTopoIPSource: topoIPSourceLegacy,
-				tagTopoIfIndex:  strconv.Itoa(port.ifIndex),
-				tagTopoIPAddr:   port.ip,
-				tagTopoIPMask:   port.netmask,
-			}))
+			if port.modernIPv4 {
+				ifIndex := strconv.Itoa(port.ifIndex)
+				metrics = append(metrics, topologyScenarioMetric(ddsnmp.KindIpIfIndex, map[string]string{
+					tagTopoIPSource: topoIPSourceModern,
+					tagTopoIfIndex:  ifIndex,
+					tagTopoIPAddr:   port.ip,
+					tagTopoIPType:   "unicast",
+					tagTopoIPPrefix: fmt.Sprintf("%s.%s.1.4.%s.%d", ipAddressPrefixOriginOID, ifIndex, port.prefixIP, port.prefixLen),
+					tagTopoIPStatus: "preferred",
+					tagTopoIPRow:    "active",
+				}))
+			} else {
+				metrics = append(metrics, topologyScenarioMetric(ddsnmp.KindIpIfIndex, map[string]string{
+					tagTopoIPSource: topoIPSourceLegacy,
+					tagTopoIfIndex:  strconv.Itoa(port.ifIndex),
+					tagTopoIPAddr:   port.ip,
+					tagTopoIPMask:   port.netmask,
+				}))
+			}
 		}
 	}
 	for _, pair := range s.lldp {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_builder_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_builder_test.go
@@ -312,9 +312,10 @@ func (s *topologyScenario) topologyMetricsForDevice(dev *topologyScenarioDevice)
 		)
 		if port.ip != "" && port.netmask != "" {
 			metrics = append(metrics, topologyScenarioMetric(ddsnmp.KindIpIfIndex, map[string]string{
-				tagTopoIfIndex: strconv.Itoa(port.ifIndex),
-				tagTopoIPAddr:  port.ip,
-				tagTopoIPMask:  port.netmask,
+				tagTopoIPSource: topoIPSourceLegacy,
+				tagTopoIfIndex:  strconv.Itoa(port.ifIndex),
+				tagTopoIPAddr:   port.ip,
+				tagTopoIPMask:   port.netmask,
 			}))
 		}
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_scenario_golden_test.go
@@ -389,8 +389,8 @@ func newL3P2P30Scenario() *topologyScenario {
 	})
 	routerA := s.Router("p2p30-router-a", "192.0.2.111", "02:00:00:00:0b:01", "192.0.2.211", "65111")
 	routerB := s.Router("p2p30-router-b", "192.0.2.112", "02:00:00:00:0b:02", "192.0.2.212", "65112")
-	routerA.Port("wan0", 1).IPv4("198.51.100.21/30")
-	routerB.Port("wan0", 1).IPv4("198.51.100.22/30")
+	routerA.Port("wan0", 1).ModernIPv4("198.51.100.21/30")
+	routerB.Port("wan0", 1).ModernIPv4("198.51.100.22/30")
 	return s
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
@@ -409,7 +409,8 @@ func topologySemanticMetricTagAllowed(kind ddsnmp.TopologyKind, key string) bool
 		}
 	case ddsnmp.KindIpIfIndex:
 		switch key {
-		case tagTopoIfIndex, tagTopoIPAddr, tagTopoIPMask:
+		case tagTopoIfIndex, tagTopoIPAddr, tagTopoIPMask, tagTopoIPSource,
+			tagTopoIPType, tagTopoIPPrefix, tagTopoIPStatus, tagTopoIPRow:
 			return true
 		}
 	case ddsnmp.KindBridgePortIfIndex:

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic_test.go
@@ -90,6 +90,19 @@ func TestTopologyAcquisitionReplayMatchesLiveBuilder(t *testing.T) {
 					"unused_lldp":             "must-not-appear-unused-lldp-tag",
 				},
 			},
+			{
+				TopologyKind: ddsnmp.KindIpIfIndex,
+				Tags: map[string]string{
+					tagTopoIPSource: topoIPSourceModern,
+					tagTopoIfIndex:  "7",
+					tagTopoIPAddr:   "192.0.2.1",
+					tagTopoIPType:   "unicast",
+					tagTopoIPPrefix: "1.3.6.1.2.1.4.32.1.5.7.1.4.192.0.2.0.24",
+					tagTopoIPStatus: "preferred",
+					tagTopoIPRow:    "active",
+					"unused_ip":     "must-not-appear-unused-ip-tag",
+				},
+			},
 		},
 		BGPRows: []ddsnmp.BGPRow{{
 			OriginProfileID: "_std-bgp4-mib.yaml",
@@ -194,6 +207,7 @@ func TestTopologyAcquisitionReplayMatchesLiveBuilder(t *testing.T) {
 		"must-not-appear-unused-profile-tag",
 		"must-not-appear-profile-tag-vendor",
 		"must-not-appear-unused-metric-tag",
+		"must-not-appear-unused-ip-tag",
 		"must-not-appear-unused-bgp-tag",
 		"must-not-appear-non-vlan-context-row",
 		"must-not-appear-invalid-octet-tag",
@@ -203,6 +217,12 @@ func TestTopologyAcquisitionReplayMatchesLiveBuilder(t *testing.T) {
 	require.Contains(t, capture.evidence.collectionContexts[0].profiles[0].values.tags, tagLldpLocSysName)
 	require.Contains(t, capture.evidence.collectionContexts[0].profiles[0].values.metrics[0].tags, tagTopoIfIndex)
 	require.Contains(t, capture.evidence.collectionContexts[0].profiles[0].values.metrics[2].tags, tagLldpRemMgmtAddrLen)
+	for _, tag := range []string{
+		tagTopoIPSource, tagTopoIfIndex, tagTopoIPAddr, tagTopoIPType,
+		tagTopoIPPrefix, tagTopoIPStatus, tagTopoIPRow,
+	} {
+		require.Contains(t, capture.evidence.collectionContexts[0].profiles[0].values.metrics[3].tags, tag)
+	}
 	require.Contains(t, capture.evidence.collectionContexts[0].profiles[0].values.bgpRows[0].tags, "neighbor")
 	require.Contains(t, capture.evidence.collectionContexts[1].profiles[0].values.metadata, tagOSPFRouterID)
 	require.Contains(t, capture.evidence.collectionContexts[1].profiles[0].values.tags, tagBridgeBaseAddress)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmp_handler_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmp_handler_test.go
@@ -13,6 +13,7 @@ type topologySNMPRecHandler struct {
 	entries           []gosnmp.SnmpPDU
 	byOID             map[string]gosnmp.SnmpPDU
 	hiddenOIDPrefixes []string
+	walkRoots         []string
 }
 
 func newTopologySNMPHandler(entries []gosnmp.SnmpPDU) *topologySNMPRecHandler {
@@ -54,6 +55,7 @@ func (h *topologySNMPRecHandler) BulkWalkAll(root string) ([]gosnmp.SnmpPDU, err
 
 func (h *topologySNMPRecHandler) walkAll(root string) []gosnmp.SnmpPDU {
 	root = strings.TrimPrefix(strings.TrimSpace(root), ".")
+	h.walkRoots = append(h.walkRoots, root)
 	prefix := root + "."
 	var out []gosnmp.SnmpPDU
 	for _, pdu := range h.entries {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmp_handler_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmp_handler_test.go
@@ -28,6 +28,13 @@ func newTopologySNMPHandler(entries []gosnmp.SnmpPDU) *topologySNMPRecHandler {
 	return handler
 }
 
+func (h *topologySNMPRecHandler) addEntries(entries ...gosnmp.SnmpPDU) {
+	for _, pdu := range entries {
+		h.entries = append(h.entries, pdu)
+		h.byOID[strings.TrimPrefix(pdu.Name, ".")] = pdu
+	}
+}
+
 func (h *topologySNMPRecHandler) Get(oids []string) (*gosnmp.SnmpPacket, error) {
 	variables := make([]gosnmp.SnmpPDU, 0, len(oids))
 	for _, oid := range oids {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_forwarding_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_snmprec_forwarding_test.go
@@ -255,6 +255,7 @@ func parseSnmprecForwardingFixture(t *testing.T, path string) snmprecForwardingF
 
 		if suffix, ok := parseOIDSuffix(oid, "1.3.6.1.2.1.4.20.1.1"); ok {
 			entry := ensureTagMap(data.ipIfEntries, suffix)
+			entry[tagTopoIPSource] = topoIPSourceLegacy
 			entry[tagTopoIPAddr] = val
 			continue
 		}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_trap_enrich_test.go
@@ -28,7 +28,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 		"uses-trap-if-index": {
 			setup: func(cache *topologyBuilder) {
 				cache.localDevice.ManagementIP = "192.0.2.30"
-				cache.ifIndexByIP["192.0.2.10"] = "99"
+				cache.ipAddressesByIP["192.0.2.10"] = resolvedIPAddress{ifIndex: "99"}
 				cache.ifNamesByIndex["7"] = "Gi0/7"
 				cache.ifNamesByIndex["99"] = "Gi0/99"
 				cache.lldpRemotes["7:2"] = &lldpRemote{localPortNum: "7", sysName: "dist-b"}
@@ -59,7 +59,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 		},
 		"does-not-infer-interface-from-source-ip": {
 			setup: func(cache *topologyBuilder) {
-				cache.ifIndexByIP["192.0.2.10"] = "7"
+				cache.ipAddressesByIP["192.0.2.10"] = resolvedIPAddress{ifIndex: "7"}
 				cache.ifNamesByIndex["7"] = "Gi0/7"
 				cache.lldpRemotes["7:1"] = &lldpRemote{sysName: "dist-a"}
 			},
@@ -74,7 +74,7 @@ func TestTopologyCacheTrapEnrichment(t *testing.T) {
 				cache.localDevice.ManagementAddresses = []topologymodel.ManagementAddress{{
 					Address: "192.0.2.10", AddressType: "ipv4", Source: "lldp_local",
 				}}
-				cache.ifIndexByIP["192.0.2.10"] = "7"
+				cache.ipAddressesByIP["192.0.2.10"] = resolvedIPAddress{ifIndex: "7"}
 			},
 			source:              "192.0.2.10",
 			wantDeviceStatus:    "matched",

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_v1_stats_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_v1_stats_test.go
@@ -259,9 +259,10 @@ func newTopologyStatsCensusRouterCache(t *testing.T, sysName, chassisID, managem
 		},
 	}})
 	cache.updateIfIndexByIP(map[string]string{
-		tagTopoIfIndex: ifIndex,
-		tagTopoIPAddr:  ifIP,
-		tagTopoIPMask:  "255.255.255.252",
+		tagTopoIPSource: topoIPSourceLegacy,
+		tagTopoIfIndex:  ifIndex,
+		tagTopoIPAddr:   ifIP,
+		tagTopoIPMask:   "255.255.255.252",
 	})
 	return cache
 }

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-ip-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-ip-mib.yaml
@@ -1,5 +1,5 @@
 # Baseline IPv4 interface facts for logical L3 topology.
-# Source: IP-MIB ipAddrTable.
+# Sources: legacy IP-MIB ipAddrTable and RFC 4293 ipAddressTable.
 
 topology:
   - kind: ip_if_index

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-ip-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-ip-mib.yaml
@@ -10,6 +10,9 @@ topology:
     symbols:
       - OID: 1.3.6.1.2.1.4.20.1.2
         name: ip_if_index
+    static_tags:
+      - tag: topo_ip_source
+        value: legacy
     metric_tags:
       - tag: topo_ip_addr
         symbol:
@@ -26,3 +29,68 @@ topology:
         symbol:
           OID: 1.3.6.1.2.1.4.20.1.3
           name: ipAdEntNetMask
+
+  # RFC 4293 ipAddressTable IPv4 rows. The walk root is the readable
+  # ipAddressIfIndex column narrowed by the InetAddressType index prefix.
+  - kind: ip_if_index
+    MIB: IP-MIB
+    table:
+      OID: 1.3.6.1.2.1.4.34.1.3.1
+      name: ipAddressTableIPv4
+    symbols:
+      - OID: 1.3.6.1.2.1.4.34.1.3
+        name: ip_if_index
+    static_tags:
+      - tag: topo_ip_source
+        value: modern
+    metric_tags:
+      - tag: topo_ip_addr
+        symbol:
+          name: ipAddressAddr
+          format: ip_address
+        index_transform:
+          - start: 2
+      - tag: topo_if_index
+        symbol:
+          OID: 1.3.6.1.2.1.4.34.1.3
+          name: ipAddressIfIndex
+      - tag: topo_ip_type
+        table: ipAddressTypeIPv4
+        symbol:
+          OID: 1.3.6.1.2.1.4.34.1.4
+          name: ipAddressType
+        mapping:
+          1: unicast
+          2: anycast
+          3: broadcast
+      - tag: topo_ip_prefix_pointer
+        table: ipAddressPrefixIPv4
+        symbol:
+          OID: 1.3.6.1.2.1.4.34.1.5
+          name: ipAddressPrefix
+      - tag: topo_ip_status
+        table: ipAddressStatusIPv4
+        symbol:
+          OID: 1.3.6.1.2.1.4.34.1.7
+          name: ipAddressStatus
+        mapping:
+          1: preferred
+          2: deprecated
+          3: invalid
+          4: inaccessible
+          5: unknown
+          6: tentative
+          7: duplicate
+          8: optimistic
+      - tag: topo_ip_row_status
+        table: ipAddressRowStatusIPv4
+        symbol:
+          OID: 1.3.6.1.2.1.4.34.1.10
+          name: ipAddressRowStatus
+        mapping:
+          1: active
+          2: notInService
+          3: notReady
+          4: createAndGo
+          5: createAndWait
+          6: destroy

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-ip-mib.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/_std-topology-ip-mib.yaml
@@ -31,11 +31,11 @@ topology:
           name: ipAdEntNetMask
 
   # RFC 4293 ipAddressTable IPv4 rows. The walk root is the readable
-  # ipAddressIfIndex column narrowed by the InetAddressType index prefix.
+  # ipAddressIfIndex column narrowed by the InetAddressType and length indexes.
   - kind: ip_if_index
     MIB: IP-MIB
     table:
-      OID: 1.3.6.1.2.1.4.34.1.3.1
+      OID: 1.3.6.1.2.1.4.34.1.3.1.4
       name: ipAddressTableIPv4
     symbols:
       - OID: 1.3.6.1.2.1.4.34.1.3
@@ -47,7 +47,6 @@ topology:
       - tag: topo_ip_addr
         symbol:
           name: ipAddressAddr
-          format: ip_address
         index_transform:
           - start: 2
       - tag: topo_if_index


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds modern IPv4 address collection from the RFC 4293 `ipAddressTable` alongside the legacy `ipAddrTable`, so devices that only expose the modern table now produce L3 interface facts instead of none. Legacy rows are tagged `topo_ip_source: legacy` and modern rows `topo_ip_source: modern`.

**Dependency walk behavior**
- Cross-table tag targets without a row producer become dependency-only routes walked only after the owning row yields anchor PDUs.
- Dormant dependencies (no eligible anchor rows) report `not_observed` instead of an empty cache result.
- Single-anchor tables with a fixed structural index prefix propagate that prefix to simple same-index dependency column walks.
- Dependencies relying on the previous eager common-prefix walk must regenerate; `lookup_symbol`, `index_transform`, multiple anchors, and conflicting scopes are unaffected.

**IP address reconciliation**
- Modern rows add `topo_ip_type`, `topo_ip_prefix_pointer`, `topo_ip_status`, and `topo_ip_row_status`, with prefix length derived from `ipAddressPrefix`.
- Legacy and modern rows are reconciled per IP, rejecting ambiguous interface-index or prefix conflicts.
- L3 interface and OSPF neighbor matching share one compact projection; OSPF builds its prefix index once per snapshot.

<sup>Written for commit 8833389605e2798b7460379a8ed383b109de7d23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for modern RFC 4293 IPv4 interface data alongside legacy IP-MIB data.
  * Reconciles both sources into a single per-address topology record with source precedence and netmask derivation.
  * Supports additional IPv4 metadata, including address type, prefix, status, and row status.

* **Bug Fixes**
  * Rejects malformed, ambiguous, inactive, or invalid address records.
  * Avoids unnecessary walks for dependency-only topology data, improving collection efficiency.

* **Documentation**
  * Updated SNMP profile guidance and topology architecture documentation for modern IPv4 collection and dependency routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->