### PR TITLE
docs: document chart annotations

### DIFF
--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -1152,6 +1152,11 @@ sidebar:
           label: Charts
           edit_url: https://github.com/netdata/netdata/edit/master/docs/dashboards-and-charts/netdata-charts.md
       - meta:
+          label: Chart Annotations
+          edit_url: https://github.com/netdata/netdata/edit/master/docs/dashboards-and-charts/chart-annotations.md
+          description: Pin notes to a moment on a chart and share them with your Space.
+          keywords: [annotations, chart annotations, notes, deployments, incidents]
+      - meta:
           label: Expanded Chart Analysis
           edit_url: https://github.com/netdata/netdata/edit/master/docs/dashboards-and-charts/expanded-chart-analysis.md
       - meta:

--- a/docs/dashboards-and-charts/README.md
+++ b/docs/dashboards-and-charts/README.md
@@ -18,6 +18,7 @@ The Netdata dashboard consists of the following main sections:
 - [Home Tab](/docs/dashboards-and-charts/home-tab.md)
 - [Nodes Tab](/docs/dashboards-and-charts/nodes-tab.md)
 - [Netdata Charts](/docs/dashboards-and-charts/netdata-charts.md)
+- [Chart Annotations](/docs/dashboards-and-charts/chart-annotations.md)
 - [Metrics Tab and Single Node Tabs](/docs/dashboards-and-charts/metrics-tab-and-single-node-tabs.md)
 - [Live Tab](/docs/dashboards-and-charts/live-tab.md)
 - [Managing Logs](/docs/dashboards-and-charts/logs-tab.md)

--- a/docs/dashboards-and-charts/chart-annotations.md
+++ b/docs/dashboards-and-charts/chart-annotations.md
@@ -1,10 +1,10 @@
 # Chart Annotations
 
-Annotations let you pin a note to a specific moment on a chart. Use them to mark deployments, incidents, configuration changes, maintenance windows, or anything else that explains what you see in the data. Every member of your Space sees the same annotations, so the context travels with the chart.
+Annotations let you pin a note to a specific moment on a chart. Use them to mark deployments, incidents, configuration changes, maintenance windows, or anything else that explains what you see in the data. Everyone in your Space who can open dashboards sees the same annotations, so the context travels with the chart.
 
 :::note
 
-Annotations are a Netdata Cloud feature. They are stored in your Space and appear on Cloud dashboards and on Agent dashboards where you are signed in to Netdata Cloud. Only Space **Admins** can create, edit, or delete annotations. All other roles see them read-only. See [Role-Based Access](/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md).
+Annotations are a Netdata Cloud feature. They are stored in your Space and appear on Cloud dashboards and on Agent dashboards where you are signed in to Netdata Cloud. Only Space **Admins** can create, edit, or delete annotations. Managers, Troubleshooters, and Observers see them read-only. The Billing role has no dashboard access and does not see them. See [Role-Based Access](/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md).
 
 :::
 
@@ -15,7 +15,7 @@ Annotations are a Netdata Cloud feature. They are stored in your Space and appea
 3. Type your note and pick a **priority** by clicking one of the color swatches (see below).
 4. Press **Enter** or click the check mark to save. Press **Escape** or click **X** to discard.
 
-![Draft annotation form on a chart](https://raw.githubusercontent.com/netdata/docs-images/0f286e34c3360d781a5b1e4d697cd74b792bcfe2/chart-annotations/chart-annotation-draft.png)
+![Draft annotation form on a chart](https://raw.githubusercontent.com/netdata/docs-images/e3cb5c113c0cf6a9eabd2d53f5602115b560da78/chart-annotations/chart-annotation-draft.png)
 
 The saved annotation is drawn as a solid vertical line in the priority color, with a small dot at the top of the chart.
 
@@ -41,7 +41,7 @@ Each annotation has a priority that sets its color on the chart:
 
 Hover the mouse close to an annotation's vertical line. A popover shows the note text, the date and time, the priority, and an action bar. The popover stays open for a moment after you move away so you can reach its buttons.
 
-![Saved annotation with its action bar](https://raw.githubusercontent.com/netdata/docs-images/0f286e34c3360d781a5b1e4d697cd74b792bcfe2/chart-annotations/chart-annotation-popover.png)
+![Saved annotation with its action bar](https://raw.githubusercontent.com/netdata/docs-images/e3cb5c113c0cf6a9eabd2d53f5602115b560da78/chart-annotations/chart-annotation-popover.png)
 
 | Action                  | Icon      | What it does                                                                                                    |
 |-------------------------|-----------|-----------------------------------------------------------------------------------------------------------------|

--- a/docs/dashboards-and-charts/chart-annotations.md
+++ b/docs/dashboards-and-charts/chart-annotations.md
@@ -4,13 +4,13 @@ Annotations let you pin a note to a specific moment on a chart. Use them to mark
 
 :::note
 
-Annotations are a Netdata Cloud feature. They are stored in your Space and appear on Cloud dashboards and on Agent dashboards where you are signed in to Netdata Cloud. Only Space **Admins** can create, edit, or delete annotations. Managers, Troubleshooters, and Observers see them read-only. The Billing role has no dashboard access and does not see them. See [Role-Based Access](/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md).
+Annotations are a Netdata Cloud feature. They are stored in your Space and are not available on Agent dashboards that are not connected to Netdata Cloud. Only Space **Admins** can create, edit, or delete annotations. Managers, Troubleshooters, and Observers see them read-only. The Billing role has no dashboard access and does not see them. See [Role-Based Access](/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md).
 
 :::
 
 ## Add an Annotation
 
-1. With the default **Pan** tool selected, **click** anywhere on a line chart at the moment you want to annotate. A dashed grey marker appears at that timestamp, together with a **New annotation** box showing the selected date and time.
+1. With the default **Pan** tool selected, **click** anywhere on a line, area, or stacked chart at the moment you want to annotate. A dashed grey marker appears at that timestamp, together with a **New annotation** box showing the selected date and time.
 2. Click the **+** button in the box to open the annotation form.
 3. Type your note and pick a **priority** by clicking one of the color swatches (see below).
 4. Press **Enter** or click the check mark to save. Press **Escape** or click **X** to discard.
@@ -55,11 +55,11 @@ Hover the mouse close to an annotation's vertical line. A popover shows the note
 
 An annotation has one of three scopes.
 
-| Scope              | How to get it                                              | Where it shows                                                                                                                                    | Saved? |
-|--------------------|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------|
-| Chart-specific     | Default when you create an annotation                      | On every chart of the same context, for example `system.cpu`, across all nodes and Rooms in the Space. On a custom dashboard, on that chart only. | Yes    |
-| Global             | Double-click the globe icon                                | On every chart in the Space.                                                                                                                      | Yes    |
-| Temporarily synced | Single-click the globe icon on a chart-specific annotation | As a dashed, semi-transparent copy on every other chart currently on the page. Disappears when you reload.                                        | No     |
+| Scope              | How to get it                                              | Where it shows                                                                                             | Saved? |
+|--------------------|------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|--------|
+| Chart-specific     | Default when you create an annotation                      | On every chart of the same context, for example `system.cpu`, across all nodes and Rooms in the Space.     | Yes    |
+| Global             | Double-click the globe icon                                | On every chart in the Space.                                                                               | Yes    |
+| Temporarily synced | Single-click the globe icon on a chart-specific annotation | As a dashed, semi-transparent copy on every other chart currently on the page. Disappears when you reload. | No     |
 
 The globe icon changes color to show the current state: blue for global, yellow for temporarily synced, grey for chart-specific.
 

--- a/docs/dashboards-and-charts/chart-annotations.md
+++ b/docs/dashboards-and-charts/chart-annotations.md
@@ -1,0 +1,75 @@
+# Chart Annotations
+
+Annotations let you pin a note to a specific moment on a chart. Use them to mark deployments, incidents, configuration changes, maintenance windows, or anything else that explains what you see in the data. Every member of your Space sees the same annotations, so the context travels with the chart.
+
+:::note
+
+Annotations are a Netdata Cloud feature. They are stored in your Space and appear on Cloud dashboards and on Agent dashboards where you are signed in to Netdata Cloud. Only Space **Admins** can create, edit, or delete annotations. All other roles see them read-only. See [Role-Based Access](/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md).
+
+:::
+
+## Add an Annotation
+
+1. With the default **Pan** tool selected, **click** anywhere on a line chart at the moment you want to annotate. A dashed grey marker appears at that timestamp, together with a **New annotation** box showing the selected date and time.
+2. Click the **+** button in the box to open the annotation form.
+3. Type your note and pick a **priority** by clicking one of the color swatches (see below).
+4. Press **Enter** or click the check mark to save. Press **Escape** or click **X** to discard.
+
+![Draft annotation form on a chart](https://raw.githubusercontent.com/netdata/docs-images/0f286e34c3360d781a5b1e4d697cd74b792bcfe2/chart-annotations/chart-annotation-draft.png)
+
+The saved annotation is drawn as a solid vertical line in the priority color, with a small dot at the top of the chart.
+
+:::tip
+
+Clicking a chart also locks playback at that point in time, as described in [Play, Pause, and Reset Controls](/docs/dashboards-and-charts/netdata-charts.md#play-pause-and-reset-controls). If you clicked by accident, use the **X** in the **New annotation** box to dismiss the draft.
+
+:::
+
+### Priorities
+
+Each annotation has a priority that sets its color on the chart:
+
+| Priority | Color    | Typical use                           |
+|----------|----------|---------------------------------------|
+| Debug    | Grey     | Low-signal notes, experiments         |
+| Info     | Blue     | Deployments, config changes (default) |
+| Warning  | Yellow   | Something to keep an eye on           |
+| Error    | Red      | A failure or incident                 |
+| Critical | Dark red | A major outage or data-loss event     |
+
+## View an Annotation
+
+Hover the mouse close to an annotation's vertical line. A popover shows the note text, the date and time, the priority, and an action bar. The popover stays open for a moment after you move away so you can reach its buttons.
+
+![Saved annotation with its action bar](https://raw.githubusercontent.com/netdata/docs-images/0f286e34c3360d781a5b1e4d697cd74b792bcfe2/chart-annotations/chart-annotation-popover.png)
+
+| Action                  | Icon      | What it does                                                                                                    |
+|-------------------------|-----------|-----------------------------------------------------------------------------------------------------------------|
+| Sync / make global      | Globe     | Click once to show the annotation temporarily on all charts in view. Double-click to make it global. See below. |
+| Run metrics correlation | Correlate | Runs [Metric Correlations](/docs/metric-correlations.md) on a five-minute window centered on the annotation.    |
+| Copy URL                | Copy      | Copies the current dashboard URL, including the visible time range, so you can share the moment with others.    |
+| Edit                    | Pencil    | Change the text or priority. Available to Admins.                                                               |
+| Delete                  | Trash     | Removes the annotation after you confirm. Available to Admins.                                                  |
+
+## Where an Annotation Appears
+
+An annotation has one of three scopes.
+
+| Scope              | How to get it                                              | Where it shows                                                                                                                                    | Saved? |
+|--------------------|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------|
+| Chart-specific     | Default when you create an annotation                      | On every chart of the same context, for example `system.cpu`, across all nodes and Rooms in the Space. On a custom dashboard, on that chart only. | Yes    |
+| Global             | Double-click the globe icon                                | On every chart in the Space.                                                                                                                      | Yes    |
+| Temporarily synced | Single-click the globe icon on a chart-specific annotation | As a dashed, semi-transparent copy on every other chart currently on the page. Disappears when you reload.                                        | No     |
+
+The globe icon changes color to show the current state: blue for global, yellow for temporarily synced, grey for chart-specific.
+
+- On a **global** annotation, double-click the globe to turn it back into a chart-specific one.
+- On a **temporarily synced** annotation, click the globe once to remove the synced copies from the other charts.
+- A synced copy has its own actions: **Go to source chart**, **Run metrics correlation**, **Copy URL**, and **Remove from this chart**.
+
+## Tips
+
+- Annotate as soon as you act. A "Deployed v2.3.1" note at the exact minute saves a lot of guesswork when the on-call engineer looks at the chart a week later.
+- Use **Critical** and **Error** sparingly so they stand out.
+- Combine an annotation with **Run metrics correlation** to find which other metrics changed at the same moment.
+- Use **Copy URL** in incident channels so teammates land on the same time range and see the same marker.

--- a/docs/dashboards-and-charts/netdata-charts.md
+++ b/docs/dashboards-and-charts/netdata-charts.md
@@ -367,7 +367,7 @@ Control chart playback and interact with time using the **Time Controls**. These
 
 These controls work when the **default “Pan” action** is selected in the toolbar.
 
-Clicking on the chart also starts a draft [annotation](/docs/dashboards-and-charts/chart-annotations.md) at that point in time.
+For Space Admins, clicking on the chart also starts a draft [annotation](/docs/dashboards-and-charts/chart-annotations.md) at that point in time.
 
 ## Toolbar
 
@@ -424,7 +424,7 @@ Zooming in helps you analyze recent events in detail, while zooming out provides
 
 ## Annotations
 
-Click on a chart to pin a note to that moment in time, pick a priority color, and share it with everyone in your Space. Hover the marker to edit it, make it visible on all charts, copy a link, or run Metric Correlations around it.
+Space **Admins** can click on a chart to pin a note to that moment in time, pick a priority color, and share it with everyone in the Space who can open dashboards. Hover the marker to edit it, make it visible on all charts, copy a link, or run Metric Correlations around it. Other roles see annotations read-only.
 
 See [Chart Annotations](/docs/dashboards-and-charts/chart-annotations.md) for the full guide.
 

--- a/docs/dashboards-and-charts/netdata-charts.md
+++ b/docs/dashboards-and-charts/netdata-charts.md
@@ -367,6 +367,8 @@ Control chart playback and interact with time using the **Time Controls**. These
 
 These controls work when the **default “Pan” action** is selected in the toolbar.
 
+Clicking on the chart also starts a draft [annotation](/docs/dashboards-and-charts/chart-annotations.md) at that point in time.
+
 ## Toolbar
 
 The chart **Toolbar** provides interactive tools for manipulating the chart view:
@@ -419,6 +421,12 @@ The **Chart Zoom** tool allows you to zoom in and out to view different time ran
 | Zoom in/out      | Shift + mouse scrollwheel | Two-finger pinch or Shift + two-finger scroll |
 
 Zooming in helps you analyze recent events in detail, while zooming out provides an overview of longer-term trends.
+
+## Annotations
+
+Click on a chart to pin a note to that moment in time, pick a priority color, and share it with everyone in your Space. Hover the marker to edit it, make it visible on all charts, copy a link, or run Metric Correlations around it.
+
+See [Chart Annotations](/docs/dashboards-and-charts/chart-annotations.md) for the full guide.
 
 ## Dimensions Bar
 

--- a/docs/dashboards-and-charts/netdata-charts.md
+++ b/docs/dashboards-and-charts/netdata-charts.md
@@ -424,7 +424,7 @@ Zooming in helps you analyze recent events in detail, while zooming out provides
 
 ## Annotations
 
-Space **Admins** can click on a chart to pin a note to that moment in time, pick a priority color, and share it with everyone in the Space who can open dashboards. Hover the marker to edit it, make it visible on all charts, copy a link, or run Metric Correlations around it. Other roles see annotations read-only.
+Space **Admins** can click on a chart to pin a note to that moment in time, pick a priority color, and share it with everyone in the Space who can open dashboards. Hover the marker to edit it, make it visible on all charts, copy a link, or run Metric Correlations around it. Other roles with dashboard access see annotations read-only.
 
 See [Chart Annotations](/docs/dashboards-and-charts/chart-annotations.md) for the full guide.
 

--- a/docs/metric-correlations.md
+++ b/docs/metric-correlations.md
@@ -33,6 +33,12 @@ This button is only active if you've selected a valid timeframe.
 
 </details>
 
+:::tip
+
+If you have [annotated](/docs/dashboards-and-charts/chart-annotations.md) the moment you care about, hover the annotation and click **Run metrics correlation**. This runs Metric Correlations on a five-minute window centered on the annotation, with no manual highlighting.
+
+:::
+
 ## Integration with Anomaly Detection
 
 You can combine Metric Correlations with Anomaly Detection for powerful troubleshooting:

--- a/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md
+++ b/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md
@@ -151,16 +151,16 @@ The **Groups** tab under **User Management** only appears after [SCIM integratio
 <details>
 <summary><strong>Dashboards</strong></summary><br/>
 
-| **Functionality**                |     **Admin**      |    **Manager**     | **Troubleshooter** |    **Observer**    | **Billing** | **Notes** |
-|:---------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:-----------:|:----------|
-| **See all dashboards in Room**   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |           |
-| **Add new dashboard to Room**    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |           |
-| **Edit any dashboard in Room**   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |         -          |      -      |           |
-| **Edit own dashboard in Room**   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |           |
-| **Delete any dashboard in Room** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |         -          |      -      |           |
-| **Delete own dashboard in Room** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |           |
-| **See chart annotations**        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      | [Chart Annotations](/docs/dashboards-and-charts/chart-annotations.md) |
-| **Create, edit, delete chart annotations** | :heavy_check_mark: |         -          |         -          |         -          |      -      |           |
+| **Functionality**                          |     **Admin**      |    **Manager**     | **Troubleshooter** |    **Observer**    | **Billing** | **Notes**                                                             |
+|:-------------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:-----------:|:----------------------------------------------------------------------|
+| **See all dashboards in Room**             | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |                                                                       |
+| **Add new dashboard to Room**              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |                                                                       |
+| **Edit any dashboard in Room**             | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |         -          |      -      |                                                                       |
+| **Edit own dashboard in Room**             | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |                                                                       |
+| **Delete any dashboard in Room**           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |         -          |      -      |                                                                       |
+| **Delete own dashboard in Room**           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |                                                                       |
+| **See chart annotations**                  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      | [Chart Annotations](/docs/dashboards-and-charts/chart-annotations.md) |
+| **Create, edit, delete chart annotations** | :heavy_check_mark: |         -          |         -          |         -          |      -      |                                                                       |
 
 </details>
 

--- a/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md
+++ b/docs/netdata-cloud/authentication-and-authorization/role-based-access-model.md
@@ -159,6 +159,8 @@ The **Groups** tab under **User Management** only appears after [SCIM integratio
 | **Edit own dashboard in Room**   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |           |
 | **Delete any dashboard in Room** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |         -          |      -      |           |
 | **Delete own dashboard in Room** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      |           |
+| **See chart annotations**        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |      -      | [Chart Annotations](/docs/dashboards-and-charts/chart-annotations.md) |
+| **Create, edit, delete chart annotations** | :heavy_check_mark: |         -          |         -          |         -          |      -      |           |
 
 </details>
 


### PR DESCRIPTION
## Summary

Community feedback pointed out that chart annotations have no documentation at all. This adds it.

- New Learn page `docs/dashboards-and-charts/chart-annotations.md`: how to add an annotation (click a chart, then **+**), the five priorities, the hover popover and its actions, the three scopes (chart-specific, global, temporarily synced), edit/delete, Copy URL, and the Run metrics correlation shortcut.
- Registered in `docs/.map/map.yaml` right after "Charts" in the Dashboards section.
- Cross-links: Annotations section and click note in the Charts page, entry in the dashboards index, two rows in the role-based access table, and a tip in the Metric Correlations doc.
- Screenshots hosted in netdata/docs-images (netdata/docs-images#16), referenced by commit SHA like the sibling Expanded Chart Analysis page.

Behavior was taken from the `@netdata/charts` annotation overlay/sync code and the cloud-frontend settings integration. Permission note: creating, editing, and deleting requires `space:UpdateSettings`, which the Cloud backend grants to the Admin role only; other roles see annotations read-only.

## Test plan

- [x] `docs/.map/map.yaml` parses; `edit_url` matches the schema regex
- [x] markdownlint on the new page (MD013 excluded, matching neighbouring pages)
- [x] All `/docs/...` link targets exist; image URLs return 200
- [x] Learn preview after ingest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for chart annotations, a Netdata Cloud feature that previously had no docs.

- New Learn page covers adding annotations to line, area, and stacked charts, the five priorities, chart-specific/global/temporarily synced scopes, hover actions, editing/deleting, sharing URLs, and the Metric Correlations shortcut.
- Cross-links the new page from the dashboards index, Charts page, role-based access table, and Metric Correlations doc.
- Only Space Admins can create, edit, or delete annotations; other roles see them read-only, and Billing has no dashboard access.

<sup>Written for commit 6e6bf43b9517e5c31c4fb6560aa1db62619b8841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a guide covering chart annotations, including creation, priorities, visibility, sharing, editing, and deletion.
  - Added Chart Annotations to the Dashboards and Charts documentation navigation.
  - Documented annotation interactions and Space Admin capabilities in the Netdata Charts guide.
  - Added instructions for running Metric Correlations from an annotation using a centered five-minute analysis window.
  - Clarified that Space Admins manage annotations, while other permitted roles can view them read-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->