### PR TITLE
docs: give the OpenTelemetry landing page a distinct rendered title

### DIFF
--- a/docs/category-overview-pages/opentelemetry.md
+++ b/docs/category-overview-pages/opentelemetry.md
@@ -1,4 +1,4 @@
-# OpenTelemetry
+# OpenTelemetry Overview
 
 The Netdata Agent receives OpenTelemetry telemetry over OTLP/gRPC, on port 4317: metrics become Netdata charts, logs
 are stored in Netdata's indexed log store, and traces are accepted and stored. Anything that speaks OTLP/gRPC can send to it — an OpenTelemetry


### PR DESCRIPTION
## Summary

The OpenTelemetry section landing page (`docs/category-overview-pages/opentelemetry.md`) and the OpenTelemetry Plugin Reference both render with the title "OpenTelemetry" on Learn. The plugin reference takes its heading from the generated integration card, so this change renames the landing page heading to "OpenTelemetry Overview". The sidebar label stays "OpenTelemetry".

## Why

Learn's ingest pull request that publishes the restructured Logs Management and OpenTelemetry sections (netdata/learn#3071) fails its Netlify build at `scripts/verify-rendered-titles.js`, which rejects duplicate rendered titles:

```
Rendered title verification failed: Duplicate rendered titles:
OpenTelemetry | Learn Netdata
  https://learn.netdata.cloud/docs/opentelemetry
  https://learn.netdata.cloud/docs/opentelemetry/opentelemetry-plugin-reference
```

## Validation

Reproduced the Netlify build of the learn `ingest` branch locally: the only failing gate is the duplicate title. With the landing title changed, `verify-rendered-titles.js` reports 1983 unique rendered titles across 1983 sitemap URLs.

## After merge

Dispatch learn's ingest workflow; it updates netdata/learn#3071, whose preview then passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the OpenTelemetry landing page's rendered title to "OpenTelemetry Overview" so it no longer duplicates the OpenTelemetry Plugin Reference page's title, which was failing Learn's build-time duplicate-title check. The sidebar label stays "OpenTelemetry".

<sup>Written for commit 2c96e6fe1cc19f18ba25b1d281536c104b0d5bb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the page title to “OpenTelemetry Overview.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->