### PR TITLE
fix(exporting): preserve OpenTSDB telnet host and prefix characters

### DIFF
--- a/src/exporting/exporting_engine.h
+++ b/src/exporting/exporting_engine.h
@@ -267,6 +267,12 @@ void prepare_buffers(struct engine *engine);
 
 size_t exporting_name_copy(char *dst, const char *src, size_t max_len);
 
+// UTF-8 primitives shared by the text-protocol connectors (Graphite plaintext, OpenTSDB telnet).
+// Both frame their records with whitespace, so both need to decode UTF-8 before deciding what to
+// neutralize. Keep the decoding here and the per-protocol replacement decision in each connector.
+size_t exporting_utf8_decode(const char *src, size_t len, uint32_t *codepoint);
+bool exporting_unicode_is_whitespace(uint32_t codepoint);
+
 int rrdhost_is_exportable(struct instance *instance, RRDHOST *host);
 int rrdset_is_exportable(struct instance *instance, RRDSET *st);
 

--- a/src/exporting/graphite/graphite.c
+++ b/src/exporting/graphite/graphite.c
@@ -82,69 +82,12 @@ void sanitize_graphite_label_value(char *dst, const char *src, size_t len)
     *dst = '\0';
 }
 
-static size_t graphite_utf8_decode(const char *src, size_t len, uint32_t *codepoint) {
-    const uint8_t *s = (const uint8_t *)src;
-    uint32_t cp = s[0];
-    uint32_t minimum = 0;
-    size_t bytes = 1;
-
-    if(cp < 0x80)
-        goto done;
-    else if((cp & 0xE0) == 0xC0) {
-        cp &= 0x1F;
-        minimum = 0x80;
-        bytes = 2;
-    }
-    else if((cp & 0xF0) == 0xE0) {
-        cp &= 0x0F;
-        minimum = 0x800;
-        bytes = 3;
-    }
-    else if((cp & 0xF8) == 0xF0) {
-        cp &= 0x07;
-        minimum = 0x10000;
-        bytes = 4;
-    }
-    else
-        goto done;
-
-    if(bytes > len)
-        goto invalid;
-
-    for(size_t i = 1; i < bytes; i++) {
-        if((s[i] & 0xC0) != 0x80)
-            goto invalid;
-
-        cp = (cp << 6) | (s[i] & 0x3F);
-    }
-
-    if(cp < minimum || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF))
-        goto invalid;
-
-done:
-    *codepoint = cp;
-    return bytes;
-
-invalid:
-    *codepoint = s[0];
-    return 1;
-}
-
-static bool graphite_unicode_is_whitespace(uint32_t codepoint) {
-    return (codepoint >= 0x0009 && codepoint <= 0x000D) ||
-           (codepoint >= 0x001C && codepoint <= 0x0020) ||
-           codepoint == 0x0085 || codepoint == 0x00A0 || codepoint == 0x1680 ||
-           (codepoint >= 0x2000 && codepoint <= 0x200A) ||
-           codepoint == 0x2028 || codepoint == 0x2029 || codepoint == 0x202F ||
-           codepoint == 0x205F || codepoint == 0x3000;
-}
-
 static void sanitize_graphite_metric_path_value(char *dst, const char *src, size_t len) {
     while(*src && len) {
         uint32_t codepoint;
-        size_t bytes = graphite_utf8_decode(src, len, &codepoint);
+        size_t bytes = exporting_utf8_decode(src, len, &codepoint);
 
-        if(codepoint == ';' || graphite_unicode_is_whitespace(codepoint))
+        if(codepoint == ';' || exporting_unicode_is_whitespace(codepoint))
             memset(dst, '_', bytes);
         else
             memcpy(dst, src, bytes);

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -134,11 +134,53 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
     *dst = '\0';
 }
 
+/**
+ * Copy a metric prefix or hostname, neutralizing only what must not reach an OpenTSDB telnet record
+ *
+ * A telnet record is `put <metric> <timestamp> <value> <tagk>=<tagv> ...\n`: whitespace-delimited
+ * fields, newline-terminated, with no quoting or escaping. So only whitespace (which splits a field)
+ * and the record terminator can corrupt or inject a record, and this sanitizer replaces those. It
+ * additionally replaces the remaining C0 controls and DEL, which cannot break our framing but are
+ * never legitimate in a hostname or prefix and would be interpreted by whatever consumes the record
+ * downstream. Everything else, punctuation included, is passed through byte for byte: this is metadata
+ * the user configured, and none of `:`, `=` or `;` can affect this record's framing. Whether the
+ * destination then accepts them is the destination's tag grammar and the operator's concern: stock
+ * OpenTSDB parses a tag by splitting on `=` and validates tag characters against its own allowlist.
+ * Corrupting the configured host identity to pre-empt that is what netdata/netdata#23684 reported.
+ *
+ * This is deliberately a superset of the Graphite metric-path sanitizer, which does not replace the
+ * non-whitespace controls. It is NOT the OpenTSDB *label value* policy: label values keep the
+ * identifier allowlist of sanitize_opentsdb_label_value().
+ *
+ * The replacement is byte-length preserving, which the callers below depend on for buffer sizing.
+ *
+ * @param dst a destination string.
+ * @param src a source string.
+ * @param len the maximum number of bytes copied.
+ */
+static void sanitize_opentsdb_telnet_metadata_value(char *dst, const char *src, size_t len) {
+    while(*src && len) {
+        uint32_t codepoint;
+        size_t bytes = exporting_utf8_decode(src, len, &codepoint);
+
+        if(codepoint < 0x20 || codepoint == 0x7F || exporting_unicode_is_whitespace(codepoint))
+            memset(dst, '_', bytes);
+        else
+            memcpy(dst, src, bytes);
+
+        dst += bytes;
+        src += bytes;
+        len -= bytes;
+    }
+
+    *dst = '\0';
+}
+
 static void buffer_strcat_opentsdb_telnet_value(BUFFER *wb, const char *src) {
     size_t len = strlen(src);
 
     buffer_need_bytes(wb, len + 1);
-    sanitize_opentsdb_label_value(&wb->buffer[wb->len], src, len);
+    sanitize_opentsdb_telnet_metadata_value(&wb->buffer[wb->len], src, len);
     wb->len += len;
     buffer_overflow_check(wb);
 }
@@ -854,12 +896,64 @@ int exporting_opentsdb_telnet_unittest(void) {
         "",
         "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name\n");
 
+    // netdata/netdata#23684: the configured hostname must survive intact. Only what can corrupt the
+    // record is replaced, so every printable byte the user configured reaches the destination.
+    errors += opentsdb_telnet_unittest_case(
+        "colon in metadata",
+        "net:data",
+        "Dev::MyHost",
+        " label=value",
+        "put net:data.chart.name.dimension.name 42 1.5 host=Dev::MyHost label=value\n");
+
+    errors += opentsdb_telnet_unittest_case(
+        "preserved punctuation",
+        "pre=fix;a,b+c%d@e#f",
+        "host=name;a,b+c(d)e[f]!g~h*i?j&k$l|m<n>o^p{q}r'\"s\\t",
+        " label=value",
+        "put pre=fix;a,b+c%d@e#f.chart.name.dimension.name 42 1.5 "
+        "host=host=name;a,b+c(d)e[f]!g~h*i?j&k$l|m<n>o^p{q}r'\"s\\t label=value\n");
+
+    errors += opentsdb_telnet_unittest_case(
+        "utf8 metadata",
+        "pr\xc3\xa9""fix",
+        "Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de",
+        " label=value",
+        "put pr\xc3\xa9""fix.chart.name.dimension.name 42 1.5 host=Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de label=value\n");
+
+    // an invalid sequence is copied byte for byte, so metadata we cannot interpret is not mangled
+    // (the exception is a lone 0x85 or 0xA0, whose byte value is itself a whitespace codepoint)
+    errors += opentsdb_telnet_unittest_case(
+        "malformed utf8 metadata",
+        "pre\xc3""fix",
+        "host\xff""name",
+        " label=value",
+        "put pre\xc3""fix.chart.name.dimension.name 42 1.5 host=host\xff""name label=value\n");
+
+    // non-breaking space: whitespace at the destination's splitter, replaced byte-length preserving
+    errors += opentsdb_telnet_unittest_case(
+        "unicode whitespace metadata",
+        "pre\xc2\xa0""fix",
+        "host\xe2\x80\x83name",
+        " label=value",
+        "put pre__fix.chart.name.dimension.name 42 1.5 host=host___name label=value\n");
+
+    // control bytes cannot break our framing, but are never legitimate metadata and would be
+    // interpreted by whatever consumes the record downstream
+    errors += opentsdb_telnet_unittest_case(
+        "control bytes in metadata",
+        "pre\x01\x1b""fix",
+        "host\x0b\x7f""name",
+        " label=value",
+        "put pre__fix.chart.name.dimension.name 42 1.5 host=host__name label=value\n");
+
     char long_prefix[4097];
     char long_hostname[4097];
     memset(long_prefix, 'p', sizeof(long_prefix) - 1);
     memset(long_hostname, 'h', sizeof(long_hostname) - 1);
     long_prefix[1024] = '\n';
+    long_prefix[2048] = ':';
     long_hostname[3072] = '\t';
+    long_hostname[2048] = ':';
     long_prefix[sizeof(long_prefix) - 1] = '\0';
     long_hostname[sizeof(long_hostname) - 1] = '\0';
 
@@ -873,10 +967,20 @@ int exporting_opentsdb_telnet_unittest(void) {
 
     const size_t expected_length = strlen("put ") + strlen(long_prefix) + strlen(".chart.name.dimension.name 42 1.5 host=") +
                                    strlen(long_hostname) + 1;
-    if(buffer_strlen(wb) != expected_length || wb->buffer[sizeof("put ") - 1 + 1024] != '_' ||
+    const size_t prefix_offset = sizeof("put ") - 1;
+    const size_t hostname_offset = prefix_offset + strlen(long_prefix) + strlen(".chart.name.dimension.name 42 1.5 host=");
+    if(buffer_strlen(wb) != expected_length || wb->buffer[prefix_offset + 1024] != '_' ||
        strchr(buffer_tostring(wb), '\t') || strchr(buffer_tostring(wb), '\r') ||
        strchr(buffer_tostring(wb), '\n') != &wb->buffer[wb->len - 1]) {
         fprintf(stderr, "OpenTSDB Telnet long metadata was truncated or retained a protocol delimiter\n");
+        errors++;
+    }
+
+    // the same length-preserving pass must leave configured punctuation alone at scale, not only in
+    // the short cases above
+    if(wb->buffer[prefix_offset + 2048] != ':' || wb->buffer[hostname_offset + 2048] != ':' ||
+       wb->buffer[hostname_offset + 3072] != '_') {
+        fprintf(stderr, "OpenTSDB Telnet long metadata lost a valid character or kept a delimiter\n");
         errors++;
     }
     buffer_free(wb);

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -145,14 +145,19 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
  * the record downstream. C1 belongs here for the same reason C0 does: U+009B is the single-character CSI,
  * the same escape hazard as U+001B. Everything else, punctuation included, is passed through byte for
  * byte: this is metadata the user configured, and none of `:`, `=` or `;` can affect this record's
- * framing. Whether the
- * destination then accepts them is the destination's tag grammar and the operator's concern: stock
- * OpenTSDB parses a tag by splitting on `=` and validates tag characters against its own allowlist.
- * Corrupting the configured host identity to pre-empt that is what netdata/netdata#23684 reported.
+ * framing. Whether the destination then accepts them is its tag grammar and the operator's concern:
+ * stock OpenTSDB parses a tag by splitting on `=` and validates tag characters against its own
+ * allowlist, so it may reject values other listeners accept. We take that trade knowingly, because
+ * corrupting the configured host identity to pre-empt it is what netdata/netdata#23684 reported: a
+ * rejected point is recoverable, a silently relabelled one splits the host's history for good. Note we
+ * do not surface the rejection -- this connector discards the destination's replies
+ * (exporting_discard_response), so it shows up as missing data at the destination, not as a netdata log
+ * line.
  *
- * This is deliberately a superset of the Graphite metric-path sanitizer, which does not replace the
- * non-whitespace controls. It is NOT the OpenTSDB *label value* policy: label values keep the
- * identifier allowlist of sanitize_opentsdb_label_value().
+ * This extends the Graphite metric-path sanitizer rather than mirroring it: it adds the non-whitespace
+ * controls Graphite passes through, and omits the `;` Graphite replaces for Carbon's tag syntax, so
+ * neither replaced set contains the other. It is also NOT the OpenTSDB *label value* policy: label
+ * values keep the identifier allowlist of sanitize_opentsdb_label_value().
  *
  * The replacement is byte-length preserving, which the callers below depend on for buffer sizing.
  *

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -147,12 +147,13 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
  * byte: this is metadata the user configured, and none of `:`, `=` or `;` can affect this record's
  * framing. Whether the destination then accepts them is its tag grammar and the operator's concern:
  * stock OpenTSDB parses a tag by splitting on `=` and validates tag characters against its own
- * allowlist, so it may reject values other listeners accept. We take that trade knowingly, because
- * corrupting the configured host identity to pre-empt it is what netdata/netdata#23684 reported: a
- * rejected point is recoverable, a silently relabelled one splits the host's history for good. Note we
- * do not surface the rejection -- this connector discards the destination's replies
- * (exporting_discard_response), so it shows up as missing data at the destination, not as a netdata log
- * line.
+ * allowlist, so it may reject values other listeners accept. We take that trade knowingly: a strict
+ * destination may reject a point, leaving a gap that requires correcting the configuration and possibly
+ * backfilling, whereas silently relabelling it would store it under a different host identity and split
+ * the host's history -- which is what netdata/netdata#23684 reported. Normal builds do not surface such a
+ * rejection: this connector drops the destination's replies (exporting_discard_response), so it appears
+ * as missing data at the destination rather than a netdata log line. Builds with NETDATA_INTERNAL_CHECKS
+ * log a debug sample before discarding the reply.
  *
  * This extends the Graphite metric-path sanitizer rather than mirroring it: it adds the non-whitespace
  * controls Graphite passes through, and omits the `;` Graphite replaces for Carbon's tag syntax, so

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -143,8 +143,9 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
  * additionally replaces the remaining control codepoints -- C0, DEL, and C1 -- which cannot break our
  * framing but are never legitimate in a hostname or prefix and would be interpreted by whatever consumes
  * the record downstream. C1 belongs here for the same reason C0 does: U+009B is the single-character CSI,
- * the same escape hazard as U+001B. Everything else, punctuation included, is passed through byte for byte: this is metadata
- * the user configured, and none of `:`, `=` or `;` can affect this record's framing. Whether the
+ * the same escape hazard as U+001B. Everything else, punctuation included, is passed through byte for
+ * byte: this is metadata the user configured, and none of `:`, `=` or `;` can affect this record's
+ * framing. Whether the
  * destination then accepts them is the destination's tag grammar and the operator's concern: stock
  * OpenTSDB parses a tag by splitting on `=` and validates tag characters against its own allowlist.
  * Corrupting the configured host identity to pre-empt that is what netdata/netdata#23684 reported.
@@ -920,7 +921,8 @@ int exporting_opentsdb_telnet_unittest(void) {
         "pr\xc3\xa9""fix",
         "Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de",
         " label=value",
-        "put pr\xc3\xa9""fix.chart.name.dimension.name 42 1.5 host=Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de label=value\n");
+        "put pr\xc3\xa9""fix.chart.name.dimension.name 42 1.5 "
+        "host=Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de label=value\n");
 
     // an invalid sequence is copied byte for byte, so metadata we cannot interpret is not mangled,
     // except where the lone byte value is itself a control or whitespace codepoint (0x80-0xA0)
@@ -998,7 +1000,8 @@ int exporting_opentsdb_telnet_unittest(void) {
     const size_t expected_length = strlen("put ") + strlen(long_prefix) + strlen(".chart.name.dimension.name 42 1.5 host=") +
                                    strlen(long_hostname) + 1;
     const size_t prefix_offset = sizeof("put ") - 1;
-    const size_t hostname_offset = prefix_offset + strlen(long_prefix) + strlen(".chart.name.dimension.name 42 1.5 host=");
+    const size_t hostname_offset =
+        prefix_offset + strlen(long_prefix) + strlen(".chart.name.dimension.name 42 1.5 host=");
     if(buffer_strlen(wb) != expected_length || wb->buffer[prefix_offset + 1024] != '_' ||
        strchr(buffer_tostring(wb), '\t') || strchr(buffer_tostring(wb), '\r') ||
        strchr(buffer_tostring(wb), '\n') != &wb->buffer[wb->len - 1]) {

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -847,136 +847,74 @@ static int opentsdb_telnet_unittest_case(
     return errors;
 }
 
-int exporting_opentsdb_telnet_unittest(void) {
-    int errors = 0;
-
-    errors += opentsdb_telnet_unittest_case(
-        "ordinary metadata",
-        "netdata",
-        "localhost",
-        " label=value",
-        "put netdata.chart.name.dimension.name 42 1.5 host=localhost label=value\n");
-
-    errors += opentsdb_telnet_unittest_case(
-        "allowed punctuation",
-        "Netdata-A_9/part.",
-        "Host-A_9/path.example",
-        " label=value",
-        "put Netdata-A_9/part..chart.name.dimension.name 42 1.5 host=Host-A_9/path.example label=value\n");
-
-    errors += opentsdb_telnet_unittest_case(
-        "hostile metadata",
-        "pre fix\tbad\r\nput",
-        "host name\tbad\r\nput",
-        " label=value",
-        "put pre_fix_bad__put.chart.name.dimension.name 42 1.5 host=host_name_bad__put label=value\n");
-
-    errors += opentsdb_telnet_unittest_case(
-        "all-invalid metadata",
-        " \t\r\n",
-        " \t\r\n",
-        " label=value",
-        "put ____.chart.name.dimension.name 42 1.5 host=____ label=value\n");
-
-    errors += opentsdb_telnet_unittest_case(
-        "empty metadata",
-        "",
-        "",
-        "",
-        "put .chart.name.dimension.name 42 1.5 host=\n");
-
-    errors += opentsdb_telnet_unittest_case(
-        "colliding invalid metadata",
-        "pre fix",
-        "host name",
-        "",
-        "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name\n");
-
-    errors += opentsdb_telnet_unittest_case(
-        "colliding valid metadata",
-        "pre_fix",
-        "host_name",
-        "",
-        "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name\n");
-
+static const struct {
+    const char *description;
+    const char *prefix;
+    const char *hostname;
+    const char *labels;
+    const char *expected;
+} opentsdb_telnet_cases[] = {
+    { "ordinary metadata", "netdata", "localhost", " label=value",
+      "put netdata.chart.name.dimension.name 42 1.5 host=localhost label=value\n" },
+    { "allowed punctuation", "Netdata-A_9/part.", "Host-A_9/path.example", " label=value",
+      "put Netdata-A_9/part..chart.name.dimension.name 42 1.5 host=Host-A_9/path.example label=value\n" },
+    { "hostile metadata", "pre fix\tbad\r\nput", "host name\tbad\r\nput", " label=value",
+      "put pre_fix_bad__put.chart.name.dimension.name 42 1.5 host=host_name_bad__put label=value\n" },
+    { "all-invalid metadata", " \t\r\n", " \t\r\n", " label=value",
+      "put ____.chart.name.dimension.name 42 1.5 host=____ label=value\n" },
+    { "empty metadata", "", "", "",
+      "put .chart.name.dimension.name 42 1.5 host=\n" },
+    { "colliding invalid metadata", "pre fix", "host name", "",
+      "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name\n" },
+    { "colliding valid metadata", "pre_fix", "host_name", "",
+      "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name\n" },
     // netdata/netdata#23684: the configured hostname must survive intact. Only what can corrupt the
     // record is replaced, so every printable byte the user configured reaches the destination.
-    errors += opentsdb_telnet_unittest_case(
-        "colon in metadata",
-        "net:data",
-        "Dev::MyHost",
-        " label=value",
-        "put net:data.chart.name.dimension.name 42 1.5 host=Dev::MyHost label=value\n");
-
-    errors += opentsdb_telnet_unittest_case(
-        "preserved punctuation",
-        "pre=fix;a,b+c%d@e#f",
-        "host=name;a,b+c(d)e[f]!g~h*i?j&k$l|m<n>o^p{q}r'\"s\\t",
-        " label=value",
-        "put pre=fix;a,b+c%d@e#f.chart.name.dimension.name 42 1.5 "
-        "host=host=name;a,b+c(d)e[f]!g~h*i?j&k$l|m<n>o^p{q}r'\"s\\t label=value\n");
-
-    errors += opentsdb_telnet_unittest_case(
-        "utf8 metadata",
-        "pr\xc3\xa9""fix",
-        "Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de",
-        " label=value",
-        "put pr\xc3\xa9""fix.chart.name.dimension.name 42 1.5 "
-        "host=Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de label=value\n");
-
+    { "colon in metadata", "net:data", "Dev::MyHost", " label=value",
+      "put net:data.chart.name.dimension.name 42 1.5 host=Dev::MyHost label=value\n" },
+    { "preserved punctuation", "pre=fix;a,b+c%d@e#f",
+      "host=name;a,b+c(d)e[f]!g~h*i?j&k$l|m<n>o^p{q}r'\"s\\t", " label=value",
+      "put pre=fix;a,b+c%d@e#f.chart.name.dimension.name 42 1.5 "
+      "host=host=name;a,b+c(d)e[f]!g~h*i?j&k$l|m<n>o^p{q}r'\"s\\t label=value\n" },
+    { "utf8 metadata", "pr\xc3\xa9""fix", "Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de", " label=value",
+      "put pr\xc3\xa9""fix.chart.name.dimension.name 42 1.5 "
+      "host=Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de label=value\n" },
     // an invalid sequence is copied byte for byte, so metadata we cannot interpret is not mangled,
     // except where the lone byte value is itself a control or whitespace codepoint (0x80-0xA0)
-    errors += opentsdb_telnet_unittest_case(
-        "malformed utf8 metadata",
-        "pre\xc3""fix",
-        "host\xff""name",
-        " label=value",
-        "put pre\xc3""fix.chart.name.dimension.name 42 1.5 host=host\xff""name label=value\n");
-
+    { "malformed utf8 metadata", "pre\xc3""fix", "host\xff""name", " label=value",
+      "put pre\xc3""fix.chart.name.dimension.name 42 1.5 host=host\xff""name label=value\n" },
     // non-breaking space: whitespace at the destination's splitter, replaced byte-length preserving
-    errors += opentsdb_telnet_unittest_case(
-        "unicode whitespace metadata",
-        "pre\xc2\xa0""fix",
-        "host\xe2\x80\x83name",
-        " label=value",
-        "put pre__fix.chart.name.dimension.name 42 1.5 host=host___name label=value\n");
-
+    { "unicode whitespace metadata", "pre\xc2\xa0""fix", "host\xe2\x80\x83name", " label=value",
+      "put pre__fix.chart.name.dimension.name 42 1.5 host=host___name label=value\n" },
     // C1 controls are the same hazard as C0 in their multi-byte form: U+009B is the
     // single-character CSI. Two source bytes become two underscores, keeping the length.
-    errors += opentsdb_telnet_unittest_case(
-        "c1 control in metadata",
-        "pre\xc2\x9b""fix",
-        "host\xc2\x80""name",
-        " label=value",
-        "put pre__fix.chart.name.dimension.name 42 1.5 host=host__name label=value\n");
-
+    { "c1 control in metadata", "pre\xc2\x9b""fix", "host\xc2\x80""name", " label=value",
+      "put pre__fix.chart.name.dimension.name 42 1.5 host=host__name label=value\n" },
     // a lead byte with no continuation left in the buffer is consumed one byte at a time, so a
     // truncated sequence is not silently rewritten. The orphan continuation byte in the hostname is
     // the documented exception: 0x82 decodes to its own value, which is a C1 control.
-    errors += opentsdb_telnet_unittest_case(
-        "truncated utf8 at end of metadata",
-        "prefix\xc3",
-        "hostname\xe2\x82",
-        " label=value",
-        "put prefix\xc3.chart.name.dimension.name 42 1.5 host=hostname\xe2_ label=value\n");
-
+    { "truncated utf8 at end of metadata", "prefix\xc3", "hostname\xe2\x82", " label=value",
+      "put prefix\xc3.chart.name.dimension.name 42 1.5 host=hostname\xe2_ label=value\n" },
     // same exception in its most likely form: a lone 0x85 or 0xA0 decodes to its own byte value,
     // which is the NEL and NBSP codepoint
-    errors += opentsdb_telnet_unittest_case(
-        "lone whitespace-valued bytes",
-        "pre\x85""fix",
-        "host\xa0""name",
-        " label=value",
-        "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name label=value\n");
-
+    { "lone whitespace-valued bytes", "pre\x85""fix", "host\xa0""name", " label=value",
+      "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name label=value\n" },
     // control bytes cannot break our framing, but are never legitimate metadata and would be
     // interpreted by whatever consumes the record downstream
-    errors += opentsdb_telnet_unittest_case(
-        "control bytes in metadata",
-        "pre\x01\x1b""fix",
-        "host\x0b\x7f""name",
-        " label=value",
-        "put pre__fix.chart.name.dimension.name 42 1.5 host=host__name label=value\n");
+    { "control bytes in metadata", "pre\x01\x1b""fix", "host\x0b\x7f""name", " label=value",
+      "put pre__fix.chart.name.dimension.name 42 1.5 host=host__name label=value\n" },
+};
+
+int exporting_opentsdb_telnet_unittest(void) {
+    int errors = 0;
+
+    for(size_t i = 0; i < sizeof(opentsdb_telnet_cases) / sizeof(opentsdb_telnet_cases[0]); i++)
+        errors += opentsdb_telnet_unittest_case(
+            opentsdb_telnet_cases[i].description,
+            opentsdb_telnet_cases[i].prefix,
+            opentsdb_telnet_cases[i].hostname,
+            opentsdb_telnet_cases[i].labels,
+            opentsdb_telnet_cases[i].expected);
 
     char long_prefix[4097];
     char long_hostname[4097];

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -138,27 +138,18 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
  * Copy a metric prefix or hostname, neutralizing only what must not reach an OpenTSDB telnet record
  *
  * A telnet record is `put <metric> <timestamp> <value> <tagk>=<tagv> ...\n`: whitespace-delimited
- * fields, newline-terminated, with no quoting or escaping. So only whitespace (which splits a field)
- * and the record terminator can corrupt or inject a record, and this sanitizer replaces those. It
- * additionally replaces the remaining control codepoints -- C0, DEL, and C1 -- which cannot break our
- * framing but are never legitimate in a hostname or prefix and would be interpreted by whatever consumes
- * the record downstream. C1 belongs here for the same reason C0 does: U+009B is the single-character CSI,
- * the same escape hazard as U+001B. Everything else, punctuation included, is passed through byte for
- * byte: this is metadata the user configured, and none of `:`, `=` or `;` can affect this record's
- * framing. Whether the destination then accepts them is its tag grammar and the operator's concern:
- * stock OpenTSDB parses a tag by splitting on `=` and validates tag characters against its own
- * allowlist, so it may reject values other listeners accept. We take that trade knowingly: a strict
- * destination may reject a point, leaving a gap that requires correcting the configuration and possibly
- * backfilling, whereas silently relabelling it would store it under a different host identity and split
- * the host's history -- which is what netdata/netdata#23684 reported. Normal builds do not surface such a
- * rejection: this connector drops the destination's replies (exporting_discard_response), so it appears
- * as missing data at the destination rather than a netdata log line. Builds with NETDATA_INTERNAL_CHECKS
- * log a debug sample before discarding the reply.
+ * fields, newline-terminated, with no quoting or escaping. Only whitespace and the record terminator
+ * can corrupt or inject a record, so those are replaced, along with the remaining control codepoints
+ * -- C0, DEL, and C1 -- which cannot break our framing but are never legitimate in a hostname or
+ * prefix: U+009B is the single-character CSI, the same escape hazard as U+001B.
  *
- * This extends the Graphite metric-path sanitizer rather than mirroring it: it adds the non-whitespace
- * controls Graphite passes through, and omits the `;` Graphite replaces for Carbon's tag syntax, so
- * neither replaced set contains the other. It is also NOT the OpenTSDB *label value* policy: label
- * values keep the identifier allowlist of sanitize_opentsdb_label_value().
+ * Everything else, punctuation included, is passed through byte for byte: none of `:`, `=` or `;`
+ * affects this record's framing, and relabelling metadata the user configured would store the point
+ * under a different host identity and split the host's history -- which is what netdata/netdata#23684
+ * reported. A destination with a stricter tag grammar (stock OpenTSDB has one) may reject such a point
+ * instead; that is the destination's rule and the operator's concern. This is therefore neither the Graphite
+ * metric-path policy (which passes the non-whitespace controls through, and replaces `;` for Carbon's
+ * tag syntax) nor the OpenTSDB label-value policy of sanitize_opentsdb_label_value().
  *
  * The replacement is byte-length preserving, which the callers below depend on for buffer sizing.
  *
@@ -901,8 +892,8 @@ static const struct {
     // the documented exception: 0x82 decodes to its own value, which is a C1 control.
     { "truncated utf8 at end of metadata", "prefix\xc3", "hostname\xe2\x82", " label=value",
       "put prefix\xc3.chart.name.dimension.name 42 1.5 host=hostname\xe2_ label=value\n" },
-    // same exception in its most likely form: a lone 0x85 or 0xA0 decodes to its own byte value,
-    // which is the NEL and NBSP codepoint
+    // the same exception, in the form most likely to occur: a lone 0x85 or 0xA0 decodes to its own
+    // byte value, which is the NEL and the NBSP codepoint
     { "lone whitespace-valued bytes", "pre\x85""fix", "host\xa0""name", " label=value",
       "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name label=value\n" },
     // control bytes cannot break our framing, but are never legitimate metadata and would be

--- a/src/exporting/opentsdb/opentsdb.c
+++ b/src/exporting/opentsdb/opentsdb.c
@@ -117,7 +117,7 @@ int init_opentsdb_http_instance(struct instance *instance)
  *
  * @param dst a destination string.
  * @param src a source string.
- * @param len the maximum number of characters copied.
+ * @param len the maximum number of bytes copied.
  */
 
 void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
@@ -140,9 +140,10 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
  * A telnet record is `put <metric> <timestamp> <value> <tagk>=<tagv> ...\n`: whitespace-delimited
  * fields, newline-terminated, with no quoting or escaping. So only whitespace (which splits a field)
  * and the record terminator can corrupt or inject a record, and this sanitizer replaces those. It
- * additionally replaces the remaining C0 controls and DEL, which cannot break our framing but are
- * never legitimate in a hostname or prefix and would be interpreted by whatever consumes the record
- * downstream. Everything else, punctuation included, is passed through byte for byte: this is metadata
+ * additionally replaces the remaining control codepoints -- C0, DEL, and C1 -- which cannot break our
+ * framing but are never legitimate in a hostname or prefix and would be interpreted by whatever consumes
+ * the record downstream. C1 belongs here for the same reason C0 does: U+009B is the single-character CSI,
+ * the same escape hazard as U+001B. Everything else, punctuation included, is passed through byte for byte: this is metadata
  * the user configured, and none of `:`, `=` or `;` can affect this record's framing. Whether the
  * destination then accepts them is the destination's tag grammar and the operator's concern: stock
  * OpenTSDB parses a tag by splitting on `=` and validates tag characters against its own allowlist.
@@ -163,7 +164,8 @@ static void sanitize_opentsdb_telnet_metadata_value(char *dst, const char *src, 
         uint32_t codepoint;
         size_t bytes = exporting_utf8_decode(src, len, &codepoint);
 
-        if(codepoint < 0x20 || codepoint == 0x7F || exporting_unicode_is_whitespace(codepoint))
+        if(codepoint < 0x20 || (codepoint >= 0x7F && codepoint <= 0x9F) ||
+           exporting_unicode_is_whitespace(codepoint))
             memset(dst, '_', bytes);
         else
             memcpy(dst, src, bytes);
@@ -920,8 +922,8 @@ int exporting_opentsdb_telnet_unittest(void) {
         " label=value",
         "put pr\xc3\xa9""fix.chart.name.dimension.name 42 1.5 host=Dev::\xc3\x9c""n\xc3\xaf""c\xc3\xb8""de label=value\n");
 
-    // an invalid sequence is copied byte for byte, so metadata we cannot interpret is not mangled
-    // (the exception is a lone 0x85 or 0xA0, whose byte value is itself a whitespace codepoint)
+    // an invalid sequence is copied byte for byte, so metadata we cannot interpret is not mangled,
+    // except where the lone byte value is itself a control or whitespace codepoint (0x80-0xA0)
     errors += opentsdb_telnet_unittest_case(
         "malformed utf8 metadata",
         "pre\xc3""fix",
@@ -936,6 +938,34 @@ int exporting_opentsdb_telnet_unittest(void) {
         "host\xe2\x80\x83name",
         " label=value",
         "put pre__fix.chart.name.dimension.name 42 1.5 host=host___name label=value\n");
+
+    // C1 controls are the same hazard as C0 in their multi-byte form: U+009B is the
+    // single-character CSI. Two source bytes become two underscores, keeping the length.
+    errors += opentsdb_telnet_unittest_case(
+        "c1 control in metadata",
+        "pre\xc2\x9b""fix",
+        "host\xc2\x80""name",
+        " label=value",
+        "put pre__fix.chart.name.dimension.name 42 1.5 host=host__name label=value\n");
+
+    // a lead byte with no continuation left in the buffer is consumed one byte at a time, so a
+    // truncated sequence is not silently rewritten. The orphan continuation byte in the hostname is
+    // the documented exception: 0x82 decodes to its own value, which is a C1 control.
+    errors += opentsdb_telnet_unittest_case(
+        "truncated utf8 at end of metadata",
+        "prefix\xc3",
+        "hostname\xe2\x82",
+        " label=value",
+        "put prefix\xc3.chart.name.dimension.name 42 1.5 host=hostname\xe2_ label=value\n");
+
+    // same exception in its most likely form: a lone 0x85 or 0xA0 decodes to its own byte value,
+    // which is the NEL and NBSP codepoint
+    errors += opentsdb_telnet_unittest_case(
+        "lone whitespace-valued bytes",
+        "pre\x85""fix",
+        "host\xa0""name",
+        " label=value",
+        "put pre_fix.chart.name.dimension.name 42 1.5 host=host_name label=value\n");
 
     // control bytes cannot break our framing, but are never legitimate metadata and would be
     // interpreted by whatever consumes the record downstream

--- a/src/exporting/process_data.c
+++ b/src/exporting/process_data.c
@@ -36,7 +36,7 @@ size_t exporting_name_copy(char *dst, const char *src, size_t max_len)
  * codepoint threatens their record framing. Invalid or truncated sequences are reported as their
  * single leading byte, so callers keep byte-for-byte length. A caller therefore passes such a byte
  * through unchanged, except where the byte value is itself a codepoint the caller replaces: an orphan
- * 0x80-0x9F is a C1 control and 0xA0 is NBSP, which is how a Latin-1 consumer would read them anyway.
+ * 0x80-0x9F is a C1 control and 0xA0 is NBSP.
  *
  * @param src the sequence to decode.
  * @param len the number of bytes available at src.

--- a/src/exporting/process_data.c
+++ b/src/exporting/process_data.c
@@ -30,6 +30,87 @@ size_t exporting_name_copy(char *dst, const char *src, size_t max_len)
 }
 
 /**
+ * Decode one UTF-8 sequence
+ *
+ * Shared by the text-protocol connectors, which must decode before they can decide whether a
+ * codepoint threatens their record framing. Invalid or truncated sequences are reported as their
+ * single leading byte, so callers keep byte-for-byte length. A caller therefore passes such a byte
+ * through unchanged, except where the byte value is itself a whitespace codepoint (0x85 NEL,
+ * 0xA0 NBSP), which a Latin-1 consumer would read as whitespace anyway.
+ *
+ * @param src the sequence to decode.
+ * @param len the number of bytes available at src.
+ * @param codepoint where the decoded codepoint is stored.
+ * @return Returns the number of bytes consumed.
+ */
+size_t exporting_utf8_decode(const char *src, size_t len, uint32_t *codepoint) {
+    const uint8_t *s = (const uint8_t *)src;
+    uint32_t cp = s[0];
+    uint32_t minimum = 0;
+    size_t bytes = 1;
+
+    if(cp < 0x80)
+        goto done;
+    else if((cp & 0xE0) == 0xC0) {
+        cp &= 0x1F;
+        minimum = 0x80;
+        bytes = 2;
+    }
+    else if((cp & 0xF0) == 0xE0) {
+        cp &= 0x0F;
+        minimum = 0x800;
+        bytes = 3;
+    }
+    else if((cp & 0xF8) == 0xF0) {
+        cp &= 0x07;
+        minimum = 0x10000;
+        bytes = 4;
+    }
+    else
+        goto done;
+
+    if(bytes > len)
+        goto invalid;
+
+    for(size_t i = 1; i < bytes; i++) {
+        if((s[i] & 0xC0) != 0x80)
+            goto invalid;
+
+        cp = (cp << 6) | (s[i] & 0x3F);
+    }
+
+    if(cp < minimum || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF))
+        goto invalid;
+
+done:
+    *codepoint = cp;
+    return bytes;
+
+invalid:
+    *codepoint = s[0];
+    return 1;
+}
+
+/**
+ * Check whether a codepoint is Unicode whitespace
+ *
+ * Receivers of our text protocols split fields on whitespace, and the Python-based ones (Carbon)
+ * split on the full Unicode set, not just ASCII. Any codepoint here can therefore split a field or
+ * terminate a record at the destination.
+ *
+ * @param codepoint the codepoint to check.
+ * @return Returns true when the codepoint is whitespace.
+ */
+bool exporting_unicode_is_whitespace(uint32_t codepoint) {
+    return (codepoint >= 0x0009 && codepoint <= 0x000D) ||
+           (codepoint >= 0x001C && codepoint <= 0x0020) ||
+           codepoint == 0x0085 || codepoint == 0x00A0 || codepoint == 0x1680 ||
+           (codepoint >= 0x2000 && codepoint <= 0x200A) ||
+           codepoint == 0x2028 || codepoint == 0x2029 || codepoint == 0x202F ||
+           codepoint == 0x205F || codepoint == 0x3000;
+}
+
+/**
  * Mark scheduled instances
  *
  * Any instance can have its own update interval. On every exporting engine update only those instances are picked,

--- a/src/exporting/process_data.c
+++ b/src/exporting/process_data.c
@@ -35,15 +35,20 @@ size_t exporting_name_copy(char *dst, const char *src, size_t max_len)
  * Shared by the text-protocol connectors, which must decode before they can decide whether a
  * codepoint threatens their record framing. Invalid or truncated sequences are reported as their
  * single leading byte, so callers keep byte-for-byte length. A caller therefore passes such a byte
- * through unchanged, except where the byte value is itself a whitespace codepoint (0x85 NEL,
- * 0xA0 NBSP), which a Latin-1 consumer would read as whitespace anyway.
+ * through unchanged, except where the byte value is itself a codepoint the caller replaces: an orphan
+ * 0x80-0x9F is a C1 control and 0xA0 is NBSP, which is how a Latin-1 consumer would read them anyway.
  *
  * @param src the sequence to decode.
  * @param len the number of bytes available at src.
  * @param codepoint where the decoded codepoint is stored.
- * @return Returns the number of bytes consumed.
+ * @return Returns the number of bytes consumed, or 0 when len is 0.
  */
 size_t exporting_utf8_decode(const char *src, size_t len, uint32_t *codepoint) {
+    if(!len) {
+        *codepoint = 0;
+        return 0;
+    }
+
     const uint8_t *s = (const uint8_t *)src;
     uint32_t cp = s[0];
     uint32_t minimum = 0;


### PR DESCRIPTION
##### Summary
- Add OpenTSDB telnet-specific sanitization that preserves valid punctuation in prefixes and hostnames.
- Replace whitespace, control characters, and delimiters that could corrupt telnet records.
- Share UTF-8 decoding/whitespace helpers with Graphite and expand OpenTSDB unit-test coverage.

Fixes #23684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata sanitization for Graphite and OpenTSDB exports.
  * Preserved configured hostnames and metric prefixes, including punctuation, UTF-8 characters, and malformed byte sequences.
  * Enhanced handling of Unicode whitespace, control characters, and truncated UTF-8 sequences while maintaining output length consistency.
  * Prevented unnecessary alteration of valid metadata during export.
  * Added coverage for punctuation, Unicode, malformed UTF-8, control characters, and long metadata values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->