### PR TITLE
Support ranked weights response limits across API formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1610,6 +1610,7 @@ set(API_PLUGIN_FILES
         src/web/api/queries/latest/latest.c
         src/web/api/queries/latest/latest.h
         src/web/api/queries/weights.c
+        src/web/api/queries/weights-ranking.h
         src/web/api/queries/weights.h
         src/web/api/formatters/rrd2json.c
         src/web/api/formatters/rrd2json.h

--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -5257,7 +5257,10 @@
             "$ref": "#/components/parameters/dataTimeGroupOptions2"
           },
           {
-            "$ref": "#/components/parameters/cardinalityLimit"
+            "$ref": "#/components/parameters/weightsLimit"
+          },
+          {
+            "$ref": "#/components/parameters/weightsCardinalityLimit"
           }
         ],
         "responses": {
@@ -6061,7 +6064,10 @@
             "$ref": "#/components/parameters/dataTimeGroupOptions2"
           },
           {
-            "$ref": "#/components/parameters/cardinalityLimit"
+            "$ref": "#/components/parameters/weightsLimit"
+          },
+          {
+            "$ref": "#/components/parameters/weightsCardinalityLimit"
           }
         ],
         "responses": {
@@ -6141,6 +6147,12 @@
           },
           {
             "$ref": "#/components/parameters/dataTimeGroupOptions1"
+          },
+          {
+            "$ref": "#/components/parameters/weightsLimit"
+          },
+          {
+            "$ref": "#/components/parameters/weightsCardinalityLimit"
           }
         ],
         "responses": {
@@ -6217,6 +6229,12 @@
           },
           {
             "$ref": "#/components/parameters/dataTimeGroupOptions1"
+          },
+          {
+            "$ref": "#/components/parameters/weightsLimit"
+          },
+          {
+            "$ref": "#/components/parameters/weightsCardinalityLimit"
           }
         ],
         "responses": {
@@ -7339,7 +7357,7 @@
       "cardinalityLimit": {
         "name": "cardinality_limit",
         "in": "query",
-        "description": "Limits the number of unique items returned, to prevent excessive memory usage and response sizes when a request matches a large number of items. For data queries, the query engine keeps the top contributing dimensions and folds the rest into one `remaining` aggregate dimension, so the total number of returned dimensions equals this limit; the `jsonwrap` summary metadata (nodes, instances, dimensions, labels) stays complete unless the `cardinality-limit-all` option is also given. Other endpoints (weights, alerts, contexts) apply this limit to their own result items.\n",
+        "description": "Limits the number of unique items returned, to prevent excessive memory usage and response sizes when a request matches a large number of items. For data queries, the query engine keeps the top contributing dimensions and folds the rest into one `remaining` aggregate dimension, so the total number of returned dimensions equals this limit; the `jsonwrap` summary metadata (nodes, instances, dimensions, labels) stays complete unless the `cardinality-limit-all` option is also given. Other endpoints (alerts, contexts) apply this limit to their own result items. Weights endpoints define separate result-limit semantics.\n",
         "required": false,
         "schema": {
           "type": "integer",
@@ -7615,6 +7633,28 @@
             "anomaly-rate",
             "value"
           ]
+        }
+      },
+      "weightsLimit": {
+        "name": "limit",
+        "in": "query",
+        "description": "Returns at most N strongest physical time series, or N complete groups when group_by is used. Parent instance, context, and node rows do not count toward N and retain their complete-query summaries. No remaining bucket is added. All matching metrics are still evaluated and normalized before selection; this bounds response size, not query work or duration.\n\nRaw scores and method=value rank higher values first. Normalized scores rank lower values first. Groups rank by the requested aggregation after complete aggregation. Equal scores use stable node/context/instance/dimension identities (group IDs for groups). Metric dictionaries include only retained entries; node metadata remains complete. correlated_dimensions and total_dimensions_count describe the complete query. A positive cap adds result_limit metadata with summary_scope=all.\n\nLegacy v1 dimension objects retain their display-name keys. Duplicate display names can collapse in clients that decode these objects into maps; returned counts emitted physical entries, not unique display-name keys. The v2/v3 dimension dictionaries use metric IDs.\n\nOmitted, empty, or zero means unlimited. Values must be nonnegative decimal integers within the Agent's size_t range; malformed, negative, fractional, and overflowing values return HTTP 400. Repeated values use the last nonempty value of each alias, but every nonempty supplied value must be valid. cardinality_limit takes precedence, including zero. Agents without weights result-limit support may ignore either parameter; clients must inspect result_limit before claiming that results were capped.\n",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "weightsCardinalityLimit": {
+        "name": "cardinality_limit",
+        "in": "query",
+        "description": "Alias of the weights limit parameter with identical strongest-result selection and complete-query summary semantics. Takes precedence over limit when both are supplied, including zero (unlimited). Unlike data-query cardinality_limit, it does not reserve a slot for a remaining bucket. See limit for validation, repeated-value, ranking, and compatibility behavior.\n",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
         }
       }
     },
@@ -9570,6 +9610,9 @@
       "metric_correlations": {
         "type": "object",
         "properties": {
+          "result_limit": {
+            "$ref": "#/components/schemas/weightsResultLimit"
+          },
           "after": {
             "description": "the start time of the highlighted window",
             "type": "integer"
@@ -9615,7 +9658,7 @@
             "type": "string"
           },
           "correlated_dimensions": {
-            "description": "the number of dimensions returned in the result"
+            "description": "the number of contributing dimensions before result limiting"
           },
           "total_dimensions_count": {
             "description": "the total number of dimensions evaluated",
@@ -9688,11 +9731,27 @@
         }
       },
       "weights2": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "result_limit": {
+            "$ref": "#/components/schemas/weightsResultLimit"
+          },
+          "correlated_dimensions": {
+            "type": "integer",
+            "description": "the number of contributing physical dimensions before result limiting or grouping"
+          },
+          "total_dimensions_count": {
+            "type": "integer",
+            "description": "the total number of dimensions evaluated before result limiting"
+          }
+        }
       },
       "weights": {
         "type": "object",
         "properties": {
+          "result_limit": {
+            "$ref": "#/components/schemas/weightsResultLimit"
+          },
           "after": {
             "description": "the start time of the highlighted window",
             "type": "integer"
@@ -9738,7 +9797,7 @@
             "type": "string"
           },
           "correlated_dimensions": {
-            "description": "the number of dimensions returned in the result"
+            "description": "the number of contributing dimensions before result limiting"
           },
           "total_dimensions_count": {
             "description": "the total number of dimensions evaluated",
@@ -9949,6 +10008,53 @@
             "type": "object",
             "description": "The data payload of the response, contents vary depending on the specific request and action.",
             "additionalProperties": true
+          }
+        }
+      },
+      "weightsResultLimit": {
+        "type": "object",
+        "description": "Present only for a positive weights result cap. Parent summaries and analyzed counts cover the complete query.",
+        "required": [
+          "limit",
+          "total",
+          "returned",
+          "unit",
+          "truncated",
+          "summary_scope"
+        ],
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "requested cap after alias precedence"
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "eligible dimensions or complete groups before limiting"
+          },
+          "returned": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "retained dimensions or groups, excluding parent rows"
+          },
+          "unit": {
+            "type": "string",
+            "enum": [
+              "dimensions",
+              "groups"
+            ]
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "true exactly when total is greater than returned"
+          },
+          "summary_scope": {
+            "type": "string",
+            "enum": [
+              "all"
+            ],
+            "description": "retained parent summaries cover all contributing metrics, including omitted children"
           }
         }
       }

--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -7638,6 +7638,7 @@
       "weightsLimit": {
         "name": "limit",
         "in": "query",
+        "allowEmptyValue": true,
         "description": "Returns at most N strongest physical time series, or N complete groups when group_by is used. Parent instance, context, and node rows do not count toward N and retain their complete-query summaries. No remaining bucket is added. All matching metrics are still evaluated and normalized before selection; this bounds response size, not query work or duration.\n\nRaw scores and method=value rank higher values first. Normalized scores rank lower values first. Groups rank by the requested aggregation after complete aggregation. Equal scores use stable node/context/instance/dimension identities (group IDs for groups). Metric dictionaries include only retained entries; node metadata remains complete. correlated_dimensions and total_dimensions_count describe the complete query. A positive cap adds result_limit metadata with summary_scope=all.\n\nLegacy v1 dimension objects retain their display-name keys. Duplicate display names can collapse in clients that decode these objects into maps; returned counts emitted physical entries, not unique display-name keys. The v2/v3 dimension dictionaries use metric IDs.\n\nOmitted, empty, or zero means unlimited. Values must be nonnegative decimal integers within the Agent's size_t range; malformed, negative, fractional, and overflowing values return HTTP 400. Repeated values use the last nonempty value of each alias, but every nonempty supplied value must be valid. cardinality_limit takes precedence, including zero. Agents without weights result-limit support may ignore either parameter; clients must inspect result_limit before claiming that results were capped.\n",
         "required": false,
         "schema": {
@@ -7649,6 +7650,7 @@
       "weightsCardinalityLimit": {
         "name": "cardinality_limit",
         "in": "query",
+        "allowEmptyValue": true,
         "description": "Alias of the weights limit parameter with identical strongest-result selection and complete-query summary semantics. Takes precedence over limit when both are supplied, including zero (unlimited). Unlike data-query cardinality_limit, it does not reserve a slot for a remaining bucket. See limit for validation, repeated-value, ranking, and compatibility behavior.\n",
         "required": false,
         "schema": {

--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -7643,8 +7643,7 @@
         "required": false,
         "schema": {
           "type": "integer",
-          "minimum": 0,
-          "default": 0
+          "minimum": 0
         }
       },
       "weightsCardinalityLimit": {
@@ -7655,8 +7654,7 @@
         "required": false,
         "schema": {
           "type": "integer",
-          "minimum": 0,
-          "default": 0
+          "minimum": 0
         }
       }
     },

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -7337,7 +7337,8 @@ paths:
         - $ref: '#/components/parameters/dataQueryOptions'
         - $ref: '#/components/parameters/dataTimeGroup2'
         - $ref: '#/components/parameters/dataTimeGroupOptions2'
-        - $ref: '#/components/parameters/cardinalityLimit'
+        - $ref: '#/components/parameters/weightsLimit'
+        - $ref: '#/components/parameters/weightsCardinalityLimit'
       responses:
         "200":
           description: JSON object with weights for each context, chart and dimension.
@@ -7965,7 +7966,8 @@ paths:
         - $ref: '#/components/parameters/dataQueryOptions'
         - $ref: '#/components/parameters/dataTimeGroup2'
         - $ref: '#/components/parameters/dataTimeGroupOptions2'
-        - $ref: '#/components/parameters/cardinalityLimit'
+        - $ref: '#/components/parameters/weightsLimit'
+        - $ref: '#/components/parameters/weightsCardinalityLimit'
       responses:
         "200":
           description: JSON object with weights for each context, chart and dimension.
@@ -8014,6 +8016,8 @@ paths:
         - $ref: '#/components/parameters/dataQueryOptions'
         - $ref: '#/components/parameters/dataTimeGroup1'
         - $ref: '#/components/parameters/dataTimeGroupOptions1'
+        - $ref: '#/components/parameters/weightsLimit'
+        - $ref: '#/components/parameters/weightsCardinalityLimit'
       responses:
         "200":
           description: JSON object with weights for each context, chart and dimension.
@@ -8061,6 +8065,8 @@ paths:
         - $ref: '#/components/parameters/dataQueryOptions'
         - $ref: '#/components/parameters/dataTimeGroup1'
         - $ref: '#/components/parameters/dataTimeGroupOptions1'
+        - $ref: '#/components/parameters/weightsLimit'
+        - $ref: '#/components/parameters/weightsCardinalityLimit'
       responses:
         "200":
           description: JSON object with weights for each chart and dimension.
@@ -9323,13 +9329,39 @@ components:
       name: cardinality_limit
       in: query
       description: |
-        Limits the number of unique items returned, to prevent excessive memory usage and response sizes when a request matches a large number of items. For data queries, the query engine keeps the top contributing dimensions and folds the rest into one `remaining` aggregate dimension, so the total number of returned dimensions equals this limit; the `jsonwrap` summary metadata (nodes, instances, dimensions, labels) stays complete unless the `cardinality-limit-all` option is also given. Other endpoints (weights, alerts, contexts) apply this limit to their own result items.
+        Limits the number of unique items returned, to prevent excessive memory usage and response sizes when a request matches a large number of items. For data queries, the query engine keeps the top contributing dimensions and folds the rest into one `remaining` aggregate dimension, so the total number of returned dimensions equals this limit; the `jsonwrap` summary metadata (nodes, instances, dimensions, labels) stays complete unless the `cardinality-limit-all` option is also given. Other endpoints (alerts, contexts) apply this limit to their own result items. Weights endpoints define separate result-limit semantics.
       required: false
       schema:
         type: integer
         format: int64
         minimum: 1
         default: 10000
+    weightsLimit:
+      name: limit
+      in: query
+      description: |
+        Returns at most N strongest physical time series, or N complete groups when group_by is used. Parent instance, context, and node rows do not count toward N and retain their complete-query summaries. No remaining bucket is added. All matching metrics are still evaluated and normalized before selection; this bounds response size, not query work or duration.
+
+        Raw scores and method=value rank higher values first. Normalized scores rank lower values first. Groups rank by the requested aggregation after complete aggregation. Equal scores use stable node/context/instance/dimension identities (group IDs for groups). Metric dictionaries include only retained entries; node metadata remains complete. correlated_dimensions and total_dimensions_count describe the complete query. A positive cap adds result_limit metadata with summary_scope=all.
+
+        Legacy v1 dimension objects retain their display-name keys. Duplicate display names can collapse in clients that decode these objects into maps; returned counts emitted physical entries, not unique display-name keys. The v2/v3 dimension dictionaries use metric IDs.
+
+        Omitted, empty, or zero means unlimited. Values must be nonnegative decimal integers within the Agent's size_t range; malformed, negative, fractional, and overflowing values return HTTP 400. Repeated values use the last nonempty value of each alias, but every nonempty supplied value must be valid. cardinality_limit takes precedence, including zero. Agents without weights result-limit support may ignore either parameter; clients must inspect result_limit before claiming that results were capped.
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    weightsCardinalityLimit:
+      name: cardinality_limit
+      in: query
+      description: |
+        Alias of the weights limit parameter with identical strongest-result selection and complete-query summary semantics. Takes precedence over limit when both are supplied, including zero (unlimited). Unlike data-query cardinality_limit, it does not reserve a slot for a remaining bucket. See limit for validation, repeated-value, ranking, and compatibility behavior.
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
     contextsQueryOptions:
       name: options
       in: query
@@ -11100,6 +11132,8 @@ components:
     metric_correlations:
       type: object
       properties:
+        result_limit:
+          $ref: '#/components/schemas/weightsResultLimit'
         after:
           description: the start time of the highlighted window
           type: integer
@@ -11134,7 +11168,7 @@ components:
           description: a comma separated list of the query options set
           type: string
         correlated_dimensions:
-          description: the number of dimensions returned in the result
+          description: the number of contributing dimensions before result limiting
         total_dimensions_count:
           description: the total number of dimensions evaluated
           type: integer
@@ -11181,9 +11215,47 @@ components:
                       type: number
     weights2:
       type: object
+      properties:
+        result_limit:
+          $ref: '#/components/schemas/weightsResultLimit'
+        correlated_dimensions:
+          type: integer
+          description: the number of contributing physical dimensions before result limiting or grouping
+        total_dimensions_count:
+          type: integer
+          description: the total number of dimensions evaluated before result limiting
+    weightsResultLimit:
+      type: object
+      description: Present only for a positive weights result cap. Parent summaries and analyzed counts cover the complete query.
+      required: [limit, total, returned, unit, truncated, summary_scope]
+      properties:
+        limit:
+          type: integer
+          minimum: 1
+          description: requested cap after alias precedence
+        total:
+          type: integer
+          minimum: 0
+          description: eligible dimensions or complete groups before limiting
+        returned:
+          type: integer
+          minimum: 0
+          description: retained dimensions or groups, excluding parent rows
+        unit:
+          type: string
+          enum: [dimensions, groups]
+        truncated:
+          type: boolean
+          description: true exactly when total is greater than returned
+        summary_scope:
+          type: string
+          enum: [all]
+          description: retained parent summaries cover all contributing metrics, including omitted children
     weights:
       type: object
       properties:
+        result_limit:
+          $ref: '#/components/schemas/weightsResultLimit'
         after:
           description: the start time of the highlighted window
           type: integer
@@ -11218,7 +11290,7 @@ components:
           description: a comma separated list of the query options set
           type: string
         correlated_dimensions:
-          description: the number of dimensions returned in the result
+          description: the number of contributing dimensions before result limiting
         total_dimensions_count:
           description: the total number of dimensions evaluated
           type: integer

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -9352,7 +9352,6 @@ components:
       schema:
         type: integer
         minimum: 0
-        default: 0
     weightsCardinalityLimit:
       name: cardinality_limit
       in: query
@@ -9363,7 +9362,6 @@ components:
       schema:
         type: integer
         minimum: 0
-        default: 0
     contextsQueryOptions:
       name: options
       in: query

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -9339,6 +9339,7 @@ components:
     weightsLimit:
       name: limit
       in: query
+      allowEmptyValue: true
       description: |
         Returns at most N strongest physical time series, or N complete groups when group_by is used. Parent instance, context, and node rows do not count toward N and retain their complete-query summaries. No remaining bucket is added. All matching metrics are still evaluated and normalized before selection; this bounds response size, not query work or duration.
 
@@ -9355,6 +9356,7 @@ components:
     weightsCardinalityLimit:
       name: cardinality_limit
       in: query
+      allowEmptyValue: true
       description: |
         Alias of the weights limit parameter with identical strongest-result selection and complete-query summary semantics. Takes precedence over limit when both are supplied, including zero (unlimited). Unlike data-query cardinality_limit, it does not reserve a slot for a remaining bucket. See limit for validation, repeated-value, ranking, and compatibility behavior.
       required: false

--- a/src/web/api/queries/weights-ranking.h
+++ b/src/web/api/queries/weights-ranking.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_WEIGHTS_RANKING_H
+#define NETDATA_WEIGHTS_RANKING_H
+
+#include <stddef.h>
+
+typedef int (*weights_rank_compare_t)(const void *, const void *, void *);
+
+// Negative comparisons mean stronger; the weakest retained candidate stays at the root.
+typedef struct {
+    void **items;
+    size_t used;
+    size_t capacity;
+    weights_rank_compare_t compare;
+    void *data;
+} WEIGHTS_RANKING;
+
+static inline void weights_ranking_sift(WEIGHTS_RANKING *ranking, size_t root, size_t count) {
+    while(root < count / 2) {
+        size_t child = root * 2 + 1;
+        if(child + 1 < count && ranking->compare(ranking->items[child + 1], ranking->items[child], ranking->data) > 0)
+            child++;
+        if(ranking->compare(ranking->items[root], ranking->items[child], ranking->data) >= 0)
+            break;
+        void *tmp = ranking->items[root];
+        ranking->items[root] = ranking->items[child];
+        ranking->items[child] = tmp;
+        root = child;
+    }
+}
+
+static inline void weights_ranking_offer(WEIGHTS_RANKING *ranking, void *item) {
+    if(!ranking->capacity)
+        return;
+    if(ranking->used < ranking->capacity) {
+        size_t pos = ranking->used++;
+        ranking->items[pos] = item;
+        while(pos) {
+            size_t parent = (pos - 1) / 2;
+            if(ranking->compare(ranking->items[parent], item, ranking->data) >= 0)
+                break;
+            ranking->items[pos] = ranking->items[parent];
+            ranking->items[parent] = item;
+            pos = parent;
+        }
+    }
+    else if(ranking->compare(item, ranking->items[0], ranking->data) < 0) {
+        ranking->items[0] = item;
+        weights_ranking_sift(ranking, 0, ranking->used);
+    }
+}
+
+static inline void weights_ranking_sort(WEIGHTS_RANKING *ranking) {
+    for(size_t count = ranking->used; count > 1; count--) {
+        void *tmp = ranking->items[0];
+        ranking->items[0] = ranking->items[count - 1];
+        ranking->items[count - 1] = tmp;
+        weights_ranking_sift(ranking, 0, count - 1);
+    }
+}
+
+#endif

--- a/src/web/api/queries/weights.c
+++ b/src/web/api/queries/weights.c
@@ -2,6 +2,7 @@
 
 #include "database/rrd.h"
 #include "KolmogorovSmirnovDist.h"
+#include "weights-ranking.h"
 
 #define MAX_POINTS 10000
 
@@ -72,6 +73,10 @@ struct register_result {
     STORAGE_POINT highlighted;
     STORAGE_POINT baseline;
     usec_t duration_ut;
+    bool selected;
+    bool instance_selected;
+    bool context_selected;
+    bool node_selected;
 };
 
 struct weights_host_snapshot {
@@ -215,6 +220,84 @@ static void register_result(DICTIONARY *results, RRDHOST *host, STRING *hostname
     dictionary_set_advanced(results, buf, len, &t, sizeof(struct register_result), NULL);
 }
 
+static int weights_result_compare(const void *left, const void *right, void *data) {
+    const struct register_result *a = left, *b = right;
+    bool normalized = *(bool *)data;
+    if(a->value != b->value)
+        return ((a->value < b->value) == normalized) ? -1 : 1;
+
+    const ND_UUID *aid = UUIDiszero(a->host->host_id) ? &a->host->node_id : &a->host->host_id;
+    const ND_UUID *bid = UUIDiszero(b->host->host_id) ? &b->host->node_id : &b->host->host_id;
+    int rc = memcmp(aid->uuid, bid->uuid, sizeof(aid->uuid));
+    if(!rc) rc = strcmp(rrdcontext_acquired_id(a->rca), rrdcontext_acquired_id(b->rca));
+    if(!rc) rc = strcmp(rrdinstance_acquired_id(a->ria), rrdinstance_acquired_id(b->ria));
+    if(!rc) rc = strcmp(rrdmetric_acquired_id(a->rma), rrdmetric_acquired_id(b->rma));
+    return rc;
+}
+
+static void weights_parent_key(char *key, size_t size, char type, const void *parent) {
+    snprintfz(key, size, "%c%p", type, parent);
+}
+
+static WEIGHTS_RANKING weights_select_results(DICTIONARY *results, size_t limit, bool *normalized, bool mark_parents) {
+    size_t total = dictionary_entries(results);
+    WEIGHTS_RANKING ranking = {
+        .capacity = MIN(limit, total), .compare = weights_result_compare, .data = normalized,
+    };
+    struct register_result *t;
+    if(mark_parents && limit >= total) {
+        dfe_start_read(results, t)
+            t->selected = t->instance_selected = t->context_selected = t->node_selected = true;
+        dfe_done(t);
+        return ranking;
+    }
+
+    ranking.items = callocz(ranking.capacity, sizeof(*ranking.items));
+    dfe_start_read(results, t)
+        weights_ranking_offer(&ranking, t);
+    dfe_done(t);
+
+    if(!mark_parents)
+        return ranking;
+
+    DICTIONARY *parents = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+    char key[2 * sizeof(void *) + 4];
+    for(size_t i = 0; i < ranking.used; i++) {
+        t = ranking.items[i];
+        t->selected = true;
+        weights_parent_key(key, sizeof(key), 'n', t->host);
+        dictionary_set(parents, key, "", 1);
+        weights_parent_key(key, sizeof(key), 'c', t->rca);
+        dictionary_set(parents, key, "", 1);
+        weights_parent_key(key, sizeof(key), 'i', t->ria);
+        dictionary_set(parents, key, "", 1);
+    }
+    dfe_start_read(results, t) {
+        weights_parent_key(key, sizeof(key), 'n', t->host);
+        t->node_selected = dictionary_get(parents, key) != NULL;
+        weights_parent_key(key, sizeof(key), 'c', t->rca);
+        t->context_selected = dictionary_get(parents, key) != NULL;
+        weights_parent_key(key, sizeof(key), 'i', t->ria);
+        t->instance_selected = dictionary_get(parents, key) != NULL;
+    }
+    dfe_done(t);
+    dictionary_destroy(parents);
+    return ranking;
+}
+
+static void weights_result_limit_to_json(BUFFER *wb, size_t limit, size_t total, size_t returned, bool grouped) {
+    if(!limit)
+        return;
+    buffer_json_member_add_object(wb, "result_limit");
+    buffer_json_member_add_uint64(wb, "limit", limit);
+    buffer_json_member_add_uint64(wb, "total", total);
+    buffer_json_member_add_uint64(wb, "returned", returned);
+    buffer_json_member_add_string(wb, "unit", grouped ? "groups" : "dimensions");
+    buffer_json_member_add_boolean(wb, "truncated", total > returned);
+    buffer_json_member_add_string(wb, "summary_scope", "all");
+    buffer_json_object_close(wb);
+}
+
 // ----------------------------------------------------------------------------
 // Generation of JSON output for the results
 
@@ -266,7 +349,7 @@ static size_t registered_results_to_json_charts(DICTIONARY *results, BUFFER *wb,
                                                 size_t points, WEIGHTS_METHOD method,
                                                 RRDR_TIME_GROUPING group, RRDR_OPTIONS options, uint32_t shifts,
                                                 size_t examined_dimensions, usec_t duration,
-                                                WEIGHTS_STATS *stats) {
+                                                WEIGHTS_STATS *stats, size_t limit) {
 
     buffer_json_initialize(wb, "\"", "\"", 0, true, (options & RRDR_OPTION_MINIFY) ? BUFFER_JSON_OPTIONS_MINIFY : BUFFER_JSON_OPTIONS_DEFAULT);
 
@@ -279,6 +362,8 @@ static size_t registered_results_to_json_charts(DICTIONARY *results, BUFFER *wb,
     struct register_result *t;
     RRDINSTANCE_ACQUIRED *last_ria = NULL; // never access this - we use it only for comparison
     dfe_start_read(results, t) {
+        if(limit && !t->selected)
+            continue;
         if(t->ria != last_ria) {
             last_ria = t->ria;
 
@@ -305,8 +390,9 @@ static size_t registered_results_to_json_charts(DICTIONARY *results, BUFFER *wb,
 
     buffer_json_object_close(wb);
 
-    buffer_json_member_add_uint64(wb, "correlated_dimensions", total_dimensions);
+    buffer_json_member_add_uint64(wb, "correlated_dimensions", dictionary_entries(results));
     buffer_json_member_add_uint64(wb, "total_dimensions_count", examined_dimensions);
+    weights_result_limit_to_json(wb, limit, dictionary_entries(results), total_dimensions, false);
     buffer_json_finalize(wb);
 
     return total_dimensions;
@@ -318,7 +404,7 @@ static size_t registered_results_to_json_contexts(DICTIONARY *results, BUFFER *w
                                                   size_t points, WEIGHTS_METHOD method,
                                                   RRDR_TIME_GROUPING group, RRDR_OPTIONS options, uint32_t shifts,
                                                   size_t examined_dimensions, usec_t duration,
-                                                  WEIGHTS_STATS *stats) {
+                                                  WEIGHTS_STATS *stats, size_t limit) {
 
     buffer_json_initialize(wb, "\"", "\"", 0, true, (options & RRDR_OPTION_MINIFY) ? BUFFER_JSON_OPTIONS_MINIFY : BUFFER_JSON_OPTIONS_DEFAULT);
 
@@ -333,6 +419,8 @@ static size_t registered_results_to_json_contexts(DICTIONARY *results, BUFFER *w
     RRDCONTEXT_ACQUIRED *last_rca = NULL;
     RRDINSTANCE_ACQUIRED *last_ria = NULL;
     dfe_start_read(results, t) {
+        if(limit && !t->context_selected)
+            continue;
 
         if(t->rca != last_rca) {
             last_rca = t->rca;
@@ -357,6 +445,11 @@ static size_t registered_results_to_json_contexts(DICTIONARY *results, BUFFER *w
             last_ria = NULL;
         }
 
+        contexts_total_weight += t->value;
+        context_dims++;
+        if(limit && !t->instance_selected)
+            continue;
+
         if(t->ria != last_ria) {
             last_ria = t->ria;
 
@@ -374,12 +467,12 @@ static size_t registered_results_to_json_contexts(DICTIONARY *results, BUFFER *w
             charts_total_weight = 0.0;
         }
 
-        buffer_json_member_add_double(wb, rrdmetric_acquired_name(t->rma), t->value);
         charts_total_weight += t->value;
-        contexts_total_weight += t->value;
         chart_dims++;
-        context_dims++;
-        total_dimensions++;
+        if(!limit || t->selected) {
+            buffer_json_member_add_double(wb, rrdmetric_acquired_name(t->rma), t->value);
+            total_dimensions++;
+        }
     }
     dfe_done(t);
 
@@ -395,8 +488,9 @@ static size_t registered_results_to_json_contexts(DICTIONARY *results, BUFFER *w
 
     buffer_json_object_close(wb);
 
-    buffer_json_member_add_uint64(wb, "correlated_dimensions", total_dimensions);
+    buffer_json_member_add_uint64(wb, "correlated_dimensions", dictionary_entries(results));
     buffer_json_member_add_uint64(wb, "total_dimensions_count", examined_dimensions);
+    weights_result_limit_to_json(wb, limit, dictionary_entries(results), total_dimensions, false);
     buffer_json_finalize(wb);
 
     return total_dimensions;
@@ -761,6 +855,8 @@ typedef enum {
 
 struct aggregated_weight {
     const char *name;
+    const char *id;
+    bool selected;
     NETDATA_DOUBLE min;
     NETDATA_DOUBLE max;
     NETDATA_DOUBLE sum;
@@ -768,6 +864,28 @@ struct aggregated_weight {
     STORAGE_POINT hsp;
     STORAGE_POINT bsp;
 };
+
+static NETDATA_DOUBLE weights_group_score(const struct aggregated_weight *aw, RRDR_GROUP_BY_FUNCTION aggregation) {
+    switch(aggregation) {
+        case RRDR_GROUP_BY_FUNCTION_MIN: return aw->min;
+        case RRDR_GROUP_BY_FUNCTION_MAX:
+        case RRDR_GROUP_BY_FUNCTION_EXTREMES: return aw->max;
+        case RRDR_GROUP_BY_FUNCTION_SUM:
+        case RRDR_GROUP_BY_FUNCTION_PERCENTAGE: return aw->sum;
+        default: return aw->count ? aw->sum / (NETDATA_DOUBLE)aw->count : 0.0;
+    }
+}
+
+static int weights_group_compare(const void *left, const void *right, void *data) {
+    const struct aggregated_weight *a = left, *b = right;
+    const QUERY_WEIGHTS_REQUEST *qwr = data;
+    NETDATA_DOUBLE av = weights_group_score(a, qwr->group_by.aggregation);
+    NETDATA_DOUBLE bv = weights_group_score(b, qwr->group_by.aggregation);
+    bool normalized = !(qwr->options & RRDR_OPTION_RETURN_RAW) && qwr->method != WEIGHTS_METHOD_VALUE;
+    if(av != bv)
+        return ((av < bv) == normalized) ? -1 : 1;
+    return strcmp(a->id, b->id);
+}
 
 static inline void storage_point_to_json(BUFFER *wb, WEIGHTS_POINT_TYPE type, ssize_t di, ssize_t ii, ssize_t ci, ssize_t ni, struct aggregated_weight *aw, RRDR_OPTIONS options __maybe_unused, bool baseline) {
     if(type != WPT_GROUP) {
@@ -1032,6 +1150,7 @@ static size_t registered_results_to_json_multinode_no_group_by(
 
     bool baseline = method == WEIGHTS_METHOD_MC_KS2 || method == WEIGHTS_METHOD_MC_VOLUME;
     multinode_data_schema(wb, options, "schema", baseline, false);
+    size_t limit = qwd->qwr->cardinality_limit;
 
     DICTIONARY *dict_nodes = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct dict_unique_node));
     DICTIONARY *dict_contexts = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct dict_unique_name_units));
@@ -1052,27 +1171,33 @@ static size_t registered_results_to_json_multinode_no_group_by(
     ssize_t di = -1, ii = -1, ci = -1, ni = -1;
     ssize_t di_max = 0, ii_max = 0, ci_max = 0, ni_max = 0;
     size_t total_dimensions = 0;
+    bool node_selected = false;
     dfe_start_read(results, t) {
 
         // close instance
         if(t->ria != last_ria && last_ria) {
-            storage_point_to_json(wb, WPT_INSTANCE, di, ii, ci, ni, &instance_aw, options, baseline);
-            instance_dun->exposed = true;
+            if(instance_dun) {
+                storage_point_to_json(wb, WPT_INSTANCE, di, ii, ci, ni, &instance_aw, options, baseline);
+                instance_dun->exposed = true;
+            }
             last_ria = NULL;
             instance_aw = AGGREGATED_WEIGHT_EMPTY;
         }
 
         // close context
         if(t->rca != last_rca && last_rca) {
-            storage_point_to_json(wb, WPT_CONTEXT, di, ii, ci, ni, &context_aw, options, baseline);
-            context_dun->exposed = true;
+            if(context_dun) {
+                storage_point_to_json(wb, WPT_CONTEXT, di, ii, ci, ni, &context_aw, options, baseline);
+                context_dun->exposed = true;
+            }
             last_rca = NULL;
             context_aw = AGGREGATED_WEIGHT_EMPTY;
         }
 
         // close node
         if(t->host != last_host && last_host) {
-            storage_point_to_json(wb, WPT_NODE, di, ii, ci, ni, &node_aw, options, baseline);
+            if(node_selected)
+                storage_point_to_json(wb, WPT_NODE, di, ii, ci, ni, &node_aw, options, baseline);
             node_dun->exposed = true;
             last_host = NULL;
             node_aw = AGGREGATED_WEIGHT_EMPTY;
@@ -1083,64 +1208,68 @@ static size_t registered_results_to_json_multinode_no_group_by(
             last_host = t->host;
             node_dun = dict_unique_node_add(dict_nodes, t->host, &ni_max);
             ni = node_dun->i;
+            node_selected = !limit || t->node_selected;
+            node_dun->exposed = true;
         }
 
         // open context
         if(t->rca != last_rca) {
             last_rca = t->rca;
-            context_dun = dict_unique_name_units_add(dict_contexts, rrdcontext_acquired_id(t->rca),
-                                                     rrdcontext_acquired_units(t->rca), &ci_max);
-            ci = context_dun->i;
+            context_dun = (!limit || t->context_selected) ?
+                dict_unique_name_units_add(dict_contexts, rrdcontext_acquired_id(t->rca),
+                                           rrdcontext_acquired_units(t->rca), &ci_max) : NULL;
+            ci = context_dun ? context_dun->i : -1;
         }
 
         // open instance
         if(t->ria != last_ria) {
             last_ria = t->ria;
-            instance_dun = dict_unique_id_name_add(dict_instances, rrdinstance_acquired_id(t->ria), rrdinstance_acquired_name(t->ria), &ii_max);
-            ii = instance_dun->i;
+            instance_dun = (!limit || t->instance_selected) ?
+                dict_unique_id_name_add(dict_instances, rrdinstance_acquired_id(t->ria), rrdinstance_acquired_name(t->ria), &ii_max) : NULL;
+            ii = instance_dun ? instance_dun->i : -1;
         }
 
-        dimension_dun = dict_unique_id_name_add(dict_dimensions, rrdmetric_acquired_id(t->rma), rrdmetric_acquired_name(t->rma), &di_max);
-        di = dimension_dun->i;
-
-        struct aggregated_weight aw = {
+        if(!limit || t->selected) {
+            dimension_dun = dict_unique_id_name_add(dict_dimensions, rrdmetric_acquired_id(t->rma), rrdmetric_acquired_name(t->rma), &di_max);
+            di = dimension_dun->i;
+            struct aggregated_weight aw = {
                 .min = t->value,
                 .max = t->value,
                 .sum = t->value,
                 .count = 1,
                 .hsp = t->highlighted,
                 .bsp = t->baseline,
-        };
+            };
 
-        storage_point_to_json(wb, WPT_DIMENSION, di, ii, ci, ni, &aw, options, baseline);
-        node_dun->exposed = true;
-        context_dun->exposed = true;
-        instance_dun->exposed = true;
-        dimension_dun->exposed = true;
+            storage_point_to_json(wb, WPT_DIMENSION, di, ii, ci, ni, &aw, options, baseline);
+            context_dun->exposed = true;
+            instance_dun->exposed = true;
+            dimension_dun->exposed = true;
+            total_dimensions++;
+        }
 
         merge_into_aw(instance_aw, t);
         merge_into_aw(context_aw, t);
         merge_into_aw(node_aw, t);
 
         node_dun->duration_ut += t->duration_ut;
-        total_dimensions++;
     }
     dfe_done(t);
 
     // close instance
-    if(last_ria) {
+    if(last_ria && instance_dun) {
         storage_point_to_json(wb, WPT_INSTANCE, di, ii, ci, ni, &instance_aw, options, baseline);
         instance_dun->exposed = true;
     }
 
     // close context
-    if(last_rca) {
+    if(last_rca && context_dun) {
         storage_point_to_json(wb, WPT_CONTEXT, di, ii, ci, ni, &context_aw, options, baseline);
         context_dun->exposed = true;
     }
 
     // close node
-    if(last_host) {
+    if(last_host && node_selected) {
         storage_point_to_json(wb, WPT_NODE, di, ii, ci, ni, &node_aw, options, baseline);
         node_dun->exposed = true;
     }
@@ -1221,8 +1350,9 @@ static size_t registered_results_to_json_multinode_no_group_by(
     buffer_json_object_close(wb); //dictionaries
 
     buffer_json_agents_v2(wb, &qwd->timings, 0, false, true, rrdr_options_to_contexts_options(options));
-    buffer_json_member_add_uint64(wb, "correlated_dimensions", total_dimensions);
+    buffer_json_member_add_uint64(wb, "correlated_dimensions", dictionary_entries(results));
     buffer_json_member_add_uint64(wb, "total_dimensions_count", examined_dimensions);
+    weights_result_limit_to_json(wb, limit, dictionary_entries(results), total_dimensions, false);
     buffer_json_finalize(wb);
 
     dictionary_destroy(dict_nodes);
@@ -1338,28 +1468,46 @@ static size_t registered_results_to_json_multinode_group_by(
     buffer_free(name); name = NULL;
 
     struct aggregated_weight *aw;
+    size_t limit = qwd->qwr->cardinality_limit;
+    size_t total_groups = dictionary_entries(group_by), returned_groups = 0;
+    WEIGHTS_RANKING ranking = {.capacity = MIN(limit, total_groups), .compare = weights_group_compare, .data = qwd->qwr};
+    if(limit && limit < total_groups) {
+        ranking.items = callocz(ranking.capacity, sizeof(*ranking.items));
+        dfe_start_read(group_by, aw) {
+            aw->id = aw_dfe.name;
+            weights_ranking_offer(&ranking, aw);
+        }
+        dfe_done(aw);
+        for(size_t i = 0; i < ranking.used; i++)
+            ((struct aggregated_weight *)ranking.items[i])->selected = true;
+    }
     buffer_json_member_add_array(wb, "result");
     dfe_start_read(group_by, aw) {
         const char *k = aw_dfe.name;
         const char *n = aw->name;
 
-        buffer_json_add_array_item_object(wb);
-        buffer_json_member_add_string(wb, "id", k);
+        if(!limit || limit >= total_groups || aw->selected) {
+            buffer_json_add_array_item_object(wb);
+            buffer_json_member_add_string(wb, "id", k);
 
-        if(strcmp(k, n) != 0)
-            buffer_json_member_add_string(wb, "nm", n);
+            if(strcmp(k, n) != 0)
+                buffer_json_member_add_string(wb, "nm", n);
 
-        storage_point_to_json(wb, WPT_GROUP, 0, 0, 0, 0, aw, options, baseline);
-        buffer_json_object_close(wb);
+            storage_point_to_json(wb, WPT_GROUP, 0, 0, 0, 0, aw, options, baseline);
+            buffer_json_object_close(wb);
+            returned_groups++;
+        }
 
         freez((void *)aw->name);
     }
     dfe_done(aw);
     buffer_json_array_close(wb); // result
+    freez(ranking.items);
 
     buffer_json_agents_v2(wb, &qwd->timings, 0, false, true, rrdr_options_to_contexts_options(options));
     buffer_json_member_add_uint64(wb, "correlated_dimensions", total_dimensions);
     buffer_json_member_add_uint64(wb, "total_dimensions_count", examined_dimensions);
+    weights_result_limit_to_json(wb, limit, total_groups, returned_groups, true);
     buffer_json_finalize(wb);
 
     dictionary_destroy(group_by);
@@ -2001,16 +2149,6 @@ static size_t spread_results_evenly(DICTIONARY *results, WEIGHTS_STATS *stats) {
 // MCP format output
 
 // Comparator for sorting results by value (descending order - highest scores first)
-static int registered_results_value_compare(const DICTIONARY_ITEM **item1, const DICTIONARY_ITEM **item2) {
-    struct register_result *r1 = dictionary_acquired_item_value(*item1);
-    struct register_result *r2 = dictionary_acquired_item_value(*item2);
-    
-    // Sort by value in descending order (highest first)
-    if (r1->value < r2->value) return 1;
-    if (r1->value > r2->value) return -1;
-    return 0;
-}
-
 // Callback for sorted dictionary walkthrough
 struct mcp_output_state {
     BUFFER *wb;
@@ -2168,8 +2306,12 @@ static size_t registered_results_to_json_mcp(
         .limit = cardinality_limit
     };
     
-    // Walk through dictionary in sorted order (by value descending)
-    dictionary_sorted_walkthrough_rw(results, 'r', registered_results_to_json_mcp_callback, &state, registered_results_value_compare);
+    bool normalized = false;
+    WEIGHTS_RANKING ranking = weights_select_results(results, cardinality_limit, &normalized, false);
+    weights_ranking_sort(&ranking);
+    for(size_t i = 0; i < ranking.used; i++)
+        registered_results_to_json_mcp_callback(NULL, ranking.items[i], &state);
+    freez(ranking.items);
     
     buffer_json_array_close(wb); // results
     
@@ -2178,7 +2320,7 @@ static size_t registered_results_to_json_mcp(
     buffer_json_member_add_uint64(wb, "total_time_series_analyzed", examined_dimensions);
     buffer_json_member_add_uint64(wb, "total_time_series_returned", state.count);
     buffer_json_member_add_string(wb, "method", weights_method_to_string(method));
-    if (state.count >= cardinality_limit) {
+    if (dictionary_entries(results) > state.count) {
         buffer_json_member_add_uint64(wb, "cardinality_limit", cardinality_limit);
         buffer_json_member_add_boolean(wb, "truncated", true);
     }
@@ -2676,6 +2818,15 @@ int web_api_v12_weights(BUFFER *wb, QUERY_WEIGHTS_REQUEST *qwr) {
         qwr->format != WEIGHTS_FORMAT_MCP)
         spread_results_evenly(qwd.results, &qwd.stats);
 
+    // Select only after complete scoring and normalization; parents keep full-query aggregates.
+    qwr->group_by.group_by &= ~(RRDR_GROUP_BY_LABEL|RRDR_GROUP_BY_SELECTED|RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE);
+    if(qwr->cardinality_limit && qwr->format != WEIGHTS_FORMAT_MCP &&
+       (qwr->format != WEIGHTS_FORMAT_MULTINODE || qwr->group_by.group_by == RRDR_GROUP_BY_NONE)) {
+        bool normalized = !(qwr->options & RRDR_OPTION_RETURN_RAW) && qwr->method != WEIGHTS_METHOD_VALUE;
+        WEIGHTS_RANKING ranking = weights_select_results(qwd.results, qwr->cardinality_limit, &normalized, true);
+        freez(ranking.items);
+    }
+
     usec_t ended_usec = qwd.timings.executed_ut = now_monotonic_usec();
 
     // generate the json output we need
@@ -2691,7 +2842,7 @@ int web_api_v12_weights(BUFFER *wb, QUERY_WEIGHTS_REQUEST *qwr) {
                             qwr->baseline_after, qwr->baseline_before,
                             qwr->points, qwr->method, qwr->time_group_method, qwr->options, qwd.shifts,
                             qwd.examined_dimensions,
-                            ended_usec - qwd.timings.received_ut, &qwd.stats);
+                            ended_usec - qwd.timings.received_ut, &qwd.stats, qwr->cardinality_limit);
             break;
 
         case WEIGHTS_FORMAT_CONTEXTS:
@@ -2702,7 +2853,7 @@ int web_api_v12_weights(BUFFER *wb, QUERY_WEIGHTS_REQUEST *qwr) {
                             qwr->baseline_after, qwr->baseline_before,
                             qwr->points, qwr->method, qwr->time_group_method, qwr->options, qwd.shifts,
                             qwd.examined_dimensions,
-                            ended_usec - qwd.timings.received_ut, &qwd.stats);
+                            ended_usec - qwd.timings.received_ut, &qwd.stats, qwr->cardinality_limit);
             break;
 
         case WEIGHTS_FORMAT_MCP:
@@ -2718,8 +2869,6 @@ int web_api_v12_weights(BUFFER *wb, QUERY_WEIGHTS_REQUEST *qwr) {
 
         default:
         case WEIGHTS_FORMAT_MULTINODE:
-            // we don't support these groupings in weights
-            qwr->group_by.group_by &= ~(RRDR_GROUP_BY_LABEL|RRDR_GROUP_BY_SELECTED|RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE);
             if(qwr->group_by.group_by == RRDR_GROUP_BY_NONE) {
                 added_dimensions =
                         registered_results_to_json_multinode_no_group_by(

--- a/src/web/api/v2/api_v2_weights.c
+++ b/src/web/api/v2/api_v2_weights.c
@@ -2,6 +2,19 @@
 
 #include "api_v2_calls.h"
 
+static bool weights_parse_limit(const char *value, size_t *result) {
+    size_t n = 0;
+    if(!*value)
+        return false;
+    for(const char *p = value; *p; p++) {
+        if(*p < '0' || *p > '9' || n > (SIZE_MAX - (size_t)(*p - '0')) / 10)
+            return false;
+        n = n * 10 + (size_t)(*p - '0');
+    }
+    *result = n;
+    return true;
+}
+
 int web_client_api_request_weights(RRDHOST *host, struct web_client *w, char *url, WEIGHTS_METHOD method, WEIGHTS_FORMAT format, size_t api_version) {
     if (!netdata_ready_load())
         return HTTP_RESP_SERVICE_UNAVAILABLE;
@@ -13,6 +26,8 @@ int web_client_api_request_weights(RRDHOST *host, struct web_client *w, char *ur
     time_t timeout_ms = 0;
     size_t tier = 0;
     size_t cardinality_limit = 0;
+    size_t limit = 0;
+    bool cardinality_limit_supplied = false;
     const char *time_group_options = NULL, *scope_contexts = NULL, *scope_nodes = NULL, *scope_instances = NULL, *scope_labels = NULL, *scope_dimensions = NULL,
                *contexts = NULL, *nodes = NULL, *instances = NULL, *dimensions = NULL, *labels = NULL, *alerts = NULL;
 
@@ -51,8 +66,21 @@ int web_client_api_request_weights(RRDHOST *host, struct web_client *w, char *ur
         else if (!strcmp(name, "timeout"))
             timeout_ms = str2l(value);
             
-        else if (!strcmp(name, "cardinality_limit"))
-            cardinality_limit = str2ul(value);
+        else if (!strcmp(name, "cardinality_limit") || !strcmp(name, "limit")) {
+            size_t parsed;
+            if(!weights_parse_limit(value, &parsed)) {
+                buffer_flush(w->response.data);
+                w->response.data->content_type = CT_APPLICATION_JSON;
+                buffer_strcat(w->response.data, "{\"error\":\"Weights limits must be nonnegative integers within the supported range.\"}");
+                return HTTP_RESP_BAD_REQUEST;
+            }
+            if(!strcmp(name, "cardinality_limit")) {
+                cardinality_limit = parsed;
+                cardinality_limit_supplied = true;
+            }
+            else
+                limit = parsed;
+        }
 
         else if((api_version == 1 && !strcmp(name, "group")) || (api_version >= 2 && !strcmp(name, "time_group")))
             time_group_method = time_grouping_parse(value, RRDR_GROUPING_AVERAGE);
@@ -147,7 +175,7 @@ int web_client_api_request_weights(RRDHOST *host, struct web_client *w, char *ur
         .options = options,
         .tier = tier,
         .timeout_ms = timeout_ms,
-        .cardinality_limit = cardinality_limit,
+        .cardinality_limit = cardinality_limit_supplied ? cardinality_limit : limit,
 
         .interrupt_callback = web_client_interrupt_callback,
         .interrupt_callback_data = w,

--- a/tests/query-corpus/MANIFEST.md
+++ b/tests/query-corpus/MANIFEST.md
@@ -271,8 +271,8 @@ set at the end.
 | W/limit-aliases | weights limit and cardinality_limit select the strongest physical dimensions with explicit cardinality_limit precedence | n/a |  |
 | W/limit-boundaries | weights omitted and zero caps preserve unlimited shape while exact and above-population caps report no truncation | n/a |  |
 | W/limit-invalid | weights HTTP endpoints reject malformed or overflowing supplied limits | n/a |  |
-| W/limit-ranking | limited weights retain the strongest entries and their complete-population raw or normalized score vectors | n/a |  |
-| W/limit-summaries | limited weights preserve complete-query parent summary vectors and full correlated and examined counts | n/a |  |
+| W/limit-ranking | limited weights retain the strongest entries and their complete-population raw or normalized score vectors; value, volume, ks2 and anomaly-rate must each run with raw enabled and disabled, and with anomaly-bit enabled and disabled | n/a |  |
+| W/limit-summaries | limited weights preserve complete-query parent summary vectors and full correlated and examined counts; value, volume, ks2 and anomaly-rate must each run with raw enabled and disabled, and with anomaly-bit enabled and disabled | n/a |  |
 | W/limit-legacy | legacy weights and metric_correlations formats honor result limits without changing full population counts | n/a |  |
 | W/limit-grouped | weights group limits select complete final group objects by the requested aggregate without changing their vectors | n/a |  |
 | W/limit-complete-groups | weights limits rank multi-dimension groups by the requested raw or normalized aggregate after complete aggregation | n/a |  |

--- a/tests/query-corpus/MANIFEST.md
+++ b/tests/query-corpus/MANIFEST.md
@@ -268,6 +268,18 @@ set at the end.
 | L8/null2zero-post-processing | options=null2zero converts gap cells to numeric zero without altering non-gap values | n/a |  |
 | L8/nonzero-all-zero | nonzero filtering self-neutralizes when every selected dimension is all-zero so the result is not emptied | n/a |  |
 | L8/cardinality-limit | cardinality limiting keeps the top N-1 dimensions by absolute view sum and folds every remaining per-row value into one named remainder column | n/a |  |
+| W/limit-aliases | weights limit and cardinality_limit select the strongest physical dimensions with explicit cardinality_limit precedence | n/a |  |
+| W/limit-boundaries | weights omitted and zero caps preserve unlimited shape while exact and above-population caps report no truncation | n/a |  |
+| W/limit-invalid | weights HTTP endpoints reject malformed or overflowing supplied limits | n/a |  |
+| W/limit-ranking | limited weights retain the strongest entries and their complete-population raw or normalized score vectors | n/a |  |
+| W/limit-summaries | limited weights preserve complete-query parent summary vectors and full correlated and examined counts | n/a |  |
+| W/limit-legacy | legacy weights and metric_correlations formats honor result limits without changing full population counts | n/a |  |
+| W/limit-grouped | weights group limits select complete final group objects by the requested aggregate without changing their vectors | n/a |  |
+| W/limit-complete-groups | weights limits rank multi-dimension groups by the requested raw or normalized aggregate after complete aggregation | n/a |  |
+| W/limit-thousand | a weights cap of 1000 retains exactly the strongest 1000 of 1005 physical metrics while preserving complete parent means | n/a |  |
+| W/limit-hierarchy | weights limiting preserves complete shared ancestors and emits only dictionaries and ancestor rows reachable from retained metrics | n/a |  |
+| W/limit-node-ties | equal weights select physical metrics by stable node and metric identity while retaining metadata for nodes without selected metrics | n/a |  |
+| W/limit-mcp | MCP weights preserve caller default and minimum limits and descending raw scores while reporting exact-boundary truncation truthfully | n/a |  |
 
 ## Corpus-wide pusher discipline
 

--- a/tests/query-corpus/harness_config.go
+++ b/tests/query-corpus/harness_config.go
@@ -53,6 +53,7 @@ var daemonFreeTests = map[string]struct{}{
 	"TestResolveCorpusPathsValidatesOneDeclaredEngine":            {},
 	"TestStrictDimensionStatsGuards":                              {},
 	"TestWeightsExpectedIDsExactlyOnce":                           {},
+	"TestWeightsLimitContractsRequireEveryMethodOptions":          {},
 	"TestWeightsTimeframeStatsRequireFiniteNumbers":               {},
 	"TestWeightsValueMultiNodeGuards":                             {},
 }

--- a/tests/query-corpus/manifest.json
+++ b/tests/query-corpus/manifest.json
@@ -1167,11 +1167,47 @@
   },
   {
     "name": "W/limit-ranking",
-    "proves": "limited weights retain the strongest entries and their complete-population raw or normalized score vectors"
+    "proves": "limited weights retain the strongest entries and their complete-population raw or normalized score vectors; value, volume, ks2 and anomaly-rate must each run with raw enabled and disabled, and with anomaly-bit enabled and disabled",
+    "components": [
+      "value/raw",
+      "value/null2zero",
+      "value/raw|anomaly-bit",
+      "value/null2zero|anomaly-bit",
+      "volume/raw",
+      "volume/null2zero",
+      "volume/raw|anomaly-bit",
+      "volume/null2zero|anomaly-bit",
+      "ks2/raw",
+      "ks2/null2zero",
+      "ks2/raw|anomaly-bit",
+      "ks2/null2zero|anomaly-bit",
+      "anomaly-rate/raw",
+      "anomaly-rate/null2zero",
+      "anomaly-rate/raw|anomaly-bit",
+      "anomaly-rate/null2zero|anomaly-bit"
+    ]
   },
   {
     "name": "W/limit-summaries",
-    "proves": "limited weights preserve complete-query parent summary vectors and full correlated and examined counts"
+    "proves": "limited weights preserve complete-query parent summary vectors and full correlated and examined counts; value, volume, ks2 and anomaly-rate must each run with raw enabled and disabled, and with anomaly-bit enabled and disabled",
+    "components": [
+      "value/raw",
+      "value/null2zero",
+      "value/raw|anomaly-bit",
+      "value/null2zero|anomaly-bit",
+      "volume/raw",
+      "volume/null2zero",
+      "volume/raw|anomaly-bit",
+      "volume/null2zero|anomaly-bit",
+      "ks2/raw",
+      "ks2/null2zero",
+      "ks2/raw|anomaly-bit",
+      "ks2/null2zero|anomaly-bit",
+      "anomaly-rate/raw",
+      "anomaly-rate/null2zero",
+      "anomaly-rate/raw|anomaly-bit",
+      "anomaly-rate/null2zero|anomaly-bit"
+    ]
   },
   {
     "name": "W/limit-legacy",

--- a/tests/query-corpus/manifest.json
+++ b/tests/query-corpus/manifest.json
@@ -1152,5 +1152,53 @@
   {
     "name": "L8/cardinality-limit",
     "proves": "cardinality limiting keeps the top N-1 dimensions by absolute view sum and folds every remaining per-row value into one named remainder column"
+  },
+  {
+    "name": "W/limit-aliases",
+    "proves": "weights limit and cardinality_limit select the strongest physical dimensions with explicit cardinality_limit precedence"
+  },
+  {
+    "name": "W/limit-boundaries",
+    "proves": "weights omitted and zero caps preserve unlimited shape while exact and above-population caps report no truncation"
+  },
+  {
+    "name": "W/limit-invalid",
+    "proves": "weights HTTP endpoints reject malformed or overflowing supplied limits"
+  },
+  {
+    "name": "W/limit-ranking",
+    "proves": "limited weights retain the strongest entries and their complete-population raw or normalized score vectors"
+  },
+  {
+    "name": "W/limit-summaries",
+    "proves": "limited weights preserve complete-query parent summary vectors and full correlated and examined counts"
+  },
+  {
+    "name": "W/limit-legacy",
+    "proves": "legacy weights and metric_correlations formats honor result limits without changing full population counts"
+  },
+  {
+    "name": "W/limit-grouped",
+    "proves": "weights group limits select complete final group objects by the requested aggregate without changing their vectors"
+  },
+  {
+    "name": "W/limit-complete-groups",
+    "proves": "weights limits rank multi-dimension groups by the requested raw or normalized aggregate after complete aggregation"
+  },
+  {
+    "name": "W/limit-thousand",
+    "proves": "a weights cap of 1000 retains exactly the strongest 1000 of 1005 physical metrics while preserving complete parent means"
+  },
+  {
+    "name": "W/limit-hierarchy",
+    "proves": "weights limiting preserves complete shared ancestors and emits only dictionaries and ancestor rows reachable from retained metrics"
+  },
+  {
+    "name": "W/limit-node-ties",
+    "proves": "equal weights select physical metrics by stable node and metric identity while retaining metadata for nodes without selected metrics"
+  },
+  {
+    "name": "W/limit-mcp",
+    "proves": "MCP weights preserve caller default and minimum limits and descending raw scores while reporting exact-boundary truncation truthfully"
   }
 ]

--- a/tests/query-corpus/manifest_tracker_test.go
+++ b/tests/query-corpus/manifest_tracker_test.go
@@ -189,3 +189,27 @@ func TestManifestComponentsAreValid(t *testing.T) {
 		}
 	}
 }
+
+func TestWeightsLimitContractsRequireEveryMethodOptions(t *testing.T) {
+	for _, name := range []string{"W/limit-ranking", "W/limit-summaries"} {
+		for _, method := range []string{"value", "volume", "ks2", "anomaly-rate"} {
+			for _, options := range []string{"raw", "null2zero", "raw|anomaly-bit", "null2zero|anomaly-bit"} {
+				missing := method + "/" + options
+				t.Run(name+"/"+missing, func(t *testing.T) {
+					ledger := newContractLedger()
+					for _, component := range requiredContractComponents(manifest[name]) {
+						if component != missing {
+							ledger.record(name, component, true, false)
+						}
+					}
+					summary := ledger.summarize(map[string]ManifestCase{name: manifest[name]})
+					want := []string{name + "/" + missing}
+					if summary.evaluated != 0 || !reflect.DeepEqual(summary.incomplete, want) {
+						t.Fatalf("omitted %s: evaluated=%d incomplete=%v, want 0/%v",
+							missing, summary.evaluated, summary.incomplete, want)
+					}
+				})
+			}
+		}
+	}
+}

--- a/tests/query-corpus/weights_limit_test.go
+++ b/tests/query-corpus/weights_limit_test.go
@@ -394,7 +394,9 @@ func TestWeightsLimitCompleteGroups(t *testing.T) {
 		weightsLimitChart("fixture.limitc", "fixture.limit-other", []int{40, 40, 40, 40}, true),
 	}
 	c020PushCharts(t, "weights-limit-groups", guid(450), charts...)
-	weightsSettle(t, "weights-limit-groups", guid(450), charts[0])
+	for _, ch := range charts {
+		weightsSettle(t, "weights-limit-groups", guid(450), ch)
+	}
 	for _, options := range []string{"raw", "null2zero"} {
 		for aggregation, rawWinner := range map[string]string{"min": "b", "average": "b", "max": "a", "sum": "c", "percentage": "c", "extremes": "a"} {
 			t.Run(options+"/"+aggregation, func(t *testing.T) {
@@ -505,7 +507,9 @@ func TestWeightsLimitHierarchy(t *testing.T) {
 		weightsLimitChart("fixture.limith-c", "fixture.limith-other", []int{3, 80}, false),
 	}
 	c020PushCharts(t, "weights-limit-hierarchy", guid(452), charts...)
-	weightsSettle(t, "weights-limit-hierarchy", guid(452), charts[0])
+	for _, ch := range charts {
+		weightsSettle(t, "weights-limit-hierarchy", guid(452), ch)
+	}
 	p := weightsLimitFixtureParams("value", "raw")
 	p.Set("scope_nodes", guid(452))
 	full, err := td.HostJSON("weights-limit-hierarchy", "api/v3/weights", p)

--- a/tests/query-corpus/weights_limit_test.go
+++ b/tests/query-corpus/weights_limit_test.go
@@ -201,6 +201,9 @@ func TestWeightsLimitScoresAndSummaries(t *testing.T) {
 	for _, method := range []string{"value", "volume", "ks2", "anomaly-rate"} {
 		for _, options := range []string{"raw", "null2zero", "raw|anomaly-bit", "null2zero|anomaly-bit"} {
 			t.Run(method+"/"+options, func(t *testing.T) {
+				component := method + "/" + options
+				registerContractComponent(t, "W/limit-ranking", component)
+				registerContractComponent(t, "W/limit-summaries", component)
 				p := weightsLimitParams(method, options)
 				full, err := td.HostJSON("weights-h", "api/v3/weights", p)
 				if err != nil {
@@ -213,7 +216,7 @@ func TestWeightsLimitScoresAndSummaries(t *testing.T) {
 				}
 				all, kept := weightsLimitRows(t, full), weightsLimitRows(t, limited)
 				t.Run("ranking", func(t *testing.T) {
-					trackContract(t, "W/limit-ranking")
+					trackContractComponent(t, "W/limit-ranking", component)
 					ids := make([]string, 0, len(all))
 					for id := range all {
 						ids = append(ids, id)
@@ -248,7 +251,7 @@ func TestWeightsLimitScoresAndSummaries(t *testing.T) {
 					weightsAssertLimit(t, limited, 1, len(all), want, "dimensions")
 				})
 				t.Run("summaries", func(t *testing.T) {
-					trackContract(t, "W/limit-summaries")
+					trackContractComponent(t, "W/limit-summaries", component)
 					parents := map[float64][]any{}
 					for _, entry := range full["result"].([]any) {
 						r := entry.([]any)

--- a/tests/query-corpus/weights_limit_test.go
+++ b/tests/query-corpus/weights_limit_test.go
@@ -1,0 +1,673 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package corpus
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/netdata/netdata/tests/query-corpus/fixture"
+	"github.com/netdata/netdata/tests/query-corpus/stream"
+)
+
+func weightsLimitParams(method, options string) url.Values {
+	p := weightsV1Params(method, wContext, options, true)
+	p.Set("scope_contexts", wContext)
+	return p
+}
+
+func weightsLimitRows(t *testing.T, doc map[string]any) map[string][]any {
+	t.Helper()
+	dicts, err := decodeWeightsMultiNodeDictionaries(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dicts
+	d := doc["dictionaries"].(map[string]any)
+	ids := map[int]string{}
+	for _, entry := range d["dimensions"].([]any) {
+		x := entry.(map[string]any)
+		ids[int(x["di"].(float64))] = x["id"].(string)
+	}
+	rows := map[string][]any{}
+	for _, entry := range doc["result"].([]any) {
+		r := entry.([]any)
+		if r[0].(float64) != 0 {
+			continue
+		}
+		id, ok := ids[int(r[4].(float64))]
+		if !ok {
+			t.Fatalf("dimension index has no dictionary entry: %v", r)
+		}
+		if _, exists := rows[id]; exists {
+			t.Fatalf("duplicate dimension %q", id)
+		}
+		rows[id] = r
+	}
+	return rows
+}
+
+func weightsAssertLimit(t *testing.T, doc map[string]any, limit, total, returned int, unit string) {
+	t.Helper()
+	want := map[string]any{"limit": float64(limit), "total": float64(total), "returned": float64(returned),
+		"unit": unit, "truncated": total > returned, "summary_scope": "all"}
+	if !reflect.DeepEqual(doc["result_limit"], want) {
+		t.Errorf("result_limit=%v, want %v", doc["result_limit"], want)
+	}
+}
+
+func TestWeightsLimitAliases(t *testing.T) {
+	weightsSettle(t, "weights-h", guid(160), weightsFixture())
+	for name, aliases := range map[string]url.Values{
+		"limit": {"limit": {"2"}}, "cardinality": {"cardinality_limit": {"2"}},
+		"precedence":           {"limit": {"1"}, "cardinality_limit": {"2"}},
+		"repeated":             {"limit": {"1", "2"}},
+		"repeated-cardinality": {"cardinality_limit": {"1", "2"}},
+		"empty-cardinality":    {"limit": {"2"}, "cardinality_limit": {""}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			trackContract(t, "W/limit-aliases")
+			p := weightsLimitParams("value", "raw")
+			for k, v := range aliases {
+				p[k] = v
+			}
+			doc, err := td.HostJSON("weights-h", "api/v3/weights", p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rows := weightsLimitRows(t, doc)
+			if len(rows) != 2 || rows["split"] == nil || rows["flat"] == nil {
+				t.Errorf("retained %v; want split and flat", rows)
+			}
+			weightsAssertLimit(t, doc, 2, 4, 2, "dimensions")
+		})
+	}
+}
+
+func TestWeightsLimitBoundaries(t *testing.T) {
+	weightsSettle(t, "weights-h", guid(160), weightsFixture())
+	for name, extra := range map[string]url.Values{
+		"absent": {}, "zero": {"limit": {"0"}}, "empty": {"limit": {""}},
+		"zero-precedence": {"limit": {"1"}, "cardinality_limit": {"0"}},
+		"exact":           {"limit": {"4"}}, "above": {"limit": {"5"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			trackContract(t, "W/limit-boundaries")
+			p := weightsLimitParams("value", "raw")
+			for k, v := range extra {
+				p[k] = v
+			}
+			doc, err := td.HostJSON("weights-h", "api/v2/weights", p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(weightsLimitRows(t, doc)) != 4 {
+				t.Error("unlimited/exact request lost dimensions")
+			}
+			if name == "exact" || name == "above" {
+				n, _ := strconv.Atoi(p.Get("limit"))
+				weightsAssertLimit(t, doc, n, 4, 4, "dimensions")
+			} else if _, ok := doc["result_limit"]; ok {
+				t.Error("unlimited request changed response shape")
+			}
+		})
+	}
+	t.Run("size-max", func(t *testing.T) {
+		trackContract(t, "W/limit-boundaries")
+		p := weightsLimitParams("value", "raw")
+		p.Set("limit", strconv.FormatUint(uint64(^uint(0)), 10))
+		doc, err := td.HostJSON("weights-h", "api/v3/weights", p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(weightsLimitRows(t, doc)) != 4 {
+			t.Error("large cap lost dimensions")
+		}
+		meta, ok := doc["result_limit"].(map[string]any)
+		if !ok {
+			t.Fatal("positive cap omitted result_limit metadata")
+		}
+		if meta["truncated"] != false || meta["returned"] != float64(4) {
+			t.Errorf("large cap metadata %v", meta)
+		}
+	})
+	for _, group := range []string{"", "dimension"} {
+		t.Run("empty-"+group, func(t *testing.T) {
+			trackContract(t, "W/limit-boundaries")
+			p := weightsLimitParams("value", "raw")
+			p.Set("scope_contexts", "fixture.no-such-weights-context")
+			p.Set("limit", "1")
+			p.Set("group_by", group)
+			doc, err := td.HostJSON("weights-h", "api/v3/weights", p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			unit := "dimensions"
+			if group != "" {
+				unit = "groups"
+			}
+			weightsAssertLimit(t, doc, 1, 0, 0, unit)
+		})
+	}
+}
+
+func TestWeightsLimitInvalid(t *testing.T) {
+	weightsSettle(t, "weights-h", guid(160), weightsFixture())
+	for _, endpoint := range []string{"api/v1/weights", "api/v1/metric_correlations", "api/v2/weights", "api/v3/weights"} {
+		for _, alias := range []string{"limit", "cardinality_limit"} {
+			for _, value := range []string{"-1", "1.5", "1junk", "junk", "18446744073709551616", " 2", "+2"} {
+				t.Run(endpoint+"/"+alias+"/"+value, func(t *testing.T) {
+					trackContract(t, "W/limit-invalid")
+					p := weightsLimitParams("value", "raw")
+					p.Set(alias, value)
+					_, err := td.HostJSON("weights-h", endpoint, p)
+					if err == nil || !strings.Contains(err.Error(), "HTTP 400") {
+						t.Errorf("want HTTP 400, got %v", err)
+					}
+				})
+			}
+		}
+	}
+	for _, aliases := range []url.Values{
+		{"limit": {"bad", "1"}}, {"cardinality_limit": {"bad", "1"}},
+		{"limit": {"bad"}, "cardinality_limit": {"1"}},
+		{"limit": {"1"}, "cardinality_limit": {"bad"}},
+	} {
+		t.Run(aliases.Encode(), func(t *testing.T) {
+			trackContract(t, "W/limit-invalid")
+			p := weightsLimitParams("value", "raw")
+			for k, v := range aliases {
+				p[k] = v
+			}
+			_, err := td.HostJSON("weights-h", "api/v3/weights", p)
+			if err == nil || !strings.Contains(err.Error(), "HTTP 400") {
+				t.Errorf("invalid supplied alias accepted: %v", err)
+			}
+		})
+	}
+}
+
+func TestWeightsLimitScoresAndSummaries(t *testing.T) {
+	weightsSettle(t, "weights-h", guid(160), weightsFixture())
+	for _, method := range []string{"value", "volume", "ks2", "anomaly-rate"} {
+		for _, options := range []string{"raw", "null2zero", "raw|anomaly-bit", "null2zero|anomaly-bit"} {
+			t.Run(method+"/"+options, func(t *testing.T) {
+				p := weightsLimitParams(method, options)
+				full, err := td.HostJSON("weights-h", "api/v3/weights", p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				p.Set("limit", "1")
+				limited, err := td.HostJSON("weights-h", "api/v3/weights", p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				all, kept := weightsLimitRows(t, full), weightsLimitRows(t, limited)
+				t.Run("ranking", func(t *testing.T) {
+					trackContract(t, "W/limit-ranking")
+					ids := make([]string, 0, len(all))
+					for id := range all {
+						ids = append(ids, id)
+					}
+					desc := strings.Contains(options, "raw") || method == "value"
+					sort.Slice(ids, func(i, j int) bool {
+						a, b := all[ids[i]][5].(float64), all[ids[j]][5].(float64)
+						if a == b {
+							return ids[i] < ids[j]
+						}
+						if desc {
+							return a > b
+						}
+						return a < b
+					})
+					want := 0
+					if len(ids) > 0 {
+						want = 1
+					}
+					if len(kept) != want {
+						t.Fatalf("kept %d, want %d", len(kept), want)
+					}
+					if want > 0 {
+						// Class C: the JSON formatter rounds scores, so identical printed
+						// values do not imply an internal tie. Exact ties have their own fixture.
+						for id, r := range kept {
+							if r[5] != all[ids[0]][5] || !reflect.DeepEqual(r[5:], all[id][5:]) {
+								t.Errorf("strongest score/vector not preserved: %v", kept)
+							}
+						}
+					}
+					weightsAssertLimit(t, limited, 1, len(all), want, "dimensions")
+				})
+				t.Run("summaries", func(t *testing.T) {
+					trackContract(t, "W/limit-summaries")
+					parents := map[float64][]any{}
+					for _, entry := range full["result"].([]any) {
+						r := entry.([]any)
+						if r[0].(float64) != 0 {
+							parents[r[0].(float64)] = r[5:]
+						}
+					}
+					for _, entry := range limited["result"].([]any) {
+						r := entry.([]any)
+						if r[0].(float64) != 0 && !reflect.DeepEqual(r[5:], parents[r[0].(float64)]) {
+							t.Errorf("parent value changed: %v", r)
+						}
+					}
+					for _, key := range []string{"correlated_dimensions", "total_dimensions_count"} {
+						if !reflect.DeepEqual(limited[key], full[key]) {
+							t.Errorf("%s changed", key)
+						}
+					}
+				})
+			})
+		}
+	}
+}
+
+func TestWeightsLimitLegacy(t *testing.T) {
+	weightsSettle(t, "weights-h", guid(160), weightsFixture())
+	for _, endpoint := range []string{"api/v1/weights", "api/v1/metric_correlations"} {
+		for _, alias := range []string{"limit", "cardinality_limit"} {
+			t.Run(endpoint+"/"+alias, func(t *testing.T) {
+				trackContract(t, "W/limit-legacy")
+				p := weightsLimitParams("value", "raw")
+				p.Set(alias, "1")
+				doc, err := td.HostJSON("weights-h", endpoint, p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var got map[string]float64
+				if endpoint == "api/v1/weights" {
+					got = v1ContextsWeights(t, doc, wContext)
+				} else {
+					got = map[string]float64{}
+					for _, entry := range doc["correlated_charts"].(map[string]any) {
+						for k, v := range entry.(map[string]any)["dimensions"].(map[string]any) {
+							got[k] = v.(float64)
+						}
+					}
+				}
+				// buffer.h:print_netdata_double rounds to seven fractional digits.
+				if len(got) != 1 || math.Abs(got["split"]-weightsHighlightAverages()["split"]) > 5e-8 {
+					t.Errorf("got %v, want strongest split", got)
+				}
+				weightsAssertLimit(t, doc, 1, 4, 1, "dimensions")
+				if doc["correlated_dimensions"] != float64(4) {
+					t.Error("pre-limit correlated population lost")
+				}
+			})
+		}
+	}
+}
+
+func TestWeightsLimitGrouped(t *testing.T) {
+	weightsSettle(t, "weights-h", guid(160), weightsFixture())
+	for _, aggregation := range []string{"min", "average", "max", "sum", "percentage", "extremes"} {
+		t.Run(aggregation, func(t *testing.T) {
+			trackContract(t, "W/limit-grouped")
+			p := weightsLimitParams("value", "raw")
+			p.Set("group_by", "dimension")
+			p.Set("aggregation", aggregation)
+			full, err := td.HostJSON("weights-h", "api/v3/weights", p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p.Set("limit", "1")
+			doc, err := td.HostJSON("weights-h", "api/v3/weights", p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rows := doc["result"].([]any)
+			if len(rows) != 1 {
+				t.Fatalf("got %d groups, want 1", len(rows))
+			}
+			r := rows[0].(map[string]any)
+			if r["id"] != "split" {
+				t.Errorf("wrong group: %v", r)
+			}
+			for _, entry := range full["result"].([]any) {
+				old := entry.(map[string]any)
+				if old["id"] == r["id"] && !reflect.DeepEqual(old, r) {
+					t.Errorf("group vector changed: %v", r)
+				}
+			}
+			weightsAssertLimit(t, doc, 1, 4, 1, "groups")
+		})
+	}
+}
+
+func weightsLimitChart(id, context string, values []int, changing bool) fixture.Chart {
+	ch := fixture.Chart{ID: id, Context: context, Title: "weights limit", Units: "units", Family: "fixture", UpdateEvery: 1}
+	for d, value := range values {
+		dim := fixture.Dimension{ID: fmt.Sprintf("d%04d", d)}
+		for i := 1; i <= wRows; i++ {
+			v := value
+			if changing {
+				v = 10
+				if i > wSplit {
+					v = 10 * (value + 1)
+				}
+			}
+			dim.Points = append(dim.Points, fixture.Point{T: fixture.T0 + int64(i), Collected: strconv.Itoa(v), Flags: stream.FlagNotAnomalous})
+		}
+		ch.Dimensions = append(ch.Dimensions, dim)
+	}
+	return ch
+}
+
+func weightsLimitFixtureParams(method, options string) url.Values {
+	p := weightsLimitParams(method, options)
+	p.Set("context", "fixture.limit*")
+	p.Set("scope_contexts", "fixture.limit*")
+	return p
+}
+
+func weightsLimitExport(t *testing.T, name, endpoint string, params url.Values, doc map[string]any) {
+	t.Helper()
+	dir := os.Getenv("QUERY_CORPUS_WEIGHTS_EXPORT")
+	if dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.MarshalIndent(map[string]any{"endpoint": endpoint, "query": params.Encode(), "response": doc}, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWeightsLimitCompleteGroups(t *testing.T) {
+	charts := []fixture.Chart{
+		weightsLimitChart("fixture.limita", "fixture.limit", []int{1, 100}, true),
+		weightsLimitChart("fixture.limitb", "fixture.limit", []int{60, 60}, true),
+		weightsLimitChart("fixture.limitc", "fixture.limit-other", []int{40, 40, 40, 40}, true),
+	}
+	c020PushCharts(t, "weights-limit-groups", guid(450), charts...)
+	weightsSettle(t, "weights-limit-groups", guid(450), charts[0])
+	for _, options := range []string{"raw", "null2zero"} {
+		for aggregation, rawWinner := range map[string]string{"min": "b", "average": "b", "max": "a", "sum": "c", "percentage": "c", "extremes": "a"} {
+			t.Run(options+"/"+aggregation, func(t *testing.T) {
+				trackContract(t, "W/limit-complete-groups")
+				p := weightsLimitFixtureParams("volume", options)
+				p.Set("group_by", "instance")
+				p.Set("aggregation", aggregation)
+				full, err := td.HostJSON("weights-limit-groups", "api/v3/weights", p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				weightsLimitExport(t, "group-"+options+"-"+aggregation+"-full", "api/v3/weights", p, full)
+				p.Set("limit", "1")
+				limited, err := td.HostJSON("weights-limit-groups", "api/v3/weights", p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				weightsLimitExport(t, "group-"+options+"-"+aggregation+"-limited", "api/v3/weights", p, limited)
+				rows := limited["result"].([]any)
+				if len(rows) != 1 {
+					t.Fatalf("got %d groups", len(rows))
+				}
+				winner := rawWinner
+				if options != "raw" {
+					winner = "b"
+					if aggregation == "min" {
+						winner = "a"
+					}
+				}
+				row := rows[0].(map[string]any)
+				if !strings.HasPrefix(row["id"].(string), "fixture.limit"+winner+"@") {
+					t.Errorf("winner=%v, want %s", row["id"], winner)
+				}
+				for _, entry := range full["result"].([]any) {
+					old := entry.(map[string]any)
+					if old["id"] == row["id"] && !reflect.DeepEqual(old, row) {
+						t.Error("complete group vector changed")
+					}
+				}
+				weightsAssertLimit(t, limited, 1, 3, 1, "groups")
+			})
+		}
+	}
+	for _, method := range []string{"volume", "value"} {
+		for _, options := range []string{"raw", "null2zero"} {
+			for _, endpoint := range []string{"api/v3/weights", "api/v1/weights"} {
+				p := weightsLimitFixtureParams(method, options)
+				for _, suffix := range []string{"full", "limited"} {
+					if suffix == "limited" {
+						p.Set("limit", "1")
+					}
+					doc, err := td.HostJSON("weights-limit-groups", endpoint, p)
+					if err != nil {
+						t.Fatal(err)
+					}
+					weightsLimitExport(t, strings.ReplaceAll(endpoint, "/", "-")+"-"+method+"-"+options+"-"+suffix, endpoint, p, doc)
+				}
+			}
+		}
+	}
+}
+
+func TestWeightsLimitThousand(t *testing.T) {
+	trackContract(t, "W/limit-thousand")
+	values := make([]int, 1005)
+	for i := range values {
+		values[i] = i + 1
+	}
+	ch := weightsLimitChart("fixture.limit-thousand", "fixture.limit-thousand", values, false)
+	weightsSettle(t, "weights-limit-thousand", guid(451), ch)
+	p := weightsLimitFixtureParams("value", "raw")
+	p.Set("scope_contexts", ch.Context)
+	p.Set("limit", "1000")
+	doc, err := td.HostJSON("weights-limit-thousand", "api/v3/weights", p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := weightsLimitRows(t, doc)
+	if len(rows) != 1000 {
+		t.Fatalf("got %d dimensions", len(rows))
+	}
+	for i := 0; i < 1005; i++ {
+		_, ok := rows[fmt.Sprintf("d%04d", i)]
+		if ok != (i >= 5) {
+			t.Errorf("incorrect membership for dimension %d", i)
+		}
+	}
+	weightsAssertLimit(t, doc, 1000, 1005, 1000, "dimensions")
+	for _, entry := range doc["result"].([]any) {
+		row := entry.([]any)
+		if row[0].(float64) != 0 && row[5].(float64) != 503 {
+			t.Errorf("complete parent mean changed: %v", row[5])
+		}
+	}
+	weightsLimitExport(t, "thousand-limited", "api/v3/weights", p, doc)
+}
+
+// Class C parity of complete-query ancestor vectors is paired with Class A
+// fixture membership, dictionary reachability, and full population assertions.
+func TestWeightsLimitHierarchy(t *testing.T) {
+	trackContract(t, "W/limit-hierarchy")
+	charts := []fixture.Chart{
+		weightsLimitChart("fixture.limith-a", "fixture.limith", []int{1, 100}, false),
+		weightsLimitChart("fixture.limith-b", "fixture.limith", []int{2, 90}, false),
+		weightsLimitChart("fixture.limith-c", "fixture.limith-other", []int{3, 80}, false),
+	}
+	c020PushCharts(t, "weights-limit-hierarchy", guid(452), charts...)
+	weightsSettle(t, "weights-limit-hierarchy", guid(452), charts[0])
+	p := weightsLimitFixtureParams("value", "raw")
+	p.Set("scope_nodes", guid(452))
+	full, err := td.HostJSON("weights-limit-hierarchy", "api/v3/weights", p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decode := func(doc map[string]any) map[string][]any {
+		d, err := decodeWeightsMultiNodeDictionaries(doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := map[string][]any{}
+		for _, item := range doc["result"].([]any) {
+			r := item.([]any)
+			kind := int(r[0].(float64))
+			key := fmt.Sprint(kind)
+			if kind <= 2 {
+				key += "/" + d.contexts[int64(r[2].(float64))]["id"].(string)
+			}
+			if kind <= 1 {
+				key += "/" + d.instances[int64(r[3].(float64))]["id"].(string)
+			}
+			if kind == 0 {
+				key += "/" + d.dimensions[int64(r[4].(float64))]
+			}
+			if rows[key] != nil {
+				t.Fatalf("duplicate physical row %s", key)
+			}
+			rows[key] = r[5:]
+		}
+		return rows
+	}
+	all := decode(full)
+	for _, limit := range []int{1, 2, 3} {
+		p.Set("limit", strconv.Itoa(limit))
+		doc, err := td.HostJSON("weights-limit-hierarchy", "api/v3/weights", p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows := decode(doc)
+		for key, vector := range rows {
+			if !reflect.DeepEqual(vector, all[key]) {
+				t.Errorf("complete-query vector changed for %s", key)
+			}
+		}
+		dicts := doc["dictionaries"].(map[string]any)
+		wantContexts := 1
+		if limit == 3 {
+			wantContexts = 2
+		}
+		if len(dicts["dimensions"].([]any)) != 1 || len(dicts["instances"].([]any)) != limit || len(dicts["contexts"].([]any)) != wantContexts {
+			t.Errorf("unused metric dictionaries retained: %v", dicts)
+		}
+		if len(rows) != limit*2+wantContexts+1 {
+			t.Errorf("orphan/missing parent rows: %v", rows)
+		}
+		weightsAssertLimit(t, doc, limit, 6, limit, "dimensions")
+		if doc["correlated_dimensions"] != float64(6) {
+			t.Error("full population changed")
+		}
+	}
+}
+
+func TestWeightsLimitNodeTies(t *testing.T) {
+	trackContract(t, "W/limit-node-ties")
+	ch := weightsLimitChart("fixture.limittie", "fixture.limittie", []int{20, 20}, false)
+	// Reverse creation order and repeat the query: pointer/order ties must not win.
+	for _, n := range []int{454, 453} {
+		weightsSettle(t, fmt.Sprintf("weights-limit-tie-%d", n), guid(n), ch)
+	}
+	p := weightsLimitFixtureParams("value", "raw")
+	p.Set("scope_nodes", guid(453)+"|"+guid(454))
+	p.Set("scope_contexts", ch.Context)
+	p.Set("limit", "1")
+	for i := 0; i < 5; i++ {
+		doc, err := td.HostJSON("weights-limit-tie-453", "api/v3/weights", p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		d, err := decodeWeightsMultiNodeDictionaries(doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(d.nodes) != 2 {
+			t.Fatalf("node metadata lost: %v", d.nodes)
+		}
+		rows := weightsLimitRows(t, doc)
+		if len(rows) != 1 || rows["d0000"] == nil {
+			t.Fatalf("dimension tie selected %v", rows)
+		}
+		node := d.nodes[int64(rows["d0000"][1].(float64))]
+		if node["mg"] != guid(453) {
+			t.Errorf("node tie selected %v", node)
+		}
+		if len(doc["result"].([]any)) != 4 {
+			t.Error("unrelated node result row retained")
+		}
+		weightsAssertLimit(t, doc, 1, 4, 1, "dimensions")
+	}
+}
+
+func TestWeightsLimitMCP(t *testing.T) {
+	values := make([]int, 55)
+	for i := range values {
+		values[i] = i + 1
+	}
+	ch := weightsLimitChart("fixture.limitmcp", "fixture.limitmcp", values, true)
+	for d := range ch.Dimensions {
+		for i := wSplit; i < wSplit+d+1; i++ {
+			ch.Dimensions[d].Points[i].Flags = stream.FlagAnomalous
+		}
+	}
+	weightsSettle(t, "weights-limit-mcp", guid(455), ch)
+	init := c023MCPPost(t, 1, "initialize", map[string]any{
+		"protocolVersion": "2025-03-26", "capabilities": map[string]any{},
+		"clientInfo": map[string]any{"name": "query-corpus", "version": "1"},
+	}, "")
+	c023MCPNotify(t, "notifications/initialized", map[string]any{}, init.Session)
+	for _, cap := range []int{-1, 1, 30, 55, 60} {
+		t.Run(strconv.Itoa(cap), func(t *testing.T) {
+			trackContract(t, "W/limit-mcp")
+			args := map[string]any{
+				"nodes": []string{guid(455)}, "metrics": []string{ch.Context},
+				"after": fixture.T0 + wSplit, "before": fixture.T0 + wRows,
+				"baseline_after": fixture.T0, "baseline_before": fixture.T0 + wSplit,
+			}
+			if cap >= 0 {
+				args["cardinality_limit"] = cap
+			}
+			response := c023MCPPost(t, cap+100, "tools/call", map[string]any{
+				"name": "find_anomalous_metrics", "arguments": args,
+			}, init.Session)
+			doc := c023MCPQueryDocument(t, response.Document)
+			rows := doc["results"].([]any)
+			want := cap
+			if cap == -1 {
+				want = 50
+			} else if cap < 30 {
+				want = 30
+			} else if cap > 55 {
+				want = 55
+			}
+			if len(rows) != want {
+				t.Fatalf("MCP returned %d, want %d", len(rows), want)
+			}
+			for i, entry := range rows {
+				row := entry.([]any)
+				if row[9] != fmt.Sprintf("d%04d", 54-i) {
+					t.Errorf("MCP order %v", row)
+				}
+				// First-principles anomaly count, including the normal left-edge sample.
+				if math.Abs(row[0].(float64)-float64(55-i)*100/121) > 5e-8 {
+					t.Errorf("MCP anomaly percentage was altered: %v", row[0])
+				}
+			}
+			meta := doc["metadata"].(map[string]any)
+			if meta["total_time_series_analyzed"] != float64(55) || meta["total_time_series_returned"] != float64(want) {
+				t.Errorf("MCP counts %v", meta)
+			}
+			truncated, _ := meta["truncated"].(bool)
+			if truncated != (want < 55) {
+				t.Errorf("MCP truncation %v", meta)
+			}
+		})
+	}
+}

--- a/tests/query-corpus/weights_limit_test.go
+++ b/tests/query-corpus/weights_limit_test.go
@@ -440,6 +440,9 @@ func TestWeightsLimitCompleteGroups(t *testing.T) {
 			})
 		}
 	}
+	if os.Getenv("QUERY_CORPUS_WEIGHTS_EXPORT") == "" {
+		return
+	}
 	for _, method := range []string{"volume", "value"} {
 		for _, options := range []string{"raw", "null2zero"} {
 			for _, endpoint := range []string{"api/v3/weights", "api/v1/weights"} {

--- a/tests/query-corpus/weights_limit_test.go
+++ b/tests/query-corpus/weights_limit_test.go
@@ -31,20 +31,13 @@ func weightsLimitRows(t *testing.T, doc map[string]any) map[string][]any {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = dicts
-	d := doc["dictionaries"].(map[string]any)
-	ids := map[int]string{}
-	for _, entry := range d["dimensions"].([]any) {
-		x := entry.(map[string]any)
-		ids[int(x["di"].(float64))] = x["id"].(string)
-	}
 	rows := map[string][]any{}
 	for _, entry := range doc["result"].([]any) {
 		r := entry.([]any)
 		if r[0].(float64) != 0 {
 			continue
 		}
-		id, ok := ids[int(r[4].(float64))]
+		id, ok := dicts.dimensions[int64(r[4].(float64))]
 		if !ok {
 			t.Fatalf("dimension index has no dictionary entry: %v", r)
 		}
@@ -252,6 +245,8 @@ func TestWeightsLimitScoresAndSummaries(t *testing.T) {
 				})
 				t.Run("summaries", func(t *testing.T) {
 					trackContractComponent(t, "W/limit-summaries", component)
+					// This fixture has one chart; TestWeightsLimitHierarchy checks
+					// sibling parents by semantic identity across dictionary compaction.
 					parents := map[float64][]any{}
 					for _, entry := range full["result"].([]any) {
 						r := entry.([]any)

--- a/tests/weights-limit/README.md
+++ b/tests/weights-limit/README.md
@@ -1,5 +1,21 @@
 # Weights result selection tests
 
+The OpenAPI alias regression requires Python 3 and PyYAML. Run from the
+repository root:
+
+```sh
+python3 tests/weights-limit/weights-openapi-test.py
+```
+
+It checks both schema representations and all four weights endpoint references.
+Optional aliases must not supply defaults for unchosen fields: a generated
+`limit=1000&cardinality_limit=0` request is unlimited because the explicit
+cardinality alias takes precedence. The checks preserve caller-supplied zero
+and empty values, optionality, and the nonnegative integer constraint. This is
+a schema regression; it does not emulate Swagger UI rendering or the HTTP
+parser. Changes to request generation should also be checked against the
+interactive explorer's Swagger UI bundle in `netdata/learn`.
+
 The standalone C test checks the bounded candidate heap against an independent
 full-sort oracle in both score directions, including ties and every cap around
 each tested population size. It also selects 1,000 entries from one million

--- a/tests/weights-limit/README.md
+++ b/tests/weights-limit/README.md
@@ -1,0 +1,51 @@
+# Weights result selection tests
+
+The standalone C test checks the bounded candidate heap against an independent
+full-sort oracle in both score directions, including ties and every cap around
+each tested population size. It also selects 1,000 entries from one million
+candidates and independently counts the entries stronger than the retained
+boundary. Run from the repository root:
+
+```sh
+cc -std=c11 -O2 -Wall -Wextra -Werror -fsanitize=address,undefined \
+  tests/weights-limit/weights-ranking-test.c -o /tmp/weights-ranking-test
+/tmp/weights-ranking-test
+```
+
+The benchmark reports candidate-heap storage and comparison cost only. It does
+not measure metric evaluation, normalization, dictionary construction, ancestor
+marking, or serialization. Full-query scoring retains its existing result
+population; selection adds per-result flags and at most N candidate pointers.
+
+The black-box API cases live in `../query-corpus/weights_limit_test.go`. They
+stream synthetic fixtures into an isolated Agent and exercise HTTP v1/v2/v3,
+legacy chart/context output, grouped aggregation, and MCP caller policies.
+Follow `.agents/skills/tests-query-corpus/SKILL.md` when changing or running the
+corpus. From `tests/query-corpus`:
+
+```sh
+go test -count=1 -run TestWeightsLimit .
+go test ./... -count=1
+```
+
+First-principles fixtures establish physical membership, complete parent means,
+group winners, exact ties, and anomaly percentages. Paired unlimited/limited
+responses additionally check unchanged serialized statistics and summaries
+(Class C parity). Internal scores are selected before JSON formatting:
+`src/libnetdata/buffer/buffer.h:print_netdata_double` rounds ordinary values to
+seven fractional digits. Distinct internal scores may therefore look equal on
+the wire; serialized-score parity does not establish internal ties or identical
+membership in another service that can rank only serialized values. Separate
+equal-valued fixtures prove stable semantic tie selection.
+
+Legacy v1 output retains display-name dimension keys. Duplicate display names
+can collapse when a client decodes those objects into maps; result-limit counts
+describe emitted physical entries, not unique display names. The v2/v3 format
+uses dimension IDs and physical rows.
+
+Set `QUERY_CORPUS_WEIGHTS_EXPORT` to a scratch directory to export controlled
+response pairs. Each JSON envelope contains the endpoint, encoded query, and
+response; node names and identifiers belong only to synthetic corpus fixtures.
+The build/source pairing is declared by the corpus harness, not inferred from
+the response. These artifacts support downstream integration replay and are
+not independent correctness oracles.

--- a/tests/weights-limit/README.md
+++ b/tests/weights-limit/README.md
@@ -10,10 +10,11 @@ python3 tests/weights-limit/weights-openapi-test.py
 It checks both schema representations and all four weights endpoint references.
 Optional aliases must not supply defaults for unchosen fields: a generated
 `limit=1000&cardinality_limit=0` request is unlimited because the explicit
-cardinality alias takes precedence. The checks preserve caller-supplied zero
-and empty values, optionality, and the nonnegative integer constraint. This is
-a schema regression; it does not emulate Swagger UI rendering or the HTTP
-parser. Changes to request generation should also be checked against the
+cardinality alias takes precedence. The checks assert absent schema defaults,
+optional query parameters, empty-value support, and the nonnegative integer
+constraint. They do not test HTTP alias precedence or emulate Swagger UI.
+The corpus tests below cover runtime alias and boundary behavior.
+Changes to request generation should also be checked against the
 interactive explorer's Swagger UI bundle in `netdata/learn`.
 
 The standalone C test checks the bounded candidate heap against an independent

--- a/tests/weights-limit/weights-openapi-test.py
+++ b/tests/weights-limit/weights-openapi-test.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Check weights query aliases without starting an Agent or contacting a server."""
+
+import json
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ENDPOINTS = (
+    "/api/v1/weights",
+    "/api/v1/metric_correlations",
+    "/api/v2/weights",
+    "/api/v3/weights",
+)
+ALIASES = {"weightsLimit": "limit", "weightsCardinalityLimit": "cardinality_limit"}
+
+
+class WeightsOpenAPI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        api = ROOT / "src/web/api"
+        cls.documents = {
+            "JSON": json.loads((api / "netdata-swagger.json").read_text()),
+            "YAML": yaml.safe_load((api / "netdata-swagger.yaml").read_text()),
+        }
+
+    def test_alias_representations_agree(self):
+        for alias in ALIASES:
+            with self.subTest(alias=alias):
+                self.assertEqual(
+                    self.documents["JSON"]["components"]["parameters"][alias],
+                    self.documents["YAML"]["components"]["parameters"][alias],
+                )
+
+    def test_combined_aliases_preserve_caller_inputs(self):
+        cases = {
+            "omitted": {},
+            "limit": {"limit": 1000},
+            "cardinality": {"cardinality_limit": 1000},
+            "explicit-zero": {"limit": 0},
+            "zero-precedence": {"limit": 1000, "cardinality_limit": 0},
+            "both-positive": {"limit": 1000, "cardinality_limit": 2},
+            "empty-limit": {"limit": ""},
+            "empty-cardinality": {"cardinality_limit": ""},
+        }
+        for representation, document in self.documents.items():
+            parameters = document["components"]["parameters"]
+            for endpoint in ENDPOINTS:
+                with self.subTest(representation=representation, endpoint=endpoint):
+                    refs = [p.get("$ref") for p in document["paths"][endpoint]["get"]["parameters"]]
+                    defaults = {}
+                    for alias, name in ALIASES.items():
+                        self.assertEqual(refs.count("#/components/parameters/" + alias), 1)
+                        parameter = parameters[alias]
+                        self.assertEqual(parameter["name"], name)
+                        self.assertEqual(parameter["in"], "query")
+                        self.assertFalse(parameter.get("required", False))
+                        self.assertTrue(parameter.get("allowEmptyValue", False))
+                        self.assertEqual(parameter["schema"]["type"], "integer")
+                        self.assertEqual(parameter["schema"]["minimum"], 0)
+                        if "default" in parameter["schema"]:
+                            defaults[name] = parameter["schema"]["default"]
+
+                    # Optional aliases must not prefill an unchosen field in API explorers.
+                    # This checks the schema inputs; browser rendering is a separate integration check.
+                    for case, supplied in cases.items():
+                        with self.subTest(case=case):
+                            populated = defaults.copy()
+                            populated.update(supplied)
+                            self.assertEqual(populated, supplied)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/weights-limit/weights-openapi-test.py
+++ b/tests/weights-limit/weights-openapi-test.py
@@ -36,23 +36,12 @@ class WeightsOpenAPI(unittest.TestCase):
                     self.documents["YAML"]["components"]["parameters"][alias],
                 )
 
-    def test_combined_aliases_preserve_caller_inputs(self):
-        cases = {
-            "omitted": {},
-            "limit": {"limit": 1000},
-            "cardinality": {"cardinality_limit": 1000},
-            "explicit-zero": {"limit": 0},
-            "zero-precedence": {"limit": 1000, "cardinality_limit": 0},
-            "both-positive": {"limit": 1000, "cardinality_limit": 2},
-            "empty-limit": {"limit": ""},
-            "empty-cardinality": {"cardinality_limit": ""},
-        }
+    def test_optional_aliases_have_no_defaults(self):
         for representation, document in self.documents.items():
             parameters = document["components"]["parameters"]
             for endpoint in ENDPOINTS:
                 with self.subTest(representation=representation, endpoint=endpoint):
                     refs = [p.get("$ref") for p in document["paths"][endpoint]["get"]["parameters"]]
-                    defaults = {}
                     for alias, name in ALIASES.items():
                         self.assertEqual(refs.count("#/components/parameters/" + alias), 1)
                         parameter = parameters[alias]
@@ -62,16 +51,8 @@ class WeightsOpenAPI(unittest.TestCase):
                         self.assertTrue(parameter.get("allowEmptyValue", False))
                         self.assertEqual(parameter["schema"]["type"], "integer")
                         self.assertEqual(parameter["schema"]["minimum"], 0)
-                        if "default" in parameter["schema"]:
-                            defaults[name] = parameter["schema"]["default"]
-
-                    # Optional aliases must not prefill an unchosen field in API explorers.
-                    # This checks the schema inputs; browser rendering is a separate integration check.
-                    for case, supplied in cases.items():
-                        with self.subTest(case=case):
-                            populated = defaults.copy()
-                            populated.update(supplied)
-                            self.assertEqual(populated, supplied)
+                        # A default on the other alias can override an explicitly chosen limit.
+                        self.assertNotIn("default", parameter["schema"])
 
 
 if __name__ == "__main__":

--- a/tests/weights-limit/weights-ranking-test.c
+++ b/tests/weights-limit/weights-ranking-test.c
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "../../src/web/api/queries/weights-ranking.h"
+
+typedef struct { uint32_t score; size_t identity; } ITEM;
+typedef struct { bool ascending; size_t comparisons; } ORDER;
+
+static int compare(const void *a, const void *b, void *data) {
+    const ITEM *left = a, *right = b;
+    ORDER *order = data;
+    order->comparisons++;
+    if(left->score != right->score)
+        return ((left->score < right->score) == order->ascending) ? -1 : 1;
+    return (left->identity > right->identity) - (left->identity < right->identity);
+}
+
+static ORDER reference_order;
+static int reference_compare(const void *a, const void *b) {
+    return compare(*(const ITEM *const *)a, *(const ITEM *const *)b, &reference_order);
+}
+
+int main(void) {
+    uint32_t random = 123456789;
+    size_t checks = 0;
+    for(size_t count = 0; count < 513; count += count < 16 ? 1 : 17) {
+        ITEM *items = calloc(count + 1, sizeof(*items));
+        ITEM **expected = calloc(count + 1, sizeof(*expected));
+        for(size_t i = 0; i < count; i++) {
+            random = random * 1664525U + 1013904223U;
+            items[i] = (ITEM){.score = random % 23, .identity = count - i};
+            expected[i] = &items[i];
+        }
+        for(unsigned direction = 0; direction < 2; direction++) {
+            reference_order = (ORDER){.ascending = direction};
+            qsort(expected, count, sizeof(*expected), reference_compare);
+            for(size_t limit = 0; limit <= count + 1; limit++) {
+                ORDER order = {.ascending = direction};
+                WEIGHTS_RANKING ranking = {.capacity = limit < count ? limit : count, .compare = compare, .data = &order};
+                ranking.items = calloc(ranking.capacity + 1, sizeof(*ranking.items));
+                for(size_t i = 0; i < count; i++)
+                    weights_ranking_offer(&ranking, &items[i]);
+                weights_ranking_sort(&ranking);
+                assert(ranking.used == ranking.capacity);
+                for(size_t i = 0; i < ranking.used; i++)
+                    assert(ranking.items[i] == expected[i]);
+                free(ranking.items);
+                checks++;
+            }
+        }
+        free(expected);
+        free(items);
+    }
+    size_t count = 1000000, limit = 1000;
+    ITEM *items = calloc(count, sizeof(*items));
+    ORDER order = {0};
+    WEIGHTS_RANKING ranking = {.capacity = limit, .compare = compare, .data = &order};
+    ranking.items = calloc(limit, sizeof(*ranking.items));
+    clock_t started = clock();
+    for(size_t i = 0; i < count; i++) {
+        random = random * 1664525U + 1013904223U;
+        items[i] = (ITEM){.score = random, .identity = i};
+        weights_ranking_offer(&ranking, &items[i]);
+    }
+    weights_ranking_sort(&ranking);
+    clock_t finished = clock();
+    size_t selection_comparisons = order.comparisons;
+    assert(ranking.used == limit);
+    assert(order.comparisons < count * 25);
+    size_t stronger = 0;
+    for(size_t i = 0; i < count; i++)
+        stronger += compare(&items[i], ranking.items[limit - 1], &order) < 0;
+    assert(stronger == limit - 1);
+    printf("%zu selector property cases passed; 1000/1000000 candidates: %.3f seconds, %zu comparisons, %zu candidate bytes\n",
+           checks, (double)(finished - started) / CLOCKS_PER_SEC, selection_comparisons, limit * sizeof(void *));
+    free(ranking.items);
+    free(items);
+    return 0;
+}


### PR DESCRIPTION
##### Summary

- Support optional `limit` and `cardinality_limit` across HTTP v1/v2/v3 weights and v1 metric_correlations, including full, legacy chart/context, and grouped output. Both are nonnegative integer aliases; `cardinality_limit` takes precedence. Validate every supplied alias. Omitted or zero remains unlimited, with no backend default cap.
- Empty alias values retain the handler's ignored-empty behavior. Both OpenAPI representations explicitly allow empty query values and omit automatic alias defaults, so choosing a positive limit in an API explorer cannot inject an unchosen, overriding zero. Explicit-zero precedence remains unchanged. Corpus fixture exports issue extra requests only when `QUERY_CORPUS_WEIGHTS_EXPORT` is enabled; ordinary assertion coverage is unchanged.
- Select the strongest physical dimensions after complete-query scoring and normalization. Summary rows do not consume the cap. Keep retained dimensions' complete-query instance/context/node summaries and counts, prune unrelated metric dictionaries, and preserve node/error metadata.
- Limit grouped responses only after complete aggregation, using the requested aggregate statistic. Preserve entire retained group vectors; do not generate a remaining aggregate.
- Use bounded candidate selection and deterministic semantic-identity ties. Raw scores rank descending; normalized scores rank ascending. Retained values do not change relative to an unlimited query.
- Add `result_limit` metadata describing the effective cap, eligible and returned counts, counting unit, exact truncation status, and complete-query summary scope. Preserve MCP caller policy and correct false truncation at exact equality; MCP maximum-parameter validation is not changed or newly qualified.

##### Test Plan

- All 12 isolated query-corpus weights-limit contracts pass. Coverage includes aliases, validation, precedence, unlimited/zero/empty/exact/oversized limits, all methods, anomaly-bit, legacy/full/grouped formats, complete summaries, stable ties, multiple nodes, and 1,000 of 1,005 physical dimensions.
- Ranking and parent-summary qualification require each of sixteen method/option components independently. Thirty-two omission regressions prevent partial execution from appearing complete. Request/decode fault injections leave the affected components visibly incomplete, and a ranking-only assertion failure does not mark the summary contract broken. An isolated full-corpus run evaluates all 269 contracts and matches the reference run using the same qualified Agent binary: eighty broken contracts, with no added failures or incomplete scopes. Other runs exhibit additional reset/retention failures; their cause remains unverified and those results are not discarded or counted as passing.
- Standalone ASan/UBSan selector tests pass 16,174 cases against an independent full-sort oracle. Selecting 1,000 of one million candidates uses 8,000 bytes of candidate-pointer storage and 1,132,796 comparisons; the measured selection takes approximately 13 ms locally. This excludes scoring, normalization, ancestor marking and serialization.
- The storage-free `build/netdata -W mctest` passes. Modified Swagger YAML/JSON contracts agree structurally. Exported legacy response pairs preserve parent summaries.
- The standalone schema regression directly checks optional query aliases, absent defaults, empty-value support and nonnegative integer constraints across both representations and all four endpoint references. Twelve deliberate schema mutations are rejected. This test does not emulate alias precedence or a browser. Fifty-six separate request-generation cases pass using the Learn explorer's vendored Swagger UI, with all network intercepted. Existing HTTP alias, boundary, invalid-value and legacy tests also pass.
- The complete 269-contract corpus is not globally green: the base reports 91 broken contracts; implementation runs report 83 and 81. Eleven previously failing weights contracts are fixed; the twelfth summary-parity contract already held on the base. Additional live-edge/retention failures vary between runs and pass paired focused checks on both binaries; their precise timing causes remain unverified. No unrelated corpus contracts were weakened.
- Schema/export validation uses the actual OpenAPI alias definitions with strict request validation for empty, zero and one. A fail-first request-count check verifies that disabled exports make zero export-only requests instead of sixteen; enabled exports retain sixteen extra requests and all forty envelopes. All twelve focused weights contracts pass. Paired complete-corpus runs using the same runtime binary report 81 broken contracts before the export guard and 80 afterward, with no added broken contracts or incomplete scopes. All 269 contracts are evaluated afterward. Timing-dependent improvements are not attributed to the export guard, and the remaining failures are not counted as passing.
- The broad `-W unittest` check could not complete because its compile-time DBengine test-cache path is not writable. It was not rerun with elevated privileges or counted as passing.
- Synthetic real-daemon responses are replayed by the companion Cloud and frontend tests to verify cross-repository wire compatibility and summary/count preservation.
- CI at `d856649dacfd2b528082fa478df97158e5c2d046` has five Debian 11 failures caused by security-package downloads returning HTTP 404: the [source-build setup job](https://github.com/netdata/netdata/actions/runs/34000653226/job/101398864342) fails before compilation, and four [package-test jobs](https://github.com/netdata/netdata/actions/runs/34000653255) fail while installing test dependencies. The dependency installer and Dockerfile are unchanged. These failures were not repaired or counted as passing.

##### Additional Information

This is output limiting, not a reduction in the number of metrics examined. Multi-route Cloud must aggregate complete inputs before applying one global cap. HTTP clients choose whether to request a cap; frontend Metrics Correlations requests 1,000, while other callers retain their existing defaults.

Companion changes: [Cloud charts-service #690](https://github.com/netdata/cloud-charts-service/pull/690) and [frontend #5742](https://github.com/netdata/cloud-frontend/pull/5742). Each backend remains compatible with unlimited callers; Cloud also enforces limits when an older Agent ignores them.

The API contract is documented in `src/web/api/netdata-swagger.{yaml,json}`. Selector and corpus instructions, benchmark scope, wire-precision limitations and legacy display-name behavior are documented in `tests/weights-limit/README.md`.

No Agent installation, Cloud deployment, or merge is included.

<details>
<summary>For users: How does this change affect me?</summary>

Weights API clients can request only the strongest physical time series or complete output groups, reducing returned data and browser work. Retained parent summaries still represent the complete query. Requests without a positive limit keep unlimited behavior.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added result limiting for weights and metric-correlation API responses across supported API versions.
  - Supports `limit` and `cardinality_limit` parameters, including validation and clear errors for invalid values.
  - Empty or omitted limits return unlimited results.
  - Responses preserve ranking, summaries, grouped results, hierarchy information, and tie handling.
  - Added result-limit metadata and contributing-dimension counts to responses.
- **Documentation**
  - Updated API specifications and usage documentation.
- **Tests**
  - Added coverage for limits, ranking, boundaries, aliases, legacy formats, grouped results, hierarchy, and MCP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
