### PR TITLE
topology: support generic response notifications

### DIFF
--- a/.agents/skills/repo-pr-reviews/SKILL.md
+++ b/.agents/skills/repo-pr-reviews/SKILL.md
@@ -177,9 +177,7 @@ open review threads. Use this as the input to the rest of the cycle.
 bash .agents/skills/repo-pr-reviews/scripts/fetch-sonar-findings.sh <PR_NUMBER>
 ```
 
-SonarCloud findings are NOT delivered as inline GitHub comments -- only a
-QualityGate summary is. The actual issue list lives behind the SonarCloud
-API. This script writes:
+This script fetches SonarCloud findings that are not posted inline on GitHub:
 - `.local/audits/pr-reviews/pr-<N>/sonar-issues.json`
 - `.local/audits/pr-reviews/pr-<N>/sonar-hotspots.json`
 - a brief summary to stdout (counts by rule and severity).
@@ -187,6 +185,13 @@ API. This script writes:
 Requires the same `.env` config the `triage-sonarqube` skill uses
 (`SONAR_TOKEN`, `SONAR_HOST_URL`, `SONAR_PROJECT`). If `.env` is missing,
 the script prints what's needed and exits.
+
+An empty issue/hotspot list does not prove the quality gate passed. Inspect
+`/api/qualitygates/project_status?projectKey=<project>&pullRequest=<PR>` for
+failed metric conditions. For duplication, use
+`/api/duplications/show?key=<file-component-key>&pullRequest=<PR>`: each
+`duplications[].blocks[]` identifies `from`, `size`, and `_ref`; `files`
+resolves those references. Preserve test cases when sharing duplicated setup.
 
 ### 1c. Note the CI signal as a third source
 

--- a/.agents/skills/topology-authoring/SKILL.md
+++ b/.agents/skills/topology-authoring/SKILL.md
@@ -50,6 +50,13 @@ developer-facing and must stay in this project skill, not under
 - Keep display composition in type-level and graph-level presentation metadata,
   not in high-cardinality rows.
 - Keep raw sensitive payload captures under `.local/` only.
+- Use optional `data.notifications` for topology information and issues, with `info`, `warning`, or `error`
+  severity, a stable code, and plain-text message. Do not invent Function-envelope or producer-specific channels.
+- Preserve notification origin separately from `affected_node_id`. An omitted origin inherits `data.producer`;
+  aggregators must make it explicit before changing the payload producer. Follow the canonical guide's
+  Notifications section and test schema/semantic parity, omission, and malformed entries.
+- Schema support does not enable emission or UI display. Verify CTS acceptance before enabling Agent notifications;
+  strict CTS decoders without the field reject otherwise valid topology responses.
 - The `topology:network-connections` producer also runs on Windows
   (`network-viewer.plugin/network-viewer-windows.c` registers the Function; the
   shared v1 renderer lives in `network-viewer-topology.c`). Windows payloads

--- a/.agents/skills/topology-authoring/topology-function-schema.md
+++ b/.agents/skills/topology-authoring/topology-function-schema.md
@@ -18,6 +18,25 @@ The production schema is defined by:
 The schema is generic across topology domains. It applies to network
 connections, streaming, SNMP, vSphere, and future topology producers.
 
+## Notifications
+
+Status: implemented in the canonical Agent schema, Go model, and validator.
+CTS and frontend consumer support must be qualified separately.
+
+- `data.notifications` MAY carry information or issues about the returned graph.
+- Entries MUST have `severity` (`info`, `warning`, or `error`), an identifier `code`, and a non-empty plain-text
+  `message`. Notifications do not change the response status or substitute for fatal Function errors.
+- `origin` MAY supply the existing full Producer object. When omitted, it means `data.producer`; aggregators MUST
+  make that origin explicit before replacing the payload producer and MUST preserve explicit origins.
+- `affected_node_id` MAY name the affected Agent, using the existing producer node-id string representation.
+  The affected source is distinct from the notification emitter.
+- Omission and `[]` report no notifications; `null` is invalid. Consumers MUST clear previously displayed
+  notifications when the displayed response omits them.
+- CTS MUST preserve source notifications and add its own through this contract. Message text MUST NOT be a merge
+  identity. No occurrence-count or automatic coalescing policy is defined.
+- Consumers MUST render messages as untrusted plain text, not HTML or Markdown. Producers MUST NOT emit secrets.
+- Full contract: `src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md`, Notifications.
+
 ## Planes
 
 Topology payloads separate these planes:

--- a/.agents/skills/topology-authoring/topology-modes-correlation-aggregation.md
+++ b/.agents/skills/topology-authoring/topology-modes-correlation-aggregation.md
@@ -98,6 +98,20 @@ absorbed, candidate, rewrite plan, partial class, or equivalence set may exist
 inside the service, but final topology output contains only normal actors,
 links, tables, labels, presentation, and diagnostics.
 
+### Notifications
+
+- Aggregation MUST preserve the optional `data.notifications` contract across topology kinds and modes.
+- A notification with no explicit `origin` belongs to the input `data.producer`. The aggregator MUST materialize
+  that origin before assigning its output producer, and MUST retain already explicit origins.
+- Aggregator notifications use its own origin; `affected_node_id` identifies an affected Agent when applicable.
+  Emitter identity and affected source MUST NOT be conflated.
+- `info`, `warning`, and `error` notifications MAY accompany usable graph data. They MUST NOT be used to conceal
+  fatal request failures or change collection completeness merely because a diagnostic exists.
+- Source reports MUST remain distinguishable. Message text is not a merge key, and this contract defines no
+  count/coalescing rule.
+- Field definitions and consumer-support status are documented in
+  `src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md`, Notifications.
+
 ### No Duplicate Display Facts
 
 Do not copy high-cardinality evidence rows only to make modal tables easier.

--- a/src/go/pkg/topology/v1/notification_test.go
+++ b/src/go/pkg/topology/v1/notification_test.go
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationGoModelRoundTripAndOmission(t *testing.T) {
+	withoutNotifications := NewResponse(minimalValidationData(nil))
+	payloadBytes, err := json.Marshal(withoutNotifications)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payloadBytes), `"notifications"`)
+
+	data := minimalValidationData(nil)
+	data.Notifications = []Notification{
+		{
+			Severity: NotificationSeverityInfo,
+			Code:     "discovery.complete",
+			Message:  "Discovery completed.",
+		},
+		{
+			Severity: NotificationSeverityWarning,
+			Code:     "correlation.ambiguous",
+			Message:  "Multiple correlation candidates were found.",
+			Origin: &Producer{
+				Source:       "network-connections",
+				Instance:     "network-viewer",
+				NodeID:       "node-a",
+				MachineGUID:  "machine-a",
+				AgentVersion: "1.99.0",
+				Plugin:       "network-viewer.plugin",
+				Capabilities: []string{"topology", "correlation"},
+			},
+		},
+		{
+			Severity:       NotificationSeverityError,
+			Code:           "source.unavailable",
+			Message:        "A requested source did not return topology data.",
+			AffectedNodeID: "node-b",
+		},
+	}
+
+	payload := NewResponse(data)
+	payloadBytes, err = json.Marshal(payload)
+	require.NoError(t, err)
+	assert.Contains(t, string(payloadBytes), `"notifications"`)
+	validateAgainstTopologySchema(t, payloadBytes)
+
+	var decoded struct {
+		Status int `json:"status"`
+		Data   struct {
+			Notifications []Notification `json:"notifications"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(payloadBytes, &decoded))
+	assert.Equal(t, 200, decoded.Status)
+	assert.Equal(t, data.Notifications, decoded.Data.Notifications)
+
+	var decodedAny any
+	require.NoError(t, json.Unmarshal(payloadBytes, &decodedAny))
+	require.NoError(t, ValidateDecodedResponse(decodedAny))
+}
+
+func TestNotificationSchemaAndSemanticValidationAgree(t *testing.T) {
+	tests := map[string]struct {
+		present       bool
+		notifications any
+		valid         bool
+		want          string
+	}{
+		"omitted": {
+			valid: true,
+		},
+		"empty array": {
+			present:       true,
+			notifications: []any{},
+			valid:         true,
+		},
+		"all severities": {
+			present: true,
+			notifications: []any{
+				testNotification(map[string]any{"severity": "info"}),
+				testNotification(map[string]any{"severity": "warning"}),
+				testNotification(map[string]any{"severity": "error"}),
+			},
+			valid: true,
+		},
+		"identifier punctuation": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"code": "A:b.c-d_0"})},
+			valid:         true,
+		},
+		"whitespace message": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"message": " \n"})},
+			valid:         true,
+		},
+		"explicit complete origin": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{
+					"node_id":       "node-a",
+					"machine_guid":  "machine-a",
+					"agent_version": "1.99.0",
+					"plugin":        "network-viewer.plugin",
+					"capabilities":  []any{"topology", "correlation"},
+				}),
+			})},
+			valid: true,
+		},
+		"empty producer strings and capabilities": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{
+					"instance":      "",
+					"node_id":       "",
+					"machine_guid":  "",
+					"agent_version": "",
+					"plugin":        "",
+					"capabilities":  []any{},
+				}),
+			})},
+			valid: true,
+		},
+		"empty affected node": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"affected_node_id": ""})},
+			valid:         true,
+		},
+		"null notifications": {
+			present:       true,
+			notifications: nil,
+			want:          "data.notifications is not an array",
+		},
+		"notifications object": {
+			present:       true,
+			notifications: map[string]any{},
+			want:          "data.notifications is not an array",
+		},
+		"null notification": {
+			present:       true,
+			notifications: []any{nil},
+			want:          "data.notifications[0] is not an object",
+		},
+		"unknown notification field": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"extra": true})},
+			want:          "data.notifications[0].extra is unknown",
+		},
+		"missing severity": {
+			present:       true,
+			notifications: []any{map[string]any{"code": "source.unavailable", "message": "Unavailable."}},
+			want:          "data.notifications[0].severity is not a non-empty string",
+		},
+		"non-string severity": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"severity": 7})},
+			want:          "data.notifications[0].severity is not a non-empty string",
+		},
+		"unsupported severity": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"severity": "fatal"})},
+			want:          "data.notifications[0].severity has unsupported value",
+		},
+		"missing code": {
+			present:       true,
+			notifications: []any{map[string]any{"severity": "warning", "message": "Unavailable."}},
+			want:          "data.notifications[0].code is not a valid identifier",
+		},
+		"non-string code": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"code": true})},
+			want:          "data.notifications[0].code is not a valid identifier",
+		},
+		"code starts with number": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"code": "1source.unavailable"})},
+			want:          "data.notifications[0].code is not a valid identifier",
+		},
+		"code contains space": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"code": "source unavailable"})},
+			want:          "data.notifications[0].code is not a valid identifier",
+		},
+		"code contains newline": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"code": "source.unavailable\n"})},
+			want:          "data.notifications[0].code is not a valid identifier",
+		},
+		"missing message": {
+			present:       true,
+			notifications: []any{map[string]any{"severity": "warning", "code": "source.unavailable"}},
+			want:          "data.notifications[0].message is required",
+		},
+		"empty message": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"message": ""})},
+			want:          "data.notifications[0].message is required",
+		},
+		"non-string message": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"message": 7})},
+			want:          "data.notifications[0].message is required",
+		},
+		"null origin": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": nil})},
+			want:          "data.notifications[0].origin is not an object",
+		},
+		"non-object origin": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": []any{}})},
+			want:          "data.notifications[0].origin is not an object",
+		},
+		"origin missing source": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": map[string]any{"instance": "job-a"}})},
+			want:          "data.notifications[0].origin.source is not a valid identifier",
+		},
+		"origin non-string source": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"source": 7})})},
+			want:          "data.notifications[0].origin.source is not a valid identifier",
+		},
+		"origin source contains newline": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"source": "network-connections\n"}),
+			})},
+			want: "data.notifications[0].origin.source is not a valid identifier",
+		},
+		"origin missing instance": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": map[string]any{"source": "snmp"}})},
+			want:          "data.notifications[0].origin.instance is required",
+		},
+		"origin non-string instance": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"instance": 7})})},
+			want:          "data.notifications[0].origin.instance is not a string",
+		},
+		"unknown origin field": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"extra": true})})},
+			want:          "data.notifications[0].origin.extra is unknown",
+		},
+		"origin null node id": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"node_id": nil})})},
+			want:          "data.notifications[0].origin.node_id is not a string",
+		},
+		"origin non-string machine guid": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"machine_guid": 7}),
+			})},
+			want: "data.notifications[0].origin.machine_guid is not a string",
+		},
+		"origin null agent version": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"agent_version": nil}),
+			})},
+			want: "data.notifications[0].origin.agent_version is not a string",
+		},
+		"origin non-string plugin": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"plugin": 7})})},
+			want:          "data.notifications[0].origin.plugin is not a string",
+		},
+		"origin capabilities not array": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"capabilities": "topology"}),
+			})},
+			want: "data.notifications[0].origin.capabilities is not an array",
+		},
+		"origin capabilities null": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"capabilities": nil}),
+			})},
+			want: "data.notifications[0].origin.capabilities is not an array",
+		},
+		"duplicate origin capability": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"capabilities": []any{"topology", "topology"}}),
+			})},
+			want: "data.notifications[0].origin.capabilities[1] duplicates value",
+		},
+		"invalid origin capability": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"capabilities": []any{"bad capability"}}),
+			})},
+			want: "data.notifications[0].origin.capabilities[0] is not a valid identifier",
+		},
+		"origin capability contains newline": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"capabilities": []any{"topology\n"}}),
+			})},
+			want: "data.notifications[0].origin.capabilities[0] is not a valid identifier",
+		},
+		"origin capability is not string": {
+			present: true,
+			notifications: []any{testNotification(map[string]any{
+				"origin": testNotificationOrigin(map[string]any{"capabilities": []any{7}}),
+			})},
+			want: "data.notifications[0].origin.capabilities[0] is not a non-empty string",
+		},
+		"null affected node": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"affected_node_id": nil})},
+			want:          "data.notifications[0].affected_node_id is not a string",
+		},
+		"non-string affected node": {
+			present:       true,
+			notifications: []any{testNotification(map[string]any{"affected_node_id": 7})},
+			want:          "data.notifications[0].affected_node_id is not a string",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			payload := decodedNotificationTestPayload(t)
+			if tc.present {
+				payload["data"].(map[string]any)["notifications"] = tc.notifications
+			}
+
+			payloadBytes, err := json.Marshal(payload)
+			require.NoError(t, err)
+			schemaErr := topologySchemaValidationError(t, payloadBytes)
+			semanticErr := ValidateDecodedResponse(payload)
+			assert.Equal(t, schemaErr == nil, semanticErr == nil, "schema and semantic validators disagree")
+			if tc.valid {
+				assert.NoError(t, schemaErr)
+				assert.NoError(t, semanticErr)
+				return
+			}
+			assert.Error(t, schemaErr)
+			if assert.Error(t, semanticErr) {
+				assert.Contains(t, semanticErr.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func testNotification(overrides map[string]any) map[string]any {
+	notification := map[string]any{
+		"severity": "warning",
+		"code":     "source.unavailable",
+		"message":  "Unavailable.",
+	}
+	for key, value := range overrides {
+		notification[key] = value
+	}
+	return notification
+}
+
+func testNotificationOrigin(overrides map[string]any) map[string]any {
+	origin := map[string]any{
+		"source":   "network-connections",
+		"instance": "network-viewer",
+	}
+	for key, value := range overrides {
+		origin[key] = value
+	}
+	return origin
+}
+
+func decodedNotificationTestPayload(t *testing.T) map[string]any {
+	t.Helper()
+
+	payloadBytes, err := json.Marshal(NewResponse(minimalValidationData(nil)))
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+	return payload
+}

--- a/src/go/pkg/topology/v1/notification_test.go
+++ b/src/go/pkg/topology/v1/notification_test.go
@@ -100,33 +100,6 @@ func TestNotificationSchemaAndSemanticValidationAgree(t *testing.T) {
 			notifications: []any{testNotification(map[string]any{"message": " \n"})},
 			valid:         true,
 		},
-		"explicit complete origin": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{
-					"node_id":       "node-a",
-					"machine_guid":  "machine-a",
-					"agent_version": "1.99.0",
-					"plugin":        "network-viewer.plugin",
-					"capabilities":  []any{"topology", "correlation"},
-				}),
-			})},
-			valid: true,
-		},
-		"empty producer strings and capabilities": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{
-					"instance":      "",
-					"node_id":       "",
-					"machine_guid":  "",
-					"agent_version": "",
-					"plugin":        "",
-					"capabilities":  []any{},
-				}),
-			})},
-			valid: true,
-		},
 		"empty affected node": {
 			present:       true,
 			notifications: []any{testNotification(map[string]any{"affected_node_id": ""})},
@@ -155,7 +128,7 @@ func TestNotificationSchemaAndSemanticValidationAgree(t *testing.T) {
 		"missing severity": {
 			present:       true,
 			notifications: []any{map[string]any{"code": "source.unavailable", "message": "Unavailable."}},
-			want:          "data.notifications[0].severity is not a non-empty string",
+			want:          "data.notifications[0].severity is required",
 		},
 		"non-string severity": {
 			present:       true,
@@ -170,7 +143,7 @@ func TestNotificationSchemaAndSemanticValidationAgree(t *testing.T) {
 		"missing code": {
 			present:       true,
 			notifications: []any{map[string]any{"severity": "warning", "message": "Unavailable."}},
-			want:          "data.notifications[0].code is not a valid identifier",
+			want:          "data.notifications[0].code is required",
 		},
 		"non-string code": {
 			present:       true,
@@ -207,114 +180,6 @@ func TestNotificationSchemaAndSemanticValidationAgree(t *testing.T) {
 			notifications: []any{testNotification(map[string]any{"message": 7})},
 			want:          "data.notifications[0].message is required",
 		},
-		"null origin": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": nil})},
-			want:          "data.notifications[0].origin is not an object",
-		},
-		"non-object origin": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": []any{}})},
-			want:          "data.notifications[0].origin is not an object",
-		},
-		"origin missing source": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": map[string]any{"instance": "job-a"}})},
-			want:          "data.notifications[0].origin.source is not a valid identifier",
-		},
-		"origin non-string source": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"source": 7})})},
-			want:          "data.notifications[0].origin.source is not a valid identifier",
-		},
-		"origin source contains newline": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"source": "network-connections\n"}),
-			})},
-			want: "data.notifications[0].origin.source is not a valid identifier",
-		},
-		"origin missing instance": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": map[string]any{"source": "snmp"}})},
-			want:          "data.notifications[0].origin.instance is required",
-		},
-		"origin non-string instance": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"instance": 7})})},
-			want:          "data.notifications[0].origin.instance is not a string",
-		},
-		"unknown origin field": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"extra": true})})},
-			want:          "data.notifications[0].origin.extra is unknown",
-		},
-		"origin null node id": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"node_id": nil})})},
-			want:          "data.notifications[0].origin.node_id is not a string",
-		},
-		"origin non-string machine guid": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"machine_guid": 7}),
-			})},
-			want: "data.notifications[0].origin.machine_guid is not a string",
-		},
-		"origin null agent version": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"agent_version": nil}),
-			})},
-			want: "data.notifications[0].origin.agent_version is not a string",
-		},
-		"origin non-string plugin": {
-			present:       true,
-			notifications: []any{testNotification(map[string]any{"origin": testNotificationOrigin(map[string]any{"plugin": 7})})},
-			want:          "data.notifications[0].origin.plugin is not a string",
-		},
-		"origin capabilities not array": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"capabilities": "topology"}),
-			})},
-			want: "data.notifications[0].origin.capabilities is not an array",
-		},
-		"origin capabilities null": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"capabilities": nil}),
-			})},
-			want: "data.notifications[0].origin.capabilities is not an array",
-		},
-		"duplicate origin capability": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"capabilities": []any{"topology", "topology"}}),
-			})},
-			want: "data.notifications[0].origin.capabilities[1] duplicates value",
-		},
-		"invalid origin capability": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"capabilities": []any{"bad capability"}}),
-			})},
-			want: "data.notifications[0].origin.capabilities[0] is not a valid identifier",
-		},
-		"origin capability contains newline": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"capabilities": []any{"topology\n"}}),
-			})},
-			want: "data.notifications[0].origin.capabilities[0] is not a valid identifier",
-		},
-		"origin capability is not string": {
-			present: true,
-			notifications: []any{testNotification(map[string]any{
-				"origin": testNotificationOrigin(map[string]any{"capabilities": []any{7}}),
-			})},
-			want: "data.notifications[0].origin.capabilities[0] is not a non-empty string",
-		},
 		"null affected node": {
 			present:       true,
 			notifications: []any{testNotification(map[string]any{"affected_node_id": nil})},
@@ -334,21 +199,138 @@ func TestNotificationSchemaAndSemanticValidationAgree(t *testing.T) {
 				payload["data"].(map[string]any)["notifications"] = tc.notifications
 			}
 
-			payloadBytes, err := json.Marshal(payload)
-			require.NoError(t, err)
-			schemaErr := topologySchemaValidationError(t, payloadBytes)
-			semanticErr := ValidateDecodedResponse(payload)
-			assert.Equal(t, schemaErr == nil, semanticErr == nil, "schema and semantic validators disagree")
-			if tc.valid {
-				assert.NoError(t, schemaErr)
-				assert.NoError(t, semanticErr)
-				return
-			}
-			assert.Error(t, schemaErr)
-			if assert.Error(t, semanticErr) {
-				assert.Contains(t, semanticErr.Error(), tc.want)
-			}
+			assertNotificationValidation(t, payload, tc.valid, tc.want)
 		})
+	}
+}
+
+func TestNotificationOriginSchemaAndSemanticValidationAgree(t *testing.T) {
+	tests := map[string]struct {
+		origin any
+		valid  bool
+		want   string
+	}{
+		"explicit complete origin": {
+			origin: testNotificationOrigin(map[string]any{
+				"node_id":       "node-a",
+				"machine_guid":  "machine-a",
+				"agent_version": "1.99.0",
+				"plugin":        "network-viewer.plugin",
+				"capabilities":  []any{"topology", "correlation"},
+			}),
+			valid: true,
+		},
+		"empty producer strings and capabilities": {
+			origin: testNotificationOrigin(map[string]any{
+				"instance":      "",
+				"node_id":       "",
+				"machine_guid":  "",
+				"agent_version": "",
+				"plugin":        "",
+				"capabilities":  []any{},
+			}),
+			valid: true,
+		},
+		"null origin": {
+			origin: nil,
+			want:   "data.notifications[0].origin is not an object",
+		},
+		"non-object origin": {
+			origin: []any{},
+			want:   "data.notifications[0].origin is not an object",
+		},
+		"origin missing source": {
+			origin: map[string]any{"instance": "job-a"},
+			want:   "data.notifications[0].origin.source is required",
+		},
+		"origin non-string source": {
+			origin: testNotificationOrigin(map[string]any{"source": 7}),
+			want:   "data.notifications[0].origin.source is not a valid identifier",
+		},
+		"origin source contains newline": {
+			origin: testNotificationOrigin(map[string]any{"source": "network-connections\n"}),
+			want:   "data.notifications[0].origin.source is not a valid identifier",
+		},
+		"origin missing instance": {
+			origin: map[string]any{"source": "snmp"},
+			want:   "data.notifications[0].origin.instance is required",
+		},
+		"origin non-string instance": {
+			origin: testNotificationOrigin(map[string]any{"instance": 7}),
+			want:   "data.notifications[0].origin.instance is not a string",
+		},
+		"unknown origin field": {
+			origin: testNotificationOrigin(map[string]any{"extra": true}),
+			want:   "data.notifications[0].origin.extra is unknown",
+		},
+		"origin null node id": {
+			origin: testNotificationOrigin(map[string]any{"node_id": nil}),
+			want:   "data.notifications[0].origin.node_id is not a string",
+		},
+		"origin non-string machine guid": {
+			origin: testNotificationOrigin(map[string]any{"machine_guid": 7}),
+			want:   "data.notifications[0].origin.machine_guid is not a string",
+		},
+		"origin null agent version": {
+			origin: testNotificationOrigin(map[string]any{"agent_version": nil}),
+			want:   "data.notifications[0].origin.agent_version is not a string",
+		},
+		"origin non-string plugin": {
+			origin: testNotificationOrigin(map[string]any{"plugin": 7}),
+			want:   "data.notifications[0].origin.plugin is not a string",
+		},
+		"origin capabilities not array": {
+			origin: testNotificationOrigin(map[string]any{"capabilities": "topology"}),
+			want:   "data.notifications[0].origin.capabilities is not an array",
+		},
+		"origin capabilities null": {
+			origin: testNotificationOrigin(map[string]any{"capabilities": nil}),
+			want:   "data.notifications[0].origin.capabilities is not an array",
+		},
+		"duplicate origin capability": {
+			origin: testNotificationOrigin(map[string]any{"capabilities": []any{"topology", "topology"}}),
+			want:   "data.notifications[0].origin.capabilities[1] duplicates value",
+		},
+		"invalid origin capability": {
+			origin: testNotificationOrigin(map[string]any{"capabilities": []any{"bad capability"}}),
+			want:   "data.notifications[0].origin.capabilities[0] is not a valid identifier",
+		},
+		"origin capability contains newline": {
+			origin: testNotificationOrigin(map[string]any{"capabilities": []any{"topology\n"}}),
+			want:   "data.notifications[0].origin.capabilities[0] is not a valid identifier",
+		},
+		"origin capability is not string": {
+			origin: testNotificationOrigin(map[string]any{"capabilities": []any{7}}),
+			want:   "data.notifications[0].origin.capabilities[0] is not a non-empty string",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			payload := decodedNotificationTestPayload(t)
+			payload["data"].(map[string]any)["notifications"] = []any{
+				testNotification(map[string]any{"origin": tc.origin}),
+			}
+			assertNotificationValidation(t, payload, tc.valid, tc.want)
+		})
+	}
+}
+
+func assertNotificationValidation(t *testing.T, payload map[string]any, valid bool, want string) {
+	t.Helper()
+
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+	schemaErr := topologySchemaValidationError(t, payloadBytes)
+	semanticErr := ValidateDecodedResponse(payload)
+	assert.Equal(t, schemaErr == nil, semanticErr == nil, "schema and semantic validators disagree")
+	if valid {
+		assert.NoError(t, schemaErr)
+		assert.NoError(t, semanticErr)
+		return
+	}
+	assert.Error(t, schemaErr)
+	if assert.Error(t, semanticErr) {
+		assert.Contains(t, semanticErr.Error(), want)
 	}
 }
 

--- a/src/go/pkg/topology/v1/types.go
+++ b/src/go/pkg/topology/v1/types.go
@@ -9,6 +9,10 @@ import "time"
 const (
 	SchemaVersion = "netdata.topology.v1"
 	ResponseType  = "topology"
+
+	NotificationSeverityInfo    = "info"
+	NotificationSeverityWarning = "warning"
+	NotificationSeverityError   = "error"
 )
 
 type Response struct {
@@ -35,6 +39,7 @@ func NewResponse(data Data) Response {
 type Data struct {
 	SchemaVersion string         `json:"schema_version"`
 	Producer      Producer       `json:"producer"`
+	Notifications []Notification `json:"notifications,omitempty"`
 	CollectedAt   time.Time      `json:"collected_at"`
 	ValidAfter    *time.Time     `json:"valid_after,omitempty"`
 	ValidUntil    *time.Time     `json:"valid_until,omitempty"`
@@ -60,6 +65,14 @@ type Producer struct {
 	AgentVersion string   `json:"agent_version,omitempty"`
 	Plugin       string   `json:"plugin,omitempty"`
 	Capabilities []string `json:"capabilities,omitempty"`
+}
+
+type Notification struct {
+	Severity       string    `json:"severity"`
+	Code           string    `json:"code"`
+	Message        string    `json:"message"`
+	Origin         *Producer `json:"origin,omitempty"`
+	AffectedNodeID string    `json:"affected_node_id,omitempty"`
 }
 
 type View struct {

--- a/src/go/pkg/topology/v1/validate.go
+++ b/src/go/pkg/topology/v1/validate.go
@@ -56,6 +56,10 @@ func ValidateDecodedResponse(payload any) error {
 }
 
 func ValidateDecodedData(data map[string]any) error {
+	if err := validateNotifications(data); err != nil {
+		return err
+	}
+
 	dictionaries, ok := data["dictionaries"].(map[string]any)
 	if !ok {
 		return fmt.Errorf("data.dictionaries is not an object")

--- a/src/go/pkg/topology/v1/validate_notification.go
+++ b/src/go/pkg/topology/v1/validate_notification.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var topologyIDPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.:-]*$`)
+
+func validateNotifications(data map[string]any) error {
+	raw, present := data["notifications"]
+	if !present {
+		return nil
+	}
+
+	notifications, ok := raw.([]any)
+	if !ok {
+		return fmt.Errorf("data.notifications is not an array")
+	}
+	for i, rawNotification := range notifications {
+		path := fmt.Sprintf("data.notifications[%d]", i)
+		notification, ok := rawNotification.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s is not an object", path)
+		}
+		if err := validateNotification(path, notification); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNotification(path string, notification map[string]any) error {
+	allowed := map[string]struct{}{
+		"severity":         {},
+		"code":             {},
+		"message":          {},
+		"origin":           {},
+		"affected_node_id": {},
+	}
+	if err := rejectUnknownFields(path, notification, allowed); err != nil {
+		return err
+	}
+	if _, err := requiredEnum(path+".severity", notification["severity"],
+		NotificationSeverityInfo, NotificationSeverityWarning, NotificationSeverityError); err != nil {
+		return err
+	}
+	if err := validateTopologyID(path+".code", notification["code"]); err != nil {
+		return err
+	}
+	if err := validateRequiredString(path+".message", notification["message"]); err != nil {
+		return err
+	}
+	if origin, present := notification["origin"]; present {
+		if err := validateNotificationOrigin(path+".origin", origin); err != nil {
+			return err
+		}
+	}
+	if affectedNodeID, present := notification["affected_node_id"]; present {
+		if _, ok := affectedNodeID.(string); !ok {
+			return fmt.Errorf("%s.affected_node_id is not a string", path)
+		}
+	}
+	return nil
+}
+
+func validateNotificationOrigin(path string, raw any) error {
+	origin, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s is not an object", path)
+	}
+	allowed := map[string]struct{}{
+		"source":        {},
+		"instance":      {},
+		"node_id":       {},
+		"machine_guid":  {},
+		"agent_version": {},
+		"plugin":        {},
+		"capabilities":  {},
+	}
+	if err := rejectUnknownFields(path, origin, allowed); err != nil {
+		return err
+	}
+	if err := validateTopologyID(path+".source", origin["source"]); err != nil {
+		return err
+	}
+	if instance, present := origin["instance"]; !present {
+		return fmt.Errorf("%s.instance is required", path)
+	} else if _, ok := instance.(string); !ok {
+		return fmt.Errorf("%s.instance is not a string", path)
+	}
+	for _, field := range []string{"node_id", "machine_guid", "agent_version", "plugin"} {
+		if value, present := origin[field]; present {
+			if _, ok := value.(string); !ok {
+				return fmt.Errorf("%s.%s is not a string", path, field)
+			}
+		}
+	}
+	if rawCapabilities, present := origin["capabilities"]; present {
+		capabilities, err := collectStringList(path+".capabilities", rawCapabilities, false)
+		if err != nil {
+			return err
+		}
+		for i, capability := range capabilities {
+			if !topologyIDPattern.MatchString(capability) {
+				return fmt.Errorf("%s.capabilities[%d] is not a valid identifier", path, i)
+			}
+		}
+	}
+	return nil
+}
+
+func validateTopologyID(path string, raw any) error {
+	value, ok := raw.(string)
+	if !ok || !topologyIDPattern.MatchString(value) {
+		return fmt.Errorf("%s is not a valid identifier", path)
+	}
+	return nil
+}
+
+func rejectUnknownFields(path string, object map[string]any, allowed map[string]struct{}) error {
+	for field := range object {
+		if _, ok := allowed[field]; !ok {
+			return fmt.Errorf("%s.%s is unknown", path, field)
+		}
+	}
+	return nil
+}

--- a/src/go/pkg/topology/v1/validate_notification.go
+++ b/src/go/pkg/topology/v1/validate_notification.go
@@ -43,14 +43,26 @@ func validateNotification(path string, notification map[string]any) error {
 	if err := rejectUnknownFields(path, notification, allowed); err != nil {
 		return err
 	}
-	if _, err := requiredEnum(path+".severity", notification["severity"],
+	severity, err := requiredNotificationField(path, notification, "severity")
+	if err != nil {
+		return err
+	}
+	if _, err := requiredEnum(path+".severity", severity,
 		NotificationSeverityInfo, NotificationSeverityWarning, NotificationSeverityError); err != nil {
 		return err
 	}
-	if err := validateTopologyID(path+".code", notification["code"]); err != nil {
+	code, err := requiredNotificationField(path, notification, "code")
+	if err != nil {
 		return err
 	}
-	if err := validateRequiredString(path+".message", notification["message"]); err != nil {
+	if err := validateTopologyID(path+".code", code); err != nil {
+		return err
+	}
+	message, err := requiredNotificationField(path, notification, "message")
+	if err != nil {
+		return err
+	}
+	if err := validateRequiredString(path+".message", message); err != nil {
 		return err
 	}
 	if origin, present := notification["origin"]; present {
@@ -83,12 +95,18 @@ func validateNotificationOrigin(path string, raw any) error {
 	if err := rejectUnknownFields(path, origin, allowed); err != nil {
 		return err
 	}
-	if err := validateTopologyID(path+".source", origin["source"]); err != nil {
+	source, err := requiredNotificationField(path, origin, "source")
+	if err != nil {
 		return err
 	}
-	if instance, present := origin["instance"]; !present {
-		return fmt.Errorf("%s.instance is required", path)
-	} else if _, ok := instance.(string); !ok {
+	if err := validateTopologyID(path+".source", source); err != nil {
+		return err
+	}
+	instance, err := requiredNotificationField(path, origin, "instance")
+	if err != nil {
+		return err
+	}
+	if _, ok := instance.(string); !ok {
 		return fmt.Errorf("%s.instance is not a string", path)
 	}
 	for _, field := range []string{"node_id", "machine_guid", "agent_version", "plugin"} {
@@ -110,6 +128,14 @@ func validateNotificationOrigin(path string, raw any) error {
 		}
 	}
 	return nil
+}
+
+func requiredNotificationField(path string, object map[string]any, field string) (any, error) {
+	value, present := object[field]
+	if !present {
+		return nil, fmt.Errorf("%s.%s is required", path, field)
+	}
+	return value, nil
 }
 
 func validateTopologyID(path string, raw any) error {

--- a/src/go/pkg/topology/v1/validate_notification_contract_test.go
+++ b/src/go/pkg/topology/v1/validate_notification_contract_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotificationValidatorReportsMissingRequiredFields(t *testing.T) {
+	tests := map[string]struct {
+		remove string
+		origin bool
+		want   string
+	}{
+		"severity": {
+			remove: "severity",
+			want:   "data.notifications[0].severity is required",
+		},
+		"code": {
+			remove: "code",
+			want:   "data.notifications[0].code is required",
+		},
+		"message": {
+			remove: "message",
+			want:   "data.notifications[0].message is required",
+		},
+		"origin source": {
+			remove: "source",
+			origin: true,
+			want:   "data.notifications[0].origin.source is required",
+		},
+		"origin instance": {
+			remove: "instance",
+			origin: true,
+			want:   "data.notifications[0].origin.instance is required",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			payload := decodedRequiredFieldTestPayload(t)
+			notification := payload["data"].(map[string]any)["notifications"].([]any)[0].(map[string]any)
+			if tc.origin {
+				delete(notification["origin"].(map[string]any), tc.remove)
+			} else {
+				delete(notification, tc.remove)
+			}
+
+			require.EqualError(t, ValidateDecodedResponse(payload), tc.want)
+		})
+	}
+}
+
+func TestTopologyIDPatternMatchesSchema(t *testing.T) {
+	schemaDoc := loadTopologySchema(t)
+	definitions, ok := schemaDoc["$defs"].(map[string]any)
+	require.True(t, ok)
+	idDefinition, ok := definitions["id"].(map[string]any)
+	require.True(t, ok)
+	schemaPattern, ok := idDefinition["pattern"].(string)
+	require.True(t, ok)
+
+	assert.Equal(t, schemaPattern, topologyIDPattern.String())
+}
+
+func decodedRequiredFieldTestPayload(t *testing.T) map[string]any {
+	t.Helper()
+
+	payload := decodedNotificationTestPayload(t)
+	payload["data"].(map[string]any)["notifications"] = []any{
+		testNotification(map[string]any{"origin": testNotificationOrigin(nil)}),
+	}
+	return payload
+}

--- a/src/go/plugin/agent/jobmgr/functions/topology_notification_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/topology_notification_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package functions
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
+	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMethodGenerationTopologyNotifications(t *testing.T) {
+	topology := topologyv1.Data{
+		SchemaVersion: topologyv1.SchemaVersion,
+		Producer: topologyv1.Producer{
+			Source:   "test-topology",
+			Instance: "sample-node",
+			NodeID:   "node-a",
+			Plugin:   "go-test",
+		},
+		CollectedAt:  time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC),
+		Dictionaries: topologyv1.Dictionaries{},
+		Types: topologyv1.TypeRegistry{
+			ActorTypes: map[string]topologyv1.ActorType{
+				"node": {
+					Layer:    "node",
+					Identity: []string{"id"},
+				},
+			},
+			LinkTypes: map[string]topologyv1.LinkType{
+				"dependency": {
+					Orientation:   "directed",
+					DirectionRole: "dependency",
+					Aggregation:   topologyv1.LinkAggregation{Direction: "preserve"},
+				},
+			},
+		},
+		Actors: topologyv1.MustTable(2, []topologyv1.Column{
+			topologyv1.NewColumn("id", "string", topologyv1.WithRole("identity")),
+			topologyv1.NewColumn("type", "string"),
+		}, []topologyv1.ColumnEncoding{
+			topologyv1.Values("node-a", "node-b"),
+			topologyv1.Const("node"),
+		}),
+		Links: topologyv1.MustTable(1, []topologyv1.Column{
+			topologyv1.NewColumn("src", "actor_ref"),
+			topologyv1.NewColumn("dst", "actor_ref"),
+			topologyv1.NewColumn("type", "string"),
+		}, []topologyv1.ColumnEncoding{
+			topologyv1.Const(0),
+			topologyv1.Const(1),
+			topologyv1.Const("dependency"),
+		}),
+	}
+	graphJSON, err := json.Marshal(topology)
+	require.NoError(t, err)
+
+	origin := &topologyv1.Producer{
+		Source:       "test-topology",
+		Instance:     "test-instance",
+		NodeID:       "node-b",
+		MachineGUID:  "machine-b",
+		AgentVersion: "test",
+		Plugin:       "go-test",
+		Capabilities: []string{"topology-v1", "aggregation"},
+	}
+	tests := map[string]struct {
+		notifications []topologyv1.Notification
+		wantJSON      string
+	}{
+		"omitted notifications": {},
+		"empty notifications": {
+			notifications: []topologyv1.Notification{},
+		},
+		"info with inherited origin": {
+			notifications: []topologyv1.Notification{{
+				Severity: topologyv1.NotificationSeverityInfo,
+				Code:     "test_context",
+				Message:  "Source \"sample-node\" returned <graph> data.\nDetails are plain text.",
+			}},
+			wantJSON: `[{"severity":"info","code":"test_context","message":"Source \"sample-node\" returned <graph> data.\nDetails are plain text."}]`,
+		},
+		"warning with inherited origin": {
+			notifications: []topologyv1.Notification{{
+				Severity:       topologyv1.NotificationSeverityWarning,
+				Code:           "test_ambiguity",
+				Message:        "The test graph contains an unresolved relationship.",
+				AffectedNodeID: "node-a",
+			}},
+			wantJSON: `[{"severity":"warning","code":"test_ambiguity","message":"The test graph contains an unresolved relationship.","affected_node_id":"node-a"}]`,
+		},
+		"warning preserves full explicit origin": {
+			notifications: []topologyv1.Notification{{
+				Severity:       topologyv1.NotificationSeverityWarning,
+				Code:           "test_ambiguity",
+				Message:        "The test graph contains an unresolved relationship.",
+				Origin:         origin,
+				AffectedNodeID: "node-a",
+			}},
+			wantJSON: `[{"severity":"warning","code":"test_ambiguity","message":"The test graph contains an unresolved relationship.",
+				"origin":{"source":"test-topology","instance":"test-instance","node_id":"node-b","machine_guid":"machine-b","agent_version":"test","plugin":"go-test","capabilities":["topology-v1","aggregation"]},
+				"affected_node_id":"node-a"}]`,
+		},
+		"error notification retains successful graph response": {
+			notifications: []topologyv1.Notification{{
+				Severity:       topologyv1.NotificationSeverityError,
+				Code:           "test_source_failure",
+				Message:        "One test source failed; other graph data remains available.",
+				Origin:         origin,
+				AffectedNodeID: "node-a",
+			}},
+			wantJSON: `[{"severity":"error","code":"test_source_failure","message":"One test source failed; other graph data remains available.",
+				"origin":{"source":"test-topology","instance":"test-instance","node_id":"node-b","machine_guid":"machine-b","agent_version":"test","plugin":"go-test","capabilities":["topology-v1","aggregation"]},
+				"affected_node_id":"node-a"}]`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data := topology
+			data.Notifications = test.notifications
+			generation := methodGeneration{kind: methodGenerationShared}
+			result, err := generation.responseResult(funcapi.FunctionConfig{
+				ID:           "topology",
+				ResponseType: topologyv1.ResponseType,
+			}, nil, &funcapi.FunctionResponse{
+				Status: 200,
+				Data:   data,
+			})
+			require.NoError(t, err)
+
+			payload := topologyNotificationResultPayload(t, result, 200)
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(payload, &decoded))
+			require.NoError(t, topologyv1.ValidateDecodedResponse(decoded))
+			var envelope map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(payload, &envelope))
+			assert.JSONEq(t, `200`, string(envelope["status"]))
+			assert.JSONEq(t, `"topology"`, string(envelope["type"]))
+			assert.NotContains(t, envelope, "errorMessage")
+			assert.NotContains(t, envelope, "notifications")
+
+			var gotData map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(envelope["data"], &gotData))
+			if test.wantJSON == "" {
+				assert.NotContains(t, gotData, "notifications")
+			} else {
+				assert.JSONEq(t, test.wantJSON, string(gotData["notifications"]))
+			}
+			delete(gotData, "notifications")
+			gotGraphJSON, err := json.Marshal(gotData)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(graphJSON), string(gotGraphJSON))
+		})
+	}
+}
+
+func TestMethodGenerationTopologyFatalResponse(t *testing.T) {
+	for name, status := range map[string]int{"bad request": 400, "unavailable": 503} {
+		t.Run(name, func(t *testing.T) {
+			generation := methodGeneration{kind: methodGenerationShared}
+			result, err := generation.responseResult(funcapi.FunctionConfig{
+				ID:           "topology",
+				ResponseType: topologyv1.ResponseType,
+			}, nil, &funcapi.FunctionResponse{
+				Status:  status,
+				Message: "The topology request failed.",
+				Data: topologyv1.Data{
+					Notifications: []topologyv1.Notification{{
+						Severity: topologyv1.NotificationSeverityError,
+						Code:     "test_source_failure",
+						Message:  "The test source is unavailable.",
+					}},
+				},
+			})
+			require.NoError(t, err)
+
+			payload := topologyNotificationResultPayload(t, result, status)
+			assert.JSONEq(t, fmt.Sprintf(`{"status":%d,"errorMessage":"The topology request failed."}`, status),
+				string(payload))
+		})
+	}
+}
+
+func topologyNotificationResultPayload(t *testing.T, result lifecycle.SealedResult, status int) []byte {
+	t.Helper()
+
+	var output bytes.Buffer
+	owner, err := lifecycle.NewFrameOwner(&output)
+	require.NoError(t, err)
+	frame, err := lifecycle.PrepareFrame("topology-test", result, 1)
+	require.NoError(t, err)
+	require.NoError(t, owner.Commit(frame))
+	header, body, ok := strings.Cut(output.String(), "\n")
+	require.True(t, ok)
+	assert.Equal(t, fmt.Sprintf("FUNCTION_RESULT_BEGIN topology-test %d application/json 1", status), header)
+	payload, ok := strings.CutSuffix(body, "\nFUNCTION_RESULT_END\n\n")
+	require.True(t, ok)
+	return []byte(payload)
+}

--- a/src/go/tools/functions-validation/validate/main_test.go
+++ b/src/go/tools/functions-validation/validate/main_test.go
@@ -51,6 +51,36 @@ func TestTopologyV1EnvelopeVersionValidates(t *testing.T) {
 	}
 }
 
+func TestTopologyV1NotificationValidates(t *testing.T) {
+	schemaBytes := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_TOPOLOGY_SCHEMA.json"))
+	fixture := readTestFile(t, filepath.Join("..", "fixtures", "topology-v1", "snmp-l2.json"))
+
+	var payload map[string]any
+	if err := json.Unmarshal(fixture, &payload); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	payload["data"].(map[string]any)["notifications"] = []any{
+		map[string]any{
+			"severity":         "error",
+			"code":             "source.unavailable",
+			"message":          "A requested source did not return topology data.",
+			"affected_node_id": "node-a",
+		},
+	}
+
+	inputBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("encode fixture: %v", err)
+	}
+	validated, err := validateJSON(schemaBytes, inputBytes)
+	if err != nil {
+		t.Fatalf("validate fixture with notification: %v", err)
+	}
+	if validated.(map[string]any)["status"] != float64(200) {
+		t.Fatalf("expected non-terminal notification response status 200")
+	}
+}
+
 func TestFunctionUISchemaValidationSkipsTopologySemanticsForTableResponses(t *testing.T) {
 	schemaBytes := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_UI_SCHEMA.json"))
 	input := []byte(`{

--- a/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
@@ -132,6 +132,61 @@ may advertise `accepted_params`, `required_params`, and help text without a
 `data` object. Validate only full topology responses against
 `FUNCTION_TOPOLOGY_SCHEMA.json`.
 
+## Notifications
+
+Status: implemented in the Agent JSON Schema, Go payload model, and validation.
+CTS merging and frontend presentation require corresponding consumer support;
+schema support alone does not enable notification emission or display.
+
+Optional `data.notifications` carries user-facing information about the returned
+topology. The same contract applies to every topology Function, whether its
+response comes directly from an Agent or through a Cloud aggregator.
+
+Each array entry is a closed object:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `severity` | Yes | `info`, `warning`, or `error`. |
+| `code` | Yes | Stable machine-readable code using the topology identifier grammar. |
+| `message` | Yes | Non-empty plain-text explanation for the user. |
+| `origin` | No | Full `producer` object identifying who emitted the notification; omission means the enclosing `data.producer`. |
+| `affected_node_id` | No | Agent node identifier that the issue concerns, using the same string representation as `producer.node_id`. |
+
+- `info` supplies relevant context without declaring a problem. `warning`
+  explains a limitation or uncertainty. `error` reports a failure affecting the
+  returned topology while a usable graph is still available.
+- Notifications do not change Function status or graph facts. A topology
+  response containing an `error` notification still has `status: 200`.
+  A fatal request failure continues to use the normal Function error response,
+  not a successful topology envelope without usable data.
+- Omit `notifications` or use `[]` when there is nothing to report. Explicit
+  `null` is invalid. Absence of notifications is not proof that no undetectable
+  issues exist. Notifications describe this response, not a persistent alert
+  history; consumers must clear previous notifications when a response omits them.
+- `origin` follows the existing producer schema, including required `source`
+  and `instance`. Before an aggregator replaces `data.producer`, it must make
+  inherited notification origins explicit using the input producer. Preserve
+  an already explicit origin. Do not invent producer identities for unavailable
+  sources or replace Agent origins with the aggregator identity.
+- The emitter and affected Agent are different concepts. For example, CTS can
+  report a source collection failure: its own producer is the origin, and
+  `affected_node_id` identifies the failed source Agent. Omit the affected-node
+  field when the issue is not about one known Agent.
+- Aggregators must preserve source notifications and add their own through the
+  same contract. Keep distinct source reports; do not use message text as a
+  merge key. The schema defines no occurrence count or automatic coalescing rule.
+- Treat messages as untrusted text. Do not interpret them as HTML, Markdown,
+  commands, or diagnostic instructions. Producers must not include credentials
+  or other secret values in notifications.
+- Go producers use `Data.Notifications` in `src/go/pkg/topology/v1`. C producers
+  use the same JSON contract. No general Function envelope extension is needed.
+
+CTS must accept and preserve the field before Agents begin emitting it to CTS
+deployments with strict JSON decoding. Existing payloads without notifications
+remain valid; a schema-version change is not required. The frontend notification
+renderer must work for all topology types and delivery paths, with an in-map
+indicator and a popover explaining the reported information and issues.
+
 ## Mode Requests
 
 Use the request parameter `__topology_mode` when a topology producer has a real

--- a/src/plugins.d/FUNCTION_TOPOLOGY_IMPLEMENTATION_SCOPE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_IMPLEMENTATION_SCOPE.md
@@ -47,6 +47,28 @@ Likely files:
 - `src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json`
 - `src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md`
 
+### Shared Topology Notifications
+
+- Implemented Agent support: optional `data.notifications` in the canonical
+  JSON Schema, topology/v1 Go types, and semantic validation. The contract uses
+  `info`, `warning`, and `error` severities, stable codes, plain-text messages,
+  optional producer origin, and optional affected Agent node identifier.
+- Producer emission is separate from schema support. Existing producers may
+  omit notifications without changing their graph or Function behavior.
+- Required CTS support: accept the field, preserve source notifications, make
+  inherited origins explicit before replacing the payload producer, and add
+  CTS notifications through the same contract. Notification severity does not
+  replace collection completeness or fatal request-error handling.
+- Required frontend support: preserve notifications during normalization and
+  display them through one topology-wide map indicator and explanatory popover,
+  independently of topology kind or direct Agent/CTS delivery. A response with
+  no notifications clears those from the previous response.
+- Compatibility gate: CTS with strict JSON decoding must gain support before
+  Agents emit notifications. This Agent schema support does not establish CTS
+  or frontend implementation or qualification.
+- Canonical field definitions and origin semantics are in
+  [Notifications](FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md#notifications).
+
 ### Shared Encoding Helpers
 
 The schema uses compact columnar tables. Producers should not hand-roll table

--- a/src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json
@@ -77,6 +77,13 @@
         "producer": {
           "$ref": "#/$defs/producer"
         },
+        "notifications": {
+          "type": "array",
+          "description": "Information and issues about this topology response. Omission or an empty array reports no notifications; notifications do not replace fatal Function errors.",
+          "items": {
+            "$ref": "#/$defs/notification"
+          }
+        },
         "collected_at": {
           "type": "string",
           "format": "date-time"
@@ -140,6 +147,44 @@
             "$ref": "#/$defs/scalar_or_array"
           },
           "default": {}
+        }
+      }
+    },
+    "notification": {
+      "type": "object",
+      "description": "A user-facing notice accompanying usable topology data, independent of topology kind or delivery path.",
+      "additionalProperties": false,
+      "required": [
+        "severity",
+        "code",
+        "message"
+      ],
+      "properties": {
+        "severity": {
+          "type": "string",
+          "description": "Info supplies context, warning identifies a limitation or uncertainty, and error reports a failure while usable topology data remains available. Severity does not change Function status.",
+          "enum": [
+            "info",
+            "warning",
+            "error"
+          ]
+        },
+        "code": {
+          "$ref": "#/$defs/id",
+          "description": "Stable machine-readable notification code. Message text is not a merge identity."
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Non-empty user-facing explanation. Treat as untrusted plain text, never HTML, Markdown, or executable instructions; do not include secrets."
+        },
+        "origin": {
+          "$ref": "#/$defs/producer",
+          "description": "Producer that emitted the notification. Omission inherits the enclosing data.producer; aggregators must make inherited origins explicit before replacing that producer and preserve explicit origins."
+        },
+        "affected_node_id": {
+          "type": "string",
+          "description": "Agent node identifier the issue concerns, using the producer.node_id string convention. This identifies the affected Agent, not the notification emitter; omit when no single known Agent is affected."
         }
       }
     },


### PR DESCRIPTION
##### Summary

Add optional `data.notifications` to the shared `netdata.topology.v1` response contract so topology producers and aggregators can report information, limitations, and failures alongside usable graph data.

- Require `severity` (`info`, `warning`, or `error`), a machine-readable `code`, and a non-empty plain-text `message`.
- Support an optional producer `origin` and an optional `affected_node_id`. Omitted origin inherits `data.producer`; aggregators must preserve that provenance before replacing the enclosing producer.
- Keep JSON Schema, Go payload types, semantic validation, and developer documentation consistent.
- Test schema/semantic agreement, exact identifier-pattern synchronization, required-field diagnostics, serialization, validator CLI behavior, and preservation through the job manager's framed Function response path.

No collector starts emitting notifications in this change. Responses without notifications, graph data, schema version, and fatal Function error behavior remain unchanged.

##### Test Plan

Passed locally from `src/go` after rebasing onto `5e76a5ca7f`:

```sh
go test -race -count=1 ./pkg/topology/v1 ./tools/functions-validation/validate ./plugin/agent/jobmgr/functions
go vet ./pkg/topology/v1 ./tools/functions-validation/validate ./plugin/agent/jobmgr/functions
```

- Positive and negative cases cover all severities, omitted/empty arrays, nulls, wrong types, required and unknown fields, identifier boundaries, full producer origins, and capability uniqueness.
- Transport tests preserve complete graph data and typed notifications, retain status 200 for usable graphs with error notifications, and preserve fatal 400/503 error envelopes.
- Origin cases share payload construction and schema/semantic assertions; all 43 original validation cases remain.
- The broader race run also passed Cato, vSphere, SNMP topology, and the job-manager packages except for `jobmgr/secrets`: `TestPreparedStoreOperationQuarantinesFailedUntakenMutationRelease` failed at `initial_test.go:325`. Its 20 focused reruns passed. The unchanged secrets package has no topology dependency; the test waits for result readiness before assuming the separately assigned attempt is available. This unrelated test was not modified.
- Formatting, schema JSON syntax, staged-diff whitespace checks, and sensitive-data checks passed.
- Local Codacy analysis completed without execution errors: Opengrep, Jackson, and markdownlint reported no issues. Lizard reported 49 size/complexity warnings across the changed Go files. The additional contract test was also analyzed explicitly with Opengrep and Lizard and reported no issues. These are metric warnings, not a claim of a warning-free analysis.

##### Additional Information

This PR implements notification schema support within the coordinated Agent and cloud-topology-service compatibility work; the broader producer/correlation compatibility audit is not complete.

The service must accept and preserve notifications before any Agent producer emits them, because its strict decoder rejects unknown fields. Service-side merging and issue detection, and generic frontend map-overlay/popover rendering, are not implemented by this PR. The frontend integration must merge after backend and Agent compatibility are qualified.

<details>
<summary>For users: How does this change affect me?</summary>

There is no visible UI or topology behavior change from this PR alone. It defines the shared response format needed to explain topology limitations and failures without discarding usable maps. Existing per-node topology output is unchanged because producers do not emit the optional field.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Topology responses can now include optional notifications with info, warning, or error severity.
  - Notifications support stable codes, messages, producer origin details, and affected node identifiers.
  - Notifications accompany usable topology data without replacing normal fatal error responses.

- **Bug Fixes**
  - Added validation for notification structure, required fields, identifiers, origins, and unsupported fields.

- **Documentation**
  - Documented notification behavior, preservation, aggregation, compatibility requirements, and consumer display guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->