### PR TITLE
Raise job concurrency limits for GHA workflows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1190,7 +1190,7 @@ jobs:
       - file-check
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 16
       matrix: ${{ fromJson(needs.src-matrix.outputs.matrix) }}
     steps:
       - name: Skip Check
@@ -1256,7 +1256,6 @@ jobs:
       - file-check
     strategy:
       fail-fast: false
-      max-parallel: 8
       matrix:
         include:
           - name: macos-14-M1

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -336,7 +336,7 @@ jobs:
       # build failure for one version doesn't prevent us from publishing
       # successfully built and tested packages for another version.
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 24
     steps:
       - name: Skip Check
         id: skip

--- a/.github/workflows/platform-eol-check.yml
+++ b/.github/workflows/platform-eol-check.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
       fail-fast: false  # We want to check everything, so don’t bail on the first failure.
-      max-parallel: 2  # Cap of two jobs at a time to limit impact on other CI.
+      max-parallel: 8
     steps:
       - name: Checkout
         id: checkout

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -74,7 +74,7 @@ jobs:
       # build failure for one version doesn't prevent us from publishing
       # successfully built and tested packages for another version.
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 16
     steps:
       - name: Checkout
         id: checkout


### PR DESCRIPTION
##### Summary

We have far less stringent limits upstream on concurrently active runners now, so relax the limits on job concurrency to speed up CI runs on PRs.

##### Test Plan

n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises GitHub Actions job concurrency limits to speed up CI runs on PRs, now that upstream runner concurrency limits are less restrictive.

- Increases `max-parallel` in `build.yml`, `packaging.yml`, `platform-eol-check.yml`, and `repoconfig-packages.yml`.
- Removes the `max-parallel` cap from the macOS job in `build.yml`.

<sup>Written for commit b16c3b1472543bc17b09d440ab55cb2c091a8e0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased parallel processing for source builds, packaging, platform compatibility checks, and repository package builds.
  - Updated macOS build scheduling to use the workflow’s default parallelism.
  - These changes can reduce the time required for automated builds and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->