### PR TITLE
fix(ml): defer ML worker queue teardown until collectors stop

### DIFF
--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -238,6 +238,11 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
     watcher_step_complete(WATCHER_STEP_ID_STOP_REPLICATION_THREADS);
 
     ml_stop_threads();
+    // ml_stop_threads() only stops and joins the ML threads. It deliberately does
+    // NOT free the per-worker queues: the collector stop above is bounded to 20s,
+    // so a slow collector can still reach ml_queue_push() from here on. The free
+    // happens in ml_workers_free(), from the FSANITIZE_ADDRESS block below.
+    //
     // ml_fini() (which closes ml_db) is deferred until after
     // metadata_sync_shutdown() drains the metasync workers below. Those
     // workers call ml_dimension_load_models() which uses ml_db; closing it
@@ -361,6 +366,11 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
     health_plugin_destroy();
     cgroup_netdev_link_destroy();
     bearer_tokens_destroy();
+
+    // Deferred from ml_stop_threads(): the ML worker queues must outlive every
+    // collector that can reach ml_queue_push(), and the collector stop above is
+    // time-bounded. Safe here, after rrdhost_free_all() removed all producers.
+    ml_workers_free();
 
     fprintf(stderr, "Cleaning up destroyed dictionaries...\n");
     size_t dictionaries_referenced = cleanup_destroyed_dictionaries(true);

--- a/src/ml/ml-dummy.c
+++ b/src/ml/ml-dummy.c
@@ -25,6 +25,8 @@ void ml_start_threads(void) {}
 
 void ml_stop_threads(void) {}
 
+void ml_workers_free(void) {}
+
 void ml_host_new(RRDHOST *rh) {
     UNUSED(rh);
 }

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -761,7 +761,6 @@ void ml_stop_threads()
         ml_worker_t *worker = &Cfg.workers[idx];
 
         nd_thread_join(worker->nd_thread);
-        worker->nd_thread = NULL;
     }
 }
 

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -95,6 +95,9 @@ void ml_host_new(RRDHOST *rh)
     host->anomaly_rate_rs = NULL;
 
     static std::atomic<size_t> times_called(0);
+    // Borrowed pointer into Cfg.workers[]. It is never invalidated: the worker
+    // queues are freed only by ml_workers_free(), long after every producer is
+    // gone. See the comment on ml_workers_free().
     host->queue = Cfg.workers[times_called++ % Cfg.num_worker_threads].queue;
 
     netdata_mutex_init(&host->mutex);
@@ -739,27 +742,49 @@ void ml_stop_threads()
     Cfg.detection_stop = true;
     Cfg.training_stop = true;
 
-    if (!Cfg.detection_thread)
-        return;
-
+    // Do NOT return early when Cfg.detection_thread is NULL. nd_thread_create()
+    // for the detection thread can fail while the training threads below were
+    // created fine; bailing out here would leave them running for the rest of
+    // the shutdown, and would leave ml_workers_free() freeing state still in use.
+    // nd_thread_join() is a no-op on a NULL thread.
     nd_thread_join(Cfg.detection_thread);
     Cfg.detection_thread = 0;
 
     // signal the worker queue of each thread
-    for (size_t idx = 0; idx != Cfg.num_worker_threads; idx++) {
+    for (size_t idx = 0; idx != Cfg.workers.size(); idx++) {
         ml_worker_t *worker = &Cfg.workers[idx];
         ml_queue_signal(worker->queue);
     }
 
     // join worker threads
-    for (size_t idx = 0; idx != Cfg.num_worker_threads; idx++) {
+    for (size_t idx = 0; idx != Cfg.workers.size(); idx++) {
         ml_worker_t *worker = &Cfg.workers[idx];
 
         nd_thread_join(worker->nd_thread);
+        worker->nd_thread = NULL;
     }
+}
 
-    // clear worker thread data
-    for (size_t idx = 0; idx != Cfg.num_worker_threads; idx++) {
+// Releases the per-worker resources allocated by ml_start_threads().
+//
+// This is NOT part of ml_stop_threads(). ml_stop_threads() runs at shutdown step
+// WATCHER_STEP_ID_DISABLE_ML_DETEC_AND_TRAIN_THREADS, and the collector stop that
+// precedes it is time-bounded (see the 20s service_wait_exit() in
+// netdata_cleanup_and_exit()). A collector that misses that deadline keeps
+// running and can still create dimensions, reaching ml_queue_push() through
+// rrddim_insert_callback() -> ml_dimension_enqueue_create_model(). Destroying
+// worker->queue there left that producer locking a destroyed mutex (SIGABRT).
+//
+// The queues therefore outlive every producer on a normal shutdown, and are
+// released only from the FSANITIZE_ADDRESS teardown block in
+// netdata_cleanup_and_exit(), after rrdhost_free_all() has removed all producers.
+// Same reasoning as ml_fini(), which is likewise deferred to a later step.
+void ml_workers_free()
+{
+    if (!Cfg.enable_anomaly_detection)
+        return;
+
+    for (size_t idx = 0; idx != Cfg.workers.size(); idx++) {
         ml_worker_t *worker = &Cfg.workers[idx];
 
         delete[] worker->training_cns;

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -746,7 +746,7 @@ void ml_stop_threads()
     // for the detection thread can fail while the training threads below were
     // created fine; bailing out here would leave them running for the rest of
     // the shutdown, and would leave ml_workers_free() freeing state still in use.
-    // nd_thread_join() is a no-op on a NULL thread.
+    // nd_thread_join() returns ESRCH on NULL and does not log; calling it unconditionally here is safe.
     nd_thread_join(Cfg.detection_thread);
     Cfg.detection_thread = 0;
 

--- a/src/ml/ml_public.h
+++ b/src/ml/ml_public.h
@@ -21,6 +21,10 @@ void ml_fini(void);
 void ml_start_threads(void);
 void ml_stop_threads(void);
 
+// ASAN-only: releases per-worker ML resources. Must run after all producers are
+// gone (see the comment on the definition in ml_public.cc).
+void ml_workers_free(void);
+
 void ml_host_new(RRDHOST *rh);
 void ml_host_delete(RRDHOST *rh);
 


### PR DESCRIPTION
##### Summary
- Prevent shutdown UAF/SIGABRT by keeping ML worker queues alive while timed-out collectors may still enqueue work.
- Release per-worker ML resources only after rrdhost_free_all() has removed all queue producers.
- Ensure ML worker threads are still signaled and joined if detection-thread creation failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved machine-learning worker shutdown handling so resources are released safely after all data producers have stopped.
  - Improved cleanup behavior in sanitizer-enabled builds, reducing the risk of shutdown-related resource issues.

- **Refactor**
  - Reorganized worker cleanup and shutdown sequencing for more reliable application termination.

- **Compatibility**
  - Added required no-op support for builds without machine-learning features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->