### PR TITLE
otel traces: expose the search view through the Functions protocol

### DIFF
--- a/src/crates/otel-ledger/src/ledger/rpc/traces/handler.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/handler.rs
@@ -44,9 +44,9 @@ use super::adapter::{
 };
 use super::sources::TracesSourceSupplier;
 use super::wire::{
-    AttributeValuesParams, AttributesParams, CoverageWire, InfoResponse, OtelTracesRequest,
-    OtelTracesResponse, OverviewParams, SearchParams, SearchResult, SlowestParams, TraceParams,
-    TracesMode,
+    AttributeValuesParams, AttributesParams, CoverageWire, FunctionsParams,
+    FunctionsTracesResponse, InfoResponse, OtelTracesRequest, OtelTracesResponse, OverviewParams,
+    SearchParams, SearchResult, SlowestParams, TraceParams, TracesMode,
 };
 
 /// Shorthand for the handler-level error every failure path maps to.
@@ -178,12 +178,12 @@ impl OtelTracesHandler {
     /// The `search` mode: the engine's bounded most-recent-first trace
     /// search over the request's (canonicalized) window, with wire-level
     /// tie-safe pagination — see the adapter's cursor docs.
-    async fn search(
+    async fn search_result(
         &self,
         ctx: &FunctionCallContext,
         params: &SearchParams,
         tenant: Option<&str>,
-    ) -> netdata_plugin_error::Result<OtelTracesResponse> {
+    ) -> netdata_plugin_error::Result<SearchResult> {
         let client_err =
             |e: String| handler_err(format!("invalid otel-traces request: {e}"));
 
@@ -307,7 +307,33 @@ impl OtelTracesHandler {
             (window.capture.start, window.capture.end),
             completion_coverage,
         );
-        Ok(OtelTracesResponse::Search(Box::new(result)))
+        Ok(result)
+    }
+
+    async fn search(
+        &self,
+        ctx: &FunctionCallContext,
+        params: &SearchParams,
+        tenant: Option<&str>,
+    ) -> netdata_plugin_error::Result<OtelTracesResponse> {
+        Ok(OtelTracesResponse::Search(Box::new(
+            self.search_result(ctx, params, tenant).await?,
+        )))
+    }
+
+    async fn functions(
+        &self,
+        ctx: &FunctionCallContext,
+        params: &FunctionsParams,
+        tenant: Option<&str>,
+    ) -> netdata_plugin_error::Result<OtelTracesResponse> {
+        let search_params = params
+            .search_params(unix_now_s())
+            .map_err(|e| handler_err(format!("invalid otel-traces request: {e}")))?;
+        let data = self.search_result(ctx, &search_params, tenant).await?;
+        Ok(OtelTracesResponse::Functions(Box::new(
+            FunctionsTracesResponse::new(data),
+        )))
     }
 
     /// Common setup for the windowed fold modes (enumeration, slowest):
@@ -546,6 +572,7 @@ impl FunctionHandler for OtelTracesHandler {
     ) -> netdata_plugin_error::Result<Self::Response> {
         let tenant = req.tenant.as_deref();
         match &req.mode {
+            TracesMode::Functions(params) => self.functions(&ctx, params, tenant).await,
             TracesMode::Info => Ok(OtelTracesResponse::Info(InfoResponse::default())),
             TracesMode::Trace(params) => self.trace(&ctx, params, tenant).await,
             TracesMode::Search(params) => self.search(&ctx, params, tenant).await,

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/handler/tests.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/handler/tests.rs
@@ -44,11 +44,14 @@ async fn info_returns_the_descriptor() {
     assert_eq!(v["mode"], "info");
     assert_eq!(v["version"], 1);
     assert_eq!(v["status"], 200);
+    assert_eq!(v["type"], "traces");
+    assert_eq!(v["has_history"], true);
+    assert_eq!(v["v"], 3);
     assert_eq!(
         v["accepted_params"],
         json!([
             "info", "trace", "attributes", "attribute_values", "overview",
-            "slowest", "search", "tenant"
+            "slowest", "search", "tenant", "after", "before", "last", "anchor"
         ])
     );
     assert_eq!(v["required_params"], json!([]));
@@ -67,6 +70,24 @@ async fn an_empty_search_object_is_an_empty_complete_page() {
     assert_eq!(v["items"], json!({"returned": 0, "max_to_return": 20}));
     assert_eq!(v["traces"], json!([]));
     assert!(v.get("anchor").is_none(), "a short page has no next cursor");
+}
+
+#[tokio::test]
+async fn a_mode_less_request_wraps_the_existing_search_contract_as_traces() {
+    let resp = call(json!({"after": -3600, "before": 0, "last": 7})).await.unwrap();
+    let v = serde_json::to_value(&resp).unwrap();
+    assert_eq!(v["status"], 200);
+    assert_eq!(v["type"], "traces");
+    assert_eq!(v["data"]["mode"], "search");
+    assert_eq!(v["data"]["version"], 1);
+    assert_eq!(v["data"]["status"], json!({"complete": true}));
+    assert_eq!(v["data"]["items"], json!({"returned": 0, "max_to_return": 7}));
+    assert_eq!(v["data"]["traces"], json!([]));
+
+    let native = serde_json::to_value(call(json!({"search": {}})).await.unwrap()).unwrap();
+    assert_eq!(native["mode"], "search");
+    assert!(native.get("type").is_none());
+    assert!(native.get("data").is_none());
 }
 
 #[tokio::test]
@@ -1069,9 +1090,11 @@ async fn raw_call(payload: Option<&[u8]>) -> (u32, String) {
 #[tokio::test]
 async fn shape_errors_are_transport_400s() {
     for (payload, needle) in [
-        (&br#"{}"#[..], "missing mode selector"),
-        (br#"{"bogus": 1}"#, "unknown field"),
-        (br#"{"search": {}, "after": 1}"#, "unknown field"),
+        (&br#"{"bogus": 1}"#[..], "unknown field"),
+        (
+            br#"{"search": {}, "after": 1}"#,
+            "cannot mix a mode selector with Functions parameters",
+        ),
         (br#"{"trace": {}, "overview": {}}"#, "conflicting mode selectors"),
         (br#"{"info": true}"#, "invalid info selector"),
         (br#"{"trace": null}"#, "invalid trace selector"),
@@ -1106,18 +1129,18 @@ async fn semantic_errors_keep_the_handler_status() {
 }
 
 #[tokio::test]
-async fn the_three_400_payload_bodies_are_distinct() {
-    // Absent payload: the bridge's special empty-payload body (a
-    // misnomer now — the cause is the missing mode — but the bridge is
-    // frozen and this pin keeps anyone from "fixing" it here).
+async fn absent_and_empty_object_payloads_use_the_functions_view() {
     let (status, body) = raw_call(None).await;
-    assert_eq!(status, 400);
-    assert!(body.contains("Request payload is empty"), "{body}");
-    // Present `{}`: the ordinary missing-mode deserialization error.
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["type"], "traces");
+    assert_eq!(v["data"]["mode"], "search");
+
     let (status, body) = raw_call(Some(b"{}")).await;
-    assert_eq!(status, 400);
-    assert!(body.contains("missing mode selector"), "{body}");
-    // Present zero bytes: the ordinary EOF deserialization error.
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["type"], "traces");
+
     let (status, body) = raw_call(Some(b"")).await;
     assert_eq!(status, 400);
     assert!(body.contains("EOF"), "{body}");

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/handler/tests.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/handler/tests.rs
@@ -51,7 +51,7 @@ async fn info_returns_the_descriptor() {
         v["accepted_params"],
         json!([
             "info", "trace", "attributes", "attribute_values", "overview",
-            "slowest", "search", "tenant", "after", "before", "last", "anchor",
+            "slowest", "search", "tenant", "after", "before", "last", "anchor", "selections",
             "min_trace_duration_ns"
         ])
     );

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/handler/tests.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/handler/tests.rs
@@ -51,7 +51,8 @@ async fn info_returns_the_descriptor() {
         v["accepted_params"],
         json!([
             "info", "trace", "attributes", "attribute_values", "overview",
-            "slowest", "search", "tenant", "after", "before", "last", "anchor"
+            "slowest", "search", "tenant", "after", "before", "last", "anchor",
+            "min_trace_duration_ns"
         ])
     );
     assert_eq!(v["required_params"], json!([]));

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/wire.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/wire.rs
@@ -1,14 +1,15 @@
 //! Netdata function wire types for `otel-traces`.
 //!
 //! The transport layer between the netdata function protocol and the
-//! wire-neutral [`sfsq::traces`] engine. One Function, seven peer
-//! modes, each selected by exactly one top-level sub-object — `info`,
+//! wire-neutral [`sfsq::traces`] engine. One Function view plus seven
+//! explicit peer modes, each selected by exactly one top-level sub-object — `info`,
 //! `trace`, `attributes`, `attribute_values`, `overview`, `slowest`,
-//! `search` — every mode's params self-contained in its object. A
-//! request naming zero or more than one selector is a client error;
-//! there is no implicit default mode. The top level is strict: the
-//! only other accepted key is `tenant`, and unknown keys anywhere are
-//! client errors.
+//! `search` — every explicit mode's params self-contained in its object.
+//! A request without a selector uses the standard Functions parameters
+//! and wraps the existing search payload as `type: "traces"`. Explicit
+//! modes preserve their native response shapes. Mixing the two request
+//! forms or naming more than one selector is a client error; unknown
+//! keys anywhere are client errors.
 //!
 //! Nanosecond values (`*_ns`, `time_unix_nano`) go on the wire as JSON
 //! numbers and exceed 2^53: JavaScript consumers read them with ~256 ns
@@ -24,10 +25,10 @@ use sfsq::traces::{PartialReason, QueryStatus};
 
 /// Request param names accepted by this function, advertised to the UI
 /// in [`InfoResponse::accepted_params`]. The list's rule: it carries
-/// exactly the TOP-LEVEL keys — the seven mode selectors plus
-/// `tenant`. Per-mode body fields (windows, `limit`, `selections`, …)
-/// live inside their mode objects and are documented on the param
-/// structs, never advertised as top-level params.
+/// exactly the TOP-LEVEL keys — the seven mode selectors, `tenant`,
+/// and the standard Functions fields supported by the implicit view.
+/// Per-mode body fields (windows, `limit`, `selections`, …) live inside
+/// their mode objects and are documented on the param structs.
 pub const ACCEPTED_PARAMS: &[&str] = &[
     "info",
     "trace",
@@ -37,10 +38,15 @@ pub const ACCEPTED_PARAMS: &[&str] = &[
     "slowest",
     "search",
     "tenant",
+    "after",
+    "before",
+    "last",
+    "anchor",
 ];
 
-/// The raw top-level shape: the seven mode selectors captured
-/// presence-preserving (see [`present`]) plus `tenant`. Deserialized
+/// The raw top-level shape: the seven mode selectors and supported
+/// Functions fields captured presence-preserving (see [`present`]),
+/// plus `tenant`. Deserialized
 /// only through [`OtelTracesRequest`]'s manual `Deserialize` (which
 /// enforces a top-level JSON object) and immediately converted by
 /// [`TryFrom`] into the typed request — nothing outside this module
@@ -71,6 +77,18 @@ struct RawOtelTracesRequest {
     /// The search mode (bounded most-recent-first trace summaries).
     #[serde(default, deserialize_with = "present")]
     search: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "present")]
+    after: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "present")]
+    before: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "present")]
+    last: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "present")]
+    anchor: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "present")]
+    selections: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "present")]
+    timeout: Option<serde_json::Value>,
     /// Tenant whose data the query reads — a scoping selector supplied
     /// by the caller, not a security boundary; omitted/invalid falls
     /// back to the default tenant
@@ -99,6 +117,7 @@ pub struct OtelTracesRequest {
 /// The typed mode: selector identity plus its parsed params.
 #[derive(Debug, Clone)]
 pub enum TracesMode {
+    Functions(FunctionsParams),
     Info,
     Trace(TraceParams),
     Attributes(AttributesParams),
@@ -158,16 +177,21 @@ impl TryFrom<RawOtelTracesRequest> for OtelTracesRequest {
         .filter_map(|(name, set)| set.then_some(name))
         .collect();
 
+        let has_function_params = raw.after.is_some()
+            || raw.before.is_some()
+            || raw.last.is_some()
+            || raw.anchor.is_some()
+            || raw.selections.is_some()
+            || raw.timeout.is_some();
+
         match present.as_slice() {
-            [] => {
-                return Err(
-                    "missing mode selector: exactly one of info, trace, attributes, \
-                     attribute_values, overview, slowest, search is required"
-                        .into(),
-                )
-            }
+            [] => {}
             [_] => {}
             names => return Err(format!("conflicting mode selectors: {}", names.join(", "))),
+        }
+
+        if !present.is_empty() && has_function_params {
+            return Err("cannot mix a mode selector with Functions parameters".into());
         }
 
         /// The typed parse behind an explicit object gate: serde's
@@ -184,7 +208,22 @@ impl TryFrom<RawOtelTracesRequest> for OtelTracesRequest {
             T::deserialize(v).map_err(|e| format!("invalid {name} selector: {e}"))
         }
 
-        let mode = if let Some(v) = &raw.info {
+        let mode = if present.is_empty() {
+            let mut params = serde_json::Map::new();
+            for (name, value) in [
+                ("after", raw.after.as_ref()),
+                ("before", raw.before.as_ref()),
+                ("last", raw.last.as_ref()),
+                ("anchor", raw.anchor.as_ref()),
+                ("selections", raw.selections.as_ref()),
+                ("timeout", raw.timeout.as_ref()),
+            ] {
+                if let Some(value) = value {
+                    params.insert(name.to_string(), value.clone());
+                }
+            }
+            TracesMode::Functions(typed("Functions", &serde_json::Value::Object(params))?)
+        } else if let Some(v) = &raw.info {
             typed::<InfoParams>("info", v)?;
             TracesMode::Info
         } else if let Some(v) = &raw.trace {
@@ -200,12 +239,79 @@ impl TryFrom<RawOtelTracesRequest> for OtelTracesRequest {
         } else if let Some(v) = &raw.search {
             TracesMode::Search(typed("search", v)?)
         } else {
-            unreachable!("exactly one selector was verified present");
+            unreachable!("an explicit selector was verified present");
         };
 
         Ok(Self {
             tenant: raw.tenant,
             mode,
+        })
+    }
+}
+
+/// Standard Functions parameters for the default trace-search view.
+/// They translate into the native search mode without changing that
+/// mode's request or response contract.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionsParams {
+    #[serde(default)]
+    pub after: i64,
+    #[serde(default)]
+    pub before: i64,
+    #[serde(default = "default_limit")]
+    pub last: usize,
+    #[serde(default)]
+    pub anchor: Option<String>,
+    #[serde(default)]
+    pub selections: std::collections::HashMap<String, Vec<String>>,
+    /// Accepted for parity with the Functions protocol. Execution
+    /// deadlines remain owned by the bridge call context.
+    #[serde(default)]
+    #[serde(rename = "timeout")]
+    pub _timeout: Option<u32>,
+}
+
+impl FunctionsParams {
+    pub fn search_params(&self, now: u32) -> Result<SearchParams, String> {
+        fn resolve(label: &str, value: i64, base: u32) -> Result<u32, String> {
+            let absolute = if value < 0 {
+                i64::from(base)
+                    .checked_add(value)
+                    .ok_or_else(|| format!("'{label}' is outside the supported time range"))?
+            } else {
+                value
+            };
+            u32::try_from(absolute)
+                .map_err(|_| format!("'{label}' is outside the supported time range"))
+        }
+
+        let before = if self.before == 0 {
+            if self.after.is_negative() { now } else { 0 }
+        } else {
+            resolve("before", self.before, now)?
+        };
+        let after = if self.after == 0 {
+            0
+        } else {
+            resolve(
+                "after",
+                self.after,
+                if before == 0 { now } else { before },
+            )?
+        };
+
+        Ok(SearchParams {
+            after,
+            before,
+            limit: self.last,
+            spans_per_trace: Some(0),
+            selections: self.selections.clone(),
+            min_duration_ns: None,
+            max_duration_ns: None,
+            min_trace_duration_ns: None,
+            max_trace_duration_ns: None,
+            anchor: self.anchor.clone(),
         })
     }
 }
@@ -403,6 +509,7 @@ pub struct TraceParams {
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum OtelTracesResponse {
+    Functions(Box<FunctionsTracesResponse>),
     Info(InfoResponse),
     Trace(Box<TraceResult>),
     Search(Box<SearchResult>),
@@ -410,6 +517,28 @@ pub enum OtelTracesResponse {
     AttributeValues(AttributeValuesResult),
     Overview(Box<OverviewResult>),
     Slowest(Box<SlowestResult>),
+}
+
+/// Functions protocol envelope for the trace-specific contract. The
+/// nested payload stays exactly the native developer-owned search
+/// response; the envelope's numeric status cannot collide with its
+/// query-completeness `status` object.
+#[derive(Debug, Serialize)]
+pub struct FunctionsTracesResponse {
+    pub status: u32,
+    #[serde(rename = "type")]
+    pub response_type: &'static str,
+    pub data: Box<SearchResult>,
+}
+
+impl FunctionsTracesResponse {
+    pub fn new(data: SearchResult) -> Self {
+        Self {
+            status: 200,
+            response_type: "traces",
+            data: Box::new(data),
+        }
+    }
 }
 
 // ── Overview response ───────────────────────────────────────────────
@@ -767,6 +896,11 @@ pub struct InfoResponse {
     pub mode: &'static str,
     version: u32,
     status: u32,
+    #[serde(rename = "type")]
+    response_type: &'static str,
+    has_history: bool,
+    #[serde(rename = "v")]
+    protocol_version: u32,
     accepted_params: Vec<&'static str>,
     required_params: Vec<&'static str>,
     help: &'static str,
@@ -778,6 +912,9 @@ impl Default for InfoResponse {
             mode: "info",
             version: 1,
             status: 200,
+            response_type: "traces",
+            has_history: true,
+            protocol_version: 3,
             accepted_params: ACCEPTED_PARAMS.to_vec(),
             required_params: vec![],
             help: "Query and visualize OpenTelemetry traces.",

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/wire.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/wire.rs
@@ -26,7 +26,8 @@ use sfsq::traces::{PartialReason, QueryStatus};
 /// Request param names accepted by this function, advertised to the UI
 /// in [`InfoResponse::accepted_params`]. The list's rule: it carries
 /// exactly the TOP-LEVEL keys — the seven mode selectors, `tenant`,
-/// and the standard Functions fields supported by the implicit view.
+/// and the fields the implicit view reads, both the standard Functions
+/// ones and its own `min_trace_duration_ns` filter.
 /// Per-mode body fields (windows, `limit`, `selections`, …) live inside
 /// their mode objects and are documented on the param structs.
 pub const ACCEPTED_PARAMS: &[&str] = &[
@@ -42,6 +43,7 @@ pub const ACCEPTED_PARAMS: &[&str] = &[
     "before",
     "last",
     "anchor",
+    "min_trace_duration_ns",
 ];
 
 /// The raw top-level shape: the seven mode selectors and supported
@@ -85,6 +87,8 @@ struct RawOtelTracesRequest {
     last: Option<serde_json::Value>,
     #[serde(default, deserialize_with = "present")]
     anchor: Option<serde_json::Value>,
+    #[serde(default, deserialize_with = "present")]
+    min_trace_duration_ns: Option<serde_json::Value>,
     #[serde(default, deserialize_with = "present")]
     selections: Option<serde_json::Value>,
     #[serde(default, deserialize_with = "present")]
@@ -181,6 +185,7 @@ impl TryFrom<RawOtelTracesRequest> for OtelTracesRequest {
             || raw.before.is_some()
             || raw.last.is_some()
             || raw.anchor.is_some()
+            || raw.min_trace_duration_ns.is_some()
             || raw.selections.is_some()
             || raw.timeout.is_some();
 
@@ -215,6 +220,7 @@ impl TryFrom<RawOtelTracesRequest> for OtelTracesRequest {
                 ("before", raw.before.as_ref()),
                 ("last", raw.last.as_ref()),
                 ("anchor", raw.anchor.as_ref()),
+                ("min_trace_duration_ns", raw.min_trace_duration_ns.as_ref()),
                 ("selections", raw.selections.as_ref()),
                 ("timeout", raw.timeout.as_ref()),
             ] {
@@ -265,6 +271,14 @@ pub struct FunctionsParams {
     pub anchor: Option<String>,
     #[serde(default)]
     pub selections: std::collections::HashMap<String, Vec<String>>,
+    /// Inclusive lower bound on the TRACE envelope duration,
+    /// nanoseconds — the "min duration" filter of the Functions view.
+    /// Trace-envelope, not span, so it narrows the same quantity the
+    /// overview grid bins by. Forwarded verbatim to
+    /// [`SearchParams::min_trace_duration_ns`]; the upper bound stays
+    /// the native mode's alone.
+    #[serde(default)]
+    pub min_trace_duration_ns: Option<i64>,
     /// Accepted for parity with the Functions protocol. Execution
     /// deadlines remain owned by the bridge call context.
     #[serde(default)]
@@ -309,7 +323,7 @@ impl FunctionsParams {
             selections: self.selections.clone(),
             min_duration_ns: None,
             max_duration_ns: None,
-            min_trace_duration_ns: None,
+            min_trace_duration_ns: self.min_trace_duration_ns,
             max_trace_duration_ns: None,
             anchor: self.anchor.clone(),
         })

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/wire.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/wire.rs
@@ -27,9 +27,20 @@ use sfsq::traces::{PartialReason, QueryStatus};
 /// in [`InfoResponse::accepted_params`]. The list's rule: it carries
 /// exactly the TOP-LEVEL keys — the seven mode selectors, `tenant`,
 /// and the fields the implicit view reads, both the standard Functions
-/// ones and its own `min_trace_duration_ns` filter.
-/// Per-mode body fields (windows, `limit`, `selections`, …) live inside
-/// their mode objects and are documented on the param structs.
+/// ones and its own `min_trace_duration_ns` filter. A client that
+/// builds its payload out of this list sends nothing else, so a field
+/// the implicit view honours but the list omits is unreachable —
+/// `selections` is listed for exactly that reason, being how the
+/// filter rail's picks travel.
+///
+/// `timeout` is deliberately NOT listed: the implicit view accepts it
+/// for protocol parity and ignores it (execution deadlines belong to
+/// the bridge call context), so advertising it would invite a client
+/// to believe it moved a deadline it did not move.
+///
+/// Per-mode body fields (windows, `limit`, the explicit modes' own
+/// `selections`, …) live inside their mode objects and are documented
+/// on the param structs.
 pub const ACCEPTED_PARAMS: &[&str] = &[
     "info",
     "trace",
@@ -43,6 +54,7 @@ pub const ACCEPTED_PARAMS: &[&str] = &[
     "before",
     "last",
     "anchor",
+    "selections",
     "min_trace_duration_ns",
 ];
 

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/wire/tests.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/wire/tests.rs
@@ -48,6 +48,23 @@ fn a_request_without_a_mode_selector_selects_the_functions_search_view() {
 }
 
 #[test]
+fn the_functions_view_forwards_the_minimum_trace_duration() {
+    let TracesMode::Functions(p) = req(json!({"min_trace_duration_ns": 250_000_000})).mode else {
+        panic!("Functions mode expected");
+    };
+    assert_eq!(
+        p.search_params(10_000).unwrap().min_trace_duration_ns,
+        Some(250_000_000)
+    );
+
+    // Omitted stays unset — existing callers keep their behaviour.
+    let TracesMode::Functions(p) = req(json!({})).mode else {
+        panic!("Functions mode expected");
+    };
+    assert_eq!(p.search_params(10_000).unwrap().min_trace_duration_ns, None);
+}
+
+#[test]
 fn info_is_the_strict_empty_object() {
     assert!(matches!(req(json!({"info": {}})).mode, TracesMode::Info));
     // Both of the old wire's boolean forms, junk scalars, null, and
@@ -147,6 +164,7 @@ fn unknown_and_retired_top_level_keys_are_client_errors() {
         json!({"search": {}, "after": 1, "before": 2}),
         json!({"search": {}, "last": 5}),
         json!({"search": {}, "timeout": 30}),
+        json!({"search": {}, "min_trace_duration_ns": 1}),
         json!({"trace": {"id": "00"}, "anchor": "x"}),
     ] {
         let err = req_err(body.clone());
@@ -321,7 +339,8 @@ fn info_response_shape_is_pinned() {
             "v": 3,
             "accepted_params": [
                 "info", "trace", "attributes", "attribute_values", "overview",
-                "slowest", "search", "tenant", "after", "before", "last", "anchor"
+                "slowest", "search", "tenant", "after", "before", "last", "anchor",
+                "min_trace_duration_ns"
             ],
             "required_params": [],
             "help": "Query and visualize OpenTelemetry traces.",

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/wire/tests.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/wire/tests.rs
@@ -15,13 +15,36 @@ fn req_err(v: serde_json::Value) -> String {
 }
 
 #[test]
-fn a_request_without_a_mode_selector_is_a_client_error() {
-    // The bridge deserializes a missing payload as `{}`; there is no
-    // implicit default mode.
-    let err = req_err(json!({}));
-    assert!(err.contains("missing mode selector"), "{err}");
-    let err = req_err(json!({"tenant": "t1"}));
-    assert!(err.contains("missing mode selector"), "{err}");
+fn a_request_without_a_mode_selector_selects_the_functions_search_view() {
+    let TracesMode::Functions(p) = req(json!({})).mode else {
+        panic!("Functions mode expected");
+    };
+    assert_eq!((p.after, p.before, p.last), (0, 0, 20));
+    assert_eq!(p.anchor, None);
+    assert!(p.selections.is_empty());
+
+    let r = req(json!({"tenant": "t1"}));
+    assert!(matches!(r.mode, TracesMode::Functions(_)));
+    assert_eq!(r.tenant.as_deref(), Some("t1"));
+
+    let TracesMode::Functions(p) = req(json!({
+        "after": -3600,
+        "before": -60,
+        "last": 7,
+        "anchor": "cursor",
+        "selections": {"root_name": ["GET /api"]},
+        "timeout": 120000
+    }))
+    .mode
+    else {
+        panic!("Functions mode expected");
+    };
+    assert_eq!((p.after, p.before, p.last), (-3600, -60, 7));
+    assert_eq!(p.anchor.as_deref(), Some("cursor"));
+    assert_eq!(p.selections["root_name"], ["GET /api"]);
+
+    let search = p.search_params(10_000).unwrap();
+    assert_eq!((search.after, search.before), (6_340, 9_940));
 }
 
 #[test]
@@ -115,17 +138,22 @@ fn the_top_level_must_be_a_json_object() {
 
 #[test]
 fn unknown_and_retired_top_level_keys_are_client_errors() {
-    // The old flat fields moved into their mode objects; `timeout` is
-    // gone entirely. Nothing at the top level is silently dropped.
+    for body in [json!({"search": {}, "bogus": 1}), json!({"bogus": 1})] {
+        let err = req_err(body.clone());
+        assert!(err.contains("unknown field"), "for {body}: {err}");
+    }
+
     for body in [
-        json!({"search": {}, "bogus": 1}),
         json!({"search": {}, "after": 1, "before": 2}),
         json!({"search": {}, "last": 5}),
         json!({"search": {}, "timeout": 30}),
         json!({"trace": {"id": "00"}, "anchor": "x"}),
     ] {
         let err = req_err(body.clone());
-        assert!(err.contains("unknown field"), "for {body}: {err}");
+        assert!(
+            err.contains("cannot mix a mode selector with Functions parameters"),
+            "for {body}: {err}"
+        );
     }
 }
 
@@ -288,9 +316,12 @@ fn info_response_shape_is_pinned() {
             "mode": "info",
             "version": 1,
             "status": 200,
+            "type": "traces",
+            "has_history": true,
+            "v": 3,
             "accepted_params": [
                 "info", "trace", "attributes", "attribute_values", "overview",
-                "slowest", "search", "tenant"
+                "slowest", "search", "tenant", "after", "before", "last", "anchor"
             ],
             "required_params": [],
             "help": "Query and visualize OpenTelemetry traces.",

--- a/src/crates/otel-ledger/src/ledger/rpc/traces/wire/tests.rs
+++ b/src/crates/otel-ledger/src/ledger/rpc/traces/wire/tests.rs
@@ -339,7 +339,7 @@ fn info_response_shape_is_pinned() {
             "v": 3,
             "accepted_params": [
                 "info", "trace", "attributes", "attribute_values", "overview",
-                "slowest", "search", "tenant", "after", "before", "last", "anchor",
+                "slowest", "search", "tenant", "after", "before", "last", "anchor", "selections",
                 "min_trace_duration_ns"
             ],
             "required_params": [],

--- a/src/go/tools/functions-validation/validate/main_test.go
+++ b/src/go/tools/functions-validation/validate/main_test.go
@@ -97,48 +97,6 @@ func TestFunctionUISchemaValidationSkipsTopologySemanticsForTableResponses(t *te
 	}
 }
 
-func TestFunctionUISchemaAcceptsTracesResponse(t *testing.T) {
-	schemaBytes := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_UI_SCHEMA.json"))
-	input := []byte(`{
-		"status": 200,
-		"type": "traces",
-		"data": {
-			"mode": "search",
-			"version": 1,
-			"status": {"complete": true},
-			"completion_coverage": {"after": 0, "before": 4294967295},
-			"items": {"returned": 0, "max_to_return": 20},
-			"traces": [],
-			"field_kinds": {
-				"fields": [],
-				"event_attributes": [],
-				"link_attributes": []
-			}
-		}
-	}`)
-
-	if _, err := validateJSON(schemaBytes, input); err != nil {
-		t.Fatalf("validate traces response: %v", err)
-	}
-}
-
-func TestFunctionUISchemaRejectsTraceDataUnderTableType(t *testing.T) {
-	schemaBytes := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_UI_SCHEMA.json"))
-	input := []byte(`{
-		"status": 200,
-		"type": "table",
-		"data": {
-			"mode": "search",
-			"version": 1,
-			"status": {"complete": true}
-		}
-	}`)
-
-	if _, err := validateJSON(schemaBytes, input); err == nil {
-		t.Fatal("expected trace object data under table type to fail validation")
-	}
-}
-
 func TestValidationSkipsTopologySemanticsForNonTopologyObjectData(t *testing.T) {
 	schemaBytes := []byte(`{"type": "object"}`)
 	input := []byte(`{

--- a/src/go/tools/functions-validation/validate/main_test.go
+++ b/src/go/tools/functions-validation/validate/main_test.go
@@ -97,6 +97,48 @@ func TestFunctionUISchemaValidationSkipsTopologySemanticsForTableResponses(t *te
 	}
 }
 
+func TestFunctionUISchemaAcceptsTracesResponse(t *testing.T) {
+	schemaBytes := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_UI_SCHEMA.json"))
+	input := []byte(`{
+		"status": 200,
+		"type": "traces",
+		"data": {
+			"mode": "search",
+			"version": 1,
+			"status": {"complete": true},
+			"completion_coverage": {"after": 0, "before": 4294967295},
+			"items": {"returned": 0, "max_to_return": 20},
+			"traces": [],
+			"field_kinds": {
+				"fields": [],
+				"event_attributes": [],
+				"link_attributes": []
+			}
+		}
+	}`)
+
+	if _, err := validateJSON(schemaBytes, input); err != nil {
+		t.Fatalf("validate traces response: %v", err)
+	}
+}
+
+func TestFunctionUISchemaRejectsTraceDataUnderTableType(t *testing.T) {
+	schemaBytes := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_UI_SCHEMA.json"))
+	input := []byte(`{
+		"status": 200,
+		"type": "table",
+		"data": {
+			"mode": "search",
+			"version": 1,
+			"status": {"complete": true}
+		}
+	}`)
+
+	if _, err := validateJSON(schemaBytes, input); err == nil {
+		t.Fatal("expected trace object data under table type to fail validation")
+	}
+}
+
 func TestValidationSkipsTopologySemanticsForNonTopologyObjectData(t *testing.T) {
 	schemaBytes := []byte(`{"type": "object"}`)
 	input := []byte(`{

--- a/src/plugins.d/FUNCTION_UI_SCHEMA.json
+++ b/src/plugins.d/FUNCTION_UI_SCHEMA.json
@@ -13,6 +13,7 @@
     { "$ref": "#/definitions/data_response" },
     { "$ref": "#/definitions/topology_response" },
     { "$ref": "#/definitions/flows_response" },
+    { "$ref": "#/definitions/traces_response" },
     { "$ref": "#/definitions/error_response" },
     { "$ref": "#/definitions/not_modified_response" }
   ],
@@ -623,6 +624,239 @@
           },
           "additionalProperties": true
         },
+        "has_history": { "type": "boolean" },
+        "accepted_params": { "$ref": "#/definitions/accepted_params" },
+        "required_params": { "$ref": "#/definitions/required_params" },
+        "help": { "type": "string" },
+        "update_every": { "type": "integer" },
+        "expires": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "traces_status": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["complete"],
+          "properties": {
+            "complete": { "const": true }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["partial"],
+          "properties": {
+            "partial": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "size_cap",
+                  "source_failure",
+                  "work_ceiling",
+                  "cancelled",
+                  "overview_ceiling",
+                  "rollup_absent",
+                  "slowest_ceiling"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "traces_coverage": {
+      "type": "object",
+      "required": ["after", "before"],
+      "properties": {
+        "after": { "type": "integer", "minimum": 0, "maximum": 4294967295 },
+        "before": { "type": "integer", "minimum": 0, "maximum": 4294967295 }
+      },
+      "additionalProperties": false
+    },
+    "traces_string_pair": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "type": "string" }
+    },
+    "traces_field_kinds": {
+      "type": "object",
+      "required": ["fields", "event_attributes", "link_attributes"],
+      "properties": {
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_string_pair" }
+        },
+        "event_attributes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_string_pair" }
+        },
+        "link_attributes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_string_pair" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "traces_event": {
+      "type": "object",
+      "required": ["time_unix_nano", "name", "dropped_attributes_count", "attributes"],
+      "properties": {
+        "time_unix_nano": { "type": "integer", "minimum": 0 },
+        "name": { "type": "string" },
+        "dropped_attributes_count": { "type": "integer", "minimum": 0 },
+        "attributes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_string_pair" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "traces_link": {
+      "type": "object",
+      "required": [
+        "trace_id",
+        "span_id",
+        "trace_state",
+        "flags",
+        "dropped_attributes_count",
+        "attributes"
+      ],
+      "properties": {
+        "trace_id": { "type": "string" },
+        "span_id": { "type": "string" },
+        "trace_state": { "type": "string" },
+        "flags": { "type": "integer", "minimum": 0 },
+        "dropped_attributes_count": { "type": "integer", "minimum": 0 },
+        "attributes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_string_pair" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "traces_span": {
+      "type": "object",
+      "required": [
+        "span_id",
+        "start_ns",
+        "duration_ns",
+        "kind",
+        "flags",
+        "dropped_attributes_count",
+        "dropped_events_count",
+        "dropped_links_count",
+        "fields",
+        "events",
+        "links"
+      ],
+      "properties": {
+        "span_id": { "type": "string" },
+        "parent_span_id": { "type": "string" },
+        "start_ns": { "type": "integer" },
+        "duration_ns": { "type": "integer" },
+        "kind": { "type": "integer" },
+        "flags": { "type": "integer", "minimum": 0 },
+        "dropped_attributes_count": { "type": "integer", "minimum": 0 },
+        "dropped_events_count": { "type": "integer", "minimum": 0 },
+        "dropped_links_count": { "type": "integer", "minimum": 0 },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_string_pair" }
+        },
+        "events": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_event" }
+        },
+        "links": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_link" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "traces_search_item": {
+      "type": "object",
+      "required": [
+        "trace_id",
+        "start_ns",
+        "newest_matched_start_ns",
+        "duration_ns",
+        "span_count",
+        "error_count",
+        "matched_count",
+        "exact",
+        "matched_spans"
+      ],
+      "properties": {
+        "trace_id": { "type": "string" },
+        "root_service": { "type": "string" },
+        "root_name": { "type": "string" },
+        "start_ns": { "type": "integer" },
+        "newest_matched_start_ns": { "type": "integer" },
+        "duration_ns": { "type": "integer" },
+        "span_count": { "type": "integer", "minimum": 0 },
+        "error_count": { "type": "integer", "minimum": 0 },
+        "matched_count": { "type": "integer", "minimum": 0 },
+        "exact": { "type": "boolean" },
+        "matched_spans": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_span" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "traces_search_data": {
+      "type": "object",
+      "required": [
+        "mode",
+        "version",
+        "status",
+        "completion_coverage",
+        "items",
+        "traces",
+        "field_kinds"
+      ],
+      "properties": {
+        "mode": { "const": "search" },
+        "version": { "type": "integer", "minimum": 1 },
+        "status": { "$ref": "#/definitions/traces_status" },
+        "completion_coverage": { "$ref": "#/definitions/traces_coverage" },
+        "items": {
+          "type": "object",
+          "required": ["returned", "max_to_return"],
+          "properties": {
+            "returned": { "type": "integer", "minimum": 0 },
+            "max_to_return": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": true
+        },
+        "traces": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/traces_search_item" }
+        },
+        "field_kinds": { "$ref": "#/definitions/traces_field_kinds" },
+        "anchor": {
+          "type": "object",
+          "required": ["next"],
+          "properties": {
+            "next": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "traces_response": {
+      "type": "object",
+      "required": ["status", "type", "data"],
+      "properties": {
+        "status": { "type": "integer" },
+        "type": { "const": "traces" },
+        "data": { "$ref": "#/definitions/traces_search_data" },
         "has_history": { "type": "boolean" },
         "accepted_params": { "$ref": "#/definitions/accepted_params" },
         "required_params": { "$ref": "#/definitions/required_params" },


### PR DESCRIPTION
The `otel-traces` Function only spoke its native mode-selector request shape, so
the standard Functions parameters could not reach the trace search view, and the
`info` response advertised no protocol version or response type.

## What this does

- Accepts the protocol's top-level `after`, `before`, `last`, `anchor`,
  `selections` and `timeout` as `FunctionsParams` and translates them into the
  native search mode, leaving that mode's own request and response contract
  untouched.
- Wraps the result in a `FunctionsTracesResponse` envelope whose numeric status
  cannot collide with the nested query-completeness status object.
- Advertises `type`, `has_history` and `v` on the `info` response, so a UI can
  select a renderer and a transport.
- Forwards `min_trace_duration_ns`, already supported by the native search mode
  but previously unreachable from the Functions view.

## Why the envelope rather than adapting the client

Without `v`, a client cannot know the function accepts a JSON body, and falls
back to appending parameters to the function name — which this function cannot
parse, producing `Request payload is empty`. Without `type`, a client cannot
select a trace-aware renderer. Both are properties of the function, so the
function advertises them.

## Verification

- `cargo test -p otel-ledger`: 162 passed, 0 failed.
- `cargo clippy -p otel-ledger`: no new warnings in any touched file.

Every added parameter is additive: omitting it reproduces the previous
behaviour exactly, and `accepted_params` lets a client detect what is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Functions view for trace searches with pagination, selections, time ranges, and minimum trace-duration filtering.
  - Requests without an explicit view now use the Functions view with sensible defaults.
  - Added structured trace responses containing status, coverage, events, links, spans, and search results.

- **Documentation**
  - Updated capability metadata with supported trace parameters and protocol version 3.
  - Expanded the UI schema to support rendering trace search responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->