### PR TITLE
test(ml): exercise dimension prediction in ML tests

### DIFF
--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -1115,6 +1115,52 @@ static void test_reset_generation_cancels_model_publish()
                    "successful publication path should leave training_in_progress unchanged");
 }
 
+static void test_dimension_predict_detects_anomaly()
+{
+    fprintf(stderr, "  test_dimension_predict_detects_anomaly...\n");
+
+    unsigned saved_diff_n = Cfg.diff_n;
+    unsigned saved_lag_n = Cfg.lag_n;
+    size_t saved_max_samples_to_smooth = Cfg.max_samples_to_smooth;
+    double saved_threshold = Cfg.dimension_anomaly_score_threshold;
+
+    Cfg.diff_n = 0;
+    Cfg.lag_n = 1;
+    Cfg.max_samples_to_smooth = 1;
+    Cfg.dimension_anomaly_score_threshold = 0.5;
+
+    RRDSET rs = {};
+    rs.update_every = 1;
+    RRDDIM rd = {};
+    rd.rrdset = &rs;
+
+    ml_dimension_t dim = {};
+    spinlock_init(&dim.slock);
+    dim.rd = &rd;
+    dim.mls = MACHINE_LEARNING_STATUS_ENABLED;
+
+    ml_kmeans_inlined_t model = {};
+    model.cluster_centers[0].set_size(6);
+    model.cluster_centers[1].set_size(6);
+    for (long i = 0; i < 6; i++)
+        model.cluster_centers[1](i) = 1.0;
+    model.min_dist = 0.0;
+    model.max_dist = 100.0;
+    dim.km_contexts.push_back(model);
+
+    ML_TEST_ASSERT(!ml_dimension_predict(&dim, 0.0, true),
+                   "the first value should only warm up prediction history");
+    ML_TEST_ASSERT(!ml_dimension_predict(&dim, 0.0, true),
+                   "a value matching the normal model should not be anomalous");
+    ML_TEST_ASSERT(ml_dimension_predict(&dim, 100.0, true),
+                   "a value outside the normal model should be anomalous");
+
+    Cfg.diff_n = saved_diff_n;
+    Cfg.lag_n = saved_lag_n;
+    Cfg.max_samples_to_smooth = saved_max_samples_to_smooth;
+    Cfg.dimension_anomaly_score_threshold = saved_threshold;
+}
+
 extern "C" int ml_unittest()
 {
     fprintf(stderr, "\nML unit tests:\n");
@@ -1147,6 +1193,7 @@ extern "C" int ml_unittest()
     test_kmeans_timestamp_rejection();
     test_downstream_model_short_circuit_and_requeue();
     test_reset_generation_cancels_model_publish();
+    test_dimension_predict_detects_anomaly();
 
     fprintf(stderr, "\nML tests: %d run, %d failed\n", tests_run, tests_failed);
 


### PR DESCRIPTION
##### Summary

Exercise the ML dimension prediction entry point and assert normal and anomalous results so detector implementations that never fire or always fire are caught. Fixes #23630

##### Test Plan

`netdata -W mltest` with ML enabled; local execution was unavailable because this worktree lacks a configured binary, cmake, and ninja.

##### Additional Information

This is a test-only change with no user-facing runtime behavior change.

<details> <summary>For users: How does this change affect me?</summary>

This change does not affect users; it strengthens the ML test suite.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exercises the ML dimension prediction entry point in unit tests so detector implementations that never fire or always fire are caught. Fixes #23630.

This is a test-only change with no user-facing runtime behavior change.

<sup>Written for commit fe0c063c542d4567f1f4e04f9577d6381e60a998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for anomaly detection using a minimal machine-learning model.
  * Verifies initial warm-up behavior, normal values, and detection of outlier values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->