### PR TITLE
docs(agents): slim root AGENTS.md to one rule, one home

### DIFF
--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -71,7 +71,8 @@ Problem / root-cause model:
 Evidence reviewed:
 
 - <Specs, code, docs, tests, logs, traces, prior PRs/issues, external references.>
-- <For mirrored open-source repositories: cite `owner/repo @ commit` and repository-relative paths; never paste machine-specific absolute mirror paths (the mirror lives at `${NETDATA_REPOS_DIR}`).>
+- <For mirrored open-source repositories: cite `owner/repo @ commit` and repository-relative paths; never paste
+  machine-specific absolute mirror paths (the mirror lives at `${NETDATA_REPOS_DIR}`).>
 
 Affected contracts and surfaces:
 
@@ -82,7 +83,8 @@ Clean-end-state target:
 - <The structure the codebase should have once the approved scope is fully delivered.>
 - Removed as redundant (i): <code/config/docs/tests this change makes redundant.>
 - Excluded coupled items (ii): <coupled items NOT part of this clean end state, each with reason + scope source.>
-- Reference search (when a path/contract is replaced): <command(s) run + result; every surviving reference mapped to (i)/(ii), or the target is incomplete.>
+- Reference search (when a path/contract is replaced): <command(s) run + result; every surviving reference mapped to
+  (i)/(ii), or the target is incomplete.>
 
 Existing patterns to reuse:
 
@@ -94,7 +96,9 @@ Risk and blast radius:
 
 Sensitive data handling plan:
 
-- <Whether the work may expose secrets, credentials, bearer tokens, SNMP communities, community/customer data, personal data, non-private customer-identifying IPs, private endpoints, or proprietary incident details; how evidence will be redacted in SOWs, specs, docs, skills, instructions, and code comments.>
+- <Whether the work may expose secrets, credentials, bearer tokens, SNMP communities, community/customer data, personal
+  data, non-private customer-identifying IPs, private endpoints, or proprietary incident details; how evidence will be
+  redacted in SOWs, specs, docs, skills, instructions, and code comments.>
 
 Implementation plan:
 
@@ -112,11 +116,13 @@ Artifact impact plan:
 - Specs: <expected update or reason likely unaffected>
 - End-user/operator docs: <expected update or reason likely unaffected>
 - End-user/operator skills: <expected update or reason likely unaffected>
-- SOW lifecycle: <local-only working file under .agents/sow/q/ (never committed); durable-knowledge targets (skills/docs/code/tests); regression = new linked SOW; follow-up issues>
+- SOW lifecycle: <local-only working file under .agents/sow/q/ (never committed); durable-knowledge targets
+  (skills/docs/code/tests); regression = new linked SOW; follow-up issues>
 
 Open-source reference evidence:
 
-- <If local mirrored repositories under `${NETDATA_REPOS_DIR}` were checked, list each as `owner/repo @ commit` plus repository-relative paths. If none were checked, record why external OSS references were not relevant.>
+- <If local mirrored repositories under `${NETDATA_REPOS_DIR}` were checked, list each as `owner/repo @ commit` plus
+  repository-relative paths. If none were checked, record why external OSS references were not relevant.>
 
 Open decisions:
 
@@ -191,7 +197,9 @@ Same-failure scan:
 
 Sensitive data gate:
 
-- <Confirm durable artifacts contain no raw secrets, credentials, bearer tokens, SNMP communities, community member names, customer names, personal data, non-private customer-identifying IPs, private endpoints, or proprietary incident details; note redactions used.>
+- <Confirm durable artifacts contain no raw secrets, credentials, bearer tokens, SNMP communities, community member
+  names, customer names, personal data, non-private customer-identifying IPs, private endpoints, or proprietary incident
+  details; note redactions used.>
 
 ## Artifact Maintenance Gate
 
@@ -200,8 +208,11 @@ Sensitive data gate:
 - Specs: <updated .agents/sow/specs/ path or evidence-backed reason no update was needed>
 - End-user/operator docs: <updated docs/runbooks/help paths or evidence-backed reason none were affected>
 - End-user/operator skills: <updated output/reference skill paths or evidence-backed reason none were affected>
-- SOW lifecycle: <durable knowledge transferred to skills/docs/code/tests; follow-ups moved to GitHub issues or rejected; `Status: completed` set; SOW working file is local-only under .agents/sow/q/ and never committed; regression-as-new-SOW handling recorded>
-- Workflow friction triaged: <each `Workflow Friction & Rule Gaps` entry resolved to a rule update (file + change), an evidence-backed rejection, or a tracked follow-up; "no workflow friction arose" if the section is empty>
+- SOW lifecycle: <durable knowledge transferred to skills/docs/code/tests; follow-ups moved to GitHub issues or
+  rejected; `Status: completed` set; SOW working file is local-only under .agents/sow/q/ and never committed;
+  regression-as-new-SOW handling recorded>
+- Workflow friction triaged: <each `Workflow Friction & Rule Gaps` entry resolved to a rule update (file + change), an
+  evidence-backed rejection, or a tracked follow-up; "no workflow friction arose" if the section is empty>
 
 Lessons:
 

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -25,6 +25,8 @@ Sub-state: <short current truth>
 
 Regresses (optional): PR #NNNNN
 
+Umbrella (optional, step SOWs only): SOW-YYYYMMDD-<family>-umbrella
+
 ### Assistant Understanding
 
 Facts:
@@ -128,6 +130,14 @@ Open decisions:
 
 1. <chunk, scope, risk, dependencies>
 2. <chunk, scope, risk, dependencies>
+
+## Steps
+
+Umbrella SOWs only (see "Umbrella And Step SOWs" in `AGENTS.md`); delete this section otherwise.
+
+| # | Step SOW | Status | PR |
+|---|---|---|---|
+| 01 | SOW-YYYYMMDD-<family>-01-<step>.md | planning | |
 
 ## Execution Log
 

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -6,7 +6,7 @@ Status: planning | ready | in-progress | paused | completed
 
 `planning` means analysis or decisions are incomplete. `ready` means the
 Pre-Implementation Gate is complete and, where the goal-approval round ("Plan
-before non-trivial work") applies, the user has approved the goal and plan.
+Before Non-Trivial Work") applies, the user has approved the goal and plan.
 `completed` means work is validated and durable memory transferred. SOW files
 are local-only working memory under `.agents/sow/q/` (gitignored) and are never
 committed.
@@ -162,6 +162,16 @@ Maintenance Gate).
 Acceptance criteria evidence:
 
 - <evidence>
+
+Clean-end-state evidence:
+
+- <Delivered state vs the recorded target: (i) removed as redundant, (ii) excluded coupled items, and the recorded
+  reference search where a path or contract was replaced; or a link to the user approval for a non-clean state.>
+
+Deferred clean-end-state remainder:
+
+- <Each deferred target item with why deferral was acceptable and when (or under what condition) it lands; or
+  "none".>
 
 Tests or equivalent validation:
 

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -203,22 +203,6 @@ Sensitive data gate:
 - SOW lifecycle: <durable knowledge transferred to skills/docs/code/tests; follow-ups moved to GitHub issues or rejected; `Status: completed` set; SOW working file is local-only under .agents/sow/q/ and never committed; regression-as-new-SOW handling recorded>
 - Workflow friction triaged: <each `Workflow Friction & Rule Gaps` entry resolved to a rule update (file + change), an evidence-backed rejection, or a tracked follow-up; "no workflow friction arose" if the section is empty>
 
-Specs update:
-
-- <updated spec or specific reason no update was needed>
-
-Project skills update:
-
-- <updated runtime project skill or specific reason no update was needed>
-
-End-user/operator docs update:
-
-- <updated docs or evidence-backed reason none were affected>
-
-End-user/operator skills update:
-
-- <updated output/reference skills affected by docs/spec changes, or evidence-backed reason none were affected>
-
 Lessons:
 
 - <lesson or specific reason none>
@@ -230,11 +214,3 @@ Follow-up mapping:
 ## Outcome
 
 Pending.
-
-## Lessons Extracted
-
-Pending.
-
-## Follow-up Issues
-
-None yet.

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Status: planning | ready | in-progress | paused | completed
+Status: planning
+
+One value only: `planning`, `ready`, `in-progress`, `paused`, or `completed`.
 
 `planning` means analysis or decisions are incomplete. `ready` means the
 Pre-Implementation Gate is complete and, where the goal-approval round ("Plan
@@ -26,6 +28,8 @@ Sub-state: <short current truth>
 Regresses (optional): PR #NNNNN
 
 Umbrella (optional, step SOWs only): SOW-YYYYMMDD-<family>-umbrella
+
+Branch (optional): <branch name, once created>
 
 ### Assistant Understanding
 
@@ -62,7 +66,9 @@ Risks:
 
 ## Pre-Implementation Gate
 
-Status: blocked | ready | needs-user-decision
+Gate status: blocked
+
+One value only: `blocked`, `ready`, or `needs-user-decision`. This is the gate's key, distinct from the SOW `Status:`.
 
 Problem / root-cause model:
 
@@ -194,6 +200,10 @@ Reviewer findings:
 Same-failure scan:
 
 - <search and result>
+
+SOW audit:
+
+- <`bash .agents/sow/audit.sh` summary line; each remaining failure fixed or explained>
 
 Sensitive data gate:
 

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -184,6 +184,7 @@ if [ -d .agents/sow/q/current ]; then
         ;;
     esac
 
+    case "$sow" in *-umbrella.md) continue ;; esac   # umbrellas hold no gate/validation by design
     for needle in \
       "## Pre-Implementation Gate" \
       "Sensitive data handling plan:" \

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -77,19 +77,21 @@ fi
 section "canonical AGENTS.md sections"
 required_sections=(
   "## Goals"
+  "## Development Principles"
   "## SOW System"
-  "### Roles"
+  "### Storage Model"
+  "### Umbrella And Step SOWs"
+  "### Pre-Implementation Gate"
   "### Git Worktrees"
+  "### Review"
+  "### Regressions"
+  "### Validation Gate"
+  "### Enforcement"
   "### Sensitive Data In Durable Artifacts"
   "### Durable AI-Facing Artifact Formatting"
   "### Open-Source Reference Evidence"
-  "### Pre-Implementation Gate"
-  "### SOW Completion And Merge"
-  "### Enforcement"
-  "### Regressions"
-  "### Project Skills"
   "### Specs"
-  "### Project-specific overrides"
+  "### Project Skills"
 )
 
 for heading in "${required_sections[@]}"; do
@@ -124,7 +126,7 @@ for path in .agents/sow/SOW.template.md .agents/sow/audit.sh .agents/sow/scan-se
   fi
 done
 
-for q in pending current active "done"; do
+for q in pending current "done"; do
   if [ -d ".agents/sow/q/$q" ]; then
     ok ".agents/sow/q/$q exists"
   else
@@ -161,9 +163,9 @@ total_sows=0
 ok "$total_sows local SOW working file(s) under .agents/sow/q (local-only, never committed)"
 
 # Structural completeness is advisory and checked only for in-flight SOWs in the
-# active queue; pending stubs and completed (done/) history are exempt.
+# current queue; pending stubs and completed (done/) history are exempt.
 active_count=0
-if [ -d .agents/sow/q/active ]; then
+if [ -d .agents/sow/q/current ]; then
   while IFS= read -r sow; do
     [ -n "$sow" ] || continue
     active_count=$((active_count + 1))
@@ -194,11 +196,11 @@ if [ -d .agents/sow/q/active ]; then
         warn "$sow is missing $needle"
       fi
     done
-  done < <(find -L .agents/sow/q/active -type f -name 'SOW-*.md' 2>/dev/null | sort)
+  done < <(find -L .agents/sow/q/current -type f -name 'SOW-*.md' 2>/dev/null | sort)
 fi
 
 if [ "$active_count" -eq 0 ]; then
-  ok "no in-flight SOWs in .agents/sow/q/active"
+  ok "no in-flight SOWs in .agents/sow/q/current"
 fi
 
 section "spec index"

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -306,7 +306,7 @@ done
 if [ -d .agents/skills ]; then
   while IFS= read -r file; do
     scan_files+=("$file")
-  done < <(find .agents/skills -type f 2>/dev/null | sort)
+  done < <(find -L .agents/skills -type f 2>/dev/null | sort)
 fi
 
 if [ -d .agents/skill-verification ]; then

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -83,6 +83,7 @@ required_sections=(
   "### Umbrella And Step SOWs"
   "### Pre-Implementation Gate"
   "### Git Worktrees"
+  "### Git And PR Workflow"
   "### Review"
   "### Regressions"
   "### Validation Gate"

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -253,6 +253,7 @@ if command -v rg >/dev/null 2>&1; then
     rg --no-filename -o '\.agents/sow/specs/[A-Za-z0-9._/-]+\.md' \
       AGENTS.md .agents/skills docs src \
       -g '*.md' -g 'SKILL.md' -g '*.sh' -g '*.yml' \
+      -g '!TODO*.md' -g '!**/TODO*.md' \
       2>/dev/null | sort -u
   )
 else

--- a/.agents/sow/worktree-link.sh
+++ b/.agents/sow/worktree-link.sh
@@ -105,6 +105,15 @@ migrate_old_queues() {
   done
 }
 
+# Retired queue: fold any leftover q/active/ into q/current/ (collision-safe).
+retire_active_queue() {
+  local q="$1" label="$2"
+  { [ -d "$q/active" ] && [ ! -L "$q/active" ]; } || return 0
+  info "retiring $q/active -> $q/current"
+  merge_into "$q/active" "$q/current" "$label"
+  rmdir "$q/active" 2>/dev/null || warn "$q/active not empty after migration; left in place"
+}
+
 # ORIGIN: if specs were dropped because this checkout crossed the untrack commit,
 # restore them from history without touching the index.
 selfheal_specs() {
@@ -184,6 +193,7 @@ if [ "$git_dir" = "$common_dir" ]; then
   run mkdir -p "$top/$SOW_DIR/q"
   migrate_old_queues "$top/$SOW_DIR/q" "migrated"
   for q in $CANON_QUEUES; do run mkdir -p "$top/$SOW_DIR/q/$q"; done
+  retire_active_queue "$top/$SOW_DIR/q" "active"
   selfheal_specs
   run mkdir -p "$top/.local"
   info "${GREEN}SOW working memory ready under $SOW_DIR/q (origin).${NC}"

--- a/.agents/sow/worktree-link.sh
+++ b/.agents/sow/worktree-link.sh
@@ -180,6 +180,7 @@ Aborting — no files were moved, no data lost."
   # Case 4: this worktree may still carry old-style top-level queue dirs; push
   # their contents into origin's shared q/ before linking (no data loss).
   migrate_old_queues "$origin/$SOW_DIR/q" "$(basename "$top")"
+  retire_active_queue "$origin/$SOW_DIR/q" "$(basename "$top")"
 
   link_one "$SOW_DIR/q"     "$origin/$SOW_DIR/q"
   link_one "$SOW_DIR/specs" "$origin/$SOW_DIR/specs"

--- a/.agents/sow/worktree-link.sh
+++ b/.agents/sow/worktree-link.sh
@@ -43,7 +43,7 @@ die()  { printf >&2 "%s\n" "${RED}ERROR:${NC} $*"; exit 1; }
 
 SOW_DIR=".agents/sow"
 NON_QUEUE=" q specs "                       # dirs under .agents/sow/ that are NOT queues
-CANON_QUEUES="pending current done active"  # queues ensured to exist inside q/
+CANON_QUEUES="pending current done"  # queues ensured to exist inside q/
 
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git work tree"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,1029 +2,629 @@
 
 ## Goals
 
-This repository is the Netdata Agent codebase. It is a large, multi-language, multi-platform monolith that serves production monitoring, troubleshooting, data collection, alerting, storage, streaming, cloud integration, packaging, and documentation workflows.
+This repository is the Netdata Agent codebase: a large, multi-language, multi-platform monolith serving production
+monitoring, troubleshooting, data collection, alerting, storage, streaming, cloud integration, packaging, and
+documentation workflows.
 
-Work in this repository must prioritize root-cause understanding, correctness, performance, maintainability, portability, security, and consistency with existing project conventions.
+Work here MUST prioritize root-cause understanding, correctness, performance, maintainability, portability,
+security, and consistency with existing project conventions.
+
+Critical rules:
+
+1. You MUST find the root cause of a problem before offering a solution. Patching without understanding the
+   problem is not allowed.
+2. Before patching code, you MUST understand the codebase and the implications of the change: what else is
+   affected, what else uses this code.
+3. Do not duplicate code. Check whether similar code already exists and reuse it.
 
 ## Requirement Language
 
-This repository uses RFC-style requirement language:
-
-- **MUST** / **REQUIRED**: mandatory. Work that violates it is not acceptable
-  unless the user explicitly changes the requirement.
+- **MUST** / **REQUIRED**: mandatory. Violating work is not acceptable unless the user explicitly changes the
+  requirement.
 - **MUST NOT**: prohibited.
-- **SHOULD** / **RECOMMENDED**: expected default. Deviate only with evidence
-  and explain the trade-off.
+- **SHOULD** / **RECOMMENDED**: expected default. Deviate only with evidence and explain the trade-off.
 - **MAY** / **OPTIONAL**: allowed, not required.
 
-CRITICAL RULES:
+## Working With The User
 
-1. You MUST ALWAYS find the root cause of a problem, before offering/giving a solution.
-   Patching without understanding the problem IS NOT ALLOWED.
+Roles:
 
-2. Before patching code, you MUST understand the codebase and the potential implications of the changes.
-   What else is affected? What else is using this part of the code?
+- **User**: purpose, scope decisions, design forks, risk acceptance, destructive approvals, final product judgment.
+- **Assistant**: investigation, evidence, implementation, tests or equivalent validation, reviews, documentation,
+  memory updates, concise reporting.
 
-3. Do not duplicate code.
-   First check if similar code already exists and reuse it.
+Communication:
 
-## Mandatory Development Principles
+- Do your homework before asking questions or requesting decisions. Check every related aspect and possibility so
+  questions are informed and to the point.
+- Never write walls of text unless asked. Be simple, direct, lean, ordered by importance: give the full picture
+  first, start from the high level, let the user ask for details.
+- Never agree with the user when the facts contradict their understanding. Always state the risks and implications
+  of their decisions. You are helpful when you reveal the truth accurately, not when you agree.
+- Ask the user only for irreducible product, design, or risk decisions.
 
-These principles are mandatory for every task. Code is cheap to add and
-expensive to live with, so a larger diff that removes debt beats a smaller one
-that preserves it.
+When a user decision is needed:
 
-**Core (read first; the bullets under each principle are the authority for forks
-and edge cases):**
+1. Present concrete evidence: files and lines, or source references.
+2. Provide numbered options.
+3. Explain pros, cons, implications, and risks of each.
+4. Recommend one option with reasoning.
+5. Record the decision in the SOW before implementation. For the goal/plan approval round, the bar is the
+   Approval bar below.
 
-- Deliver the **clean end state** of the approved scope, not the smallest diff —
-  including removing what the change makes redundant; refactor low-risk mess in
-  code you touch.
-- **Record that target in the SOW first** (what you remove; any coupled item you
-  exclude, with its reason). When you replace a path or contract, record a
-  reference search proving the list is complete.
-- **You are not the scope authority.** Coupled cleanup is in scope: do the
-  low-risk part and disclose it; never silently drop it or relabel it
-  "independent."
-- Falling short of the recorded target — or any user-owned **fork** (competing
-  designs, a public-contract or destructive change, unclear scope) — triggers a
-  **Mandatory pause**: stop, state the trade-off, get explicit approval.
-- **Plan before non-trivial work:** establish the user-approved end state plus
-  acceptance criteria, then ordered steps; re-evaluate against the target at each
-  step, before any PR, and before completion.
-- **Default on doubt:** if unsure whether something is in scope, trivial, or a
-  user-owned fork, treat it as in-scope / non-trivial / user-owned and ask.
+## Development Principles
 
-1. **Clean end state over less churn.**
-   - Binding rule (read first): you MUST recommend and deliver the clean end
-     state — the structure the codebase SHOULD have once the approved scope is
-     fully delivered, including removing the code, config, docs, and tests the
-     change makes redundant — not the smallest diff. You MUST NOT relabel the
-     smallest working diff as "the clean end state."
-   - Record the target: before generating options, record that clean end state in
-     the SOW. The recorded target is the clean end state of this SOW's approved
-     scope; for staged work, each stage's SOW records that stage's target and the
-     stages together MUST reach the full target. Any option that does not match
-     the recorded target is a non-clean state and triggers the Mandatory pause.
-   - Open design decision: when the clean end state is itself an open design
-     decision that is the user's to make, do not invent a fixed target; record a
-     provisional target plus the open design question and resolve it with the
-     user first.
-   - Approved scope: "the approved scope" is the union of (a) the issue or user
-     request, (b) the SOW Purpose and Acceptance Criteria, and (c) the
-     migration/contract surface they imply. If it is unclear whether work is in
-     scope, treat it as in-scope and raise it with the user; never silently
-     exclude it.
-   - You are not the scope authority:
-     - A "coupled item" is code, config, docs, or tests the current change makes
-       redundant or leaves inconsistent (for example a replaced path, its
-       callers, or its tests).
-     - You MUST NOT reclassify in-scope or coupled work as "independent" or "out
-       of scope" to avoid doing it, and you MUST NOT silently drop coupled work.
-     - When you only suspect something is coupled and including it is low-risk and
-       confined to what you are changing, include it and disclose it rather than
-       stopping to ask.
-     - Pause for the user only when including it would expand the blast radius,
-       change a user-visible contract, or the boundary is itself a genuine scope
-       fork.
-     - This overrides any reading of "Scope discipline" that would defer coupled
-       cleanup.
-   - Disclose exclusions: in the recorded target you MUST list (i) what you will
-     remove as redundant, and (ii) any coupled item you are treating as NOT part
-     of this clean end state, each with its reason and the scope source it rests
-     on. Excluding an in-scope or coupled item without recording it there is
-     silent scope-narrowing and is prohibited, so a reviewer or the next agent can
-     check your exclusions against those sources.
-   - Touch-the-mess-you-touch: when your change modifies code that already
-     contains adjacent duplication, dead code, or a clear pre-existing defect, you
-     SHOULD clean that adjacent mess as part of this work rather than build on top
-     of it, provided the cleanup is low-risk and confined to the code you are
-     already modifying. Cleanup that would reach into unrelated code is
-     independent work (Scope discipline) — track it, do not silently bundle it. If you
-     choose NOT to clean adjacent mess you touched, record why under the
-     disclosure list (ii).
-   - Reference search (when replacing a path or altering a contract):
-     - You MUST run and record in the SOW a reference search for remaining
-       references to the replaced path or contract.
-     - Search construction sites and prefixes too, not only literal final names —
-       identifiers here are often built dynamically (for example via
-       `fmt.Sprintf`).
-     - Every surviving reference MUST appear in (i) or (ii) with its scope source,
-       or the target is incomplete; an item you did not search for counts as
-       silent scope-narrowing.
-     - A repository-wide search cannot prove safety for consumers outside this
-       repo (Netdata Cloud, exporters, streaming, ML, the docs pipeline); treat
-       renaming a shipped public contract as a user-owned breaking decision (an
-       Allowed-exceptions pause), not something the search clears.
-   - Allowed exceptions (pause conditions, not auto-routes): recommend a
-     non-clean route ONLY for one of:
-     - (a) technically impossible — impossible to implement correctly at all, NOT
-       impossible within a preferred diff size;
-     - (b) a concrete, evidenced safety risk — a named hazard such as data loss
-       or a security/production-stability regression, NOT "a larger diff is
-       riskier";
-     - (c) confirmed by the user as outside the approved scope; or
-     - (d) accepted by the user, through the Mandatory pause, as an in-scope
-       partial to ship now.
+These principles are mandatory for every task. Code is cheap to add and expensive to live with: a larger diff that
+removes debt beats a smaller one that preserves it.
 
-     For (a)/(b) you MUST cite specific evidence (file/line, failure class, or
-     test) and route through the Mandatory pause — you do not self-certify
-     "unsafe." For (d) track the remainder per "Followup Discipline" with why
-     deferral is acceptable and when it lands; repeatedly shipping partials is
-     debt accumulation, not delivery. Risk reduction, review convenience, smaller
-     diff, and issue staging are NEVER valid and MUST NOT be relabeled "unsafe"
-     or "independent."
-   - Mandatory pause: if the delivered state will fall short of its recorded
-     target for any reason other than approved staged delivery, you MUST present
-     the evidence, STOP, and obtain explicit user approval (see Approval bar)
-     before proceeding, before requesting non-draft review, and before marking
-     the work complete.
-   - Approval bar (used by every gate): approval means the user explicitly
-     accepts a trade-off, goal, or plan that you stated in your own words (what
-     stays redundant or partial, and why). A bare "ok" or "sounds good" to a
-     one-sided pitch is not approval.
-   - Re-evaluation: at the completion of each planned step, before opening or
-     updating a PR, and before marking a SOW completed (the Re-evaluation
-     checkpoints), you MUST re-evaluate already-written changes against the
-     recorded target; you SHOULD also re-evaluate whenever you pause to report
-     progress. Do not keep a compromise only because it already exists in the
-     branch.
-   - Staged delivery: allowed ONLY when every stage is an in-scope decomposition
-     of one approved clean end state and the stages together reach it. The user
-     approval recorded for the staged plan covers the intermediate states, so an
-     approved stage does not re-trigger the Mandatory pause; every later stage
-     MUST be tracked per "Followup Discipline" (implemented here, rejected with
-     evidence, or a linked GitHub issue) before an earlier stage merges. A
-     self-certified "a later stage will finish it" with no tracked item is not
-     acceptable.
-   - Re-ground staged designs: a design recorded during planning or an earlier
-     stage MAY have drifted from the code a previous stage produced (a removed
-     structure, an obsoleted mechanism). Before implementing a later stage you
-     MUST re-verify its recorded design against the current code and record the
-     correction in the SOW; never implement against stale assumptions.
-   - Deferral check: before recommending deferral, check the issue, SOW,
-     acceptance criteria, and affected migration scope. Silence or ambiguity MUST
-     NOT be read as permission to defer; if those sources do not clearly place
-     the work outside the approved clean end state, treat it as in-scope and
-     either complete it or pause for a user decision.
-   - Trivial-work exemption: trivial work (per "When A SOW Is Required") has no
-     SOW and is exempt from the record-the-target, disclosure, and
-     reference-search bullets above; the clean-end-state preference still applies.
-     When unsure, treat the work as non-trivial.
+### Definitions
 
-2. **Plan before non-trivial work.**
-   - Plan first: non-trivial work (see "When A SOW Is Required") MUST start with
-     a plan recorded in the SOW before any implementation-file change and before
-     any implementation-equivalent action — migrations, deletions, pushes,
-     non-draft PRs, or external-state mutations via tools. Trivial work is exempt;
-     when unsure, treat the work as non-trivial.
-   - Human-owned goal: the desired end state — the goal, or coherent goal set, the
-     work must reach — MUST be created with or approved by the user. You MUST NOT
-     finalize the goal unilaterally (same user-owned target as Clean end state).
-   - End state first: you MUST establish the desired end state — including its
-     acceptance criteria — before planning the steps; the goal drives the work,
-     not a first diff. If you cannot yet state the end state, keep investigating
-     until you can; do not start work against an unknown target. When the end
-     state is itself a user-owned design decision, record a provisional target
-     plus the open question and resolve it with the user first (Clean end state).
-     Then plan the steps to move from the current state toward that end state.
-   - Decompose into steps: split the work into ordered steps, each with its own
-     clean end state and acceptance criteria, each building on the previous one
-     toward the desired end state. A single coherent step is a valid decomposition
-     when the work is atomic; do not invent artificial sub-steps.
-   - Resolve huge or vague work: if the deliverable is large or vague, keep
-     refining the plan until every step has a clean end state and acceptance
-     criteria. Do not start implementation while steps are still unclear.
-   - Reachability: the plan MUST either reach the desired end state through its
-     steps, or produce evidence that it is not achievable; an unachievable goal
-     is a pause condition for a user decision, not a silent partial result.
-   - Human approval gate: when a goal-approval round is required (see "Approval is
-     for goal-decisions" below), the whole plan — the desired end state and the
-     step breakdown — MUST be explicitly approved by the user before
-     implementation. The assistant proposes and investigates; the user approves.
-     State the goal and step breakdown being accepted, and get confirmation that
-     meets the Approval bar (Clean end state). If the user rejects or edits the
-     plan, revise and re-seek approval; the SOW stays in `planning` until an
-     explicit approval is recorded, then reaches `Status: ready`. This gate is the
-     canonical statement of the approval requirement that the Pre-Implementation
-     Gate and Required First Checks reference.
-   - Approval is for goal-decisions, not work categories:
-     - The goal-approval round fires ONLY when the end state is a genuine
-       user-owned fork — competing designs, a public-contract change, a
-       destructive or irreversible step, or unclear scope.
-     - Other non-trivial work whose end state is already fixed by the triggering
-       request, an existing project skill, or an established repository pattern
-       (for example a clear bug fix, a metadata/docs edit with no contract change,
-       or a collector's skeleton and wiring fixed by its authoring skill — though
-       its Function surface, vnode/host-scope design, and new public config
-       options remain user-owned forks) still needs a recorded plan and the
-       Pre-Implementation Gate, but the triggering request IS the recorded goal
-       approval — no separate round, which also satisfies the resume re-check and
-       the progress rule.
-     - When it is unclear whether a real fork exists, treat it as user-owned and
-       seek approval.
-   - Approval persists; re-check on resume: before continuing an `in-progress` or
-     `paused` SOW you did not personally take through this gate — including
-     takeover or handoff — you MUST confirm the SOW records explicit approval of
-     the current goal and plan. If it does not, or the plan changed materially
-     since approval, treat the SOW as `planning` and re-obtain approval before
-     further implementation.
+- **Trivial vs non-trivial work**: defined under "When A SOW Is Required". Trivial work has no SOW and is exempt from
+  the record-the-target, disclosure, and reference-search rules below; the clean-end-state preference still applies.
+- **Approved scope**: the union of (a) the issue or user request, (b) the SOW Purpose and Acceptance Criteria, and
+  (c) the migration/contract surface they imply.
+- **Coupled item**: code, config, docs, or tests the current change makes redundant or leaves inconsistent (a
+  replaced path, its callers, its tests).
+- **Independent work**: new work is genuinely independent only if ALL hold: (a) the approved clean end state is
+  complete and correct without it, (b) it is not a coupled item or a remaining reference recorded under the target,
+  (c) it has its own separable acceptance criteria.
+- **User-owned fork**: competing designs, a public-contract change, a destructive or irreversible step, or unclear
+  scope.
+- **Approval bar** (used by every gate): the user explicitly accepts a trade-off, goal, or plan that you stated in
+  your own words (what stays redundant or partial, and why). A bare "ok" or "sounds good" to a one-sided pitch is
+  not approval.
+- **Default on doubt**: if unsure whether something is in scope, trivial, coupled, or a user-owned fork, treat it as
+  in-scope, non-trivial, coupled, user-owned, and ask.
 
-3. **Scope discipline at every step.**
-   - Drift check: at each Re-evaluation checkpoint (Clean end state), you MUST
-     also check whether the work has drifted outside the approved scope, not only
-     whether the diff still matches the recorded target.
-   - Independence test: new work is "genuinely independent" only if ALL hold —
-     (a) the approved clean end state is still complete and correct without it,
-     (b) it is not a coupled item or a remaining reference recorded under Clean
-     end state, and (c) it has its own separable acceptance criteria. If any test
-     fails, or you are unsure, treat the work as coupled, not independent, and
-     handle it under Clean end state (do the low-risk part and disclose it; pause
-     only for a genuine fork) — you are not the scope authority.
-   - Disposition of independent work:
-     - Do NOT silently bundle it.
-     - Submit it as a separate PR first and rebase the current branch after it
-       merges, or track it as a GitHub issue per "Followup Discipline."
-     - Do NOT fold it into this SOW's steps — Clean-end-state staged-delivery
-       stages must be a decomposition of one clean end state.
-   - Governed elsewhere: coupled cleanup is in scope (Clean end state), and
-     non-trivial work is delivered in coherent incremental steps (Plan before
-     non-trivial work); this principle does not restate them.
+### Clean End State Over Less Churn
 
-**Flow diagrams (human reading aid, non-normative):** the bullets above are
-authoritative; the diagrams below summarize the flow for human readers and MUST
-be kept in sync when the principles change.
+- You MUST recommend and deliver the clean end state: the structure the codebase SHOULD have once the approved
+  scope is fully delivered, including removing the code, config, docs, and tests the change makes redundant. Not
+  the smallest diff. You MUST NOT relabel the smallest working diff as "the clean end state".
+- Record the target: before generating options, record the clean end state in the SOW. For staged work each stage's
+  SOW records its own target, and the stages together MUST reach the full target. Any option that does not match
+  the recorded target is a non-clean state and triggers the Mandatory pause.
+- Open design decision: when the clean end state is itself the user's design decision, do not invent a fixed
+  target. Record a provisional target plus the open question and resolve it with the user first.
+- Disclose exclusions: the recorded target MUST list (i) what you remove as redundant and (ii) every coupled item
+  you treat as NOT part of this clean end state, each with its reason and the scope source it rests on. Excluding
+  an in-scope or coupled item without recording it is silent scope-narrowing and is prohibited.
+- You are not the scope authority:
+  - Coupled cleanup is in scope. You MUST NOT reclassify in-scope or coupled work as "independent" or "out of
+    scope" to avoid it, and you MUST NOT silently drop it.
+  - When you only suspect coupling and including it is low-risk and confined to what you are changing, include it
+    and disclose it rather than stopping to ask.
+  - Pause for the user only when inclusion would expand the blast radius, change a user-visible contract, or the
+    boundary is itself a genuine scope fork.
+  - If it is unclear whether work is in scope, treat it as in-scope and raise it. Never silently exclude it.
+- Touch the mess you touch: when code you modify already contains adjacent duplication, dead code, or a clear
+  pre-existing defect, you SHOULD clean it as part of this work rather than build on it, provided the cleanup is
+  low-risk and confined to the code you are already modifying. Cleanup reaching into unrelated code is independent
+  work (see Scope Discipline). If you leave adjacent mess in place, record why under disclosure (ii).
+- Reference search (when replacing a path or altering a contract):
+  - You MUST run and record in the SOW a search for remaining references. Search construction sites and prefixes
+    too, not only literal final names; identifiers here are often built dynamically (for example via
+    `fmt.Sprintf`).
+  - Every surviving reference MUST appear in (i) or (ii) with its scope source, or the target is incomplete. An
+    item you did not search for counts as silent scope-narrowing.
+  - A repository-wide search cannot prove safety for consumers outside this repo (Netdata Cloud, exporters,
+    streaming, ML, the docs pipeline). Renaming a shipped public contract is a user-owned breaking decision routed
+    through the Mandatory pause, not something the search clears.
+- Allowed exceptions (pause conditions, not auto-routes). Recommend a non-clean route ONLY for:
+  - (a) technically impossible: impossible to implement correctly at all, NOT within a preferred diff size;
+  - (b) a concrete, evidenced safety risk: a named hazard such as data loss or a security/production-stability
+    regression, NOT "a larger diff is riskier";
+  - (c) confirmed by the user as outside the approved scope;
+  - (d) accepted by the user, through the Mandatory pause, as an in-scope partial to ship now.
+  - For (a)/(b) you MUST cite specific evidence (file/line, failure class, or test) and route through the Mandatory
+    pause; you do not self-certify "unsafe". For (d) track the remainder per Followup Discipline with why deferral
+    is acceptable and when it lands; repeatedly shipping partials is debt accumulation, not delivery.
+  - Risk reduction, review convenience, smaller diff, and issue staging are NEVER valid reasons and MUST NOT be
+    relabeled "unsafe" or "independent".
+- Mandatory pause: if the delivered state will fall short of the recorded target for any reason other than approved
+  staged delivery, or the work reaches a user-owned fork, you MUST present the evidence, STOP, and obtain approval
+  (Approval bar) before proceeding, before requesting non-draft review, and before marking the work complete.
+- Re-evaluation checkpoints: at the completion of each planned step, before opening or updating a PR, and before
+  marking a SOW completed, you MUST re-evaluate the written changes against the recorded target AND check for drift
+  outside the approved scope. You SHOULD also re-evaluate whenever you pause to report progress. Do not keep a
+  compromise only because it already exists in the branch.
+- Staged delivery: allowed ONLY when every stage is an in-scope decomposition of one approved clean end state and
+  the stages together reach it. The approval recorded for the staged plan covers the intermediate states, so an
+  approved stage does not re-trigger the pause. Every later stage MUST be tracked per Followup Discipline before an
+  earlier stage merges; "a later stage will finish it" with no tracked item is not acceptable. Mechanics: see
+  "Umbrella And Step SOWs".
+- Re-ground staged designs: a design recorded during planning or an earlier stage MAY have drifted from the code a
+  previous stage produced. Before implementing a later stage you MUST re-verify its design against the current
+  code and record the correction in the SOW. Never implement against stale assumptions.
+- Deferral check: before recommending deferral, check the issue, SOW, acceptance criteria, and affected migration
+  scope. Silence or ambiguity MUST NOT be read as permission to defer. If those sources do not clearly place the
+  work outside the target, treat it as in-scope and either complete it or pause for a user decision.
 
-<details>
-<summary>Show per-principle flow diagrams</summary>
+### Plan Before Non-Trivial Work
 
-How the three principles connect (lifecycle order):
+- Non-trivial work MUST start with a plan recorded in the SOW before any implementation-file change and before any
+  implementation-equivalent action: migrations, deletions, pushes, non-draft PRs, external-state mutations via tools.
+- Human-owned goal: the desired end state MUST be created with or approved by the user. You MUST NOT finalize the
+  goal unilaterally.
+- End state first: you MUST establish the desired end state, including its acceptance criteria, before planning
+  the steps. The goal drives the work, not a first diff. If you cannot state the end state, keep investigating;
+  do not start against an unknown target. If the end state is a user-owned design decision, record a provisional
+  target plus the open question and resolve it first.
+- Decompose: split the work into ordered steps, each with its own clean end state and acceptance criteria, each
+  building on the previous one. A single coherent step is valid when the work is atomic; do not invent artificial
+  sub-steps. If the deliverable is large or vague, keep refining until every step is clear. Do not start while
+  steps are still unclear.
+- Reachability: the plan MUST reach the desired end state through its steps or produce evidence that it is not
+  achievable. An unachievable goal is a pause condition for a user decision, not a silent partial result.
+- Approval is for goal-decisions, not work categories:
+  - The goal-approval round fires ONLY when the end state is a user-owned fork. Then the whole plan (end state plus
+    step breakdown) MUST be explicitly approved by the user (Approval bar) before implementation: state what is
+    being accepted and get confirmation. If the user rejects or edits the plan, revise and re-seek approval. The
+    SOW stays `planning` until approval is recorded, then becomes `ready`.
+  - Non-trivial work whose end state is already fixed by the request, an existing project skill, or an established
+    repository pattern (a clear bug fix, a metadata/docs edit with no contract change, a collector skeleton fixed by
+    its authoring skill) still needs a recorded plan and the Pre-Implementation Gate, but the request IS the
+    recorded approval. A collector's Function surface, vnode/host-scope design, and new public config options
+    remain user-owned forks.
+  - When it is unclear whether a real fork exists, treat it as user-owned and seek approval.
+- Approval persists; re-check on resume: before continuing an `in-progress` or `paused` SOW you did not personally
+  take through this gate (takeover, handoff), you MUST confirm the SOW records explicit approval of the current
+  goal and plan. If it does not, or the plan changed materially since, treat the SOW as `planning` and re-obtain
+  approval.
 
-```mermaid
-flowchart LR
-    A("1. Clean end state<br/>defines the target (what 'done' means)")
-    B("2. Plan before non-trivial work<br/>establish the target + steps; user approves real forks")
-    C("3. Scope discipline<br/>stay on the target while executing each step")
-    A --> B --> C
-    C -->|re-evaluate vs target| A
-```
+### Scope Discipline At Every Step
 
-1. Clean end state over less churn:
-
-```mermaid
-flowchart TD
-    A("Approved scope = issue + SOW Purpose/Acceptance + implied surface")
-    B("Define the clean end state, incl. removing what the change makes redundant")
-    C("Record target in SOW: exclusions list + reference search if a path/contract is replaced")
-    D{"Matches recorded target?"}
-    E("Deliver the clean end state")
-    F{"Allowed exception?"}
-    Fx("Only: a) impossible, b) evidenced safety risk, c) out of scope, d) user-accepted partial")
-    G("NOT allowed: risk reduction, smaller diff, or staging")
-    H("Mandatory pause: present evidence, STOP")
-    I{"Explicit approval?"}
-    Ix("Approval bar: a bare 'ok' is not approval")
-    J("Proceed; track remainder per Followup Discipline")
-    K("Re-evaluate vs target: each step, before a PR, before complete")
-    A --> B --> C --> D
-    D -->|yes| E
-    D -->|no| F
-    F -->|no| G --> B
-    F -->|yes| H --> I
-    I -->|no| B
-    I -->|yes| J
-    F -.- Fx
-    I -.- Ix
-    E --> K
-    J --> K
-```
-
-2. Plan before non-trivial work:
-
-```mermaid
-flowchart TD
-    A("Task")
-    B{"Trivial?"}
-    C("Exempt: just do it (clean-end-state preference still applies)")
-    D("Establish the desired end state + acceptance criteria FIRST; keep investigating until you can")
-    E("Decompose into ordered steps, each with its own clean end state + criteria; move current toward desired")
-    F{"End state a user-owned fork?"}
-    Fk("Fork = competing designs, public-contract/destructive change, or unclear scope")
-    G("Fixed by request/skill/pattern: the request IS the approval (recorded plan + gate, no separate round)")
-    H("Goal-approval round: explicit user approval of the whole plan (Approval bar)")
-    I("Status: ready, implement")
-    J("Pause for a user decision (not a silent partial)")
-    A --> B
-    B -->|yes| C
-    B -->|no| D
-    D --> E --> F
-    F -->|no| G
-    F -->|yes| H
-    F -.- Fk
-    G --> I
-    H --> I
-    D -->|goal unreachable| J
-```
-
-3. Scope discipline at every step:
-
-```mermaid
-flowchart TD
-    A("At each Re-evaluation checkpoint")
-    B{"Drifted outside approved scope?"}
-    C("Continue")
-    D{"Genuinely independent?"}
-    Dx("Independent only if ALL: end state complete without it; not a coupled item/reference; separable acceptance criteria")
-    E("Treat as COUPLED: handle under Clean end state (do the low-risk part + disclose); pause only for a genuine fork")
-    F("Do NOT bundle silently: separate PR + rebase, or track as a GitHub issue; never fold into this SOW's steps")
-    A --> B
-    B -->|no| C
-    B -->|new work| D
-    D -->|no or unsure| E
-    D -->|yes| F
-    D -.- Dx
-```
-
-</details>
-
-USER COMMUNICATION:
-
-1. ALWAYS DO YOUR HOMEWORK BEFORE ASKING QUESTIONS OR REQUESTING USER DECISIONS.
-   PROACTIVELY CHECK ALL RELATED ASPECTS AND ALL POSSIBILITIES SO THAT YOUR QUESTIONS AND REQUESTS ARE WELL INFORMED AND TO THE POINT.
-
-2. NEVER WRITE WALLS OF TEXT TO THE USER, UNLESS THEY ASKED FOR IT.
-   YOUR COMMUNICATION MUST BE SIMPLE, DIRECT, LEAN, ORDERED BY IMPORTANCE.
-   PROVIDE THE FULL PICTURE AT THE BEGINNING, START FROM THE HIGH LEVEL, AND LET THE USER ASK FOR DETAILS.
-
-3. NEVER AGREE TO THE USER WHEN THE FACTS CONTRADICT THEIR UNDERSTANDING.
-   YOU MUST ALWAYS PROVIDE CLEAR DESCRIPTIONS OF THE RISKS AND IMPLICATIONS OF THEIR DECISIONS.
-   YOU ARE HELPFUL WHEN YOU ACCURATELY REVEAL THE TRUTH, NOT WHEN YOU AGREE.
+- Drift is checked at every Re-evaluation checkpoint, not only diff-vs-target.
+- New work that fails the Independent-work test, or that you are unsure about, is coupled: handle it under Clean
+  End State (do the low-risk part and disclose it; pause only for a genuine fork).
+- Genuinely independent work: do NOT silently bundle it. Submit it as a separate PR first and rebase after it
+  merges, or track it as a GitHub issue per Followup Discipline. Do NOT fold it into this SOW's steps; staged
+  stages must decompose one clean end state.
 
 ## SOW System
 
 Project SOW status: initialized
 
-This project uses a local Statement of Work system.
+This project uses a local Statement of Work (SOW) system. It is self-contained: normal SOW work MUST NOT depend on
+`~/.agents`, `~/.AGENTS.md`, global skills, global templates, or global scripts. Use this `AGENTS.md`, the local
+SOW, project-local specs, and project-local skills.
 
-SOWs and specs are **local-only working memory, never committed**:
+### Storage Model
 
-- SOW working files live under `.agents/sow/q/**` (the queue tree) and MUST NOT
-  be committed to any branch.
-- Specs live under `.agents/sow/specs/**` and are likewise local-only and
-  gitignored. They may be re-introduced to git later, reorganized, as a
-  deliberate decision; until then treat them as local memory.
-- Only the SOW framework files are committed and shared via git:
-  `.agents/sow/SOW.template.md`, `.agents/sow/audit.sh`,
-  `.agents/sow/scan-sensitive.sh`, `.agents/sow/worktree-link.sh`.
-- `.gitignore` enforces this: `/.agents/sow/q` and `/.agents/sow/specs` are
-  ignored; the framework files are tracked normally.
-- Durable knowledge that must survive a SOW belongs in project skills, docs,
-  code, and tests (and, once reorganized, specs) — not in the SOW body.
-- Worktree sharing: SOW working memory is per-developer, not per-worktree. Run
-  `.agents/sow/worktree-link.sh` after creating a git worktree (or after
-  updating an old checkout to this model) to create the queues and symlink
-  `.agents/sow/q`, `.agents/sow/specs`, `.local`, and `.env` to the origin
-  checkout. See "### SOW Locations And Naming".
+SOWs and specs are local-only working memory, never committed:
 
-The SOW system is self-contained in this repository. Normal SOW work must not depend on `~/.agents`, `~/.AGENTS.md`, global skills, global templates, or global scripts. Use this `AGENTS.md`, the local SOW, project-local specs, and project-local skills.
+- SOW working files live under `.agents/sow/q/**`, specs under `.agents/sow/specs/**`. `.gitignore` ignores
+  `/.agents/sow/q` and `/.agents/sow/specs`; neither MUST ever be committed to any branch. Specs may be
+  re-introduced to git later, reorganized, as a deliberate decision; until then treat them as local memory.
+- Committed framework files: `.agents/sow/SOW.template.md`, `.agents/sow/audit.sh`, `.agents/sow/scan-sensitive.sh`,
+  `.agents/sow/worktree-link.sh`.
+- Durable knowledge that must survive a SOW belongs in project skills, docs, code, and tests (and specs once
+  re-introduced), not in the SOW body.
+- Queues under `.agents/sow/q/`. Move the file as its state changes; a queue move is normal lifecycle, not deletion.
 
-### Roles
+  | Queue | Meaning | Status values inside |
+  |---|---|---|
+  | `pending/` | not started: no gate, no branch | `planning` stubs |
+  | `current/` | in flight; a paused SOW stays here | `planning`, `ready`, `in-progress`, `paused` |
+  | `done/` | finished | `completed` |
 
-- **User responsibilities:** purpose, scope decisions, design forks, risk acceptance, destructive approvals, and final product judgment.
-- **Assistant responsibilities:** investigation, evidence, implementation, tests or equivalent validation, reviews, documentation, memory updates, and concise reporting.
+- Worktrees: SOW working memory is per-developer, not per-worktree. After creating a git worktree, or after
+  updating an old checkout to this model, run `.agents/sow/worktree-link.sh`. It creates the queues and symlinks
+  `.agents/sow/q`, `.agents/sow/specs`, `.local`, and `.env` to the origin checkout. A worktree that already has
+  its own real `.env` keeps it. The script is idempotent, never loses data on a name collision, re-points a symlink
+  whose origin moved, and refuses to run when the origin checkout is not yet on this model (it prints how to
+  update it).
+- Deletion guard: assistants MUST NOT remove a SOW working file from the local checkout (`rm`, patch delete hunks,
+  editor deletes, or any equivalent) unless the user explicitly asks to discard it. A completed SOW MAY stay in
+  `done/` as local history or be deleted at the user's request. Never delete one without the user asking.
+- Because nothing is committed there is no commit-for-handoff, no remove-before-merge step, and no CI merge guard
+  to clear.
+
+### When A SOW Is Required
+
+Non-trivial work needs a SOW: feature work; bug fixes with behavioral impact; refactors; migrations; documentation
+or content changes with product/business impact; process changes; regressions; spec hygiene; project skill changes;
+collector changes; packaging, install, or deployment changes; PR review iteration; static analysis triage that
+changes source, docs, or project policy; any work with unclear risk.
+
+Trivial work needs no SOW: typo fixes; formatting-only changes; mechanical renames with no behavior change; simple
+low-risk search/replace (still grep the old token to confirm no call site is missed).
+
+When unsure, treat the work as non-trivial.
 
 ### Required First Checks
 
 Before non-trivial work:
 
-1. Read the active SOWs under `.agents/sow/q/` (the local-only queue tree) if any exist. SOWs are local working memory; discover other in-flight work through open PRs and issues, not through `master`.
-2. Read relevant specs under `.agents/sow/specs/` (local-only memory).
-3. Inspect `.agents/skills/*/SKILL.md` if any exist, and load every runtime project skill whose trigger matches the work.
-4. Inspect legacy runtime skills listed below when the user request matches their frontmatter trigger.
-5. Inspect code, docs, tests, and existing project instructions as ground truth.
-6. Ask the user only for irreducible product/design/risk decisions. For non-trivial work, the goal and plan are user-owned decisions gated by the "Plan before non-trivial work" Human approval gate.
+1. Read the in-flight SOWs under `.agents/sow/q/current/` and `pending/`. Discover other in-flight work through
+   open PRs and issues, not through `master`.
+2. Read relevant specs under `.agents/sow/specs/`.
+3. Inspect `.agents/skills/*/SKILL.md` and load every runtime project skill whose trigger matches the work (index
+   under Project Skills).
+4. Inspect code, docs, tests, and existing project instructions as ground truth.
+5. Ask the user only for irreducible product/design/risk decisions. For non-trivial work the goal and plan are
+   user-owned per "Plan Before Non-Trivial Work".
 
-### Git Worktrees
+### SOW Lifecycle
 
-Assistants must not create git worktrees on their own. Create a git worktree only when the user explicitly asks for it or approves it.
+- Create new SOWs from `.agents/sow/SOW.template.md`; the template is project-local and MAY be customized.
+- Filename: `SOW-YYYYMMDD-{slug}.md`, creation date plus descriptive slug. There is no sequential counter because it
+  cannot be allocated safely across parallel branches.
+- State lives in the file's `Status:` field:
+  - `planning`: analysis or decisions incomplete; implementation blocked.
+  - `ready`: Pre-Implementation Gate complete and, where the goal-approval round applies, goal and plan approved;
+    implementation can start.
+  - `in-progress`: implementation underway.
+  - `paused`: intentionally stopped; may resume on the branch.
+  - `completed`: validated and durable memory transferred. The successful terminal status.
+- Content hygiene: an active SOW is a current-state handoff, not an append-only transcript.
+  - When a plan, assumption, or decision is superseded, replace it with the current truth. Keep prior history only
+    when it explains a current constraint, approval, or rejected alternative.
+  - Preserve user approvals, durable evidence, and material checkpoints; consolidate repeated review rounds and
+    remove duplicated analysis.
+  - The execution log SHOULD record state transitions, deviations, and validation results. It SHOULD NOT reproduce
+    the conversation or every review nit.
+  - Before completion, prune stale history and verify another contributor can determine the current target,
+    remaining work, decisions, and evidence without reconstructing chronology.
+- One SOW at a time: never execute multiple SOWs as one batch. If work overlaps, coordinate through the open PRs
+  and issues, merge or consolidate branches before implementation, or split into separate SOWs and complete one
+  before starting the next.
+- Progress reports and Re-evaluation checkpoints are not stop points. Once a SOW is in progress with its approval
+  recorded, continue until it is delivered, failed with evidence, blocked on a real user decision, or superseded by
+  newer user instructions.
+- Completion, when the work is ready to merge:
+  1. Finish implementation, docs, skills, validation, and follow-up mapping.
+  2. Transfer all durable knowledge into project skills, docs, code, and tests (and specs once re-introduced). The
+     SOW body MUST then hold nothing durable that is not captured elsewhere.
+  3. Set `Status: completed` and move the file to `done/`.
 
-After a git worktree is created — or after an old checkout is updated to the
-local-only SOW model — run `.agents/sow/worktree-link.sh`. It builds the SOW
-queues and symlinks `.agents/sow/q`, `.agents/sow/specs`, `.local`, and `.env`
-to the origin checkout, so SOW working memory is shared per-developer rather than
-re-created per worktree. (Exception: a worktree that already has its own real
-`.env` keeps it and is not relinked, so per-worktree secrets are never
-overwritten.) The script is idempotent, never loses data on a name collision,
-re-points a symlink whose origin moved, and refuses to run in a worktree whose
-origin checkout is not yet on this model (it prints how to update the origin
-first).
+### Umbrella And Step SOWs
 
-### Sensitive Data In Durable Artifacts
+Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeable deliverable).
 
-SOWs, specs, documentation, project skills, agent instructions, and code comments are commit-ready artifacts. Treat them as public unless a repository-specific policy explicitly says otherwise.
-
-CRITICAL: Never write raw sensitive data to durable artifacts. This includes passwords, API keys, bearer tokens, SNMP communities, private keys, connection strings with embedded credentials, session cookies, community member names, customer names, customer identifiers, personal data, non-private IP addresses that can identify customers, private endpoints, account IDs, and proprietary incident details.
-
-Write only sanitized evidence:
-
-- use placeholders such as `[REDACTED_SECRET]`, `[CUSTOMER]`, `[ACCOUNT]`, `[PRIVATE_ENDPOINT]`;
-- use stable aliases such as `customer-a` only when the real mapping is not stored in the repository;
-- cite file paths, line numbers, command names, schema fields, or error classes instead of copying sensitive values;
-- summarize logs and traces; include only minimal redacted snippets.
-
-If sensitive data is required to continue, stop and ask the user for a secure handling path. If sensitive data is found in a durable artifact, sanitize it before any commit. If sensitive data was already committed, tell the user and do not rewrite history without explicit approval.
-
-### Durable AI-Facing Artifact Formatting
-
-AI-facing durable artifacts include `AGENTS.md`, SOW specs, runtime project
-skills, public/operator skills, SOW templates, instruction bridge files, and
-other docs primarily written so future AI agents can execute repository rules
-correctly.
-
-When writing or updating these artifacts:
-
-- Structure for retrieval and scanning. Use headings, short sections, labeled
-  bullets, and numbered procedures so both humans and AI agents can find the
-  exact rule quickly.
-- Avoid dense multi-rule paragraphs. If a paragraph contains multiple
-  requirements, exceptions, or decision branches, split it into bullets or a
-  table.
-- Use tables only for matrices or comparisons where the cells stay short. Use
-  bullets for rules, workflows, checklists, and exception handling.
-- Put RFC-style requirement words (`MUST`, `MUST NOT`, `SHOULD`, `MAY`) close
-  to the action they govern. Do not hide mandatory behavior in explanatory
-  prose.
-- Prefer labeled bullets for operational guardrails, such as `Target`,
-  `Exception handling`, `Validation`, or `Failure mode`.
-- Keep one durable idea per bullet. If a bullet needs multiple sentences, the
-  first sentence states the rule and later sentences provide evidence,
-  rationale, or examples.
-- For a guardrail with several distinct requirements, use a labeled parent
-  bullet with an indented sub-list — one requirement per sub-bullet — rather than
-  a multi-requirement paragraph; keep a single rule-plus-rationale as one bullet.
-- Preserve precision over brevity. Formatting is for readability, not for
-  weakening contracts or removing necessary evidence.
-- Wrap markdown prose at ~120 columns (SHOULD), not 80. Code blocks, tables, and generated files keep their own
-  formats. Keep reflow-only (whitespace) changes in separate commits from content changes.
-
-### Open-Source Reference Evidence
-
-When SOW evidence comes from other open-source repositories, cite the upstream repository and checked commit instead of the workstation absolute path.
-
-Use:
-
-```text
-owner/repo @ commit
-relative/path/inside/repo:line
-```
-
-Resolve `owner/repo` from the repository remote, record the checked commit, and keep paths relative to the upstream repository root. Never write absolute paths into SOW evidence.
+- Naming: umbrella `SOW-YYYYMMDD-<family>-umbrella.md`; steps `SOW-YYYYMMDD-<family>-NN-<step>.md` with a two-digit
+  ordinal. All files of one initiative share the `<family>` slug.
+- Links by filename, never by queue path (paths go stale when files move). Each step records
+  `Umbrella: SOW-YYYYMMDD-<family>-umbrella` in Requirements. The umbrella keeps a `## Steps` table: ordinal, step
+  SOW filename, status, PR.
+- Content split: the umbrella holds the full clean end state, all user decisions, the decomposition, and cross-step
+  follow-up mapping. A step holds its own Pre-Implementation Gate and Validation and cites umbrella decisions by
+  number. A step whose end state is fixed by the approved decomposition needs no new approval round.
+- Placement and status: the umbrella lives in `current/` from the first step's start until the last step completes,
+  then moves to `done/`. Its status is `planning` until the decomposition is approved, then `in-progress` while any
+  step is in flight. `paused` on an umbrella means the initiative itself is parked, not "waiting on steps".
+- One SOW at a time applies to steps. The umbrella is never executed and does not count.
 
 ### Pre-Implementation Gate
 
-Implementation must not begin until the local SOW contains a concrete `## Pre-Implementation Gate` section with `Status: ready` or `Status: in-progress`. Before changing implementation files, or before continuing implementation in an existing SOW that lacks this section, fill the gate. Reaching `Status: ready` additionally requires the "Plan before non-trivial work" Human approval gate (explicit user approval of the goal and plan).
+Implementation MUST NOT begin until the SOW contains a concrete `## Pre-Implementation Gate` section with
+`Status: ready` or `Status: in-progress`. Before changing implementation files, or before continuing an existing SOW
+that lacks the section, fill the gate. Reaching `Status: ready` additionally requires the goal/plan approval of
+"Plan Before Non-Trivial Work" where that round applies.
 
-The gate must record the problem/root-cause model, evidence reviewed, affected contracts and surfaces, the clean-end-state target (its removed-redundant and excluded-coupled items, and the reference search where a path or contract is replaced), existing patterns to reuse, risk and blast radius, sensitive data handling plan, implementation plan, validation plan, artifact impact plan, and open decisions. The sensitive data plan must cover SOWs, specs, documentation, project skills, agent instructions, and code comments. Generic placeholders such as `TBD`, `N/A`, or "to be checked later" are invalid unless the SOW explains why the item truly does not apply. If the gate exposes an unknown that cannot be resolved by investigation, stop and ask the user before implementation.
+The gate MUST record: problem/root-cause model; evidence reviewed; affected contracts and surfaces; the
+clean-end-state target with its removed-redundant and excluded-coupled items and the reference search where a path
+or contract is replaced; existing patterns to reuse; risk and blast radius; sensitive data handling plan (covering
+SOWs, specs, documentation, project skills, agent instructions, and code comments); implementation plan; validation
+plan; artifact impact plan; open decisions. Placeholders such as `TBD`, `N/A`, or "to be checked later" are invalid
+unless the SOW explains why the item truly does not apply. If the gate exposes an unknown that investigation cannot
+resolve, stop and ask the user before implementation.
 
-### When A SOW Is Required
+### Git Worktrees
 
-Create or reuse a SOW for non-trivial work:
-
-- feature work;
-- bug fixes with behavioral impact;
-- refactors;
-- migrations;
-- documentation or content changes with product/business impact;
-- process changes;
-- regressions;
-- spec hygiene;
-- project skill changes;
-- collector changes;
-- packaging, install, or deployment changes;
-- PR review iteration;
-- static analysis triage that changes source, docs, or project policy;
-- any work with unclear risk.
-
-Trivial work does not need a SOW:
-
-- typo fixes;
-- formatting-only changes;
-- mechanical rename with no behavior change;
-- simple search/replace with low risk (still grep for the old token to confirm no call sites are missed).
-
-When unsure, treat the work as non-trivial.
-
-### SOW Locations And Naming
-
-- SOW queues (local-only): `.agents/sow/q/` with sub-queues `pending/`,
-  `current/`, `active/`, `done/`. Move a SOW file between these as its state
-  changes; the whole `q/` tree is gitignored.
-- Specs (local-only): `.agents/sow/specs/`
-- Template for new SOWs (committed): `.agents/sow/SOW.template.md`
-- Local audit (committed): `.agents/sow/audit.sh`
-- Worktree/queue setup (committed): `.agents/sow/worktree-link.sh`
-
-SOW working files and specs are never committed. `.gitignore` ignores
-`/.agents/sow/q` and `/.agents/sow/specs`; only the framework files above are
-tracked. The queue directories are created locally by
-`.agents/sow/worktree-link.sh`, not by committed `.gitkeep` markers, so there is
-no committed SOW layout to preserve.
-
-Worktree model: SOW working memory is shared per-developer, not per-worktree.
-In a linked worktree, `.agents/sow/worktree-link.sh` symlinks `.agents/sow/q`,
-`.agents/sow/specs`, `.local`, and `.env` to the origin checkout, and migrates
-any pre-existing top-level queue dirs into `q/` without data loss.
-
-Create new SOW files from `.agents/sow/SOW.template.md`. The template is project-local and may be customized for this repository.
+Assistants MUST NOT create git worktrees on their own. Create one only when the user explicitly asks for it or
+approves it, then run `.agents/sow/worktree-link.sh` (see Storage Model).
 
 ### Local SOW Parking
 
-Users may keep private paused, abandoned, or not-yet-public SOW drafts under
-`<repo-root>/.local/sow/`. This directory is gitignored and outside the project
-SOW lifecycle.
+- Users MAY keep private paused, abandoned, or not-yet-public SOW drafts under `<repo-root>/.local/sow/`. It is
+  gitignored and outside the project SOW lifecycle. Use it to preserve work locally without creating a public or
+  team-visible GitHub issue yet.
+- Parked SOWs are private memory only: not durable project memory, not visible to other contributors, and not
+  acceptable as the only tracking for work that must coordinate a team, block a merge, or survive across machines.
+- Deferred work has two tracking paths: public or team-visible follow-up is a GitHub issue; private or local
+  follow-up is `<repo-root>/.local/sow/`.
+- Active implementation work still MUST use the `.agents/sow/q/` queues.
 
-Use `<repo-root>/.local/sow/` when the user wants to preserve work locally
-without creating a public or team-visible GitHub issue yet.
+### Review
 
-Local parked SOWs are private memory only:
+Review findings are leads until verified against the shipped code and its contracts.
 
-- they are not durable project memory;
-- they are not visible to other contributors;
-- they are not acceptable as the only tracking for work that must coordinate a
-  team, block a merge, or survive across machines.
-
-Deferred work has two valid tracking paths:
-
-- public or team-visible follow-up: GitHub issue;
-- private or local follow-up: `<repo-root>/.local/sow/`.
-
-Active implementation work still MUST use the `.agents/sow/q/` queues. SOW
-working files are never committed (the `q/` tree is gitignored), so there is no
-commit-for-handoff and no remove-before-merge step.
-
-Destructive local deletion guard:
-
-- Assistants MUST NOT use `rm`, `apply_patch` delete hunks, editor delete
-  operations, or any equivalent filesystem operation to remove a SOW working
-  file from the local checkout unless the user explicitly asks to discard the
-  local SOW.
-- SOW working files are local-only and gitignored, so there is no tracked SOW to
-  untrack and no merge guard to clear.
-- Moving a SOW between `.agents/sow/q/` sub-queues (for example `current/` →
-  `done/`) is normal lifecycle, not deletion.
-
-Filename:
-
-```text
-SOW-YYYYMMDD-{slug}.md
-```
-
-Use the creation date plus a descriptive slug. There is no sequential `NNNN`
-counter because it cannot be allocated safely across parallel branches.
-
-SOW state lives in the file's `Status:` field:
-
-- `planning` - analysis or decisions are incomplete; implementation is blocked.
-- `ready` - the Pre-Implementation Gate is complete and, where the goal-approval round ("Plan before non-trivial work") applies, the user has approved the goal and plan; implementation can start.
-- `in-progress` - implementation is underway.
-- `paused` - work is intentionally stopped but may resume on the branch.
-- `completed` - work is validated and durable memory has been transferred. The
-  SOW file is local-only and never committed; it MAY be moved to
-  `.agents/sow/q/done/` as local history or deleted locally at the user's
-  request. Never delete it without the user asking.
-
-### SOW Content Hygiene
-
-An active SOW is a current-state handoff, not an append-only transcript.
-
-- When a plan, assumption, or decision is superseded, replace the stale guidance
-  with the current truth. Retain prior history only when it is needed to explain
-  a current constraint, approval, or rejected alternative.
-- Preserve user approvals, durable evidence, and material checkpoints, but
-  consolidate repeated review rounds and remove duplicated analysis.
-- The execution log SHOULD record meaningful state transitions, deviations, and
-  validation results. It SHOULD NOT reproduce the conversation or every review
-  nit.
-- Before completion, prune stale history and verify that another contributor can
-  determine the current target, remaining work, decisions, and evidence without
-  reconstructing chronology.
-
-### SOW Completion And Merge
-
-The successful terminal SOW status is `completed`.
-
-When a SOW's work is ready to merge:
-
-1. Finish implementation, docs, skills, validation, and follow-up mapping.
-2. Transfer all durable knowledge into project skills, docs, code, and tests
-   (and specs once specs are re-introduced to git). After this step, the SOW
-   body MUST hold nothing durable that is not captured elsewhere.
-3. Update the SOW to `Status: completed`.
-
-SOW working files are never committed (they live under the gitignored
-`.agents/sow/q/`), so there is no "remove SOW from git before merge" step and no
-CI merge guard to clear. A completed SOW MAY stay in `.agents/sow/q/done/` as
-local history or be deleted locally at the user's discretion — never delete a
-local SOW working file without the user's request (see the deletion guard above).
-
-### Enforcement
-
-The SOW system is enforced by local audit tooling and CI:
-
-- `.agents/sow/audit.sh` is the local consistency audit for SOW rules, the
-  local-only queue/spec layout, framework files, and sensitive-data scanning.
-- `.agents/sow/scan-sensitive.sh` is the shared sensitive-data scanner used by
-  local audit and CI.
-- `.agents/sow/worktree-link.sh` builds the local queues and links a worktree's
-  SOW working memory to its origin checkout.
-- `.github/workflows/sow.yml` rejects pull requests that commit SOW working
-  files or specs — anything under `.agents/sow/q/**`, `.agents/sow/specs/**`, or
-  a stray `.agents/sow/{active,pending,current,done}/SOW-*.md`. These paths are
-  local-only and gitignored; a hit means the file was force-added and MUST be
-  removed before merge.
-- The same workflow scans changed instruction, skill, and framework files for
-  raw sensitive data.
-
-These checks are guards, not substitutes for the SOW Validation Gate. The
-assistant still owns transferring durable knowledge out of the SOW before
-merge.
-
-### One SOW At A Time
-
-Never execute multiple SOWs as one batch.
-
-If work overlaps:
-
-- coordinate through the relevant open PRs and issues;
-- merge or consolidate branches before implementation; or
-- split into separate SOWs and complete one before starting the next.
-
-Progress reports are not stop points (re-evaluating against the target per the Clean-end-state rule is not itself a stop point). Once a SOW is in progress and its goal/plan approval is recorded ("Plan before non-trivial work"), continue until it is delivered, failed with evidence, blocked on a real user decision/approval, or superseded by newer user instructions.
-
-### User Decisions
-
-When user decisions are needed:
-
-1. Present concrete evidence with files/lines or source references.
-2. Provide numbered options.
-3. Explain pros, cons, implications, and risks.
-4. Recommend one option with reasoning.
-5. Record the user's decision in the SOW before implementation. For the goal/plan approval round, the bar is the "Plan before non-trivial work" Human approval gate.
-
-### Review Materiality And Stop Condition
-
-Review findings are leads until they are verified against the shipped code and
-its contracts.
-
-- A shipping blocker MUST identify a production-reachable trigger, the violated
-  contract or invariant, the concrete consequence, and supporting code or test
-  evidence.
-- Failing required validation or an unmet explicit acceptance criterion is also
-  a shipping blocker, regardless of the reviewer's severity label.
-- An unreachable defensive scenario, optional refactor, style preference, or
-  speculative future risk MUST NOT be promoted to a blocker. Reject it with
-  evidence, or track it separately when it has independent value.
-- Optional test expansion, documentation polish, and maintainability suggestions
-  without a concrete current defect MUST NOT extend the review cycle by
-  themselves.
-- One complete review round is the default. Repeat the same full scope only when
-  a verified shipping blocker required a material change to shipped
-  implementation or behavior, or when the prior review could not assess the
+- A shipping blocker MUST identify a production-reachable trigger, the violated contract or invariant, the
+  concrete consequence, and supporting code or test evidence.
+- Failing required validation or an unmet explicit acceptance criterion is also a shipping blocker, regardless of
+  the reviewer's severity label.
+- An unreachable defensive scenario, optional refactor, style preference, or speculative future risk MUST NOT be
+  promoted to a blocker. Reject it with evidence, or track it separately when it has independent value.
+- Optional test expansion, documentation polish, and maintainability suggestions without a concrete current defect
+  MUST NOT extend the review cycle by themselves.
+- Reproduce a reviewer-reported bug as a FAILING test first, then fix to green. The red test proves the finding,
+  pins the contract, and catches wrong assumptions in your own tests.
+- Multi-round review: checkpoint-commit each validated change (specific files only) before its review and squash at
+  PR time. If findings keep clustering in one subsystem for ~2-3 rounds, stop patching individual cases, name the
+  missing invariant, and propose one class-level fix as a user decision.
+- One complete review round is the default. Repeat the same full scope only when a verified shipping blocker
+  required a material change to shipped implementation or behavior, or when the prior review could not assess the
   complete change.
-- Stop when no verified shipping blocker remains. Reviewer unanimity, exact
-  readiness phrases, and zero optional suggestions are NOT required. Nits alone
-  MUST NOT keep a review cycle open.
+- Stop when no verified shipping blocker remains. Reviewer unanimity, exact readiness phrases, and zero optional
+  suggestions are NOT required. Nits alone MUST NOT keep a review cycle open.
 
 ### Followup Discipline
 
-"Deferred" is not a terminal outcome.
+"Deferred" is not a terminal outcome. Before a SOW can close, every valid deferred item MUST be implemented in the
+current SOW, explicitly rejected as not worth doing with evidence, or represented by a GitHub issue linked from the
+SOW or PR.
 
-Before a SOW can close, every valid deferred item must be:
-
-- implemented in the current SOW; or
-- explicitly rejected as not worth doing, with evidence; or
-- represented by a GitHub issue linked from the current SOW or PR.
-
-Pre-close, search the SOW for:
-
-```text
-defer|later|follow-up|future|TODO|pending
-```
-
-Map every remaining item to implemented, rejected, or tracked.
+Pre-close, search the SOW for `defer|later|follow-up|future|TODO|pending` and map every hit to implemented,
+rejected, or tracked.
 
 ### Regressions
 
-A regression is broken behavior discovered after a SOW's work merged, where the
-original claimed outcome is no longer true.
+A regression is broken behavior discovered after a SOW's work merged, where the original claimed outcome is no
+longer true. Completed SOWs are not on `master`, so a regression is new work:
 
-Because completed SOWs are not retained on `master`, a regression is handled as
-new work:
+1. Open a new local SOW under `.agents/sow/q/current/`.
+2. In `## Requirements`, link the prior work: `Regresses: PR #NNNNN`, plus any known commit, spec, issue, or test
+   evidence.
+3. Run the normal Pre-Implementation Gate and Validation.
+4. Update the relevant spec, skill, doc, code, or test so durable memory reflects current reality.
 
-1. Open a new local SOW under `.agents/sow/q/active/`.
-2. In `## Requirements`, link the prior work: `Regresses: PR #NNNNN` and cite
-   any known commit, spec, issue, or test evidence.
-3. Run the normal Pre-Implementation Gate and Validation for the new SOW.
-4. Update the relevant spec, skill, doc, code, or test so durable memory reflects
-   current reality.
-
-Do not attempt to resurrect or mutate a prior SOW.
+Do not resurrect or mutate a prior SOW.
 
 ### Validation Gate
 
 A SOW cannot be completed until Validation records:
 
 - acceptance criteria evidence;
-- clean-end-state evidence: the delivered state matches the clean end state recorded in the SOW, including its recorded list of removed-redundant and excluded coupled items (and, where a path or contract was replaced, the recorded reference search), or an explicit user approval for a non-clean state is recorded and linked;
-- deferred clean-end-state remainder: any clean-end-state work deferred under an approved partial (exception (d)) or otherwise tracked rather than done is listed with why deferral was acceptable and when (or under what condition) it lands;
+- clean-end-state evidence: the delivered state matches the recorded target, including its removed-redundant and
+  excluded-coupled lists and, where a path or contract was replaced, the recorded reference search; or an explicit
+  user approval for a non-clean state is recorded and linked;
+- deferred clean-end-state remainder: any target work deferred under an approved partial (exception (d)) or
+  otherwise tracked rather than done, with why deferral was acceptable and when (or under what condition) it lands;
 - tests or equivalent validation;
 - real-use evidence when a runnable path exists;
 - reviewer findings and how they were handled;
 - same-failure search results;
-- artifact maintenance gate for `AGENTS.md`, runtime project skills, specs, end-user/operator docs, end-user/operator skills, and SOW lifecycle;
-- local-only SOW layout respected: no SOW working file or spec was committed
-  (they stay under the gitignored `.agents/sow/q/` and `.agents/sow/specs/`);
-- spec update or specific reason no spec update was needed;
-- project skill update or specific reason no skill update was needed;
-- end-user/operator docs update or evidence-backed reason none were affected;
-- end-user/operator skill update or evidence-backed reason none were affected by docs/spec changes;
-- lessons extracted or specific reason there were none;
-- workflow-friction triage: each recorded `Workflow Friction & Rule Gaps` note resolved to a rule update (`AGENTS.md`, project skill, spec, or SOW template), an evidence-backed rejection, or a tracked follow-up (or an explicit "none arose");
+- the Artifact Maintenance Gate below, including that no SOW working file or spec was committed;
+- lessons extracted, or the specific reason there were none;
+- workflow-friction triage: each `Workflow Friction & Rule Gaps` note resolved to a rule update (`AGENTS.md`,
+  project skill, spec, or SOW template), an evidence-backed rejection, or a tracked follow-up (or an explicit "none
+  arose");
 - follow-up mapping.
 
 Generic "N/A" is invalid.
 
 ### Artifact Maintenance Gate
 
-Every SOW close must explicitly record whether each durable artifact class was updated or why no update was needed:
+Every SOW close MUST record, per durable artifact class, what was updated or the evidence-backed reason no update
+was needed:
 
-- `AGENTS.md` - workflow, responsibility, local framework, project-wide guardrails.
-- Runtime project skills - `.agents/skills/project-*/SKILL.md` for HOW to work here.
-- Specs - `.agents/sow/specs/` for WHAT the project does.
-- End-user/operator docs - README, docs site, runbooks, published guides, help text, or other human-facing documentation.
-- End-user/operator skills - output/reference skills copied or consumed outside normal repo work.
-- SOW lifecycle - local-only SOW under `.agents/sow/q/` (never committed), durable memory transfer, deferred work tracked as GitHub issues, and regressions handled as new linked SOWs.
+- `AGENTS.md`: workflow, responsibilities, local framework, project-wide guardrails.
+- Runtime project skills: `.agents/skills/project-*/SKILL.md`, HOW to work here.
+- Specs: `.agents/sow/specs/`, WHAT the project does.
+- End-user/operator docs: README, docs site, runbooks, published guides, help text, other human-facing docs.
+- End-user/operator skills: output/reference skills copied or consumed outside normal repo work.
+- SOW lifecycle: local-only SOW under `.agents/sow/q/`, durable memory transferred, deferred work tracked as GitHub
+  issues, regressions handled as new linked SOWs.
 
-This is an assistant responsibility. If a SOW changes behavior, docs, specs, commands, schemas, defaults, workflows, examples, or operating procedure, the assistant must update every affected artifact in the same SOW, or record the evidence-backed reason an artifact is unaffected.
+This is an assistant responsibility. If a SOW changes behavior, docs, specs, commands, schemas, defaults, workflows,
+examples, or operating procedure, update every affected artifact in the same SOW or record why it is unaffected.
+
+### Enforcement
+
+- `.agents/sow/audit.sh`: local consistency audit for SOW rules, the local-only queue/spec layout, framework files,
+  and sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use.
+- `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs (anything under
+  `.agents/sow/q/**`, `.agents/sow/specs/**`, or a stray `.agents/sow/{active,pending,current,done}/SOW-*.md`); a
+  hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and
+  framework files for raw sensitive data.
+- These checks are guards, not substitutes for the Validation Gate. The assistant still owns transferring durable
+  knowledge out of the SOW before merge.
+
+## Durable Artifacts
+
+### Sensitive Data In Durable Artifacts
+
+SOWs, specs, documentation, project skills, agent instructions, and code comments are commit-ready artifacts.
+Treat them as public unless a repository-specific policy explicitly says otherwise.
+
+CRITICAL: Never write raw sensitive data to durable artifacts. This includes passwords, API keys, bearer tokens,
+SNMP communities, private keys, connection strings with embedded credentials, session cookies, community member
+names, customer names, customer identifiers, personal data, non-private IP addresses that can identify customers,
+private endpoints, account IDs, and proprietary incident details.
+
+Write only sanitized evidence:
+
+- placeholders such as `[REDACTED_SECRET]`, `[CUSTOMER]`, `[ACCOUNT]`, `[PRIVATE_ENDPOINT]`;
+- stable aliases such as `customer-a` only when the real mapping is not stored in the repository;
+- file paths, line numbers, command names, schema fields, or error classes instead of the sensitive values;
+- summarized logs and traces with minimal redacted snippets.
+
+If sensitive data is required to continue, stop and ask the user for a secure handling path. If found in a durable
+artifact, sanitize it before any commit. If already committed, tell the user and do not rewrite history without
+explicit approval.
+
+### Durable AI-Facing Artifact Formatting
+
+Applies to `AGENTS.md`, specs, runtime project skills, public/operator skills, SOW templates, instruction bridge
+files, and other docs written so future AI agents can execute repository rules correctly.
+
+- Structure for retrieval: headings, short sections, labeled bullets, numbered procedures, so humans and agents find
+  the exact rule quickly.
+- No dense multi-rule paragraphs. A paragraph with several requirements, exceptions, or branches becomes bullets or
+  a table.
+- Tables only for matrices or comparisons with short cells. Bullets for rules, workflows, checklists, exceptions.
+- Put requirement words (`MUST`, `MUST NOT`, `SHOULD`, `MAY`) next to the action they govern. Do not hide mandatory
+  behavior in explanatory prose.
+- Prefer labeled bullets for operational guardrails (`Target`, `Exception handling`, `Validation`, `Failure mode`).
+  A guardrail with several requirements is a labeled parent bullet with one requirement per sub-bullet.
+- One durable idea per bullet. When a bullet needs several sentences, the first states the rule; the rest give
+  evidence, rationale, or examples.
+- Precision over brevity. Formatting is for readability, never for weakening contracts or removing evidence.
+- Wrap markdown prose at ~120 columns (SHOULD), not 80. Code blocks, tables, and generated files keep their own
+  formats. Keep reflow-only (whitespace) changes in separate commits from content changes.
+
+### Open-Source Reference Evidence
+
+When SOW evidence comes from another open-source repository, cite the upstream repository and the checked commit,
+never the workstation path:
+
+```text
+owner/repo @ commit
+relative/path/inside/repo:line
+```
+
+Resolve `owner/repo` from the repository remote, record the checked commit, keep paths relative to the upstream
+root. Never write absolute paths into SOW evidence.
 
 ### Specs
 
-Specs are memory of WHAT this project does.
+Specs are memory of WHAT this project does. They live under `.agents/sow/specs/` as local-only memory (Storage
+Model); the source tree and public documentation remain the primary ground truth, and specs capture durable
+decisions, cross-cutting rules, and area contracts as they are worked.
 
-Specs currently live under `.agents/sow/specs/` as **local-only** memory
-(gitignored, not committed). They are being reorganized and will be
-re-introduced to git later as a deliberate decision; until then they are
-per-developer local memory, shared across worktrees by
-`.agents/sow/worktree-link.sh`. Durable contracts that must be shared with the
-team right now belong in project skills, docs, code, and tests.
-
-This repository is bootstrapped incrementally. The existing source tree and public documentation remain the primary ground truth. Specs under `.agents/sow/specs/` capture durable project decisions, cross-cutting behavioral rules, and area-specific contracts as they are worked.
-
-`.agents/sow/specs/` stays flat until scale proves hierarchy is needed. Use
-`<domain>-<topic>.md` names, one durable contract or cross-cutting rule per file,
-and update `.agents/sow/specs/README.md` in the same change. Do not split specs
-by repository path; specs are organized by contract ownership, not source-file
-location.
-
-Update specs when shipped work changes:
-
-- product behavior;
-- public contracts;
-- collector behavior;
-- APIs and schemas;
-- data formats;
-- alerting semantics;
-- packaging or deployment behavior;
-- operational guarantees;
-- known edge cases.
-
-Specs describe current reality, not aspiration. If specs and code disagree, record the discrepancy in the active SOW and resolve or track it.
+- Layout stays flat until scale proves hierarchy is needed. Use `<domain>-<topic>.md`, one durable contract or
+  cross-cutting rule per file, organized by contract ownership, not by repository path. Update
+  `.agents/sow/specs/README.md` in the same change.
+- Update specs when shipped work changes product behavior, public contracts, collector behavior, APIs and schemas,
+  data formats, alerting semantics, packaging or deployment behavior, operational guarantees, or known edge cases.
+- Specs describe current reality, not aspiration. If specs and code disagree, record the discrepancy in the active
+  SOW and resolve or track it.
 
 ### Project Skills
 
 Project skills are memory of HOW to work here.
 
-Runtime input project skills should live under `.agents/skills/*/SKILL.md`. Before non-trivial work, inspect those skill descriptions and load every matching runtime skill.
+- Runtime input skills live under `.agents/skills/*/SKILL.md`. Before non-trivial work, inspect their descriptions
+  and load every skill whose trigger matches.
+- Output/reference skills may also exist under product documentation or generated skill directories. Do not rename,
+  shorten, or change their descriptions only to satisfy runtime discovery. Update them when their related
+  public/operator workflow changes.
+- Skill updates that close gaps or fix outdated pointers ship in the same PR that exposed the issue.
 
-Output/reference skills may also exist under product documentation or generated skill directories. Do not rename, shorten, or change their descriptions only to satisfy runtime discovery. Update them when their related public/operator workflow changes.
+Public skill convention (`docs/netdata-ai/skills/`):
 
-### Public skill convention (`docs/netdata-ai/skills/`)
+- Shape: `docs/netdata-ai/skills/<skill-name>/SKILL.md`, optional supporting `<topic>.md` files, optional
+  `scripts/`. Frontmatter has `name` and `description`; the description is the trigger text and MUST enumerate
+  the phrases users actually type.
+- Audience: operators and end-users. Public skills MAY teach querying Netdata Cloud or Agents, inspecting
+  metrics/logs/topology/alerts, and running safe operational commands. They MUST NOT contain developer-contract
+  validation, schema migration plans, producer authoring workflows, UI adapter work, aggregator implementation
+  notes, SOW handoff instructions, fixture maintenance, PR-review tasks, or codebase-internal recipes.
+- Developer-facing skills live under `.agents/skills/`, preferably with a `project-` prefix when they are runtime
+  input. A workflow that reads source files, updates schemas, validates fixtures, changes collectors/producers, or
+  coordinates frontend/backend/aggregator code is a project developer skill, not a public one.
+- Skill verification harness inputs (seed questions, grader rubrics, runner scripts, transcript-generation prompts)
+  live under `.agents/skill-verification/<skill>/`, never under `docs/netdata-ai/skills/<skill>/`.
+- Each public skill is reachable from `.agents/skills/<skill-name>` via a relative symlink
+  (`.agents/skills/<name>` -> `../../docs/netdata-ai/skills/<name>`), created with `ln -srfn` and verified with
+  `readlink -f .agents/skills/<name>`.
+- Scripts follow the existing `_lib.sh` shape: `set -euo pipefail`; ANSI colors as real ESC bytes via
+  `$'\033[...]'`; `<prefix>_repo_root` via `git rev-parse --show-toplevel`; `<prefix>_load_env` sourcing
+  `<repo>/.env` with `: "${VAR:?}"` validation; `<prefix>_audit_dir` creating `<repo>/.local/audits/<topic>/`;
+  masked-token `<prefix>_run` / `<prefix>_run_read` wrappers.
+- Scripts that touch credentials (cloud tokens, per-agent bearers, claim ids, session cookies) MUST be token-safe:
+  helpers handling credential bytes are named with a leading underscore (`_skill_*`, internal-only) and return them
+  via bash namerefs into the caller's locals, NEVER to stdout. Public wrappers (no underscore) read credentials from
+  `.env` internally and emit ONLY the response body. Each token-handling lib ships a
+  `<prefix>_selftest_no_token_leak` that drives every public wrapper with a sentinel token and asserts it never
+  reaches captured stdout.
+- How-tos catalog: each public skill ships `how-tos/INDEX.md`, and the catalog is live. Whenever an assistant
+  answers a concrete operator/end-user question that needs analysis (multiple wrapper calls, jq pipelines, or
+  cross-referencing more than one per-domain guide) and the answer is not yet under `how-tos/`, it MUST author the
+  how-to and add it to `INDEX.md` BEFORE completing the task. Each `SKILL.md` repeats this rule. Skipping it is a
+  framework violation: the next assistant repeats the analysis from scratch. Audience boundaries still apply: a
+  developer validation recipe goes into the matching `.agents/skills/` project skill and its index instead.
+- The private skills `coverity-audit`, `sonarqube-audit`, `graphql-audit`, and `pr-reviews` keep their
+  `.agents/skills/<name>/` location with no public counterpart.
 
-End-user-facing AI skills under `docs/netdata-ai/skills/` follow the directory shape `docs/netdata-ai/skills/<skill-name>/SKILL.md`, with optional supporting docs (`<topic>.md`) and an optional `scripts/` subdirectory for helper code. SKILL.md frontmatter has `name` and `description`; the description is the trigger-matching text and must enumerate the phrases users will actually type.
+Skills index (runtime input under `.agents/skills/`):
 
-Public skills are for operators and end-users. They may teach users how to
-query Netdata Cloud, query Agents, inspect metrics/logs/topology/alerts, or run
-safe operational commands. They must not contain developer-contract validation,
-schema migration plans, producer authoring workflows, UI adapter work,
-aggregator implementation notes, SOW handoff instructions, fixture maintenance,
-PR-review tasks, or codebase-internal implementation recipes.
+| Skill | Trigger |
+|---|---|
+| `project-writing-collectors` | authoring or modifying any data-collection plugin or module (go.d, ibm.d, Rust, C, PLUGINSD); logs, topology, NetFlow/sFlow/IPFIX, OTEL, SNMP profiles, statsd, Prometheus scraping, Functions |
+| `project-writing-go-modules-framework-v2` | creating or migrating a go.d collector to framework V2; `CollectorV2`, `metrix.CollectorStore`, `ChartTemplateYAML`/`charts.yaml`, `charttpl`, `chartengine`, V2 host scopes, V2 tests |
+| `project-snmp-profiles-authoring` | SNMP profile YAMLs, topology SNMP profiles, ddsnmp profile parsing, profile-format docs; requires MIB `MAX-ACCESS` checks and index-derived extraction for `not-accessible` INDEX objects |
+| `project-snmp-trap-profiles-authoring` | SNMP trap profile YAMLs, trap profile-format docs, the `snmptrapprofilegen` helper, OOB trap profile regeneration; closed 8-category / 8-severity taxonomy |
+| `project-prometheus-profiles` | creating, reviewing, validating, iterating, or installing Prometheus chart profiles from exposition dumps; selector/relabel/fallback policy, coverage, NIDL, live verification |
+| `project-create-topology` | topology producers, topology Function payloads, schema fixtures, graph presentation, correlation rules, direction semantics, drilldowns, telemetry overlays, Cloud aggregation fixtures |
+| `project-health-alert-authoring` | authoring, adapting, or reviewing health alerts and templates in `src/health/health.d/*.conf`; lookup/calc/warn/crit, lifecycle, routing, health-config tests |
+| `project-query-corpus` | running or extending `tests/query-corpus/`; fixtures, oracles, red/green cases for query-engine bugs, formatter byte-pins, validating a fix branch |
+| `project-build-static-binary` | building or testing the static self-extracting installer (`netdata-<arch>-latest.gz.run`) under `packaging/makeself/` |
+| `integrations-lifecycle` | any `metadata.yaml` or collector `taxonomy.yaml`; `integrations/` generators, schemas, taxonomy registries, templates, generated outputs, `COLLECTORS.md`/`SECRETS.md`/`SERVICE-DISCOVERY.md`; ibm.d `contexts.yaml`; the collector-consistency rule |
+| `learn-site-structure` | adding, moving, renaming, or deleting a docs page for `learn.netdata.cloud`; `docs/.map/map.yaml`; why a Learn page looks the way it does; MDX escape rules; redirects; Netlify deploy |
+| `learn-pr-preview` | only when the user explicitly asks to build, preview, or validate `learn.netdata.cloud` locally from a PR or docs branch |
+| `query-agent-events` | investigating crashes, panics, or fatals across the fleet via the agent-events namespace; `AE_*` fields; 23h dedup; journal multi-value `selections` filters. Bug-investigation tool, not generic logs |
+| `mirror-netdata-repos` | setting up or syncing the local mirror of Netdata-org repos at `${NETDATA_REPOS_DIR}`; reset-to-default safety; `--repo` scoping |
+| `pr-reviews` | PR comment and review iteration |
+| `coverity-audit` | Coverity Scan defect triage |
+| `sonarqube-audit` | SonarCloud findings triage |
+| `graphql-audit` | GitHub Code Scanning / CodeQL triage |
+| `codacy-audit` | Codacy pre-push local analysis and read-only PR-issue fetching; write actions require a GitHub issue or SOW |
 
-Developer-facing skills must live under `.agents/skills/`, preferably with a
-`project-` prefix when they are runtime input for repository work. If a workflow
-requires reading source files, updating schemas, validating fixtures, changing
-collectors/producers, or coordinating frontend/backend/aggregator code, it is a
-project developer skill, not a public skill.
+Public skills (canonical under `docs/netdata-ai/skills/<name>/`, symlinked at `.agents/skills/<name>`):
 
-Skill verification harness inputs are not public skill content. Keep seed
-questions, grader rubrics, runner scripts, and transcript-generation prompts
-under `.agents/skill-verification/<skill>/`, not under
-`docs/netdata-ai/skills/<skill>/`.
+| Skill | Trigger |
+|---|---|
+| `query-netdata-cloud` | querying the Netdata Cloud REST API: metrics, logs (systemd-journal), alerts, generic Functions on a node |
+| `query-netdata-agents` | querying Agents directly on port 19999, including auto-minting per-agent bearer tokens from a Cloud token |
+| `query-snmp-traps` | SNMP trap logs via Cloud or Agent: entries, severities, categories, senders, dedup summaries, `TRAP_*` fields, `TRAP_JSON` searches |
 
-Each public skill is reachable from `.agents/skills/<skill-name>` via a relative symlink (`.agents/skills/<name>` → `../../docs/netdata-ai/skills/<name>`) so local AI assistants reading from `.agents/skills/` see the same skill as end-users. Create the symlink with `ln -srfn`. Verify with `readlink -f .agents/skills/<name>`.
+Output/reference skill trees, updated when the related public/operator workflow changes: `docs/netdata-ai/skills/`
+(Netdata AI skill artifacts) and `src/ai-skills/` (generated or source AI skill artifacts, when present).
 
-Public-skill scripts must follow the same `_lib.sh` shape as existing skills (`set -euo pipefail`, ANSI colors with real ESC bytes via `$'\033[...]'`, `<prefix>_repo_root` via `git rev-parse --show-toplevel`, `<prefix>_load_env` that sources `<repo>/.env` with `: "${VAR:?}"` validation, `<prefix>_audit_dir` that creates `<repo>/.local/audits/<topic>/`, masked-token `<prefix>_run`/`<prefix>_run_read` wrappers).
+## Repository Rules
 
-Public-skill scripts that touch credentials (cloud tokens, per-agent bearers, claim ids, session cookies) MUST be **token-safe** -- helpers that handle credential bytes are named with a leading underscore (`_skill_*`, internal-only) and return them via bash namerefs into the caller's local variables, NEVER to stdout. Public wrappers (no leading underscore) read credentials from `.env` internally and emit ONLY the response body. Each token-handling lib must ship a `<prefix>_selftest_no_token_leak` function that drives every public wrapper with a sentinel token and asserts the sentinel never appears on captured stdout.
+### Collector Consistency
 
-### How-tos catalog rule
-
-Each public skill ships a `how-tos/` subdirectory with `INDEX.md`. The catalog is **live**: every time an AI assistant is asked a concrete operator/end-user question that requires analysis (multiple wrapper calls, jq pipelines, or cross-referencing more than one per-domain guide) and the answer isn't already documented under `how-tos/`, the assistant MUST author a new how-to and add it to `INDEX.md` BEFORE completing the task. This rule is repeated in each skill's `SKILL.md` so future assistants honor it. Skipping it means the next assistant repeats the same analysis from scratch -- an explicit framework violation.
-
-The how-to rule does not override audience boundaries. If the analysis produced
-a developer validation recipe, put it in the matching `.agents/skills/` project
-skill and update that skill's index instead of adding it under
-`docs/netdata-ai/skills/`.
-
-The existing private skills (`coverity-audit`, `sonarqube-audit`, `graphql-audit`, `pr-reviews`) keep their `.agents/skills/<name>/` location -- they are intentionally private and have no `docs/netdata-ai/skills/` counterpart.
-
-### Project Skills Index
-
-Runtime input skills:
-
-- `.agents/skills/project-snmp-profiles-authoring/`
-  Trigger: editing SNMP profile YAMLs, topology SNMP profiles, ddsnmp profile parsing, or SNMP profile-format documentation.
-  Purpose: require MIB `MAX-ACCESS` checks and index-derived extraction for `not-accessible` INDEX objects.
-
-- `.agents/skills/project-snmp-trap-profiles-authoring/`
-  Trigger: editing SNMP trap profile YAMLs under `src/go/plugin/go.d/config/go.d/snmp.trap-profiles/`, the trap profile-format documentation, the `src/go/cmd/snmptrapprofilegen/` Go helper, or running a regeneration of the OOB trap profile pack.
-  Purpose: enforce the closed 8-category / 8-severity taxonomy, the file-scoped `varbinds:` table pattern, cardinality discipline on `labels:`, and stock/operator separation. Documents the regeneration recipe.
-
-- `.agents/skills/project-writing-collectors/`
-  Trigger: authoring or modifying any Netdata data-collection plugin or module (Go go.d / ibm.d, Rust crates, internal C plugins, external plugins via PLUGINSD). Read before adding a new collector, modifying an existing one, working on NetFlow/sFlow/IPFIX, OTEL ingestion, topology, SNMP profiles, or interactive Functions.
-  Status: live. Updates that close gaps or fix outdated pointers must ship in the same PR that exposed the issue.
-
-- `.agents/skills/project-prometheus-profiles/`
-  Trigger: creating, reviewing, validating, iterating, or installing Netdata Prometheus collector chart profiles from
-  Prometheus exposition dumps; diagnosing profile schema/runtime behavior, selector/relabel/fallback policy, coverage,
-  NIDL hierarchy, or profile installation and live verification.
-  Status: live. Reasoning-first dashboard-design guidance, focused metric/schema/application references, a thin
-  validation launcher, and a repository Go validator that exercises the real collector-to-emitter pipeline.
-
-- `.agents/skills/project-create-topology/`
-  Trigger: creating or updating Netdata topology producers, topology Function payloads, topology schema fixtures, graph presentation, correlation rules, direction semantics, topology drilldowns, telemetry overlays, or Cloud topology aggregation fixtures.
-  Status: live. Developer-facing topology authoring workflow. End-user/operator-facing AI skills belong under `docs/netdata-ai/skills/`; this project skill is the runtime guidance for repository work.
-
-- `.agents/skills/project-writing-go-modules-framework-v2/`
-  Trigger: creating or migrating a Go go.d collector to framework V2; touching `CollectorV2`, `metrix.CollectorStore`, `ChartTemplateYAML` / `charts.yaml`, `charttpl`, `chartengine`, V2 host scopes, or V2 collector tests.
-  Purpose: mirror maintainer-preferred framework V2 patterns from accepted collectors so new or migrated modules blend with repository style.
-
-- `.agents/skills/project-query-corpus/`
-  Trigger: running or extending `tests/query-corpus/`; authoring corpus fixtures or oracles; adding a red case for a query-engine bug or flipping one green after a fix merges; changing a formatter byte-pin; validating a query-engine fix branch against the corpus.
-  Status: live. The developer contract for the query contract corpus: the three oracle classes and the anti-fit-to-engine rule, the manifest green/red ledger, fixture/settle/GUID discipline, the red→green bug workflow, and the known extension boundaries. Overview of the layered ladder stays in `tests/query-corpus/README.md`.
-
-- `.agents/skills/integrations-lifecycle/`
-  Trigger: editing any `metadata.yaml` or collector `taxonomy.yaml`; modifying `integrations/` generators, schemas, taxonomy registries, or templates; debugging generated gitignored integration outputs (`integrations.js`, `integrations.json`, `integrations/taxonomy.json`); working with committed per-integration `.md` files / `COLLECTORS.md` / `SECRETS.md` / `SERVICE-DISCOVERY.md`; ibm.d module generation (`contexts.yaml` -> `metadata.yaml`); CI workflows `generate-integrations.yml` and `check-markdown.yml`; the collector-consistency rule.
-  Status: live. SKILL.md plus per-domain guides (`pipeline.md`, `schema-reference.md`, `per-type-matrix.md`, `artifacts-and-banners.md`, `ibm-d.md`, `consistency.md`, `in-app-contract.md`, `gotchas.md`) and `recipes/`, `how-tos/` directories.
-
-- `.agents/skills/learn-site-structure/`
-  Trigger: adding/moving/renaming/deleting any docs page that should appear on `learn.netdata.cloud`; editing `<repo>/docs/.map/map.yaml`; investigating why a Learn page looks the way it does; reading the live `ingest/ingest.py` orchestrator or the legacy `ingest.js` / `ingest.md` (which are stale); MDX escape rules; redirects; the Netlify deploy contract.
-  Status: live. SKILL.md plus per-domain guides (`mapping.md`, `pipeline.md`, `sidebars.md`, `mdx-rules.md`, `redirects.md`, `pitfalls-and-gotchas.md`, `authoring-boundary.md`) and `recipes/`, `how-tos/` directories.
-- `.agents/skills/learn-pr-preview/`
-  Trigger: only when the user explicitly asks to build, run, preview, inspect, or validate `learn.netdata.cloud` locally using the contents of a PR or documentation branch before merge.
-  Status: live. SKILL.md with an isolated preview workflow that copies PR source content, runs Learn ingest with `--local-repo`, builds Docusaurus with the Netlify-pinned runtime, and inspects representative pages without dirtying the real Learn checkout.
-- `.agents/skills/query-agent-events/`
-  Trigger: investigating crashes, panics, or fatals across the Netdata fleet; downloading events from the agent-events ingestion namespace; analyzing AE_* fields and their enums; understanding the 23h client-side dedup or the after-the-fact event timing; using the systemd-journal Function multi-value `selections` filter for index-friendly queries.
-  Status: live. SKILL.md plus per-domain guides (`AE_FIELDS.md`, `transports.md`, `update-cadence.md`, `query-discipline.md`, `finding-crashes.md`, `finding-fatals.md`), scripts (`scripts/_lib.sh`, `get-events.sh`, `analyze-events.sh`, `redact-events.sh`) and `recipes/`, `how-tos/` directories. Bug-investigation tool, NOT a generic logs query skill -- consumes `query-netdata-{cloud,agents}` for transport.
-
-- `.agents/skills/mirror-netdata-repos/`
-  Trigger: setting up or updating a local mirror of Netdata-org source repositories at `${NETDATA_REPOS_DIR}` for cross-repo grep / code review without GitHub API calls; running the vendored sync script; questions about the reset-to-default-branch safety mechanism or the `--repo NAME` scoping flag.
-  Status: live. SKILL.md (single-file overview) plus the vendored `scripts/sync-netdata-repos.sh` (env-driven, sanitized, `--repo` scoping, `gh` optional for Phase 2) and `how-tos/` catalog. Independent from any other repo mirrors this workstation may have.
-
-- `.agents/skills/coverity-audit/`
-  Trigger: Coverity Scan defect triage for this repository.
-  Status: live.
-
-- `.agents/skills/sonarqube-audit/`
-  Trigger: SonarCloud findings triage for this repository.
-  Status: live.
-
-- `.agents/skills/graphql-audit/`
-  Trigger: GitHub Code Scanning/CodeQL triage for this repository.
-  Status: live.
-
-- `.agents/skills/pr-reviews/`
-  Trigger: PR comment and review iteration work for this repository.
-  Status: live.
-
-- `.agents/skills/codacy-audit/`
-  Trigger: Codacy Cloud workflow for this repository -- pre-push local analysis (`codacy-analysis-cli` via docker or local binary) and read-only PR-issue fetching via the v3 API.
-  Status: live. SKILL.md plus `scripts/_lib.sh` (token-safe wrappers + sentinel no-leak self-test), `scripts/analyze-local.sh`, `scripts/pr-issues.sh`, and a live `how-tos/INDEX.md` catalog. Read-only by design; write actions require a GitHub issue or branch-local SOW.
-
-Public skills (canonical under `docs/netdata-ai/skills/<name>/`; relative symlinks at `.agents/skills/<name>`):
-
-- `docs/netdata-ai/skills/query-netdata-cloud/`
-  Trigger: querying Netdata Cloud REST API -- metrics, logs (systemd-journal), alerts, generic Function calls on a node.
-  Symlink: `.agents/skills/query-netdata-cloud` -> `../../docs/netdata-ai/skills/query-netdata-cloud`.
-  Status: live. SKILL.md plus per-domain guides (`query-metrics.md`, `query-logs.md`, `query-alerts.md`, `query-functions.md`).
-
-- `docs/netdata-ai/skills/query-netdata-agents/`
-  Trigger: querying Netdata Agents directly on port 19999, including auto-mint of per-agent bearer tokens from a Cloud token.
-  Symlink: `.agents/skills/query-netdata-agents` -> `../../docs/netdata-ai/skills/query-netdata-agents`.
-  Status: live. SKILL.md plus `scripts/_lib.sh` helpers (`agents_resolve_bearer`, `agents_call_function`, `agents_netdata_prefix`).
-
-- `docs/netdata-ai/skills/query-snmp-traps/`
-  Trigger: querying SNMP trap logs through Netdata Cloud or directly from a Netdata Agent; use for trap journal entries, severities, categories, senders, deduplication summaries, `TRAP_*` fields, and `TRAP_JSON` varbind searches.
-  Symlink: `.agents/skills/query-snmp-traps` -> `../../docs/netdata-ai/skills/query-snmp-traps`.
-  Status: live. SKILL.md plus `how-tos/INDEX.md` and seeded operator how-tos.
-
-Output/reference skills:
-
-- `docs/netdata-ai/skills/`
-  Consumer: downstream assistants and users of Netdata AI skill artifacts.
-  Update when: public/operator AI skill docs, examples, commands, schemas, or workflows change.
-
-- `src/ai-skills/`
-  Consumer: downstream assistants and users of generated or source AI skill artifacts when this tree is present in the working copy.
-  Update when: generated/source AI skill behavior, tests, examples, commands, schemas, or workflows change.
-
-### Project-specific commands
-
-- This bootstrap pass does not define a full-project command matrix for the monolith.
-- Use the narrowest existing command that validates the changed subsystem.
-- Do not claim full-project validation from a narrow subsystem command.
-- Existing local helper scripts such as `install.sh` may exist in this working copy; inspect before use and do not assume they are tracked project interfaces.
-
-### Go test style
-
-- Prefer table-driven tests using `map[string]struct{}` keyed by test-case name
-  when cases share setup and assertion shape.
-- Use separate test functions only when setup or assertions are materially
-  different.
-- Prefer map keys over a `name` field in `[]struct{}` so case names are
-  prominent and order-independent.
-
-### Project-specific overrides
-
-All existing project-specific instructions in this file remain active. The SOW framework adds durable work tracking; it does not weaken the root-cause, collector consistency, C code, naming, local-output, or secret-handling rules below.
-
-## Collector Consistency Requirements
-
-When working on collectors, runtime behavior, metrics, charts, configuration,
-alerts, taxonomy, and authoritative documentation sources MUST stay consistent
-in the source PR. Generated integration and umbrella documentation is validated
-locally, then committed by the post-merge generated-artifact PR.
-The detailed collector consistency checklist and CI enforcement notes live in
+When working on collectors, runtime behavior, metrics, charts, configuration, alerts, taxonomy, and authoritative
+documentation sources MUST stay consistent in the source PR. Generated integration and umbrella documentation is
+validated locally, then committed by the post-merge generated-artifact PR. Checklist and CI notes:
 `.agents/skills/integrations-lifecycle/consistency.md`.
 
-## C code
-- gcc, clang, glibc and muslc
-- libnetdata.h includes everything in libnetdata (just a couple of exceptions) so there is no need to include individual libnetdata headers
-- Functions with 'z' suffix (mallocz, reallocz, callocz, strdupz, etc.) handle allocation failures automatically by calling fatal() to exit Netdata
-- The freez() function accepts NULL pointers without crashing
-- Resuable, generic, module agnostic code, goes to libnetdata
-- Double linked lists are managed with DOUBLE_LINKED_LIST_* macros
-- json-c for json parsing
-- buffer_json_* for manual json generation
+### Validation Commands
 
-## Naming Conventions
-- "Netdata Agent" (capitalized) when referring to the product
-- "`netdata`" (lowercase, code-formatted) when referring to the process
-- See DICTIONARY.md for precise terminology
+There is no full-project command matrix. Use the narrowest existing command that validates the changed subsystem,
+and do not claim full-project validation from it. Local helper scripts such as `install.sh` may exist in a working
+copy; inspect before use and do not assume they are tracked project interfaces.
 
-## Local-only working directory
+### Go Test Style
 
-`/.local/` at the repo root is gitignored and reserved for per-user runtime
-artifacts: audit reports, fetched API data, scratch notes, queue files,
-intermediate triage decisions. Agents writing skill output should default to
-`<repo-root>/.local/audits/<topic>/...` -- where `<topic>` is the skill
-name with any trailing `-audit` suffix removed (so `coverity-audit/`
-writes under `coverity/`, `pr-reviews/` writes under `pr-reviews/`).
+- Prefer table-driven tests using `map[string]struct{}` keyed by case name when cases share setup and assertion
+  shape. Map keys beat a `name` field in `[]struct{}`: names stay prominent and order-independent.
+- Use separate test functions only when setup or assertions differ materially.
 
-Convention:
-- `/.local/audits/coverity/`  - Coverity raw fetches, per-defect details, triage decisions
-- `/.local/audits/sonarqube/` - Sonar finding queues, FP comment templates
-- `/.local/audits/graphql/`   - GitHub Code Scanning fetches and dismissals
-- `/.local/audits/pr-reviews/`- Per-PR comment / review caches
+### C Code
 
-Naming: each skill `<topic>-audit/` writes to `.local/audits/<topic>/`
-(the `-audit` suffix is dropped from the directory name so the URL-style
-path stays short). Skills without the `-audit` suffix keep their full
-name (e.g. `pr-reviews/` writes to `.local/audits/pr-reviews/`). When
-adding a new skill, follow this convention.
+- Compilers and libcs: gcc, clang, glibc, musl.
+- `libnetdata.h` includes everything in libnetdata (a couple of exceptions); do not include individual headers.
+- `z`-suffixed allocators (`mallocz`, `reallocz`, `callocz`, `strdupz`, ...) call `fatal()` on failure. `freez()`
+  accepts NULL.
+- Reusable, generic, module-agnostic code goes to libnetdata.
+- Doubly linked lists use the `DOUBLE_LINKED_LIST_*` macros.
+- JSON: json-c for parsing, `buffer_json_*` for manual generation.
 
-Nothing under `/.local/` is committed. Treat the directory as ephemeral
-between users and machines, not as a shared source of truth.
+### Naming Conventions
 
-## Per-user secrets via `.env`
+- "Netdata Agent" (capitalized) for the product; "`netdata`" (lowercase, code-formatted) for the process.
+- See `DICTIONARY.md` for precise terminology.
 
-`/.env` at the repo root is gitignored and holds per-user secrets and
-endpoint configuration consumed by skill scripts: API tokens, session
-cookies, project keys. Never commit secrets; never hard-code tokens in scripts.
+### Local-Only Working Directory
 
-**Setup**: copy `<repo>/.env.template` to `<repo>/.env` and fill in
-the keys you need.
+`/.local/` at the repo root is gitignored and reserved for per-user runtime artifacts: audit reports, fetched API
+data, scratch notes, queue files, intermediate triage decisions. Nothing under it is committed; treat it as
+ephemeral between users and machines, not a shared source of truth.
 
-**Reference**: `<repo>/.agents/ENV.md` is the single canonical guide
-covering every key -- what it is, where to find the value, sample
-format, common mistakes, and which skills require it. When a script
-errors with `<KEY> is empty`, check `.agents/ENV.md` for that key.
+Skill output defaults to `<repo-root>/.local/audits/<topic>/`, where `<topic>` is the skill name minus a trailing
+`-audit` (so `coverity-audit` writes under `coverity/`, `pr-reviews` under `pr-reviews/`). Existing directories:
+`coverity/` (raw fetches, per-defect details, triage), `sonarqube/` (finding queues, FP templates), `graphql/`
+(Code Scanning fetches and dismissals), `pr-reviews/` (per-PR comment and review caches).
+
+### Per-User Secrets
+
+`/.env` at the repo root is gitignored and holds per-user secrets and endpoint configuration consumed by skill
+scripts: API tokens, session cookies, project keys. Never commit secrets; never hard-code tokens in scripts.
+
+- Setup: copy `<repo>/.env.template` to `<repo>/.env` and fill in the keys you need.
+- Reference: `<repo>/.agents/ENV.md` documents every key (what it is, where to find it, format, common mistakes,
+  which skills need it). When a script errors with `<KEY> is empty`, check it there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Roles:
 
 - **User**: purpose, scope decisions, design forks, risk acceptance, destructive approvals, final product judgment.
 - **Assistant**: investigation, evidence, implementation, tests or equivalent validation, reviews, documentation,
-  memory updates, concise reporting.
+  memory updates, concise reporting. The assistant proposes and investigates; the user approves.
 
 Communication:
 
@@ -42,8 +42,8 @@ Communication:
   questions are informed and to the point.
 - Never write walls of text unless asked. Be simple, direct, lean, ordered by importance: give the full picture
   first, start from the high level, let the user ask for details.
-- Never agree with the user when the facts contradict their understanding. Always state the risks and implications
-  of their decisions. You are helpful when you reveal the truth accurately, not when you agree.
+- Never agree with the user when the facts contradict their understanding. You MUST always describe the risks and
+  implications of their decisions clearly. You are helpful when you reveal the truth accurately, not when you agree.
 - Ask the user only for irreducible product, design, or risk decisions.
 
 When a user decision is needed:
@@ -65,7 +65,7 @@ removes debt beats a smaller one that preserves it.
 - **Trivial vs non-trivial work**: defined under "When A SOW Is Required". Trivial work has no SOW and is exempt from
   the record-the-target, disclosure, and reference-search rules below; the clean-end-state preference still applies.
 - **Approved scope**: the union of (a) the issue or user request, (b) the SOW Purpose and Acceptance Criteria as
-  approved by the user, and (c) the migration/contract surface they imply.
+  recorded in the SOW, and (c) the migration/contract surface they imply.
 - **Coupled item**: code, config, docs, or tests the current change makes redundant or leaves inconsistent (a
   replaced path, its callers, its tests).
 - **Independent work**: new work is genuinely independent only if ALL hold: (a) the approved clean end state is
@@ -76,9 +76,10 @@ removes debt beats a smaller one that preserves it.
 - **Approval bar** (used by every gate): the user explicitly accepts a trade-off, goal, or plan that you stated in
   your own words (what stays redundant or partial, and why). A bare "ok" or "sounds good" to a one-sided pitch is
   not approval.
-- **Mandatory pause**: present the evidence, STOP, and obtain approval (Approval bar) before proceeding, before
-  requesting non-draft review, and before marking the work complete. Triggered when the delivered state would fall
-  short of the recorded target for any reason other than approved staged delivery, and by any user-owned fork.
+- **Mandatory pause**: you MUST present the evidence, STOP, and obtain explicit user approval (Approval bar) before
+  proceeding, before requesting non-draft review, and before marking the work complete. It is triggered whenever the
+  delivered state would fall short of the recorded target for any reason other than approved staged delivery, and by
+  any user-owned fork.
 - **Default on doubt**: if unsure whether something is in scope, trivial, coupled, or a user-owned fork, treat it as
   in-scope, non-trivial, coupled, user-owned, and ask.
 
@@ -94,7 +95,8 @@ removes debt beats a smaller one that preserves it.
   target. Record a provisional target plus the open question and resolve it with the user first.
 - Disclose exclusions: the recorded target MUST list (i) what you remove as redundant and (ii) every coupled item
   you treat as NOT part of this clean end state, each with its reason and the scope source it rests on. Excluding
-  an in-scope or coupled item without recording it is silent scope-narrowing and is prohibited.
+  an in-scope or coupled item without recording it is silent scope-narrowing and is prohibited. The list lets a
+  reviewer or the next agent check your exclusions against their sources.
 - You are not the scope authority:
   - Coupled cleanup is in scope. You MUST NOT reclassify in-scope or coupled work as "independent" or "out of
     scope" to avoid it, and you MUST NOT silently drop it.
@@ -102,7 +104,6 @@ removes debt beats a smaller one that preserves it.
     and disclose it rather than stopping to ask.
   - Pause for the user only when inclusion would expand the blast radius, change a user-visible contract, or the
     boundary is itself a genuine scope fork.
-  - If it is unclear whether work is in scope, treat it as in-scope and raise it. Never silently exclude it.
 - Touch the mess you touch: when code you modify already contains adjacent duplication, dead code, or a clear
   pre-existing defect, you SHOULD clean it as part of this work rather than build on it, provided the cleanup is
   low-risk and confined to the code you are already modifying. Cleanup reaching into unrelated code is independent
@@ -153,12 +154,13 @@ removes debt beats a smaller one that preserves it.
   goal unilaterally.
 - End state first: you MUST establish the desired end state, including its acceptance criteria, before planning
   the steps. The goal drives the work, not a first diff. If you cannot state the end state, keep investigating;
-  do not start against an unknown target. If the end state is a user-owned design decision, record a provisional
-  target plus the open question and resolve it first.
+  do not start against an unknown target. A user-owned design decision follows the open-design-decision rule under
+  "Clean End State Over Less Churn".
 - Decompose: split the work into ordered steps, each with its own clean end state and acceptance criteria, each
   building on the previous one. A single coherent step is valid when the work is atomic; do not invent artificial
   sub-steps.
-- Large or vague deliverables: keep refining until every step is clear. Do not start while steps are still unclear.
+- Large or vague deliverables: keep refining the plan until every step has a clean end state and acceptance
+  criteria. Do not start implementation while steps are still unclear.
 - Reachability: the plan MUST reach the desired end state through its steps or produce evidence that it is not
   achievable. An unachievable goal is a pause condition for a user decision, not a silent partial result.
 - Approval is for goal-decisions, not work categories:
@@ -174,7 +176,6 @@ removes debt beats a smaller one that preserves it.
       progress rule ("SOW Lifecycle").
     - A collector's Function surface, vnode/host-scope design, and new public config options remain user-owned
       forks.
-  - When it is unclear whether a real fork exists, treat it as user-owned and seek approval.
 - Approval persists; re-check on resume: before continuing an `in-progress` or `paused` SOW you did not personally
   take through this gate (takeover, handoff), you MUST confirm the SOW records explicit approval of the current
   goal and plan. If it does not, or the plan changed materially since, treat the SOW as `planning` and re-obtain
@@ -182,12 +183,10 @@ removes debt beats a smaller one that preserves it.
 
 ### Scope Discipline At Every Step
 
-- Drift is checked at every Re-evaluation checkpoint, not only diff-vs-target.
 - New work that fails the Independent work definition, or that you are unsure about, is coupled: handle it under
   "Clean End State Over Less Churn" (do the low-risk part and disclose it; pause only for a genuine fork).
 - Genuinely independent work: do NOT silently bundle it. Submit it as a separate PR first and rebase after it
-  merges, or track it as a GitHub issue per Followup Discipline. Do NOT fold it into this SOW's steps; staged
-  stages must decompose one clean end state.
+  merges, or track it as a GitHub issue per Followup Discipline. Do NOT fold it into this SOW's steps.
 
 ## SOW System
 
@@ -201,9 +200,9 @@ global scripts. Use this `AGENTS.md`, the local SOW, project-local specs, and pr
 
 SOWs and specs are local-only working memory, never committed:
 
-- SOW working files live under `.agents/sow/q/**`, specs under `.agents/sow/specs/**`. `.gitignore` ignores
-  `/.agents/sow/q` and `/.agents/sow/specs`; neither MUST ever be committed to any branch. Specs may be
-  re-introduced to git later, reorganized, as a deliberate decision; until then treat them as local memory.
+- SOW working files live under `.agents/sow/q/**`, specs under `.agents/sow/specs/**`. Both are gitignored
+  (`/.agents/sow/q`, `/.agents/sow/specs`) and MUST NOT be committed to any branch. Specs may be re-introduced to
+  git later, reorganized, as a deliberate decision; until then treat them as local memory.
 - Committed framework files: `.agents/sow/SOW.template.md`, `.agents/sow/audit.sh`, `.agents/sow/scan-sensitive.sh`,
   `.agents/sow/worktree-link.sh`.
 - Durable knowledge that must survive a SOW belongs in project skills, docs, code, and tests (and specs once
@@ -247,7 +246,7 @@ Create or reuse a SOW for non-trivial work:
 Trivial work needs no SOW: typo fixes; formatting-only changes; mechanical renames with no behavior change; simple
 low-risk search/replace (still grep the old token to confirm no call site is missed).
 
-When unsure, treat the work as non-trivial.
+Default on doubt applies: unsure means non-trivial.
 
 ### Required First Checks
 
@@ -316,7 +315,8 @@ Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeab
 - One SOW at a time applies to steps. The umbrella is never executed and does not count.
 
 ### Pre-Implementation Gate
- Implementation MUST NOT begin until the SOW's `## Pre-Implementation Gate` section records `Gate status: ready` and the
+
+Implementation MUST NOT begin until the SOW's `## Pre-Implementation Gate` section records `Gate status: ready` and the
 SOW's top-level `Status:` is `ready` or `in-progress`. The `Gate status:` line takes only `blocked` (gate incomplete),
 `ready`, or `needs-user-decision` (blocked on a user-owned fork); it is a different key from the SOW `Status:` so the
 two are never confused. Before changing implementation files, or before continuing an existing SOW that lacks the
@@ -499,8 +499,8 @@ files, and other docs written so future AI agents can execute repository rules c
 - No dense multi-rule paragraphs. A paragraph with several requirements, exceptions, or branches becomes bullets or
   a table.
 - Tables only for matrices or comparisons with short cells. Bullets for rules, workflows, checklists, exceptions.
-- Put requirement words (`MUST`, `MUST NOT`, `SHOULD`, `MAY`) next to the action they govern. Do not hide mandatory
-  behavior in explanatory prose.
+- Put RFC-style requirement words (`MUST`, `MUST NOT`, `SHOULD`, `MAY`) next to the action they govern. Do not hide
+  mandatory behavior in explanatory prose.
 - Prefer labeled bullets for operational guardrails (`Target`, `Exception handling`, `Validation`, `Failure mode`).
   A guardrail with several requirements is a labeled parent bullet with one requirement per sub-bullet.
 - One durable idea per bullet. When a bullet needs several sentences, the first states the rule; the rest give
@@ -541,8 +541,7 @@ the team right now belong in project skills, docs, code, and tests, not in specs
 
 Project skills are memory of HOW to work here.
 
-- Runtime input skills SHOULD live under `.agents/skills/*/SKILL.md`. Before non-trivial work, inspect their
-  descriptions and load every skill whose trigger matches.
+- Runtime input skills SHOULD live under `.agents/skills/*/SKILL.md`. Required First Checks loads the matching ones.
 - Output/reference skills may also exist under product documentation or generated skill directories. Do not rename,
   shorten, or change their descriptions only to satisfy runtime discovery. Update them when their related
   public/operator workflow changes.
@@ -585,7 +584,7 @@ Public skill convention (`docs/netdata-ai/skills/`):
   `pr-reviews`) stay under `.agents/skills/<name>/` with no public counterpart.
 
 Skills index (runtime input under `.agents/skills/`; each skill's frontmatter description is the authoritative
-trigger, the table is a pointer):
+trigger, this list is a pointer):
 
 - `project-writing-collectors`: authoring or modifying any data-collection plugin or module (go.d, ibm.d, Rust, C,
   PLUGINSD); logs, topology, NetFlow/sFlow/IPFIX, OTEL, SNMP profiles, statsd, Prometheus scraping, Functions
@@ -660,8 +659,8 @@ copy; inspect before use and do not assume they are tracked project interfaces.
 
 - Compilers and libcs: gcc, clang, glibc, musl.
 - `libnetdata.h` includes everything in libnetdata (a couple of exceptions); do not include individual headers.
-- `z`-suffixed allocators (`mallocz`, `reallocz`, `callocz`, `strdupz`, ...) call `fatal()` on failure. `freez()`
-  accepts NULL.
+- `z`-suffixed allocators (`mallocz`, `reallocz`, `callocz`, `strdupz`, ...) call `fatal()` on failure, exiting the
+  process. `freez()` accepts NULL.
 - Reusable, generic, module-agnostic code goes to libnetdata.
 - Doubly linked lists use the `DOUBLE_LINKED_LIST_*` macros.
 - JSON: json-c for parsing, `buffer_json_*` for manual generation.
@@ -688,5 +687,5 @@ Skill output SHOULD default to `<repo-root>/.local/audits/<topic>/`, where `<top
 scripts: API tokens, session cookies, project keys. Never commit secrets; never hard-code tokens in scripts.
 
 - Setup: copy `<repo>/.env.template` to `<repo>/.env` and fill in the keys you need.
-- Reference: `<repo>/.agents/ENV.md` documents every key (what it is, where to find it, format, common mistakes,
-  which skills need it). When a script errors with `<KEY> is empty`, check it there.
+- Reference: `<repo>/.agents/ENV.md` is the single canonical guide to every key (what it is, where to find it, format,
+  common mistakes, which skills need it). When a script errors with `<KEY> is empty`, check it there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ Critical rules:
 
 ## Requirement Language
 
+This repository uses RFC-style requirement language. Durable AI-facing artifacts (instruction files, specs, skills)
+SHOULD use these words when documenting enforceable rules:
+
 - **MUST** / **REQUIRED**: mandatory. Violating work is not acceptable unless the user explicitly changes the
   requirement.
 - **MUST NOT**: prohibited.
@@ -50,7 +53,7 @@ When a user decision is needed:
 3. Explain pros, cons, implications, and risks of each.
 4. Recommend one option with reasoning.
 5. Record the decision in the SOW before implementation. For the goal/plan approval round, the bar is the
-   Approval bar below.
+   Approval bar (Development Principles, Definitions).
 
 ## Development Principles
 
@@ -61,8 +64,8 @@ removes debt beats a smaller one that preserves it.
 
 - **Trivial vs non-trivial work**: defined under "When A SOW Is Required". Trivial work has no SOW and is exempt from
   the record-the-target, disclosure, and reference-search rules below; the clean-end-state preference still applies.
-- **Approved scope**: the union of (a) the issue or user request, (b) the SOW Purpose and Acceptance Criteria, and
-  (c) the migration/contract surface they imply.
+- **Approved scope**: the union of (a) the issue or user request, (b) the SOW Purpose and Acceptance Criteria as
+  approved by the user, and (c) the migration/contract surface they imply.
 - **Coupled item**: code, config, docs, or tests the current change makes redundant or leaves inconsistent (a
   replaced path, its callers, its tests).
 - **Independent work**: new work is genuinely independent only if ALL hold: (a) the approved clean end state is
@@ -73,6 +76,9 @@ removes debt beats a smaller one that preserves it.
 - **Approval bar** (used by every gate): the user explicitly accepts a trade-off, goal, or plan that you stated in
   your own words (what stays redundant or partial, and why). A bare "ok" or "sounds good" to a one-sided pitch is
   not approval.
+- **Mandatory pause**: present the evidence, STOP, and obtain approval (Approval bar) before proceeding, before
+  requesting non-draft review, and before marking the work complete. Triggered when the delivered state would fall
+  short of the recorded target for any reason other than approved staged delivery, and by any user-owned fork.
 - **Default on doubt**: if unsure whether something is in scope, trivial, coupled, or a user-owned fork, treat it as
   in-scope, non-trivial, coupled, user-owned, and ask.
 
@@ -100,11 +106,11 @@ removes debt beats a smaller one that preserves it.
 - Touch the mess you touch: when code you modify already contains adjacent duplication, dead code, or a clear
   pre-existing defect, you SHOULD clean it as part of this work rather than build on it, provided the cleanup is
   low-risk and confined to the code you are already modifying. Cleanup reaching into unrelated code is independent
-  work (see Scope Discipline). If you leave adjacent mess in place, record why under disclosure (ii).
+  work (see "Scope Discipline At Every Step"). If you leave adjacent mess in place, record why under disclosure (ii).
 - Reference search (when replacing a path or altering a contract):
-  - You MUST run and record in the SOW a search for remaining references. Search construction sites and prefixes
-    too, not only literal final names; identifiers here are often built dynamically (for example via
-    `fmt.Sprintf`).
+  - You MUST run and record in the SOW a search for remaining references to the replaced path or contract. Search
+    construction sites and prefixes
+    too, not only literal final names; identifiers here are often built dynamically (for example via `fmt.Sprintf`).
   - Every surviving reference MUST appear in (i) or (ii) with its scope source, or the target is incomplete. An
     item you did not search for counts as silent scope-narrowing.
   - A repository-wide search cannot prove safety for consumers outside this repo (Netdata Cloud, exporters,
@@ -121,18 +127,17 @@ removes debt beats a smaller one that preserves it.
     is acceptable and when it lands; repeatedly shipping partials is debt accumulation, not delivery.
   - Risk reduction, review convenience, smaller diff, and issue staging are NEVER valid reasons and MUST NOT be
     relabeled "unsafe" or "independent".
-- Mandatory pause: if the delivered state will fall short of the recorded target for any reason other than approved
-  staged delivery, or the work reaches a user-owned fork, you MUST present the evidence, STOP, and obtain approval
-  (Approval bar) before proceeding, before requesting non-draft review, and before marking the work complete.
 - Re-evaluation checkpoints: at the completion of each planned step, before opening or updating a PR, and before
   marking a SOW completed, you MUST re-evaluate the written changes against the recorded target AND check for drift
   outside the approved scope. You SHOULD also re-evaluate whenever you pause to report progress. Do not keep a
   compromise only because it already exists in the branch.
-- Staged delivery: allowed ONLY when every stage is an in-scope decomposition of one approved clean end state and
-  the stages together reach it. The approval recorded for the staged plan covers the intermediate states, so an
-  approved stage does not re-trigger the pause. Every later stage MUST be tracked per Followup Discipline before an
-  earlier stage merges; "a later stage will finish it" with no tracked item is not acceptable. Mechanics: see
-  "Umbrella And Step SOWs".
+- Staged delivery (mechanics: "Umbrella And Step SOWs"):
+  - Allowed ONLY when every stage is an in-scope decomposition of one approved clean end state and the stages
+    together reach it.
+  - The approval recorded for the staged plan covers the intermediate states, so an approved stage does not
+    re-trigger the pause.
+  - Every later stage MUST be tracked per Followup Discipline before an earlier stage merges; "a later stage will
+    finish it" with no tracked item is not acceptable.
 - Re-ground staged designs: a design recorded during planning or an earlier stage MAY have drifted from the code a
   previous stage produced. Before implementing a later stage you MUST re-verify its design against the current
   code and record the correction in the SOW. Never implement against stale assumptions.
@@ -152,8 +157,8 @@ removes debt beats a smaller one that preserves it.
   target plus the open question and resolve it first.
 - Decompose: split the work into ordered steps, each with its own clean end state and acceptance criteria, each
   building on the previous one. A single coherent step is valid when the work is atomic; do not invent artificial
-  sub-steps. If the deliverable is large or vague, keep refining until every step is clear. Do not start while
-  steps are still unclear.
+  sub-steps.
+- Large or vague deliverables: keep refining until every step is clear. Do not start while steps are still unclear.
 - Reachability: the plan MUST reach the desired end state through its steps or produce evidence that it is not
   achievable. An unachievable goal is a pause condition for a user decision, not a silent partial result.
 - Approval is for goal-decisions, not work categories:
@@ -162,10 +167,11 @@ removes debt beats a smaller one that preserves it.
     being accepted and get confirmation. If the user rejects or edits the plan, revise and re-seek approval. The
     SOW stays `planning` until approval is recorded, then becomes `ready`.
   - Non-trivial work whose end state is already fixed by the request, an existing project skill, or an established
-    repository pattern (a clear bug fix, a metadata/docs edit with no contract change, a collector skeleton fixed by
-    its authoring skill) still needs a recorded plan and the Pre-Implementation Gate, but the request IS the
-    recorded approval. A collector's Function surface, vnode/host-scope design, and new public config options
-    remain user-owned forks.
+    repository pattern (a clear bug fix, a metadata/docs edit with no contract change, a collector skeleton and
+    wiring fixed by its authoring skill) still needs a recorded plan and the Pre-Implementation Gate, but the
+    request IS the recorded approval: no separate round, and this also satisfies the resume re-check and the
+    progress rule. A collector's Function surface, vnode/host-scope design, and new public config options remain
+    user-owned forks.
   - When it is unclear whether a real fork exists, treat it as user-owned and seek approval.
 - Approval persists; re-check on resume: before continuing an `in-progress` or `paused` SOW you did not personally
   take through this gate (takeover, handoff), you MUST confirm the SOW records explicit approval of the current
@@ -175,8 +181,8 @@ removes debt beats a smaller one that preserves it.
 ### Scope Discipline At Every Step
 
 - Drift is checked at every Re-evaluation checkpoint, not only diff-vs-target.
-- New work that fails the Independent-work test, or that you are unsure about, is coupled: handle it under Clean
-  End State (do the low-risk part and disclose it; pause only for a genuine fork).
+- New work that fails the Independent work definition, or that you are unsure about, is coupled: handle it under
+  "Clean End State Over Less Churn" (do the low-risk part and disclose it; pause only for a genuine fork).
 - Genuinely independent work: do NOT silently bundle it. Submit it as a separate PR first and rebase after it
   merges, or track it as a GitHub issue per Followup Discipline. Do NOT fold it into this SOW's steps; staged
   stages must decompose one clean end state.
@@ -185,9 +191,9 @@ removes debt beats a smaller one that preserves it.
 
 Project SOW status: initialized
 
-This project uses a local Statement of Work (SOW) system. It is self-contained: normal SOW work MUST NOT depend on
-`~/.agents`, `~/.AGENTS.md`, global skills, global templates, or global scripts. Use this `AGENTS.md`, the local
-SOW, project-local specs, and project-local skills.
+The line above is the audit marker; do not edit it. This project uses a local Statement of Work (SOW) system. It is
+self-contained: normal SOW work MUST NOT depend on `~/.agents`, `~/.AGENTS.md`, global skills, global templates, or
+global scripts. Use this `AGENTS.md`, the local SOW, project-local specs, and project-local skills.
 
 ### Storage Model
 
@@ -208,23 +214,25 @@ SOWs and specs are local-only working memory, never committed:
   | `current/` | in flight; a paused SOW stays here | `planning`, `ready`, `in-progress`, `paused` |
   | `done/` | finished | `completed` |
 
-- Worktrees: SOW working memory is per-developer, not per-worktree. After creating a git worktree, or after
-  updating an old checkout to this model, run `.agents/sow/worktree-link.sh`. It creates the queues and symlinks
-  `.agents/sow/q`, `.agents/sow/specs`, `.local`, and `.env` to the origin checkout. A worktree that already has
-  its own real `.env` keeps it. The script is idempotent, never loses data on a name collision, re-points a symlink
-  whose origin moved, and refuses to run when the origin checkout is not yet on this model (it prints how to
-  update it).
+- Legacy `active/`: retired. Fold any `.agents/sow/q/active/` files into `current/` (or `done/` if completed);
+  nothing reads `active/` any more, and `worktree-link.sh` does this fold on its next run.
 - Deletion guard: assistants MUST NOT remove a SOW working file from the local checkout (`rm`, patch delete hunks,
   editor deletes, or any equivalent) unless the user explicitly asks to discard it. A completed SOW MAY stay in
   `done/` as local history or be deleted at the user's request. Never delete one without the user asking.
+- Worktrees: SOW working memory is per-developer, not per-worktree. After creating a git worktree, or after updating an
+  old checkout to this model, run `.agents/sow/worktree-link.sh`. In the origin checkout it creates the queues and folds
+  any legacy top-level queue dirs into `q/`; in a linked worktree it symlinks `.agents/sow/q`, `.agents/sow/specs`,
+  `.local`, and `.env` to the origin checkout (a worktree that already has its own real `.env` keeps it). The script is
+  idempotent, never loses data on a name collision, re-points a symlink whose origin moved, and refuses to run in a
+  worktree whose origin checkout is not yet on this model (it prints how to update it).
 - Because nothing is committed there is no commit-for-handoff, no remove-before-merge step, and no CI merge guard
   to clear.
 
 ### When A SOW Is Required
 
-Non-trivial work needs a SOW: feature work; bug fixes with behavioral impact; refactors; migrations; documentation
-or content changes with product/business impact; process changes; regressions; spec hygiene; project skill changes;
-collector changes; packaging, install, or deployment changes; PR review iteration; static analysis triage that
+Create or reuse a SOW for non-trivial work: feature work; bug fixes with behavioral impact; refactors; migrations;
+documentation or content changes with product/business impact; process changes; regressions; spec hygiene; project skill
+changes; collector changes; packaging, install, or deployment changes; PR review iteration; static analysis triage that
 changes source, docs, or project policy; any work with unclear risk.
 
 Trivial work needs no SOW: typo fixes; formatting-only changes; mechanical renames with no behavior change; simple
@@ -242,12 +250,13 @@ Before non-trivial work:
 3. Inspect `.agents/skills/*/SKILL.md` and load every runtime project skill whose trigger matches the work (index
    under Project Skills).
 4. Inspect code, docs, tests, and existing project instructions as ground truth.
-5. Ask the user only for irreducible product/design/risk decisions. For non-trivial work the goal and plan are
-   user-owned per "Plan Before Non-Trivial Work".
+5. For non-trivial work the goal and plan are user-owned: see "Plan Before Non-Trivial Work".
 
 ### SOW Lifecycle
 
-- Create new SOWs from `.agents/sow/SOW.template.md`; the template is project-local and MAY be customized.
+- Create new SOWs from `.agents/sow/SOW.template.md` (project-local; MAY be customized). Create the file in
+  `pending/` when the work is queued but not started, or directly in `current/` when starting now; move it from
+  `pending/` to `current/` when you begin filling the Pre-Implementation Gate.
 - Filename: `SOW-YYYYMMDD-{slug}.md`, creation date plus descriptive slug. There is no sequential counter because it
   cannot be allocated safely across parallel branches.
 - State lives in the file's `Status:` field:
@@ -266,24 +275,25 @@ Before non-trivial work:
     the conversation or every review nit.
   - Before completion, prune stale history and verify another contributor can determine the current target,
     remaining work, decisions, and evidence without reconstructing chronology.
-- One SOW at a time: never execute multiple SOWs as one batch. If work overlaps, coordinate through the open PRs
+- One SOW at a time: several SOWs MAY be in flight in `current/`, but never execute multiple SOWs as one batch. If
+  work overlaps, coordinate through the open PRs
   and issues, merge or consolidate branches before implementation, or split into separate SOWs and complete one
   before starting the next.
 - Progress reports and Re-evaluation checkpoints are not stop points. Once a SOW is in progress with its approval
-  recorded, continue until it is delivered, failed with evidence, blocked on a real user decision, or superseded by
-  newer user instructions.
+  recorded, continue until it is delivered, failed with evidence, blocked on a real user decision or approval, or
+  superseded by newer user instructions.
 - Completion, when the work is ready to merge:
   1. Finish implementation, docs, skills, validation, and follow-up mapping.
   2. Transfer all durable knowledge into project skills, docs, code, and tests (and specs once re-introduced). The
      SOW body MUST then hold nothing durable that is not captured elsewhere.
-  3. Set `Status: completed` and move the file to `done/`.
+  3. Set `Status: completed` and move the file to `.agents/sow/q/done/`.
 
 ### Umbrella And Step SOWs
 
 Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeable deliverable).
 
 - Naming: umbrella `SOW-YYYYMMDD-<family>-umbrella.md`; steps `SOW-YYYYMMDD-<family>-NN-<step>.md` with a two-digit
-  ordinal. All files of one initiative share the `<family>` slug.
+  ordinal. All files of one initiative share the `<family>` slug; each keeps its own creation date.
 - Links by filename, never by queue path (paths go stale when files move). Each step records
   `Umbrella: SOW-YYYYMMDD-<family>-umbrella` in Requirements. The umbrella keeps a `## Steps` table: ordinal, step
   SOW filename, status, PR.
@@ -292,15 +302,19 @@ Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeab
   number. A step whose end state is fixed by the approved decomposition needs no new approval round.
 - Placement and status: the umbrella lives in `current/` from the first step's start until the last step completes,
   then moves to `done/`. Its status is `planning` until the decomposition is approved, then `in-progress` while any
-  step is in flight. `paused` on an umbrella means the initiative itself is parked, not "waiting on steps".
+  step is in flight. `paused` on an umbrella means the initiative itself is parked, not "waiting on steps". Steps
+  follow the normal queue rules; the assistant updates the umbrella's `## Steps` table whenever a step changes
+  status or gains a PR.
 - One SOW at a time applies to steps. The umbrella is never executed and does not count.
 
 ### Pre-Implementation Gate
 
-Implementation MUST NOT begin until the SOW contains a concrete `## Pre-Implementation Gate` section with
-`Status: ready` or `Status: in-progress`. Before changing implementation files, or before continuing an existing SOW
-that lacks the section, fill the gate. Reaching `Status: ready` additionally requires the goal/plan approval of
-"Plan Before Non-Trivial Work" where that round applies.
+Implementation MUST NOT begin until the SOW's `## Pre-Implementation Gate` section records `Status: ready` and the
+SOW's top-level status is `ready` or `in-progress`. The gate's own status line takes only `blocked` (gate
+incomplete), `ready`, or `needs-user-decision` (blocked on a user-owned fork); these are gate values, distinct from
+the SOW status values. Before changing implementation files, or before continuing an existing SOW that lacks the
+section, fill the gate. Gate `ready` additionally requires the goal/plan approval of "Plan Before Non-Trivial Work"
+where that round applies.
 
 The gate MUST record: problem/root-cause model; evidence reviewed; affected contracts and surfaces; the
 clean-end-state target with its removed-redundant and excluded-coupled items and the reference search where a path
@@ -341,7 +355,8 @@ Review findings are leads until verified against the shipped code and its contra
 - Reproduce a reviewer-reported bug as a FAILING test first, then fix to green. The red test proves the finding,
   pins the contract, and catches wrong assumptions in your own tests.
 - Multi-round review: checkpoint-commit each validated change (specific files only) before its review and squash at
-  PR time. If findings keep clustering in one subsystem for ~2-3 rounds, stop patching individual cases, name the
+  PR time.
+- Recurrence: if findings keep clustering in one subsystem for ~2-3 rounds, stop patching individual cases, name the
   missing invariant, and propose one class-level fix as a user decision.
 - One complete review round is the default. Repeat the same full scope only when a verified shipping blocker
   required a material change to shipped implementation or behavior, or when the prior review could not assess the
@@ -408,15 +423,16 @@ was needed:
   issues, regressions handled as new linked SOWs.
 
 This is an assistant responsibility. If a SOW changes behavior, docs, specs, commands, schemas, defaults, workflows,
-examples, or operating procedure, update every affected artifact in the same SOW or record why it is unaffected.
+examples, or operating procedure, the assistant MUST update every affected artifact in the same SOW or record the
+evidence-backed reason it is unaffected.
 
 ### Enforcement
 
 - `.agents/sow/audit.sh`: local consistency audit for SOW rules, the local-only queue/spec layout, framework files,
   and sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use.
-- `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs (anything under
-  `.agents/sow/q/**`, `.agents/sow/specs/**`, or a stray `.agents/sow/{active,pending,current,done}/SOW-*.md`); a
-  hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and
+- `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
+  `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
+  A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and
   framework files for raw sensitive data.
 - These checks are guards, not substitutes for the Validation Gate. The assistant still owns transferring durable
   knowledge out of the SOW before merge.
@@ -481,11 +497,12 @@ root. Never write absolute paths into SOW evidence.
 
 Specs are memory of WHAT this project does. They live under `.agents/sow/specs/` as local-only memory (Storage
 Model); the source tree and public documentation remain the primary ground truth, and specs capture durable
-decisions, cross-cutting rules, and area contracts as they are worked.
+decisions, cross-cutting rules, and area contracts as they are worked. Durable contracts that must be shared with
+the team right now belong in project skills, docs, code, and tests, not in specs.
 
 - Layout stays flat until scale proves hierarchy is needed. Use `<domain>-<topic>.md`, one durable contract or
   cross-cutting rule per file, organized by contract ownership, not by repository path. Update
-  `.agents/sow/specs/README.md` in the same change.
+  `.agents/sow/specs/README.md` (a flat index; create it if missing) in the same change.
 - Update specs when shipped work changes product behavior, public contracts, collector behavior, APIs and schemas,
   data formats, alerting semantics, packaging or deployment behavior, operational guarantees, or known edge cases.
 - Specs describe current reality, not aspiration. If specs and code disagree, record the discrepancy in the active
@@ -495,12 +512,12 @@ decisions, cross-cutting rules, and area contracts as they are worked.
 
 Project skills are memory of HOW to work here.
 
-- Runtime input skills live under `.agents/skills/*/SKILL.md`. Before non-trivial work, inspect their descriptions
-  and load every skill whose trigger matches.
+- Runtime input skills SHOULD live under `.agents/skills/*/SKILL.md`. Before non-trivial work, inspect their
+  descriptions and load every skill whose trigger matches.
 - Output/reference skills may also exist under product documentation or generated skill directories. Do not rename,
   shorten, or change their descriptions only to satisfy runtime discovery. Update them when their related
   public/operator workflow changes.
-- Skill updates that close gaps or fix outdated pointers ship in the same PR that exposed the issue.
+- Skill updates that close gaps or fix outdated pointers MUST ship in the same PR that exposed the issue.
 
 Public skill convention (`docs/netdata-ai/skills/`):
 
@@ -511,7 +528,7 @@ Public skill convention (`docs/netdata-ai/skills/`):
   metrics/logs/topology/alerts, and running safe operational commands. They MUST NOT contain developer-contract
   validation, schema migration plans, producer authoring workflows, UI adapter work, aggregator implementation
   notes, SOW handoff instructions, fixture maintenance, PR-review tasks, or codebase-internal recipes.
-- Developer-facing skills live under `.agents/skills/`, preferably with a `project-` prefix when they are runtime
+- Developer-facing skills MUST live under `.agents/skills/`, preferably with a `project-` prefix when they are runtime
   input. A workflow that reads source files, updates schemas, validates fixtures, changes collectors/producers, or
   coordinates frontend/backend/aggregator code is a project developer skill, not a public one.
 - Skill verification harness inputs (seed questions, grader rubrics, runner scripts, transcript-generation prompts)
@@ -519,14 +536,14 @@ Public skill convention (`docs/netdata-ai/skills/`):
 - Each public skill is reachable from `.agents/skills/<skill-name>` via a relative symlink
   (`.agents/skills/<name>` -> `../../docs/netdata-ai/skills/<name>`), created with `ln -srfn` and verified with
   `readlink -f .agents/skills/<name>`.
-- Scripts follow the existing `_lib.sh` shape: `set -euo pipefail`; ANSI colors as real ESC bytes via
+- Scripts MUST follow the existing `_lib.sh` shape: `set -euo pipefail`; ANSI colors as real ESC bytes via
   `$'\033[...]'`; `<prefix>_repo_root` via `git rev-parse --show-toplevel`; `<prefix>_load_env` sourcing
   `<repo>/.env` with `: "${VAR:?}"` validation; `<prefix>_audit_dir` creating `<repo>/.local/audits/<topic>/`;
   masked-token `<prefix>_run` / `<prefix>_run_read` wrappers.
 - Scripts that touch credentials (cloud tokens, per-agent bearers, claim ids, session cookies) MUST be token-safe:
   helpers handling credential bytes are named with a leading underscore (`_skill_*`, internal-only) and return them
   via bash namerefs into the caller's locals, NEVER to stdout. Public wrappers (no underscore) read credentials from
-  `.env` internally and emit ONLY the response body. Each token-handling lib ships a
+  `.env` internally and emit ONLY the response body. Each token-handling lib MUST ship a
   `<prefix>_selftest_no_token_leak` that drives every public wrapper with a sentinel token and asserts it never
   reaches captured stdout.
 - How-tos catalog: each public skill ships `how-tos/INDEX.md`, and the catalog is live. Whenever an assistant
@@ -535,10 +552,11 @@ Public skill convention (`docs/netdata-ai/skills/`):
   how-to and add it to `INDEX.md` BEFORE completing the task. Each `SKILL.md` repeats this rule. Skipping it is a
   framework violation: the next assistant repeats the analysis from scratch. Audience boundaries still apply: a
   developer validation recipe goes into the matching `.agents/skills/` project skill and its index instead.
-- The private skills `coverity-audit`, `sonarqube-audit`, `graphql-audit`, and `pr-reviews` keep their
-  `.agents/skills/<name>/` location with no public counterpart.
+- Skills without an operator audience (for example `coverity-audit`, `sonarqube-audit`, `graphql-audit`,
+  `pr-reviews`) stay under `.agents/skills/<name>/` with no public counterpart.
 
-Skills index (runtime input under `.agents/skills/`):
+Skills index (runtime input under `.agents/skills/`; each skill's frontmatter description is the authoritative
+trigger, the table is a pointer):
 
 | Skill | Trigger |
 |---|---|
@@ -607,7 +625,7 @@ copy; inspect before use and do not assume they are tracked project interfaces.
 ### Naming Conventions
 
 - "Netdata Agent" (capitalized) for the product; "`netdata`" (lowercase, code-formatted) for the process.
-- See `DICTIONARY.md` for precise terminology.
+- See `docs/DICTIONARY.md` for precise terminology.
 
 ### Local-Only Working Directory
 
@@ -615,7 +633,7 @@ copy; inspect before use and do not assume they are tracked project interfaces.
 data, scratch notes, queue files, intermediate triage decisions. Nothing under it is committed; treat it as
 ephemeral between users and machines, not a shared source of truth.
 
-Skill output defaults to `<repo-root>/.local/audits/<topic>/`, where `<topic>` is the skill name minus a trailing
+Skill output SHOULD default to `<repo-root>/.local/audits/<topic>/`, where `<topic>` is the skill name minus a trailing
 `-audit` (so `coverity-audit` writes under `coverity/`, `pr-reviews` under `pr-reviews/`). Existing directories:
 `coverity/` (raw fetches, per-defect details, triage), `sonarqube/` (finding queues, FP templates), `graphql/`
 (Code Scanning fetches and dismissals), `pr-reviews/` (per-PR comment and review caches).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,6 +329,17 @@ resolve, stop and ask the user before implementation.
 Assistants MUST NOT create git worktrees on their own. Create one only when the user explicitly asks for it or
 approves it, then run `.agents/sow/worktree-link.sh` (see Storage Model).
 
+### Git And PR Workflow
+
+- Work on a branch per SOW created off local `master`; never commit to `master` directly.
+- Stage only the specific files you changed. Never `git add -A`: the working copy holds untracked files that MUST
+  NOT be committed.
+- Never `git checkout <file>`, `git reset`, delete files, or rewrite history without explicit user approval. Undo a
+  change by editing it out, not by checking the file out.
+- Commit and push only when the user asks or the approved plan says so. Checkpoint commits before review rounds
+  and squashing at PR time are described under "Review".
+- Commit messages and PR bodies describe the change. A PR body links the follow-up issues tracked from its SOW.
+
 ### Local SOW Parking
 
 - Users MAY keep private paused, abandoned, or not-yet-public SOW drafts under `<repo-root>/.local/sow/`. It is
@@ -358,6 +369,9 @@ Review findings are leads until verified against the shipped code and its contra
   PR time.
 - Recurrence: if findings keep clustering in one subsystem for ~2-3 rounds, stop patching individual cases, name the
   missing invariant, and propose one class-level fix as a user decision.
+- Obtaining a review: spawn independent, full-scope reviewers with clean context, or run the external assistants
+  the user names. For performance-sensitive code at least one reviewer MUST carry an explicit hot-path performance
+  lens. Record each reviewer and its findings under Validation in the SOW.
 - One complete review round is the default. Repeat the same full scope only when a verified shipping blocker
   required a material change to shipped implementation or behavior, or when the prior review could not assess the
   complete change.
@@ -405,7 +419,8 @@ A SOW cannot be completed until Validation records:
 - workflow-friction triage: each `Workflow Friction & Rule Gaps` note resolved to a rule update (`AGENTS.md`,
   project skill, spec, or SOW template), an evidence-backed rejection, or a tracked follow-up (or an explicit "none
   arose");
-- follow-up mapping.
+- follow-up mapping;
+- `.agents/sow/audit.sh` passing, or every remaining failure explained.
 
 Generic "N/A" is invalid.
 
@@ -558,35 +573,50 @@ Public skill convention (`docs/netdata-ai/skills/`):
 Skills index (runtime input under `.agents/skills/`; each skill's frontmatter description is the authoritative
 trigger, the table is a pointer):
 
-| Skill | Trigger |
-|---|---|
-| `project-writing-collectors` | authoring or modifying any data-collection plugin or module (go.d, ibm.d, Rust, C, PLUGINSD); logs, topology, NetFlow/sFlow/IPFIX, OTEL, SNMP profiles, statsd, Prometheus scraping, Functions |
-| `project-writing-go-modules-framework-v2` | creating or migrating a go.d collector to framework V2; `CollectorV2`, `metrix.CollectorStore`, `ChartTemplateYAML`/`charts.yaml`, `charttpl`, `chartengine`, V2 host scopes, V2 tests |
-| `project-snmp-profiles-authoring` | SNMP profile YAMLs, topology SNMP profiles, ddsnmp profile parsing, profile-format docs; requires MIB `MAX-ACCESS` checks and index-derived extraction for `not-accessible` INDEX objects |
-| `project-snmp-trap-profiles-authoring` | SNMP trap profile YAMLs, trap profile-format docs, the `snmptrapprofilegen` helper, OOB trap profile regeneration; closed 8-category / 8-severity taxonomy |
-| `project-prometheus-profiles` | creating, reviewing, validating, iterating, or installing Prometheus chart profiles from exposition dumps; selector/relabel/fallback policy, coverage, NIDL, live verification |
-| `project-create-topology` | topology producers, topology Function payloads, schema fixtures, graph presentation, correlation rules, direction semantics, drilldowns, telemetry overlays, Cloud aggregation fixtures |
-| `project-health-alert-authoring` | authoring, adapting, or reviewing health alerts and templates in `src/health/health.d/*.conf`; lookup/calc/warn/crit, lifecycle, routing, health-config tests |
-| `project-query-corpus` | running or extending `tests/query-corpus/`; fixtures, oracles, red/green cases for query-engine bugs, formatter byte-pins, validating a fix branch |
-| `project-build-static-binary` | building or testing the static self-extracting installer (`netdata-<arch>-latest.gz.run`) under `packaging/makeself/` |
-| `integrations-lifecycle` | any `metadata.yaml` or collector `taxonomy.yaml`; `integrations/` generators, schemas, taxonomy registries, templates, generated outputs, `COLLECTORS.md`/`SECRETS.md`/`SERVICE-DISCOVERY.md`; ibm.d `contexts.yaml`; the collector-consistency rule |
-| `learn-site-structure` | adding, moving, renaming, or deleting a docs page for `learn.netdata.cloud`; `docs/.map/map.yaml`; why a Learn page looks the way it does; MDX escape rules; redirects; Netlify deploy |
-| `learn-pr-preview` | only when the user explicitly asks to build, preview, or validate `learn.netdata.cloud` locally from a PR or docs branch |
-| `query-agent-events` | investigating crashes, panics, or fatals across the fleet via the agent-events namespace; `AE_*` fields; 23h dedup; journal multi-value `selections` filters. Bug-investigation tool, not generic logs |
-| `mirror-netdata-repos` | setting up or syncing the local mirror of Netdata-org repos at `${NETDATA_REPOS_DIR}`; reset-to-default safety; `--repo` scoping |
-| `pr-reviews` | PR comment and review iteration |
-| `coverity-audit` | Coverity Scan defect triage |
-| `sonarqube-audit` | SonarCloud findings triage |
-| `graphql-audit` | GitHub Code Scanning / CodeQL triage |
-| `codacy-audit` | Codacy pre-push local analysis and read-only PR-issue fetching; write actions require a GitHub issue or SOW |
+- `project-writing-collectors`: authoring or modifying any data-collection plugin or module (go.d, ibm.d, Rust, C,
+  PLUGINSD); logs, topology, NetFlow/sFlow/IPFIX, OTEL, SNMP profiles, statsd, Prometheus scraping, Functions
+- `project-writing-go-modules-framework-v2`: creating or migrating a go.d collector to framework V2; `CollectorV2`,
+  `metrix.CollectorStore`, `ChartTemplateYAML`/`charts.yaml`, `charttpl`, `chartengine`, V2 host scopes, V2 tests
+- `project-snmp-profiles-authoring`: SNMP profile YAMLs, topology SNMP profiles, ddsnmp profile parsing, profile-format
+  docs; requires MIB `MAX-ACCESS` checks and index-derived extraction for `not-accessible` INDEX objects
+- `project-snmp-trap-profiles-authoring`: SNMP trap profile YAMLs, trap profile-format docs, the `snmptrapprofilegen`
+  helper, OOB trap profile regeneration; closed 8-category / 8-severity taxonomy
+- `project-prometheus-profiles`: creating, reviewing, validating, iterating, or installing Prometheus chart profiles
+  from exposition dumps; selector/relabel/fallback policy, coverage, NIDL, live verification
+- `project-create-topology`: topology producers, topology Function payloads, schema fixtures, graph presentation,
+  correlation rules, direction semantics, drilldowns, telemetry overlays, Cloud aggregation fixtures
+- `project-health-alert-authoring`: authoring, adapting, or reviewing health alerts and templates in
+  `src/health/health.d/*.conf`; lookup/calc/warn/crit, lifecycle, routing, health-config tests
+- `project-query-corpus`: running or extending `tests/query-corpus/`; fixtures, oracles, red/green cases for
+  query-engine bugs, formatter byte-pins, validating a fix branch
+- `project-build-static-binary`: building or testing the static self-extracting installer
+  (`netdata-<arch>-latest.gz.run`) under `packaging/makeself/`
+- `integrations-lifecycle`: any `metadata.yaml` or collector `taxonomy.yaml`; `integrations/` generators, schemas,
+  taxonomy registries, templates, generated outputs, `COLLECTORS.md`/`SECRETS.md`/`SERVICE-DISCOVERY.md`; ibm.d
+  `contexts.yaml`; the collector-consistency rule
+- `learn-site-structure`: adding, moving, renaming, or deleting a docs page for `learn.netdata.cloud`;
+  `docs/.map/map.yaml`; why a Learn page looks the way it does; MDX escape rules; redirects; Netlify deploy
+- `learn-pr-preview`: only when the user explicitly asks to build, preview, or validate `learn.netdata.cloud` locally
+  from a PR or docs branch
+- `query-agent-events`: investigating crashes, panics, or fatals across the fleet via the agent-events namespace; `AE_*`
+  fields; 23h dedup; journal multi-value `selections` filters. Bug-investigation tool, not generic logs
+- `mirror-netdata-repos`: setting up or syncing the local mirror of Netdata-org repos at `${NETDATA_REPOS_DIR}`;
+  reset-to-default safety; `--repo` scoping
+- `pr-reviews`: PR comment and review iteration
+- `coverity-audit`: Coverity Scan defect triage
+- `sonarqube-audit`: SonarCloud findings triage
+- `graphql-audit`: GitHub Code Scanning / CodeQL triage
+- `codacy-audit`: Codacy pre-push local analysis and read-only PR-issue fetching; write actions require a GitHub issue
+  or SOW
 
 Public skills (canonical under `docs/netdata-ai/skills/<name>/`, symlinked at `.agents/skills/<name>`):
 
-| Skill | Trigger |
-|---|---|
-| `query-netdata-cloud` | querying the Netdata Cloud REST API: metrics, logs (systemd-journal), alerts, generic Functions on a node |
-| `query-netdata-agents` | querying Agents directly on port 19999, including auto-minting per-agent bearer tokens from a Cloud token |
-| `query-snmp-traps` | SNMP trap logs via Cloud or Agent: entries, severities, categories, senders, dedup summaries, `TRAP_*` fields, `TRAP_JSON` searches |
+- `query-netdata-cloud`: querying the Netdata Cloud REST API: metrics, logs (systemd-journal), alerts, generic Functions
+  on a node
+- `query-netdata-agents`: querying Agents directly on port 19999, including auto-minting per-agent bearer tokens from a
+  Cloud token
+- `query-snmp-traps`: SNMP trap logs via Cloud or Agent: entries, severities, categories, senders, dedup summaries,
+  `TRAP_*` fields, `TRAP_JSON` searches
 
 Output/reference skill trees, updated when the related public/operator workflow changes: `docs/netdata-ai/skills/`
 (Netdata AI skill artifacts) and `src/ai-skills/` (generated or source AI skill artifacts, when present).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,9 @@ removes debt beats a smaller one that preserves it.
   low-risk and confined to the code you are already modifying. Cleanup reaching into unrelated code is independent
   work (see "Scope Discipline At Every Step"). If you leave adjacent mess in place, record why under disclosure (ii).
 - Reference search (when replacing a path or altering a contract):
-  - You MUST run and record in the SOW a search for remaining references to the replaced path or contract. Search
-    construction sites and prefixes
-    too, not only literal final names; identifiers here are often built dynamically (for example via `fmt.Sprintf`).
+  - You MUST run and record in the SOW (command and result) a search for remaining references to the replaced path
+    or contract. Search construction sites and prefixes too, not only literal final names; identifiers here are often
+    built dynamically (for example via `fmt.Sprintf`).
   - Every surviving reference MUST appear in (i) or (ii) with its scope source, or the target is incomplete. An
     item you did not search for counts as silent scope-narrowing.
   - A repository-wide search cannot prove safety for consumers outside this repo (Netdata Cloud, exporters,
@@ -122,11 +122,11 @@ removes debt beats a smaller one that preserves it.
     regression, NOT "a larger diff is riskier";
   - (c) confirmed by the user as outside the approved scope;
   - (d) accepted by the user, through the Mandatory pause, as an in-scope partial to ship now.
-  - For (a)/(b) you MUST cite specific evidence (file/line, failure class, or test) and route through the Mandatory
-    pause; you do not self-certify "unsafe". For (d) track the remainder per Followup Discipline with why deferral
-    is acceptable and when it lands; repeatedly shipping partials is debt accumulation, not delivery.
-  - Risk reduction, review convenience, smaller diff, and issue staging are NEVER valid reasons and MUST NOT be
-    relabeled "unsafe" or "independent".
+- Exception evidence: for (a)/(b) you MUST cite specific evidence (file/line, failure class, or test) and route
+  through the Mandatory pause; you do not self-certify "unsafe". For (d) track the remainder per Followup Discipline
+  with why deferral is acceptable and when it lands; repeatedly shipping partials is debt accumulation, not delivery.
+- Never valid: risk reduction, review convenience, smaller diff, and issue staging are NEVER valid reasons for a
+  non-clean route and MUST NOT be relabeled "unsafe" or "independent".
 - Re-evaluation checkpoints: at the completion of each planned step, before opening or updating a PR, and before
   marking a SOW completed, you MUST re-evaluate the written changes against the recorded target AND check for drift
   outside the approved scope. You SHOULD also re-evaluate whenever you pause to report progress. Do not keep a
@@ -166,12 +166,14 @@ removes debt beats a smaller one that preserves it.
     step breakdown) MUST be explicitly approved by the user (Approval bar) before implementation: state what is
     being accepted and get confirmation. If the user rejects or edits the plan, revise and re-seek approval. The
     SOW stays `planning` until approval is recorded, then becomes `ready`.
-  - Non-trivial work whose end state is already fixed by the request, an existing project skill, or an established
-    repository pattern (a clear bug fix, a metadata/docs edit with no contract change, a collector skeleton and
-    wiring fixed by its authoring skill) still needs a recorded plan and the Pre-Implementation Gate, but the
-    request IS the recorded approval: no separate round, and this also satisfies the resume re-check and the
-    progress rule. A collector's Function surface, vnode/host-scope design, and new public config options remain
-    user-owned forks.
+  - Fixed end state: non-trivial work whose end state is already fixed by the request, an existing project skill,
+    or an established repository pattern (a clear bug fix, a metadata/docs edit with no contract change, a collector
+    skeleton and wiring fixed by its authoring skill) still needs a recorded plan and the Pre-Implementation Gate,
+    but the request IS the recorded approval.
+    - No separate approval round is held, and the same approval satisfies the resume re-check below and the
+      progress rule ("SOW Lifecycle").
+    - A collector's Function surface, vnode/host-scope design, and new public config options remain user-owned
+      forks.
   - When it is unclear whether a real fork exists, treat it as user-owned and seek approval.
 - Approval persists; re-check on resume: before continuing an `in-progress` or `paused` SOW you did not personally
   take through this gate (takeover, handoff), you MUST confirm the SOW records explicit approval of the current
@@ -215,25 +217,32 @@ SOWs and specs are local-only working memory, never committed:
   | `done/` | finished | `completed` |
 
 - Legacy `active/`: retired. Fold any `.agents/sow/q/active/` files into `current/` (or `done/` if completed);
-  nothing reads `active/` any more, and `worktree-link.sh` does this fold on its next run.
+  nothing reads `active/` any more, and `worktree-link.sh` does this fold whenever it runs.
 - Deletion guard: assistants MUST NOT remove a SOW working file from the local checkout (`rm`, patch delete hunks,
   editor deletes, or any equivalent) unless the user explicitly asks to discard it. A completed SOW MAY stay in
   `done/` as local history or be deleted at the user's request. Never delete one without the user asking.
-- Worktrees: SOW working memory is per-developer, not per-worktree. After creating a git worktree, or after updating an
-  old checkout to this model, run `.agents/sow/worktree-link.sh`. In the origin checkout it creates the queues and folds
-  any legacy top-level queue dirs into `q/`; in a linked worktree it symlinks `.agents/sow/q`, `.agents/sow/specs`,
-  `.local`, and `.env` to the origin checkout (a worktree that already has its own real `.env` keeps it). The script is
-  idempotent, never loses data on a name collision, re-points a symlink whose origin moved, and refuses to run in a
-  worktree whose origin checkout is not yet on this model (it prints how to update it).
+- Worktrees and setup: SOW working memory is per-developer, not per-worktree. Run `.agents/sow/worktree-link.sh`:
+  - once on a fresh clone (it creates the queues), after creating a git worktree, and after updating an old checkout
+    to this model;
+  - in the origin checkout it creates the queues, folds legacy top-level queue dirs into `q/`, and folds a leftover
+    `q/active/` into `current/`;
+  - in a linked worktree it first moves worktree-local `q/`, `specs/`, and `.local/` content into the origin, then
+    symlinks `.agents/sow/q`, `.agents/sow/specs`, `.local`, and `.env` to the origin checkout (a worktree that
+    already has its own real `.env` keeps it);
+  - it is idempotent, never loses data on a name collision, re-points a symlink whose origin moved, and refuses to run
+    in a worktree whose origin checkout is not yet on this model (it prints how to update it).
 - Because nothing is committed there is no commit-for-handoff, no remove-before-merge step, and no CI merge guard
   to clear.
 
 ### When A SOW Is Required
 
-Create or reuse a SOW for non-trivial work: feature work; bug fixes with behavioral impact; refactors; migrations;
-documentation or content changes with product/business impact; process changes; regressions; spec hygiene; project skill
-changes; collector changes; packaging, install, or deployment changes; PR review iteration; static analysis triage that
-changes source, docs, or project policy; any work with unclear risk.
+Create or reuse a SOW for non-trivial work:
+
+- feature work; bug fixes with behavioral impact; refactors; migrations; regressions;
+- documentation or content changes with product/business impact; spec hygiene; project skill changes;
+- process changes; collector changes; packaging, install, or deployment changes;
+- PR review iteration; static analysis triage that changes source, docs, or project policy;
+- any work with unclear risk.
 
 Trivial work needs no SOW: typo fixes; formatting-only changes; mechanical renames with no behavior change; simple
 low-risk search/replace (still grep the old token to confirm no call site is missed).
@@ -263,7 +272,7 @@ Before non-trivial work:
   - `planning`: analysis or decisions incomplete; implementation blocked.
   - `ready`: Pre-Implementation Gate complete and, where the goal-approval round applies, goal and plan approved;
     implementation can start.
-  - `in-progress`: implementation underway.
+  - `in-progress`: implementation underway. Set it with the first implementation-file change.
   - `paused`: intentionally stopped; may resume on the branch.
   - `completed`: validated and durable memory transferred. The successful terminal status.
 - Content hygiene: an active SOW is a current-state handoff, not an append-only transcript.
@@ -275,10 +284,9 @@ Before non-trivial work:
     the conversation or every review nit.
   - Before completion, prune stale history and verify another contributor can determine the current target,
     remaining work, decisions, and evidence without reconstructing chronology.
-- One SOW at a time: several SOWs MAY be in flight in `current/`, but never execute multiple SOWs as one batch. If
-  work overlaps, coordinate through the open PRs
-  and issues, merge or consolidate branches before implementation, or split into separate SOWs and complete one
-  before starting the next.
+- One SOW at a time: several SOWs MAY be in flight in `current/`, but a branch executes one SOW at a time and never
+  executes multiple SOWs as one batch. If work overlaps, coordinate through the open PRs and issues, merge or
+  consolidate branches before implementation, or split into separate SOWs and complete one before starting the next.
 - Progress reports and Re-evaluation checkpoints are not stop points. Once a SOW is in progress with its approval
   recorded, continue until it is delivered, failed with evidence, blocked on a real user decision or approval, or
   superseded by newer user instructions.
@@ -300,19 +308,18 @@ Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeab
 - Content split: the umbrella holds the full clean end state, all user decisions, the decomposition, and cross-step
   follow-up mapping. A step holds its own Pre-Implementation Gate and Validation and cites umbrella decisions by
   number. A step whose end state is fixed by the approved decomposition needs no new approval round.
-- Placement and status: the umbrella lives in `current/` from the first step's start until the last step completes,
-  then moves to `done/`. Its status is `planning` until the decomposition is approved, then `in-progress` while any
-  step is in flight. `paused` on an umbrella means the initiative itself is parked, not "waiting on steps". Steps
-  follow the normal queue rules; the assistant updates the umbrella's `## Steps` table whenever a step changes
-  status or gains a PR.
+- Placement and status: the umbrella lives in `current/` from the first step's start until the last step completes, then
+  moves to `done/`. Its status is `planning` until the decomposition is approved, then `in-progress` while any step is
+  in flight (it skips `ready`: an umbrella is never implemented against directly). `paused` on an umbrella means the
+  initiative itself is parked, not "waiting on steps". Steps follow the normal queue rules; the assistant updates the
+  umbrella's `## Steps` table whenever a step changes status or gains a PR.
 - One SOW at a time applies to steps. The umbrella is never executed and does not count.
 
 ### Pre-Implementation Gate
-
-Implementation MUST NOT begin until the SOW's `## Pre-Implementation Gate` section records `Status: ready` and the
-SOW's top-level status is `ready` or `in-progress`. The gate's own status line takes only `blocked` (gate
-incomplete), `ready`, or `needs-user-decision` (blocked on a user-owned fork); these are gate values, distinct from
-the SOW status values. Before changing implementation files, or before continuing an existing SOW that lacks the
+ Implementation MUST NOT begin until the SOW's `## Pre-Implementation Gate` section records `Gate status: ready` and the
+SOW's top-level `Status:` is `ready` or `in-progress`. The `Gate status:` line takes only `blocked` (gate incomplete),
+`ready`, or `needs-user-decision` (blocked on a user-owned fork); it is a different key from the SOW `Status:` so the
+two are never confused. Before changing implementation files, or before continuing an existing SOW that lacks the
 section, fill the gate. Gate `ready` additionally requires the goal/plan approval of "Plan Before Non-Trivial Work"
 where that round applies.
 
@@ -414,9 +421,12 @@ A SOW cannot be completed until Validation records:
 - real-use evidence when a runnable path exists;
 - reviewer findings and how they were handled;
 - same-failure search results;
+- sensitive data gate: confirmation that the durable artifacts carry no raw sensitive data, with the redactions
+  used;
 - the Artifact Maintenance Gate below, including that no SOW working file or spec was committed;
 - lessons extracted, or the specific reason there were none;
-- workflow-friction triage: each `Workflow Friction & Rule Gaps` note resolved to a rule update (`AGENTS.md`,
+- workflow-friction triage: each note in the SOW's `## Workflow Friction & Rule Gaps` section (template) resolved to
+  a rule update (`AGENTS.md`,
   project skill, spec, or SOW template), an evidence-backed rejection, or a tracked follow-up (or an explicit "none
   arose");
 - follow-up mapping;
@@ -444,7 +454,10 @@ evidence-backed reason it is unaffected.
 ### Enforcement
 
 - `.agents/sow/audit.sh`: local consistency audit for SOW rules, the local-only queue/spec layout, framework files,
-  and sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use.
+  and sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use. The audit pins, as hard
+  failures, the marker line under "SOW System", the section headings listed in its `required_sections`, the exact
+  CRITICAL sensitive-data sentence, legacy `SOW-NNNN` references, and relocated spec paths; renaming a pinned
+  heading means updating `audit.sh` in the same change. It does not scan SOW working files or specs for secrets.
 - `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and
@@ -456,8 +469,9 @@ evidence-backed reason it is unaffected.
 
 ### Sensitive Data In Durable Artifacts
 
-SOWs, specs, documentation, project skills, agent instructions, and code comments are commit-ready artifacts.
-Treat them as public unless a repository-specific policy explicitly says otherwise.
+SOWs, specs, documentation, project skills, agent instructions, and code comments are durable artifacts. Treat them
+as public even when they are local-only, unless a repository-specific policy explicitly says otherwise; no scanner
+covers SOWs and specs, so redaction there is your responsibility.
 
 CRITICAL: Never write raw sensitive data to durable artifacts. This includes passwords, API keys, bearer tokens,
 SNMP communities, private keys, connection strings with embedded credentials, session cookies, community member

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,7 +293,7 @@ Before non-trivial work:
   1. Finish implementation, docs, skills, validation, and follow-up mapping.
   2. Transfer all durable knowledge into project skills, docs, code, and tests (and specs once re-introduced). The
      SOW body MUST then hold nothing durable that is not captured elsewhere.
-  3. Set `Status: completed` and move the file to `.agents/sow/q/done/`.
+  3. Set `Status: completed` and move the file to `.agents/sow/q/done/` (unless the user asks to discard it).
 
 ### Umbrella And Step SOWs
 
@@ -456,8 +456,9 @@ evidence-backed reason it is unaffected.
 - `.agents/sow/audit.sh`: local consistency audit for SOW rules, the local-only queue/spec layout, framework files,
   and sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use. The audit pins, as hard
   failures, the marker line under "SOW System", the section headings listed in its `required_sections`, the exact
-  CRITICAL sensitive-data sentence, legacy `SOW-NNNN` references, and relocated spec paths; renaming a pinned
-  heading means updating `audit.sh` in the same change. It does not scan SOW working files or specs for secrets.
+  CRITICAL sensitive-data sentence, legacy `SOW-NNNN` references, relocated spec paths, missing or untracked
+  framework files, and a `q/` or `specs/` path that is not gitignored; renaming a pinned heading means updating
+  `audit.sh` in the same change. It does not scan SOW working files or specs for secrets.
 - `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and
@@ -524,10 +525,10 @@ root. Never write absolute paths into SOW evidence.
 
 ### Specs
 
-Specs are memory of WHAT this project does. They live under `.agents/sow/specs/` as local-only memory (Storage
-Model); the source tree and public documentation remain the primary ground truth, and specs capture durable
-decisions, cross-cutting rules, and area contracts as they are worked. Durable contracts that must be shared with
-the team right now belong in project skills, docs, code, and tests, not in specs.
+Specs are memory of WHAT this project does (location and local-only status: Storage Model). The source tree and public
+documentation remain the primary ground truth, and specs capture durable decisions, cross-cutting rules, and area
+contracts as they are worked. Durable contracts that must be shared with the team right now belong in project skills,
+docs, code, and tests, not in specs.
 
 - Layout stays flat until scale proves hierarchy is needed. Use `<domain>-<topic>.md`, one durable contract or
   cross-cutting rule per file, organized by contract ownership, not by repository path. Update

--- a/src/go/AGENTS.md
+++ b/src/go/AGENTS.md
@@ -1,9 +1,11 @@
 # Go Area Instructions
 
-This file routes Go-specific work under `src/go/`. The repo-root `AGENTS.md` applies in full; a more specific
-`AGENTS.md` in a subdirectory overrides this file where they conflict, for that subtree. Paths in the routing table
-are repo-relative; Go commands and Go package paths are relative to the module root `src/go/` (the only `go.mod`),
-so run them from there.
+This file routes Go-specific work under `src/go/`. The repo-root `AGENTS.md` applies in full; where the two
+conflict, this more specific file wins. A more specific
+`AGENTS.md` in a subdirectory (today `src/go/plugin/ibm.d/AGENTS.md`) overrides this file for that subtree only where
+the two conflict; everything here that it does not contradict still applies there. Paths are repo-relative unless
+they are Go commands or Go package paths, which are relative to this tree's module root `src/go/` (its `go.mod`); run
+them from there.
 
 ## Task Routing
 
@@ -94,8 +96,8 @@ a plausible future problem is not a requirement.
 metrix commit/collect, per-sample/per-write, and per-cycle code are hot paths: they run for every collector on
 every cycle.
 
-- A hot-path change MUST include before/after `go test -bench` numbers (use `git stash` for the "before"
-  baseline), not just "tests pass".
+- Before/after REQUIRED: a hot-path change MUST include before/after `go test -bench` numbers (use `git stash` for the
+  "before" baseline), not just "tests pass".
 - Allocation count is the gate: assert allocs stay within the intended envelope (for example a sparse commit stays
   ~O(touched), never O(retained)). `ns/op` is a dev-machine trend indicator, NOT a CI gate; label it as such inline
   and never record a personal name in the file.
@@ -109,8 +111,8 @@ every cycle.
 `gofmt` and `goimports` are the baseline. The repository additionally RECOMMENDS (not CI-enforced) this pipeline,
 which keeps wrapping tight and keyed struct literals readable:
 
-1. `golines -m 120 -t 4 -w <paths>`: join over-wrapped signatures/calls and split lines past ~120 columns. Skip if
-   `golines` is not installed (`go install github.com/segmentio/golines@latest`).
+1. `golines -m 120 -t 4 -w <paths>`: join over-wrapped signatures/calls and split lines past ~120 columns. SKIP this
+   step if `golines` is not installed (`go install github.com/segmentio/golines@latest`).
 2. `go run ./tools/expandstructs <paths>`: one keyed struct-literal field per line (formats in-process with
    `go/format`).
 3. `goimports -w <paths>`: order imports.
@@ -122,7 +124,7 @@ Conventions this encodes:
 - Keyed struct literals of a named type go ONE field per line.
 
 `gofmt`/`goimports` cannot express these two rules, so they are not CI-enforced; re-run the pipeline if code drifts.
-See `tools/expandstructs/README.md`.
+See `src/go/tools/expandstructs/README.md`.
 
 ## Validation For Go Changes
 
@@ -132,7 +134,8 @@ See `tools/expandstructs/README.md`.
 - Shared framework code: ALSO build and test representative consumers (a couple of real collectors) plus
   `-race ./plugin/agent/jobmgr/`, so the change is proven against real users, not only its own package.
 - Prefer `testify/require` for prerequisites and `testify/assert` for comparisons. Use `t.Fatal`/`t.Fatalf`
-  directly for genuine test control flow or when no clearer assertion exists.
+  directly for genuine test control flow or when no clearer assertion exists. Test shape: root `AGENTS.md`, "Go
+  Test Style".
 
 ## Go Review And Reachability
 
@@ -147,8 +150,8 @@ See `tools/expandstructs/README.md`.
 
 - Changes SHOULD stay atomic. If a collector or framework task grows, split it into coherent batches before review
   becomes difficult.
-- Every batch boundary is a Re-evaluation checkpoint (root `AGENTS.md`): you MUST re-evaluate clean end state and
-  scope there. If a separate framework fix, collector cleanup, or docs rewrite has become necessary, split it into
-  its own step or submit it independently before continuing.
+- Treat every batch boundary as an additional Re-evaluation checkpoint (root `AGENTS.md`, "Clean End State Over Less
+  Churn"): you MUST re-evaluate clean end state and scope there. If a separate framework fix, collector cleanup, or docs
+  rewrite has become necessary, split it into its own step or submit it independently before continuing.
 - Changes MUST NOT mix framework changes, collector migrations, and integration-doc regeneration unless one coherent
   behavior change requires them.

--- a/src/go/AGENTS.md
+++ b/src/go/AGENTS.md
@@ -16,7 +16,7 @@ This file routes Go-specific work under `src/go/`. The repo-root `AGENTS.md` app
 | IBM.d work | `src/go/plugin/ibm.d/AGENTS.md` | Generator-driven workflow; go.d V2 layout rules MUST NOT be applied there. |
 | Function handlers | `src/go/plugin/framework/functions/README.md`, `src/go/tools/functions-validation/README.md` | Collector Functions SHOULD be isolated behind narrow dependencies. |
 | Topology payloads | `.agents/skills/project-create-topology/SKILL.md`, `.agents/skills/project-create-topology/topology-function-schema.md`, `src/go/pkg/topology/v1` | New producers MUST use the production `netdata.topology.v1` schema. |
-| Host scopes / vnodes | `.agents/skills/project-writing-go-modules-framework-v2/go-v2-host-scope.md`, `src/go/plugin/go.d/collector/azure_monitor/` | Use host scopes when one job emits metrics for resources that SHOULD appear as separate Netdata nodes. |
+| Host scopes / vnodes | `.agents/skills/project-writing-go-modules-framework-v2/go-v2-host-scope.md`, `src/go/plugin/go.d/collector/azure_monitor/` | One job emitting metrics for resources that SHOULD appear as separate Netdata nodes MUST use host scopes. |
 | Matchers/selectors | `src/go/pkg/matcher/README.md` | Prefer existing matcher APIs over custom selector grammars. |
 | Core framework changes | `src/go/plugin/framework/docs/changing-framework-code.md` and "Core Framework Change Gate" below | The applicable approval tier MUST be satisfied before implementation. |
 
@@ -33,8 +33,9 @@ This file routes Go-specific work under `src/go/`. The repo-root `AGENTS.md` app
   Framework Change Gate".
 - Functions: put Function code in a dedicated `<name>func/` package behind a narrow `Deps` interface declared in
   that package. The Function package MUST NOT import the collector package or hold `*Collector`.
-- Topology: use `netdata.topology.v1` with the Go producer model in `src/go/pkg/topology/v1` and validate payloads
-  against `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`. New producers MUST NOT use legacy topology payloads.
+- Topology: producers MUST use `netdata.topology.v1` with the Go producer model in `src/go/pkg/topology/v1` and
+  MUST validate payloads against `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`. New producers MUST NOT use legacy
+  topology payloads.
 - One job emitting metrics for multiple remote resources that SHOULD appear as separate Netdata nodes MUST use V2
   host scopes/vnodes.
 
@@ -50,8 +51,8 @@ This file routes Go-specific work under `src/go/`. The repo-root `AGENTS.md` app
 
 ## Core Framework Change Gate
 
-Shared Go framework code (`metrix`, `chartengine`, `charttpl`, the job runtime, `collectorapi`) runs in EVERY
-collector, most of it on the per-cycle hot path. Before changing it, read
+Shared Go framework code (`metrix`, `chartengine`, `charttpl`, the job runtime, `collectorapi`) is
+high-blast-radius: it runs in EVERY collector, most of it on the per-cycle hot path. Before changing it, read
 `src/go/plugin/framework/docs/changing-framework-code.md`, the canonical owner of the framework-change scope list,
 required design note, validation expectations, and artifact checks. Implementation MUST NOT begin until that guide's
 applicable approval tier is satisfied.
@@ -66,9 +67,6 @@ applicable approval tier is satisfied.
   idle past `expireAfterSuccessCycles + descriptorGraceCycles` is evicted and re-registers cleanly afterward. A
   consumer that caches per-name state across cycles MUST couple its lifetime to the optional
   `metrix.DescriptorRetention` accessor. See `src/go/pkg/metrix/README.md` ("Descriptor Lifecycle and Retention").
-- Batching: changes SHOULD stay atomic; split a growing collector or framework task into coherent batches before
-  review becomes difficult. Changes MUST NOT mix framework changes, collector migrations, and integration-doc
-  regeneration unless one coherent behavior change requires them.
 
 ## Evidence Before Complexity
 
@@ -91,13 +89,14 @@ a plausible future problem is not a requirement.
 
 ## Hot-Path And Benchmark Discipline
 
-metrix commit/collect, per-sample/per-write, and per-cycle code run for every collector on every cycle.
+metrix commit/collect, per-sample/per-write, and per-cycle code are hot paths: they run for every collector on
+every cycle.
 
 - A hot-path change MUST include before/after `go test -bench` numbers (use `git stash` for the "before"
   baseline), not just "tests pass".
-- Allocation count is the gate: assert allocs stay within the intended envelope (a sparse commit stays ~O(touched),
-  never O(retained)). `ns/op` is a dev-machine trend indicator, NOT a CI gate; label it as such inline and never
-  record a personal name in the file.
+- Allocation count is the gate: assert allocs stay within the intended envelope (for example a sparse commit stays
+  ~O(touched), never O(retained)). `ns/op` is a dev-machine trend indicator, NOT a CI gate; label it as such inline
+  and never record a personal name in the file.
 - State the complexity envelope explicitly (for example "commit is O(live-series + touched + distinct-names)") and
   prove the change introduced no O(samples), O(retained), or O(n^2) regression.
 - Keep bench comments in sync with the code they measure, in the same change, with self-contained wording (no
@@ -114,10 +113,14 @@ which keeps wrapping tight and keyed struct literals readable:
    `go/format`).
 3. `goimports -w <paths>`: order imports.
 
-Conventions encoded: a signature, call, return, or composite literal stays on ONE line when it fits ~120 columns
-and wraps only when it does not; keyed struct literals of a named type go ONE field per line. `gofmt`/`goimports`
-cannot express these, so they are not CI-enforced; re-run the pipeline if code drifts. See
-`tools/expandstructs/README.md`.
+Conventions this encodes:
+
+- A signature, call, return, or composite literal stays on ONE line when it fits within ~120 columns; wrap only when
+  it does not.
+- Keyed struct literals of a named type go ONE field per line.
+
+`gofmt`/`goimports` cannot express these two rules, so they are not CI-enforced; re-run the pipeline if code drifts.
+See `tools/expandstructs/README.md`.
 
 ## Validation For Go Changes
 
@@ -137,3 +140,13 @@ cannot express these, so they are not CI-enforced; re-run the pipeline if code d
 - Before deleting Go code as unused, check every reference form: selector reads and writes, struct literals,
   constructor arguments, method values, interface satisfaction, reflection, build-tagged and platform files,
   generated code, and test-only injection. A call-site-only search is not proof of unreachability.
+
+## Batching
+
+- Changes SHOULD stay atomic. If a collector or framework task grows, split it into coherent batches before review
+  becomes difficult.
+- Every batch boundary is a Re-evaluation checkpoint (root `AGENTS.md`): you MUST re-evaluate clean end state and
+  scope there. If a separate framework fix, collector cleanup, or docs rewrite has become necessary, split it into
+  its own step or submit it independently before continuing.
+- Changes MUST NOT mix framework changes, collector migrations, and integration-doc regeneration unless one coherent
+  behavior change requires them.

--- a/src/go/AGENTS.md
+++ b/src/go/AGENTS.md
@@ -1,29 +1,7 @@
 # Go Area Instructions
 
-This file routes Go-specific work under `src/go/`. Repository-wide rules in
-the repo-root `AGENTS.md` still apply. More specific `AGENTS.md` files under
-subdirectories override this file for that subtree. Paths below are
-repo-relative unless stated otherwise.
-
-## Sensitive Data
-
-The repo-root `AGENTS.md` sensitive-data policy applies in full to all durable
-Go artifacts, including code comments, docs, specs, skills, and SOWs.
-
-## Mandatory Development Principles
-
-The repo-root clean-end-state and scope-discipline principles are mandatory and
-apply in full. For Go work, enforce them explicitly when changing collectors,
-framework code, runtime behavior, `metrix`, chart templates, Functions,
-topology, tests, specs, or skills.
-
-- You MUST prefer the clean framework or collector shape over preserving a
-  smaller diff.
-- You MUST re-check scope after each coherent batch. If a separate framework fix,
-  collector cleanup, or docs rewrite becomes necessary, split it into its own
-  step or submit it independently before continuing.
-- You SHOULD use RFC-style requirement language (`MUST`, `SHOULD`, `MAY`) in
-  Go-area specs, skills, and instructions when documenting enforceable rules.
+This file routes Go-specific work under `src/go/`. The repo-root `AGENTS.md` applies in full; a more specific
+`AGENTS.md` in a subdirectory overrides this file for that subtree. Paths are repo-relative unless stated otherwise.
 
 ## Task Routing
 
@@ -31,196 +9,131 @@ topology, tests, specs, or skills.
 |---|---|---|
 | New go.d collector | `src/go/plugin/go.d/docs/how-to-write-a-collector.md` | New go.d collectors use framework V2. |
 | Migrating go.d V1 collector to V2 | `src/go/plugin/go.d/docs/migrate-v1-to-v2.md` | Preserve public contracts unless a breaking change is explicitly approved. |
-| go.d V2 implementation details | `.agents/skills/project-writing-go-modules-framework-v2/SKILL.md`, `src/go/pkg/metrix/README.md`, `src/go/plugin/framework/charttpl/README.md`, `src/go/plugin/framework/chartengine/README.md` | Use the skill for maintainer style and the READMEs for framework API contracts. Editing `metrix` or framework packages is framework-gated work. |
+| go.d V2 implementation details | `.agents/skills/project-writing-go-modules-framework-v2/SKILL.md`, `src/go/pkg/metrix/README.md`, `src/go/plugin/framework/charttpl/README.md`, `src/go/plugin/framework/chartengine/README.md` | Skill for maintainer style, READMEs for framework API contracts. Editing `metrix` or framework packages is framework-gated work. |
 | go.d helper packages | `src/go/plugin/go.d/docs/helper-packages.md` | Check existing HTTP, config-option, matcher, logger, socket, command, SQL, ping, log-file, and cloud-auth helpers before adding custom plumbing. |
-| Collector design across plugins | `.agents/skills/project-writing-collectors/SKILL.md` | Use for NIDL, cardinality, obsoletion, missing data, logging, and config discipline. |
-| Integration metadata, taxonomy, generated docs | `.agents/skills/integrations-lifecycle/SKILL.md`, `.agents/skills/integrations-lifecycle/consistency.md` | Source artifacts and generated artifacts MUST stay synchronized. |
-| IBM.d work | `src/go/plugin/ibm.d/AGENTS.md` | IBM.d has a generator-driven workflow; go.d V2 layout rules MUST NOT be applied there. |
+| Collector design across plugins | `.agents/skills/project-writing-collectors/SKILL.md` | NIDL, cardinality, obsoletion, missing data, logging, config discipline. |
+| Integration metadata, taxonomy, generated docs | `.agents/skills/integrations-lifecycle/SKILL.md`, `.agents/skills/integrations-lifecycle/consistency.md` | Source and generated artifacts MUST stay synchronized. |
+| IBM.d work | `src/go/plugin/ibm.d/AGENTS.md` | Generator-driven workflow; go.d V2 layout rules MUST NOT be applied there. |
 | Function handlers | `src/go/plugin/framework/functions/README.md`, `src/go/tools/functions-validation/README.md` | Collector Functions SHOULD be isolated behind narrow dependencies. |
-| Topology payloads | `.agents/skills/project-create-topology/SKILL.md`, `.agents/skills/project-create-topology/topology-function-schema.md`, `src/go/pkg/topology/v1` | New topology producers MUST use the production `netdata.topology.v1` schema. |
+| Topology payloads | `.agents/skills/project-create-topology/SKILL.md`, `.agents/skills/project-create-topology/topology-function-schema.md`, `src/go/pkg/topology/v1` | New producers MUST use the production `netdata.topology.v1` schema. |
 | Host scopes / vnodes | `.agents/skills/project-writing-go-modules-framework-v2/go-v2-host-scope.md`, `src/go/plugin/go.d/collector/azure_monitor/` | Use host scopes when one job emits metrics for resources that SHOULD appear as separate Netdata nodes. |
 | Matchers/selectors | `src/go/pkg/matcher/README.md` | Prefer existing matcher APIs over custom selector grammars. |
-| Core framework changes | `src/go/plugin/framework/docs/changing-framework-code.md` and `Core Framework Change Gate` below | The applicable approval tier MUST be satisfied before implementation. |
+| Core framework changes | `src/go/plugin/framework/docs/changing-framework-code.md` and "Core Framework Change Gate" below | The applicable approval tier MUST be satisfied before implementation. |
 
 ## New go.d Collector Rules
 
 - New go.d collectors MUST implement `collectorapi.CollectorV2` from
-  `src/go/plugin/framework/collectorapi/collector.go` and register via
-  `CreateV2`. This includes writing metrics through `metrix.CollectorStore` and
-  providing `ChartTemplateYAML()`.
-- New go.d collector guidance MUST NOT teach or copy the V1
-  `Collect() map[string]int64` pattern for new
-  collectors.
-- Collector runtime, metric, chart, config, alert, taxonomy, and documentation
-  changes MUST follow the repository collector consistency policy. The detailed
-  checklist lives in `.agents/skills/integrations-lifecycle/consistency.md`.
-- Public config options SHOULD be added only when they represent a real
-  operator decision. Implementation tuning such as page sizes, scan windows,
-  retry limits, and cadence SHOULD use internal constants unless user control is
-  clearly justified.
-- New collectors MUST NOT inherit unsupported config knobs from adjacent
-  collectors or generic templates.
-- Collector-local globals, singletons, adapters, caches, or glue layers that
-  substitute for missing shared framework/helper capabilities are
-  framework-scope work and MUST follow
-  `src/go/plugin/framework/docs/changing-framework-code.md` before
-  implementation.
-- If the collector exposes Functions, put Function code in a dedicated
-  `<name>func/` package behind a narrow `Deps` interface declared in that
-  package. The Function package MUST NOT import the collector package or hold
-  `*Collector`.
-- If the collector emits topology, it MUST use `netdata.topology.v1`, the Go
-  producer model in `src/go/pkg/topology/v1`, and validate payloads against
-  `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`. New producers MUST NOT use
-  legacy topology payloads.
-- If one job emits metrics for multiple remote resources that SHOULD appear as
-  separate Netdata nodes, it MUST use V2 host scopes/vnodes.
+  `src/go/plugin/framework/collectorapi/collector.go` and register via `CreateV2`: metrics through
+  `metrix.CollectorStore`, charts through `ChartTemplateYAML()`.
+- Guidance for new collectors MUST NOT teach or copy the V1 `Collect() map[string]int64` pattern.
+- Public config options SHOULD exist only for real operator decisions. Implementation tuning (page sizes, scan
+  windows, retry limits, cadence) SHOULD be internal constants unless user control is clearly justified.
+- New collectors MUST NOT inherit unsupported config knobs from adjacent collectors or generic templates.
+- Collector-local glue that substitutes for a missing shared capability is framework-scope work: see "Core
+  Framework Change Gate".
+- Functions: put Function code in a dedicated `<name>func/` package behind a narrow `Deps` interface declared in
+  that package. The Function package MUST NOT import the collector package or hold `*Collector`.
+- Topology: use `netdata.topology.v1` with the Go producer model in `src/go/pkg/topology/v1` and validate payloads
+  against `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`. New producers MUST NOT use legacy topology payloads.
+- One job emitting metrics for multiple remote resources that SHOULD appear as separate Netdata nodes MUST use V2
+  host scopes/vnodes.
 
 ## go.d V1-to-V2 Migration Rules
 
-- V1-to-V2 migrations MUST start with
-  `src/go/plugin/go.d/docs/migrate-v1-to-v2.md`.
-- Migrations MUST preserve chart IDs, contexts, dimensions, config keys,
-  defaults, health lookups, metadata, taxonomy, stock config, and service
-  discovery behavior unless the user explicitly approves a breaking change.
-- Compatibility migration SHOULD be separate from enrichment such as new labels,
-  host scopes, topology, Functions, or config expansion.
-- Completed migrations MUST NOT keep a runtime V1-to-V2 bridge. Temporary V1
-  logic can be used during development for parity checks, but it MUST be
-  removed from the final migrated collector.
+- Migrations MUST start with `src/go/plugin/go.d/docs/migrate-v1-to-v2.md`.
+- Migrations MUST preserve chart IDs, contexts, dimensions, config keys, defaults, health lookups, metadata,
+  taxonomy, stock config, and service discovery behavior unless the user explicitly approves a breaking change.
+- Compatibility migration SHOULD be separate from enrichment (new labels, host scopes, topology, Functions, config
+  expansion).
+- A completed migration MUST NOT keep a runtime V1-to-V2 bridge. Temporary V1 logic MAY serve parity checks during
+  development but MUST be removed from the final collector.
 
 ## Core Framework Change Gate
 
-Changes to shared Go framework code (`metrix`, `chartengine`, `charttpl`, the job
-runtime, `collectorapi`) are high-blast-radius: this code runs in EVERY collector,
-most of it on the per-cycle hot path. Before changing these areas, read
-`src/go/plugin/framework/docs/changing-framework-code.md` — the canonical owner of
-the framework-change scope list, required design note, validation expectations, and
-artifact checks. Implementation MUST NOT begin until that guide's applicable
-approval tier is satisfied.
+Shared Go framework code (`metrix`, `chartengine`, `charttpl`, the job runtime, `collectorapi`) runs in EVERY
+collector, most of it on the per-cycle hot path. Before changing it, read
+`src/go/plugin/framework/docs/changing-framework-code.md`, the canonical owner of the framework-change scope list,
+required design note, validation expectations, and artifact checks. Implementation MUST NOT begin until that guide's
+applicable approval tier is satisfied.
 
-- Clean extension over glue: prefer a clean framework extension over
-  collector-local globals, singletons, adapters, or private-package coupling when
-  the problem is general.
-- Behavior preservation: when a framework change also touches shipped collectors,
-  preserve their observable behavior (chart IDs, contexts, dimensions, config keys,
-  defaults) and validate representative consumers, not only the framework package
-  (see "Validation For Go Changes").
-- metrix contract: `metrix` keeps one descriptor per metric NAME, resolved
-  atomically at commit and bounded — a name idle past `expireAfterSuccessCycles +
-  descriptorGraceCycles` is evicted, and re-registers cleanly afterward. A consumer
-  that caches per-name state across cycles MUST couple its lifetime to the optional
-  `metrix.DescriptorRetention` accessor. See `src/go/pkg/metrix/README.md`
-  ("Descriptor Lifecycle and Retention").
+- Clean extension over glue: when the problem is general, prefer a clean framework extension over collector-local
+  globals, singletons, adapters, caches, or private-package coupling. Such glue that substitutes for a missing
+  shared framework or helper capability MUST go through this gate before implementation.
+- Behavior preservation: when a framework change also touches shipped collectors, preserve their observable
+  behavior (chart IDs, contexts, dimensions, config keys, defaults) and validate representative consumers, not only
+  the framework package (see "Validation For Go Changes").
+- metrix contract: `metrix` keeps one descriptor per metric NAME, resolved atomically at commit and bounded: a name
+  idle past `expireAfterSuccessCycles + descriptorGraceCycles` is evicted and re-registers cleanly afterward. A
+  consumer that caches per-name state across cycles MUST couple its lifetime to the optional
+  `metrix.DescriptorRetention` accessor. See `src/go/pkg/metrix/README.md` ("Descriptor Lifecycle and Retention").
+- Batching: changes SHOULD stay atomic; split a growing collector or framework task into coherent batches before
+  review becomes difficult. Changes MUST NOT mix framework changes, collector migrations, and integration-doc
+  regeneration unless one coherent behavior change requires them.
 
 ## Evidence Before Complexity
 
-Readability and maintainability are the default for Go control-plane and
-framework code. Complexity needs evidence; a plausible future problem is not a
-requirement.
+Readability and maintainability are the default for Go control-plane and framework code. Complexity needs evidence;
+a plausible future problem is not a requirement.
 
-- Code MUST NOT introduce population, byte, concurrency, queue, retry, or
-  backpressure limits, nor add accounting, scheduling, pooling, caching, custom
-  data structures, or lifecycle machinery, unless the design follows from a
-  concrete correctness, liveness, protocol, compatibility, or security contract,
-  a documented scale requirement, or a measured production workload.
-- The justification MUST identify the input or producer, the failure being
-  prevented, the expected scale, and why simpler slices, maps, channels, or
-  direct ownership are insufficient. A round number, hypothetical abuse case,
-  or benchmark in isolation is not evidence of a product requirement.
-- Protocol- and security-derived bounds MUST remain tied to their source with a
-  concise rationale and boundary tests. Do not generalize one per-item bound
-  into an aggregate process policy without separate evidence.
-- When a limit has no valid requirement, remove the policy and its coupled
-  machinery. Raising it to an effectively unreachable value is not the clean
-  end state.
-- Do not add allocation- or latency-oriented complexity until the path is shown
-  to be hot by its production frequency, a profile, or representative benchmark.
-  Once a path is established as hot, follow "Hot-Path And Benchmark Discipline."
+- Code MUST NOT introduce population, byte, concurrency, queue, retry, or backpressure limits, nor add accounting,
+  scheduling, pooling, caching, custom data structures, or lifecycle machinery, unless the design follows from a
+  concrete correctness, liveness, protocol, compatibility, or security contract, a documented scale requirement, or
+  a measured production workload.
+- The justification MUST identify the input or producer, the failure being prevented, the expected scale, and why
+  simpler slices, maps, channels, or direct ownership are insufficient. A round number, a hypothetical abuse case,
+  or a benchmark in isolation is not evidence of a product requirement.
+- Protocol- and security-derived bounds MUST stay tied to their source with a concise rationale and boundary tests.
+  Do not generalize one per-item bound into an aggregate process policy without separate evidence.
+- When a limit has no valid requirement, remove the policy and its coupled machinery. Raising it to an effectively
+  unreachable value is not the clean end state.
+- Do not add allocation- or latency-oriented complexity until the path is shown hot by production frequency, a
+  profile, or a representative benchmark. Once hot, follow "Hot-Path And Benchmark Discipline".
 
 ## Hot-Path And Benchmark Discipline
 
-metrix commit/collect, per-sample/per-write, and per-cycle code are hot paths that
-run for every collector on every cycle.
+metrix commit/collect, per-sample/per-write, and per-cycle code run for every collector on every cycle.
 
-- Before/after REQUIRED: a hot-path change MUST include before/after
-  `go test -bench` numbers (use `git stash` for the "before" baseline), not just
-  "tests pass".
-- Allocation count is the gate: assert allocs stay within the intended envelope
-  (e.g. a sparse commit stays ~O(touched), never O(retained)). `ns/op` is a
-  dev-machine trend indicator, NOT a CI gate — label it as such inline, and never
+- A hot-path change MUST include before/after `go test -bench` numbers (use `git stash` for the "before"
+  baseline), not just "tests pass".
+- Allocation count is the gate: assert allocs stay within the intended envelope (a sparse commit stays ~O(touched),
+  never O(retained)). `ns/op` is a dev-machine trend indicator, NOT a CI gate; label it as such inline and never
   record a personal name in the file.
-- State the complexity envelope explicitly (e.g. "commit is O(live-series +
-  touched + distinct-names)") and prove the change did not introduce an
-  O(samples)/O(retained)/O(n^2) regression.
-- Keep bench comments in sync with the code they measure, in the same change, with
-  self-contained wording (no round/session references).
+- State the complexity envelope explicitly (for example "commit is O(live-series + touched + distinct-names)") and
+  prove the change introduced no O(samples), O(retained), or O(n^2) regression.
+- Keep bench comments in sync with the code they measure, in the same change, with self-contained wording (no
+  round or session references).
 
 ## Go Formatting
 
-`gofmt` and `goimports` are the baseline. This repository additionally
-RECOMMENDS (not CI-enforced) a fuller formatting pipeline that keeps line
-wrapping tight and keyed struct literals readable:
+`gofmt` and `goimports` are the baseline. The repository additionally RECOMMENDS (not CI-enforced) this pipeline,
+which keeps wrapping tight and keyed struct literals readable:
 
-1. `golines -m 120 -t 4 -w <paths>` — join over-wrapped signatures/calls and
-   split lines past ~120 columns. SKIP this step if `golines` is not installed
-   (`go install github.com/segmentio/golines@latest`).
-2. `go run ./tools/expandstructs <paths>` — put each keyed struct-literal field
-   on its own line. Formats source in-process with `go/format`.
-3. `goimports -w <paths>` — order imports.
+1. `golines -m 120 -t 4 -w <paths>`: join over-wrapped signatures/calls and split lines past ~120 columns. Skip if
+   `golines` is not installed (`go install github.com/segmentio/golines@latest`).
+2. `go run ./tools/expandstructs <paths>`: one keyed struct-literal field per line (formats in-process with
+   `go/format`).
+3. `goimports -w <paths>`: order imports.
 
-Conventions this encodes:
-
-- Keep a signature / call / return / composite literal on ONE line when it fits
-  within ~120 columns; wrap only when it does not.
-- Keyed struct literals of a named type go ONE field per line.
-
-`gofmt`/`goimports` cannot express these two rules, so they are not CI-enforced;
-re-run the pipeline if code drifts. See `tools/expandstructs/README.md`.
+Conventions encoded: a signature, call, return, or composite literal stays on ONE line when it fits ~120 columns
+and wraps only when it does not; keyed struct literals of a named type go ONE field per line. `gofmt`/`goimports`
+cannot express these, so they are not CI-enforced; re-run the pipeline if code drifts. See
+`tools/expandstructs/README.md`.
 
 ## Validation For Go Changes
 
-Run the narrowest command that actually exercises the change; do not claim
-full-project validation from a narrow one.
-
-- Always: formatted per "Go Formatting" above (at minimum `gofmt` clean) and
-  `go vet ./<pkg>/` clean.
-- Unit: `go test -count=1 ./<pkg>/...` for every package you touched.
-- Concurrency: add `-race` for concurrency-sensitive packages (`metrix`, the job
-  runtime, `plugin/agent/jobmgr`).
-- Shared framework code: ALSO build and test representative consumers (a couple of
-  real collectors) plus `-race ./plugin/agent/jobmgr/`, so a framework change is
-  proven against real users, not just its own package.
-- Reproduce a reviewer-reported bug as a FAILING test first, then fix to green
-  (repo-wide working-style rule).
-- Prefer `testify/require` for test prerequisites and `testify/assert` for
-  comparisons when applicable. Use `t.Fatal` or `t.Fatalf` directly when it
-  represents genuine test control flow or has no clearer assertion equivalent.
+- Always: formatted per "Go Formatting" (at minimum `gofmt` clean) and `go vet ./<pkg>/` clean.
+- Unit: `go test -count=1 ./<pkg>/...` for every package touched.
+- Concurrency: add `-race` for concurrency-sensitive packages (`metrix`, the job runtime, `plugin/agent/jobmgr`).
+- Shared framework code: ALSO build and test representative consumers (a couple of real collectors) plus
+  `-race ./plugin/agent/jobmgr/`, so the change is proven against real users, not only its own package.
+- Prefer `testify/require` for prerequisites and `testify/assert` for comparisons. Use `t.Fatal`/`t.Fatalf`
+  directly for genuine test control flow or when no clearer assertion exists.
 
 ## Go Review And Reachability
 
-- Start review at the declared interface and the shipped production adapter.
-  Inspect implementation internals behind that boundary only when the contract
-  leaves relevant behavior unspecified or concrete evidence points across it.
-  Do not make a caller responsible for arbitrary private behavior of every
-  implementation.
-- Before deleting Go code as unused, check all relevant reference forms:
-  selector reads and writes, struct literals, constructor arguments, method
-  values, interface satisfaction, reflection, build-tagged and platform files,
-  generated code, and test-only injection. A call-site-only search is not proof
-  of unreachability.
-
-## Batching And Review
-
-- Changes SHOULD stay atomic. If a collector or framework task grows, split it
-  into coherent batches before review becomes difficult.
-- At every batch boundary, you MUST re-evaluate clean end state and scope. If
-  the branch now contains independent work, pause and submit that work
-  separately or defer it before continuing.
-- Changes MUST NOT mix framework changes, collector migrations, and
-  integration-doc regeneration unless they are required for one coherent
-  behavior change.
-- Multi-round review: checkpoint-commit each validated change before its review and
-  squash at PR time; if findings keep clustering in one subsystem (~2-3 rounds),
-  stop patching and fix the class (repo-wide review rules).
-- For Go test style, follow the repo-root `AGENTS.md` "Go test style" section.
+- Start review at the declared interface and the shipped production adapter. Inspect implementation internals
+  behind that boundary only when the contract leaves relevant behavior unspecified or concrete evidence points
+  across it. Do not make a caller responsible for arbitrary private behavior of every implementation.
+- Before deleting Go code as unused, check every reference form: selector reads and writes, struct literals,
+  constructor arguments, method values, interface satisfaction, reflection, build-tagged and platform files,
+  generated code, and test-only injection. A call-site-only search is not proof of unreachability.

--- a/src/go/AGENTS.md
+++ b/src/go/AGENTS.md
@@ -1,7 +1,9 @@
 # Go Area Instructions
 
 This file routes Go-specific work under `src/go/`. The repo-root `AGENTS.md` applies in full; a more specific
-`AGENTS.md` in a subdirectory overrides this file for that subtree. Paths are repo-relative unless stated otherwise.
+`AGENTS.md` in a subdirectory overrides this file where they conflict, for that subtree. Paths in the routing table
+are repo-relative; Go commands and Go package paths are relative to the module root `src/go/` (the only `go.mod`),
+so run them from there.
 
 ## Task Routing
 


### PR DESCRIPTION
##### Summary

Slim the two agent-instruction files without dropping any directive.

- `AGENTS.md`: 1030 -> 691 lines (~15.4k -> ~11.9k tokens). Every rule is now stated once in the section that owns
  it; SOW terms are defined before the principles that use them; the "Core" summary, the three mermaid diagrams,
  and bootstrap residue are gone. New: SOW queue definitions (`pending/current/done`, `active/` retired), umbrella +
  step SOW mechanics, Git And PR Workflow, how a review is obtained, `audit.sh` in the Validation Gate, gate-status
  vocabulary (`Gate status:` as its own key), and a complete skills index.
- `src/go/AGENTS.md`: 226 -> 157 lines. Sections that only restated root rules are removed; Go-specific rules kept.
- Framework files: `audit.sh` (new required headings; audits `current/`; no longer scans gitignored `TODO-*.md`,
  which produced two false failures on a clean checkout), `worktree-link.sh` (drops `active/` from the canonical
  queues and folds a leftover `q/active/` into `q/current/`), `SOW.template.md` (optional `Umbrella:` line and
  `## Steps` table, Validation slots for clean-end-state evidence, duplicate close-out fields removed, reflowed at
  120 columns in a separate commit; umbrella SOWs exempt from the audit's structural needles).



##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slims the agent instruction files without dropping any directive: `AGENTS.md` drops from 1030 to 691 lines and `src/go/AGENTS.md` from 226 to 157. Rules that were repeated across sections and files are now stated once in the section that owns them.

**Behavior changes**
- Retires the `active/` SOW queue: `worktree-link.sh` folds any leftover `active/` folder into `current/` instead of treating it as canonical.
- `audit.sh` now checks the new required headings and audits `current/`; it also stops scanning gitignored `TODO-*.md` files, fixing two false failures on a clean checkout.
- `SOW.template.md` adds an optional `Umbrella:` line, a `## Steps` table, and clean-end-state evidence slots, and removes duplicate close-out fields; umbrella SOWs skip structural audit checks.

**Content moves**
- `AGENTS.md` states each rule once in the section that owns it, adding SOW queue definitions, umbrella/step SOW mechanics, a Git And PR Workflow section, review sourcing, and a complete skills index, and drops the Core summary, diagrams, and bootstrap residue.
- `src/go/AGENTS.md` keeps only Go-specific rules; sections that restated root rules are removed.

<sup>Written for commit 44485f696d1d3bcc616594b95fe279626bf4f919. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated SOW templates with clearer lifecycle statuses, approval gates, umbrella/step tracking, validation evidence, maintenance checks, and streamlined outcome reporting.
  - Revised Go development guidance with clarified module paths, task routing, collector requirements, formatting references, and validation practices.

- **Chores**
  - Updated SOW auditing to recognize the revised documentation structure and handle umbrella SOWs, specification files, and symlinked skills.
  - Retired the legacy `active` queue by merging existing entries into `current` and preventing new `active` queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->