### PR TITLE
chore(sow): complete the SOW schema for umbrellas and harden the audit matcher

### DIFF
--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -1,9 +1,11 @@
 # SOW-YYYYMMDD-<slug> - <Title>
 
 This template is the schema of a SOW. `.agents/sow/audit.sh` derives the required sections from the `##` headings and
-their tags: untagged = required in every SOW; `<!-- sow:implementation -->` = required except in umbrella SOWs;
-`<!-- sow:umbrella-only -->` = required only in umbrella SOWs; `<!-- sow:optional -->` = never required. The audit
-checks presence; filling every field is your responsibility. Field semantics live in the placeholders.
+their tag, written exactly `<!-- sow:VALUE -->` (tags on `###` headings are ignored): no tag = required in every SOW,
+umbrellas included; `sow:implementation` = required except in umbrella SOWs; `sow:umbrella-only` = required in umbrella
+SOWs; `sow:optional` = never required. The audit also expects the field labels `Sensitive data handling plan:` and
+`Sensitive data gate:` verbatim (renaming them needs an audit change). The check is advisory and covers presence only;
+filling every field is your responsibility. Field semantics live in the placeholders.
 
 ## Status
 
@@ -69,7 +71,7 @@ Risks:
 
 - <risk and implication>
 
-## Pre-Implementation Gate <!-- sow:implementation -->
+## Pre-Implementation Gate
 
 Gate status: blocked
 
@@ -141,8 +143,8 @@ Open decisions:
 
 ## Implications And Decisions
 
-<Numbered user decisions, options, selection, and reasoning. User decisions must be recorded before implementation.>
-
+<Numbered user decisions, options, selection, and reasoning. User decisions must be recorded before implementation.
+A step SOW cites the umbrella's decisions by number instead of restating them.>
 
 ## Steps <!-- sow:umbrella-only -->
 
@@ -151,6 +153,10 @@ See "Umbrella And Step SOWs" in `AGENTS.md`; delete this section in non-umbrella
 | # | Step SOW | Status | PR |
 |---|---|---|---|
 | 01 | SOW-YYYYMMDD-<family>-01-<step>.md | planning | |
+
+Cross-step follow-up mapping:
+
+- <every item deferred across steps: implemented in step NN, rejected with evidence, or a linked GitHub issue>
 
 ## Execution Log
 

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -3,9 +3,9 @@
 This template is the schema of a SOW. `.agents/sow/audit.sh` derives the required sections from the `##` headings and
 their tag, written exactly `<!-- sow:VALUE -->` (tags on `###` headings are ignored): no tag = required in every SOW,
 umbrellas included; `sow:implementation` = required except in umbrella SOWs; `sow:umbrella-only` = required in umbrella
-SOWs; `sow:optional` = never required. The audit also expects the field labels `Sensitive data handling plan:` and
-`Sensitive data gate:` verbatim (renaming them needs an audit change). The check is advisory and covers presence only;
-filling every field is your responsibility. Field semantics live in the placeholders.
+SOWs; `sow:optional` = never required. The audit also expects two field labels verbatim: `Sensitive data handling plan:`
+in every SOW and `Sensitive data gate:` in non-umbrella SOWs (renaming either needs an audit change). The check is
+advisory and covers presence only; filling every field is your responsibility. Field semantics live in the placeholders.
 
 ## Status
 

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -137,32 +137,52 @@ ok "$total_sows local SOW working file(s) under .agents/sow/q (local-only, never
 
 # Structural completeness is advisory and checked only for in-flight SOWs in the
 # current queue; pending stubs and completed (done/) history are exempt.
-# Required sections come from the template (the SOW schema). Each '## ' heading
-# carries an optional HTML-comment tag: none = required in every SOW;
-# sow:implementation = required except in umbrella SOWs; sow:umbrella-only =
-# required only in umbrella SOWs; sow:optional = never required. The two
-# sensitive-data field labels are pinned here as a security contract (they also
-# exist in the template). Needles are compared as whole lines after stripping
-# trailing whitespace and any HTML comment, on both sides.
+# Required sections come from the template (the SOW schema). Each '## ' heading may
+# carry one tag written exactly '<!-- sow:VALUE -->': none = required in every SOW
+# (umbrellas included); implementation = required except in umbrella SOWs;
+# umbrella-only = required in umbrella SOWs; optional = never required. Malformed,
+# unknown, or multiple tags are reported and the heading is treated as required
+# everywhere. The two sensitive-data field labels are pinned as a security contract.
 sow_base_sections=(); sow_impl_sections=(); sow_umbrella_sections=()
-# Normalize a line for matching: drop CR, trailing HTML comment, trailing space,
-# a leading list marker, and bold markers.
-strip_line() { tr -d '\r' | sed -E 's/[[:space:]]*<!--.*-->[[:space:]]*$//; s/[[:space:]]+$//; s/^[[:space:]]*[-*]+[[:space:]]+//; s/\*\*//g'; }
+sow_heading_text() { printf '%s\n' "$1" | tr -d '\r' | sed -E 's/[[:space:]]*<!--.*-->[[:space:]]*$//; s/[[:space:]]+$//'; }
 while IFS= read -r h; do
   [ -n "$h" ] || continue
-  case "$h" in
-    *"<!--"*sow:optional*)      ;;
-    *"<!--"*sow:umbrella-only*) sow_umbrella_sections+=("$(printf '%s\n' "$h" | strip_line)") ;;
-    *"<!--"*sow:implementation*) sow_impl_sections+=("$(printf '%s\n' "$h" | strip_line)") ;;
-    *)                          sow_base_sections+=("$(printf '%s\n' "$h" | strip_line)") ;;
+  text=$(sow_heading_text "$h")
+  tag_list=$(printf '%s\n' "$h" | grep -o -- '<!-- sow:[a-z-]* -->' | sed -E 's/^<!-- sow:([a-z-]*) -->$/\1/')
+  ntag=0; [ -n "$tag_list" ] && ntag=$(printf '%s\n' "$tag_list" | wc -l | tr -d ' ')
+  tag=""
+  if [ "$ntag" -eq 1 ]; then
+    tag="$tag_list"
+  elif [ "$ntag" -gt 1 ]; then
+    warn "template heading carries several sow: tags; treated as required everywhere: $h"
+  elif printf '%s\n' "$h" | grep -qi -- 'sow:'; then
+    warn "template heading carries a malformed sow: tag; treated as required everywhere: $h"
+  fi
+  case "$tag" in
+    optional)       ;;
+    umbrella-only)  sow_umbrella_sections+=("$text") ;;
+    implementation) sow_impl_sections+=("$text") ;;
+    "")             sow_base_sections+=("$text") ;;
+    *) warn "template heading carries unknown sow: tag '$tag'; treated as required everywhere: $h"
+       sow_base_sections+=("$text") ;;
   esac
 done < <(grep -E '^## ' .agents/sow/SOW.template.md 2>/dev/null)
 pinned_sow_fields=("Sensitive data handling plan:" "Sensitive data gate:")
-# $1 needle, $2 file. "## " headings must match a whole line; "Label:" fields match a
-# line prefix (inline content allowed). awk reads all input, so no SIGPIPE under pipefail.
+[ "${#sow_base_sections[@]}" -gt 0 ] || warn "no untagged '## ' heading in .agents/sow/SOW.template.md; structural SOW check skipped"
+
+# $1 needle, $2 file. A '## ' needle must equal a whole heading line; any other
+# needle ("Label:") must start a line once a list marker and bold markers are
+# dropped. Lines inside ``` fences are ignored. awk reads to EOF (pipefail-safe).
 sow_has_line() {
   local mode=prefix; case "$1" in "## "*) mode=exact ;; esac
-  strip_line < "$2" | awk -v n="$1" -v m="$mode" '(m=="exact" && $0==n) || (m=="prefix" && index($0,n)==1) {f=1} END{exit !f}'
+  awk -v n="$1" -v m="$mode" '
+    { sub(/\r$/, "") }
+    /^[[:space:]]*```/ { fence = !fence; next }
+    fence { next }
+    { sub(/[[:space:]]*<!--.*-->[[:space:]]*$/, ""); sub(/[[:space:]]+$/, "") }
+    m == "exact" && $0 == n { f = 1 }
+    m == "prefix" { l = $0; sub(/^[[:space:]]*[-*]+[[:space:]]+/, "", l); gsub(/\*\*/, "", l); if (index(l, n) == 1) f = 1 }
+    END { exit !f }' "$2"
 }
 active_count=0
 if [ -d .agents/sow/q/current ]; then
@@ -183,11 +203,9 @@ if [ -d .agents/sow/q/current ]; then
         ;;
     esac
 
-    if [ "${#sow_base_sections[@]}" -eq 0 ]; then
-      warn "template headings unreadable; structural SOW check skipped"
-      continue
-    fi
-    # Umbrella SOWs hold decisions and the step table, not a gate or validation.
+    [ "${#sow_base_sections[@]}" -gt 0 ] || continue
+    # Umbrella SOWs get the base set plus umbrella-only sections; others get the
+    # base set plus implementation sections and the pinned field labels.
     needles=("${sow_base_sections[@]}")
     case "$sow" in
       *-umbrella.md) needles+=(${sow_umbrella_sections[@]+"${sow_umbrella_sections[@]}"}) ;;

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -151,14 +151,15 @@ sow_heading_text() { printf '%s\n' "$1" | tr -d '\r' | sed -E 's/[[:space:]]*<!-
 while IFS= read -r h; do
   [ -n "$h" ] || continue
   text=$(sow_heading_text "$h")
+  # Every HTML comment mentioning sow: counts; only one, in the exact trailing form, is a valid tag.
+  ncomment=$(printf '%s\n' "$h" | grep -o -- '<!--[^>]*-->' | grep -ci -- 'sow:')
   tag_list=$(printf '%s\n' "$h" | sed -E 's/[[:space:]]+$//' | grep -o -- '<!-- sow:[a-z-]* -->$' | sed -E 's/^<!-- sow:([a-z-]*) -->$/\1/')
-  ntag=0; [ -n "$tag_list" ] && ntag=$(printf '%s\n' "$tag_list" | wc -l | tr -d ' ')
   tag=""
-  if [ "$ntag" -eq 1 ]; then
-    tag="$tag_list"
-  elif [ "$ntag" -gt 1 ]; then
+  if [ "$ncomment" -gt 1 ]; then
     warn "template heading carries several sow: tags; treated as required everywhere: $h"
-  elif printf '%s\n' "$h" | grep -qi -- '<!--[^>]*sow:'; then
+  elif [ "$ncomment" -eq 1 ] && [ -n "$tag_list" ]; then
+    tag="$tag_list"
+  elif [ "$ncomment" -eq 1 ]; then
     warn "template heading carries a malformed sow: tag; treated as required everywhere: $h"
   fi
   case "$tag" in
@@ -169,21 +170,21 @@ while IFS= read -r h; do
     *) warn "template heading carries unknown sow: tag '$tag'; treated as required everywhere: $h"
        sow_base_sections+=("$text") ;;
   esac
-done < <(awk '/^[[:space:]]*```/ { fence = !fence; next } !fence && /^## /' .agents/sow/SOW.template.md 2>/dev/null)
+done < <(awk '/^[[:space:]]*(```|~~~)/ { fence = !fence; next } !fence && /^## /' .agents/sow/SOW.template.md 2>/dev/null)
 pinned_sow_fields_all=("Sensitive data handling plan:")
 pinned_sow_fields_impl=("Sensitive data gate:")
 [ "${#sow_base_sections[@]}" -gt 0 ] || warn "no untagged '## ' heading in .agents/sow/SOW.template.md; structural SOW check skipped"
 
 # $1 needle, $2 file. A '## ' needle must equal a whole heading line; any other
 # needle ("Label:") must start a line once a list marker and bold markers are
-# dropped. Lines inside ``` fences are ignored. The needle travels via the environment
+# dropped. Lines inside ``` or ~~~ fences are ignored. The needle travels via the environment
 # so a backslash in a heading is not reinterpreted by awk.
 sow_has_line() {
   local mode=prefix; case "$1" in "## "*) mode=exact ;; esac
   n="$1" awk -v m="$mode" '
     BEGIN { n = ENVIRON["n"] }
     { sub(/\r$/, "") }
-    /^[[:space:]]*```/ { fence = !fence; next }
+    /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
     fence { next }
     { sub(/[[:space:]]*<!--.*-->[[:space:]]*$/, ""); sub(/[[:space:]]+$/, "") }
     m == "exact" && $0 == n { f = 1 }

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -42,6 +42,7 @@ section() {
 
 read_sow_status() {
   awk '
+    { sub(/\r$/, "") }
     function clean(s, a) {
       gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
       gsub(/`/, "", s)
@@ -106,6 +107,7 @@ for q in pending current "done"; do
     warn ".agents/sow/q/$q missing (run .agents/sow/worktree-link.sh)"
   fi
 done
+[ ! -d .agents/sow/q/active ] || warn "retired queue .agents/sow/q/active exists; run .agents/sow/worktree-link.sh to fold it into current/"
 
 section "tracking invariants"
 for f in .agents/sow/SOW.template.md .agents/sow/audit.sh .agents/sow/scan-sensitive.sh .agents/sow/worktree-link.sh; do
@@ -149,7 +151,7 @@ sow_heading_text() { printf '%s\n' "$1" | tr -d '\r' | sed -E 's/[[:space:]]*<!-
 while IFS= read -r h; do
   [ -n "$h" ] || continue
   text=$(sow_heading_text "$h")
-  tag_list=$(printf '%s\n' "$h" | grep -o -- '<!-- sow:[a-z-]* -->' | sed -E 's/^<!-- sow:([a-z-]*) -->$/\1/')
+  tag_list=$(printf '%s\n' "$h" | sed -E 's/[[:space:]]+$//' | grep -o -- '<!-- sow:[a-z-]* -->$' | sed -E 's/^<!-- sow:([a-z-]*) -->$/\1/')
   ntag=0; [ -n "$tag_list" ] && ntag=$(printf '%s\n' "$tag_list" | wc -l | tr -d ' ')
   tag=""
   if [ "$ntag" -eq 1 ]; then
@@ -185,7 +187,7 @@ sow_has_line() {
     fence { next }
     { sub(/[[:space:]]*<!--.*-->[[:space:]]*$/, ""); sub(/[[:space:]]+$/, "") }
     m == "exact" && $0 == n { f = 1 }
-    m == "prefix" { l = $0; sub(/^[[:space:]]*[-*]+[[:space:]]+/, "", l); gsub(/\*\*/, "", l); if (index(l, n) == 1) f = 1 }
+    m == "prefix" { l = $0; sub(/^[[:space:]]*[-*]+[[:space:]]+/, "", l); gsub(/\*\*/, "", l); gsub(/`/, "", l); if (index(l, n) == 1) f = 1 }
     END { exit !f }' "$2"
 }
 active_count=0

--- a/.agents/sow/audit.sh
+++ b/.agents/sow/audit.sh
@@ -142,7 +142,8 @@ ok "$total_sows local SOW working file(s) under .agents/sow/q (local-only, never
 # (umbrellas included); implementation = required except in umbrella SOWs;
 # umbrella-only = required in umbrella SOWs; optional = never required. Malformed,
 # unknown, or multiple tags are reported and the heading is treated as required
-# everywhere. The two sensitive-data field labels are pinned as a security contract.
+# everywhere. Two field labels are pinned as a security contract: the handling plan
+# (in the gate, every SOW) and the gate label (in Validation, non-umbrella SOWs).
 sow_base_sections=(); sow_impl_sections=(); sow_umbrella_sections=()
 sow_heading_text() { printf '%s\n' "$1" | tr -d '\r' | sed -E 's/[[:space:]]*<!--.*-->[[:space:]]*$//; s/[[:space:]]+$//'; }
 while IFS= read -r h; do
@@ -155,7 +156,7 @@ while IFS= read -r h; do
     tag="$tag_list"
   elif [ "$ntag" -gt 1 ]; then
     warn "template heading carries several sow: tags; treated as required everywhere: $h"
-  elif printf '%s\n' "$h" | grep -qi -- 'sow:'; then
+  elif printf '%s\n' "$h" | grep -qi -- '<!--[^>]*sow:'; then
     warn "template heading carries a malformed sow: tag; treated as required everywhere: $h"
   fi
   case "$tag" in
@@ -166,16 +167,19 @@ while IFS= read -r h; do
     *) warn "template heading carries unknown sow: tag '$tag'; treated as required everywhere: $h"
        sow_base_sections+=("$text") ;;
   esac
-done < <(grep -E '^## ' .agents/sow/SOW.template.md 2>/dev/null)
-pinned_sow_fields=("Sensitive data handling plan:" "Sensitive data gate:")
+done < <(awk '/^[[:space:]]*```/ { fence = !fence; next } !fence && /^## /' .agents/sow/SOW.template.md 2>/dev/null)
+pinned_sow_fields_all=("Sensitive data handling plan:")
+pinned_sow_fields_impl=("Sensitive data gate:")
 [ "${#sow_base_sections[@]}" -gt 0 ] || warn "no untagged '## ' heading in .agents/sow/SOW.template.md; structural SOW check skipped"
 
 # $1 needle, $2 file. A '## ' needle must equal a whole heading line; any other
 # needle ("Label:") must start a line once a list marker and bold markers are
-# dropped. Lines inside ``` fences are ignored. awk reads to EOF (pipefail-safe).
+# dropped. Lines inside ``` fences are ignored. The needle travels via the environment
+# so a backslash in a heading is not reinterpreted by awk.
 sow_has_line() {
   local mode=prefix; case "$1" in "## "*) mode=exact ;; esac
-  awk -v n="$1" -v m="$mode" '
+  n="$1" awk -v m="$mode" '
+    BEGIN { n = ENVIRON["n"] }
     { sub(/\r$/, "") }
     /^[[:space:]]*```/ { fence = !fence; next }
     fence { next }
@@ -204,12 +208,12 @@ if [ -d .agents/sow/q/current ]; then
     esac
 
     [ "${#sow_base_sections[@]}" -gt 0 ] || continue
-    # Umbrella SOWs get the base set plus umbrella-only sections; others get the
-    # base set plus implementation sections and the pinned field labels.
-    needles=("${sow_base_sections[@]}")
+    # Every SOW: base sections + the handling-plan label. Umbrellas add the
+    # umbrella-only sections; others add implementation sections + the gate label.
+    needles=("${sow_base_sections[@]}" "${pinned_sow_fields_all[@]}")
     case "$sow" in
       *-umbrella.md) needles+=(${sow_umbrella_sections[@]+"${sow_umbrella_sections[@]}"}) ;;
-      *)             needles+=(${sow_impl_sections[@]+"${sow_impl_sections[@]}"} "${pinned_sow_fields[@]}") ;;
+      *)             needles+=(${sow_impl_sections[@]+"${sow_impl_sections[@]}"} "${pinned_sow_fields_impl[@]}") ;;
     esac
     for needle in "${needles[@]}"; do
       if sow_has_line "$needle" "$sow"; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,17 +311,18 @@ Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeab
   SOW filename, status, PR.
 - Content split: the umbrella's Pre-Implementation Gate holds the full clean end state, the decomposition (as its
   implementation plan), and the open decisions; its `## Implications And Decisions` holds every user decision; its `##
-  Steps` section holds the step table and the cross-step follow-up mapping. An umbrella has no Workflow Friction,
-  Validation, or Artifact Maintenance Gate sections: its gate's `Validation plan:` and `Artifact impact plan:` describe
-  what the steps will do, and friction is recorded in the step SOWs. A step holds its own gate and Validation and cites
-  umbrella decisions by number. A step whose end state is fixed by the approved decomposition needs no new approval
-  round.
+  Steps` section holds the step table and the cross-step follow-up mapping. An umbrella does not need the Workflow
+  Friction, Validation, or Artifact Maintenance Gate sections (the schema does not require them for umbrellas): its
+  gate's `Validation plan:` and `Artifact impact plan:` describe what the steps will do, and friction is recorded in the
+  step SOWs. A step holds its own gate and Validation and cites umbrella decisions by number. A step whose end state is
+  fixed by the approved decomposition needs no new approval round.
 - Placement and status: the umbrella moves to `current/` when you begin filling its gate and stays there until the last
-  step completes. Its status is `planning` until the decomposition is approved (its gate `ready`), `in-progress` while
-  any step is in flight, and `completed` once the last step is complete and the cross-step follow-up mapping in `##
-  Steps` is resolved; then move it to `.agents/sow/q/done/`. `paused` on an umbrella means the initiative itself is
-  parked, not "waiting on steps". Steps follow the normal queue rules; the assistant updates the umbrella's `## Steps`
-  table whenever a step changes status or gains a PR.
+  step completes. Its status follows the normal ladder: `planning` until the decomposition is approved (its gate
+  `ready`), `ready` once approved with no step in flight yet, `in-progress` while any step is in flight, and `completed`
+  once the last step is complete and the cross-step follow-up mapping in `## Steps` is resolved; then move it to
+  `.agents/sow/q/done/`. `paused` on an umbrella means the initiative itself is parked, not "waiting on steps". Steps
+  follow the normal queue rules; the assistant updates the umbrella's `## Steps` table whenever a step changes status or
+  gains a PR.
 - One SOW at a time applies to steps. The umbrella is never executed and does not count.
 
 ### Pre-Implementation Gate
@@ -424,8 +425,9 @@ invalid.
 
 ### Artifact Maintenance Gate
 
-Every SOW close MUST record, per durable artifact class, what was updated or the evidence-backed reason no update
-was needed:
+Every standalone or step SOW close MUST record, per durable artifact class, what was updated or the evidence-backed
+reason no update was needed (an umbrella records nothing here: its gate's `Artifact impact plan:` covers the initiative
+and each step's Artifact Maintenance Gate records the actual updates):
 
 - `AGENTS.md`: workflow, responsibilities, local framework, project-wide guardrails.
 - Runtime project skills: `.agents/skills/project-*/SKILL.md`, HOW to work here.
@@ -445,10 +447,12 @@ evidence-backed reason it is unaffected.
   sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use. The audit pins, as hard failures,
   the marker line under "SOW System", the exact CRITICAL sensitive-data sentence, legacy `SOW-NNNN` references,
   relocated spec paths, missing or untracked framework files, a `q/` or `specs/` path that is not gitignored, a
-  `current/` SOW with a missing or invalid `Status:`, and a committed SOW or spec working file. It checks in-flight SOW
-  files under `q/current/` (advisory) for the template's required sections for their kind, the `Sensitive data handling
-  plan:` label in every SOW, and `Sensitive data gate:` in non-umbrella SOWs; a missing section or label there is a
-  warning, not a failure. It does not scan SOW working files or specs for secrets.
+  `current/` SOW with a missing or invalid `Status:`, a committed SOW or spec working file, and a sensitive-data hit in
+  the committed durable artifacts it scans (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.agents/ENV.md`, the framework
+  files, `.agents/skills/**`, `.agents/skill-verification/**`). It checks in-flight SOW files under `q/current/`
+  (advisory) for the template's required sections for their kind, the `Sensitive data handling plan:` label in every
+  SOW, and `Sensitive data gate:` in non-umbrella SOWs; a missing section or label there is a warning, not a failure. It
+  does not scan SOW working files or specs for secrets.
 - `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ Before non-trivial work:
 - Progress reports and Re-evaluation checkpoints are not stop points. Once a SOW is in progress with its approval
   recorded, continue until it is delivered, failed with evidence, blocked on a real user decision or approval, or
   superseded by newer user instructions.
-- Completion, when the work is ready to merge:
+- Completion of a standalone or step SOW, when the work is ready to merge (umbrellas: see "Umbrella And Step SOWs"):
   1. Finish implementation, docs, skills, validation, and follow-up mapping.
   2. Transfer all durable knowledge into project skills, docs, code, and tests (and specs once re-introduced). The
      SOW body MUST then hold nothing durable that is not captured elsewhere.
@@ -310,15 +310,18 @@ Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeab
   `Umbrella: SOW-YYYYMMDD-<family>-umbrella` in Requirements. The umbrella keeps a `## Steps` table: ordinal, step
   SOW filename, status, PR.
 - Content split: the umbrella's Pre-Implementation Gate holds the full clean end state, the decomposition (as its
-  implementation plan), and the open decisions; its `## Implications And Decisions` holds every user decision; its
-  `## Steps` section holds the step table and the cross-step follow-up mapping. An umbrella has no Validation or
-  Artifact Maintenance Gate. A step holds its own gate and Validation and cites umbrella decisions by number. A step
-  whose end state is fixed by the approved decomposition needs no new approval round.
-- Placement and status: the umbrella lives in `current/` from the first step's start until the last step completes, then
-  moves to `done/`. Its status is `planning` until the decomposition is approved (its gate `ready`), then `in-progress`
-  while any step is in flight. `paused` on an umbrella means the initiative itself is parked, not "waiting on steps".
-  Steps follow the normal queue rules; the assistant updates the umbrella's `## Steps` table whenever a step changes
-  status or gains a PR.
+  implementation plan), and the open decisions; its `## Implications And Decisions` holds every user decision; its `##
+  Steps` section holds the step table and the cross-step follow-up mapping. An umbrella has no Workflow Friction,
+  Validation, or Artifact Maintenance Gate sections: its gate's `Validation plan:` and `Artifact impact plan:` describe
+  what the steps will do, and friction is recorded in the step SOWs. A step holds its own gate and Validation and cites
+  umbrella decisions by number. A step whose end state is fixed by the approved decomposition needs no new approval
+  round.
+- Placement and status: the umbrella moves to `current/` when you begin filling its gate and stays there until the last
+  step completes. Its status is `planning` until the decomposition is approved (its gate `ready`), `in-progress` while
+  any step is in flight, and `completed` once the last step is complete and the cross-step follow-up mapping in `##
+  Steps` is resolved; then move it to `.agents/sow/q/done/`. `paused` on an umbrella means the initiative itself is
+  parked, not "waiting on steps". Steps follow the normal queue rules; the assistant updates the umbrella's `## Steps`
+  table whenever a step changes status or gains a PR.
 - One SOW at a time applies to steps. The umbrella is never executed and does not count.
 
 ### Pre-Implementation Gate
@@ -441,10 +444,11 @@ evidence-backed reason it is unaffected.
 - `.agents/sow/audit.sh`: local consistency audit for SOW rules, the local-only queue/spec layout, framework files, and
   sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use. The audit pins, as hard failures,
   the marker line under "SOW System", the exact CRITICAL sensitive-data sentence, legacy `SOW-NNNN` references,
-  relocated spec paths, missing or untracked framework files, and a `q/` or `specs/` path that is not gitignored. It
-  checks in-flight SOW files under `q/current/` (advisory) for the template's required sections for their kind and, in
-  non-umbrella SOWs, the two sensitive-data field labels; a missing section is a warning, not a failure. It does not
-  scan SOW working files or specs for secrets.
+  relocated spec paths, missing or untracked framework files, a `q/` or `specs/` path that is not gitignored, a
+  `current/` SOW with a missing or invalid `Status:`, and a committed SOW or spec working file. It checks in-flight SOW
+  files under `q/current/` (advisory) for the template's required sections for their kind, the `Sensitive data handling
+  plan:` label in every SOW, and `Sensitive data gate:` in non-umbrella SOWs; a missing section or label there is a
+  warning, not a failure. It does not scan SOW working files or specs for secrets.
 - `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,14 +309,16 @@ Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeab
 - Links by filename, never by queue path (paths go stale when files move). Each step records
   `Umbrella: SOW-YYYYMMDD-<family>-umbrella` in Requirements. The umbrella keeps a `## Steps` table: ordinal, step
   SOW filename, status, PR.
-- Content split: the umbrella holds the full clean end state, all user decisions, the decomposition, and cross-step
-  follow-up mapping. A step holds its own Pre-Implementation Gate and Validation and cites umbrella decisions by
-  number. A step whose end state is fixed by the approved decomposition needs no new approval round.
+- Content split: the umbrella's Pre-Implementation Gate holds the full clean end state, the decomposition (as its
+  implementation plan), and the open decisions; its `## Implications And Decisions` holds every user decision; its
+  `## Steps` section holds the step table and the cross-step follow-up mapping. An umbrella has no Validation or
+  Artifact Maintenance Gate. A step holds its own gate and Validation and cites umbrella decisions by number. A step
+  whose end state is fixed by the approved decomposition needs no new approval round.
 - Placement and status: the umbrella lives in `current/` from the first step's start until the last step completes, then
-  moves to `done/`. Its status is `planning` until the decomposition is approved, then `in-progress` while any step is
-  in flight (it skips `ready`: an umbrella is never implemented against directly). `paused` on an umbrella means the
-  initiative itself is parked, not "waiting on steps". Steps follow the normal queue rules; the assistant updates the
-  umbrella's `## Steps` table whenever a step changes status or gains a PR.
+  moves to `done/`. Its status is `planning` until the decomposition is approved (its gate `ready`), then `in-progress`
+  while any step is in flight. `paused` on an umbrella means the initiative itself is parked, not "waiting on steps".
+  Steps follow the normal queue rules; the assistant updates the umbrella's `## Steps` table whenever a step changes
+  status or gains a PR.
 - One SOW at a time applies to steps. The umbrella is never executed and does not count.
 
 ### Pre-Implementation Gate
@@ -411,9 +413,11 @@ Do not resurrect or mutate a prior SOW.
 
 ### Validation Gate
 
-A SOW cannot be completed until every field of the template's `## Validation` and `## Artifact Maintenance Gate`
-sections holds evidence. The template is the authoritative list of what Validation records; the semantics of each
-field live in its placeholder. Generic "N/A" is invalid.
+A SOW cannot be completed until every field of the template sections required for its kind holds evidence (tag
+legend at the top of the template): for a standalone or step SOW, `## Validation` and `## Artifact Maintenance Gate`;
+for an umbrella, every step completed and the cross-step follow-up mapping in `## Steps` resolved. The template is the
+authoritative list of what Validation records; the semantics of each field live in its placeholder. Generic "N/A" is
+invalid.
 
 ### Artifact Maintenance Gate
 
@@ -438,8 +442,9 @@ evidence-backed reason it is unaffected.
   sensitive data. `.agents/sow/scan-sensitive.sh` is the shared scanner it and CI use. The audit pins, as hard failures,
   the marker line under "SOW System", the exact CRITICAL sensitive-data sentence, legacy `SOW-NNNN` references,
   relocated spec paths, missing or untracked framework files, and a `q/` or `specs/` path that is not gitignored. It
-  checks in-flight SOW files under `q/current/` (advisory) for the template's required sections for their kind (umbrella
-  or not) plus the two sensitive-data field labels. It does not scan SOW working files or specs for secrets.
+  checks in-flight SOW files under `q/current/` (advisory) for the template's required sections for their kind and, in
+  non-umbrella SOWs, the two sensitive-data field labels; a missing section is a warning, not a failure. It does not
+  scan SOW working files or specs for secrets.
 - `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and


### PR DESCRIPTION
##### Summary

Follow-ups from the review of #23743 that landed after it merged.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves umbrella end-state and decomposition requirements into a required `## Pre-Implementation Gate` and adds explicit cross-step follow-up tracking. Previously, those requirements lived in sections excluded from umbrella SOWs; umbrellas now follow the normal status ladder and complete only after their steps and follow-ups resolve.

- Umbrella gates describe the clean end state, decomposition, validation plan, and artifact impact; standalone and step SOWs still require `## Validation` and `## Artifact Maintenance Gate`.
- Adds a follow-up mapping to `## Steps`, with step SOWs citing umbrella decisions by number.
- Parses only exact `<!-- sow:VALUE -->` tags; malformed, unknown, or multiple tags warn and make the section required everywhere.
- Ignores fenced code (``` and ~~~) and bullet-prefixed pseudo-headings, while supporting CRLF status lines and backticked field labels.
- Pins `Sensitive data handling plan:` in every SOW and `Sensitive data gate:` in non-umbrella SOWs.
- Adds hard failures for invalid `Status:`, committed SOW working files, and sensitive-data hits in scanned durable artifacts; warns about the retired `q/active/` queue and documents the lifecycle in `AGENTS.md`.

<sup>Written for commit 8202d5f3fd870b4d8761824ccd1d92d86ff91254. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified SOW heading-tag parsing and required sensitive-data labels.
  - Documented lifecycle and completion rules for standalone, step, and umbrella SOWs.
  - Added guidance for umbrella follow-up mappings, validation, and working-file handling.

- **Validation**
  - Improved audits for malformed, unknown, duplicate, and fenced-code headings.
  - Added SOW-type-specific checks for required sections and sensitive-data handling fields.
  - Expanded status and committed-artifact checks, including warnings for the retired `active` queue status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->