### PR TITLE
fix(skills): close the failure paths in the skill scripts the review surfaced

### DIFF
--- a/.agents/ENV.md
+++ b/.agents/ENV.md
@@ -96,6 +96,7 @@ it during a triage session).
 | `CODACY_HOST` | API host. Defaults to `https://api.codacy.com`; set only if Codacy moves the API host. | n/a | URL |
 | `CODACY_PROVIDER` | git provider. Defaults to `gh` (GitHub). | n/a | `gh` |
 | `CODACY_ORG` | Codacy organization (matches the GitHub org). Defaults to `netdata`. | n/a | short string |
+| `CODACY_CLI_VERSION` | Docker image tag for `analyze-local.sh`. Defaults to `latest`; set to pin the analyzer. Not a secret. | n/a | image tag |
 | `CODACY_REPO` | Codacy repository name. Defaults to `netdata`. | n/a | short string |
 
 `CODACY_TOKEN` is required by `pr-issues.sh` and any wrapper that

--- a/.agents/ENV.md
+++ b/.agents/ENV.md
@@ -95,8 +95,8 @@ it during a triage session).
 | `CODACY_TOKEN` | Account API token (header `api-token: <value>`) | https://app.codacy.com -> top-right avatar -> Account -> API tokens -> "Create API Token" | 20-char opaque string |
 | `CODACY_HOST` | API host. Defaults to `https://api.codacy.com`; set only if Codacy moves the API host. | n/a | URL |
 | `CODACY_PROVIDER` | git provider. Defaults to `gh` (GitHub). | n/a | `gh` |
+| `CODACY_CLI_VERSION` | Docker image tag for `analyze-local.sh`; defaults to `latest`. Read from the process environment only, `analyze-local.sh` does not source `.env`: export it or prefix the command. Not a secret. | n/a | image tag |
 | `CODACY_ORG` | Codacy organization (matches the GitHub org). Defaults to `netdata`. | n/a | short string |
-| `CODACY_CLI_VERSION` | Docker image tag for `analyze-local.sh`. Defaults to `latest`; set to pin the analyzer. Not a secret. | n/a | image tag |
 | `CODACY_REPO` | Codacy repository name. Defaults to `netdata`. | n/a | short string |
 
 `CODACY_TOKEN` is required by `pr-issues.sh` and any wrapper that

--- a/.agents/skills/collectors-prometheus-profiles/SKILL.md
+++ b/.agents/skills/collectors-prometheus-profiles/SKILL.md
@@ -208,6 +208,9 @@ Before semantic review, render the actual family table of contents:
   --app application-name
 ```
 
+`--app` is the resolved job application (default: the profile's own `app:`). Contexts render as the collector emits
+them: the template's `context_namespace` is kept unless it equals the app.
+
 The helper prints the operator-visible family tree with contexts and effective priorities, then emits advisory UX
 warnings. It is not a gate and does not make design decisions. Investigate each warning and either repair the hierarchy
 or record why the warning is intentional:

--- a/.agents/skills/collectors-prometheus-profiles/SKILL.md
+++ b/.agents/skills/collectors-prometheus-profiles/SKILL.md
@@ -208,8 +208,9 @@ Before semantic review, render the actual family table of contents:
   --app application-name
 ```
 
-`--app` is the resolved job application (default: the profile's own `app:`). Contexts render as the collector emits
-them: the template's `context_namespace` is kept unless it equals the app.
+`--app` is the resolved job application (default: the profile's own `app:`). The ToC renders the profile-relative
+context with the collector's rule applied: the template's `context_namespace` is kept unless it equals the app. The
+collector additionally prefixes `prometheus.<app>.`, which the ToC omits.
 
 The helper prints the operator-visible family tree with contexts and effective priorities, then emits advisory UX
 warnings. It is not a gate and does not make design decisions. Investigate each warning and either repair the hierarchy

--- a/.agents/skills/collectors-prometheus-profiles/how-tos/capture-metrics-dump.md
+++ b/.agents/skills/collectors-prometheus-profiles/how-tos/capture-metrics-dump.md
@@ -10,7 +10,9 @@ surface.
 For a local unprotected endpoint:
 
 ```bash
-curl -fsS "http://127.0.0.1:PORT/metrics" -o metrics.txt
+mkdir -p .local/prometheus-dumps
+DUMP=".local/prometheus-dumps/APP-$(date -u +%Y%m%dT%H%M%SZ).prom"
+curl -fsS "http://127.0.0.1:PORT/metrics" -o "$DUMP"
 ```
 
 For an authenticated endpoint, use the operator's existing secret-safe curl or
@@ -23,9 +25,9 @@ and `# TYPE` lines are part of the evidence.
 ## Check the evidence
 
 ```bash
-grep -c '^# TYPE ' metrics.txt
-grep -c '^# HELP ' metrics.txt
-wc -l metrics.txt
+grep -c '^# TYPE ' "$DUMP"
+grep -c '^# HELP ' "$DUMP"
+wc -l "$DUMP"
 ```
 
 Then inspect family names, types, label keys, and cardinality without copying

--- a/.agents/skills/collectors-prometheus-profiles/how-tos/capture-metrics-dump.md
+++ b/.agents/skills/collectors-prometheus-profiles/how-tos/capture-metrics-dump.md
@@ -25,9 +25,8 @@ and `# TYPE` lines are part of the evidence.
 
 ## Check the evidence
 
-In the same shell (or set `DUMP` to the path printed above):
-
 ```bash
+DUMP="${DUMP:?set DUMP to the path printed by the capture}"
 grep -c '^# TYPE ' "$DUMP"
 grep -c '^# HELP ' "$DUMP"
 wc -l "$DUMP"

--- a/.agents/skills/collectors-prometheus-profiles/how-tos/capture-metrics-dump.md
+++ b/.agents/skills/collectors-prometheus-profiles/how-tos/capture-metrics-dump.md
@@ -10,9 +10,10 @@ surface.
 For a local unprotected endpoint:
 
 ```bash
-DUMP="$(git rev-parse --show-toplevel)/.local/audits/prometheus-dumps/APP-$(date -u +%Y%m%dT%H%M%SZ).prom"
+DUMP="$(git rev-parse --show-toplevel)/.local/audits/prometheus-profiles/APP-$(date -u +%Y%m%dT%H%M%SZ).prom"
 mkdir -p "$(dirname "$DUMP")"
 curl -fsS "http://127.0.0.1:PORT/metrics" -o "$DUMP"
+echo "$DUMP"   # keep this path; the checks below read it
 ```
 
 For an authenticated endpoint, use the operator's existing secret-safe curl or
@@ -23,6 +24,8 @@ Do not pipe through `grep` or another transformation during capture. `# HELP`
 and `# TYPE` lines are part of the evidence.
 
 ## Check the evidence
+
+In the same shell (or set `DUMP` to the path printed above):
 
 ```bash
 grep -c '^# TYPE ' "$DUMP"

--- a/.agents/skills/collectors-prometheus-profiles/how-tos/capture-metrics-dump.md
+++ b/.agents/skills/collectors-prometheus-profiles/how-tos/capture-metrics-dump.md
@@ -10,8 +10,8 @@ surface.
 For a local unprotected endpoint:
 
 ```bash
-mkdir -p .local/prometheus-dumps
-DUMP=".local/prometheus-dumps/APP-$(date -u +%Y%m%dT%H%M%SZ).prom"
+DUMP="$(git rev-parse --show-toplevel)/.local/audits/prometheus-dumps/APP-$(date -u +%Y%m%dT%H%M%SZ).prom"
+mkdir -p "$(dirname "$DUMP")"
 curl -fsS "http://127.0.0.1:PORT/metrics" -o "$DUMP"
 ```
 

--- a/.agents/skills/collectors-prometheus-profiles/scripts/profile-toc.py
+++ b/.agents/skills/collectors-prometheus-profiles/scripts/profile-toc.py
@@ -194,7 +194,11 @@ def warnings(root: Node, app_name: str | None = None) -> list[str]:
             # CephFS-style product names legitimately begin with the same letters as the
             # application; only flag an exact application token, not a longer product word.
             exact_application_prefix = name.casefold() == lowered or name.casefold().startswith(lowered + " ")
-            if exact_application_prefix:
+            if name.casefold() == lowered:
+                results.append(
+                    f"top-level family {name!r} equals the application name: name the product area it holds instead"
+                )
+            elif exact_application_prefix:
                 results.append(
                     f"top-level family {name!r} starts with application name {application!r}: remove the redundant prefix"
                 )
@@ -221,7 +225,11 @@ def warnings(root: Node, app_name: str | None = None) -> list[str]:
 def parse_arguments(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("profile", type=Path, help="profile YAML path")
-    parser.add_argument("--app", help="application name used to detect redundant application prefixes")
+    parser.add_argument(
+        "--app",
+        help="resolved job application (default: the profile's app:); drops the root context_namespace segment when it"
+        " equals the app, as the collector does, and detects redundant application prefixes in family names",
+    )
     parser.add_argument("--quiet", action="store_true", help="print ToC without warnings")
     return parser.parse_args(argv)
 

--- a/.agents/skills/collectors-prometheus-profiles/scripts/profile-toc.py
+++ b/.agents/skills/collectors-prometheus-profiles/scripts/profile-toc.py
@@ -50,12 +50,17 @@ def group_priority(group: dict, inherited: int) -> int:
     return inherited if priority == 0 else priority
 
 
-def build_tree(profile: dict) -> Node:
+def build_tree(profile: dict, app: str = "") -> Node:
     template = profile.get("template")
     if not isinstance(template, dict):
         raise ValueError("profile has no template mapping")
 
     root = Node(normalize(template.get("family")) or "(root)")
+    # The template root is a chartengine group, so its context_namespace is a real context
+    # segment. The collector drops it only when it equals the resolved app, to avoid
+    # prometheus.<app>.<app>.<context> (collector/prometheus/chart_template.go).
+    root_namespace = normalize(template.get("context_namespace"))
+    root_context: list[str] = [root_namespace] if root_namespace and root_namespace != normalize(app) else []
 
     def add_charts(group: dict, node: Node, context_parts: list[str], effective_priority: int) -> None:
         for chart in group.get("charts") or []:
@@ -71,7 +76,7 @@ def build_tree(profile: dict) -> Node:
             node.charts.append(Chart(context, priority))
 
     root_priority = group_priority(template, 0)
-    add_charts(template, root, [], root_priority)
+    add_charts(template, root, root_context, root_priority)
     groups = template.get("groups")
     if not isinstance(groups, list):
         return root
@@ -92,7 +97,7 @@ def build_tree(profile: dict) -> Node:
             add_group(child, node, child_context_parts, effective_priority)
 
     for group in groups:
-        add_group(group, root, [], root_priority)
+        add_group(group, root, root_context, root_priority)
     return root
 
 
@@ -185,12 +190,11 @@ def warnings(root: Node, app_name: str | None = None) -> list[str]:
 
     if application:
         lowered = application.casefold()
-        exact_names = {name.casefold() for name in top_names}
         for name in top_names:
             # CephFS-style product names legitimately begin with the same letters as the
             # application; only flag an exact application token, not a longer product word.
             exact_application_prefix = name.casefold() == lowered or name.casefold().startswith(lowered + " ")
-            if exact_application_prefix and name.casefold() not in exact_names:
+            if exact_application_prefix:
                 results.append(
                     f"top-level family {name!r} starts with application name {application!r}: remove the redundant prefix"
                 )
@@ -233,15 +237,16 @@ def main(argv: list[str]) -> int:
         print(f"error: profile {args.profile} is not a YAML mapping", file=sys.stderr)
         return 2
 
+    application = args.app or normalize(document.get("app"))
     try:
-        tree = build_tree(document)
+        tree = build_tree(document, application)
     except ValueError as error:
         print(f"error: {error}", file=sys.stderr)
         return 2
 
     print("\n".join(render(tree)))
     if not args.quiet:
-        design_warnings = warnings(tree, args.app or normalize(document.get("app")))
+        design_warnings = warnings(tree, application)
         print("\nUX warnings (not validation failures):")
         if design_warnings:
             for index, warning in enumerate(design_warnings, 1):

--- a/.agents/skills/collectors-prometheus-profiles/scripts/test_profile_toc.py
+++ b/.agents/skills/collectors-prometheus-profiles/scripts/test_profile_toc.py
@@ -25,14 +25,62 @@ def load_module():
 profile_toc = load_module()
 
 
-def tree_from_yaml(text: str):
+def tree_from_yaml(text: str, app: str = ""):
     with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as stream:
         stream.write(text)
         path = Path(stream.name)
     try:
-        return profile_toc.build_tree(yaml.safe_load(path.read_text()))
+        return profile_toc.build_tree(yaml.safe_load(path.read_text()), app)
     finally:
         path.unlink()
+
+
+NAMESPACED_PROFILE = """
+template:
+  family: Exporter
+  context_namespace: exporter
+  charts:
+    - context: availability
+      title: A
+  groups:
+    - family: Requests
+      charts:
+        - context: requests.rate
+          title: R
+"""
+
+
+def all_contexts(node) -> set[str]:
+    return {chart.context for chart in profile_toc.descendant_charts(node)}
+
+
+class ProfileTocContextNamespaceTest(unittest.TestCase):
+    # The rule under test mirrors collector/prometheus/chart_template.go: the template's
+    # context_namespace is a real segment unless it equals the resolved app.
+    def test_root_namespace_kept_when_app_differs(self) -> None:
+        root = tree_from_yaml(NAMESPACED_PROFILE, app="other")
+        self.assertEqual({"exporter.availability", "exporter.requests.rate"}, all_contexts(root))
+
+    def test_root_namespace_dropped_when_it_equals_the_app(self) -> None:
+        root = tree_from_yaml(NAMESPACED_PROFILE, app="exporter")
+        self.assertEqual({"availability", "requests.rate"}, all_contexts(root))
+
+    def test_application_prefix_warning_fires_for_an_exact_token(self) -> None:
+        root = tree_from_yaml(
+            """
+app: ceph
+template:
+  family: Ceph
+  groups:
+    - family: Ceph Cluster
+      charts: [{context: health, title: H}]
+    - family: CephFS
+      charts: [{context: fs, title: F}]
+"""
+        )
+        flagged = [w for w in profile_toc.warnings(root, "ceph") if "application name" in w]
+        self.assertEqual(1, len(flagged))
+        self.assertIn("'Ceph Cluster'", flagged[0])
 
 
 class ProfileTocWarningsTest(unittest.TestCase):

--- a/.agents/skills/collectors-prometheus-profiles/scripts/test_profile_toc.py
+++ b/.agents/skills/collectors-prometheus-profiles/scripts/test_profile_toc.py
@@ -65,7 +65,7 @@ class ProfileTocContextNamespaceTest(unittest.TestCase):
         root = tree_from_yaml(NAMESPACED_PROFILE, app="exporter")
         self.assertEqual({"availability", "requests.rate"}, all_contexts(root))
 
-    def test_application_prefix_warning_fires_for_an_exact_token(self) -> None:
+    def test_application_prefix_warning_fires_for_a_prefixed_family(self) -> None:
         root = tree_from_yaml(
             """
 app: ceph
@@ -81,6 +81,23 @@ template:
         flagged = [w for w in profile_toc.warnings(root, "ceph") if "application name" in w]
         self.assertEqual(1, len(flagged))
         self.assertIn("'Ceph Cluster'", flagged[0])
+
+    def test_family_equal_to_the_application_gets_its_own_message(self) -> None:
+        root = tree_from_yaml(
+            """
+app: ceph
+template:
+  family: Ceph
+  groups:
+    - family: Ceph
+      charts: [{context: health, title: H}]
+    - family: Pools
+      charts: [{context: pools, title: P}]
+"""
+        )
+        flagged = [w for w in profile_toc.warnings(root, "ceph") if "application name" in w]
+        self.assertEqual(1, len(flagged))
+        self.assertIn("equals the application name", flagged[0])
 
 
 class ProfileTocWarningsTest(unittest.TestCase):

--- a/.agents/skills/docs-learn-site-structure/mapping.md
+++ b/.agents/skills/docs-learn-site-structure/mapping.md
@@ -90,7 +90,7 @@ For files marked `learn_status: Published`, the destination is
 computed by `create_mdx_path_from_metadata`
 (`ingest.py:1140-1204`):
 
-```
+```text
 docs/<learn_rel_path>/<sanitized_sidebar_label>.mdx
 ```
 
@@ -203,7 +203,7 @@ the other. On Linux they coexist as separate files.
 
 The lookup key is the **canonical edit URL**:
 
-```
+```text
 https://github.com/netdata/<repo>/edit/<branch>/<repo-rel-path>
 ```
 

--- a/.agents/skills/docs-learn-site-structure/mdx-rules.md
+++ b/.agents/skills/docs-learn-site-structure/mdx-rules.md
@@ -222,7 +222,7 @@ intact.
 - `< ` or ` <` with spaces around the `<`.
 - Closing-brace-only sequences if they're standalone.
 
-## Onbroken-links policy
+## onBrokenLinks policy
 
 `docusaurus.config.js:22`: `onBrokenLinks: 'warn'`. Broken
 links never fail the Docusaurus build at the parse level; they

--- a/.agents/skills/docs-learn-site-structure/recipes/delete-doc-page.md
+++ b/.agents/skills/docs-learn-site-structure/recipes/delete-doc-page.md
@@ -43,7 +43,7 @@ with the ingest PR):
 
 1. Open `${NETDATA_REPOS_DIR}/learn/LegacyLearnCorrelateLinksWithGHURLs.json`.
 2. Search for the GitHub blob/edit URL of the deleted file:
-   ```
+   ```text
    "https://github.com/netdata/netdata/blob/master/docs/<...>/<deleted-page>.md"
    ```
 3. Find the entry. Apply your decision from step 1:

--- a/.agents/skills/repo-mirror-sources/SKILL.md
+++ b/.agents/skills/repo-mirror-sources/SKILL.md
@@ -115,8 +115,9 @@ output, end-of-run summary). Run it on demand.
 ### First sync
 
 ```bash
-# Source the env, run the script.
-source <(grep -E '^NETDATA_REPOS_DIR=' <repo>/.env)
+# Export the variable (the script is a child process and reads the environment;
+# it does not source .env itself), then run the script.
+set -a; source <(grep -E '^NETDATA_REPOS_DIR=' <repo>/.env); set +a
 .agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
 ```
 

--- a/.agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
+++ b/.agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
@@ -154,12 +154,13 @@ has_uncommitted_changes() {
     git diff-index --quiet HEAD -- 2>/dev/null
     local diff_result=$?
     
-    # git diff-index returns 0 if no changes, 1 if changes exist
-    # We want to return 0 (true) if changes exist, 1 (false) if no changes
-    if [ $diff_result -eq 1 ]; then
-        local result=0  # Has changes
-    else
+    # git diff-index: 0 = clean, 1 = changes, anything else = the command itself
+    # failed (corrupt index, unreadable repo). Only exit 0 proves the tree is clean;
+    # every other status must skip the repo rather than pull into an unknown state.
+    if [ $diff_result -eq 0 ]; then
         local result=1  # No changes
+    else
+        local result=0  # Has changes, or we could not tell
     fi
     
     cd "$MIRROR_DIR" 2>/dev/null || true  # Try to return to script directory
@@ -325,8 +326,12 @@ update_repo() {
             REPOS_BRANCH_SWITCHED+=("$repo: $current_branch → $default_branch")
             current_branch="$default_branch"
         else
-            print_status "  ${RED}✗ Failed to switch to ${default_branch}${NC}"
+            print_status "  ${RED}✗ Failed to switch to ${default_branch}; leaving ${current_branch} untouched${NC}"
             REPOS_WRONG_BRANCH+=("$repo: stuck on $current_branch, default is $default_branch")
+            # The contract is "sync the default branch": pulling the branch we could not
+            # leave would mutate work the safety check meant to protect.
+            cd "$MIRROR_DIR" 2>/dev/null || true
+            return 1
         fi
     fi
     
@@ -371,7 +376,9 @@ clone_new_repos() {
     local repos_list
     repos_list=$(gh repo list "$ORG" --limit 1000 --json name,sshUrl,defaultBranchRef --source --no-archived)
     
-    echo "$repos_list" | jq -r '.[] | "\(.name) \(.sshUrl) \(.defaultBranchRef.name)"' | while read -r name url default_branch; do
+    # Process substitution keeps the loop in this shell; a pipeline would run it in a
+    # subshell and discard new_repos_count.
+    while read -r name url default_branch; do
         if [ ! -d "$name" ]; then
             new_repos_count=$((new_repos_count + 1))
             print_status "${GREEN}→ Cloning new repo: $name (default branch: $default_branch, with submodules)${NC}"
@@ -389,7 +396,7 @@ clone_new_repos() {
                 print_status "  ${RED}✗ Clone failed${NC}"
             fi
         fi
-    done
+    done < <(echo "$repos_list" | jq -r '.[] | "\(.name) \(.sshUrl) \(.defaultBranchRef.name)"')
     
     if [ $new_repos_count -eq 0 ]; then
         print_status "No new repositories to clone."

--- a/.agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
+++ b/.agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
@@ -387,7 +387,8 @@ clone_new_repos() {
         if [ ! -d "$name" ]; then
             new_repos_count=$((new_repos_count + 1))
             print_status "${GREEN}→ Cloning new repo: $name (default branch: $default_branch, with submodules)${NC}"
-            if git clone --quiet --recursive "$url" "$name" 2>/dev/null; then
+            # stdin is the repo list (process substitution): keep ssh or credential prompts from eating it.
+            if git clone --quiet --recursive "$url" "$name" </dev/null 2>/dev/null; then
                 # Set up tracking for the default branch without changing this shell's
                 # directory (the loop now runs in the caller's shell).
                 git -C "$name" symbolic-ref refs/remotes/origin/HEAD "refs/remotes/origin/$default_branch" 2>/dev/null \

--- a/.agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
+++ b/.agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
@@ -71,8 +71,8 @@ done
 # 1. NETDATA_REPOS_DIR set and points to an existing directory.
 if [ -z "${NETDATA_REPOS_DIR:-}" ]; then
     echo "ERROR: NETDATA_REPOS_DIR is not set." >&2
-    echo "       Set it in <repo>/.env (or your shell env) to the directory" >&2
-    echo "       that holds (or will hold) your Netdata-org repos mirror." >&2
+    echo "       Export it (for example: set -a; source <repo>/.env; set +a); this script does" >&2
+    echo "       not read .env. It names the directory that holds your Netdata-org repos mirror." >&2
     exit 2
 fi
 MIRROR_DIR="$NETDATA_REPOS_DIR"

--- a/.agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
+++ b/.agents/skills/repo-mirror-sources/scripts/sync-netdata-repos.sh
@@ -198,8 +198,8 @@ get_uncommitted_details() {
     fi
     cd "$repo" || { echo "cannot access"; return; }
     local staged unstaged
-    staged=$(git diff --cached --numstat | wc -l)
-    unstaged=$(git diff --numstat | wc -l)
+    staged=$(git diff --cached --numstat 2>/dev/null | wc -l)
+    unstaged=$(git diff --numstat 2>/dev/null | wc -l)
     cd "$MIRROR_DIR" 2>/dev/null || true  # Try to return to script directory
     
     # Report details - note that untracked files are shown but don't block updates
@@ -374,7 +374,12 @@ clone_new_repos() {
     # Get list of all repos from GitHub
     print_status "Fetching repository list from GitHub..."
     local repos_list
-    repos_list=$(gh repo list "$ORG" --limit 1000 --json name,sshUrl,defaultBranchRef --source --no-archived)
+    if ! repos_list=$(gh repo list "$ORG" --limit 1000 --json name,sshUrl,defaultBranchRef --source --no-archived) \
+        || [ -z "$repos_list" ]; then
+        # An auth or rate-limit failure must not read as "nothing new to clone".
+        print_status "${RED}✗ gh repo list failed; skipping discovery (check gh auth and rate limits)${NC}"
+        return 1
+    fi
     
     # Process substitution keeps the loop in this shell; a pipeline would run it in a
     # subshell and discard new_repos_count.
@@ -383,14 +388,10 @@ clone_new_repos() {
             new_repos_count=$((new_repos_count + 1))
             print_status "${GREEN}→ Cloning new repo: $name (default branch: $default_branch, with submodules)${NC}"
             if git clone --quiet --recursive "$url" "$name" 2>/dev/null; then
-                # Set up tracking for default branch
-                # Safety: validate we can enter the directory
-                if cd "$name" 2>/dev/null; then
-                    git symbolic-ref refs/remotes/origin/HEAD "refs/remotes/origin/$default_branch" 2>/dev/null || true
-                    cd "$MIRROR_DIR" 2>/dev/null || true
-                else
-                    print_status "  ${YELLOW}⚠️  Warning: Could not enter cloned directory${NC}"
-                fi
+                # Set up tracking for the default branch without changing this shell's
+                # directory (the loop now runs in the caller's shell).
+                git -C "$name" symbolic-ref refs/remotes/origin/HEAD "refs/remotes/origin/$default_branch" 2>/dev/null \
+                    || print_status "  ${YELLOW}⚠️  Warning: could not set origin/HEAD for $name${NC}"
                 print_status "  ${GREEN}✓ Cloned successfully${NC}"
             else
                 print_status "  ${RED}✗ Clone failed${NC}"

--- a/.agents/skills/repo-pr-reviews/SKILL.md
+++ b/.agents/skills/repo-pr-reviews/SKILL.md
@@ -156,6 +156,8 @@ State for each PR is cached under `<repo-root>/.local/audits/pr-reviews/pr-<N>/`
 - `reviews.json` -- review submissions with body (REST)
 - `review-threads.json` -- per-thread, with `isResolved` (GraphQL)
 - `summary.txt` -- human-readable triage summary
+- `FETCH-INCOMPLETE` -- present only while a fetch is running or after one aborted; the snapshot is partial, re-run
+  `fetch-all.sh` before reading anything else here
 
 ## Workflow
 

--- a/.agents/skills/repo-pr-reviews/SKILL.md
+++ b/.agents/skills/repo-pr-reviews/SKILL.md
@@ -528,6 +528,7 @@ If a new AI reviewer appears in the project, classify it by adding to
 | Symptom                                                | Likely cause                                                         |
 |--------------------------------------------------------|----------------------------------------------------------------------|
 | `fetch-all.sh` returns suspiciously round counts       | Pagination missed pages. Re-run; fetch-all auto-probes when count is a multiple of 100. |
+| `fetch-all.sh` aborts with `page N probe FAILED` and leaves `FETCH-INCOMPLETE` in the state dir | `gh` auth or rate limit; the cache is incomplete. Fix `gh auth status`, re-run; do not read the partial dump. |
 | A GraphQL helper script fails with `cursor_args[@]: unbound variable` | macOS Bash 3.2 plus `set -u` treats empty array expansion as unbound. Keep `gh api` argument arrays non-empty before expansion or branch the first-page GraphQL call. This affected both `fetch-all.sh` and `wait-for-activity.sh`. |
 | `reply-thread.sh` -> 404                               | Wrong comment id (use `databaseId` from `review-threads.json`, not the GraphQL node id). |
 | `reply-thread.sh` -> `line N: 2: usage`, yet the thread ends up resolved | The comment id expanded to empty AND the resolve ran anyway. Never chain reply and resolve so that resolve can run after reply fails: run `reply-thread.sh`, confirm it printed `posted reply id=...`, THEN resolve. See the bash-vs-zsh note below. |

--- a/.agents/skills/repo-pr-reviews/SKILL.md
+++ b/.agents/skills/repo-pr-reviews/SKILL.md
@@ -538,6 +538,7 @@ If a new AI reviewer appears in the project, classify it by adding to
 | `resolve-thread.sh` -> "thread not found"              | Used REST id instead of GraphQL node id.                              |
 | `trigger-copilot.sh` succeeds but no new review        | Expected. The org has no Copilot review credits, which is why it is not in the loop. Do not wait on it. |
 | `trigger-cubic.sh` succeeds but no new review          | cubic ignores comments without an explicit `@cubic-dev-ai` mention. The script always prepends it. |
+| `ci-status.sh` exits 3 (failing)                       | At least one check failed or a commit status is in FAILURE/ERROR. Fix before pushing; 3 wins over 2 when checks are also running. |
 | `ci-status.sh` exits 2 (running)                       | CI hasn't finished. Push anyway -- waiting on CI between iterations destroys throughput. The next push triggers a fresh CI run on the new code, which is what matters. (See Step 4b.) |
 | Bot keeps re-flagging the same line after a fix push   | The bot didn't see the new commit because it wasn't re-triggered.    |
 | `wait-for-activity.sh` 124 timeout                     | Bots are silent -- could be done, could be quota-limited. Check `summary.txt`; if all threads resolved, you're done. |

--- a/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
@@ -55,7 +55,7 @@ jq -r '
 
 echo
 total=$(jq '(.statusCheckRollup // []) | length' <<< "${data}")
-fail=$(jq '[(.statusCheckRollup // [])[] | select(((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|STARTUP_FAILURE")) or ((.state // "")|test("^(FAILURE|ERROR)$")))] | length' <<< "${data}")
+fail=$(jq '[(.statusCheckRollup // [])[] | select(((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|STARTUP_FAILURE|STALE")) or ((.state // "")|test("^(FAILURE|ERROR)$")))] | length' <<< "${data}")
 running=$(jq '[(.statusCheckRollup // [])[] | select(((.status // "")|test("^(IN_PROGRESS|QUEUED|WAITING|PENDING|REQUESTED)$")) or ((.state // "")|test("^(PENDING|EXPECTED)$")))] | length' <<< "${data}")
 echo "Total checks: ${total}   Failing: ${fail}   Running: ${running}"
 

--- a/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
@@ -55,8 +55,8 @@ jq -r '
 
 echo
 total=$(jq '.statusCheckRollup | length' <<< "${data}")
-fail=$(jq '[.statusCheckRollup[] | select(((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|STARTUP_FAILURE")) or ((.state // "")|test("^(FAILURE|ERROR)$")))] | length' <<< "${data}")
-running=$(jq '[.statusCheckRollup[] | select((.status // "")=="IN_PROGRESS" or (.status // "")=="QUEUED" or ((.state // "")|test("^(PENDING|EXPECTED)$")))] | length' <<< "${data}")
+fail=$(jq '[(.statusCheckRollup // [])[] | select(((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|STARTUP_FAILURE")) or ((.state // "")|test("^(FAILURE|ERROR)$")))] | length' <<< "${data}")
+running=$(jq '[(.statusCheckRollup // [])[] | select(((.status // "")|test("^(IN_PROGRESS|QUEUED|WAITING|PENDING|REQUESTED)$")) or ((.state // "")|test("^(PENDING|EXPECTED)$")))] | length' <<< "${data}")
 echo "Total checks: ${total}   Failing: ${fail}   Running: ${running}"
 
 # Failures are decided first: a PR with failures and running checks must exit 3, because

--- a/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
@@ -44,10 +44,10 @@ jq -r '
     # carry .state, not .conclusion/.status, and gh reports an in-progress CheckRun with
     # conclusion "". Empty strings are truthy in jq, so // alone picks the wrong field.
     def nz: if . == null or . == "" then empty else . end;
-    .statusCheckRollup
+    (.statusCheckRollup // [])
     | map(. + {key: ((.conclusion|nz) // (.state|nz) // (.status|nz) // "PENDING")})
     | group_by(.key)
-    | map({key: .[0].key, count: length, names: [.[].name // .[].context]})
+    | map({key: .[0].key, count: length, names: [.[] | .name // .context]})
     | sort_by(.key)
     | .[]
     | "\(.key)\t\(.count)\t\((.names | sort | unique | join(", ")[0:200]))"
@@ -56,7 +56,7 @@ jq -r '
 echo
 total=$(jq '.statusCheckRollup | length' <<< "${data}")
 fail=$(jq '[.statusCheckRollup[] | select(((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|STARTUP_FAILURE")) or ((.state // "")|test("^(FAILURE|ERROR)$")))] | length' <<< "${data}")
-running=$(jq '[.statusCheckRollup[] | select((.status // "")=="IN_PROGRESS" or (.status // "")=="QUEUED" or (.state // "")=="PENDING")] | length' <<< "${data}")
+running=$(jq '[.statusCheckRollup[] | select((.status // "")=="IN_PROGRESS" or (.status // "")=="QUEUED" or ((.state // "")|test("^(PENDING|EXPECTED)$")))] | length' <<< "${data}")
 echo "Total checks: ${total}   Failing: ${fail}   Running: ${running}"
 
 # Failures are decided first: a PR with failures and running checks must exit 3, because

--- a/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
@@ -54,7 +54,7 @@ jq -r '
 ' <<< "${data}" | column -t -s $'\t'
 
 echo
-total=$(jq '.statusCheckRollup | length' <<< "${data}")
+total=$(jq '(.statusCheckRollup // []) | length' <<< "${data}")
 fail=$(jq '[(.statusCheckRollup // [])[] | select(((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|STARTUP_FAILURE")) or ((.state // "")|test("^(FAILURE|ERROR)$")))] | length' <<< "${data}")
 running=$(jq '[(.statusCheckRollup // [])[] | select(((.status // "")|test("^(IN_PROGRESS|QUEUED|WAITING|PENDING|REQUESTED)$")) or ((.state // "")|test("^(PENDING|EXPECTED)$")))] | length' <<< "${data}")
 echo "Total checks: ${total}   Failing: ${fail}   Running: ${running}"

--- a/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/ci-status.sh
@@ -40,8 +40,12 @@ echo
 
 # Group checks by conclusion / status.
 jq -r '
+    # StatusContext nodes (commit-status API: Codacy and other non-Actions integrations)
+    # carry .state, not .conclusion/.status, and gh reports an in-progress CheckRun with
+    # conclusion "". Empty strings are truthy in jq, so // alone picks the wrong field.
+    def nz: if . == null or . == "" then empty else . end;
     .statusCheckRollup
-    | map(. + {key: ((.conclusion // .status) // "PENDING")})
+    | map(. + {key: ((.conclusion|nz) // (.state|nz) // (.status|nz) // "PENDING")})
     | group_by(.key)
     | map({key: .[0].key, count: length, names: [.[].name // .[].context]})
     | sort_by(.key)
@@ -51,19 +55,21 @@ jq -r '
 
 echo
 total=$(jq '.statusCheckRollup | length' <<< "${data}")
-fail=$(jq '[.statusCheckRollup[] | select((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED"))] | length' <<< "${data}")
-running=$(jq '[.statusCheckRollup[] | select((.status // "")=="IN_PROGRESS" or (.status // "")=="QUEUED")] | length' <<< "${data}")
+fail=$(jq '[.statusCheckRollup[] | select(((.conclusion // "")|test("FAILURE|TIMED_OUT|CANCELLED|ACTION_REQUIRED|STARTUP_FAILURE")) or ((.state // "")|test("^(FAILURE|ERROR)$")))] | length' <<< "${data}")
+running=$(jq '[.statusCheckRollup[] | select((.status // "")=="IN_PROGRESS" or (.status // "")=="QUEUED" or (.state // "")=="PENDING")] | length' <<< "${data}")
 echo "Total checks: ${total}   Failing: ${fail}   Running: ${running}"
 
+# Failures are decided first: a PR with failures and running checks must exit 3, because
+# the skill tells the caller to ignore exit 2 and push.
+if (( fail > 0 )); then
+    echo -e "${PR_RED}WARNING: ${fail} check(s) failing. Address these BEFORE pushing.${PR_NC}" >&2
+    exit 3
+fi
 if (( running > 0 )); then
     # Exit 2 is informational, not a "do not push" signal. The next push
     # will start a fresh CI run on top of the new code -- that's what we
     # actually want to verify. The skill's policy is to push anyway.
     echo -e "${PR_GRAY}Note: ${running} check(s) still running; the next push will start a fresh CI run.${PR_NC}" >&2
     exit 2
-fi
-if (( fail > 0 )); then
-    echo -e "${PR_RED}WARNING: ${fail} check(s) failing. Address these BEFORE pushing.${PR_NC}" >&2
-    exit 3
 fi
 exit 0

--- a/.agents/skills/repo-pr-reviews/scripts/fetch-all.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/fetch-all.sh
@@ -11,6 +11,7 @@
 #   reviews.json           -- /repos/{slug}/pulls/{n}/reviews         (review submissions with body)
 #   review-threads.json    -- GraphQL reviewThreads (per-thread isResolved + comments[])
 #   summary.txt            -- human-readable triage summary
+#   FETCH-INCOMPLETE       -- present while a run is in progress or after it aborted; the snapshot is partial
 #
 # Pagination paranoia:
 #   GitHub paginates everything. Default page size is 30, max 100. The skill's

--- a/.agents/skills/repo-pr-reviews/scripts/fetch-all.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/fetch-all.sh
@@ -89,8 +89,14 @@ fetch_paranoid() {
         local next_page=$(( n / 100 + 1 ))
         echo -e "${PR_YELLOW}[fetch-all] ${kind}: count is exactly ${n} (multiple of 100). Verifying with explicit page=${next_page}...${PR_NC}" >&2
 
+        # Never substitute [] for a failed call: an auth or rate-limit error would look
+        # identical to "no more pages" and the cache would be reported complete while
+        # truncated. fetch_paranoid runs under set -e, so return 1 aborts the script.
         local probe
-        probe="$(gh api "${path}${sep}per_page=100&page=${next_page}" 2>/dev/null || echo '[]')"
+        if ! probe="$(gh api "${path}${sep}per_page=100&page=${next_page}" 2>/dev/null)"; then
+            echo -e "${PR_RED}[fetch-all] ${kind}: page ${next_page} probe FAILED (auth? rate limit?); the cache would be incomplete${PR_NC}" >&2
+            return 1
+        fi
         local extra
         extra="$(jq 'length' <<< "${probe}")"
         if (( extra > 0 )); then
@@ -100,7 +106,10 @@ fetch_paranoid() {
             mv "${out}.merged" "${out}"
             local p=$(( next_page + 1 ))
             while true; do
-                probe="$(gh api "${path}${sep}per_page=100&page=${p}" 2>/dev/null || echo '[]')"
+                if ! probe="$(gh api "${path}${sep}per_page=100&page=${p}" 2>/dev/null)"; then
+                    echo -e "${PR_RED}[fetch-all] ${kind}: page ${p} FAILED (auth? rate limit?); the cache would be incomplete${PR_NC}" >&2
+                    return 1
+                fi
                 extra="$(jq 'length' <<< "${probe}")"
                 (( extra == 0 )) && break
                 echo -e "${PR_YELLOW}[fetch-all] ${kind}: page ${p} had ${extra} more.${PR_NC}" >&2

--- a/.agents/skills/repo-pr-reviews/scripts/fetch-all.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/fetch-all.sh
@@ -35,6 +35,10 @@ PR="${1:?usage: $0 <pr-number>}"
 pr_require_numeric "${PR}"
 SLUG="$(pr_require_slug)"
 DIR="$(pr_state_dir "${PR}")"
+# A marker that survives an abort: readers of the state dir must not treat a partial
+# fetch (an earlier run's files next to this run's) as a complete snapshot.
+touch "${DIR}/FETCH-INCOMPLETE"
+rm -f "${DIR}/summary.txt"
 
 echo -e "${PR_GRAY}[fetch-all] PR ${SLUG}#${PR} -> ${DIR}${PR_NC}" >&2
 
@@ -93,8 +97,9 @@ fetch_paranoid() {
         # identical to "no more pages" and the cache would be reported complete while
         # truncated. fetch_paranoid runs under set -e, so return 1 aborts the script.
         local probe
-        if ! probe="$(gh api "${path}${sep}per_page=100&page=${next_page}" 2>/dev/null)"; then
-            echo -e "${PR_RED}[fetch-all] ${kind}: page ${next_page} probe FAILED (auth? rate limit?); the cache would be incomplete${PR_NC}" >&2
+        if ! probe="$(gh api "${path}${sep}per_page=100&page=${next_page}")" \
+            || ! jq -e 'type=="array"' <<< "${probe}" >/dev/null 2>&1; then
+            echo -e "${PR_RED}[fetch-all] ${kind}: page ${next_page} probe FAILED or was not an array (see gh output above); the cache would be incomplete${PR_NC}" >&2
             return 1
         fi
         local extra
@@ -106,8 +111,9 @@ fetch_paranoid() {
             mv "${out}.merged" "${out}"
             local p=$(( next_page + 1 ))
             while true; do
-                if ! probe="$(gh api "${path}${sep}per_page=100&page=${p}" 2>/dev/null)"; then
-                    echo -e "${PR_RED}[fetch-all] ${kind}: page ${p} FAILED (auth? rate limit?); the cache would be incomplete${PR_NC}" >&2
+                if ! probe="$(gh api "${path}${sep}per_page=100&page=${p}")" \
+                    || ! jq -e 'type=="array"' <<< "${probe}" >/dev/null 2>&1; then
+                    echo -e "${PR_RED}[fetch-all] ${kind}: page ${p} FAILED or was not an array (see gh output above); the cache would be incomplete${PR_NC}" >&2
                     return 1
                 fi
                 extra="$(jq 'length' <<< "${probe}")"
@@ -249,6 +255,7 @@ echo -e "${PR_GRAY}[fetch-all] review-threads: ${n_threads} threads total${PR_NC
         + "  by=" + (.comments.nodes[0].author.login // "?")' \
         "${DIR}/review-threads.json"
 } > "${DIR}/summary.txt"
+rm -f "${DIR}/FETCH-INCOMPLETE"
 
 echo
 cat "${DIR}/summary.txt"

--- a/.agents/skills/repo-pr-reviews/scripts/list-open-threads.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/list-open-threads.sh
@@ -20,7 +20,7 @@ SHORT=0
 DIR="$(pr_state_dir "${PR}")"
 FILE="${DIR}/review-threads.json"
 if [[ -e "${DIR}/FETCH-INCOMPLETE" ]]; then
-    echo "[list-open-threads] the last fetch-all.sh run for PR ${PR} did not complete; re-run it before reading threads" >&2
+    echo -e "${PR_RED}The last fetch-all.sh run for PR ${PR} did not complete (FETCH-INCOMPLETE present); re-run it before reading threads.${PR_NC}" >&2
     exit 1
 fi
 if [[ ! -f "${FILE}" || ! -r "${FILE}" || ! -s "${FILE}" ]]; then

--- a/.agents/skills/repo-pr-reviews/scripts/list-open-threads.sh
+++ b/.agents/skills/repo-pr-reviews/scripts/list-open-threads.sh
@@ -19,6 +19,10 @@ SHORT=0
 
 DIR="$(pr_state_dir "${PR}")"
 FILE="${DIR}/review-threads.json"
+if [[ -e "${DIR}/FETCH-INCOMPLETE" ]]; then
+    echo "[list-open-threads] the last fetch-all.sh run for PR ${PR} did not complete; re-run it before reading threads" >&2
+    exit 1
+fi
 if [[ ! -f "${FILE}" || ! -r "${FILE}" || ! -s "${FILE}" ]]; then
     echo -e "${PR_RED}Missing ${FILE}. Run fetch-all.sh ${PR} first.${PR_NC}" >&2
     exit 1

--- a/.agents/skills/triage-agent-events/AE_FIELDS.md
+++ b/.agents/skills/triage-agent-events/AE_FIELDS.md
@@ -239,7 +239,7 @@ exist in the producer source.)
 
 ### `AE_AGENT_HEALTH`
 
-Source: `src/daemon/status-file.c:929-952`. Computed by the
+Source: `src/daemon/status-file.c:1167-1189` (`agent_health()`). Computed by the
 **agent** (not the ingestion server) at POST time across
 restart history. Used to isolate crash classes.
 

--- a/.agents/skills/triage-agent-events/AE_FIELDS.md
+++ b/.agents/skills/triage-agent-events/AE_FIELDS.md
@@ -312,7 +312,7 @@ Source: `src/daemon/status-file.c:1097-1286`. Computed by the
 **agent**, NOT the ingestion server. The most useful field for
 classifying records.
 
-26 distinct strings:
+27 distinct strings (29 rows below; `abnormal power off` and `out of memory` each appear under two prior states):
 
 **Initial / no prior state (1):**
 
@@ -332,7 +332,7 @@ classifying records.
 | `exit and updated` | Stopped and was replaced by a new version. |
 | `exit instructed` | `netdata --exit` or service stop. |
 
-**Prior was INITIALIZING (8):**
+**Prior was INITIALIZING (9):**
 
 | Value | Meaning |
 |---|---|
@@ -346,7 +346,7 @@ classifying records.
 | `fatal on start` | fatal() during startup. |
 | `killed hard on start` | SIGKILL/SIGTERM during startup. |
 
-**Prior was EXITING (5):**
+**Prior was EXITING (6):**
 
 | Value | Meaning |
 |---|---|

--- a/.agents/skills/triage-agent-events/AE_FIELDS.md
+++ b/.agents/skills/triage-agent-events/AE_FIELDS.md
@@ -308,7 +308,7 @@ exist in producer source.)
 
 ### `AE_EXIT_CAUSE` (top-level)
 
-Source: `src/daemon/status-file.c:1097-1286`. Computed by the
+Source: `src/daemon/status-file.c:1349-1524`. Computed by the
 **agent**, NOT the ingestion server. The most useful field for
 classifying records.
 

--- a/.agents/skills/triage-agent-events/finding-crashes.md
+++ b/.agents/skills/triage-agent-events/finding-crashes.md
@@ -11,7 +11,7 @@ Get recent signal crashes on stable + recent nightlies:
 .agents/skills/triage-agent-events/scripts/get-events.sh \
     --health crash \
     --since '24h ago' \
-    --versions auto
+    --version auto
 ```
 
 Output is a JSON dump under
@@ -121,11 +121,11 @@ see `AE_FIELDS.md` for the full table)
 ## Filtering out noise
 
 Many crashes from old / unsupported versions are already
-fixed. The default `--versions auto` filter handles this.
+fixed. The default `--version auto` filter handles this.
 For wider investigations, scope to stable releases only:
 
 ```bash
-get-events.sh --health crash --versions '^v2\.\d+\.\d+$'
+get-events.sh --health crash --version '^v2\.\d+\.\d+$'
 ```
 
 ## Related recipes

--- a/.agents/skills/triage-agent-events/finding-crashes.md
+++ b/.agents/skills/triage-agent-events/finding-crashes.md
@@ -128,6 +128,9 @@ For wider investigations, scope to stable releases only:
 get-events.sh --health crash --version '^v2\.\d+\.\d+$'
 ```
 
+The regex filters the page the server returned (`--last`, default 500); raise `--last` or pass the releases with
+`--versions` when you need every stable-release row.
+
 ## Related recipes
 
 - `recipes/find-by-function.md` -- when you have a function

--- a/.agents/skills/triage-agent-events/finding-fatals.md
+++ b/.agents/skills/triage-agent-events/finding-fatals.md
@@ -12,7 +12,7 @@ called `exit()` or `_exit()` ourselves).
 .agents/skills/triage-agent-events/scripts/get-events.sh \
     --exit-cause fatal \
     --since '24h ago' \
-    --versions auto
+    --version auto
 ```
 
 `--exit-cause fatal` is shorthand for the deliberate-fatal

--- a/.agents/skills/triage-agent-events/query-discipline.md
+++ b/.agents/skills/triage-agent-events/query-discipline.md
@@ -15,7 +15,7 @@ anti-patterns to avoid.
 
 ## The hard rule
 
-```
+```text
 selections (structured, indexable)  -->  query (FTS, residual narrower)
 ```
 

--- a/.agents/skills/triage-agent-events/recipes/find-by-function.md
+++ b/.agents/skills/triage-agent-events/recipes/find-by-function.md
@@ -9,7 +9,7 @@ Use case: "Is anyone hitting a crash in `function_name` /
 .agents/skills/triage-agent-events/scripts/get-events.sh \
     --function 'rrdcontext_release,rrdcontext_dispatch_updates_to_main' \
     --since '7d ago' \
-    --versions auto \
+    --version auto \
     --last 200 \
     --output /tmp/by-function.json
 ```
@@ -62,7 +62,7 @@ callee):
     --health crash \
     --query 'inlined_callee_name' \
     --since '7d ago' \
-    --versions auto \
+    --version auto \
     --output /tmp/by-symbol.json
 ```
 

--- a/.agents/skills/triage-agent-events/recipes/find-by-version.md
+++ b/.agents/skills/triage-agent-events/recipes/find-by-version.md
@@ -85,7 +85,7 @@ Check if the count drops to ~zero in nightly N+1 and beyond.
 - **Old version events from unupdated agents are normal**.
   Don't conclude "the bug is back" from a single old-version
   record -- check the date.
-- **`--versions auto` masks regressions** because it filters
+- **`--version auto` masks regressions** because it filters
   to recent versions. Use `--version all` for "when did this
   start?" investigations.
 - **Nightly numbers are commits-since-tag**. Higher number =

--- a/.agents/skills/triage-agent-events/recipes/find-related-to-work.md
+++ b/.agents/skills/triage-agent-events/recipes/find-related-to-work.md
@@ -29,7 +29,7 @@ Working on dbengine page eviction:
 .agents/skills/triage-agent-events/scripts/get-events.sh \
     --function 'rrdeng_page_descr_t,rrdeng_evict_pages,evict_main' \
     --since '14d ago' \
-    --versions auto \
+    --version auto \
     --output /tmp/related-pass1.json
 
 # 2. If pass 1 is sparse, widen to filename.
@@ -51,7 +51,7 @@ agentevents_query_function cloud "$payload" > /tmp/related-pass2.json
     --health crash \
     --query 'page_descr OR cache_evict OR rrdeng' \
     --since '14d ago' \
-    --versions auto \
+    --version auto \
     --output /tmp/related-pass3.json
 ```
 

--- a/.agents/skills/triage-agent-events/scripts/analyze-events.sh
+++ b/.agents/skills/triage-agent-events/scripts/analyze-events.sh
@@ -76,6 +76,10 @@ while [ $# -gt 0 ]; do
 done
 
 [ -z "$BY" ] && { usage >&2; exit 2; }
+case "$FORMAT" in
+    text|json) ;;
+    *) echo "Unknown --format '$FORMAT' (expected text or json)" >&2; exit 2 ;;
+esac
 
 FIELD="$(field_for_dim "$BY")"
 
@@ -153,9 +157,5 @@ case "$FORMAT" in
         echo "----------------------------------------"
         total=$(echo "$result" | jq '[.[].count] | add // 0')
         echo "  Total in top: $total"
-        ;;
-    *)
-        echo "Unknown --format '$FORMAT' (expected text or json)" >&2
-        exit 2
         ;;
 esac

--- a/.agents/skills/triage-agent-events/scripts/analyze-events.sh
+++ b/.agents/skills/triage-agent-events/scripts/analyze-events.sh
@@ -80,6 +80,9 @@ case "$FORMAT" in
     text|json) ;;
     *) echo "Unknown --format '$FORMAT' (expected text or json)" >&2; exit 2 ;;
 esac
+case "$TOP" in
+    ''|*[!0-9]*) echo "--top must be a positive integer, got '$TOP'" >&2; exit 2 ;;
+esac
 
 FIELD="$(field_for_dim "$BY")"
 
@@ -109,7 +112,8 @@ fi
 
 # Build filter expression.
 filter_expr='true'
-for f in "${FILTERS[@]}"; do
+# ${arr[@]+"${arr[@]}"} keeps bash 3.2 with set -u from treating an empty array as unbound.
+for f in ${FILTERS[@]+"${FILTERS[@]}"}; do
     k="${f%%=*}"
     v="${f#*=}"
     filter_expr="$filter_expr and (.\"$k\" == \"$v\")"

--- a/.agents/skills/triage-agent-events/scripts/analyze-events.sh
+++ b/.agents/skills/triage-agent-events/scripts/analyze-events.sh
@@ -81,7 +81,7 @@ case "$FORMAT" in
     *) echo "Unknown --format '$FORMAT' (expected text or json)" >&2; exit 2 ;;
 esac
 case "$TOP" in
-    ''|*[!0-9]*) echo "--top must be a positive integer, got '$TOP'" >&2; exit 2 ;;
+    ''|*[!0-9]*|0*) echo "--top must be a positive integer, got '$TOP'" >&2; exit 2 ;;
 esac
 
 FIELD="$(field_for_dim "$BY")"

--- a/.agents/skills/triage-agent-events/scripts/analyze-events.sh
+++ b/.agents/skills/triage-agent-events/scripts/analyze-events.sh
@@ -144,7 +144,7 @@ case "$FORMAT" in
     json)
         echo "$result" | jq .
         ;;
-    text|*)
+    text)
         echo
         echo "Top $TOP by $BY ($FIELD):"
         printf '%s\n' "----------------------------------------"
@@ -153,5 +153,9 @@ case "$FORMAT" in
         echo "----------------------------------------"
         total=$(echo "$result" | jq '[.[].count] | add // 0')
         echo "  Total in top: $total"
+        ;;
+    *)
+        echo "Unknown --format '$FORMAT' (expected text or json)" >&2
+        exit 2
         ;;
 esac

--- a/.agents/skills/triage-agent-events/scripts/get-events.sh
+++ b/.agents/skills/triage-agent-events/scripts/get-events.sh
@@ -261,8 +261,12 @@ agentevents_query_function "$VIA" "$PAYLOAD" > "$OUTPUT"
 if [ -n "$VERSION_REGEX" ]; then
     # The facet API takes explicit values only, so the pattern is applied to the fetched
     # page. Every failure path says so instead of claiming a filter that was not applied.
-    if ! jq -e '.columns.AE_AGENT_VERSION.index != null' "$OUTPUT" >/dev/null 2>&1; then
-        echo "[get-events] --version regex NOT applied: the response has no AE_AGENT_VERSION column" >&2
+    if ! jq -e . "$OUTPUT" >/dev/null 2>&1; then
+        echo "[get-events] --version regex NOT applied: the response at $OUTPUT is not JSON" >&2
+        exit 2
+    elif ! jq -e '.columns.AE_AGENT_VERSION.index != null' "$OUTPUT" >/dev/null 2>&1; then
+        echo "[get-events] --version regex NOT applied: the response has no AE_AGENT_VERSION column (dump kept unfiltered at $OUTPUT)" >&2
+        exit 2
     else
         pre_rows="$(jq '(.data // []) | length' "$OUTPUT")"
         if ! jq --arg re "$VERSION_REGEX" '

--- a/.agents/skills/triage-agent-events/scripts/get-events.sh
+++ b/.agents/skills/triage-agent-events/scripts/get-events.sh
@@ -70,6 +70,7 @@ EXIT_CAUSE=all
 SIGNAL=
 FUNCTION=
 VERSION=auto
+VERSION_REGEX=
 VERSIONS_EXPLICIT=
 ARCH=
 OS_FAMILY=
@@ -196,9 +197,9 @@ elif [ "$VERSION" = "auto" ]; then
 elif [ "$VERSION" = "all" ]; then
     : # no filter
 else
-    # Pattern -- best-effort: not multi-value selection, leave it
-    # to the caller to client-side-filter the dump after fetch.
-    echo "[get-events] --version <regex> is not pushed to the server; filter the resulting JSON with jq" >&2
+    # A regex cannot be pushed to the server (the facet API takes explicit values), so it is
+    # applied to AE_AGENT_VERSION after the dump is written (see below).
+    VERSION_REGEX="$VERSION"
 fi
 
 # ---------------------------------------------------------------
@@ -256,6 +257,18 @@ fi
 
 echo "[get-events] fetching via $VIA (output: $OUTPUT)..." >&2
 agentevents_query_function "$VIA" "$PAYLOAD" > "$OUTPUT"
+
+if [ -n "$VERSION_REGEX" ]; then
+    jq --arg re "$VERSION_REGEX" '
+        if (type == "object" and has("columns") and has("data")) then
+            (.columns.AE_AGENT_VERSION.index) as $i
+            | if $i == null then .
+              else .data = [ .data[] | select(((.[$i] // "") | tostring) | test($re)) ]
+              end
+        else . end
+    ' "$OUTPUT" > "$OUTPUT.tmp" && mv "$OUTPUT.tmp" "$OUTPUT"
+    echo "[get-events] applied client-side --version regex: $VERSION_REGEX" >&2
+fi
 
 rows="$(jq '.data | length // 0' "$OUTPUT" 2>/dev/null || echo 0)"
 echo "[get-events] wrote $rows row(s) to $OUTPUT" >&2

--- a/.agents/skills/triage-agent-events/scripts/get-events.sh
+++ b/.agents/skills/triage-agent-events/scripts/get-events.sh
@@ -269,6 +269,7 @@ if [ -n "$VERSION_REGEX" ]; then
         exit 2
     else
         pre_rows="$(jq '(.data // []) | length' "$OUTPUT")"
+        trap 'rm -f "$OUTPUT.tmp"' EXIT
         if ! jq --arg re "$VERSION_REGEX" '
             (.columns.AE_AGENT_VERSION.index) as $i
             | .data = [ (.data // [])[] | select(((.[$i] // "") | tostring) | test($re)) ]

--- a/.agents/skills/triage-agent-events/scripts/get-events.sh
+++ b/.agents/skills/triage-agent-events/scripts/get-events.sh
@@ -259,15 +259,26 @@ echo "[get-events] fetching via $VIA (output: $OUTPUT)..." >&2
 agentevents_query_function "$VIA" "$PAYLOAD" > "$OUTPUT"
 
 if [ -n "$VERSION_REGEX" ]; then
-    jq --arg re "$VERSION_REGEX" '
-        if (type == "object" and has("columns") and has("data")) then
+    # The facet API takes explicit values only, so the pattern is applied to the fetched
+    # page. Every failure path says so instead of claiming a filter that was not applied.
+    if ! jq -e '.columns.AE_AGENT_VERSION.index != null' "$OUTPUT" >/dev/null 2>&1; then
+        echo "[get-events] --version regex NOT applied: the response has no AE_AGENT_VERSION column" >&2
+    else
+        pre_rows="$(jq '(.data // []) | length' "$OUTPUT")"
+        if ! jq --arg re "$VERSION_REGEX" '
             (.columns.AE_AGENT_VERSION.index) as $i
-            | if $i == null then .
-              else .data = [ .data[] | select(((.[$i] // "") | tostring) | test($re)) ]
-              end
-        else . end
-    ' "$OUTPUT" > "$OUTPUT.tmp" && mv "$OUTPUT.tmp" "$OUTPUT"
-    echo "[get-events] applied client-side --version regex: $VERSION_REGEX" >&2
+            | .data = [ (.data // [])[] | select(((.[$i] // "") | tostring) | test($re)) ]
+        ' "$OUTPUT" > "$OUTPUT.tmp"; then
+            rm -f "$OUTPUT.tmp"
+            echo "[get-events] --version regex '$VERSION_REGEX' failed; the dump at $OUTPUT is NOT filtered" >&2
+            exit 2
+        fi
+        mv "$OUTPUT.tmp" "$OUTPUT"
+        echo "[get-events] applied client-side --version regex: $VERSION_REGEX" >&2
+        if [ "$pre_rows" -ge "$LAST" ]; then
+            echo "[get-events] the fetched page was full ($pre_rows rows, --last $LAST): the regex narrowed that page only; raise --last or use --versions for a server-side filter" >&2
+        fi
+    fi
 fi
 
 rows="$(jq '.data | length // 0' "$OUTPUT" 2>/dev/null || echo 0)"

--- a/.agents/skills/triage-agent-events/update-cadence.md
+++ b/.agents/skills/triage-agent-events/update-cadence.md
@@ -170,8 +170,9 @@ that still matter.
 
 `--version all` skips the auto filter for "when did X
 start?" investigations.
-`--version <regex>` overrides with a custom pattern, applied client-side to the fetched dump;
-`--versions <list>` overrides with explicit server-side values.
+`--version <regex>` overrides with a custom pattern, applied client-side to the fetched dump: it narrows the page
+`--last` returned, it does not widen the query, so raise `--last` when a rare version matters. `--versions <list>`
+overrides with explicit server-side values.
 
 ## What this means in practice
 

--- a/.agents/skills/triage-agent-events/update-cadence.md
+++ b/.agents/skills/triage-agent-events/update-cadence.md
@@ -158,7 +158,7 @@ because many unupdated agents report crashes that have been
 fixed. Filtering to recent versions focuses triage on bugs
 that still matter.
 
-`get-events.sh --versions auto` (the default) computes:
+`get-events.sh --version auto` (the default) computes:
 1. Quick discovery query: 24h window, no version filter,
    `AE_AGENT_VERSION` as a facet.
 2. From the facet result, pick the latest stable
@@ -168,9 +168,10 @@ that still matter.
 3. Re-run the main query with `selections.AE_AGENT_VERSION`
    set to that list.
 
-`--all-versions` skips the auto filter for "when did X
+`--version all` skips the auto filter for "when did X
 start?" investigations.
-`--versions <regex>` overrides with a custom pattern.
+`--version <regex>` overrides with a custom pattern, applied client-side to the fetched dump;
+`--versions <list>` overrides with explicit server-side values.
 
 ## What this means in practice
 
@@ -181,5 +182,5 @@ start?" investigations.
   within 23h, OR the version filter excluded it".
 - High-cardinality crashes from old versions are mostly
   noise; default-version-filtering keeps triage focused.
-- For "is this fixed in v2.X?", run `--versions auto` and
+- For "is this fixed in v2.X?", run `--version auto` and
   compare crash counts across the auto-selected versions.

--- a/.agents/skills/triage-agent-events/update-cadence.md
+++ b/.agents/skills/triage-agent-events/update-cadence.md
@@ -159,7 +159,7 @@ fixed. Filtering to recent versions focuses triage on bugs
 that still matter.
 
 `get-events.sh --version auto` (the default) computes:
-1. Quick discovery query: 24h window, no version filter,
+1. Quick discovery query: the same time window as the main query, no version filter,
    `AE_AGENT_VERSION` as a facet.
 2. From the facet result, pick the latest stable
    (`v\d+\.\d+\.\d+` matching `^v2\.([89]|\d\d)\.\d+$` or the

--- a/.agents/skills/triage-codacy/SKILL.md
+++ b/.agents/skills/triage-codacy/SKILL.md
@@ -54,7 +54,8 @@ Out of scope until a real use case creates a GitHub issue or branch-local SOW:
 | `CODACY_ORG` | Defaults to `netdata`. |
 | `CODACY_REPO` | Defaults to `netdata`. |
 
-All values live in `<repo>/.env` (gitignored). See `<repo>/.agents/ENV.md` for setup (where each value comes from, sample formats, common mistakes).
+All values except `CODACY_CLI_VERSION` live in `<repo>/.env` (gitignored). See `<repo>/.agents/ENV.md` for setup (where
+each value comes from, sample formats, common mistakes).
 
 ## Scripts (in scripts/)
 
@@ -74,9 +75,10 @@ $ .agents/skills/triage-codacy/scripts/analyze-local.sh
 
 Run this before `git push`. If it returns 0 findings, the Codacy gate on the PR will be green (modulo Codacy server-side patterns the local CLI doesn't bundle). If it returns findings, fix them locally first.
 
-Failed analyses are not clean trees: when the CLI dies before a tool can emit
-results, the dump holds tool-runner logs instead of JSON, and the script exits 4
-(also when the CLI exits non-zero with zero findings). Treat exit 4 as "no
+Failed analyses are not clean trees: when the dump is not JSON, is JSON of the
+wrong shape (not a findings array, an `{issues: [...]}` object, or a SARIF `runs`
+document), or the CLI exits non-zero with zero findings, the script exits 4 and
+keeps the CLI's stderr in `<dump>.log`. Treat exit 4 as "no
 evidence", not as green. If GitHub check-run annotations are empty too, use
 `pr-issues.sh` with `CODACY_TOKEN`; without that token, record the evidence gap
 and re-check after the next push.

--- a/.agents/skills/triage-codacy/SKILL.md
+++ b/.agents/skills/triage-codacy/SKILL.md
@@ -50,6 +50,7 @@ Out of scope until a real use case creates a GitHub issue or branch-local SOW:
 | `CODACY_TOKEN` | Account API token, header `api-token: <value>`. Required by `pr-issues.sh` and any wrapper that calls `_codacyaudit_run`. NOT required by `analyze-local.sh` (the CLI runs anonymously). |
 | `CODACY_HOST` | Defaults to `https://api.codacy.com`. Override only if Codacy moves the API host. |
 | `CODACY_PROVIDER` | Defaults to `gh` (GitHub). |
+| `CODACY_CLI_VERSION` | Optional, not a secret. Docker image tag for `analyze-local.sh`; defaults to `latest`. Set to pin the analyzer. |
 | `CODACY_ORG` | Defaults to `netdata`. |
 | `CODACY_REPO` | Defaults to `netdata`. |
 

--- a/.agents/skills/triage-codacy/SKILL.md
+++ b/.agents/skills/triage-codacy/SKILL.md
@@ -50,7 +50,7 @@ Out of scope until a real use case creates a GitHub issue or branch-local SOW:
 | `CODACY_TOKEN` | Account API token, header `api-token: <value>`. Required by `pr-issues.sh` and any wrapper that calls `_codacyaudit_run`. NOT required by `analyze-local.sh` (the CLI runs anonymously). |
 | `CODACY_HOST` | Defaults to `https://api.codacy.com`. Override only if Codacy moves the API host. |
 | `CODACY_PROVIDER` | Defaults to `gh` (GitHub). |
-| `CODACY_CLI_VERSION` | Optional, not a secret. Docker image tag for `analyze-local.sh`; defaults to `latest`. Set to pin the analyzer. |
+| `CODACY_CLI_VERSION` | Optional, not a secret, and read from the process environment only (`analyze-local.sh` does not source `.env`): `CODACY_CLI_VERSION=1.2.3 analyze-local.sh` pins the docker image tag; defaults to `latest`. |
 | `CODACY_ORG` | Defaults to `netdata`. |
 | `CODACY_REPO` | Defaults to `netdata`. |
 

--- a/.agents/skills/triage-codacy/SKILL.md
+++ b/.agents/skills/triage-codacy/SKILL.md
@@ -73,10 +73,10 @@ $ .agents/skills/triage-codacy/scripts/analyze-local.sh
 
 Run this before `git push`. If it returns 0 findings, the Codacy gate on the PR will be green (modulo Codacy server-side patterns the local CLI doesn't bundle). If it returns findings, fix them locally first.
 
-Operational gotcha: when the Dockerized Codacy CLI fails before a tool can emit
-results, the output file may have a `.json` suffix but contain tool-runner logs
-instead of JSON. Always verify with `jq empty <dump>` before treating a local
-dump as finding evidence. If GitHub check-run annotations are empty too, use
+Failed analyses are not clean trees: when the CLI dies before a tool can emit
+results, the dump holds tool-runner logs instead of JSON, and the script exits 4
+(also when the CLI exits non-zero with zero findings). Treat exit 4 as "no
+evidence", not as green. If GitHub check-run annotations are empty too, use
 `pr-issues.sh` with `CODACY_TOKEN`; without that token, record the evidence gap
 and re-check after the next push.
 

--- a/.agents/skills/triage-codacy/how-tos/handle-malformed-local-json.md
+++ b/.agents/skills/triage-codacy/how-tos/handle-malformed-local-json.md
@@ -1,8 +1,8 @@
 # Handle Malformed Local Codacy JSON
 
-Use this when `analyze-local.sh` exits 4 (the dump is not JSON, or the CLI failed
-with zero findings; the script's `<dump>.log` holds the CLI's stderr) or a dump from
-another source does not parse.
+Use this when `analyze-local.sh` exits 4 (the dump is not JSON, is JSON of the wrong
+shape, or the CLI failed with zero findings; `<dump>.log` holds the CLI's stderr) or a
+dump from another source does not parse.
 
 1. Verify the dump before reading it as findings:
 

--- a/.agents/skills/triage-codacy/how-tos/handle-malformed-local-json.md
+++ b/.agents/skills/triage-codacy/how-tos/handle-malformed-local-json.md
@@ -1,7 +1,7 @@
 # Handle Malformed Local Codacy JSON
 
-Use this when `analyze-local.sh` writes a `local-*.json` file but `jq` cannot
-parse it.
+Use this when `analyze-local.sh` exits 4 (it now detects this itself: the dump
+is not JSON, or the CLI failed with zero findings) or an older dump does not parse.
 
 1. Verify the dump before reading it as findings:
 

--- a/.agents/skills/triage-codacy/how-tos/handle-malformed-local-json.md
+++ b/.agents/skills/triage-codacy/how-tos/handle-malformed-local-json.md
@@ -1,7 +1,8 @@
 # Handle Malformed Local Codacy JSON
 
-Use this when `analyze-local.sh` exits 4 (it now detects this itself: the dump
-is not JSON, or the CLI failed with zero findings) or an older dump does not parse.
+Use this when `analyze-local.sh` exits 4 (the dump is not JSON, or the CLI failed
+with zero findings; the script's `<dump>.log` holds the CLI's stderr) or a dump from
+another source does not parse.
 
 1. Verify the dump before reading it as findings:
 

--- a/.agents/skills/triage-codacy/how-tos/triage-action-required-without-token.md
+++ b/.agents/skills/triage-codacy/how-tos/triage-action-required-without-token.md
@@ -14,6 +14,7 @@ GitHub exposes no annotations and the local checkout has no `.env` with
 2. Fetch public PR issue details from Codacy v3:
 
    ```bash
+   mkdir -p .local/audits/codacy
    curl -fsS \
      "https://api.codacy.com/api/v3/analysis/organizations/gh/netdata/repositories/netdata/pull-requests/<PR>/issues?limit=100" \
      -o .local/audits/codacy/pr-<PR>-public-issues.json

--- a/.agents/skills/triage-codacy/scripts/analyze-local.sh
+++ b/.agents/skills/triage-codacy/scripts/analyze-local.sh
@@ -78,6 +78,11 @@ if [ -z "$OUTPUT" ]; then
     OUTPUT="${audit_dir}/local${suffix}-$(date -u +%Y%m%dT%H%M%SZ).${FORMAT}"
 fi
 
+case "$FORMAT" in
+    json|sarif) ;;
+    *) echo -e "${CA_RED}[ERROR]${CA_NC} unknown --format '${FORMAT}' (expected json or sarif)" >&2; exit 2 ;;
+esac
+
 # Pick a runner.
 if [ "$RUNNER" = "auto" ]; then
     if command -v codacy-analysis-cli >/dev/null 2>&1; then
@@ -142,7 +147,11 @@ if [ "$FORMAT" = "json" ]; then
         echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not JSON (tool-runner logs?); the analysis did not complete" >&2
         exit 4
     fi
-    n="$(jq 'if type=="array" then length elif type=="object" and has("issues") then (.issues|length) else 0 end' "$OUTPUT")"
+    if ! jq -e 'type=="array" or (type=="object" and has("issues"))' "$OUTPUT" >/dev/null 2>&1; then
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is JSON but not a findings array or an {issues} object" >&2
+        exit 4
+    fi
+    n="$(jq 'if type=="array" then length else (.issues|length) end' "$OUTPUT")"
     if [ "$rc" -ne 0 ] && [ "$n" -eq 0 ]; then
         echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc} with 0 findings: a failed analysis, not a clean tree" >&2
         exit 4
@@ -152,11 +161,17 @@ if [ "$FORMAT" = "json" ]; then
     fi
     echo -e "${CA_GREEN}[analyze-local]${CA_NC} wrote ${n} finding(s) to ${OUTPUT}" >&2
 else
-    if [ "$rc" -ne 0 ]; then
-        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}; ${FORMAT} output cannot be validated, rerun with --format json" >&2
+    # SARIF is JSON too; count results across runs so the same failed-versus-clean rule applies.
+    if ! jq -e . "$OUTPUT" >/dev/null 2>&1; then
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not parseable ${FORMAT}; the analysis did not complete" >&2
         exit 4
     fi
-    echo -e "${CA_GREEN}[analyze-local]${CA_NC} wrote ${OUTPUT} (${FORMAT} format)" >&2
+    n="$(jq '[.runs[]?.results[]?] | length' "$OUTPUT")"
+    if [ "$rc" -ne 0 ] && [ "$n" -eq 0 ]; then
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc} with 0 findings: a failed analysis, not a clean tree" >&2
+        exit 4
+    fi
+    echo -e "${CA_GREEN}[analyze-local]${CA_NC} wrote ${n} finding(s) to ${OUTPUT} (${FORMAT} format)" >&2
 fi
 
 # Last line on stdout: the path. Pipe-friendly.

--- a/.agents/skills/triage-codacy/scripts/analyze-local.sh
+++ b/.agents/skills/triage-codacy/scripts/analyze-local.sh
@@ -25,10 +25,11 @@ Options:
   --format json|sarif    output format (default: json)
   --output PATH          explicit dump path (default: auto under .local/audits/codacy/)
   --runner docker|local  installer to use (default: auto -- prefer local
-                         binary, fall back to docker, fall back to npm)
+                         binary, fall back to docker)
   -h, --help
 
 Required tools: docker (default) OR a local codacy-analysis-cli binary.
+Set CODACY_CLI_VERSION to pin the docker image tag (default: latest).
 EOF
 }
 
@@ -99,9 +100,8 @@ case "$RUNNER" in
         # Local binary expects host paths.
         local_args=(analyze --directory "$SUBDIR" --format "$FORMAT")
         [ -n "$TOOL" ] && local_args+=(--tool "$TOOL")
-        if ! codacy-analysis-cli "${local_args[@]}" > "$OUTPUT" 2>/dev/null; then
-            echo -e "${CA_YELLOW}[analyze-local] cli returned non-zero (this is normal when findings are present)${CA_NC}" >&2
-        fi
+        rc=0
+        codacy-analysis-cli "${local_args[@]}" > "$OUTPUT" 2>/dev/null || rc=$?
         ;;
     docker)
         # Per https://github.com/codacy/codacy-analysis-cli the CLI
@@ -112,14 +112,15 @@ case "$RUNNER" in
         #     CLI container so child containers can resolve it
         cli_args=(analyze --directory "$SUBDIR" --format "$FORMAT")
         [ -n "$TOOL" ] && cli_args+=(--tool "$TOOL")
-        if ! docker run --rm \
+        # The container gets the host docker socket, so a moving tag is a supply-chain
+        # surface; CODACY_CLI_VERSION lets a caller pin it without changing the default.
+        rc=0
+        docker run --rm \
                 --env CODACY_CODE="$SUBDIR" \
                 --volume /var/run/docker.sock:/var/run/docker.sock \
                 --volume "$SUBDIR":"$SUBDIR" \
-                codacy/codacy-analysis-cli:latest \
-                "${cli_args[@]}" > "$OUTPUT" 2>/dev/null; then
-            echo -e "${CA_YELLOW}[analyze-local] cli returned non-zero (this is normal when findings are present)${CA_NC}" >&2
-        fi
+                "codacy/codacy-analysis-cli:${CODACY_CLI_VERSION:-latest}" \
+                "${cli_args[@]}" > "$OUTPUT" 2>/dev/null || rc=$?
         ;;
     *)
         echo -e "${CA_RED}[ERROR]${CA_NC} unknown --runner '${RUNNER}'" >&2
@@ -133,11 +134,28 @@ if [ ! -s "$OUTPUT" ]; then
     exit 1
 fi
 
-# Quick summary if format=json.
-if [ "$FORMAT" = "json" ] && jq -e . "$OUTPUT" >/dev/null 2>&1; then
+# The CLI exits non-zero both when findings are present and when the analysis failed or
+# partially failed (tool-runner logs instead of results). Only the first may pass: a run
+# that produced no results must never be reported as a clean tree.
+if [ "$FORMAT" = "json" ]; then
+    if ! jq -e . "$OUTPUT" >/dev/null 2>&1; then
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not JSON (tool-runner logs?); the analysis did not complete" >&2
+        exit 4
+    fi
     n="$(jq 'if type=="array" then length elif type=="object" and has("issues") then (.issues|length) else 0 end' "$OUTPUT")"
+    if [ "$rc" -ne 0 ] && [ "$n" -eq 0 ]; then
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc} with 0 findings: a failed analysis, not a clean tree" >&2
+        exit 4
+    fi
+    if [ "$rc" -ne 0 ]; then
+        echo -e "${CA_YELLOW}[analyze-local] cli exit ${rc} (expected when findings are present)${CA_NC}" >&2
+    fi
     echo -e "${CA_GREEN}[analyze-local]${CA_NC} wrote ${n} finding(s) to ${OUTPUT}" >&2
 else
+    if [ "$rc" -ne 0 ]; then
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}; ${FORMAT} output cannot be validated, rerun with --format json" >&2
+        exit 4
+    fi
     echo -e "${CA_GREEN}[analyze-local]${CA_NC} wrote ${OUTPUT} (${FORMAT} format)" >&2
 fi
 

--- a/.agents/skills/triage-codacy/scripts/analyze-local.sh
+++ b/.agents/skills/triage-codacy/scripts/analyze-local.sh
@@ -148,7 +148,7 @@ if [ "$FORMAT" = "json" ]; then
         echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not JSON; the analysis did not complete (stderr: ${OUTPUT}.log)" >&2
         exit 4
     fi
-    if ! jq -e 'type=="array" or (type=="object" and has("issues"))' "$OUTPUT" >/dev/null 2>&1; then
+    if ! jq -e 'type=="array" or (type=="object" and (.issues|type)=="array")' "$OUTPUT" >/dev/null 2>&1; then
         echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is JSON but not a findings array or an {issues} object" >&2
         exit 4
     fi
@@ -160,6 +160,7 @@ if [ "$FORMAT" = "json" ]; then
     if [ "$rc" -ne 0 ]; then
         echo -e "${CA_YELLOW}[analyze-local] cli exit ${rc} (expected when findings are present)${CA_NC}" >&2
     fi
+    rm -f "$OUTPUT.log"  # the CLI's stderr is kept only when the run failed
     echo -e "${CA_GREEN}[analyze-local]${CA_NC} wrote ${n} finding(s) to ${OUTPUT}" >&2
 else
     # SARIF is JSON too; count results across runs so the same failed-versus-clean rule applies.
@@ -167,7 +168,7 @@ else
         echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not parseable ${FORMAT}; the analysis did not complete (stderr: ${OUTPUT}.log)" >&2
         exit 4
     fi
-    if ! jq -e 'type=="object" and has("runs")' "$OUTPUT" >/dev/null 2>&1; then
+    if ! jq -e 'type=="object" and (.runs|type)=="array"' "$OUTPUT" >/dev/null 2>&1; then
         echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is JSON but not a SARIF document (stderr: ${OUTPUT}.log)" >&2
         exit 4
     fi
@@ -176,6 +177,7 @@ else
         echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc} with 0 findings: a failed analysis, not a clean tree" >&2
         exit 4
     fi
+    rm -f "$OUTPUT.log"
     echo -e "${CA_GREEN}[analyze-local]${CA_NC} wrote ${n} finding(s) to ${OUTPUT} (${FORMAT} format)" >&2
 fi
 

--- a/.agents/skills/triage-codacy/scripts/analyze-local.sh
+++ b/.agents/skills/triage-codacy/scripts/analyze-local.sh
@@ -29,7 +29,8 @@ Options:
   -h, --help
 
 Required tools: docker (default) OR a local codacy-analysis-cli binary.
-Set CODACY_CLI_VERSION to pin the docker image tag (default: latest).
+CODACY_CLI_VERSION=<tag> in the environment pins the docker image tag (default: latest);
+this script does not read .env.
 EOF
 }
 
@@ -106,7 +107,7 @@ case "$RUNNER" in
         local_args=(analyze --directory "$SUBDIR" --format "$FORMAT")
         [ -n "$TOOL" ] && local_args+=(--tool "$TOOL")
         rc=0
-        codacy-analysis-cli "${local_args[@]}" > "$OUTPUT" 2>/dev/null || rc=$?
+        codacy-analysis-cli "${local_args[@]}" > "$OUTPUT" 2> "$OUTPUT.log" || rc=$?
         ;;
     docker)
         # Per https://github.com/codacy/codacy-analysis-cli the CLI
@@ -125,7 +126,7 @@ case "$RUNNER" in
                 --volume /var/run/docker.sock:/var/run/docker.sock \
                 --volume "$SUBDIR":"$SUBDIR" \
                 "codacy/codacy-analysis-cli:${CODACY_CLI_VERSION:-latest}" \
-                "${cli_args[@]}" > "$OUTPUT" 2>/dev/null || rc=$?
+                "${cli_args[@]}" > "$OUTPUT" 2> "$OUTPUT.log" || rc=$?
         ;;
     *)
         echo -e "${CA_RED}[ERROR]${CA_NC} unknown --runner '${RUNNER}'" >&2
@@ -144,7 +145,7 @@ fi
 # that produced no results must never be reported as a clean tree.
 if [ "$FORMAT" = "json" ]; then
     if ! jq -e . "$OUTPUT" >/dev/null 2>&1; then
-        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not JSON (tool-runner logs?); the analysis did not complete" >&2
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not JSON; the analysis did not complete (stderr: ${OUTPUT}.log)" >&2
         exit 4
     fi
     if ! jq -e 'type=="array" or (type=="object" and has("issues"))' "$OUTPUT" >/dev/null 2>&1; then
@@ -163,7 +164,11 @@ if [ "$FORMAT" = "json" ]; then
 else
     # SARIF is JSON too; count results across runs so the same failed-versus-clean rule applies.
     if ! jq -e . "$OUTPUT" >/dev/null 2>&1; then
-        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not parseable ${FORMAT}; the analysis did not complete" >&2
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is not parseable ${FORMAT}; the analysis did not complete (stderr: ${OUTPUT}.log)" >&2
+        exit 4
+    fi
+    if ! jq -e 'type=="object" and has("runs")' "$OUTPUT" >/dev/null 2>&1; then
+        echo -e "${CA_RED}[ERROR]${CA_NC} cli exit ${rc}: ${OUTPUT} is JSON but not a SARIF document (stderr: ${OUTPUT}.log)" >&2
         exit 4
     fi
     n="$(jq '[.runs[]?.results[]?] | length' "$OUTPUT")"

--- a/.agents/skills/triage-coverity/SKILL.md
+++ b/.agents/skills/triage-coverity/SKILL.md
@@ -462,8 +462,8 @@ Used to decide whether a tainted-data path is `FALSE_POSITIVE_TRUSTED_INPUT`:
 - The `lastDefectInstanceId` field, NOT `cid`, is what `defectdetails.json` wants.
 - Coverity caches results aggressively; if a CID disappears from "Outstanding"
   immediately after finalize, a fresh fetch can take a few seconds to reflect.
-- Idempotence: `fetch-details.sh` skips files already present, so partial runs
-  are safe to re-invoke.
+- Idempotence: `fetch-details.sh` skips cached files that hold a defect-details object and refetches any other cached
+  body (an expired-session login page, for example), so partial runs are safe to re-invoke.
 - `prepare-defect.sh` uses Coverity's `displayFile` and the main-event line
   to extract source context. If Coverity's line numbers are stale (after a
   refactor), the context may not center on the current code -- use it as a

--- a/.agents/skills/triage-coverity/scripts/fetch-details.sh
+++ b/.agents/skills/triage-coverity/scripts/fetch-details.sh
@@ -50,8 +50,12 @@ while IFS=$'\t' read -r cid defect_instance_id; do
     fi
     out_file="${OUT_DIR}/cid-${cid}.json"
     if [[ -s "${out_file}" ]]; then
-        skipped=$((skipped + 1))
-        continue
+        # A cache entry written before the shape guard below existed may hold a login page.
+        if jq -e 'type=="object" and has("occurrences")' "${out_file}" >/dev/null 2>&1; then
+            skipped=$((skipped + 1))
+            continue
+        fi
+        rm -f "${out_file}"
     fi
     sleep 0.3
 

--- a/.agents/skills/triage-coverity/scripts/fetch-details.sh
+++ b/.agents/skills/triage-coverity/scripts/fetch-details.sh
@@ -6,7 +6,9 @@
 #
 # Reads cookies/XSRF/UA from .env via _lib.sh.
 # For each row, calls /sourcebrowser/defectdetails.json?defectInstanceId=<lastDefectInstanceId>.
-# Skips rows whose output file already exists (idempotent; safe to re-run).
+# Skips rows whose cached output is a defect-details object; anything else cached (for
+# example a login page fetched with an expired session) is discarded and refetched, so
+# partial runs are safe to re-run.
 
 set -euo pipefail
 

--- a/.agents/skills/triage-coverity/scripts/fetch-details.sh
+++ b/.agents/skills/triage-coverity/scripts/fetch-details.sh
@@ -77,6 +77,16 @@ while IFS=$'\t' read -r cid defect_instance_id; do
         continue
     fi
 
+    # A 200 body is not proof of a defect payload (an expired session can return a
+    # login page with 200). Anything cached here is skipped forever by the -s guard
+    # above, and prepare-defect.sh then dies on an opaque jq parse error.
+    if ! jq -e 'type=="object" and has("occurrences")' "${out_file}" >/dev/null 2>&1; then
+        failed=$((failed + 1))
+        echo -e "${COV_RED}[${i}/${TOTAL}] cid=${cid} HTTP=200 but the body is not a defect-details object; discarding${COV_NC}" >&2
+        rm -f "${out_file}"
+        continue
+    fi
+
     fetched=$((fetched + 1))
     if (( i % 20 == 0 )); then
         echo -e "${COV_GRAY}[${i}/${TOTAL}] fetched=${fetched} skipped=${skipped} failed=${failed}${COV_NC}" >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -718,6 +718,7 @@ renames:
 | `triage-codeql` | `graphql/` | Code Scanning fetches and dismissals |
 | `triage-agent-events` | `query-agent-events/` | fetched event batches |
 | `repo-pr-reviews` | `pr-reviews/` | per-PR comment and review caches |
+| `collectors-prometheus-profiles` | `prometheus-profiles/` | captured exposition dumps |
 | `query-netdata-agents` (public) | `query-netdata-agents/` | output of the agent-query wrappers and the bearer cache |
 | `query-netdata-cloud` (public) | `query-netdata-cloud/` | saved Cloud API responses from its how-tos |
 | `query-snmp-traps` (public) | `query-snmp-traps/` | saved trap query results from its how-tos |


### PR DESCRIPTION
##### Summary

Fixes some issues reported by CodeRabbit in #23769 (none of the issues were addressed in that PR because its scope was limited to renaming the skills).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the failure paths the skills rename review surfaced in the agent skill scripts, so broken or partial runs can no longer be reported as clean.

**Bug fixes**
- `analyze-local.sh` keeps the Codacy CLI exit code, exits 4 on failed or malformed analyses (non-JSON output, a body that isn't a findings or SARIF array, or a non-zero exit with zero findings), validates `--format`, writes CLI stderr to `<dump>.log` only when the run fails, adds `CODACY_CLI_VERSION` to pin the Docker image, and drops the npm fallback.
- `ci-status.sh` evaluates failures (including STALE conclusions and FAILURE/ERROR commit statuses) before running checks, null-guards all jq expressions, reads commit-status `state` and `EXPECTED` as running, counts WAITING/PENDING/REQUESTED checks, treats empty conclusions as absent, and collects names per element, so a PR with failures and running checks exits 3 instead of 2.
- `fetch-all.sh` aborts on `gh api` errors, type-checks probe pages, and writes `FETCH-INCOMPLETE` so `list-open-threads.sh` refuses a partial state instead of reading it as complete.
- `fetch-details.sh` discards 200 responses and stale cache entries whose body isn't a defect-details object, and documents the revalidation.
- `sync-netdata-repos.sh` skips repos when the branch switch or `git diff-index` fails, aborts discovery when `gh repo list` fails, keeps the new-repo count accurate, and detaches `git clone` from the repo-list stdin.
- `get-events.sh` applies `--version <regex>` client-side and fails the run with distinct messages if the response isn't JSON, lacks the version column, or the regex is invalid; `analyze-events.sh` rejects unknown `--format` and non-positive `--top`.

**Docs**
- Skill docs use the accepted flags, document `CODACY_CLI_VERSION` and the exit-4 signal, export `NETDATA_REPOS_DIR`, correct the `onBrokenLinks` heading, code fences, and agent-event counts, require `DUMP` to be set for captures, and write captures and audits under `.local/`.

<sup>Written for commit 750f6fd09a0ef1c6dca476b832bc9d474874f5d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pinning the Codacy CLI version through an environment variable.
  - Added client-side version filtering for event searches.
  - Added Prometheus profile context handling and timestamped metrics-dump locations.

- **Bug Fixes**
  - Improved validation of analysis results, cached Coverity responses, and command-line options.
  - Prevented incomplete repository and pull-request fetches from being treated as complete.
  - Improved CI status detection and failure reporting.

- **Documentation**
  - Updated CLI flag examples, environment-variable guidance, workflow instructions, and Markdown formatting across troubleshooting and operational guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->