### PR TITLE
feat(go.d/snmp): query system scalars with GET requests

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -384,6 +384,7 @@ func TestCollectorLifecycleRecordsPanicsAsFailures(t *testing.T) {
 		collr.Config = prepareV2Config()
 		mockSNMP := snmpmock.NewMockHandler(ctrl)
 		mockSNMP.EXPECT().MaxOids().Return(20)
+		mockSNMP.EXPECT().Version().Return(gosnmp.Version2c)
 		mockSNMP.EXPECT().Get(gomock.Any()).DoAndReturn(func([]string) (*gosnmp.SnmpPacket, error) {
 			panic("check panic")
 		})
@@ -611,23 +612,23 @@ func TestCollector_Check(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().MaxOids().Return(2),
 					m.EXPECT().Get([]string{snmputils.OidSysDescr, snmputils.OidSysObject}).Return(
-						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+						sysInfoResponseForTest(gosnmp.Version1, []gosnmp.SnmpPDU{
 							{Name: snmputils.OidSysDescr, Value: []byte("mock sysDescr"), Type: gosnmp.OctetString},
 							{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
-						}},
+						}),
 						nil,
 					),
 					m.EXPECT().Get([]string{snmputils.OidSysContact, snmputils.OidSysName}).Return(
-						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+						sysInfoResponseForTest(gosnmp.Version1, []gosnmp.SnmpPDU{
 							{Name: snmputils.OidSysContact, Value: []byte("mock sysContact"), Type: gosnmp.OctetString},
 							{Name: snmputils.OidSysName, Value: []byte("mock sysName"), Type: gosnmp.OctetString},
-						}},
+						}),
 						nil,
 					),
 					m.EXPECT().Get([]string{snmputils.OidSysLocation}).Return(
-						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+						sysInfoResponseForTest(gosnmp.Version1, []gosnmp.SnmpPDU{
 							{Name: snmputils.OidSysLocation, Value: []byte("mock sysLocation"), Type: gosnmp.OctetString},
-						}},
+						}),
 						nil,
 					),
 				)
@@ -809,7 +810,8 @@ func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
 
 			client := snmpmock.NewMockHandler(ctrl)
 			client.EXPECT().MaxOids().Return(20)
-			client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: tc.pdus}, nil)
+			client.EXPECT().Version().Return(gosnmp.Version2c)
+			client.EXPECT().Get(sysInfoOIDsForTest()).Return(sysInfoResponseForTest(gosnmp.Version2c, tc.pdus), nil)
 
 			collr := newTestSNMPCollector()
 			collr.Config = prepareV2Config()
@@ -839,9 +841,10 @@ func TestCollector_CheckRetainsIdentityForInitialization(t *testing.T) {
 
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(20)
-	client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+	client.EXPECT().Version().Return(gosnmp.Version2c)
+	client.EXPECT().Get(sysInfoOIDsForTest()).Return(sysInfoResponseForTest(gosnmp.Version2c, []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.14988.1"},
-	}}, nil).Times(1)
+	}), nil).Times(1)
 
 	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
@@ -1608,13 +1611,17 @@ func setMockClientSetterExpectWithoutMaxOids(m *snmpmock.MockHandler) {
 
 func setMockClientSysInfoExpect(m *snmpmock.MockHandler) {
 	m.EXPECT().MaxOids().Return(20).MinTimes(1)
-	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+	m.EXPECT().Get(sysInfoOIDsForTest()).Return(sysInfoResponseForTest(gosnmp.Version1, []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysDescr, Value: []uint8("mock sysDescr"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
 		{Name: snmputils.OidSysContact, Value: []uint8("mock sysContact"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysName, Value: []uint8("mock sysName"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysLocation, Value: []uint8("mock sysLocation"), Type: gosnmp.OctetString},
-	}}, nil).MinTimes(1)
+	}), nil).MinTimes(1)
+}
+
+func sysInfoResponseForTest(version gosnmp.SnmpVersion, pdus []gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
+	return &gosnmp.SnmpPacket{Version: version, PDUType: gosnmp.GetResponse, Variables: pdus}
 }
 
 func sysInfoOIDsForTest() []string {

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -383,6 +383,7 @@ func TestCollectorLifecycleRecordsPanicsAsFailures(t *testing.T) {
 		collr := New(store)
 		collr.Config = prepareV2Config()
 		mockSNMP := snmpmock.NewMockHandler(ctrl)
+		mockSNMP.EXPECT().MaxOids().Return(20)
 		mockSNMP.EXPECT().Get(gomock.Any()).DoAndReturn(func([]string) (*gosnmp.SnmpPacket, error) {
 			panic("check panic")
 		})
@@ -622,6 +623,7 @@ func TestCollector_Check(t *testing.T) {
 			wantErr: true,
 			prepare: func(m *snmpmock.MockHandler) *Collector {
 				setMockClientInitExpect(m)
+				m.EXPECT().MaxOids().Return(20)
 				m.EXPECT().
 					Get(sysInfoOIDsForTest()).
 					Return(nil, errors.New("query failed"))
@@ -768,6 +770,7 @@ func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
 			defer ctrl.Finish()
 
 			client := snmpmock.NewMockHandler(ctrl)
+			client.EXPECT().MaxOids().Return(20)
 			client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: tc.pdus}, nil)
 
 			collr := newTestSNMPCollector()
@@ -797,6 +800,7 @@ func TestCollector_CheckRetainsIdentityForInitialization(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(20)
 	client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.14988.1"},
 	}}, nil).Times(1)
@@ -1557,6 +1561,7 @@ func setMockClientSetterExpect(m *snmpmock.MockHandler) {
 }
 
 func setMockClientSysInfoExpect(m *snmpmock.MockHandler) {
+	m.EXPECT().MaxOids().Return(20).MinTimes(1)
 	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysDescr, Value: []uint8("mock sysDescr"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -383,7 +383,7 @@ func TestCollectorLifecycleRecordsPanicsAsFailures(t *testing.T) {
 		collr := New(store)
 		collr.Config = prepareV2Config()
 		mockSNMP := snmpmock.NewMockHandler(ctrl)
-		mockSNMP.EXPECT().WalkAll(gomock.Any()).DoAndReturn(func(string) ([]gosnmp.SnmpPDU, error) {
+		mockSNMP.EXPECT().Get(gomock.Any()).DoAndReturn(func([]string) (*gosnmp.SnmpPacket, error) {
 			panic("check panic")
 		})
 		collr.snmpClient = mockSNMP
@@ -618,17 +618,13 @@ func TestCollector_Check(t *testing.T) {
 			},
 		},
 
-		"failure: sysInfo walk error": {
+		"failure: sysInfo query error": {
 			wantErr: true,
 			prepare: func(m *snmpmock.MockHandler) *Collector {
-				// Normal init succeeds
 				setMockClientInitExpect(m)
-				// But sysInfo retrieval (WalkAll on system tree) fails
-				// If your helper is too opinionated, stub directly:
-				// The collector ultimately calls WalkAll on the system OID tree.
 				m.EXPECT().
-					WalkAll(gomock.Any()).
-					Return(nil, errors.New("walk failed"))
+					Get(sysInfoOIDsForTest()).
+					Return(nil, errors.New("query failed"))
 
 				c := newTestSNMPCollector()
 				c.Config = prepareV2Config()
@@ -725,10 +721,10 @@ func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
 		wantErr        string
 		wantAbsent     []string
 	}{
-		"empty system walk": {
-			wantErr: "system subtree walk returned no PDUs",
+		"empty system query": {
+			wantErr: "SNMP system scalar query returned no PDUs",
 		},
-		"partial system walk with ordinary ping enabled": {
+		"partial system query with ordinary ping enabled": {
 			pdus: []gosnmp.SnmpPDU{
 				{Name: snmputils.OidSysDescr, Type: gosnmp.OctetString, Value: []byte("private description")},
 				{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("private hostname")},
@@ -747,11 +743,11 @@ func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
 		},
 		"invalid manual profile": {
 			manualProfiles: []string{"profile-that-does-not-exist"},
-			wantErr:        "system subtree walk returned no PDUs",
+			wantErr:        "SNMP system scalar query returned no PDUs",
 		},
 		"topology-only manual profile": {
 			manualProfiles: []string{"topology-role-qbridge"},
-			wantErr:        "system subtree walk returned no PDUs",
+			wantErr:        "SNMP system scalar query returned no PDUs",
 		},
 		"applicable manual metric profile": {
 			manualProfiles: []string{"generic-device"},
@@ -772,7 +768,7 @@ func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
 			defer ctrl.Finish()
 
 			client := snmpmock.NewMockHandler(ctrl)
-			client.EXPECT().WalkAll(snmputils.RootOidMibSystem).Return(tc.pdus, nil)
+			client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: tc.pdus}, nil)
 
 			collr := newTestSNMPCollector()
 			collr.Config = prepareV2Config()
@@ -801,9 +797,9 @@ func TestCollector_CheckRetainsIdentityForInitialization(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
-	client.EXPECT().WalkAll(snmputils.RootOidMibSystem).Return([]gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.14988.1"},
-	}, nil).Times(1)
+	}}, nil).Times(1)
 
 	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
@@ -1561,11 +1557,21 @@ func setMockClientSetterExpect(m *snmpmock.MockHandler) {
 }
 
 func setMockClientSysInfoExpect(m *snmpmock.MockHandler) {
-	m.EXPECT().WalkAll(snmputils.RootOidMibSystem).Return([]gosnmp.SnmpPDU{
+	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysDescr, Value: []uint8("mock sysDescr"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
 		{Name: snmputils.OidSysContact, Value: []uint8("mock sysContact"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysName, Value: []uint8("mock sysName"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysLocation, Value: []uint8("mock sysLocation"), Type: gosnmp.OctetString},
-	}, nil).MinTimes(1)
+	}}, nil).MinTimes(1)
+}
+
+func sysInfoOIDsForTest() []string {
+	return []string{
+		snmputils.OidSysDescr,
+		snmputils.OidSysObject,
+		snmputils.OidSysContact,
+		snmputils.OidSysName,
+		snmputils.OidSysLocation,
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -612,23 +612,23 @@ func TestCollector_Check(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().MaxOids().Return(2),
 					m.EXPECT().Get([]string{snmputils.OidSysDescr, snmputils.OidSysObject}).Return(
-						sysInfoResponseForTest(gosnmp.Version1, []gosnmp.SnmpPDU{
+						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 							{Name: snmputils.OidSysDescr, Value: []byte("mock sysDescr"), Type: gosnmp.OctetString},
 							{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
-						}),
+						}},
 						nil,
 					),
 					m.EXPECT().Get([]string{snmputils.OidSysContact, snmputils.OidSysName}).Return(
-						sysInfoResponseForTest(gosnmp.Version1, []gosnmp.SnmpPDU{
+						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 							{Name: snmputils.OidSysContact, Value: []byte("mock sysContact"), Type: gosnmp.OctetString},
 							{Name: snmputils.OidSysName, Value: []byte("mock sysName"), Type: gosnmp.OctetString},
-						}),
+						}},
 						nil,
 					),
 					m.EXPECT().Get([]string{snmputils.OidSysLocation}).Return(
-						sysInfoResponseForTest(gosnmp.Version1, []gosnmp.SnmpPDU{
+						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 							{Name: snmputils.OidSysLocation, Value: []byte("mock sysLocation"), Type: gosnmp.OctetString},
-						}),
+						}},
 						nil,
 					),
 				)
@@ -811,7 +811,7 @@ func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
 			client := snmpmock.NewMockHandler(ctrl)
 			client.EXPECT().MaxOids().Return(20)
 			client.EXPECT().Version().Return(gosnmp.Version2c)
-			client.EXPECT().Get(sysInfoOIDsForTest()).Return(sysInfoResponseForTest(gosnmp.Version2c, tc.pdus), nil)
+			client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: tc.pdus}, nil)
 
 			collr := newTestSNMPCollector()
 			collr.Config = prepareV2Config()
@@ -842,9 +842,9 @@ func TestCollector_CheckRetainsIdentityForInitialization(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(20)
 	client.EXPECT().Version().Return(gosnmp.Version2c)
-	client.EXPECT().Get(sysInfoOIDsForTest()).Return(sysInfoResponseForTest(gosnmp.Version2c, []gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.14988.1"},
-	}), nil).Times(1)
+	}}, nil).Times(1)
 
 	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
@@ -1611,17 +1611,13 @@ func setMockClientSetterExpectWithoutMaxOids(m *snmpmock.MockHandler) {
 
 func setMockClientSysInfoExpect(m *snmpmock.MockHandler) {
 	m.EXPECT().MaxOids().Return(20).MinTimes(1)
-	m.EXPECT().Get(sysInfoOIDsForTest()).Return(sysInfoResponseForTest(gosnmp.Version1, []gosnmp.SnmpPDU{
+	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysDescr, Value: []uint8("mock sysDescr"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
 		{Name: snmputils.OidSysContact, Value: []uint8("mock sysContact"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysName, Value: []uint8("mock sysName"), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysLocation, Value: []uint8("mock sysLocation"), Type: gosnmp.OctetString},
-	}), nil).MinTimes(1)
-}
-
-func sysInfoResponseForTest(version gosnmp.SnmpVersion, pdus []gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
-	return &gosnmp.SnmpPacket{Version: version, PDUType: gosnmp.GetResponse, Variables: pdus}
+	}}, nil).MinTimes(1)
 }
 
 func sysInfoOIDsForTest() []string {

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -830,8 +830,6 @@ func TestSysInfoDiagnosticOmitsRawSystemValues(t *testing.T) {
 		Model:       "ASR 1000",
 		Probe: snmputils.SysInfoProbe{
 			PDUCount:        5,
-			FirstOID:        snmputils.OidSysDescr,
-			LastOID:         snmputils.OidSysLocation,
 			SeenSysDescr:    true,
 			SeenSysObjectID: true,
 			SeenSysContact:  true,

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -604,6 +604,44 @@ func TestCollector_Check(t *testing.T) {
 			},
 		},
 
+		"success: chunks sysInfo by configured max OIDs": {
+			wantErr: false,
+			prepare: func(m *snmpmock.MockHandler) *Collector {
+				setMockClientInitExpectWithMaxOids(m, 2)
+				gomock.InOrder(
+					m.EXPECT().MaxOids().Return(2),
+					m.EXPECT().Get([]string{snmputils.OidSysDescr, snmputils.OidSysObject}).Return(
+						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+							{Name: snmputils.OidSysDescr, Value: []byte("mock sysDescr"), Type: gosnmp.OctetString},
+							{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
+						}},
+						nil,
+					),
+					m.EXPECT().Get([]string{snmputils.OidSysContact, snmputils.OidSysName}).Return(
+						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+							{Name: snmputils.OidSysContact, Value: []byte("mock sysContact"), Type: gosnmp.OctetString},
+							{Name: snmputils.OidSysName, Value: []byte("mock sysName"), Type: gosnmp.OctetString},
+						}},
+						nil,
+					),
+					m.EXPECT().Get([]string{snmputils.OidSysLocation}).Return(
+						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+							{Name: snmputils.OidSysLocation, Value: []byte("mock sysLocation"), Type: gosnmp.OctetString},
+						}},
+						nil,
+					),
+				)
+
+				c := newTestSNMPCollector()
+				c.Config = prepareV2Config()
+				c.Options.MaxOIDs = 2
+				c.CreateVnode = false
+				c.Ping.Enabled = false
+				c.newSnmpClient = func() gosnmp.Handler { return m }
+				return c
+			},
+		},
+
 		"failure: SNMP connect error": {
 			wantErr: true,
 			prepare: func(m *snmpmock.MockHandler) *Collector {
@@ -1537,7 +1575,18 @@ func setMockClientInitExpect(m *snmpmock.MockHandler) {
 	m.EXPECT().Connect().Return(nil).AnyTimes()
 }
 
+func setMockClientInitExpectWithMaxOids(m *snmpmock.MockHandler, maxOids int) {
+	setMockClientSetterExpectWithoutMaxOids(m)
+	m.EXPECT().SetMaxOids(maxOids).Times(2)
+	m.EXPECT().Connect().Return(nil).AnyTimes()
+}
+
 func setMockClientSetterExpect(m *snmpmock.MockHandler) {
+	setMockClientSetterExpectWithoutMaxOids(m)
+	m.EXPECT().SetMaxOids(gomock.Any()).AnyTimes()
+}
+
+func setMockClientSetterExpectWithoutMaxOids(m *snmpmock.MockHandler) {
 	m.EXPECT().Target().AnyTimes()
 	m.EXPECT().Port().AnyTimes()
 	m.EXPECT().Version().AnyTimes()
@@ -1546,7 +1595,6 @@ func setMockClientSetterExpect(m *snmpmock.MockHandler) {
 	m.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	m.EXPECT().SetRetries(gomock.Any()).AnyTimes()
 	m.EXPECT().SetMaxRepetitions(gomock.Any()).AnyTimes()
-	m.EXPECT().SetMaxOids(gomock.Any()).AnyTimes()
 	m.EXPECT().SetLogger(gomock.Any()).AnyTimes()
 	m.EXPECT().SetTimeout(gomock.Any()).AnyTimes()
 	m.EXPECT().SetCommunity(gomock.Any()).AnyTimes()

--- a/src/go/plugin/go.d/collector/snmp/profile_sets.go
+++ b/src/go/plugin/go.d/collector/snmp/profile_sets.go
@@ -85,15 +85,13 @@ func formatSysInfoDiagnostic(si *snmputils.SysInfo) string {
 
 	p := si.Probe
 	return fmt.Sprintf(
-		"sys_object_id=%q vendor=%q category=%q model=%q probe={pdu_count=%d first_oid=%q last_oid=%q "+
+		"sys_object_id=%q vendor=%q category=%q model=%q probe={pdu_count=%d "+
 			"sys_descr=%t sys_object_id=%t sys_contact=%t sys_name=%t sys_location=%t}",
 		si.SysObjectID,
 		si.Vendor,
 		si.Category,
 		si.Model,
 		p.PDUCount,
-		p.FirstOID,
-		p.LastOID,
 		p.SeenSysDescr,
 		p.SeenSysObjectID,
 		p.SeenSysContact,

--- a/src/go/plugin/go.d/collector/snmp/profile_sets.go
+++ b/src/go/plugin/go.d/collector/snmp/profile_sets.go
@@ -61,10 +61,10 @@ func noMetricProfilesError(si *snmputils.SysInfo) error {
 
 	switch {
 	case si == nil || si.Probe.PDUCount == 0:
-		return fmt.Errorf("no SNMP metric profiles available: system subtree walk returned no PDUs; %s", missingIdentityRemediation)
+		return fmt.Errorf("no SNMP metric profiles available: SNMP system scalar query returned no PDUs; %s", missingIdentityRemediation)
 	case si.SysObjectID == "":
 		return fmt.Errorf(
-			"no SNMP metric profiles available: system subtree walk returned %d PDU(s) without sysObjectID (%s); %s",
+			"no SNMP metric profiles available: SNMP system scalar query returned %d PDU(s) without sysObjectID (%s); %s",
 			si.Probe.PDUCount,
 			formatSysInfoDiagnostic(si),
 			missingIdentityRemediation,

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/discoverer_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/discoverer_test.go
@@ -281,8 +281,6 @@ func prepareNewTarget(sub subnet, ip string) *target {
 		Model:        "Linux",
 		Probe: snmputils.SysInfoProbe{
 			PDUCount:        5,
-			FirstOID:        snmputils.OidSysDescr,
-			LastOID:         snmputils.OidSysLocation,
 			SeenSysDescr:    true,
 			SeenSysObjectID: true,
 			SeenSysContact:  true,

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/sim_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/sim_test.go
@@ -187,6 +187,7 @@ const (
 )
 
 func (m *mockSnmpHandler) setExpectSysInfo() {
+	m.EXPECT().MaxOids().Return(60).AnyTimes()
 	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysDescr, Value: []uint8(mockSysDescr), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysObject, Value: mockSysObject, Type: gosnmp.ObjectIdentifier},

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/sim_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/sim_test.go
@@ -158,10 +158,11 @@ func prepareMockSnmpHandler(t *testing.T) (*mockSnmpHandler, func()) {
 
 func (m *mockSnmpHandler) setExpectInit() {
 	var ip string
+	var version gosnmp.SnmpVersion
 	m.EXPECT().Target().DoAndReturn(func() string { return ip }).AnyTimes()
 	m.EXPECT().SetTarget(gomock.Any()).Do(func(target string) { ip = target }).AnyTimes()
 	m.EXPECT().Port().AnyTimes()
-	m.EXPECT().Version().AnyTimes()
+	m.EXPECT().Version().DoAndReturn(func() gosnmp.SnmpVersion { return version }).AnyTimes()
 	m.EXPECT().Community().AnyTimes()
 	m.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	m.EXPECT().SetRetries(gomock.Any()).AnyTimes()
@@ -170,7 +171,7 @@ func (m *mockSnmpHandler) setExpectInit() {
 	m.EXPECT().SetLogger(gomock.Any()).AnyTimes()
 	m.EXPECT().SetTimeout(gomock.Any()).AnyTimes()
 	m.EXPECT().SetCommunity(gomock.Any()).AnyTimes()
-	m.EXPECT().SetVersion(gomock.Any()).AnyTimes()
+	m.EXPECT().SetVersion(gomock.Any()).Do(func(v gosnmp.SnmpVersion) { version = v }).AnyTimes()
 	m.EXPECT().SetSecurityModel(gomock.Any()).AnyTimes()
 	m.EXPECT().SetMsgFlags(gomock.Any()).AnyTimes()
 	m.EXPECT().SetSecurityParameters(gomock.Any()).AnyTimes()
@@ -188,13 +189,17 @@ const (
 
 func (m *mockSnmpHandler) setExpectSysInfo() {
 	m.EXPECT().MaxOids().Return(60).AnyTimes()
-	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-		{Name: snmputils.OidSysDescr, Value: []uint8(mockSysDescr), Type: gosnmp.OctetString},
-		{Name: snmputils.OidSysObject, Value: mockSysObject, Type: gosnmp.ObjectIdentifier},
-		{Name: snmputils.OidSysContact, Value: []uint8(mockSysContact), Type: gosnmp.OctetString},
-		{Name: snmputils.OidSysName, Value: []uint8(mockSysName), Type: gosnmp.OctetString},
-		{Name: snmputils.OidSysLocation, Value: []uint8(mockSysLocation), Type: gosnmp.OctetString},
-	}}, nil).AnyTimes()
+	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{
+		Version: gosnmp.Version2c,
+		PDUType: gosnmp.GetResponse,
+		Variables: []gosnmp.SnmpPDU{
+			{Name: snmputils.OidSysDescr, Value: []uint8(mockSysDescr), Type: gosnmp.OctetString},
+			{Name: snmputils.OidSysObject, Value: mockSysObject, Type: gosnmp.ObjectIdentifier},
+			{Name: snmputils.OidSysContact, Value: []uint8(mockSysContact), Type: gosnmp.OctetString},
+			{Name: snmputils.OidSysName, Value: []uint8(mockSysName), Type: gosnmp.OctetString},
+			{Name: snmputils.OidSysLocation, Value: []uint8(mockSysLocation), Type: gosnmp.OctetString},
+		},
+	}, nil).AnyTimes()
 }
 
 func sysInfoOIDsForTest() []string {

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/sim_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/sim_test.go
@@ -158,11 +158,10 @@ func prepareMockSnmpHandler(t *testing.T) (*mockSnmpHandler, func()) {
 
 func (m *mockSnmpHandler) setExpectInit() {
 	var ip string
-	var version gosnmp.SnmpVersion
 	m.EXPECT().Target().DoAndReturn(func() string { return ip }).AnyTimes()
 	m.EXPECT().SetTarget(gomock.Any()).Do(func(target string) { ip = target }).AnyTimes()
 	m.EXPECT().Port().AnyTimes()
-	m.EXPECT().Version().DoAndReturn(func() gosnmp.SnmpVersion { return version }).AnyTimes()
+	m.EXPECT().Version().AnyTimes()
 	m.EXPECT().Community().AnyTimes()
 	m.EXPECT().SetPort(gomock.Any()).AnyTimes()
 	m.EXPECT().SetRetries(gomock.Any()).AnyTimes()
@@ -171,7 +170,7 @@ func (m *mockSnmpHandler) setExpectInit() {
 	m.EXPECT().SetLogger(gomock.Any()).AnyTimes()
 	m.EXPECT().SetTimeout(gomock.Any()).AnyTimes()
 	m.EXPECT().SetCommunity(gomock.Any()).AnyTimes()
-	m.EXPECT().SetVersion(gomock.Any()).Do(func(v gosnmp.SnmpVersion) { version = v }).AnyTimes()
+	m.EXPECT().SetVersion(gomock.Any()).AnyTimes()
 	m.EXPECT().SetSecurityModel(gomock.Any()).AnyTimes()
 	m.EXPECT().SetMsgFlags(gomock.Any()).AnyTimes()
 	m.EXPECT().SetSecurityParameters(gomock.Any()).AnyTimes()
@@ -190,8 +189,6 @@ const (
 func (m *mockSnmpHandler) setExpectSysInfo() {
 	m.EXPECT().MaxOids().Return(60).AnyTimes()
 	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{
-		Version: gosnmp.Version2c,
-		PDUType: gosnmp.GetResponse,
 		Variables: []gosnmp.SnmpPDU{
 			{Name: snmputils.OidSysDescr, Value: []uint8(mockSysDescr), Type: gosnmp.OctetString},
 			{Name: snmputils.OidSysObject, Value: mockSysObject, Type: gosnmp.ObjectIdentifier},

--- a/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/sim_test.go
+++ b/src/go/plugin/go.d/discovery/sdext/discoverer/snmpsd/sim_test.go
@@ -187,11 +187,21 @@ const (
 )
 
 func (m *mockSnmpHandler) setExpectSysInfo() {
-	m.EXPECT().WalkAll(snmputils.RootOidMibSystem).Return([]gosnmp.SnmpPDU{
+	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: snmputils.OidSysDescr, Value: []uint8(mockSysDescr), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysObject, Value: mockSysObject, Type: gosnmp.ObjectIdentifier},
 		{Name: snmputils.OidSysContact, Value: []uint8(mockSysContact), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysName, Value: []uint8(mockSysName), Type: gosnmp.OctetString},
 		{Name: snmputils.OidSysLocation, Value: []uint8(mockSysLocation), Type: gosnmp.OctetString},
-	}, nil).AnyTimes()
+	}}, nil).AnyTimes()
+}
+
+func sysInfoOIDsForTest() []string {
+	return []string{
+		snmputils.OidSysDescr,
+		snmputils.OidSysObject,
+		snmputils.OidSysContact,
+		snmputils.OidSysName,
+		snmputils.OidSysLocation,
+	}
 }

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -151,36 +151,16 @@ func getSysInfoChunkPDUs(client gosnmp.Handler, version gosnmp.SnmpVersion, oids
 		if packet == nil {
 			return nil, fmt.Errorf("get SNMP system scalars: nil response")
 		}
-		if packet.PDUType != gosnmp.GetResponse {
-			return nil, fmt.Errorf("get SNMP system scalars: unexpected response PDU type %s", packet.PDUType)
-		}
-		if packet.Version != version {
-			return nil, fmt.Errorf(
-				"get SNMP system scalars: response SNMP version %s does not match requested version %s",
-				packet.Version,
-				version,
-			)
-		}
 
 		switch packet.Error {
 		case gosnmp.NoError:
-			if packet.ErrorIndex != 0 {
-				return nil, fmt.Errorf(
-					"get SNMP system scalars: response error %s with nonzero error index %d",
-					packet.Error,
-					packet.ErrorIndex,
-				)
-			}
-			if err := validateSysInfoResponsePDUs(oids, packet.Variables); err != nil {
-				return nil, err
-			}
 			return packet.Variables, nil
 		case gosnmp.NoSuchName:
-			if packet.Version != gosnmp.Version1 {
+			if version != gosnmp.Version1 {
 				return nil, fmt.Errorf(
-					"get SNMP system scalars: unexpected response error %s for SNMP version %s (index %d)",
+					"get SNMP system scalars: unexpected response error %s for requested SNMP version %s (index %d)",
 					packet.Error,
-					packet.Version,
+					version,
 					packet.ErrorIndex,
 				)
 			}
@@ -208,21 +188,6 @@ func getSysInfoChunkPDUs(client gosnmp.Handler, version gosnmp.SnmpVersion, oids
 	}
 
 	return nil, nil
-}
-
-func validateSysInfoResponsePDUs(requestedOIDs []string, pdus []gosnmp.SnmpPDU) error {
-	seen := make(map[string]struct{}, len(pdus))
-	for _, pdu := range pdus {
-		oid := strings.TrimPrefix(pdu.Name, ".")
-		if !slices.Contains(requestedOIDs, oid) {
-			return fmt.Errorf("get SNMP system scalars: response contains unrequested OID %q", pdu.Name)
-		}
-		if _, ok := seen[oid]; ok {
-			return fmt.Errorf("get SNMP system scalars: response contains duplicate OID %q", pdu.Name)
-		}
-		seen[oid] = struct{}{}
-	}
-	return nil
 }
 
 var valueSanitizer = strings.NewReplacer(

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -129,8 +130,24 @@ func sysInfoOIDs() []string {
 }
 
 func getSysInfoPDUs(client gosnmp.Handler) ([]gosnmp.SnmpPDU, error) {
-	oids := sysInfoOIDs()
+	maxOids := client.MaxOids()
+	if maxOids < 1 {
+		return nil, fmt.Errorf("get SNMP system scalars: invalid maximum OIDs per request %d", maxOids)
+	}
 
+	oids := sysInfoOIDs()
+	pdus := make([]gosnmp.SnmpPDU, 0, len(oids))
+	for chunk := range slices.Chunk(oids, maxOids) {
+		chunkPDUs, err := getSysInfoChunkPDUs(client, chunk)
+		if err != nil {
+			return nil, err
+		}
+		pdus = append(pdus, chunkPDUs...)
+	}
+	return pdus, nil
+}
+
+func getSysInfoChunkPDUs(client gosnmp.Handler, oids []string) ([]gosnmp.SnmpPDU, error) {
 	for len(oids) > 0 {
 		packet, err := client.Get(oids)
 		if err != nil {

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -128,11 +128,12 @@ func getSysInfoPDUs(client gosnmp.Handler) ([]gosnmp.SnmpPDU, error) {
 	if maxOids < 1 {
 		return nil, fmt.Errorf("get SNMP system scalars: invalid maximum OIDs per request %d", maxOids)
 	}
+	version := client.Version()
 
 	oids := sysInfoOIDs()
 	pdus := make([]gosnmp.SnmpPDU, 0, len(oids))
 	for chunk := range slices.Chunk(oids, maxOids) {
-		chunkPDUs, err := getSysInfoChunkPDUs(client, chunk)
+		chunkPDUs, err := getSysInfoChunkPDUs(client, version, chunk)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +142,7 @@ func getSysInfoPDUs(client gosnmp.Handler) ([]gosnmp.SnmpPDU, error) {
 	return pdus, nil
 }
 
-func getSysInfoChunkPDUs(client gosnmp.Handler, oids []string) ([]gosnmp.SnmpPDU, error) {
+func getSysInfoChunkPDUs(client gosnmp.Handler, version gosnmp.SnmpVersion, oids []string) ([]gosnmp.SnmpPDU, error) {
 	for len(oids) > 0 {
 		packet, err := client.Get(oids)
 		if err != nil {
@@ -149,6 +150,16 @@ func getSysInfoChunkPDUs(client gosnmp.Handler, oids []string) ([]gosnmp.SnmpPDU
 		}
 		if packet == nil {
 			return nil, fmt.Errorf("get SNMP system scalars: nil response")
+		}
+		if packet.PDUType != gosnmp.GetResponse {
+			return nil, fmt.Errorf("get SNMP system scalars: unexpected response PDU type %s", packet.PDUType)
+		}
+		if packet.Version != version {
+			return nil, fmt.Errorf(
+				"get SNMP system scalars: response SNMP version %s does not match requested version %s",
+				packet.Version,
+				version,
+			)
 		}
 
 		switch packet.Error {
@@ -159,6 +170,9 @@ func getSysInfoChunkPDUs(client gosnmp.Handler, oids []string) ([]gosnmp.SnmpPDU
 					packet.Error,
 					packet.ErrorIndex,
 				)
+			}
+			if err := validateSysInfoResponsePDUs(oids, packet.Variables); err != nil {
+				return nil, err
 			}
 			return packet.Variables, nil
 		case gosnmp.NoSuchName:
@@ -194,6 +208,21 @@ func getSysInfoChunkPDUs(client gosnmp.Handler, oids []string) ([]gosnmp.SnmpPDU
 	}
 
 	return nil, nil
+}
+
+func validateSysInfoResponsePDUs(requestedOIDs []string, pdus []gosnmp.SnmpPDU) error {
+	seen := make(map[string]struct{}, len(pdus))
+	for _, pdu := range pdus {
+		oid := strings.TrimPrefix(pdu.Name, ".")
+		if !slices.Contains(requestedOIDs, oid) {
+			return fmt.Errorf("get SNMP system scalars: response contains unrequested OID %q", pdu.Name)
+		}
+		if _, ok := seen[oid]; ok {
+			return fmt.Errorf("get SNMP system scalars: response contains duplicate OID %q", pdu.Name)
+		}
+		seen[oid] = struct{}{}
+	}
+	return nil
 }
 
 var valueSanitizer = strings.NewReplacer(

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -57,9 +57,9 @@ type SysInfoProbe struct {
 }
 
 func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
-	pdus, err := client.WalkAll(RootOidMibSystem)
+	pdus, err := getSysInfoPDUs(client)
 	if err != nil {
-		return nil, fmt.Errorf("walk SNMP system subtree %q: %w", RootOidMibSystem, err)
+		return nil, err
 	}
 
 	si := &SysInfo{
@@ -76,6 +76,9 @@ func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 			si.Probe.FirstOID = oid
 		}
 		si.Probe.LastOID = oid
+		if !isPduWithData(pdu) {
+			continue
+		}
 
 		switch oid {
 		case OidSysDescr:
@@ -113,6 +116,58 @@ func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 	updateMetadata(si)
 
 	return si, nil
+}
+
+func sysInfoOIDs() []string {
+	return []string{
+		OidSysDescr,
+		OidSysObject,
+		OidSysContact,
+		OidSysName,
+		OidSysLocation,
+	}
+}
+
+func getSysInfoPDUs(client gosnmp.Handler) ([]gosnmp.SnmpPDU, error) {
+	oids := sysInfoOIDs()
+
+	for len(oids) > 0 {
+		packet, err := client.Get(oids)
+		if err != nil {
+			return nil, fmt.Errorf("get SNMP system scalars: %w", err)
+		}
+		if packet == nil {
+			return nil, fmt.Errorf("get SNMP system scalars: nil response")
+		}
+
+		switch packet.Error {
+		case gosnmp.NoError:
+			return packet.Variables, nil
+		case gosnmp.NoSuchName:
+			idx := int(packet.ErrorIndex)
+			if idx < 1 || idx > len(oids) {
+				return nil, fmt.Errorf(
+					"get SNMP system scalars: response error %s with invalid error index %d for %d requested OIDs",
+					packet.Error,
+					packet.ErrorIndex,
+					len(oids),
+				)
+			}
+
+			next := make([]string, 0, len(oids)-1)
+			next = append(next, oids[:idx-1]...)
+			next = append(next, oids[idx:]...)
+			oids = next
+		default:
+			return nil, fmt.Errorf(
+				"get SNMP system scalars: response error %s (index %d)",
+				packet.Error,
+				packet.ErrorIndex,
+			)
+		}
+	}
+
+	return nil, nil
 }
 
 var valueSanitizer = strings.NewReplacer(

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -48,8 +48,6 @@ type SysInfo struct {
 
 type SysInfoProbe struct {
 	PDUCount        int
-	FirstOID        string
-	LastOID         string
 	SeenSysDescr    bool
 	SeenSysObjectID bool
 	SeenSysContact  bool
@@ -73,10 +71,6 @@ func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
 	for _, pdu := range pdus {
 		oid := strings.TrimPrefix(pdu.Name, ".")
 		si.Probe.PDUCount++
-		if si.Probe.PDUCount == 1 {
-			si.Probe.FirstOID = oid
-		}
-		si.Probe.LastOID = oid
 		if !isPduWithData(pdu) {
 			continue
 		}

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -153,8 +153,23 @@ func getSysInfoChunkPDUs(client gosnmp.Handler, oids []string) ([]gosnmp.SnmpPDU
 
 		switch packet.Error {
 		case gosnmp.NoError:
+			if packet.ErrorIndex != 0 {
+				return nil, fmt.Errorf(
+					"get SNMP system scalars: response error %s with nonzero error index %d",
+					packet.Error,
+					packet.ErrorIndex,
+				)
+			}
 			return packet.Variables, nil
 		case gosnmp.NoSuchName:
+			if packet.Version != gosnmp.Version1 {
+				return nil, fmt.Errorf(
+					"get SNMP system scalars: unexpected response error %s for SNMP version %s (index %d)",
+					packet.Error,
+					packet.Version,
+					packet.ErrorIndex,
+				)
+			}
 			idx := int(packet.ErrorIndex)
 			if idx < 1 || idx > len(oids) {
 				return nil, fmt.Errorf(

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
@@ -29,7 +29,7 @@ func TestGetSysInfoRecordsProbeDiagnostics(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Version().Return(gosnmp.Version2c)
-	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, pdus), nil)
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(pdus), nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -53,15 +53,15 @@ func TestGetSysInfoChunksRequestsByMaxOids(t *testing.T) {
 	gomock.InOrder(
 		client.EXPECT().MaxOids().Return(2),
 		client.EXPECT().Version().Return(gosnmp.Version2c),
-		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
+		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 			{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
 		}), nil),
-		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
+		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 			{Name: OidSysContact, Type: gosnmp.OctetString, Value: []byte("operations")},
 			{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
 		}), nil),
-		client.EXPECT().Get([]string{OidSysLocation}).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
+		client.EXPECT().Get([]string{OidSysLocation}).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 			{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
 		}), nil),
 	)
@@ -93,7 +93,7 @@ func TestGetSysInfoReturnsPartialProbeWithoutIdentityError(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Version().Return(gosnmp.Version2c)
-	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
 	}), nil)
@@ -116,7 +116,7 @@ func TestGetSysInfoReturnsEmptyProbeWithoutIdentityError(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Version().Return(gosnmp.Version2c)
-	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, nil), nil)
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(nil), nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestGetSysInfoRejectsWrongTypedSysObjectWithoutEchoingValue(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Version().Return(gosnmp.Version2c)
-	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 		{Name: OidSysObject, Type: gosnmp.OctetString, Value: []byte(rawValue)},
 	}), nil)
 
@@ -176,97 +176,44 @@ func TestGetSysInfoReturnsErrorForNilResponse(t *testing.T) {
 	assert.Contains(t, err.Error(), "nil response")
 }
 
-func TestGetSysInfoRejectsUnexpectedResponseEnvelope(t *testing.T) {
-	tests := map[string]struct {
-		packet    *gosnmp.SnmpPacket
-		wantError string
-	}{
-		"non-response PDU": {
-			packet: &gosnmp.SnmpPacket{
-				Version: gosnmp.Version2c,
-				PDUType: gosnmp.GetRequest,
-				Variables: []gosnmp.SnmpPDU{
-					{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
-				},
-			},
-			wantError: "unexpected response PDU type GetRequest",
+func TestGetSysInfoAcceptsNoErrorWithNonzeroErrorIndex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
+	client.EXPECT().Version().Return(gosnmp.Version2c)
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{
+		ErrorIndex: 1,
+		Variables: []gosnmp.SnmpPDU{
+			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
 		},
-		"mismatched version": {
-			packet: &gosnmp.SnmpPacket{
-				Version: gosnmp.Version1,
-				PDUType: gosnmp.GetResponse,
-				Variables: []gosnmp.SnmpPDU{
-					{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
-				},
-			},
-			wantError: "response SNMP version 1 does not match requested version 2c",
-		},
-	}
+	}, nil)
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			client := snmpmock.NewMockHandler(ctrl)
-			client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
-			client.EXPECT().Version().Return(gosnmp.Version2c)
-			client.EXPECT().Get(sysInfoOIDs()).Return(test.packet, nil)
-
-			si, err := GetSysInfo(client)
-			require.Error(t, err)
-			assert.Nil(t, si)
-			assert.Contains(t, err.Error(), test.wantError)
-		})
-	}
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Equal(t, "1.3.6.1.4.1.9.1.1166", si.SysObjectID)
 }
 
-func TestGetSysInfoRejectsUnexpectedResponseVarbinds(t *testing.T) {
-	tests := map[string]struct {
-		maxOids   int
-		request   []string
-		variables []gosnmp.SnmpPDU
-		wantError string
-	}{
-		"unrequested OID": {
-			maxOids: len(sysInfoOIDs()),
-			request: sysInfoOIDs(),
-			variables: []gosnmp.SnmpPDU{
-				{Name: "1.3.6.1.2.1.1.7.0", Type: gosnmp.Integer, Value: 72},
-			},
-			wantError: "unrequested OID",
-		},
-		"duplicate OID": {
-			maxOids: len(sysInfoOIDs()),
-			request: sysInfoOIDs(),
-			variables: []gosnmp.SnmpPDU{
-				{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
-				{Name: "." + OidSysDescr, Type: gosnmp.OctetString, Value: []byte("duplicate")},
-			},
-			wantError: "duplicate OID",
-		},
-	}
+func TestGetSysInfoAcceptsExtraAndDuplicateResponseOIDs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
+	client.EXPECT().Version().Return(gosnmp.Version2c)
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
+		{Name: "1.3.6.1.2.1.1.7.0", Type: gosnmp.Integer, Value: 72},
+		{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1"},
+		{Name: "." + OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
+	}), nil)
 
-			client := snmpmock.NewMockHandler(ctrl)
-			client.EXPECT().MaxOids().Return(test.maxOids)
-			client.EXPECT().Version().Return(gosnmp.Version2c)
-			client.EXPECT().Get(test.request).Return(&gosnmp.SnmpPacket{
-				Version:   gosnmp.Version2c,
-				PDUType:   gosnmp.GetResponse,
-				Variables: test.variables,
-			}, nil)
-
-			si, err := GetSysInfo(client)
-			require.Error(t, err)
-			assert.Nil(t, si)
-			assert.Contains(t, err.Error(), test.wantError)
-		})
-	}
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Equal(t, "1.3.6.1.4.1.9.1.1166", si.SysObjectID)
+	assert.Equal(t, 3, si.Probe.PDUCount)
 }
 
 func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
@@ -295,16 +242,11 @@ func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
 			errorIndex: 6,
 			wantError:  "invalid error index 6",
 		},
-		"no such name from v2c response": {
+		"no such name for configured v2c": {
 			version:    gosnmp.Version2c,
 			status:     gosnmp.NoSuchName,
 			errorIndex: 2,
-			wantError:  "unexpected response error NoSuchName for SNMP version 2c",
-		},
-		"no error with nonzero index": {
-			status:     gosnmp.NoError,
-			errorIndex: 1,
-			wantError:  "response error NoError with nonzero error index 1",
+			wantError:  "unexpected response error NoSuchName for requested SNMP version 2c",
 		},
 	}
 
@@ -317,8 +259,6 @@ func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
 			client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 			client.EXPECT().Version().Return(test.version)
 			client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{
-				Version:    test.version,
-				PDUType:    gosnmp.GetResponse,
 				Error:      test.status,
 				ErrorIndex: test.errorIndex,
 			}, nil)
@@ -338,7 +278,7 @@ func TestGetSysInfoReturnsPartialResultForExceptionPDUs(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Version().Return(gosnmp.Version2c)
-	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysObject, Type: gosnmp.NoSuchInstance},
 		{Name: OidSysContact, Type: gosnmp.NoSuchObject},
@@ -365,20 +305,18 @@ func TestGetSysInfoRetriesIndexedNoSuchName(t *testing.T) {
 	gomock.InOrder(
 		client.EXPECT().MaxOids().Return(2),
 		client.EXPECT().Version().Return(gosnmp.Version1),
-		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(testSysInfoResponse(gosnmp.Version1, []gosnmp.SnmpPDU{
+		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 			{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
 		}), nil),
 		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(&gosnmp.SnmpPacket{
-			Version:    gosnmp.Version1,
-			PDUType:    gosnmp.GetResponse,
 			Error:      gosnmp.NoSuchName,
 			ErrorIndex: 1,
 		}, nil),
-		client.EXPECT().Get([]string{OidSysName}).Return(testSysInfoResponse(gosnmp.Version1, []gosnmp.SnmpPDU{
+		client.EXPECT().Get([]string{OidSysName}).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 			{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
 		}), nil),
-		client.EXPECT().Get([]string{OidSysLocation}).Return(testSysInfoResponse(gosnmp.Version1, []gosnmp.SnmpPDU{
+		client.EXPECT().Get([]string{OidSysLocation}).Return(testSysInfoResponse([]gosnmp.SnmpPDU{
 			{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
 		}), nil),
 	)
@@ -403,7 +341,7 @@ func TestGetSysInfoNoSuchNameRetriesAreBounded(t *testing.T) {
 		requestCount++
 		assert.Len(t, oids, 6-requestCount)
 		return &gosnmp.SnmpPacket{
-			Version: gosnmp.Version1, PDUType: gosnmp.GetResponse, Error: gosnmp.NoSuchName, ErrorIndex: 1,
+			Error: gosnmp.NoSuchName, ErrorIndex: 1,
 		}, nil
 	}).Times(5)
 
@@ -431,6 +369,6 @@ func TestSysInfoProbeIsNotSerialized(t *testing.T) {
 	assert.NotContains(t, string(got), OidSysDescr)
 }
 
-func testSysInfoResponse(version gosnmp.SnmpVersion, pdus []gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
-	return &gosnmp.SnmpPacket{Version: version, PDUType: gosnmp.GetResponse, Variables: pdus}
+func testSysInfoResponse(pdus []gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
+	return &gosnmp.SnmpPacket{Variables: pdus}
 }

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
@@ -22,13 +22,12 @@ func TestGetSysInfoRecordsProbeDiagnostics(t *testing.T) {
 		{Name: "." + OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
 		{Name: OidSysContact, Type: gosnmp.OctetString, Value: []byte("operations")},
-		{Name: "1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(123)},
 		{Name: "." + OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
 		{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
 	}
 
 	client := snmpmock.NewMockHandler(ctrl)
-	client.EXPECT().WalkAll(RootOidMibSystem).Return(pdus, nil)
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: pdus}, nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -51,10 +50,10 @@ func TestGetSysInfoReturnsPartialProbeWithoutIdentityError(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
-	client.EXPECT().WalkAll(RootOidMibSystem).Return([]gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
-	}, nil)
+	}}, nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -74,7 +73,7 @@ func TestGetSysInfoReturnsEmptyProbeWithoutIdentityError(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
-	client.EXPECT().WalkAll(RootOidMibSystem).Return(nil, nil)
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{}, nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -83,19 +82,19 @@ func TestGetSysInfoReturnsEmptyProbeWithoutIdentityError(t *testing.T) {
 	assert.Equal(t, SysInfoProbe{}, si.Probe)
 }
 
-func TestGetSysInfoWrapsWalkErrorWithSystemRoot(t *testing.T) {
+func TestGetSysInfoWrapsGetError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	walkErr := errors.New("timeout")
+	getErr := errors.New("timeout")
 	client := snmpmock.NewMockHandler(ctrl)
-	client.EXPECT().WalkAll(RootOidMibSystem).Return(nil, walkErr)
+	client.EXPECT().Get(sysInfoOIDs()).Return(nil, getErr)
 
 	si, err := GetSysInfo(client)
 	require.Error(t, err)
 	assert.Nil(t, si)
-	assert.ErrorIs(t, err, walkErr)
-	assert.Contains(t, err.Error(), RootOidMibSystem)
+	assert.ErrorIs(t, err, getErr)
+	assert.Contains(t, err.Error(), "SNMP system scalars")
 }
 
 func TestGetSysInfoRejectsWrongTypedSysObjectWithoutEchoingValue(t *testing.T) {
@@ -104,15 +103,146 @@ func TestGetSysInfoRejectsWrongTypedSysObjectWithoutEchoingValue(t *testing.T) {
 
 	const rawValue = "private device identifier"
 	client := snmpmock.NewMockHandler(ctrl)
-	client.EXPECT().WalkAll(RootOidMibSystem).Return([]gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: OidSysObject, Type: gosnmp.OctetString, Value: []byte(rawValue)},
-	}, nil)
+	}}, nil)
 
 	si, err := GetSysInfo(client)
 	require.Error(t, err)
 	assert.Nil(t, si)
 	assert.Contains(t, err.Error(), "expected ObjectIdentifier")
 	assert.NotContains(t, err.Error(), rawValue)
+}
+
+func TestGetSysInfoReturnsErrorForNilResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().Get(sysInfoOIDs()).Return(nil, nil)
+
+	si, err := GetSysInfo(client)
+	require.Error(t, err)
+	assert.Nil(t, si)
+	assert.Contains(t, err.Error(), "nil response")
+}
+
+func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
+	tests := map[string]struct {
+		status     gosnmp.SNMPError
+		errorIndex uint8
+		wantError  string
+	}{
+		"authorization error": {
+			status:     gosnmp.AuthorizationError,
+			errorIndex: 2,
+			wantError:  "AuthorizationError",
+		},
+		"general error": {
+			status:     gosnmp.GenErr,
+			errorIndex: 4,
+			wantError:  "GenErr",
+		},
+		"no such name with zero index": {
+			status:    gosnmp.NoSuchName,
+			wantError: "invalid error index 0",
+		},
+		"no such name with out-of-range index": {
+			status:     gosnmp.NoSuchName,
+			errorIndex: 6,
+			wantError:  "invalid error index 6",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			client := snmpmock.NewMockHandler(ctrl)
+			client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{
+				Error:      test.status,
+				ErrorIndex: test.errorIndex,
+			}, nil)
+
+			si, err := GetSysInfo(client)
+			require.Error(t, err)
+			assert.Nil(t, si)
+			assert.Contains(t, err.Error(), test.wantError)
+		})
+	}
+}
+
+func TestGetSysInfoReturnsPartialResultForExceptionPDUs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
+		{Name: OidSysObject, Type: gosnmp.NoSuchInstance},
+		{Name: OidSysContact, Type: gosnmp.NoSuchObject},
+		{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
+		{Name: OidSysLocation, Type: gosnmp.Null},
+	}}, nil)
+
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Empty(t, si.SysObjectID)
+	assert.Equal(t, SysInfoProbe{
+		PDUCount:     5,
+		FirstOID:     OidSysDescr,
+		LastOID:      OidSysLocation,
+		SeenSysDescr: true,
+		SeenSysName:  true,
+	}, si.Probe)
+}
+
+func TestGetSysInfoRetriesIndexedNoSuchName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{
+		Error:      gosnmp.NoSuchName,
+		ErrorIndex: 3,
+	}, nil)
+	client.EXPECT().Get([]string{OidSysDescr, OidSysObject, OidSysName, OidSysLocation}).Return(
+		&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+			{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
+			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
+			{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
+			{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
+		}},
+		nil,
+	)
+
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Equal(t, "1.3.6.1.4.1.9.1.1166", si.SysObjectID)
+	assert.False(t, si.Probe.SeenSysContact)
+	assert.Equal(t, 4, si.Probe.PDUCount)
+}
+
+func TestGetSysInfoNoSuchNameRetriesAreBounded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	requestCount := 0
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().Get(gomock.Any()).DoAndReturn(func(oids []string) (*gosnmp.SnmpPacket, error) {
+		requestCount++
+		assert.Len(t, oids, 6-requestCount)
+		return &gosnmp.SnmpPacket{Error: gosnmp.NoSuchName, ErrorIndex: 1}, nil
+	}).Times(5)
+
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Equal(t, 5, requestCount)
+	assert.Equal(t, SysInfoProbe{}, si.Probe)
 }
 
 func TestSysInfoProbeIsNotSerialized(t *testing.T) {

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
@@ -27,6 +27,7 @@ func TestGetSysInfoRecordsProbeDiagnostics(t *testing.T) {
 	}
 
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: pdus}, nil)
 
 	si, err := GetSysInfo(client)
@@ -45,11 +46,52 @@ func TestGetSysInfoRecordsProbeDiagnostics(t *testing.T) {
 	}, si.Probe)
 }
 
+func TestGetSysInfoChunksRequestsByMaxOids(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	gomock.InOrder(
+		client.EXPECT().MaxOids().Return(2),
+		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+			{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
+			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
+		}}, nil),
+		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+			{Name: OidSysContact, Type: gosnmp.OctetString, Value: []byte("operations")},
+			{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
+		}}, nil),
+		client.EXPECT().Get([]string{OidSysLocation}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+			{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
+		}}, nil),
+	)
+
+	si, err := GetSysInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, si)
+	assert.Equal(t, "1.3.6.1.4.1.9.1.1166", si.SysObjectID)
+	assert.Equal(t, 5, si.Probe.PDUCount)
+}
+
+func TestGetSysInfoRejectsInvalidMaxOids(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(0)
+
+	si, err := GetSysInfo(client)
+	require.Error(t, err)
+	assert.Nil(t, si)
+	assert.Contains(t, err.Error(), "invalid maximum OIDs per request 0")
+}
+
 func TestGetSysInfoReturnsPartialProbeWithoutIdentityError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
@@ -73,6 +115,7 @@ func TestGetSysInfoReturnsEmptyProbeWithoutIdentityError(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{}, nil)
 
 	si, err := GetSysInfo(client)
@@ -88,6 +131,7 @@ func TestGetSysInfoWrapsGetError(t *testing.T) {
 
 	getErr := errors.New("timeout")
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Get(sysInfoOIDs()).Return(nil, getErr)
 
 	si, err := GetSysInfo(client)
@@ -103,6 +147,7 @@ func TestGetSysInfoRejectsWrongTypedSysObjectWithoutEchoingValue(t *testing.T) {
 
 	const rawValue = "private device identifier"
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: OidSysObject, Type: gosnmp.OctetString, Value: []byte(rawValue)},
 	}}, nil)
@@ -119,6 +164,7 @@ func TestGetSysInfoReturnsErrorForNilResponse(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Get(sysInfoOIDs()).Return(nil, nil)
 
 	si, err := GetSysInfo(client)
@@ -160,6 +206,7 @@ func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
 			defer ctrl.Finish()
 
 			client := snmpmock.NewMockHandler(ctrl)
+			client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 			client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{
 				Error:      test.status,
 				ErrorIndex: test.errorIndex,
@@ -178,6 +225,7 @@ func TestGetSysInfoReturnsPartialResultForExceptionPDUs(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysObject, Type: gosnmp.NoSuchInstance},
@@ -204,18 +252,22 @@ func TestGetSysInfoRetriesIndexedNoSuchName(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := snmpmock.NewMockHandler(ctrl)
-	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{
-		Error:      gosnmp.NoSuchName,
-		ErrorIndex: 3,
-	}, nil)
-	client.EXPECT().Get([]string{OidSysDescr, OidSysObject, OidSysName, OidSysLocation}).Return(
-		&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+	gomock.InOrder(
+		client.EXPECT().MaxOids().Return(2),
+		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 			{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
+		}}, nil),
+		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(&gosnmp.SnmpPacket{
+			Error:      gosnmp.NoSuchName,
+			ErrorIndex: 1,
+		}, nil),
+		client.EXPECT().Get([]string{OidSysName}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 			{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
+		}}, nil),
+		client.EXPECT().Get([]string{OidSysLocation}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
 			{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
-		}},
-		nil,
+		}}, nil),
 	)
 
 	si, err := GetSysInfo(client)
@@ -232,6 +284,7 @@ func TestGetSysInfoNoSuchNameRetriesAreBounded(t *testing.T) {
 
 	requestCount := 0
 	client := snmpmock.NewMockHandler(ctrl)
+	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 	client.EXPECT().Get(gomock.Any()).DoAndReturn(func(oids []string) (*gosnmp.SnmpPacket, error) {
 		requestCount++
 		assert.Len(t, oids, 6-requestCount)

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
@@ -90,7 +90,7 @@ func TestGetSysInfoReturnsPartialProbeWithoutIdentityError(t *testing.T) {
 
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
-	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Version: gosnmp.Version2c, Variables: []gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
 	}}, nil)
@@ -171,6 +171,7 @@ func TestGetSysInfoReturnsErrorForNilResponse(t *testing.T) {
 
 func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
 	tests := map[string]struct {
+		version    gosnmp.SnmpVersion
 		status     gosnmp.SNMPError
 		errorIndex uint8
 		wantError  string
@@ -194,6 +195,17 @@ func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
 			errorIndex: 6,
 			wantError:  "invalid error index 6",
 		},
+		"no such name from v2c response": {
+			version:    gosnmp.Version2c,
+			status:     gosnmp.NoSuchName,
+			errorIndex: 2,
+			wantError:  "unexpected response error NoSuchName for SNMP version 2c",
+		},
+		"no error with nonzero index": {
+			status:     gosnmp.NoError,
+			errorIndex: 1,
+			wantError:  "response error NoError with nonzero error index 1",
+		},
 	}
 
 	for name, test := range tests {
@@ -204,6 +216,7 @@ func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
 			client := snmpmock.NewMockHandler(ctrl)
 			client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
 			client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{
+				Version:    test.version,
 				Error:      test.status,
 				ErrorIndex: test.errorIndex,
 			}, nil)
@@ -222,7 +235,7 @@ func TestGetSysInfoReturnsPartialResultForExceptionPDUs(t *testing.T) {
 
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
-	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Version: gosnmp.Version2c, Variables: []gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysObject, Type: gosnmp.NoSuchInstance},
 		{Name: OidSysContact, Type: gosnmp.NoSuchObject},
@@ -253,6 +266,7 @@ func TestGetSysInfoRetriesIndexedNoSuchName(t *testing.T) {
 			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
 		}}, nil),
 		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(&gosnmp.SnmpPacket{
+			Version:    gosnmp.Version1,
 			Error:      gosnmp.NoSuchName,
 			ErrorIndex: 1,
 		}, nil),
@@ -282,7 +296,7 @@ func TestGetSysInfoNoSuchNameRetriesAreBounded(t *testing.T) {
 	client.EXPECT().Get(gomock.Any()).DoAndReturn(func(oids []string) (*gosnmp.SnmpPacket, error) {
 		requestCount++
 		assert.Len(t, oids, 6-requestCount)
-		return &gosnmp.SnmpPacket{Error: gosnmp.NoSuchName, ErrorIndex: 1}, nil
+		return &gosnmp.SnmpPacket{Version: gosnmp.Version1, Error: gosnmp.NoSuchName, ErrorIndex: 1}, nil
 	}).Times(5)
 
 	si, err := GetSysInfo(client)

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
@@ -28,7 +28,8 @@ func TestGetSysInfoRecordsProbeDiagnostics(t *testing.T) {
 
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
-	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: pdus}, nil)
+	client.EXPECT().Version().Return(gosnmp.Version2c)
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, pdus), nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -51,17 +52,18 @@ func TestGetSysInfoChunksRequestsByMaxOids(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	gomock.InOrder(
 		client.EXPECT().MaxOids().Return(2),
-		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+		client.EXPECT().Version().Return(gosnmp.Version2c),
+		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
 			{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
-		}}, nil),
-		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+		}), nil),
+		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
 			{Name: OidSysContact, Type: gosnmp.OctetString, Value: []byte("operations")},
 			{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
-		}}, nil),
-		client.EXPECT().Get([]string{OidSysLocation}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+		}), nil),
+		client.EXPECT().Get([]string{OidSysLocation}).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
 			{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
-		}}, nil),
+		}), nil),
 	)
 
 	si, err := GetSysInfo(client)
@@ -90,10 +92,11 @@ func TestGetSysInfoReturnsPartialProbeWithoutIdentityError(t *testing.T) {
 
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
-	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Version: gosnmp.Version2c, Variables: []gosnmp.SnmpPDU{
+	client.EXPECT().Version().Return(gosnmp.Version2c)
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
-	}}, nil)
+	}), nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -112,7 +115,8 @@ func TestGetSysInfoReturnsEmptyProbeWithoutIdentityError(t *testing.T) {
 
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
-	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{}, nil)
+	client.EXPECT().Version().Return(gosnmp.Version2c)
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, nil), nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -128,6 +132,7 @@ func TestGetSysInfoWrapsGetError(t *testing.T) {
 	getErr := errors.New("timeout")
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
+	client.EXPECT().Version().Return(gosnmp.Version2c)
 	client.EXPECT().Get(sysInfoOIDs()).Return(nil, getErr)
 
 	si, err := GetSysInfo(client)
@@ -144,9 +149,10 @@ func TestGetSysInfoRejectsWrongTypedSysObjectWithoutEchoingValue(t *testing.T) {
 	const rawValue = "private device identifier"
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
-	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+	client.EXPECT().Version().Return(gosnmp.Version2c)
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
 		{Name: OidSysObject, Type: gosnmp.OctetString, Value: []byte(rawValue)},
-	}}, nil)
+	}), nil)
 
 	si, err := GetSysInfo(client)
 	require.Error(t, err)
@@ -161,12 +167,106 @@ func TestGetSysInfoReturnsErrorForNilResponse(t *testing.T) {
 
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
+	client.EXPECT().Version().Return(gosnmp.Version2c)
 	client.EXPECT().Get(sysInfoOIDs()).Return(nil, nil)
 
 	si, err := GetSysInfo(client)
 	require.Error(t, err)
 	assert.Nil(t, si)
 	assert.Contains(t, err.Error(), "nil response")
+}
+
+func TestGetSysInfoRejectsUnexpectedResponseEnvelope(t *testing.T) {
+	tests := map[string]struct {
+		packet    *gosnmp.SnmpPacket
+		wantError string
+	}{
+		"non-response PDU": {
+			packet: &gosnmp.SnmpPacket{
+				Version: gosnmp.Version2c,
+				PDUType: gosnmp.GetRequest,
+				Variables: []gosnmp.SnmpPDU{
+					{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
+				},
+			},
+			wantError: "unexpected response PDU type GetRequest",
+		},
+		"mismatched version": {
+			packet: &gosnmp.SnmpPacket{
+				Version: gosnmp.Version1,
+				PDUType: gosnmp.GetResponse,
+				Variables: []gosnmp.SnmpPDU{
+					{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
+				},
+			},
+			wantError: "response SNMP version 1 does not match requested version 2c",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			client := snmpmock.NewMockHandler(ctrl)
+			client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
+			client.EXPECT().Version().Return(gosnmp.Version2c)
+			client.EXPECT().Get(sysInfoOIDs()).Return(test.packet, nil)
+
+			si, err := GetSysInfo(client)
+			require.Error(t, err)
+			assert.Nil(t, si)
+			assert.Contains(t, err.Error(), test.wantError)
+		})
+	}
+}
+
+func TestGetSysInfoRejectsUnexpectedResponseVarbinds(t *testing.T) {
+	tests := map[string]struct {
+		maxOids   int
+		request   []string
+		variables []gosnmp.SnmpPDU
+		wantError string
+	}{
+		"unrequested OID": {
+			maxOids: len(sysInfoOIDs()),
+			request: sysInfoOIDs(),
+			variables: []gosnmp.SnmpPDU{
+				{Name: "1.3.6.1.2.1.1.7.0", Type: gosnmp.Integer, Value: 72},
+			},
+			wantError: "unrequested OID",
+		},
+		"duplicate OID": {
+			maxOids: len(sysInfoOIDs()),
+			request: sysInfoOIDs(),
+			variables: []gosnmp.SnmpPDU{
+				{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
+				{Name: "." + OidSysDescr, Type: gosnmp.OctetString, Value: []byte("duplicate")},
+			},
+			wantError: "duplicate OID",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			client := snmpmock.NewMockHandler(ctrl)
+			client.EXPECT().MaxOids().Return(test.maxOids)
+			client.EXPECT().Version().Return(gosnmp.Version2c)
+			client.EXPECT().Get(test.request).Return(&gosnmp.SnmpPacket{
+				Version:   gosnmp.Version2c,
+				PDUType:   gosnmp.GetResponse,
+				Variables: test.variables,
+			}, nil)
+
+			si, err := GetSysInfo(client)
+			require.Error(t, err)
+			assert.Nil(t, si)
+			assert.Contains(t, err.Error(), test.wantError)
+		})
+	}
 }
 
 func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
@@ -215,8 +315,10 @@ func TestGetSysInfoReturnsPacketErrors(t *testing.T) {
 
 			client := snmpmock.NewMockHandler(ctrl)
 			client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
+			client.EXPECT().Version().Return(test.version)
 			client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{
 				Version:    test.version,
+				PDUType:    gosnmp.GetResponse,
 				Error:      test.status,
 				ErrorIndex: test.errorIndex,
 			}, nil)
@@ -235,13 +337,14 @@ func TestGetSysInfoReturnsPartialResultForExceptionPDUs(t *testing.T) {
 
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
-	client.EXPECT().Get(sysInfoOIDs()).Return(&gosnmp.SnmpPacket{Version: gosnmp.Version2c, Variables: []gosnmp.SnmpPDU{
+	client.EXPECT().Version().Return(gosnmp.Version2c)
+	client.EXPECT().Get(sysInfoOIDs()).Return(testSysInfoResponse(gosnmp.Version2c, []gosnmp.SnmpPDU{
 		{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 		{Name: OidSysObject, Type: gosnmp.NoSuchInstance},
 		{Name: OidSysContact, Type: gosnmp.NoSuchObject},
 		{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
 		{Name: OidSysLocation, Type: gosnmp.Null},
-	}}, nil)
+	}), nil)
 
 	si, err := GetSysInfo(client)
 	require.NoError(t, err)
@@ -261,21 +364,23 @@ func TestGetSysInfoRetriesIndexedNoSuchName(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	gomock.InOrder(
 		client.EXPECT().MaxOids().Return(2),
-		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+		client.EXPECT().Version().Return(gosnmp.Version1),
+		client.EXPECT().Get([]string{OidSysDescr, OidSysObject}).Return(testSysInfoResponse(gosnmp.Version1, []gosnmp.SnmpPDU{
 			{Name: OidSysDescr, Type: gosnmp.OctetString, Value: []byte("network device")},
 			{Name: OidSysObject, Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1166"},
-		}}, nil),
+		}), nil),
 		client.EXPECT().Get([]string{OidSysContact, OidSysName}).Return(&gosnmp.SnmpPacket{
 			Version:    gosnmp.Version1,
+			PDUType:    gosnmp.GetResponse,
 			Error:      gosnmp.NoSuchName,
 			ErrorIndex: 1,
 		}, nil),
-		client.EXPECT().Get([]string{OidSysName}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+		client.EXPECT().Get([]string{OidSysName}).Return(testSysInfoResponse(gosnmp.Version1, []gosnmp.SnmpPDU{
 			{Name: OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
-		}}, nil),
-		client.EXPECT().Get([]string{OidSysLocation}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+		}), nil),
+		client.EXPECT().Get([]string{OidSysLocation}).Return(testSysInfoResponse(gosnmp.Version1, []gosnmp.SnmpPDU{
 			{Name: OidSysLocation, Type: gosnmp.OctetString, Value: []byte("datacenter")},
-		}}, nil),
+		}), nil),
 	)
 
 	si, err := GetSysInfo(client)
@@ -293,10 +398,13 @@ func TestGetSysInfoNoSuchNameRetriesAreBounded(t *testing.T) {
 	requestCount := 0
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(len(sysInfoOIDs()))
+	client.EXPECT().Version().Return(gosnmp.Version1)
 	client.EXPECT().Get(gomock.Any()).DoAndReturn(func(oids []string) (*gosnmp.SnmpPacket, error) {
 		requestCount++
 		assert.Len(t, oids, 6-requestCount)
-		return &gosnmp.SnmpPacket{Version: gosnmp.Version1, Error: gosnmp.NoSuchName, ErrorIndex: 1}, nil
+		return &gosnmp.SnmpPacket{
+			Version: gosnmp.Version1, PDUType: gosnmp.GetResponse, Error: gosnmp.NoSuchName, ErrorIndex: 1,
+		}, nil
 	}).Times(5)
 
 	si, err := GetSysInfo(client)
@@ -321,4 +429,8 @@ func TestSysInfoProbeIsNotSerialized(t *testing.T) {
 	assert.NotContains(t, string(got), "Probe")
 	assert.NotContains(t, string(got), "probe")
 	assert.NotContains(t, string(got), OidSysDescr)
+}
+
+func testSysInfoResponse(version gosnmp.SnmpVersion, pdus []gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
+	return &gosnmp.SnmpPacket{Version: version, PDUType: gosnmp.GetResponse, Variables: pdus}
 }

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo_test.go
@@ -36,8 +36,6 @@ func TestGetSysInfoRecordsProbeDiagnostics(t *testing.T) {
 	assert.Equal(t, "1.3.6.1.4.1.9.1.1166", si.SysObjectID)
 	assert.Equal(t, SysInfoProbe{
 		PDUCount:        len(pdus),
-		FirstOID:        OidSysDescr,
-		LastOID:         OidSysLocation,
 		SeenSysDescr:    true,
 		SeenSysObjectID: true,
 		SeenSysContact:  true,
@@ -103,8 +101,6 @@ func TestGetSysInfoReturnsPartialProbeWithoutIdentityError(t *testing.T) {
 	assert.Empty(t, si.SysObjectID)
 	assert.Equal(t, SysInfoProbe{
 		PDUCount:     2,
-		FirstOID:     OidSysDescr,
-		LastOID:      OidSysName,
 		SeenSysDescr: true,
 		SeenSysName:  true,
 	}, si.Probe)
@@ -240,8 +236,6 @@ func TestGetSysInfoReturnsPartialResultForExceptionPDUs(t *testing.T) {
 	assert.Empty(t, si.SysObjectID)
 	assert.Equal(t, SysInfoProbe{
 		PDUCount:     5,
-		FirstOID:     OidSysDescr,
-		LastOID:      OidSysLocation,
 		SeenSysDescr: true,
 		SeenSysName:  true,
 	}, si.Probe)
@@ -303,8 +297,6 @@ func TestSysInfoProbeIsNotSerialized(t *testing.T) {
 		SysObjectID: "1.3.6.1.4.1.9.1.1166",
 		Probe: SysInfoProbe{
 			PDUCount:        2,
-			FirstOID:        OidSysDescr,
-			LastOID:         OidSysObject,
 			SeenSysDescr:    true,
 			SeenSysObjectID: true,
 		},

--- a/src/go/plugin/go.d/pkg/snmputils/sysuptime.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysuptime.go
@@ -44,7 +44,7 @@ func GetSysUptime(client gosnmp.Handler) (int64, error) {
 	var lastErr error
 	for _, source := range sysUptimeSources {
 		pdu, ok := pdusByOID[source.oid]
-		if !ok || !isSysUptimePduWithData(pdu) {
+		if !ok || !isPduWithData(pdu) {
 			continue
 		}
 
@@ -79,7 +79,7 @@ func sysUptimePduValue(pdu gosnmp.SnmpPDU) (int64, error) {
 	return gosnmp.ToBigInt(pdu.Value).Int64(), nil
 }
 
-func isSysUptimePduWithData(pdu gosnmp.SnmpPDU) bool {
+func isPduWithData(pdu gosnmp.SnmpPDU) bool {
 	switch pdu.Type {
 	case gosnmp.NoSuchObject,
 		gosnmp.NoSuchInstance,


### PR DESCRIPTION
##### Summary

Replace the system subtree walk with GET requests for the five required sysinfo OIDs. Requests respect max_request_size, validate SNMP response errors, and preserve partial results and SNMPv1 NoSuchName compatibility.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the SNMP system subtree walk with bounded GET requests for the five required sysinfo OIDs, retrieving device identity more efficiently and reliably.

- Chunks GET requests by the client's max OIDs per request, respecting `max_request_size`.
- Rejects nil packets and unexpected response errors.
- Retries `NoSuchName` responses for SNMPv1 by dropping the offending OID, preserving partial results.
- Tolerates extra or duplicate OIDs, exception PDUs, and nonzero error indexes in otherwise successful responses.
- Drops first/last OID tracking from sysinfo probe diagnostics and renames `isSysUptimePduWithData` to `isPduWithData`.

<sup>Written for commit 063657ff2f31bcadb793bfcc4c7bb7125003fb54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SNMP system-information retrieval with batched requests that respect device limits.
  * Enhanced compatibility with SNMP v1 devices returning indexed “No Such Name” responses, with bounded retries.
  * Improved handling of incomplete responses, exception data, and transport failures.
* **Tests**
  * Expanded coverage for request chunking, invalid limits, response validation, partial results, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->