### PR TITLE
Support HTTP requests up to 1 MiB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2069,6 +2069,7 @@ set(WEB_PLUGIN_FILES
         src/web/server/static/static-threaded.c
         src/web/server/static/static-threaded.h
         src/web/server/web_client.c
+        src/web/server/web_client-unittest.c
         src/web/server/web_client.h
         src/web/server/web_client_cache.c
         src/web/server/web_client_cache.h

--- a/src/aclk/aclk_query.c
+++ b/src/aclk/aclk_query.c
@@ -140,7 +140,8 @@ int http_api_v2(mqtt_wss_client client, aclk_query_t *query)
     if(validation != HTTP_VALIDATION_OK) {
         nd_log(NDLS_ACCESS, NDLP_ERR, "ACLK received request is not valid, code %d", validation);
         retval = 1;
-        w->response.code = HTTP_RESP_BAD_REQUEST;
+        w->response.code =
+            validation == HTTP_VALIDATION_URI_TOO_LONG ? HTTP_RESP_URI_TOO_LONG : HTTP_RESP_BAD_REQUEST;
         w->response.code = (short)aclk_http_msg_v2(client, query->callback_topic, query->msg_id,
                                                    dt_ut, query->created, w->response.code,
                                                    NULL, 0);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -223,6 +223,7 @@ int pgc_unittest(void);
 int mrg_unittest(void);
 int pluginsd_parser_unittest(void);
 int websocket_compression_unittest(void);
+int web_client_request_size_unittest(void);
 void replication_initialize(void);
 void bearer_tokens_init(void);
 int unittest_stream_compressions(void);
@@ -481,6 +482,7 @@ int netdata_main(int argc, char **argv) {
 
                             if (pluginsd_parser_unittest()) return 1;
                             if (websocket_compression_unittest()) return 1;
+                            if (web_client_request_size_unittest()) return 1;
                             if (stream_conf_unittest()) return 1;
                             if (unit_test_static_threads()) return 1;
                             if (unit_test_buffer()) return 1;

--- a/src/libnetdata/http/http_defs.h
+++ b/src/libnetdata/http/http_defs.h
@@ -28,6 +28,7 @@
 #define HTTP_RESP_METHOD_NOT_ALLOWED 405
 #define HTTP_RESP_CONFLICT 409
 #define HTTP_RESP_CONTENT_TOO_LONG 413
+#define HTTP_RESP_URI_TOO_LONG 414
 
 #define HTTP_RESP_UNAUTHORIZED                  401 // do not use 401 when responding to users - it is used by authenticating proxies
 #define HTTP_RESP_FORBIDDEN                     403 // not enough permissions to access this resource

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -248,14 +248,67 @@ fail_cleanup:
 }
 
 inline bool
-url_is_request_complete_and_extract_payload(const char *begin, const char *end, size_t length, BUFFER **post_payload) {
-    if (begin == end || length < 4)
+url_is_request_complete_and_extract_payload(
+    const char *begin, const char *end, size_t length, BUFFER **post_payload, size_t *expected_size) {
+    if (length < 4)
+        return false;
+
+    // A prior four-byte "PUT " receive rewinds the incremental cursor to begin.
+    if (begin == end && strncmp(begin, "PUT ", 4) != 0)
         return false;
 
     if(likely(strncmp(begin, "GET ", 4)) == 0) {
         return strstr(end - 4, "\r\n\r\n");
     }
     else if(unlikely(strncmp(begin, "POST ", 5) == 0 || strncmp(begin, "PUT ", 4) == 0)) {
+        if(*expected_size == SIZE_MAX)
+            return false;
+
+        if(!*expected_size) {
+            // The first call may contain the whole request; later calls begin before newly received bytes.
+            const char *headers_search_from = (end == begin + length) ? begin : end;
+            if(!strstr(headers_search_from, "\r\n\r\n"))
+                return false;
+
+            const char *cl = strcasestr(begin, "Content-Length: ");
+            if(!cl)
+                goto invalid_content_length;
+            cl = &cl[16];
+
+            while(*cl == ' ' || *cl == '\t')
+                cl++;
+
+            if(!isdigit((uint8_t)*cl))
+                goto invalid_content_length;
+
+            char *content_length_end;
+            errno_clear();
+            unsigned long long parsed_content_length = strtoull(cl, &content_length_end, 10);
+            if(errno != 0 || parsed_content_length > SIZE_MAX)
+                goto invalid_content_length;
+
+            while(*content_length_end == ' ' || *content_length_end == '\t')
+                content_length_end++;
+
+            if(content_length_end[0] != '\r' || content_length_end[1] != '\n')
+                goto invalid_content_length;
+
+            const char *payload = strstr(cl, "\r\n\r\n");
+            if(!payload)
+                goto invalid_content_length;
+            payload += 4;
+
+            size_t payload_offset = payload - begin;
+            size_t content_length = (size_t)parsed_content_length;
+            if(content_length > SIZE_MAX - payload_offset)
+                goto invalid_content_length;
+
+            *expected_size = payload_offset + content_length;
+        }
+
+        if(length != *expected_size)
+            return false;
+
         const char *cl = strcasestr(begin, "Content-Length: ");
         if(!cl) return false;
         cl = &cl[16];
@@ -313,6 +366,10 @@ url_is_request_complete_and_extract_payload(const char *begin, const char *end, 
             return true;
         }
 
+        return false;
+
+invalid_content_length:
+        *expected_size = SIZE_MAX;
         return false;
     }
     else {

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -253,9 +253,13 @@ url_is_request_complete_and_extract_payload(
     if (length < 4)
         return false;
 
-    // A prior four-byte "PUT " receive rewinds the incremental cursor to begin.
-    if (begin == end && strncmp(begin, "PUT ", 4) != 0)
-        return false;
+    // The caller rewinds the incremental cursor by 4 bytes so a "\r\n\r\n" split
+    // across two receives is still found, and the searches below subtract another
+    // 4. A previous receive of 4 to 7 bytes therefore leaves end at or before
+    // begin, which would put those searches before the buffer. Clamp so they
+    // always start inside it; larger cursors keep the incremental rescan.
+    if (end < begin + 4)
+        end = begin + 4;
 
     if(likely(strncmp(begin, "GET ", 4)) == 0) {
         return strstr(end - 4, "\r\n\r\n");

--- a/src/libnetdata/url/url.c
+++ b/src/libnetdata/url/url.c
@@ -253,11 +253,11 @@ url_is_request_complete_and_extract_payload(
     if (length < 4)
         return false;
 
-    // The caller rewinds the incremental cursor by 4 bytes so a "\r\n\r\n" split
-    // across two receives is still found, and the searches below subtract another
-    // 4. A previous receive of 4 to 7 bytes therefore leaves end at or before
-    // begin, which would put those searches before the buffer. Clamp so they
-    // always start inside it; larger cursors keep the incremental rescan.
+    // The caller rewinds the incremental cursor by up to 4 bytes.
+    // After a previous receive of 4 to 7 bytes, end is begin through begin + 3,
+    // so searches starting at end - 4 would start before the buffer.
+    // Clamp end to begin + 4 so those searches start at begin; larger cursors
+    // keep the incremental rescan.
     if (end < begin + 4)
         end = begin + 4;
 

--- a/src/libnetdata/url/url.h
+++ b/src/libnetdata/url/url.h
@@ -21,7 +21,8 @@ char *url_encode(const char *str);
 
 char *url_decode_r(char *to, const char *url, size_t size);
 
-bool url_is_request_complete_and_extract_payload(const char *begin, const char *end, size_t length, BUFFER **post_payload);
+bool url_is_request_complete_and_extract_payload(
+    const char *begin, const char *end, size_t length, BUFFER **post_payload, size_t *expected_size);
 char *url_find_protocol(char *s, const char *end);
 
 #endif /* NETDATA_URL_H */

--- a/src/web/rtc/webrtc.c
+++ b/src/web/rtc/webrtc.c
@@ -335,10 +335,17 @@ static void webrtc_execute_api_request(WEBRTC_DC *chan, const char *request, siz
     }
 
     web_client_timeout_checkpoint_set(w, 0);
-    web_client_decode_path_and_query_string(w, path);
-    path = (char *)buffer_tostring(w->url_path_decoded);
-
-    w->response.code = (short)web_client_api_request_with_node_selection(localhost, w, path);
+    if(unlikely(!web_client_decode_path_and_query_string(w, path))) {
+        buffer_flush(w->url_as_received);
+        buffer_strcat(w->url_as_received, "too long request URI");
+        buffer_flush(w->response.data);
+        buffer_strcat(w->response.data, "Request URI is too long.\r\n");
+        w->response.code = HTTP_RESP_URI_TOO_LONG;
+    }
+    else {
+        path = (char *)buffer_tostring(w->url_path_decoded);
+        w->response.code = (short)web_client_api_request_with_node_selection(localhost, w, path);
+    }
     web_client_timeout_checkpoint_response_ready(w, NULL);
 
     size_t sent_bytes = 0;

--- a/src/web/server/web_client-unittest.c
+++ b/src/web/server/web_client-unittest.c
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "web_client.h"
+
+#define WEB_CLIENT_TEST(condition, ...)                                                                                \
+    do {                                                                                                               \
+        if (!(condition)) {                                                                                            \
+            fprintf(stderr, "  FAILED: ");                                                                             \
+            fprintf(stderr, __VA_ARGS__);                                                                              \
+            fprintf(stderr, "\n");                                                                                     \
+            errors++;                                                                                                  \
+        }                                                                                                              \
+    } while (0)
+
+static char *web_client_test_target(size_t length)
+{
+    char *target = mallocz(length + 1);
+    target[0] = '/';
+    if (length > 1)
+        memset(&target[1], 'a', length - 1);
+    target[length] = '\0';
+    return target;
+}
+
+static char *web_client_test_request(size_t target_length, size_t *request_length)
+{
+    static const char prefix[] = "GET ";
+    static const char suffix[] = " HTTP/1.1\r\n\r\n";
+
+    *request_length = sizeof(prefix) - 1 + target_length + sizeof(suffix) - 1;
+    char *request = mallocz(*request_length + 1);
+    char *p = request;
+
+    memcpy(p, prefix, sizeof(prefix) - 1);
+    p += sizeof(prefix) - 1;
+    *p++ = '/';
+    if (target_length > 1) {
+        memset(p, 'a', target_length - 1);
+        p += target_length - 1;
+    }
+    memcpy(p, suffix, sizeof(suffix));
+
+    return request;
+}
+
+static char *
+web_client_test_payload_request(const char *method, size_t payload_length, size_t *request_length, size_t *header_length)
+{
+    char prefix[128];
+    int prefix_length = snprintf(prefix, sizeof(prefix), "%s /api/v1/info HTTP/1.1\r\nX-Pad: ", method);
+
+    char suffix[128];
+    int suffix_length =
+        snprintf(suffix, sizeof(suffix), "\r\nContent-Length: %zu\r\nContent-Type: text/plain\r\n\r\n", payload_length);
+
+    if (prefix_length < 0 || (size_t)prefix_length >= sizeof(prefix) || suffix_length < 0 ||
+        (size_t)suffix_length >= sizeof(suffix) ||
+        (size_t)prefix_length + (size_t)suffix_length + payload_length > NETDATA_WEB_REQUEST_MAX_SIZE)
+        return NULL;
+
+    *request_length = NETDATA_WEB_REQUEST_MAX_SIZE;
+    size_t padding_length = *request_length - (size_t)prefix_length - (size_t)suffix_length - payload_length;
+    *header_length = (size_t)prefix_length + padding_length + (size_t)suffix_length;
+
+    char *request = mallocz(*request_length + 1);
+    char *p = request;
+
+    memcpy(p, prefix, (size_t)prefix_length);
+    p += prefix_length;
+    memset(p, 'a', padding_length);
+    p += padding_length;
+    memcpy(p, suffix, (size_t)suffix_length);
+    p += suffix_length;
+    memset(p, 'b', payload_length);
+
+    return request;
+}
+
+int web_client_request_size_unittest(void)
+{
+    fprintf(stderr, "\n%s() running...\n", __FUNCTION__);
+
+    int errors = 0;
+    size_t memory_accounting = 0;
+    struct web_client *w = web_client_create(&memory_accounting);
+
+    WEB_CLIENT_TEST(!w->url_decode_buffer, "new client has a URL decode buffer");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == 0, "new client URL decode capacity is %zu, expected 0", w->url_decode_buffer_size);
+
+    const char small_target[] = "/api/v1/info?value=a%20b";
+    WEB_CLIENT_TEST(web_client_decode_path_and_query_string(w, small_target), "small target was rejected");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == NETDATA_WEB_REQUEST_URL_DECODE_INITIAL_SIZE,
+        "small target capacity is %zu, expected %zu",
+        w->url_decode_buffer_size,
+        (size_t)NETDATA_WEB_REQUEST_URL_DECODE_INITIAL_SIZE);
+    WEB_CLIENT_TEST(
+        strcmp(buffer_tostring(w->url_path_decoded), "/api/v1/info") == 0, "small target path decoded incorrectly");
+    WEB_CLIENT_TEST(
+        strcmp(buffer_tostring(w->url_query_string_decoded), "?value=a b") == 0,
+        "small target query decoded incorrectly");
+
+    char *retained = w->url_decode_buffer;
+    web_client_reuse_from_cache(w);
+    WEB_CLIENT_TEST(w->url_decode_buffer == retained, "cached 4 KiB buffer was not retained");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == NETDATA_WEB_REQUEST_URL_DECODE_INITIAL_SIZE,
+        "cached 4 KiB capacity was not retained");
+
+    char *target = web_client_test_target(NETDATA_WEB_REQUEST_URL_DECODE_CACHE_MAX_SIZE - 1);
+    WEB_CLIENT_TEST(web_client_decode_path_and_query_string(w, target), "target fitting 64 KiB was rejected");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == NETDATA_WEB_REQUEST_URL_DECODE_CACHE_MAX_SIZE,
+        "target fitting 64 KiB grew to %zu",
+        w->url_decode_buffer_size);
+    retained = w->url_decode_buffer;
+    web_client_trim_url_decode_buffer_for_cache(w);
+    WEB_CLIENT_TEST(w->url_decode_buffer == retained, "exactly 64 KiB was not retained for cache reuse");
+
+    freez(target);
+    target = web_client_test_target(NETDATA_WEB_REQUEST_URL_DECODE_CACHE_MAX_SIZE);
+    WEB_CLIENT_TEST(web_client_decode_path_and_query_string(w, target), "target requiring 128 KiB was rejected");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == 2 * NETDATA_WEB_REQUEST_URL_DECODE_CACHE_MAX_SIZE,
+        "target requiring 128 KiB grew to %zu",
+        w->url_decode_buffer_size);
+    web_client_trim_url_decode_buffer_for_cache(w);
+    WEB_CLIENT_TEST(!w->url_decode_buffer, "buffer above 64 KiB was retained");
+    WEB_CLIENT_TEST(w->url_decode_buffer_size == 0, "freed buffer retained capacity %zu", w->url_decode_buffer_size);
+
+    web_client_reuse_from_cache(w);
+    WEB_CLIENT_TEST(!w->url_decode_buffer, "NULL cached buffer was not preserved");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == 0, "NULL cached buffer restored capacity %zu", w->url_decode_buffer_size);
+
+    freez(target);
+    target = web_client_test_target(NETDATA_WEB_REQUEST_MAX_SIZE - 1);
+    WEB_CLIENT_TEST(web_client_decode_path_and_query_string(w, target), "largest fitting target was rejected");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == NETDATA_WEB_REQUEST_MAX_SIZE,
+        "largest fitting target capacity is %zu",
+        w->url_decode_buffer_size);
+
+    char *maximum_buffer = w->url_decode_buffer;
+    freez(target);
+    target = web_client_test_target(NETDATA_WEB_REQUEST_MAX_SIZE);
+    WEB_CLIENT_TEST(!web_client_decode_path_and_query_string(w, target), "oversized target was accepted");
+    WEB_CLIENT_TEST(w->url_decode_buffer == maximum_buffer, "oversized target replaced the 1 MiB buffer");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == NETDATA_WEB_REQUEST_MAX_SIZE,
+        "oversized target changed capacity to %zu",
+        w->url_decode_buffer_size);
+
+    web_client_trim_url_decode_buffer_for_cache(w);
+    WEB_CLIENT_TEST(!w->url_decode_buffer, "1 MiB buffer was retained for cache reuse");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == 0, "trimmed 1 MiB buffer retained capacity %zu", w->url_decode_buffer_size);
+    WEB_CLIENT_TEST(
+        !web_client_decode_path_and_query_string(w, target), "oversized target with NULL scratch buffer was accepted");
+    WEB_CLIENT_TEST(!w->url_decode_buffer, "oversized target allocated scratch before failing");
+
+    freez(target);
+    target = NULL;
+    web_client_reuse_from_cache(w);
+
+    static const char request_prefix[] = "GET ";
+    static const char request_suffix[] = " HTTP/1.1\r\n\r\n";
+    size_t exact_target_length =
+        NETDATA_WEB_REQUEST_MAX_SIZE - (sizeof(request_prefix) - 1) - (sizeof(request_suffix) - 1);
+    size_t request_length;
+    char *request = web_client_test_request(exact_target_length, &request_length);
+    WEB_CLIENT_TEST(
+        request_length == NETDATA_WEB_REQUEST_MAX_SIZE,
+        "boundary request size is %zu, expected %zu",
+        request_length,
+        (size_t)NETDATA_WEB_REQUEST_MAX_SIZE);
+    buffer_flush(w->response.data);
+    buffer_memcat(w->response.data, request, request_length);
+    WEB_CLIENT_TEST(http_request_validate(w) == HTTP_VALIDATION_OK, "exactly 1 MiB whole request did not validate");
+
+    freez(request);
+    web_client_reuse_from_cache(w);
+
+    request = web_client_test_request(exact_target_length, &request_length);
+    for (size_t offset = 0; offset < request_length;) {
+        size_t chunk_size = MIN((size_t)8192, request_length - offset);
+        buffer_memcat(w->response.data, &request[offset], chunk_size);
+        offset += chunk_size;
+
+        HTTP_VALIDATION validation = http_request_validate(w);
+        if (offset < request_length)
+            WEB_CLIENT_TEST(validation == HTTP_VALIDATION_INCOMPLETE, "fragmented request failed at byte %zu", offset);
+        else
+            WEB_CLIENT_TEST(validation == HTTP_VALIDATION_OK, "fragmented 1 MiB request did not validate");
+    }
+
+    freez(request);
+    web_client_reuse_from_cache(w);
+
+    static const char complete_payload_request[] =
+        "POST /api/v1/info HTTP/1.1\r\nContent-Length: 4\r\nContent-Type: text/plain\r\n\r\ntest";
+    buffer_memcat(w->response.data, complete_payload_request, sizeof(complete_payload_request) - 1);
+    WEB_CLIENT_TEST(http_request_validate(w) == HTTP_VALIDATION_OK, "complete POST request did not validate");
+    WEB_CLIENT_TEST(
+        w->payload && buffer_strlen(w->payload) == 4 && !memcmp(buffer_tostring(w->payload), "test", 4),
+        "complete POST payload changed");
+    WEB_CLIENT_TEST(w->header_parse_expected_size == 0, "complete POST framing state was not reset");
+    web_client_reuse_from_cache(w);
+
+    static const char split_put_header[] =
+        "PUT /api/v1/info HTTP/1.1\r\nContent-Length: 1048496\r\nContent-Type: text/plain\r\n\r\n";
+    const size_t split_put_payload_length = NETDATA_WEB_REQUEST_MAX_SIZE - (sizeof(split_put_header) - 1);
+    WEB_CLIENT_TEST(split_put_payload_length == 1048496, "split PUT test header length changed");
+
+    request = mallocz(NETDATA_WEB_REQUEST_MAX_SIZE + 1);
+    memcpy(request, split_put_header, sizeof(split_put_header) - 1);
+    memset(&request[sizeof(split_put_header) - 1], 'b', split_put_payload_length);
+
+    for (size_t offset = 0; offset < NETDATA_WEB_REQUEST_MAX_SIZE;) {
+        size_t chunk_size = offset ? MIN((size_t)1024, NETDATA_WEB_REQUEST_MAX_SIZE - offset) : 4;
+        buffer_memcat(w->response.data, &request[offset], chunk_size);
+        offset += chunk_size;
+
+        HTTP_VALIDATION validation = http_request_validate(w);
+        if (offset < NETDATA_WEB_REQUEST_MAX_SIZE)
+            WEB_CLIENT_TEST(
+                validation == HTTP_VALIDATION_INCOMPLETE, "split-after-method PUT failed at byte %zu", offset);
+        else
+            WEB_CLIENT_TEST(validation == HTTP_VALIDATION_OK, "split-after-method 1 MiB PUT did not validate");
+    }
+
+    WEB_CLIENT_TEST(
+        w->payload && buffer_strlen(w->payload) == split_put_payload_length,
+        "split-after-method PUT payload size is %zu",
+        w->payload ? buffer_strlen(w->payload) : 0);
+    WEB_CLIENT_TEST(w->header_parse_expected_size == 0, "split-after-method PUT framing state was not reset");
+    freez(request);
+    web_client_reuse_from_cache(w);
+
+    static const char *payload_methods[] = {"POST", "PUT"};
+    for (size_t method = 0; method < sizeof(payload_methods) / sizeof(payload_methods[0]); method++) {
+        size_t header_length;
+        request = web_client_test_payload_request(payload_methods[method], 4096, &request_length, &header_length);
+        WEB_CLIENT_TEST(request, "%s test request allocation failed", payload_methods[method]);
+        if (!request)
+            continue;
+
+        bool framing_state_seen = false;
+        for (size_t offset = 0; offset < request_length;) {
+            size_t chunk_size = MIN((size_t)64, request_length - offset);
+            buffer_memcat(w->response.data, &request[offset], chunk_size);
+            offset += chunk_size;
+
+            HTTP_VALIDATION validation = http_request_validate(w);
+            if (offset < request_length) {
+                WEB_CLIENT_TEST(
+                    validation == HTTP_VALIDATION_INCOMPLETE,
+                    "fragmented %s request failed at byte %zu",
+                    payload_methods[method],
+                    offset);
+
+                if (offset >= header_length) {
+                    framing_state_seen = true;
+                    WEB_CLIENT_TEST(
+                        w->header_parse_expected_size == request_length,
+                        "%s expected request size is %zu, expected %zu",
+                        payload_methods[method],
+                        w->header_parse_expected_size,
+                        request_length);
+                }
+            } else
+                WEB_CLIENT_TEST(
+                    validation == HTTP_VALIDATION_OK,
+                    "fragmented 1 MiB %s request did not validate",
+                    payload_methods[method]);
+        }
+
+        WEB_CLIENT_TEST(
+            framing_state_seen, "%s framing state was not retained while receiving its body", payload_methods[method]);
+        WEB_CLIENT_TEST(
+            w->payload && buffer_strlen(w->payload) == 4096,
+            "%s payload size is %zu",
+            payload_methods[method],
+            w->payload ? buffer_strlen(w->payload) : 0);
+        if (w->payload)
+            WEB_CLIENT_TEST(
+                !memcmp(buffer_tostring(w->payload), &request[request_length - 4096], 4096),
+                "%s payload content changed",
+                payload_methods[method]);
+        WEB_CLIENT_TEST(
+            w->header_parse_expected_size == 0,
+            "%s framing state was not reset after completion",
+            payload_methods[method]);
+
+        freez(request);
+        web_client_reuse_from_cache(w);
+    }
+
+    static const char missing_content_length[] = "POST /api/v1/info HTTP/1.1\r\nX-Pad: a\r\n\r\n";
+    buffer_memcat(w->response.data, missing_content_length, sizeof(missing_content_length) - 1);
+    WEB_CLIENT_TEST(
+        http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE,
+        "POST without Content-Length did not remain incomplete");
+    size_t invalid_framing_state = w->header_parse_expected_size;
+    WEB_CLIENT_TEST(invalid_framing_state != 0, "missing Content-Length framing state was not remembered");
+
+    char missing_content_length_body[64];
+    memset(missing_content_length_body, 'b', sizeof(missing_content_length_body));
+    while (buffer_strlen(w->response.data) < NETDATA_WEB_REQUEST_MAX_SIZE) {
+        size_t chunk_size =
+            MIN(sizeof(missing_content_length_body), NETDATA_WEB_REQUEST_MAX_SIZE - buffer_strlen(w->response.data));
+        buffer_memcat(w->response.data, missing_content_length_body, chunk_size);
+        WEB_CLIENT_TEST(
+            http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE,
+            "POST without Content-Length changed validation while growing");
+        WEB_CLIENT_TEST(
+            w->header_parse_expected_size == invalid_framing_state,
+            "missing Content-Length framing state changed while receiving body bytes");
+    }
+    WEB_CLIENT_TEST(
+        w->header_parse_tries == 0,
+        "progressive POST without Content-Length consumed %zu retries",
+        w->header_parse_tries);
+    for (size_t attempt = 0; attempt < HTTP_REQ_MAX_HEADER_FETCH_TRIES; attempt++) {
+        WEB_CLIENT_TEST(
+            http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE,
+            "POST without Content-Length exhausted no-progress retries early");
+        WEB_CLIENT_TEST(
+            w->header_parse_expected_size == invalid_framing_state,
+            "missing Content-Length framing state changed during no-progress validation");
+    }
+    WEB_CLIENT_TEST(
+        http_request_validate(w) == HTTP_VALIDATION_TOO_MANY_READ_RETRIES,
+        "POST without Content-Length did not exhaust its no-progress retry budget");
+    WEB_CLIENT_TEST(
+        w->header_parse_expected_size == 0,
+        "missing Content-Length framing state was not reset after retry exhaustion");
+
+    web_client_reuse_from_cache(w);
+    WEB_CLIENT_TEST(w->header_parse_expected_size == 0, "cached client retained POST framing state");
+
+    buffer_strcat(w->response.data, "GET /api/v1/info");
+    WEB_CLIENT_TEST(
+        http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE, "initial partial request was not incomplete");
+    for (size_t attempt = 0; attempt < HTTP_REQ_MAX_HEADER_FETCH_TRIES; attempt++)
+        WEB_CLIENT_TEST(http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE, "no-progress request failed early");
+    WEB_CLIENT_TEST(
+        http_request_validate(w) == HTTP_VALIDATION_TOO_MANY_READ_RETRIES,
+        "no-progress request did not exhaust its retry budget");
+
+    web_client_reuse_from_cache(w);
+    request = web_client_test_request(NETDATA_WEB_REQUEST_MAX_SIZE, &request_length);
+    buffer_flush(w->response.data);
+    buffer_memcat(w->response.data, request, request_length);
+    WEB_CLIENT_TEST(
+        http_request_validate(w) == HTTP_VALIDATION_URI_TOO_LONG,
+        "oversized request target did not return URI-too-long validation");
+    WEB_CLIENT_TEST(
+        w->url_decode_buffer_size == NETDATA_WEB_REQUEST_MAX_SIZE,
+        "oversized validator target grew scratch to %zu",
+        w->url_decode_buffer_size);
+    WEB_CLIENT_TEST(HTTP_RESP_URI_TOO_LONG == 414, "URI-too-long HTTP status is not 414");
+
+    freez(request);
+    web_client_free(w);
+    WEB_CLIENT_TEST(memory_accounting == 0, "web client leaked %zu accounted bytes", memory_accounting);
+
+    if (errors)
+        fprintf(stderr, "%s() failed with %d error(s)\n", __FUNCTION__, errors);
+    else
+        fprintf(stderr, "%s() passed\n", __FUNCTION__);
+
+    return errors;
+}

--- a/src/web/server/web_client-unittest.c
+++ b/src/web/server/web_client-unittest.c
@@ -238,6 +238,48 @@ int web_client_request_size_unittest(void)
     freez(request);
     web_client_reuse_from_cache(w);
 
+    // The incremental cursor is rewound 4 bytes by the caller and the completeness
+    // searches subtract another 4, so a first receive of 4 to 7 bytes used to place
+    // them before the buffer and report an already-complete request as incomplete.
+    // Every accepted method must survive a two-receive split at those sizes. The
+    // smallest first receive per method is its token length: shorter first receives
+    // are rejected as an unsupported method before the cursor is ever used.
+    static const struct {
+        const char *request;
+        size_t smallest_first;
+    } split_methods[] = {
+        {"GET /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 4},
+        {"PUT /api/v1/info HTTP/1.1\r\nContent-Length: 4\r\n\r\ntest", 4},
+        {"POST /api/v1/info HTTP/1.1\r\nContent-Length: 4\r\n\r\ntest", 5},
+        {"DELETE /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 7},
+        {"STREAM key=abc HTTP/1.1\r\nHost: x\r\n\r\n", 7},
+        {"OPTIONS /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 8},
+    };
+    for (size_t m = 0; m < sizeof(split_methods) / sizeof(split_methods[0]); m++) {
+        const char *split_request = split_methods[m].request;
+        size_t split_request_length = strlen(split_request);
+
+        for (size_t first = split_methods[m].smallest_first; first <= 8; first++) {
+            web_client_reuse_from_cache(w);
+
+            buffer_memcat(w->response.data, split_request, first);
+            WEB_CLIENT_TEST(
+                http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE,
+                "'%.*s' alone was not incomplete",
+                (int)first,
+                split_request);
+
+            buffer_memcat(w->response.data, &split_request[first], split_request_length - first);
+            WEB_CLIENT_TEST(
+                http_request_validate(w) == HTTP_VALIDATION_OK,
+                "'%.*s' split after %zu byte(s) did not validate once complete",
+                (int)split_methods[m].smallest_first,
+                split_request,
+                first);
+        }
+    }
+    web_client_reuse_from_cache(w);
+
     static const char *payload_methods[] = {"POST", "PUT"};
     for (size_t method = 0; method < sizeof(payload_methods) / sizeof(payload_methods[0]); method++) {
         size_t header_length;

--- a/src/web/server/web_client-unittest.c
+++ b/src/web/server/web_client-unittest.c
@@ -238,9 +238,9 @@ int web_client_request_size_unittest(void)
     freez(request);
     web_client_reuse_from_cache(w);
 
-    // The incremental cursor is rewound 4 bytes by the caller and the completeness
-    // searches subtract another 4, so a first receive of 4 to 7 bytes used to place
-    // them before the buffer and report an already-complete request as incomplete.
+    // A four-byte GET first receive used to trigger an early incomplete return
+    // on the next receive. GET splits at 5 to 7 bytes and DELETE/STREAM splits
+    // at 7 bytes instead made completeness searches start before the buffer.
     // Every accepted method must survive a two-receive split at those sizes. The
     // smallest first receive per method is its token length: shorter first receives
     // are rejected as an unsupported method before the cursor is ever used.

--- a/src/web/server/web_client-unittest.c
+++ b/src/web/server/web_client-unittest.c
@@ -244,20 +244,25 @@ int web_client_request_size_unittest(void)
     // Every accepted method must survive a two-receive split at those sizes. The
     // smallest first receive per method is its token length: shorter first receives
     // are rejected as an unsupported method before the cursor is ever used.
+    // SPLIT_CASE carries each request's length from sizeof at compile time, so the
+    // loop never has to measure a string at runtime.
+#define SPLIT_CASE(request, smallest_first) {(request), sizeof(request) - 1, (smallest_first)}
     static const struct {
         const char *request;
+        size_t request_length;
         size_t smallest_first;
     } split_methods[] = {
-        {"GET /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 4},
-        {"PUT /api/v1/info HTTP/1.1\r\nContent-Length: 4\r\n\r\ntest", 4},
-        {"POST /api/v1/info HTTP/1.1\r\nContent-Length: 4\r\n\r\ntest", 5},
-        {"DELETE /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 7},
-        {"STREAM key=abc HTTP/1.1\r\nHost: x\r\n\r\n", 7},
-        {"OPTIONS /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 8},
+        SPLIT_CASE("GET /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 4),
+        SPLIT_CASE("PUT /api/v1/info HTTP/1.1\r\nContent-Length: 4\r\n\r\ntest", 4),
+        SPLIT_CASE("POST /api/v1/info HTTP/1.1\r\nContent-Length: 4\r\n\r\ntest", 5),
+        SPLIT_CASE("DELETE /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 7),
+        SPLIT_CASE("STREAM key=abc HTTP/1.1\r\nHost: x\r\n\r\n", 7),
+        SPLIT_CASE("OPTIONS /api/v1/info HTTP/1.1\r\nHost: x\r\n\r\n", 8),
     };
+#undef SPLIT_CASE
     for (size_t m = 0; m < sizeof(split_methods) / sizeof(split_methods[0]); m++) {
         const char *split_request = split_methods[m].request;
-        size_t split_request_length = strlen(split_request);
+        size_t split_request_length = split_methods[m].request_length;
 
         for (size_t first = split_methods[m].smallest_first; first <= 8; first++) {
             web_client_reuse_from_cache(w);
@@ -273,7 +278,7 @@ int web_client_request_size_unittest(void)
             WEB_CLIENT_TEST(
                 http_request_validate(w) == HTTP_VALIDATION_OK,
                 "'%.*s' split after %zu byte(s) did not validate once complete",
-                (int)split_methods[m].smallest_first,
+                (int)first,
                 split_request,
                 first);
         }

--- a/src/web/server/web_client-unittest.c
+++ b/src/web/server/web_client-unittest.c
@@ -248,7 +248,10 @@ int web_client_request_size_unittest(void)
 
         bool framing_state_seen = false;
         for (size_t offset = 0; offset < request_length;) {
-            size_t chunk_size = MIN((size_t)64, request_length - offset);
+            // 1024-byte fragments: a 1 MiB request costs ~1024 parse attempts,
+            // within HTTP_REQ_MAX_HEADER_FETCH_TRIES. Smaller fragments are
+            // rejected by the budget on purpose (see the exhaustion tests below).
+            size_t chunk_size = MIN((size_t)1024, request_length - offset);
             buffer_memcat(w->response.data, &request[offset], chunk_size);
             offset += chunk_size;
 
@@ -305,7 +308,7 @@ int web_client_request_size_unittest(void)
     size_t invalid_framing_state = w->header_parse_expected_size;
     WEB_CLIENT_TEST(invalid_framing_state != 0, "missing Content-Length framing state was not remembered");
 
-    char missing_content_length_body[64];
+    char missing_content_length_body[1024];
     memset(missing_content_length_body, 'b', sizeof(missing_content_length_body));
     while (buffer_strlen(w->response.data) < NETDATA_WEB_REQUEST_MAX_SIZE) {
         size_t chunk_size =
@@ -318,21 +321,37 @@ int web_client_request_size_unittest(void)
             w->header_parse_expected_size == invalid_framing_state,
             "missing Content-Length framing state changed while receiving body bytes");
     }
+    // Every parse attempt consumes budget now, including the ones that saw new
+    // bytes, so a growing request spends part of it - but delivering 1 MiB in
+    // 1024-byte fragments must stay well inside the allowance. Pin the exact
+    // count: a loose bound would still pass if the growth loop consumed the
+    // whole budget, which would silently make the exhaustion loop below vacuous.
+    // 40 header bytes + 1023 full 1024-byte fragments + one 984-byte remainder,
+    // plus the initial validation above = 1025 attempts.
     WEB_CLIENT_TEST(
-        w->header_parse_tries == 0,
-        "progressive POST without Content-Length consumed %zu retries",
-        w->header_parse_tries);
-    for (size_t attempt = 0; attempt < HTTP_REQ_MAX_HEADER_FETCH_TRIES; attempt++) {
+        w->header_parse_tries == 1025,
+        "progressive POST without Content-Length consumed %zu of %zu attempts, expected 1025",
+        w->header_parse_tries,
+        (size_t)HTTP_REQ_MAX_HEADER_FETCH_TRIES);
+
+    // WEB_CLIENT_TEST only counts errors and keeps going, so the pin above may
+    // have failed. Clamp instead of subtracting blindly: an unsigned underflow
+    // here would spin this loop ~SIZE_MAX times and hang the run rather than
+    // failing it.
+    size_t remaining_attempts = (w->header_parse_tries <= (size_t)HTTP_REQ_MAX_HEADER_FETCH_TRIES)
+                                    ? (size_t)HTTP_REQ_MAX_HEADER_FETCH_TRIES - w->header_parse_tries
+                                    : 0;
+    for (size_t attempt = 0; attempt < remaining_attempts; attempt++) {
         WEB_CLIENT_TEST(
             http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE,
-            "POST without Content-Length exhausted no-progress retries early");
+            "POST without Content-Length exhausted its attempt budget early");
         WEB_CLIENT_TEST(
             w->header_parse_expected_size == invalid_framing_state,
             "missing Content-Length framing state changed during no-progress validation");
     }
     WEB_CLIENT_TEST(
         http_request_validate(w) == HTTP_VALIDATION_TOO_MANY_READ_RETRIES,
-        "POST without Content-Length did not exhaust its no-progress retry budget");
+        "POST without Content-Length did not exhaust its attempt budget");
     WEB_CLIENT_TEST(
         w->header_parse_expected_size == 0,
         "missing Content-Length framing state was not reset after retry exhaustion");
@@ -343,11 +362,42 @@ int web_client_request_size_unittest(void)
     buffer_strcat(w->response.data, "GET /api/v1/info");
     WEB_CLIENT_TEST(
         http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE, "initial partial request was not incomplete");
-    for (size_t attempt = 0; attempt < HTTP_REQ_MAX_HEADER_FETCH_TRIES; attempt++)
+    // The initial validation above already consumed attempt #1, so only
+    // HTTP_REQ_MAX_HEADER_FETCH_TRIES - 1 further attempts remain.
+    for (size_t attempt = 0; attempt < (size_t)HTTP_REQ_MAX_HEADER_FETCH_TRIES - 1; attempt++)
         WEB_CLIENT_TEST(http_request_validate(w) == HTTP_VALIDATION_INCOMPLETE, "no-progress request failed early");
     WEB_CLIENT_TEST(
         http_request_validate(w) == HTTP_VALIDATION_TOO_MANY_READ_RETRIES,
         "no-progress request did not exhaust its retry budget");
+
+    // The production-reachable case: a client that keeps delivering bytes. The
+    // socket server only validates after web_client_receive() returned bytes>0,
+    // so every real validation of an incomplete request has seen new data. This
+    // is the case that could never exhaust the budget while the counter only
+    // incremented on no-progress attempts.
+    web_client_reuse_from_cache(w);
+    buffer_strcat(w->response.data, "GET /api/v1/info");
+    HTTP_VALIDATION dribble = http_request_validate(w);
+    size_t dribble_attempts = 1;
+    while (dribble == HTTP_VALIDATION_INCOMPLETE && dribble_attempts < (size_t)HTTP_REQ_MAX_HEADER_FETCH_TRIES + 10) {
+        buffer_memcat(w->response.data, "a", 1);
+        dribble = http_request_validate(w);
+        dribble_attempts++;
+    }
+    WEB_CLIENT_TEST(
+        dribble == HTTP_VALIDATION_TOO_MANY_READ_RETRIES,
+        "request growing by one byte per attempt was not disconnected (validation %d after %zu attempts)",
+        (int)dribble,
+        dribble_attempts);
+    WEB_CLIENT_TEST(
+        dribble_attempts == (size_t)HTTP_REQ_MAX_HEADER_FETCH_TRIES + 1,
+        "request growing by one byte per attempt was disconnected after %zu attempts, expected %zu",
+        dribble_attempts,
+        (size_t)HTTP_REQ_MAX_HEADER_FETCH_TRIES + 1);
+    WEB_CLIENT_TEST(
+        buffer_strlen(w->response.data) < NETDATA_WEB_REQUEST_MAX_SIZE,
+        "growing request hit the %zu byte size cap instead of the attempt budget",
+        (size_t)NETDATA_WEB_REQUEST_MAX_SIZE);
 
     web_client_reuse_from_cache(w);
     request = web_client_test_request(NETDATA_WEB_REQUEST_MAX_SIZE, &request_length);

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -113,6 +113,22 @@ static inline char *strip_control_characters(char *url) {
     return url;
 }
 
+static void web_client_free_url_decode_buffer(struct web_client *w) {
+    size_t size = w->url_decode_buffer_size;
+
+    freez(w->url_decode_buffer);
+    w->url_decode_buffer = NULL;
+    w->url_decode_buffer_size = 0;
+
+    if(w->statistics.memory_accounting && size)
+        __atomic_sub_fetch(w->statistics.memory_accounting, size, __ATOMIC_RELAXED);
+}
+
+void web_client_trim_url_decode_buffer_for_cache(struct web_client *w) {
+    if(w->url_decode_buffer_size > NETDATA_WEB_REQUEST_URL_DECODE_CACHE_MAX_SIZE)
+        web_client_free_url_decode_buffer(w);
+}
+
 static void web_client_reset_allocations(struct web_client *w, bool free_all) {
 
     if(free_all) {
@@ -138,6 +154,8 @@ static void web_client_reset_allocations(struct web_client *w, bool free_all) {
 
         buffer_free(w->payload);
         w->payload = NULL;
+
+        web_client_free_url_decode_buffer(w);
     }
     else {
         // the web client is to be re-used
@@ -292,6 +310,7 @@ void web_client_request_done(struct web_client *w) {
 
     w->header_parse_tries = 0;
     w->header_parse_last_size = 0;
+    w->header_parse_expected_size = 0;
 
     web_client_enable_wait_receive(w);
     web_client_disable_wait_send(w);
@@ -708,6 +727,7 @@ static inline char *web_client_valid_method(struct web_client *w, char *s) {
         if (!SSL_connection(&w->ssl) && http_is_using_ssl_force(w)) {
             w->header_parse_tries = 0;
             w->header_parse_last_size = 0;
+            w->header_parse_expected_size = 0;
             web_client_disable_wait_receive(w);
 
             char hostname[256];
@@ -755,26 +775,32 @@ HTTP_VALIDATION http_request_validate(struct web_client *w) {
 
     size_t last_pos = w->header_parse_last_size;
 
-    w->header_parse_tries++;
     w->header_parse_last_size = buffer_strlen(w->response.data);
+    if(w->header_parse_last_size <= last_pos)
+        w->header_parse_tries++;
+
     char *request_end = request + w->header_parse_last_size;
 
     int is_it_valid;
-    if(w->header_parse_tries > 1) {
+    if(last_pos) {
         if(last_pos > 4) last_pos -= 4; // allow searching for \r\n\r\n
         else last_pos = 0;
 
         if(w->header_parse_last_size <= last_pos)
             last_pos = 0;
 
-        is_it_valid = url_is_request_complete_and_extract_payload(s, &s[last_pos],
-                                                                  w->header_parse_last_size, &w->payload);
+        is_it_valid = url_is_request_complete_and_extract_payload(s, &s[last_pos], w->header_parse_last_size,
+                                                                  &w->payload, &w->header_parse_expected_size);
 
         if(!is_it_valid) {
             if(w->header_parse_tries > HTTP_REQ_MAX_HEADER_FETCH_TRIES) {
-                netdata_log_info("Disabling slow client after %zu attempts to read the request (%zu bytes received)", w->header_parse_tries, buffer_strlen(w->response.data));
+                netdata_log_info(
+                    "Disabling slow client after %zu attempts to parse without receiving more data (%zu bytes received)",
+                    w->header_parse_tries,
+                    buffer_strlen(w->response.data));
                 w->header_parse_tries = 0;
                 w->header_parse_last_size = 0;
+                w->header_parse_expected_size = 0;
                 web_client_disable_wait_receive(w);
                 return HTTP_VALIDATION_TOO_MANY_READ_RETRIES;
             }
@@ -785,14 +811,15 @@ HTTP_VALIDATION http_request_validate(struct web_client *w) {
         is_it_valid = 1;
     } else {
         last_pos = w->header_parse_last_size;
-        is_it_valid =
-            url_is_request_complete_and_extract_payload(s, &s[last_pos], w->header_parse_last_size, &w->payload);
+        is_it_valid = url_is_request_complete_and_extract_payload(s, &s[last_pos], w->header_parse_last_size,
+                                                                  &w->payload, &w->header_parse_expected_size);
     }
 
     s = web_client_valid_method(w, s);
     if (!s) {
         w->header_parse_tries = 0;
         w->header_parse_last_size = 0;
+        w->header_parse_expected_size = 0;
         web_client_disable_wait_receive(w);
 
         return HTTP_VALIDATION_NOT_SUPPORTED;
@@ -838,13 +865,22 @@ HTTP_VALIDATION http_request_validate(struct web_client *w) {
 
                 char c = *ue;
                 *ue = '\0';
-                web_client_decode_path_and_query_string(w, encoded_url);
+                bool decoded = web_client_decode_path_and_query_string(w, encoded_url);
                 *ue = c;
+
+                if(unlikely(!decoded)) {
+                    w->header_parse_tries = 0;
+                    w->header_parse_last_size = 0;
+                    w->header_parse_expected_size = 0;
+                    web_client_disable_wait_receive(w);
+                    return HTTP_VALIDATION_URI_TOO_LONG;
+                }
 
                 if ( (web_client_check_conn_tcp(w)) && (netdata_ssl_web_server_ctx) ) {
                     if (!w->ssl.conn && (http_is_using_ssl_force(w) || http_is_using_ssl_default(w)) && (w->mode != HTTP_REQUEST_MODE_STREAM)) {
                         w->header_parse_tries = 0;
                         w->header_parse_last_size = 0;
+                        w->header_parse_expected_size = 0;
                         web_client_disable_wait_receive(w);
                         return HTTP_VALIDATION_REDIRECT;
                     }
@@ -852,6 +888,7 @@ HTTP_VALIDATION http_request_validate(struct web_client *w) {
 
                 w->header_parse_tries = 0;
                 w->header_parse_last_size = 0;
+                w->header_parse_expected_size = 0;
                 web_client_disable_wait_receive(w);
                 return HTTP_VALIDATION_OK;
             }
@@ -1598,6 +1635,17 @@ void web_client_process_request_from_web_server(struct web_client *w) {
             break;
         }
 
+        case HTTP_VALIDATION_URI_TOO_LONG:
+            netdata_log_debug(D_WEB_CLIENT_ACCESS, "%llu: Request URI is too long (%zu request bytes received).",
+                              w->id, (size_t)w->response.data->len);
+
+            buffer_flush(w->url_as_received);
+            buffer_strcat(w->url_as_received, "too long request URI");
+            buffer_flush(w->response.data);
+            buffer_strcat(w->response.data, "Request URI is too long.\r\n");
+            w->response.code = HTTP_RESP_URI_TOO_LONG;
+            break;
+
         case HTTP_VALIDATION_MALFORMED_URL:
             netdata_log_debug(D_WEB_CLIENT_ACCESS, "%llu: Malformed URL '%s'.", w->id, w->response.data->buffer);
 
@@ -2006,9 +2054,37 @@ ssize_t web_client_receive(struct web_client *w) {
     return(bytes);
 }
 
-void web_client_decode_path_and_query_string(struct web_client *w, const char *path_and_query_string) {
-    char buffer[NETDATA_WEB_REQUEST_URL_SIZE + 2];
-    buffer[0] = '\0';
+static bool web_client_ensure_url_decode_buffer(struct web_client *w, const char *path_and_query_string) {
+    size_t encoded_length = strnlen(path_and_query_string, NETDATA_WEB_REQUEST_MAX_SIZE);
+    if(unlikely(encoded_length == NETDATA_WEB_REQUEST_MAX_SIZE))
+        return false;
+
+    size_t required_size = encoded_length + 1;
+    if(w->url_decode_buffer && w->url_decode_buffer_size >= required_size)
+        return true;
+
+    size_t old_size = w->url_decode_buffer ? w->url_decode_buffer_size : 0;
+    size_t new_size = old_size;
+    if(new_size < NETDATA_WEB_REQUEST_URL_DECODE_INITIAL_SIZE)
+        new_size = NETDATA_WEB_REQUEST_URL_DECODE_INITIAL_SIZE;
+
+    while(new_size < required_size)
+        new_size *= 2;
+
+    w->url_decode_buffer = reallocz(w->url_decode_buffer, new_size);
+    w->url_decode_buffer_size = new_size;
+
+    if(w->statistics.memory_accounting)
+        __atomic_add_fetch(w->statistics.memory_accounting, new_size - old_size, __ATOMIC_RELAXED);
+
+    return true;
+}
+
+bool web_client_decode_path_and_query_string(struct web_client *w, const char *path_and_query_string) {
+    if(unlikely(!web_client_ensure_url_decode_buffer(w, path_and_query_string)))
+        return false;
+
+    char *buffer = w->url_decode_buffer;
 
     buffer_flush(w->url_path_decoded);
     buffer_flush(w->url_query_string_decoded);
@@ -2025,9 +2101,7 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
     if(w->mode == HTTP_REQUEST_MODE_STREAM) {
         // in stream mode, there is no path
 
-        url_decode_r(buffer, path_and_query_string, NETDATA_WEB_REQUEST_URL_SIZE + 1);
-
-        buffer[NETDATA_WEB_REQUEST_URL_SIZE + 1] = '\0';
+        url_decode_r(buffer, path_and_query_string, w->url_decode_buffer_size);
         buffer_strcat(w->url_query_string_decoded, buffer);
     }
     else {
@@ -2037,7 +2111,7 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
         // dictionary and decode each of the parameters individually.
         // OR: in url_query_string_decoded use as separator a control character that cannot appear in the URL.
 
-        url_decode_r(buffer, path_and_query_string, NETDATA_WEB_REQUEST_URL_SIZE + 1);
+        url_decode_r(buffer, path_and_query_string, w->url_decode_buffer_size);
 
         char *question_mark_start = strchr(buffer, '?');
         if (question_mark_start) {
@@ -2065,6 +2139,8 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
            && (decoded_path_len == 4 || decoded_path[4] == '/'))
             web_client_flag_set(w, WEB_CLIENT_FLAG_PATH_IS_MCP);
     }
+
+    return true;
 }
 
 void web_client_reuse_from_cache(struct web_client *w) {
@@ -2080,6 +2156,8 @@ void web_client_reuse_from_cache(struct web_client *w) {
     BUFFER *b5 = w->url_as_received;
     BUFFER *b6 = w->url_query_string_decoded;
     BUFFER *b7 = w->payload;
+    char *url_decode_buffer = w->url_decode_buffer;
+    size_t url_decode_buffer_size = w->url_decode_buffer_size;
 
     NETDATA_SSL ssl = w->ssl;
 
@@ -2103,6 +2181,8 @@ void web_client_reuse_from_cache(struct web_client *w) {
     w->url_as_received = b5;
     w->url_query_string_decoded = b6;
     w->payload = b7;
+    w->url_decode_buffer = url_decode_buffer;
+    w->url_decode_buffer_size = url_decode_buffer_size;
 }
 
 struct web_client *web_client_create(size_t *statistics_memory_accounting) {

--- a/src/web/server/web_client.c
+++ b/src/web/server/web_client.c
@@ -776,8 +776,13 @@ HTTP_VALIDATION http_request_validate(struct web_client *w) {
     size_t last_pos = w->header_parse_last_size;
 
     w->header_parse_last_size = buffer_strlen(w->response.data);
-    if(w->header_parse_last_size <= last_pos)
-        w->header_parse_tries++;
+
+    // Count every parse attempt, not only the ones that saw no new bytes.
+    // http_request_validate() is reached from the socket server only after
+    // web_client_receive() returned bytes > 0, so counting no-progress
+    // attempts alone would never increment here and the budget below would
+    // be unreachable in production.
+    w->header_parse_tries++;
 
     char *request_end = request + w->header_parse_last_size;
 
@@ -795,7 +800,7 @@ HTTP_VALIDATION http_request_validate(struct web_client *w) {
         if(!is_it_valid) {
             if(w->header_parse_tries > HTTP_REQ_MAX_HEADER_FETCH_TRIES) {
                 netdata_log_info(
-                    "Disabling slow client after %zu attempts to parse without receiving more data (%zu bytes received)",
+                    "Disabling slow client after %zu attempts to read the request (%zu bytes received)",
                     w->header_parse_tries,
                     buffer_strlen(w->response.data));
                 w->header_parse_tries = 0;

--- a/src/web/server/web_client.h
+++ b/src/web/server/web_client.h
@@ -21,7 +21,8 @@ typedef enum __attribute__((packed)) {
     HTTP_VALIDATION_TOO_MANY_READ_RETRIES,
     HTTP_VALIDATION_MALFORMED_URL,
     HTTP_VALIDATION_INCOMPLETE,
-    HTTP_VALIDATION_REDIRECT
+    HTTP_VALIDATION_REDIRECT,
+    HTTP_VALIDATION_URI_TOO_LONG
 } HTTP_VALIDATION;
 
 typedef enum __attribute__((packed)) {
@@ -145,14 +146,14 @@ void web_client_set_conn_unix(struct web_client *w);
 void web_client_set_conn_cloud(struct web_client *w);
 void web_client_set_conn_webrtc(struct web_client *w);
 
-#define NETDATA_WEB_REQUEST_URL_SIZE 65536              // static allocation
-
 #define NETDATA_WEB_RESPONSE_ZLIB_CHUNK_SIZE 16384
 
 #define NETDATA_WEB_RESPONSE_HEADER_INITIAL_SIZE 4096
 #define NETDATA_WEB_RESPONSE_INITIAL_SIZE 8192
 #define NETDATA_WEB_REQUEST_INITIAL_SIZE 8192
-#define NETDATA_WEB_REQUEST_MAX_SIZE (128 * 1024)
+#define NETDATA_WEB_REQUEST_MAX_SIZE (1024 * 1024)
+#define NETDATA_WEB_REQUEST_URL_DECODE_INITIAL_SIZE (4 * 1024)
+#define NETDATA_WEB_REQUEST_URL_DECODE_CACHE_MAX_SIZE (64 * 1024)
 #define NETDATA_WEB_DECODED_URL_INITIAL_SIZE 512
 
 struct response {
@@ -191,6 +192,7 @@ struct web_client {
     HTTP_ACCESS access;                 // the access permissions of the client
     size_t header_parse_tries;
     size_t header_parse_last_size;
+    size_t header_parse_expected_size;  // POST/PUT total; SIZE_MAX means invalid framing
 
     int fd;
 
@@ -202,6 +204,8 @@ struct web_client {
     BUFFER *url_as_received;            // the entire URL as received, used for logging - DO NOT MODIFY
     BUFFER *url_path_decoded;           // the path, decoded - it is incrementally parsed and altered
     BUFFER *url_query_string_decoded;   // the query string, decoded - it is incrementally parsed and altered
+    char *url_decode_buffer;            // reusable URL-decoding scratch space
+    size_t url_decode_buffer_size;
 
     // THESE NEED TO BE FREED
     char *auth_bearer_token;            // the Bearer auth token (if sent)
@@ -275,7 +279,8 @@ void web_client_free(struct web_client *w);
 #include "web/api/web_api_v2.h"
 #include "database/rrd.h"
 
-void web_client_decode_path_and_query_string(struct web_client *w, const char *path_and_query_string);
+bool web_client_decode_path_and_query_string(struct web_client *w, const char *path_and_query_string);
+void web_client_trim_url_decode_buffer_for_cache(struct web_client *w);
 int web_client_api_request(RRDHOST *host, struct web_client *w, char *url_path_fragment);
 int web_client_api_request_with_node_selection(RRDHOST *host, struct web_client *w, char *decoded_url_path);
 

--- a/src/web/server/web_client.h
+++ b/src/web/server/web_client.h
@@ -10,8 +10,6 @@ struct web_client;
 
 extern int web_enable_gzip, web_gzip_level, web_gzip_strategy;
 
-#define HTTP_REQ_MAX_HEADER_FETCH_TRIES 100
-
 extern int respect_web_browser_do_not_track_policy;
 extern const char *web_x_frame_options;
 
@@ -152,6 +150,19 @@ void web_client_set_conn_webrtc(struct web_client *w);
 #define NETDATA_WEB_RESPONSE_INITIAL_SIZE 8192
 #define NETDATA_WEB_REQUEST_INITIAL_SIZE 8192
 #define NETDATA_WEB_REQUEST_MAX_SIZE (1024 * 1024)
+
+// Number of parse attempts (i.e. receive events) a request may consume while it
+// is still incomplete. Completeness is checked before exhaustion, so a request
+// that completes on the attempt that would have exceeded this budget is still
+// served; only requests that remain incomplete are disconnected.
+//
+// Budgeted as one receive per 512 bytes of the maximum request size: a chosen
+// fragmentation allowance, not a guaranteed minimum receive size. A 1 MiB
+// request delivered in 1460-byte TCP segments needs ~719 receives, so this
+// leaves ~2.8x headroom. Requests fragmented more finely than the allowance are
+// rejected on purpose.
+#define HTTP_REQ_MAX_HEADER_FETCH_TRIES ((NETDATA_WEB_REQUEST_MAX_SIZE + 511) / 512)
+
 #define NETDATA_WEB_REQUEST_URL_DECODE_INITIAL_SIZE (4 * 1024)
 #define NETDATA_WEB_REQUEST_URL_DECODE_CACHE_MAX_SIZE (64 * 1024)
 #define NETDATA_WEB_DECODED_URL_INITIAL_SIZE 512

--- a/src/web/server/web_client_cache.c
+++ b/src/web/server/web_client_cache.c
@@ -130,6 +130,7 @@ struct web_client *web_client_get_from_cache(void) {
 
 void web_client_release_to_cache(struct web_client *w) {
     netdata_ssl_close(&w->ssl);
+    web_client_trim_url_decode_buffer_for_cache(w);
 
     // unlink it from the used
     spinlock_lock(&web_clients_cache.used.spinlock);


### PR DESCRIPTION
## Summary

- raise the whole HTTP request limit from 128 KiB to 1 MiB
- replace the fixed 64 KiB URL-decoding stack array with per-client heap scratch space that grows from 4 KiB to at most 1 MiB
- retain at most 64 KiB of decoder scratch in the global web-client cache and return HTTP 414 when the request target exceeds the decoder ceiling

Requests that already fit retain the existing parsing, decoding, routing, and response behavior. The generic incomplete/oversized whole-request path remains HTTP 400.

## Validation

- full C-only Debug `netdata -W unittest`: passed
- full AddressSanitizer `netdata -W unittest`: passed with no sanitizer report
- `ENABLE_WEBRTC=ON` full `netdata` build: passed
- live AddressSanitizer HTTP boundary test: exactly 1 MiB whole request returned 200; exactly 1 MiB request target returned 414
- alternating local Release/LTO benchmarks: ordinary API requests +1.12%; 60 KiB request targets +0.28% (both within run-to-run noise)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the maximum HTTP request size from 128 KiB to 1 MiB so larger requests are accepted. Request targets that reach the 1 MiB URL-decoder ceiling now return HTTP 414; other incomplete or oversized whole requests remain HTTP 400.

**Implementation and tests**

- Replaces the fixed URL-decoding stack buffer with per-client heap scratch space that grows from 4 KiB to 1 MiB; at most 64 KiB is retained when clients return to the global cache.
- Applies URI-length handling to WebRTC and ACLK requests.
- Counts every parse attempt against a 2048-attempt budget so overly fragmented or stalled requests are disconnected, and clamps the completeness cursor so short first receives validate correctly.
- Adds unit tests for request boundaries, buffer reuse, cache trimming, fragmented requests, retry exhaustion, and memory accounting.

<sup>Written for commit 157b704ad8fd5f7e47ff75538237ff743fbd625c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large URLs and requests, supporting requests up to 1 MB.
  * Oversized request URIs now return HTTP 414 errors.
  * Improved processing of fragmented POST and PUT requests.
  * Improved validation retry behavior when request data arrives in multiple parts.
  * Improved request handling for ACLK and WebRTC API endpoints.

* **Tests**
  * Added coverage for request-size limits, URL decoding, payload framing, fragmented requests, retry behavior, and oversized URI responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->