### PR TITLE
sow: make the template the single schema for SOW structure

### DIFF
--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -1,5 +1,8 @@
 # SOW-YYYYMMDD-<slug> - <Title>
 
+This template is the schema of a SOW. Every `##` section not marked `(optional ...)` MUST be present and filled;
+`.agents/sow/audit.sh` derives its structural check from these headings. Field semantics live in the placeholders.
+
 ## Status
 
 Status: planning
@@ -50,7 +53,7 @@ Unknowns:
 - <Outcome with verification method.>
 - <Outcome with verification method.>
 
-## Analysis
+## Analysis (optional)
 
 Sources checked:
 
@@ -138,14 +141,14 @@ Open decisions:
 
 <Numbered user decisions, options, selection, and reasoning. User decisions must be recorded before implementation.>
 
-## Plan
+## Plan (optional)
 
 1. <chunk, scope, risk, dependencies>
 2. <chunk, scope, risk, dependencies>
 
-## Steps
+## Steps (optional: umbrella SOWs only)
 
-Umbrella SOWs only (see "Umbrella And Step SOWs" in `AGENTS.md`); delete this section otherwise.
+See "Umbrella And Step SOWs" in `AGENTS.md`; delete this section in step SOWs.
 
 | # | Step SOW | Status | PR |
 |---|---|---|---|
@@ -232,6 +235,6 @@ Follow-up mapping:
 
 - <implemented/rejected/GitHub issue link>
 
-## Outcome
+## Outcome (optional)
 
 Pending.

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -141,10 +141,6 @@ Open decisions:
 
 <Numbered user decisions, options, selection, and reasoning. User decisions must be recorded before implementation.>
 
-## Plan (optional)
-
-1. <chunk, scope, risk, dependencies>
-2. <chunk, scope, risk, dependencies>
 
 ## Steps (optional: umbrella SOWs only)
 

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -1,7 +1,9 @@
 # SOW-YYYYMMDD-<slug> - <Title>
 
-This template is the schema of a SOW. Every `##` section not marked `(optional ...)` MUST be present and filled;
-`.agents/sow/audit.sh` derives its structural check from these headings. Field semantics live in the placeholders.
+This template is the schema of a SOW. `.agents/sow/audit.sh` derives the required sections from the `##` headings and
+their tags: untagged = required in every SOW; `<!-- sow:implementation -->` = required except in umbrella SOWs;
+`<!-- sow:umbrella-only -->` = required only in umbrella SOWs; `<!-- sow:optional -->` = never required. The audit
+checks presence; filling every field is your responsibility. Field semantics live in the placeholders.
 
 ## Status
 
@@ -53,7 +55,7 @@ Unknowns:
 - <Outcome with verification method.>
 - <Outcome with verification method.>
 
-## Analysis (optional)
+## Analysis <!-- sow:optional -->
 
 Sources checked:
 
@@ -67,7 +69,7 @@ Risks:
 
 - <risk and implication>
 
-## Pre-Implementation Gate
+## Pre-Implementation Gate <!-- sow:implementation -->
 
 Gate status: blocked
 
@@ -142,9 +144,9 @@ Open decisions:
 <Numbered user decisions, options, selection, and reasoning. User decisions must be recorded before implementation.>
 
 
-## Steps (optional: umbrella SOWs only)
+## Steps <!-- sow:umbrella-only -->
 
-See "Umbrella And Step SOWs" in `AGENTS.md`; delete this section in step SOWs.
+See "Umbrella And Step SOWs" in `AGENTS.md`; delete this section in non-umbrella SOWs.
 
 | # | Step SOW | Status | PR |
 |---|---|---|---|
@@ -158,7 +160,7 @@ See "Umbrella And Step SOWs" in `AGENTS.md`; delete this section in step SOWs.
   and reviewers. Keep this a current-state handoff: consolidate superseded rounds
   and do not reproduce the conversation or every review nit.>
 
-## Workflow Friction & Rule Gaps
+## Workflow Friction & Rule Gaps <!-- sow:implementation -->
 
 Running capture of anything that suggests a rule or workflow change: a rule that
 was missing, ambiguous, or slowed the work; a practice worth codifying; a review
@@ -168,7 +170,7 @@ Maintenance Gate).
 
 - <observation + which artifact it may touch (AGENTS.md / project skill / spec / SOW template)>
 
-## Validation
+## Validation <!-- sow:implementation -->
 
 Acceptance criteria evidence:
 
@@ -190,11 +192,11 @@ Tests or equivalent validation:
 
 Real-use evidence:
 
-- <manual/API/CLI/UI path>
+- <manual/API/CLI/UI path; or why no runnable path exists>
 
 Reviewer findings:
 
-- <reviewer and findings>
+- <reviewer; each finding and how it was handled: verified and fixed, rejected with evidence, or tracked>
 
 Same-failure scan:
 
@@ -210,7 +212,7 @@ Sensitive data gate:
   names, customer names, personal data, non-private customer-identifying IPs, private endpoints, or proprietary incident
   details; note redactions used.>
 
-## Artifact Maintenance Gate
+## Artifact Maintenance Gate <!-- sow:implementation -->
 
 - AGENTS.md: <updated path or evidence-backed reason no update was needed>
 - Runtime project skills: <updated .agents/skills/project-*/ path or evidence-backed reason no update was needed>
@@ -231,6 +233,6 @@ Follow-up mapping:
 
 - <implemented/rejected/GitHub issue link>
 
-## Outcome (optional)
+## Outcome <!-- sow:optional -->
 
 Pending.

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -137,15 +137,33 @@ ok "$total_sows local SOW working file(s) under .agents/sow/q (local-only, never
 
 # Structural completeness is advisory and checked only for in-flight SOWs in the
 # current queue; pending stubs and completed (done/) history are exempt.
-# Required sections come from the template (the SOW schema): every '## ' heading
-# not marked "(optional". The two sensitive-data field labels are pinned here as a
-# security contract (they also exist in the template).
-required_sow_sections=()
+# Required sections come from the template (the SOW schema). Each '## ' heading
+# carries an optional HTML-comment tag: none = required in every SOW;
+# sow:implementation = required except in umbrella SOWs; sow:umbrella-only =
+# required only in umbrella SOWs; sow:optional = never required. The two
+# sensitive-data field labels are pinned here as a security contract (they also
+# exist in the template). Needles are compared as whole lines after stripping
+# trailing whitespace and any HTML comment, on both sides.
+sow_base_sections=(); sow_impl_sections=(); sow_umbrella_sections=()
+# Normalize a line for matching: drop CR, trailing HTML comment, trailing space,
+# a leading list marker, and bold markers.
+strip_line() { tr -d '\r' | sed -E 's/[[:space:]]*<!--.*-->[[:space:]]*$//; s/[[:space:]]+$//; s/^[[:space:]]*[-*]+[[:space:]]+//; s/\*\*//g'; }
 while IFS= read -r h; do
-  [ -n "$h" ] && required_sow_sections+=("$h")
-done < <(grep -E '^## ' .agents/sow/SOW.template.md 2>/dev/null | grep -v -i '(optional')
+  [ -n "$h" ] || continue
+  case "$h" in
+    *"<!--"*sow:optional*)      ;;
+    *"<!--"*sow:umbrella-only*) sow_umbrella_sections+=("$(printf '%s\n' "$h" | strip_line)") ;;
+    *"<!--"*sow:implementation*) sow_impl_sections+=("$(printf '%s\n' "$h" | strip_line)") ;;
+    *)                          sow_base_sections+=("$(printf '%s\n' "$h" | strip_line)") ;;
+  esac
+done < <(grep -E '^## ' .agents/sow/SOW.template.md 2>/dev/null)
 pinned_sow_fields=("Sensitive data handling plan:" "Sensitive data gate:")
-[ "${#required_sow_sections[@]}" -gt 0 ] || fail "could not derive required SOW sections from .agents/sow/SOW.template.md"
+# $1 needle, $2 file. "## " headings must match a whole line; "Label:" fields match a
+# line prefix (inline content allowed). awk reads all input, so no SIGPIPE under pipefail.
+sow_has_line() {
+  local mode=prefix; case "$1" in "## "*) mode=exact ;; esac
+  strip_line < "$2" | awk -v n="$1" -v m="$mode" '(m=="exact" && $0==n) || (m=="prefix" && index($0,n)==1) {f=1} END{exit !f}'
+}
 active_count=0
 if [ -d .agents/sow/q/current ]; then
   while IFS= read -r sow; do
@@ -165,9 +183,18 @@ if [ -d .agents/sow/q/current ]; then
         ;;
     esac
 
-    case "$sow" in *-umbrella.md) continue ;; esac   # umbrellas hold no gate/validation by design
-    for needle in "${required_sow_sections[@]}" "${pinned_sow_fields[@]}"; do
-      if grep -qF "$needle" "$sow"; then
+    if [ "${#sow_base_sections[@]}" -eq 0 ]; then
+      warn "template headings unreadable; structural SOW check skipped"
+      continue
+    fi
+    # Umbrella SOWs hold decisions and the step table, not a gate or validation.
+    needles=("${sow_base_sections[@]}")
+    case "$sow" in
+      *-umbrella.md) needles+=(${sow_umbrella_sections[@]+"${sow_umbrella_sections[@]}"}) ;;
+      *)             needles+=(${sow_impl_sections[@]+"${sow_impl_sections[@]}"} "${pinned_sow_fields[@]}") ;;
+    esac
+    for needle in "${needles[@]}"; do
+      if sow_has_line "$needle" "$sow"; then
         ok "$sow contains $needle"
       else
         warn "$sow is missing $needle"

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -74,35 +74,7 @@ else
   fail "AGENTS.md is missing"
 fi
 
-section "canonical AGENTS.md sections"
-required_sections=(
-  "## Goals"
-  "## Development Principles"
-  "## SOW System"
-  "### Storage Model"
-  "### Umbrella And Step SOWs"
-  "### Pre-Implementation Gate"
-  "### Git Worktrees"
-  "### Git And PR Workflow"
-  "### Review"
-  "### Regressions"
-  "### Validation Gate"
-  "### Enforcement"
-  "### Sensitive Data In Durable Artifacts"
-  "### Durable AI-Facing Artifact Formatting"
-  "### Open-Source Reference Evidence"
-  "### Specs"
-  "### Project Skills"
-)
-
-for heading in "${required_sections[@]}"; do
-  if grep -qF "$heading" AGENTS.md 2>/dev/null; then
-    ok "$heading"
-  else
-    fail "$heading is missing"
-  fi
-done
-
+section "AGENTS.md machine contracts"
 if grep -qF "CRITICAL: Never write raw sensitive data to durable artifacts." AGENTS.md 2>/dev/null; then
   ok "CRITICAL sensitive-data warning"
 else
@@ -165,6 +137,15 @@ ok "$total_sows local SOW working file(s) under .agents/sow/q (local-only, never
 
 # Structural completeness is advisory and checked only for in-flight SOWs in the
 # current queue; pending stubs and completed (done/) history are exempt.
+# Required sections come from the template (the SOW schema): every '## ' heading
+# not marked "(optional". The two sensitive-data field labels are pinned here as a
+# security contract (they also exist in the template).
+required_sow_sections=()
+while IFS= read -r h; do
+  [ -n "$h" ] && required_sow_sections+=("$h")
+done < <(grep -E '^## ' .agents/sow/SOW.template.md 2>/dev/null | grep -v -i '(optional')
+pinned_sow_fields=("Sensitive data handling plan:" "Sensitive data gate:")
+[ "${#required_sow_sections[@]}" -gt 0 ] || fail "could not derive required SOW sections from .agents/sow/SOW.template.md"
 active_count=0
 if [ -d .agents/sow/q/current ]; then
   while IFS= read -r sow; do
@@ -185,13 +166,7 @@ if [ -d .agents/sow/q/current ]; then
     esac
 
     case "$sow" in *-umbrella.md) continue ;; esac   # umbrellas hold no gate/validation by design
-    for needle in \
-      "## Pre-Implementation Gate" \
-      "Sensitive data handling plan:" \
-      "Sensitive data gate:" \
-      "## Validation" \
-      "## Artifact Maintenance Gate"
-    do
+    for needle in "${required_sow_sections[@]}" "${pinned_sow_fields[@]}"; do
       if grep -qF "$needle" "$sow"; then
         ok "$sow contains $needle"
       else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,9 @@ Before non-trivial work:
 
 ### SOW Lifecycle
 
-- Create new SOWs from `.agents/sow/SOW.template.md` (project-local; MAY be customized). Create the file in
+- Create new SOWs from `.agents/sow/SOW.template.md` (project-local; MAY be customized). The template is the schema
+  of a SOW: every `##` section not marked `(optional ...)` MUST be present and filled, and `audit.sh` derives its
+  structural check from those headings, so adding a field means editing the template only. Create the file in
   `pending/` when the work is queued but not started, or directly in `current/` when starting now; move it from
   `pending/` to `current/` when you begin filling the Pre-Implementation Gate.
 - Filename: `SOW-YYYYMMDD-{slug}.md`, creation date plus descriptive slug. There is no sequential counter because it
@@ -323,13 +325,10 @@ two are never confused. Before changing implementation files, or before continui
 section, fill the gate. Gate `ready` additionally requires the goal/plan approval of "Plan Before Non-Trivial Work"
 where that round applies.
 
-The gate MUST record: problem/root-cause model; evidence reviewed; affected contracts and surfaces; the
-clean-end-state target with its removed-redundant and excluded-coupled items and the reference search where a path
-or contract is replaced; existing patterns to reuse; risk and blast radius; sensitive data handling plan (covering
-SOWs, specs, documentation, project skills, agent instructions, and code comments); implementation plan; validation
-plan; artifact impact plan; open decisions. Placeholders such as `TBD`, `N/A`, or "to be checked later" are invalid
-unless the SOW explains why the item truly does not apply. If the gate exposes an unknown that investigation cannot
-resolve, stop and ask the user before implementation.
+The gate MUST fill every field of the template's `## Pre-Implementation Gate` section (the template is the SOW schema,
+see "SOW Lifecycle"; field semantics live in its placeholders). Placeholders such as `TBD`, `N/A`, or "to be checked
+later" are invalid unless the SOW explains why the item truly does not apply. If the gate exposes an unknown that
+investigation cannot resolve, stop and ask the user before implementation.
 
 ### Git Worktrees
 
@@ -409,30 +408,9 @@ Do not resurrect or mutate a prior SOW.
 
 ### Validation Gate
 
-A SOW cannot be completed until Validation records:
-
-- acceptance criteria evidence;
-- clean-end-state evidence: the delivered state matches the recorded target, including its removed-redundant and
-  excluded-coupled lists and, where a path or contract was replaced, the recorded reference search; or an explicit
-  user approval for a non-clean state is recorded and linked;
-- deferred clean-end-state remainder: any target work deferred under an approved partial (exception (d)) or
-  otherwise tracked rather than done, with why deferral was acceptable and when (or under what condition) it lands;
-- tests or equivalent validation;
-- real-use evidence when a runnable path exists;
-- reviewer findings and how they were handled;
-- same-failure search results;
-- sensitive data gate: confirmation that the durable artifacts carry no raw sensitive data, with the redactions
-  used;
-- the Artifact Maintenance Gate below, including that no SOW working file or spec was committed;
-- lessons extracted, or the specific reason there were none;
-- workflow-friction triage: each note in the SOW's `## Workflow Friction & Rule Gaps` section (template) resolved to
-  a rule update (`AGENTS.md`,
-  project skill, spec, or SOW template), an evidence-backed rejection, or a tracked follow-up (or an explicit "none
-  arose");
-- follow-up mapping;
-- `.agents/sow/audit.sh` passing, or every remaining failure explained.
-
-Generic "N/A" is invalid.
+A SOW cannot be completed until every field of the template's `## Validation` and `## Artifact Maintenance Gate`
+sections holds evidence. The template is the authoritative list of what Validation records; the semantics of each
+field live in its placeholder. Generic "N/A" is invalid.
 
 ### Artifact Maintenance Gate
 
@@ -455,10 +433,10 @@ evidence-backed reason it is unaffected.
 
 - `.agents/sow/audit.sh`: local consistency audit for SOW rules, the local-only queue/spec layout, framework files,
   and sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use. The audit pins, as hard
-  failures, the marker line under "SOW System", the section headings listed in its `required_sections`, the exact
-  CRITICAL sensitive-data sentence, legacy `SOW-NNNN` references, relocated spec paths, missing or untracked
-  framework files, and a `q/` or `specs/` path that is not gitignored; renaming a pinned heading means updating
-  `audit.sh` in the same change. It does not scan SOW working files or specs for secrets.
+  failures, the marker line under "SOW System", the exact CRITICAL sensitive-data sentence, legacy `SOW-NNNN`
+  references, relocated spec paths, missing or untracked framework files, and a `q/` or `specs/` path that is not
+  gitignored. It checks in-flight SOW files (advisory) for the template's required sections plus the two
+  sensitive-data field labels. It does not scan SOW working files or specs for secrets.
 - `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,8 +263,11 @@ Before non-trivial work:
 ### SOW Lifecycle
 
 - Create new SOWs from `.agents/sow/SOW.template.md` (project-local; MAY be customized). The template is the schema
-  of a SOW: every `##` section not marked `(optional ...)` MUST be present and filled, and `audit.sh` derives its
-  structural check from those headings, so adding a field means editing the template only. Create the file in
+  of a SOW: its `##` headings carry `<!-- sow:... -->` tags saying which SOW kinds require each section (explained at
+  the top of the template), and `audit.sh` derives its structural check from them, so adding or renaming a section
+  needs no audit change. Two field labels are additionally pinned in `audit.sh` (`Sensitive data handling plan:`,
+  `Sensitive data gate:`); renaming either in the template means updating `audit.sh` in the same change. The audit
+  checks presence only; every required section MUST still be filled. Create the file in
   `pending/` when the work is queued but not started, or directly in `current/` when starting now; move it from
   `pending/` to `current/` when you begin filling the Pre-Implementation Gate.
 - Filename: `SOW-YYYYMMDD-{slug}.md`, creation date plus descriptive slug. There is no sequential counter because it
@@ -431,12 +434,12 @@ evidence-backed reason it is unaffected.
 
 ### Enforcement
 
-- `.agents/sow/audit.sh`: local consistency audit for SOW rules, the local-only queue/spec layout, framework files,
-  and sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use. The audit pins, as hard
-  failures, the marker line under "SOW System", the exact CRITICAL sensitive-data sentence, legacy `SOW-NNNN`
-  references, relocated spec paths, missing or untracked framework files, and a `q/` or `specs/` path that is not
-  gitignored. It checks in-flight SOW files (advisory) for the template's required sections plus the two
-  sensitive-data field labels. It does not scan SOW working files or specs for secrets.
+- `.agents/sow/audit.sh`: local consistency audit for SOW rules, the local-only queue/spec layout, framework files, and
+  sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use. The audit pins, as hard failures,
+  the marker line under "SOW System", the exact CRITICAL sensitive-data sentence, legacy `SOW-NNNN` references,
+  relocated spec paths, missing or untracked framework files, and a `q/` or `specs/` path that is not gitignored. It
+  checks in-flight SOW files under `q/current/` (advisory) for the template's required sections for their kind (umbrella
+  or not) plus the two sensitive-data field labels. It does not scan SOW working files or specs for secrets.
 - `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and


### PR DESCRIPTION
##### Summary

Make `.agents/sow/SOW.template.md` the single schema for what a SOW working file contains, ending the drift between `AGENTS.md` prose, the template, and `audit.sh` that two review rounds of #23742 kept surfacing.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `.agents/sow/SOW.template.md` the single schema for SOW structure. Previously, `AGENTS.md` and `audit.sh` maintained separate section lists; now the audit derives required sections from the template, reducing drift and keeping SOW checks aligned.

- Tags classify sections as required everywhere, implementation-only, umbrella-only, or optional.
- Umbrella SOWs are now checked for their required sections instead of being skipped.
- `AGENTS.md` points to the template for gate and validation field semantics; renaming the two pinned sensitive-data fields still requires an audit update.

<sup>Written for commit 804db3804bc2e2173c9405749a2f15cd514cc635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SOW guidance to clarify section structure, heading requirements, optional versus required content, and umbrella-only steps.
  * Added clearer instructions for documenting manual validation evidence and reviewer findings, including disposition details.
  * Established the template as the source of truth for required sections and fields.

* **Bug Fixes**
  * Improved SOW audits to recognize normalized headings and field labels while applying the correct requirements for each SOW type.
  * Added warnings when template information is missing or unreadable instead of performing unreliable structural checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->