### PR TITLE
Fix credential leakage in go.d/upsd command errors

### DIFF
--- a/src/go/plugin/go.d/collector/upsd/client.go
+++ b/src/go/plugin/go.d/collector/upsd/client.go
@@ -147,20 +147,31 @@ func (c *upsdClient) sendCommand(cmd string) ([]string, error) {
 		return nil, err
 	}
 	if errMsg != "" {
-		return nil, fmt.Errorf("%w: %s (cmd: '%s')", errUpsdCommand, errMsg, cmd)
+		return nil, fmt.Errorf("%w: %s (cmd: '%s')", errUpsdCommand, errMsg, commandName(cmd))
+	}
+	// Not errUpsdCommand: an empty response means the peer closed the
+	// connection, so the caller must drop it, not keep using it.
+	if len(resp) == 0 {
+		return nil, fmt.Errorf("no response to command '%s'", commandName(cmd))
 	}
 
 	return resp, nil
 }
 
 func getEndLine(cmd string) string {
-	px, _, _ := strings.Cut(cmd, " ")
-
-	switch px {
+	switch commandName(cmd) {
 	case "USERNAME", "PASSWORD", "VER":
 		return "OK"
 	}
 	return fmt.Sprintf("END %s", cmd)
+}
+
+// commandName returns the command verb without its arguments. USERNAME and
+// PASSWORD carry credentials in their arguments, so only the verb may be put
+// in an error or a log line.
+func commandName(cmd string) string {
+	name, _, _ := strings.Cut(cmd, " ")
+	return name
 }
 
 func splitLine(s string) []string {

--- a/src/go/plugin/go.d/collector/upsd/client.go
+++ b/src/go/plugin/go.d/collector/upsd/client.go
@@ -147,31 +147,39 @@ func (c *upsdClient) sendCommand(cmd string) ([]string, error) {
 		return nil, err
 	}
 	if errMsg != "" {
-		return nil, fmt.Errorf("%w: %s (cmd: '%s')", errUpsdCommand, errMsg, commandName(cmd))
+		return nil, fmt.Errorf("%w: %s (cmd: '%s')", errUpsdCommand, errMsg, redactCommand(cmd))
 	}
 	// Not errUpsdCommand: an empty response means the peer closed the
 	// connection, so the caller must drop it, not keep using it.
 	if len(resp) == 0 {
-		return nil, fmt.Errorf("no response to command '%s'", commandName(cmd))
+		return nil, fmt.Errorf("no response to command '%s'", redactCommand(cmd))
 	}
 
 	return resp, nil
 }
 
 func getEndLine(cmd string) string {
-	switch commandName(cmd) {
+	px, _, _ := strings.Cut(cmd, " ")
+
+	switch px {
 	case "USERNAME", "PASSWORD", "VER":
 		return "OK"
 	}
 	return fmt.Sprintf("END %s", cmd)
 }
 
-// commandName returns the command verb without its arguments. USERNAME and
-// PASSWORD carry credentials in their arguments, so only the verb may be put
-// in an error or a log line.
-func commandName(cmd string) string {
-	name, _, _ := strings.Cut(cmd, " ")
-	return name
+// redactCommand returns cmd safe to put in an error or a log line. USERNAME
+// and PASSWORD carry credentials in their arguments, so only the verb is kept.
+// Every other command is logged in full: its arguments (the UPS name in
+// "LIST VAR <ups>") are what makes the error diagnosable.
+func redactCommand(cmd string) string {
+	verb, _, _ := strings.Cut(cmd, " ")
+
+	switch verb {
+	case "USERNAME", "PASSWORD":
+		return verb
+	}
+	return cmd
 }
 
 func splitLine(s string) []string {

--- a/src/go/plugin/go.d/collector/upsd/client_test.go
+++ b/src/go/plugin/go.d/collector/upsd/client_test.go
@@ -4,6 +4,7 @@ package upsd
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -13,7 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testPassword = "s3cr3t-password"
+const (
+	testUsername = "s3cr3t-user"
+	testPassword = "s3cr3t-password"
+)
 
 // fakeSocket replays a canned response per command verb.
 type fakeSocket struct {
@@ -39,12 +43,38 @@ func TestUpsdClient_authenticateDoesNotLeakPassword(t *testing.T) {
 		"PASSWORD": {"ERR ACCESS-DENIED"},
 	}}}
 
-	err := client.authenticate("user", testPassword)
+	err := client.authenticate(testUsername, testPassword)
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errUpsdCommand))
 	assert.NotContains(t, err.Error(), testPassword)
 	assert.Contains(t, err.Error(), "PASSWORD")
+}
+
+func TestUpsdClient_authenticateDoesNotLeakUsername(t *testing.T) {
+	client := &upsdClient{conn: &fakeSocket{responses: map[string][]string{
+		"USERNAME": {"ERR ACCESS-DENIED"},
+	}}}
+
+	err := client.authenticate(testUsername, testPassword)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errUpsdCommand))
+	assert.NotContains(t, err.Error(), testUsername)
+	assert.Contains(t, err.Error(), "USERNAME")
+}
+
+func TestUpsdClient_errorKeepsNonCredentialCommandArguments(t *testing.T) {
+	client := &upsdClient{conn: &fakeSocket{responses: map[string][]string{
+		"LIST": {"ERR VAR-NOT-SUPPORTED"},
+	}}}
+
+	_, err := client.sendCommand(fmt.Sprintf(commandListVar, "ups1"))
+
+	require.Error(t, err)
+	// Only USERNAME/PASSWORD arguments are redacted: the UPS name is what
+	// makes this error diagnosable.
+	assert.Contains(t, err.Error(), "LIST VAR ups1")
 }
 
 func TestUpsdClient_emptyResponseIsAnError(t *testing.T) {
@@ -56,4 +86,5 @@ func TestUpsdClient_emptyResponseIsAnError(t *testing.T) {
 	// The peer closed the connection; the caller must drop it, so this must
 	// not be reported as a protocol-level upsd command error.
 	assert.False(t, errors.Is(err, errUpsdCommand))
+	assert.Contains(t, err.Error(), commandListUPS)
 }

--- a/src/go/plugin/go.d/collector/upsd/client_test.go
+++ b/src/go/plugin/go.d/collector/upsd/client_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package upsd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/socket"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testPassword = "s3cr3t-password"
+
+// fakeSocket replays a canned response per command verb.
+type fakeSocket struct {
+	responses map[string][]string
+}
+
+func (f *fakeSocket) Connect() error    { return nil }
+func (f *fakeSocket) Disconnect() error { return nil }
+
+func (f *fakeSocket) Command(command string, process socket.Processor) error {
+	verb, _, _ := strings.Cut(strings.TrimSuffix(command, "\n"), " ")
+	for _, line := range f.responses[verb] {
+		if more, err := process([]byte(line)); err != nil || !more {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestUpsdClient_authenticateDoesNotLeakPassword(t *testing.T) {
+	client := &upsdClient{conn: &fakeSocket{responses: map[string][]string{
+		"USERNAME": {"OK"},
+		"PASSWORD": {"ERR ACCESS-DENIED"},
+	}}}
+
+	err := client.authenticate("user", testPassword)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errUpsdCommand))
+	assert.NotContains(t, err.Error(), testPassword)
+	assert.Contains(t, err.Error(), "PASSWORD")
+}
+
+func TestUpsdClient_emptyResponseIsAnError(t *testing.T) {
+	client := &upsdClient{conn: &fakeSocket{responses: map[string][]string{}}}
+
+	_, err := client.sendCommand(commandListUPS)
+
+	require.Error(t, err)
+	// The peer closed the connection; the caller must drop it, so this must
+	// not be reported as a protocol-level upsd command error.
+	assert.False(t, errors.Is(err, errUpsdCommand))
+}

--- a/src/go/plugin/go.d/collector/upsd/client_test.go
+++ b/src/go/plugin/go.d/collector/upsd/client_test.go
@@ -37,54 +37,87 @@ func (f *fakeSocket) Command(command string, process socket.Processor) error {
 	return nil
 }
 
-func TestUpsdClient_authenticateDoesNotLeakPassword(t *testing.T) {
-	client := &upsdClient{conn: &fakeSocket{responses: map[string][]string{
-		"USERNAME": {"OK"},
-		"PASSWORD": {"ERR ACCESS-DENIED"},
-	}}}
+func TestUpsdClient_commandErrorsDoNotLeakCredentials(t *testing.T) {
+	tests := map[string]struct {
+		command        string
+		responses      map[string][]string
+		wantUpsdError  bool
+		wantContains   string
+		wantNotContain string
+	}{
+		"username protocol error is redacted": {
+			command: fmt.Sprintf(commandUsername, testUsername),
+			responses: map[string][]string{
+				"USERNAME": {"ERR ACCESS-DENIED"},
+			},
+			wantUpsdError:  true,
+			wantContains:   "USERNAME",
+			wantNotContain: testUsername,
+		},
+		"password protocol error is redacted": {
+			command: fmt.Sprintf(commandPassword, testPassword),
+			responses: map[string][]string{
+				"PASSWORD": {"ERR ACCESS-DENIED"},
+			},
+			wantUpsdError:  true,
+			wantContains:   "PASSWORD",
+			wantNotContain: testPassword,
+		},
+		"username empty response is redacted": {
+			command:        fmt.Sprintf(commandUsername, testUsername),
+			responses:      map[string][]string{},
+			wantContains:   "USERNAME",
+			wantNotContain: testUsername,
+		},
+		"password empty response is redacted": {
+			command:        fmt.Sprintf(commandPassword, testPassword),
+			responses:      map[string][]string{},
+			wantContains:   "PASSWORD",
+			wantNotContain: testPassword,
+		},
+		"list ups protocol error is unchanged": {
+			command: commandListUPS,
+			responses: map[string][]string{
+				"LIST": {"ERR UNKNOWN-COMMAND"},
+			},
+			wantUpsdError: true,
+			wantContains:  commandListUPS,
+		},
+		"list var protocol error keeps ups name": {
+			command: fmt.Sprintf(commandListVar, "ups1"),
+			responses: map[string][]string{
+				"LIST": {"ERR VAR-NOT-SUPPORTED"},
+			},
+			wantUpsdError: true,
+			wantContains:  "LIST VAR ups1",
+		},
+		"list ups empty response is unchanged": {
+			command:      commandListUPS,
+			responses:    map[string][]string{},
+			wantContains: commandListUPS,
+		},
+		"logout empty response is unchanged": {
+			command:      commandLogout,
+			responses:    map[string][]string{},
+			wantContains: commandLogout,
+		},
+	}
 
-	err := client.authenticate(testUsername, testPassword)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &upsdClient{conn: &fakeSocket{responses: tt.responses}}
 
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, errUpsdCommand))
-	assert.NotContains(t, err.Error(), testPassword)
-	assert.Contains(t, err.Error(), "PASSWORD")
-}
+			_, err := client.sendCommand(tt.command)
 
-func TestUpsdClient_authenticateDoesNotLeakUsername(t *testing.T) {
-	client := &upsdClient{conn: &fakeSocket{responses: map[string][]string{
-		"USERNAME": {"ERR ACCESS-DENIED"},
-	}}}
+			require.Error(t, err)
+			// An empty response means the peer closed the connection: the
+			// caller must drop it, so it must not be an upsd command error.
+			assert.Equal(t, tt.wantUpsdError, errors.Is(err, errUpsdCommand))
+			assert.Contains(t, err.Error(), tt.wantContains)
 
-	err := client.authenticate(testUsername, testPassword)
-
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, errUpsdCommand))
-	assert.NotContains(t, err.Error(), testUsername)
-	assert.Contains(t, err.Error(), "USERNAME")
-}
-
-func TestUpsdClient_errorKeepsNonCredentialCommandArguments(t *testing.T) {
-	client := &upsdClient{conn: &fakeSocket{responses: map[string][]string{
-		"LIST": {"ERR VAR-NOT-SUPPORTED"},
-	}}}
-
-	_, err := client.sendCommand(fmt.Sprintf(commandListVar, "ups1"))
-
-	require.Error(t, err)
-	// Only USERNAME/PASSWORD arguments are redacted: the UPS name is what
-	// makes this error diagnosable.
-	assert.Contains(t, err.Error(), "LIST VAR ups1")
-}
-
-func TestUpsdClient_emptyResponseIsAnError(t *testing.T) {
-	client := &upsdClient{conn: &fakeSocket{responses: map[string][]string{}}}
-
-	_, err := client.sendCommand(commandListUPS)
-
-	require.Error(t, err)
-	// The peer closed the connection; the caller must drop it, so this must
-	// not be reported as a protocol-level upsd command error.
-	assert.False(t, errors.Is(err, errUpsdCommand))
-	assert.Contains(t, err.Error(), commandListUPS)
+			if tt.wantNotContain != "" {
+				assert.NotContains(t, err.Error(), tt.wantNotContain)
+			}
+		})
+	}
 }


### PR DESCRIPTION
##### Summary
- Report only the command verb in upsd command errors, preventing USERNAME and PASSWORD arguments from appearing in logs.
- Treat empty responses as connection errors so callers drop the connection and avoid indexing an empty response.
- Add regression tests for password omission from authentication errors and empty-response error classification.
- Closes CodeQL code scanning alerts go/clear-text-logging 3629 and 3630.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Credentials are now excluded from UPSD authentication error messages, reducing the risk of passwords or usernames appearing in logs.
  - Non-sensitive command arguments remain available in errors to support troubleshooting.
  - Empty UPSD responses are reported distinctly from protocol-level command failures.
- **Tests**
  - Added coverage for credential redaction, preservation of diagnostic command details, and empty-response error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->