### PR TITLE
fix(dbengine): repair -W createdataset

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -282,23 +282,36 @@ int unittest_prepare_rrd(const char **user) {
     return 0;
 }
 
-// Standalone `-W <name>` unittest driver: bring up sqlite + RRD, run one test,
-// tear everything down, and return the test's exit code.
-static int unittest_run_with_rrd(int (*test_fn)(void)) {
+// Library bring-up every `-W` option that creates an RRDHOST needs. Without the
+// rrdlabels ARAL, the first rrdlabels_create() inside rrdhost_create() crashes.
+static int unittest_libs_init(void) {
     unittest_running = true;
 
     if(sqlite_library_init())
         return 1;
     rrdlabels_aral_init(false);
 
+    return 0;
+}
+
+static void unittest_libs_shutdown(void) {
+    sqlite_close_databases();
+    sqlite_library_shutdown();
+    rrdlabels_aral_destroy(false);
+}
+
+// Standalone `-W <name>` unittest driver: bring up sqlite + RRD, run one test,
+// tear everything down, and return the test's exit code.
+static int unittest_run_with_rrd(int (*test_fn)(void)) {
+    if(unittest_libs_init())
+        return 1;
+
     const char *user = NULL;
     int rc = unittest_prepare_rrd(&user);
     if(!rc)
         rc = test_fn();
 
-    sqlite_close_databases();
-    sqlite_library_shutdown();
-    rrdlabels_aral_destroy(false);
+    unittest_libs_shutdown();
     return rc;
 }
 
@@ -776,15 +789,15 @@ int netdata_main(int argc, char **argv) {
                         else if(strncmp(optarg, createdataset_string, strlen(createdataset_string)) == 0) {
                             optarg += strlen(createdataset_string);
                             unsigned history_seconds = strtoul(optarg, NULL, 0);
-                            netdata_conf_section_global_run_as_user(&user);
-                            netdata_conf_section_global();
-                            nd_profile.update_every = 1;
-                            registry_init();
-                            if(rrd_init("dbengine-dataset", NULL, true)) {
-                                fprintf(stderr, "rrd_init failed for unittest\n");
+
+                            if(unittest_libs_init())
                                 return 1;
-                            }
+                            if(unittest_prepare_rrd(&user))
+                                return 1;
+
                             generate_dbengine_dataset(history_seconds);
+
+                            unittest_libs_shutdown();
                             return 0;
                         }
                         else if(strncmp(optarg, stresstest_string, strlen(stresstest_string)) == 0) {
@@ -813,8 +826,16 @@ int netdata_main(int argc, char **argv) {
                             char workers_str[16];
                             snprintf(workers_str, 15, "%u", workers);
                             setenv("UV_THREADPOOL_SIZE", workers_str, 1);
+
+                            if(unittest_libs_init())
+                                return 1;
+                            if(unittest_prepare_rrd(&user))
+                                return 1;
+
                             dbengine_stress_test(test_duration_sec, dset_charts, query_threads, ramp_up_seconds,
                                                  page_cache_mb, disk_space_mb);
+
+                            unittest_libs_shutdown();
                             return 0;
                         }
 #endif

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -792,13 +792,13 @@ int netdata_main(int argc, char **argv) {
 
                             if(unittest_libs_init())
                                 return 1;
-                            if(unittest_prepare_rrd(&user))
-                                return 1;
 
-                            generate_dbengine_dataset(history_seconds);
+                            int rc = unittest_prepare_rrd(&user);
+                            if(!rc)
+                                generate_dbengine_dataset(history_seconds);
 
                             unittest_libs_shutdown();
-                            return 0;
+                            return rc;
                         }
                         else if(strncmp(optarg, stresstest_string, strlen(stresstest_string)) == 0) {
                             char *endptr;
@@ -829,14 +829,14 @@ int netdata_main(int argc, char **argv) {
 
                             if(unittest_libs_init())
                                 return 1;
-                            if(unittest_prepare_rrd(&user))
-                                return 1;
 
-                            dbengine_stress_test(test_duration_sec, dset_charts, query_threads, ramp_up_seconds,
-                                                 page_cache_mb, disk_space_mb);
+                            int rc = unittest_prepare_rrd(&user);
+                            if(!rc)
+                                dbengine_stress_test(test_duration_sec, dset_charts, query_threads, ramp_up_seconds,
+                                                     page_cache_mb, disk_space_mb);
 
                             unittest_libs_shutdown();
-                            return 0;
+                            return rc;
                         }
 #endif
                         else if(strcmp(optarg, "simple-pattern") == 0) {

--- a/src/database/engine/dbengine-stresstest.c
+++ b/src/database/engine/dbengine-stresstest.c
@@ -463,10 +463,15 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
         freez(query_threads[i]);
     }
     freez(query_threads);
+    // same teardown as generate_dbengine_dataset() above: rrdeng_exit() frees the
+    // ctx under unittest_running, so clear the host's pointer to it, and release
+    // the host we created before the caller tears the shared libraries down
     rrd_wrlock();
     rrdeng_quiesce((struct rrdengine_instance *)host->db[0].si);
     rrdeng_exit((struct rrdengine_instance *)host->db[0].si);
     rrdeng_enq_cmd(NULL, RRDENG_OPCODE_SHUTDOWN_EVLOOP, NULL, NULL, STORAGE_PRIORITY_BEST_EFFORT, NULL, NULL);
+    host->db[0].si = NULL;
+    rrdhost_free___while_having_rrd_wrlock(host);
     rrd_wrunlock();
 }
 

--- a/src/database/engine/dbengine-stresstest.c
+++ b/src/database/engine/dbengine-stresstest.c
@@ -123,12 +123,17 @@ static void generate_dbengine_chart(void *arg)
             rrddim_set_by_pointer_fake_time(rd[j], value, time_current);
             ++thread_info->stored_metrics_nr;
         }
-        rrdset_done(st);
+        // drive the fake clock explicitly: rrdset_done() would stamp the sample with
+        // the wall clock and, via rrdset_timed_next(), overwrite the
+        // usec_since_last_update set above - so every sample landed at real "now"
+        // and the generated history collapsed to the run's own duration
+        struct timeval fake_now = { .tv_sec = time_current, .tv_usec = 0 };
+        rrdset_timed_done(st, fake_now, false);
         thread_info->time_max = time_current;
     }
-    for (j = 0; j < DSET_DIMS; ++j) {
-        rrdeng_store_metric_finalize((rd[j])->tiers[0].sch);
-    }
+    // finalize through the rrdset API: it clears rd->tiers[].sch, so the later
+    // teardown of the host does not finalize (and free) the handles a second time
+    rrdset_finalize_collection(st, true);
 }
 
 void generate_dbengine_dataset(unsigned history_seconds)
@@ -186,8 +191,19 @@ void generate_dbengine_dataset(unsigned history_seconds)
         freez(thread_info[i]);
     }
     freez(thread_info);
+
+    // shut the dbengine instance down before freeing the host: rrdhost_free() does
+    // not do it, and destroying the charts under a live instance lets the flush
+    // workers touch freed memory. Same teardown as dbengine_stress_test() below.
+    struct rrdengine_instance *ctx = (struct rrdengine_instance *)host->db[0].si;
+    rrdeng_quiesce(ctx);
+    rrdeng_exit(ctx);
+    rrdeng_enq_cmd(NULL, RRDENG_OPCODE_SHUTDOWN_EVLOOP, NULL, NULL, STORAGE_PRIORITY_BEST_EFFORT, NULL, NULL);
+    host->db[0].si = NULL;
+
+    // free the host we generated into, not localhost
     rrd_wrlock();
-    rrdhost_free___while_having_rrd_wrlock(localhost);
+    rrdhost_free___while_having_rrd_wrlock(host);
     rrd_wrunlock();
 }
 
@@ -350,7 +366,6 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
 
     fprintf(stderr, "Initializing localhost with hostname 'dbengine-stress-test'\n");
 
-    (void)sql_init_meta_database(DB_CHECK_NONE, 1);
     host = dbengine_rrdhost_find_or_create("dbengine-stress-test");
     if (NULL == host)
         return;


### PR DESCRIPTION
##### Summary
- Initialize and shut down the shared SQLite/RRD-label test libraries for the standalone DBEngine workload commands.
- Generate samples with the intended fake timestamps, preserving the requested historical range.
- Finalize chart storage safely and clean up the generated DBEngine host and instance to prevent teardown crashes.

Note: Fixes the crash, but this will eventually be one of ---> (reworked / removed / replaced)

Fixes #23750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved standalone unit-test and stress-test execution with more reliable setup and teardown.
  - Test commands now correctly report preparation and execution results.
  - Database engine stress tests finalize chart data consistently and clean up test resources after completion.

- **Refactor**
  - Streamlined library initialization and shutdown across standalone test workflows.
  - Updated stress-test chart generation and dataset cleanup for more predictable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->