### PR TITLE
fix(ibm.d/as400): clamp row counts before converting int64 to int

### DIFF
--- a/src/go/plugin/ibm.d/modules/as400/collect_data.go
+++ b/src/go/plugin/ibm.d/modules/as400/collect_data.go
@@ -211,6 +211,20 @@ func parseInt64OrZero(value string) int64 {
 	return 0
 }
 
+// int64ToCount narrows a row count to int, saturating instead of wrapping.
+// The values come from SQL COUNT(*) results parsed as int64, so a bogus or
+// hostile value must not become a negative or tiny int.
+func int64ToCount(v int64) int {
+	switch {
+	case v < 0:
+		return 0
+	case v > math.MaxInt:
+		return math.MaxInt
+	default:
+		return int(v)
+	}
+}
+
 func boolToInt(cond bool) int64 {
 	if cond {
 		return 1
@@ -911,7 +925,7 @@ func (a *Collector) countDisks(ctx context.Context) (int, error) {
 	var count int
 	err := a.doQuery(ctx, "count_disks", queryCountDisks, func(column, value string, lineEnd bool) {
 		if column == "COUNT" {
-			count = int(parseInt64OrZero(value))
+			count = int64ToCount(parseInt64OrZero(value))
 		}
 	})
 	return count, err
@@ -946,7 +960,7 @@ func (a *Collector) countNetworkInterfaces(ctx context.Context) (int, error) {
 	err := a.doQueryRow(ctx, "count_network_interfaces", queryCountNetworkInterfaces, func(column, value string) {
 		if column == "COUNT" {
 			if v, ok := a.parseInt64Value(value, 1); ok {
-				count = int(v)
+				count = int64ToCount(v)
 			}
 		}
 	})
@@ -962,7 +976,7 @@ func (a *Collector) countHTTPServers(ctx context.Context) (int, error) {
 			}
 		}
 	})
-	return int(count), err
+	return int64ToCount(count), err
 }
 
 func withFetchLimit(query string, limit int) string {
@@ -986,7 +1000,7 @@ func (a *Collector) countSubsystems(ctx context.Context) (int, error) {
 			}
 		}
 	})
-	return int(count), err
+	return int64ToCount(count), err
 }
 
 // Temporary storage collection

--- a/src/go/plugin/ibm.d/modules/as400/collect_data.go
+++ b/src/go/plugin/ibm.d/modules/as400/collect_data.go
@@ -215,14 +215,7 @@ func parseInt64OrZero(value string) int64 {
 // The values come from SQL COUNT(*) results parsed as int64, so a bogus or
 // hostile value must not become a negative or tiny int.
 func int64ToCount(v int64) int {
-	switch {
-	case v < 0:
-		return 0
-	case v > math.MaxInt:
-		return math.MaxInt
-	default:
-		return int(v)
-	}
+	return int(min(max(v, 0), math.MaxInt))
 }
 
 func boolToInt(cond bool) int64 {

--- a/src/go/plugin/ibm.d/modules/as400/collect_data_test.go
+++ b/src/go/plugin/ibm.d/modules/as400/collect_data_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build cgo
+
+package as400
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInt64ToCount(t *testing.T) {
+	tests := map[string]struct {
+		input int64
+		want  int
+	}{
+		"zero":           {input: 0, want: 0},
+		"small positive": {input: 42, want: 42},
+		"negative":       {input: -1, want: 0},
+		"min int64":      {input: math.MinInt64, want: 0},
+		"max int":        {input: math.MaxInt, want: math.MaxInt},
+		"above max int":  {input: math.MaxInt64, want: math.MaxInt},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, int64ToCount(test.input))
+		})
+	}
+}

--- a/src/go/plugin/ibm.d/modules/as400/slow_path.go
+++ b/src/go/plugin/ibm.d/modules/as400/slow_path.go
@@ -630,7 +630,7 @@ func (c *Collector) countSubsystemsWith(doRow queryRowFunc, ctx context.Context)
 			}
 		}
 	})
-	return int(count), err
+	return int64ToCount(count), err
 }
 
 func (c *Collector) fetchSubsystems(ctx context.Context, beat time.Time, do queryFunc, doRow queryRowFunc) (subsystemSnapshot, error) {


### PR DESCRIPTION
##### Summary
- Add `int64ToCount` to clamp negative counts to zero and values above `math.MaxInt` to `math.MaxInt`, preventing integer wraparound from altering cardinality limits.
- Apply the helper to disk, network interface, HTTP server, and subsystem counts, including the subsystem slow path.
- Add unit tests covering zero, positive and negative counts, and integer boundaries.
- Closes CodeQL code scanning alerts `go/incorrect-integer-conversion` 2779, 2780, 2782, 2783 and 2784.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of collected row and subsystem counts.
  * Prevented negative counts from appearing in monitoring results.
  * Prevented excessively large counts from overflowing and producing inaccurate values.
  * Applied consistent validation across disk, network interface, HTTP server, and subsystem data collection.
  * Counts are now safely constrained to valid platform-supported values for more reliable reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->