### PR TITLE
Optimize weights query arena reuse

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -212,6 +212,7 @@ int help(int exitcode) {
 
 int buffer_unittest(void);
 int ringbuffer_unittest(void);
+int onewayalloc_unittest(void);
 int log_stack_unittest(void);
 int clocks_unittest(void);
 int ws_client_unittest(void);
@@ -492,6 +493,7 @@ int netdata_main(int argc, char **argv) {
                             if (exporting_opentsdb_http_unittest()) return 1;
                             if (exporting_opentsdb_telnet_unittest()) return 1;
                             if (ringbuffer_unittest()) return 1;
+                            if (onewayalloc_unittest()) return 1;
                             if (log_stack_unittest()) return 1;
                             if (clocks_unittest()) return 1;
                             if (ws_client_unittest()) return 1;
@@ -636,6 +638,10 @@ int netdata_main(int argc, char **argv) {
                         else if(strcmp(optarg, "ringbuffertest") == 0) {
                             unittest_running = true;
                             return ringbuffer_unittest();
+                        }
+                        else if(strcmp(optarg, "owatest") == 0) {
+                            unittest_running = true;
+                            return onewayalloc_unittest();
                         }
                         else if(strcmp(optarg, "wsclienttest") == 0) {
                             unittest_running = true;

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -433,20 +433,13 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
             return;
     }
 
-    // Reuse the caller-provided arena across every alert's DB lookup. Each
-    // alert's scratch (RRDR + query state) is released via onewayalloc_reset
-    // at the top of the next iteration — trims the page list back to a
-    // single head page. Net effect: one mmap/munmap for the whole health
-    // iteration, regardless of host count or alert count.
+    // Reuse query scratch across alerts. All arena pages are retained until
+    // the caller destroys the arena at the end of this health iteration.
 
     // the first loop is to lookup values from the db
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
-        // Reclaim the previous alert's query scratch before starting the
-        // next one. The arena is reused across every alert of every host in
-        // this iteration, so this reset trims trailing pages left by the
-        // previous alert (same host or prior host). No-op only on the very
-        // first alert after the arena was created.
+        // The previous alert's RRDR is dead; its pages can now be reused.
         onewayalloc_reset(owa);
 
         if(unlikely(!service_running(SERVICE_HEALTH) || !rrdhost_should_run_health(host))) {
@@ -952,8 +945,7 @@ static void health_event_loop(void) {
         worker_is_busy(WORKER_HEALTH_JOB_RRD_LOCK);
         uint64_t loop = __atomic_add_fetch(&health_evloop_iteration, 1, __ATOMIC_RELAXED);
 
-        // Single onewayalloc arena reused across every host in this iteration —
-        // one mmap/munmap pair for the whole cycle instead of per host.
+        // Bound retained query scratch to this iteration, across all hosts.
         ONEWAYALLOC *iter_owa = onewayalloc_create(0);
 
         RRDHOST *host;

--- a/src/libnetdata/onewayalloc/README.md
+++ b/src/libnetdata/onewayalloc/README.md
@@ -15,7 +15,7 @@ these data can be freed immediately after the query finishes.
 
 1. The caller calls `ONEWAYALLOC *owa = onewayalloc_create(sizehint)` to create an OWA.
    Internally this allocates the first memory buffer with size >= `sizehint`.
-   If `sizehint` is zero, it will allocate 1 hardware page (usually 4kb).
+   The minimum buffer is 32 KiB, rounded up to a hardware page boundary.
    No need to check for success or failure. As with `mallocz()` in netdata, a `fatal()`
    will be called if the allocation fails - although this will never fail, since Linux
    does not really check if there is memory available for `mmap()` calls.
@@ -26,8 +26,18 @@ these data can be freed immediately after the query finishes.
    - `onewayalloc_strdupz(owa, string)`, similar to `strdupz()`
    - `onewayalloc_memdupz(owa, ptr, size)`, similar to `mallocz()` and then `memcpy()`
    
-3. Once the caller has done all the work with the allocated buffers, all memory allocated 
-   can be freed with `onewayalloc_destroy(owa)`.
+3. Once all allocated buffers are no longer needed, `onewayalloc_reset(owa)` invalidates
+   them and makes every page available for reuse. Reset takes constant time; overflow
+   pages are rewound when allocation reaches them. No pages are freed on reset, and
+   memory is not zeroed. Use `onewayalloc_callocz()` when zero initialization is required.
+
+4. `onewayalloc_destroy(owa)` releases all pages, including unused retained pages.
+   Choose the arena lifetime to bound how long its high-water capacity is retained.
+   An arena must never be shared by concurrently executing workers.
+
+Address-sanitizer builds allocate each buffer separately to detect memory errors.
+In these builds, callers must release each buffer with `onewayalloc_freez()`;
+reset is a no-op and destroy does not release those individual allocations.
 
 ## How faster it is?
 

--- a/src/libnetdata/onewayalloc/README.md
+++ b/src/libnetdata/onewayalloc/README.md
@@ -15,10 +15,15 @@ these data can be freed immediately after the query finishes.
 
 1. The caller calls `ONEWAYALLOC *owa = onewayalloc_create(sizehint)` to create an OWA.
    Internally this allocates the first memory buffer with size >= `sizehint`.
-   The minimum buffer is 32 KiB, rounded up to a hardware page boundary.
+   The minimum buffer is 64 KiB, including its header, rounded up to an OS page boundary.
    No need to check for success or failure. As with `mallocz()` in netdata, a `fatal()`
-   will be called if the allocation fails - although this will never fail, since Linux
-   does not really check if there is memory available for `mmap()` calls.
+   will be called if the allocation fails.
+
+   New-page targets double from 64 to 128, 256, 512, and 1024 KiB, then remain at 1024 KiB.
+   These targets include the header; a request can require a larger page. Above 1 MiB,
+   only the aligned payload, aligned header, and OS page padding are allocated. A large
+   request does not make subsequent ordinary pages exceed 1 MiB. The OS page size is
+   typically 4 KiB, but the allocator respects platforms with larger pages.
    
 2. The caller can then perform any number of the following calls to acquire memory:
    - `onewayalloc_mallocz(owa, size)`, similar to `mallocz()`
@@ -28,7 +33,12 @@ these data can be freed immediately after the query finishes.
    
 3. Once all allocated buffers are no longer needed, `onewayalloc_reset(owa)` invalidates
    them and makes every page available for reuse. Reset takes constant time; overflow
-   pages are rewound when allocation reaches them. No pages are freed on reset, and
+   pages are rewound only when selected for allocation. If the current page cannot fit
+   a request, the allocator searches unused pages and moves only the first fitting page
+   immediately after the current page. Skipped pages remain available for later requests.
+   A new page is allocated only when neither the current page nor an unused page fits.
+   Residual space in earlier pages containing live allocations is not revisited until reset.
+   No pages are freed on reset, and
    memory is not zeroed. Use `onewayalloc_callocz()` when zero initialization is required.
 
 4. `onewayalloc_destroy(owa)` releases all pages, including unused retained pages.

--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -9,7 +9,7 @@ typedef struct owa_page {
     size_t offset;              // the first free byte of the page
     bool mmap;
     struct owa_page *next;      // the next page on the list
-    struct owa_page *last;      // the last page on the list - we currently allocate on this
+    struct owa_page *current;   // the allocation cursor (used only on the head page)
 } OWA_PAGE;
 
 static size_t onewayalloc_total_memory = 0;
@@ -100,7 +100,7 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
 
     page->size = size;
     page->offset = natural_alignment(sizeof(OWA_PAGE));
-    page->next = page->last = NULL;
+    page->next = page->current = NULL;
 
     if(!head) {
         // this is the first time we are called
@@ -112,10 +112,10 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     }
     else {
         // link this page into our existing linked list
-        head->last->next = page;
+        head->current->next = page;
     }
 
-    head->last = page;
+    head->current = page;
     head->stats_pages++;
     head->stats_pages_size += size;
 
@@ -132,7 +132,7 @@ void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
 #endif
 
     OWA_PAGE *head = (OWA_PAGE *)owa;
-    OWA_PAGE *page = head->last;
+    OWA_PAGE *page = head->current;
 
     // update stats
     head->stats_mallocs_made++;
@@ -142,9 +142,17 @@ void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
     size = onewayalloc_natural_alignment_or_fatal(size);
 
     if(unlikely(page->size - page->offset < size)) {
-        // we don't have enough space to fit the data
-        // let's get another page
-        page = onewayalloc_create_internal(head, (size > page->size)?size:page->size);
+        // Pages after the cursor have not been used since reset. Rewind lazily.
+        while(page->next) {
+            page = page->next;
+            page->offset = natural_alignment(sizeof(OWA_PAGE));
+            if(page->size - page->offset >= size)
+                break;
+        }
+        head->current = page;
+
+        if(page->size - page->offset < size)
+            page = onewayalloc_create_internal(head, (size > page->size)?size:page->size);
     }
 
     char *mem = (char *)page;
@@ -231,36 +239,9 @@ void onewayalloc_reset(ONEWAYALLOC *owa) {
 
     OWA_PAGE *head = (OWA_PAGE *)owa;
 
-    // Free every page except the head; we keep the head so the caller can
-    // reuse the arena without another mmap.
-    size_t freed_size = 0;
-    OWA_PAGE *page = head->next;
-    while (page) {
-        OWA_PAGE *p = page;
-        page = page->next;
-        freed_size += p->size;
-        if (p->mmap)
-            nd_munmap(p, p->size);
-        else
-            freez(p);
-    }
-
-    if (freed_size)
-        __atomic_sub_fetch(&onewayalloc_total_memory, freed_size, __ATOMIC_RELAXED);
-
-    // Roll the head page's bump cursor back to the position right after the
-    // OWA_PAGE header, and rewire the single-page list so head == last.
-    head->next = NULL;
-    head->last = head;
+    // Keep all pages until destroy; allocation rewinds the unused suffix on demand.
+    head->current = head;
     head->offset = natural_alignment(sizeof(OWA_PAGE));
-
-    // stats_pages / stats_pages_size describe the arena's *current* footprint
-    // (what is mapped right now), so they reflect the single-page post-reset
-    // state. stats_mallocs_made / stats_mallocs_size are lifetime counters
-    // (total allocations ever served by this arena) and are intentionally
-    // preserved across resets, to stay useful for diagnostics.
-    head->stats_pages = 1;
-    head->stats_pages_size = head->size;
 }
 
 void onewayalloc_destroy(ONEWAYALLOC *owa) {
@@ -288,4 +269,91 @@ void onewayalloc_destroy(ONEWAYALLOC *owa) {
     }
 
     __atomic_sub_fetch(&onewayalloc_total_memory, total_size, __ATOMIC_RELAXED);
+}
+
+int onewayalloc_unittest(void) {
+    const size_t cases[][9] = {
+        {0, 1, 15, 32768, 65537, 4000, 2 * 1024 * 1024, 1, 100000},
+        {2 * 1024 * 1024, 65537, 32768, 1, 17, 3, 4000, 0, 100000},
+        {1, 3, 17, 0, 31, 64, 7, 9, 1},
+        {32768, 65537, 4 * 1024 * 1024, 17, 4000, 1, 0, 3, 100000},
+    };
+    size_t initial_memory = onewayalloc_allocated_memory();
+    ONEWAYALLOC *owa = onewayalloc_create(0);
+    int errors = 0;
+
+    onewayalloc_reset(NULL);
+    for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+#ifndef FSANITIZE_ADDRESS
+        uintptr_t first_addresses[9];
+        size_t first_memory = 0;
+#endif
+        for (size_t repeat = 0; repeat < 8; repeat++) {
+            size_t before_reset = onewayalloc_allocated_memory();
+            onewayalloc_reset(owa);
+            onewayalloc_reset(owa);
+            if (onewayalloc_allocated_memory() != before_reset) {
+                fprintf(stderr, "OWA: reset did not retain allocated pages\n");
+                errors++;
+                goto cleanup;
+            }
+
+            unsigned char *ptrs[9];
+            for (size_t i = 0; i < 9; i++) {
+                size_t size = cases[c][i];
+                ptrs[i] = repeat % 2 ? onewayalloc_callocz(owa, size, 1) : onewayalloc_mallocz(owa, size);
+                if ((uintptr_t)ptrs[i] % SYSTEM_REQUIRED_ALIGNMENT) {
+                    fprintf(stderr, "OWA: allocation is not naturally aligned\n");
+                    errors++;
+                }
+                if (repeat % 2) {
+                    for (size_t j = 0; j < size; j++) {
+                        if (ptrs[i][j] != 0) {
+                            fprintf(stderr, "OWA: calloc did not clear reused memory\n");
+                            errors++;
+                            break;
+                        }
+                    }
+                }
+                memset(ptrs[i], (int)i + 1, size);
+#ifndef FSANITIZE_ADDRESS
+                if (!repeat)
+                    first_addresses[i] = (uintptr_t)ptrs[i];
+                else if (first_addresses[i] != (uintptr_t)ptrs[i]) {
+                    fprintf(stderr, "OWA: repeated allocation did not reuse its address\n");
+                    errors++;
+                }
+#endif
+            }
+
+            // Check all live buffers after allocation to detect overlapping bump cursors.
+            for (size_t i = 0; i < 9; i++) {
+                for (size_t j = 0; j < cases[c][i]; j++) {
+                    if (ptrs[i][j] != i + 1) {
+                        fprintf(stderr, "OWA: live allocation was overwritten\n");
+                        errors++;
+                        break;
+                    }
+                }
+                onewayalloc_freez(owa, ptrs[i]);
+            }
+#ifndef FSANITIZE_ADDRESS
+            if (!repeat)
+                first_memory = onewayalloc_allocated_memory();
+            else if (first_memory != onewayalloc_allocated_memory()) {
+                fprintf(stderr, "OWA: repeated allocation sequence grew the arena\n");
+                errors++;
+            }
+#endif
+        }
+    }
+
+cleanup:
+    onewayalloc_destroy(owa);
+    if (onewayalloc_allocated_memory() != initial_memory) {
+        fprintf(stderr, "OWA: destroy did not release all pages\n");
+        errors++;
+    }
+    fprintf(stderr, "OWA tests: %s\n", errors ? "FAILED" : "PASSED");
+    return errors ? 1 : 0;
 }

--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -279,7 +279,7 @@ static int onewayalloc_list_unittest(OWA_PAGE *head) {
     for (; page && pages < head->stats_pages; page = page->next) {
         if (previous && page->prev != previous)
             break;
-        found_current |= page == head->current;
+        found_current = found_current || page == head->current;
         total += page->size;
         pages++;
         previous = page;

--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -1,5 +1,8 @@
 #include "onewayalloc.h"
 
+#define OWA_MIN_PAGE_SIZE (64 * 1024)
+#define OWA_MAX_PAGE_SIZE (1024 * 1024)
+
 typedef struct owa_page {
     size_t stats_pages;
     size_t stats_pages_size;
@@ -8,6 +11,7 @@ typedef struct owa_page {
     size_t size;                // the total size of the page
     size_t offset;              // the first free byte of the page
     bool mmap;
+    struct owa_page *prev;      // previous page; the head caches the tail here
     struct owa_page *next;      // the next page on the list
     struct owa_page *current;   // the allocation cursor (used only on the head page)
 } OWA_PAGE;
@@ -60,29 +64,17 @@ static size_t onewayalloc_page_alignment_or_fatal(size_t size, size_t page_size)
 static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     size_t OWA_NATURAL_PAGE_SIZE = os_get_system_page_size();
 
-    // our default page size
-    size_t size = 32768;
+    // Targets include the header and do not inherit the size of oversized pages.
+    size_t size = OWA_MIN_PAGE_SIZE;
+    for (size_t i = 0; head && i < head->stats_pages && size < OWA_MAX_PAGE_SIZE; i++)
+        size *= 2;
 
-    // make sure the new page will fit both the requested size
-    // and the OWA_PAGE structure at its beginning
-    size_hint = onewayalloc_add_or_fatal(size_hint, natural_alignment(sizeof(OWA_PAGE)), "page");
+    size_hint = onewayalloc_add_or_fatal(onewayalloc_natural_alignment_or_fatal(size_hint),
+                                       natural_alignment(sizeof(OWA_PAGE)), "page");
 
     // prefer the user size if it is bigger than our size
     if(size_hint > size)
         size = size_hint;
-
-    if(head) {
-        // double the current allocation
-        size_t optimal_size = head->stats_pages_size;
-
-        // cap it at 1 MiB
-        if(optimal_size > 1ULL * 1024 * 1024)
-            optimal_size = 1ULL * 1024 * 1024;
-
-        // use the optimal if it is more than the required size
-        if(optimal_size > size)
-            size = optimal_size;
-    }
 
     // Make sure our allocations are always a multiple of the hardware page size
     size = onewayalloc_page_alignment_or_fatal(size, OWA_NATURAL_PAGE_SIZE);
@@ -100,19 +92,19 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
 
     page->size = size;
     page->offset = natural_alignment(sizeof(OWA_PAGE));
-    page->next = page->current = NULL;
+    page->prev = page->next = page->current = NULL;
 
     if(!head) {
         // this is the first time we are called
-        head = page;
+        DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(head, page, prev, next);
         head->stats_pages = 0;
         head->stats_pages_size = 0;
         head->stats_mallocs_made = 0;
         head->stats_mallocs_size = 0;
     }
     else {
-        // link this page into our existing linked list
-        head->current->next = page;
+        OWA_PAGE *current = head->current;
+        DOUBLE_LINKED_LIST_INSERT_ITEM_AFTER_UNSAFE(head, current, page, prev, next);
     }
 
     head->current = page;
@@ -142,17 +134,25 @@ void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
     size = onewayalloc_natural_alignment_or_fatal(size);
 
     if(unlikely(page->size - page->offset < size)) {
-        // Pages after the cursor have not been used since reset. Rewind lazily.
-        while(page->next) {
-            page = page->next;
-            page->offset = natural_alignment(sizeof(OWA_PAGE));
-            if(page->size - page->offset >= size)
+        OWA_PAGE *current = page;
+        size_t header = natural_alignment(sizeof(OWA_PAGE));
+
+        // Keep skipped pages unused: only the selected page enters the used prefix.
+        for (page = current->next; page; page = page->next) {
+            if (page->size - header >= size)
                 break;
         }
-        head->current = page;
 
-        if(page->size - page->offset < size)
-            page = onewayalloc_create_internal(head, (size > page->size)?size:page->size);
+        if (page) {
+            if (page != current->next) {
+                DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(head, page, prev, next);
+                DOUBLE_LINKED_LIST_INSERT_ITEM_AFTER_UNSAFE(head, current, page, prev, next);
+            }
+            page->offset = header;
+            head->current = page;
+        }
+        else
+            page = onewayalloc_create_internal(head, size);
     }
 
     char *mem = (char *)page;
@@ -271,6 +271,135 @@ void onewayalloc_destroy(ONEWAYALLOC *owa) {
     __atomic_sub_fetch(&onewayalloc_total_memory, total_size, __ATOMIC_RELAXED);
 }
 
+#ifndef FSANITIZE_ADDRESS
+static int onewayalloc_list_unittest(OWA_PAGE *head) {
+    size_t pages = 0, total = 0;
+    bool found_current = false;
+    OWA_PAGE *previous = NULL, *page = head;
+    for (; page && pages < head->stats_pages; page = page->next) {
+        if (previous && page->prev != previous)
+            break;
+        found_current |= page == head->current;
+        total += page->size;
+        pages++;
+        previous = page;
+    }
+    if (page || pages != head->stats_pages || total != head->stats_pages_size ||
+        head->prev != previous || !found_current) {
+        fprintf(stderr, "OWA: page list or accounting is inconsistent\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int onewayalloc_reuse_unittest(void) {
+    size_t header = natural_alignment(sizeof(OWA_PAGE));
+    OWA_PAGE *head = onewayalloc_create(0);
+    OWA_PAGE *small = onewayalloc_create_internal(head, 0);
+    OWA_PAGE *medium = onewayalloc_create_internal(head, 0);
+    OWA_PAGE *large = onewayalloc_create_internal(head, 0);
+    size_t retained = onewayalloc_allocated_memory();
+    int errors = 0;
+
+    onewayalloc_reset(head);
+    unsigned char *large_ptr = onewayalloc_mallocz(head, large->size - header);
+    errors += onewayalloc_list_unittest(head);
+    memset(large_ptr, 0xa5, large->size - header);
+    if (large_ptr != (unsigned char *)large + header || head->next != large ||
+        large->next != small || small->next != medium || medium->next) {
+        fprintf(stderr, "OWA: selection did not move only the fitting page\n");
+        errors++;
+    }
+
+    void *small_ptr = onewayalloc_mallocz(head, small->size - header);
+    errors += onewayalloc_list_unittest(head);
+    void *medium_ptr = onewayalloc_mallocz(head, medium->size - header);
+    errors += onewayalloc_list_unittest(head);
+    if (small_ptr != (char *)small + header || medium_ptr != (char *)medium + header ||
+        onewayalloc_allocated_memory() != retained) {
+        fprintf(stderr, "OWA: skipped exact-fit pages were not reused\n");
+        errors++;
+    }
+    for (size_t i = 0; i < large->size - header; i++) {
+        if (large_ptr[i] != 0xa5) {
+            fprintf(stderr, "OWA: page selection overwrote a live buffer\n");
+            errors++;
+            break;
+        }
+    }
+
+    onewayalloc_reset(head);
+    OWA_PAGE *unused = head->next;
+    onewayalloc_mallocz(head, 2 * 1024 * 1024);
+    OWA_PAGE *added = head->current;
+    errors += onewayalloc_list_unittest(head);
+    if (head->next != added || added->next != unused) {
+        fprintf(stderr, "OWA: new page did not preserve the unused suffix\n");
+        errors++;
+    }
+    if (added->size != onewayalloc_page_alignment_or_fatal(2 * 1024 * 1024 + header, os_get_system_page_size())) {
+        fprintf(stderr, "OWA: oversized allocation was not sized exactly\n");
+        errors++;
+    }
+    retained = onewayalloc_allocated_memory();
+    if (onewayalloc_mallocz(head, unused->size - header) != (char *)unused + header ||
+        onewayalloc_allocated_memory() != retained) {
+        fprintf(stderr, "OWA: unused suffix was lost after a failed search\n");
+        errors++;
+    }
+
+    errors += onewayalloc_list_unittest(head);
+
+    onewayalloc_destroy(head);
+    return errors;
+}
+
+static int onewayalloc_growth_unittest(void) {
+    size_t header = natural_alignment(sizeof(OWA_PAGE));
+    size_t os_page = os_get_system_page_size();
+    OWA_PAGE *head = onewayalloc_create(0);
+    int errors = 0;
+
+    for (size_t i = 0; i < 8; i++) {
+        size_t expected = onewayalloc_page_alignment_or_fatal((size_t)65536 << (i < 4 ? i : 4), os_page);
+        OWA_PAGE *page = head->current;
+        errors += onewayalloc_list_unittest(head);
+        if (page->size != expected) {
+            fprintf(stderr, "OWA: page %zu size %zu differs from target %zu\n", i, page->size, expected);
+            errors++;
+        }
+        onewayalloc_mallocz(head, page->size - page->offset);
+        if (i < 7)
+            onewayalloc_mallocz(head, 1);
+    }
+    onewayalloc_destroy(head);
+
+    const size_t requests[] = {
+        65536 - header, 65536 - header + 1,
+        1024 * 1024 - header, 1024 * 1024 - header + 1,
+        1024 * 1024, 2 * 1024 * 1024 + 17,
+    };
+    for (size_t i = 0; i < sizeof(requests) / sizeof(requests[0]); i++) {
+        size_t expected = onewayalloc_page_alignment_or_fatal(natural_alignment(requests[i]) + header, os_page);
+        head = onewayalloc_create(requests[i]);
+        errors += onewayalloc_list_unittest(head);
+        if (head->size != expected) {
+            fprintf(stderr, "OWA: size hint %zu produced %zu instead of %zu\n", requests[i], head->size, expected);
+            errors++;
+        }
+        onewayalloc_mallocz(head, head->size - header);
+        onewayalloc_mallocz(head, 1);
+        expected = onewayalloc_page_alignment_or_fatal(128 * 1024, os_page);
+        if (head->current->size != expected) {
+            fprintf(stderr, "OWA: size hint inflated the next ordinary page\n");
+            errors++;
+        }
+        onewayalloc_destroy(head);
+    }
+    return errors;
+}
+#endif
+
 int onewayalloc_unittest(void) {
     const size_t cases[][9] = {
         {0, 1, 15, 32768, 65537, 4000, 2 * 1024 * 1024, 1, 100000},
@@ -281,6 +410,11 @@ int onewayalloc_unittest(void) {
     size_t initial_memory = onewayalloc_allocated_memory();
     ONEWAYALLOC *owa = onewayalloc_create(0);
     int errors = 0;
+
+#ifndef FSANITIZE_ADDRESS
+    errors += onewayalloc_reuse_unittest();
+    errors += onewayalloc_growth_unittest();
+#endif
 
     onewayalloc_reset(NULL);
     for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
@@ -317,6 +451,7 @@ int onewayalloc_unittest(void) {
                 }
                 memset(ptrs[i], (int)i + 1, size);
 #ifndef FSANITIZE_ADDRESS
+                errors += onewayalloc_list_unittest(owa);
                 if (!repeat)
                     first_addresses[i] = (uintptr_t)ptrs[i];
                 else if (first_addresses[i] != (uintptr_t)ptrs[i]) {

--- a/src/libnetdata/onewayalloc/onewayalloc.h
+++ b/src/libnetdata/onewayalloc/onewayalloc.h
@@ -8,19 +8,19 @@ typedef void ONEWAYALLOC;
 ONEWAYALLOC *onewayalloc_create(size_t size_hint);
 void onewayalloc_destroy(ONEWAYALLOC *owa);
 
-// Reset the arena to an empty state without destroying it. Frees every
-// page except the head, and rolls the head page's bump pointer back to
-// its initial offset so the arena is reusable. Intended for callers that
-// do many short bursts of allocations back-to-back (e.g. evaluating all
-// the alerts of one host) and want to amortise the mmap/munmap cost of
-// create/destroy across the whole burst.
+// Reset invalidates all allocations and retains every page for reuse.
+// The allocation cursor is rewound in O(1); retained overflow pages are
+// rewound lazily as needed. Capacity is released only by destroy, so the
+// caller owns the lifetime of the arena's high-water footprint.
 //
-// Important: reset does NOT zero the retained head page. Subsequent
+// Important: reset does NOT zero retained pages. Subsequent
 // onewayalloc_mallocz() calls may return memory that still holds bytes
 // from the previous burst — this matches the mallocz() contract (the "z"
 // means "fatal on failure", not "zeroed"). Callers that need zeroed
 // memory must use onewayalloc_callocz() just as they would against a
 // freshly-created arena; the reset path does not relax that contract.
+// Under ASAN, allocations bypass the arena and callers must free them
+// individually with onewayalloc_freez(); reset remains a no-op.
 void onewayalloc_reset(ONEWAYALLOC *owa);
 
 size_t onewayalloc_mul_or_fatal(size_t nmemb, size_t size, const char *context);

--- a/src/libnetdata/onewayalloc/onewayalloc.h
+++ b/src/libnetdata/onewayalloc/onewayalloc.h
@@ -10,8 +10,10 @@ void onewayalloc_destroy(ONEWAYALLOC *owa);
 
 // Reset invalidates all allocations and retains every page for reuse.
 // The allocation cursor is rewound in O(1); retained overflow pages are
-// rewound lazily as needed. Capacity is released only by destroy, so the
-// caller owns the lifetime of the arena's high-water footprint.
+// rewound lazily as needed. Only a fitting unused page is moved after
+// the current page; skipped pages remain available to later allocations.
+// Capacity is released only by destroy, so the caller owns the lifetime
+// of the arena's high-water footprint.
 //
 // Important: reset does NOT zero retained pages. Subsequent
 // onewayalloc_mallocz() calls may return memory that still holds bytes

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1413,11 +1413,8 @@ void ml_detect_main(void *arg)
     heartbeat_t hb;
     heartbeat_init(&hb, USEC_PER_SEC);
 
-    // Single onewayalloc arena reused across every host and loop iteration
-    // for the whole detect thread lifetime — one mmap/munmap pair instead
-    // of one per host per second. The arena is reset between hosts inside
-    // ml_update_host_and_detection_rate_charts, so peak memory stays bounded
-    // by a single host's anomaly-rate query scratch.
+    // Reuse query scratch across hosts and iterations. Reset between hosts
+    // retains the arena's high-water capacity until this detector stops.
     ONEWAYALLOC *detect_owa = onewayalloc_create(0);
 
     while (!Cfg.detection_stop && service_running(SERVICE_COLLECTORS)) {

--- a/src/web/api/formatters/rrd2json.h
+++ b/src/web/api/formatters/rrd2json.h
@@ -53,8 +53,8 @@ int rrdset2value_api_v1(
 // onewayalloc arena. Lets a caller that issues many back-to-back queries
 // (e.g. evaluating all alerts on one host) amortise the mmap/munmap cost
 // of owa create/destroy across the whole burst. The caller owns the owa's
-// lifetime; between calls they should invoke onewayalloc_reset() to reclaim
-// trailing pages and keep peak memory bounded. `owa` must be non-NULL.
+// lifetime; between calls they should invoke onewayalloc_reset() to reuse
+// query scratch. All pages are retained until destroy. `owa` must be non-NULL.
 int rrdset2value_api_v1_with_owa(
         ONEWAYALLOC *owa
         , RRDSET *st

--- a/src/web/api/formatters/value/value.c
+++ b/src/web/api/formatters/value/value.c
@@ -73,12 +73,15 @@ inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all
     return v;
 }
 
-QUERY_VALUE rrdmetric2value(RRDHOST *host,
-                            struct rrdcontext_acquired *rca, struct rrdinstance_acquired *ria, struct rrdmetric_acquired *rma,
-                            time_t after, time_t before,
-                            RRDR_OPTIONS options, RRDR_TIME_GROUPING time_group_method, const char *time_group_options,
-                            size_t tier, time_t timeout, QUERY_SOURCE query_source, STORAGE_PRIORITY priority
+QUERY_VALUE rrdmetric2value_with_owa(ONEWAYALLOC *owa, RRDHOST *host,
+                                     struct rrdcontext_acquired *rca, struct rrdinstance_acquired *ria,
+                                     struct rrdmetric_acquired *rma, time_t after, time_t before,
+                                     RRDR_OPTIONS options, RRDR_TIME_GROUPING time_group_method,
+                                     const char *time_group_options, size_t tier, time_t timeout,
+                                     QUERY_SOURCE query_source, STORAGE_PRIORITY priority
 ) {
+    internal_fatal(!owa, "rrdmetric2value_with_owa(): owa must be non-NULL");
+
     QUERY_TARGET_REQUEST qtr = {
             .version = 1,
             .host = host,
@@ -97,7 +100,6 @@ QUERY_VALUE rrdmetric2value(RRDHOST *host,
             .priority = priority,
     };
 
-    ONEWAYALLOC *owa = onewayalloc_create(16 * 1024);
     QUERY_TARGET *qt = query_target_create(&qtr);
     RRDR *r = rrd2rrdr(owa, qt);
 
@@ -150,7 +152,19 @@ QUERY_VALUE rrdmetric2value(RRDHOST *host,
 
     rrdr_free(owa, r);
     query_target_release(qt);
-    onewayalloc_destroy(owa);
 
+    return qv;
+}
+
+QUERY_VALUE rrdmetric2value(RRDHOST *host,
+                            struct rrdcontext_acquired *rca, struct rrdinstance_acquired *ria,
+                            struct rrdmetric_acquired *rma, time_t after, time_t before,
+                            RRDR_OPTIONS options, RRDR_TIME_GROUPING time_group_method,
+                            const char *time_group_options, size_t tier, time_t timeout,
+                            QUERY_SOURCE query_source, STORAGE_PRIORITY priority) {
+    ONEWAYALLOC *owa = onewayalloc_create(16 * 1024);
+    QUERY_VALUE qv = rrdmetric2value_with_owa(owa, host, rca, ria, rma, after, before, options, time_group_method,
+                                             time_group_options, tier, timeout, query_source, priority);
+    onewayalloc_destroy(owa);
     return qv;
 }

--- a/src/web/api/formatters/value/value.h
+++ b/src/web/api/formatters/value/value.h
@@ -28,6 +28,15 @@ QUERY_VALUE rrdmetric2value(RRDHOST *host,
                             size_t tier, time_t timeout, QUERY_SOURCE query_source, STORAGE_PRIORITY priority
 );
 
+// Same contract as rrdmetric2value(), using a caller-owned OWA. The returned
+// value owns no arena-backed data, so the caller may reset the OWA immediately.
+QUERY_VALUE rrdmetric2value_with_owa(ONEWAYALLOC *owa, RRDHOST *host,
+                                     struct rrdcontext_acquired *rca, struct rrdinstance_acquired *ria,
+                                     struct rrdmetric_acquired *rma, time_t after, time_t before,
+                                     RRDR_OPTIONS options, RRDR_TIME_GROUPING time_group_method,
+                                     const char *time_group_options, size_t tier, time_t timeout,
+                                     QUERY_SOURCE query_source, STORAGE_PRIORITY priority);
+
 NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, NETDATA_DOUBLE *anomaly_rate);
 
 #endif //NETDATA_API_FORMATTER_VALUE_H

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -440,6 +440,7 @@ struct query_weights_data {
     DICTIONARY *results;
     DICTIONARY *host_snapshots;
     struct weights_host_snapshot *host_snapshot;
+    ONEWAYALLOC *query_owa;
     WEIGHTS_STATS stats;
     RRDHOST **hosts_array;
     size_t total_hosts;
@@ -590,6 +591,8 @@ void query_weights_worker_thread(void *arg)
         thread_data->local_examined_dimensions = local_qwd.examined_dimensions;
         thread_data->local_stats = local_qwd.stats;
     }
+
+    onewayalloc_destroy(local_qwd.query_owa);
 }
 
 // Thread-safe statistics merging - use simple addition since we're in single-threaded merge
@@ -1638,6 +1641,7 @@ cleanup:
 }
 
 static void rrdset_metric_correlations_ks2(
+        ONEWAYALLOC *owa,
         RRDHOST *host, STRING *hostname,
         RRDCONTEXT_ACQUIRED *rca, RRDINSTANCE_ACQUIRED *ria, RRDMETRIC_ACQUIRED *rma,
         DICTIONARY *results,
@@ -1652,8 +1656,6 @@ static void rrdset_metric_correlations_ks2(
     options |= RRDR_OPTION_NATURAL_POINTS;
 
     usec_t started_ut = now_monotonic_usec();
-    ONEWAYALLOC *owa = onewayalloc_create(16 * 1024);
-
     size_t high_points = 0;
     STORAGE_POINT highlighted_sp;
     NETDATA_DOUBLE *highlight = NULL, *baseline = NULL;
@@ -1700,7 +1702,7 @@ static void rrdset_metric_correlations_ks2(
 cleanup:
     onewayalloc_freez(owa, highlight);
     onewayalloc_freez(owa, baseline);
-    onewayalloc_destroy(owa);
+    onewayalloc_reset(owa);
 }
 
 // ----------------------------------------------------------------------------
@@ -1715,6 +1717,7 @@ static void merge_query_value_to_stats(QUERY_VALUE *qv, WEIGHTS_STATS *stats, si
 }
 
 static void rrdset_metric_correlations_volume(
+        ONEWAYALLOC *owa,
         RRDHOST *host, STRING *hostname,
         RRDCONTEXT_ACQUIRED *rca, RRDINSTANCE_ACQUIRED *ria, RRDMETRIC_ACQUIRED *rma,
         DICTIONARY *results,
@@ -1726,9 +1729,11 @@ static void rrdset_metric_correlations_volume(
 
     options |= RRDR_OPTION_MATCH_IDS | RRDR_OPTION_ABSOLUTE | RRDR_OPTION_NATURAL_POINTS;
 
-    QUERY_VALUE baseline_average = rrdmetric2value(host, rca, ria, rma, baseline_after, baseline_before,
-                                                   options, time_group_method, time_group_options, tier, 0,
-                                                   QUERY_SOURCE_API_WEIGHTS, STORAGE_PRIORITY_SYNCHRONOUS_FIRST);
+    QUERY_VALUE baseline_average = rrdmetric2value_with_owa(
+            owa, host, rca, ria, rma, baseline_after, baseline_before,
+            options, time_group_method, time_group_options, tier, 0,
+            QUERY_SOURCE_API_WEIGHTS, STORAGE_PRIORITY_SYNCHRONOUS_FIRST);
+    onewayalloc_reset(owa);
     merge_query_value_to_stats(&baseline_average, stats, 1);
 
     if(!netdata_double_isnumber(baseline_average.value)) {
@@ -1736,9 +1741,11 @@ static void rrdset_metric_correlations_volume(
         baseline_average.value = 0.0;
     }
 
-    QUERY_VALUE highlight_average = rrdmetric2value(host, rca, ria, rma, after, before,
-                                                    options, time_group_method, time_group_options, tier, 0,
-                                                    QUERY_SOURCE_API_WEIGHTS, STORAGE_PRIORITY_SYNCHRONOUS_FIRST);
+    QUERY_VALUE highlight_average = rrdmetric2value_with_owa(
+            owa, host, rca, ria, rma, after, before,
+            options, time_group_method, time_group_options, tier, 0,
+            QUERY_SOURCE_API_WEIGHTS, STORAGE_PRIORITY_SYNCHRONOUS_FIRST);
+    onewayalloc_reset(owa);
     merge_query_value_to_stats(&highlight_average, stats, 1);
 
     if(!netdata_double_isnumber(highlight_average.value))
@@ -1756,9 +1763,11 @@ static void rrdset_metric_correlations_volume(
 
     char highlight_countif_options[50 + 1];
     snprintfz(highlight_countif_options, 50, "%s" NETDATA_DOUBLE_FORMAT, highlight_average.value < baseline_average.value ? "<" : ">", baseline_average.value);
-    QUERY_VALUE highlight_countif = rrdmetric2value(host, rca, ria, rma, after, before,
-                                                    options, RRDR_GROUPING_COUNTIF, highlight_countif_options, tier, 0,
-                                                    QUERY_SOURCE_API_WEIGHTS, STORAGE_PRIORITY_SYNCHRONOUS_FIRST);
+    QUERY_VALUE highlight_countif = rrdmetric2value_with_owa(
+            owa, host, rca, ria, rma, after, before,
+            options, RRDR_GROUPING_COUNTIF, highlight_countif_options, tier, 0,
+            QUERY_SOURCE_API_WEIGHTS, STORAGE_PRIORITY_SYNCHRONOUS_FIRST);
+    onewayalloc_reset(owa);
     merge_query_value_to_stats(&highlight_countif, stats, 1);
 
     if(!netdata_double_isnumber(highlight_countif.value)) {
@@ -1790,6 +1799,7 @@ static void rrdset_metric_correlations_volume(
 // VALUE / ANOMALY RATE algorithm functions
 
 static void rrdset_weights_value(
+        ONEWAYALLOC *owa,
         RRDHOST *host, STRING *hostname,
         RRDCONTEXT_ACQUIRED *rca, RRDINSTANCE_ACQUIRED *ria, RRDMETRIC_ACQUIRED *rma,
         DICTIONARY *results,
@@ -1800,9 +1810,11 @@ static void rrdset_weights_value(
 
     options |= RRDR_OPTION_MATCH_IDS | RRDR_OPTION_NATURAL_POINTS;
 
-    QUERY_VALUE qv = rrdmetric2value(host, rca, ria, rma, after, before,
-                                     options, time_group_method, time_group_options, tier, 0,
-                                     QUERY_SOURCE_API_WEIGHTS, STORAGE_PRIORITY_SYNCHRONOUS_FIRST);
+    QUERY_VALUE qv = rrdmetric2value_with_owa(
+            owa, host, rca, ria, rma, after, before,
+            options, time_group_method, time_group_options, tier, 0,
+            QUERY_SOURCE_API_WEIGHTS, STORAGE_PRIORITY_SYNCHRONOUS_FIRST);
+    onewayalloc_reset(owa);
 
     merge_query_value_to_stats(&qv, stats, 1);
 
@@ -2207,9 +2219,13 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
 
     __atomic_fetch_add(&qwd->examined_dimensions, 1, __ATOMIC_RELAXED);
 
+    if(unlikely(!qwd->query_owa))
+        qwd->query_owa = onewayalloc_create(16 * 1024);
+
     switch(qwr->method) {
         case WEIGHTS_METHOD_VALUE:
             rrdset_weights_value(
+                    qwd->query_owa,
                     host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->after, qwr->before,
@@ -2220,6 +2236,7 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
 
         case WEIGHTS_METHOD_ANOMALY_RATE:
             rrdset_weights_value(
+                    qwd->query_owa,
                     host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->after, qwr->before,
@@ -2231,6 +2248,7 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
 
         case WEIGHTS_METHOD_MC_VOLUME:
             rrdset_metric_correlations_volume(
+                    qwd->query_owa,
                     host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->baseline_after, qwr->baseline_before,
@@ -2243,6 +2261,7 @@ static ssize_t weights_for_rrdmetric(void *data, RRDHOST *host, RRDCONTEXT_ACQUI
         default:
         case WEIGHTS_METHOD_MC_KS2:
             rrdset_metric_correlations_ks2(
+                    qwd->query_owa,
                     host, qwd->host_snapshot->hostname, rca, ria, rma,
                     qwd->results,
                     qwr->baseline_after, qwr->baseline_before,
@@ -2730,6 +2749,8 @@ int web_api_v12_weights(BUFFER *wb, QUERY_WEIGHTS_REQUEST *qwr) {
     }
 
 cleanup:
+    onewayalloc_destroy(qwd.query_owa);
+
     simple_pattern_free(qwd.scope_nodes_sp);
     simple_pattern_free(qwd.scope_contexts_sp);
     simple_pattern_free(qwd.scope_instances_sp);


### PR DESCRIPTION
## Summary

- Reuse one private `ONEWAYALLOC` per active weights worker, and one for serial execution, across all four per-metric weights methods.
- Retain every arena page until destroy. Reset is constant-time; no page is unmapped between metric evaluations.
- Use the repository's doubly linked list macros. Search unused pages without changing their order, then move only the first fitting page immediately after the current page. Skipped pages remain available to subsequent smaller allocations.
- Make normal new-page targets 64, 128, 256, 512, and 1024 KiB, including headers, then keep the 1024 KiB target. Larger requests receive only the required aligned payload, header, and OS page padding. Prior oversized pages do not inflate subsequent ordinary pages above 1 MiB.

No weights API, method default, numerical algorithm, DBEngine query geometry, response schema, or worker parallelism changes. The existing self-contained scalar helper remains available.

## Memory lifetime

Reset invalidates prior allocations but retains capacity until `onewayalloc_destroy()`. Arenas remain single-thread-owned: weights releases them at worker/request completion, health at the end of its evaluation cycle, and ML at detector shutdown. Health/ML query algorithms and lifecycle calls are unchanged; their comments describe the changed allocator semantics.

Only wholly unused pages are rewound during allocation; residual space in earlier entered pages is not revisited until reset. Overflow searches can examine the unused suffix, but normal bump allocation and reset remain constant-time. The minimum increase adds 32 KiB of initial arena capacity on 4 KiB-page systems, not per metric. OS page-size alignment is preserved.

## Performance: master versus this PR

Compared directly with master without this PR, the latest PR is **1.90× faster for Volume** and **1.98× faster for KS2** on this workload, using the faster of the two master control medians.

One centralized parent, 150 nodes × 6,600 collected metrics = 990,000 metrics, one hour of multiplexed one-second data per metric, Netdata configured for 8 CPUs, and a 32 GiB main page-cache target. Volume and KS2 use the same 10-minute highlight and 20-minute baseline; all request parameters are identical except `method`. LTO builds, normal-priority execution, no profiler, and a 50 GiB systemd memory cap.

Master is pinned to `66a1efe000`, the unmodified master commit from which this PR was branched; the latest PR is `88280bbfda`. This compares the complete PR against its master base, not intermediate PR revisions or the moving upstream tip.

Each time below is the median agent-reported endpoint time of three measured warm queries. Warm-up queries are excluded. The same master binary runs before and after the PR binary to expose variation during the experiment.

| Method | Master, control 1 | Latest PR | Same master, control 2 | Speedup versus faster master control |
|---|---:|---:|---:|---:|
| Volume | 38.938 s | 20.510 s | 47.194 s | **1.90×** |
| KS2 | 58.704 s | 29.625 s | 69.710 s | **1.98×** |

The second master control was 18.7–21.2% slower than the first. Ratios against both control medians span 1.90–2.30× for Volume and 1.98–2.35× for KS2; the headline uses the lower observed speedup. These are workload-specific measurements, not a fixed performance guarantee. Median daemon CPU time also decreased: 44–51% for Volume and 43–48% for KS2 relative to the two master controls.

Exact workload counters match across all 18 measured queries and six warmups:

- Volume: 2,475,000 DB queries and 2,081,475,000 DB points read.
- KS2: 1,980,000 DB queries, 1,783,980,000 DB points read, and 3,564,000,000 binary searches.
- Both: 990,000 metrics examined and 495,000 nonzero results returned.

## Validation

- LTO `RelWithDebInfo` build; `netdata -W owatest` and `netdata -W mctest` pass.
- Skipped-page and sizing regression tests failed before the allocator change and pass afterward. Coverage also includes selected-page-only movement, failed searches preserving unused pages, list/tail/accounting invariants, live buffers, boundary sizes, and exact oversized mappings.
- Existing allocator tests cover repeated reset, stable address/capacity reuse, alignment, calloc clearing, and complete destruction. The same suite is wired into `-W unittest`.
- Allocator-only ASAN/UBSAN checks against the actual source pass with leak detection: normal arena mode and sanitizer allocation bypass, mmap and forced malloc fallback, native 4 KiB and emulated 64 KiB page sizes. This is not full-daemon sanitizer coverage or native 64 KiB-platform execution.
- Full query corpus: exactly the same 79 broken contracts out of 257 as the previous PR revision; no new failure or missing-contract regression.
- Complete identity-resolved 990k Volume and KS2 response digests match master exactly for the latest PR, including node, context, instance, dimension, row, and normalized envelope components. This direct master-versus-PR check ran separately from headline timing.
- Independent whole-PR ownership and hot-path source review found no verified blocker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved memory reuse during metric, weights, health, and machine-learning queries, helping reduce temporary memory growth during repeated or large operations.

- **Reliability**
  - Enhanced memory-management behavior and validation across repeated query processing.

- **Tests**
  - Added dedicated allocator coverage, including standalone and aggregate test commands for improved regression detection.

- **Documentation**
  - Expanded guidance on memory reuse, allocation limits, reset behavior, platform alignment, and troubleshooting with memory sanitizers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
