### PR TITLE
Validate topology search labels and aggregation memberships

### DIFF
--- a/.agents/skills/topology-authoring/SKILL.md
+++ b/.agents/skills/topology-authoring/SKILL.md
@@ -53,7 +53,8 @@ State these as facts in reviews; do not re-derive them, and do not claim enforce
 - Go semantic validator (`topologyv1.ValidateDecodedData` on `data`, `topologyv1.ValidateDecodedResponse` on a whole
   envelope; both return an error, there is no warning level): actor and link reference bounds (evidence references
   only where the table type declares `source_evidence`), column-length equality with `rows`,
-  dictionary indexes, label-policy display types, search columns, the `ports.sources[]` rules except the
+  dictionary indexes, label-policy display types, search columns and label-key shape independently of optional actor
+  presentation, declared actor aggregation-scope memberships, the `ports.sources[]` rules except the
   `actor_table` carve-out below (and `show_bullets` is read untyped, so only the schema rejects a non-boolean),
   highlight-path column types (including that a `path_table` not under `data.tables.actor` is owned by `actor`, the
   one use the validator makes of `table_type.owner`), every overlay-refs convention rule except the id-pattern rule (schema-only), correlation rules

--- a/.github/workflows/topology-container-tests.yml
+++ b/.github/workflows/topology-container-tests.yml
@@ -145,9 +145,13 @@ jobs:
             fi
             python3 src/collectors/network-viewer.plugin/tests/validate_topology_payload.py "$out" "$@"
           }
-          validate aggregated '{}' --mode aggregated --group-by process_name
-          validate pid '{"selections":{"group_by":"pid"}}' --mode aggregated --group-by pid
-          validate detailed '{"selections":{"__topology_mode":"detailed","mode":"detailed"}}' --mode detailed
+          validate default '{}' --mode aggregated --group-by process_name
+          validate aggregated-process-name '{"selections":{"__topology_mode":"aggregated","mode":"aggregated","group_by":"process_name"}}' --mode aggregated --group-by process_name
+          validate aggregated-pid '{"selections":{"__topology_mode":"aggregated","mode":"aggregated","group_by":"pid"}}' --mode aggregated --group-by pid
+          validate aggregated-container '{"selections":{"__topology_mode":"aggregated","mode":"aggregated","group_by":"container"}}' --mode aggregated --group-by container
+          validate detailed-process-name '{"selections":{"__topology_mode":"detailed","mode":"detailed","group_by":"process_name"}}' --mode detailed --group-by process_name
+          validate detailed-pid '{"selections":{"__topology_mode":"detailed","mode":"detailed","group_by":"pid"}}' --mode detailed --group-by pid
+          validate detailed-container '{"selections":{"__topology_mode":"detailed","mode":"detailed","group_by":"container"}}' --mode detailed --group-by container
 
   asan-tests:
     name: Unit Tests (ASAN)

--- a/src/collectors/network-viewer.plugin/network-viewer-topology.c
+++ b/src/collectors/network-viewer.plugin/network-viewer-topology.c
@@ -4120,7 +4120,6 @@ static void topology_v1_emit_type_registry(
     static const char *const self_scopes[] = { "node" };
     static const char *const process_scopes[] = { "process_name", "pid" };
     static const char *const container_scopes[] = { "container" };
-    static const char *const endpoint_scopes[] = { "endpoint" };
     const char *process_merge_a = "process";
     const char *process_merge_b = NULL;
 
@@ -4149,7 +4148,7 @@ static void topology_v1_emit_type_registry(
                 topology_v1_emit_runtime_actor_type(
                     wb, payload, &topology_runtime_actor_types[i], container_scopes, _countof(container_scopes), group_by, detailed);
             topology_v1_emit_actor_type(
-                wb, payload, "endpoint", "ip", "address_space", endpoint_scopes, _countof(endpoint_scopes),
+                wb, payload, "endpoint", "ip", "address_space", NULL, 0,
                 "Correlation endpoint", "derived", "remote-endpoint", "endpoint", true, "fixed", NULL, "compact", "weaker", false, NULL,
                 group_by,
                 detailed,

--- a/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
+++ b/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
@@ -52,26 +52,37 @@ def load_payload(path):
 
 
 def aggregation_scope_reference_errors(types):
-    """Return actor-type references that have no matching scope definition."""
+    """Require well-formed actor scope memberships and declared scope IDs."""
     if not isinstance(types, dict):
-        return []
+        return ["types is not an object"]
 
     actor_types = types.get("actor_types")
     aggregation_scopes = types.get("aggregation_scopes", {})
-    if not isinstance(actor_types, dict) or not isinstance(aggregation_scopes, dict):
-        return []
+    if not isinstance(actor_types, dict):
+        return ["types.actor_types is not an object"]
+    if not isinstance(aggregation_scopes, dict):
+        return ["types.aggregation_scopes is not an object"]
 
     errors = []
     for actor_type_id, actor_type in actor_types.items():
         if not isinstance(actor_type, dict):
+            errors.append(f"actor type {actor_type_id!r} is not an object")
             continue
         actor_scopes = actor_type.get("aggregation_scopes", [])
         if not isinstance(actor_scopes, list):
             errors.append(
                 f"actor type {actor_type_id!r} aggregation_scopes is not an array")
             continue
+        seen = set()
         for scope_id in actor_scopes:
-            if isinstance(scope_id, str) and scope_id not in aggregation_scopes:
+            if not isinstance(scope_id, str) or not scope_id:
+                errors.append(
+                    f"actor type {actor_type_id!r} aggregation_scopes members must be non-empty strings")
+                continue
+            if scope_id in seen:
+                errors.append(f"actor type {actor_type_id!r} repeats aggregation scope {scope_id!r}")
+            seen.add(scope_id)
+            if scope_id not in aggregation_scopes:
                 errors.append(
                     f"actor type {actor_type_id!r} references undefined "
                     f"aggregation scope {scope_id!r}")
@@ -105,7 +116,7 @@ def semantic_checks(data, expect_mode=None, expect_group_by=None):
         t = d.get(table)
         if not isinstance(t, dict) or "columns" not in t or "values" not in t:
             errors.append(f"{table} table missing columns/values")
-    if "types" not in d or "actor_types" not in d.get("types", {}):
+    if not isinstance(d.get("types"), dict) or "actor_types" not in d["types"]:
         errors.append("missing types.actor_types registry")
     else:
         errors.extend(aggregation_scope_reference_errors(d["types"]))
@@ -206,7 +217,121 @@ def run_self_test():
             "self-test FAILED: topology schema did not select Draft 2020-12; got",
             validator.__class__.__name__)
         return 1
+    if run_payload_validation_self_test(schema_file):
+        return 1
     print("self-test OK")
+    return 0
+
+
+def self_test_payload_result(data, schema_file, missing_dependency, expected, prefix):
+    """Check status and diagnostic prefix to pin validation-branch precedence."""
+    from contextlib import redirect_stdout
+    from unittest.mock import patch
+
+    unavailable = {"jsonschema": None} if missing_dependency else {}
+    with patch.dict(sys.modules, unavailable), redirect_stdout(io.StringIO()) as output:
+        result = validate_payload(data, schema_file, None, None)
+    if result != expected or not output.getvalue().startswith(prefix):
+        print("self-test FAILED: payload validation result", result, output.getvalue())
+        return False
+    return True
+
+
+def run_payload_validation_self_test(schema_file):
+    """Exercise the actual validator with and without its optional dependency."""
+    fixture = os.path.join(
+        os.path.dirname(schema_file), "..", "go", "tools", "functions-validation",
+        "fixtures", "topology-v1", "network-connections.json")
+    payload = load_payload(fixture)
+    payload["v"] = 3
+    for missing in (False, True):
+        cases = (
+            (payload, 0, "jsonschema not available;" if missing else "OK:"),
+            (dict(payload, v=2), 1, "SEMANTIC FAILURES:"),
+            (dict(payload, unexpected=True), 0 if missing else 1,
+             "jsonschema not available;" if missing else "SCHEMA FAILURES"),
+            (dict(payload, v=2, unexpected=True), 1,
+             "SEMANTIC FAILURES:" if missing else "SCHEMA FAILURES"),
+        )
+        for data, expected, prefix in cases:
+            if not self_test_payload_result(data, schema_file, missing, expected, prefix):
+                return 1
+    return (run_scope_validation_self_test(payload, schema_file)
+            or run_schema_errors_self_test(payload))
+
+
+def run_scope_validation_self_test(payload, schema_file):
+    """Reject malformed scope metadata even when JSON Schema is unavailable."""
+    import copy
+
+    bad_objects = (None, True, 7, 1.5, "scope", [])
+    cases = (
+        (("types",), bad_objects, True),
+        (("types", "actor_types"), bad_objects, True),
+        (("types", "aggregation_scopes"), bad_objects, True),
+        (("types", "actor_types", "process"), bad_objects, True),
+        (("types", "actor_types", "process", "aggregation_scopes"),
+         (None, True, 7, 1.5, "pid", {}, [None], [True], [7], [1.5], [{}], [[]], [""],
+          ["pid", "pid"]), True),
+        (("types", "actor_types", "process", "aggregation_scopes"), (["undefined_scope"],), False),
+    )
+    for path, values, schema_rejects in cases:
+        for value in values:
+            data = copy.deepcopy(payload)
+            target = data["data"]
+            for key in path[:-1]:
+                target = target[key]
+            target[path[-1]] = value
+            for missing in (False, True):
+                prefix = "SCHEMA FAILURES" if schema_rejects and not missing else "SEMANTIC FAILURES:"
+                if not self_test_payload_result(data, schema_file, missing, 1, prefix):
+                    print("scope case:", path, repr(value), "missing dependency:", missing)
+                    return 1
+
+    for omit_memberships in (False, True):
+        for omit_registry in (False, True):
+            data = copy.deepcopy(payload)
+            types = data["data"]["types"]
+            for actor_type in types["actor_types"].values():
+                actor_type["aggregation_scopes"] = []
+                if omit_memberships:
+                    actor_type.pop("aggregation_scopes")
+            types["aggregation_scopes"] = {}
+            if omit_registry:
+                types.pop("aggregation_scopes")
+            for missing in (False, True):
+                prefix = "jsonschema not available;" if missing else "OK:"
+                if not self_test_payload_result(data, schema_file, missing, 0, prefix):
+                    return 1
+    return 0
+
+
+def run_schema_errors_self_test(payload):
+    """Schema file errors must not be mistaken for a missing optional library."""
+    import tempfile
+    from contextlib import redirect_stdout
+    from unittest.mock import patch
+    from jsonschema.exceptions import SchemaError
+
+    cases = (("{", False, json.JSONDecodeError), ("{", True, json.JSONDecodeError),
+             ('{"type":"invalid"}', False, SchemaError), ('{"type":"invalid"}', True, None))
+    for content, missing, exception in cases:
+        with tempfile.TemporaryDirectory() as directory:
+            schema_file = os.path.join(directory, "schema.json")
+            with io.open(schema_file, "w", encoding="utf-8") as output:
+                output.write(content)
+            if exception is None:
+                if not self_test_payload_result(payload, schema_file, missing, 0, "jsonschema not available;"):
+                    return 1
+                continue
+            unavailable = {"jsonschema": None} if missing else {}
+            try:
+                with patch.dict(sys.modules, unavailable), redirect_stdout(io.StringIO()):
+                    validate_payload(payload, schema_file, None, None)
+            except exception:
+                continue
+            print("self-test FAILED: schema file did not raise", exception.__name__)
+            return 1
     return 0
 
 
@@ -241,7 +366,7 @@ def validate_payload(data, schema_file, expect_mode, expect_group_by):
     schema = json.load(io.open(schema_file, encoding='utf-8'))
 
     try:
-        import jsonschema
+        validator = schema_validator(schema)
     except ImportError:
         errors = semantic_checks(data, expect_mode, expect_group_by)
         if errors:
@@ -252,7 +377,6 @@ def validate_payload(data, schema_file, expect_mode, expect_group_by):
         print("jsonschema not available; semantic checks passed")
         return 0
 
-    validator = schema_validator(schema)
     errs = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
     if errs:
         print(f"SCHEMA FAILURES ({len(errs)}):")

--- a/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
+++ b/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
@@ -89,6 +89,40 @@ def aggregation_scope_reference_errors(types):
     return errors
 
 
+def actor_search_label_key_errors(types):
+    """Validate optional search label keys without normalizing literal keys."""
+    if not isinstance(types, dict) or not isinstance(types.get("actor_types"), dict):
+        return []
+
+    errors = []
+    for actor_type_id, actor_type in types["actor_types"].items():
+        if not isinstance(actor_type, dict):
+            continue
+        search = actor_type.get("search")
+        # A null policy is absent in semantic-only validation, matching the Go helper.
+        if search is None:
+            continue
+        path = f"actor type {actor_type_id!r} search"
+        if not isinstance(search, dict):
+            errors.append(f"{path} is not an object")
+            continue
+        if "label_keys" not in search:
+            continue
+        keys = search["label_keys"]
+        if not isinstance(keys, list):
+            errors.append(f"{path}.label_keys is not an array")
+            continue
+        seen = set()
+        for key in keys:
+            if not isinstance(key, str) or not key:
+                errors.append(f"{path}.label_keys members must be non-empty strings")
+                continue
+            if key in seen:
+                errors.append(f"{path}.label_keys repeats {key!r}")
+            seen.add(key)
+    return errors
+
+
 def network_viewer_actor_type_errors(types):
     """Enforce network-viewer's endpoint actor contract."""
     if not isinstance(types, dict) or not isinstance(types.get("actor_types"), dict):
@@ -121,6 +155,7 @@ def semantic_checks(data, expect_mode=None, expect_group_by=None):
     else:
         errors.extend(aggregation_scope_reference_errors(d["types"]))
         errors.extend(network_viewer_actor_type_errors(d["types"]))
+        errors.extend(actor_search_label_key_errors(d["types"]))
     if "presentation" not in d:
         errors.append("missing presentation")
     view = d.get("view")
@@ -257,6 +292,7 @@ def run_payload_validation_self_test(schema_file):
             if not self_test_payload_result(data, schema_file, missing, expected, prefix):
                 return 1
     return (run_scope_validation_self_test(payload, schema_file)
+            or run_search_validation_self_test(payload, schema_file)
             or run_schema_errors_self_test(payload))
 
 
@@ -302,6 +338,44 @@ def run_scope_validation_self_test(payload, schema_file):
             for missing in (False, True):
                 prefix = "jsonschema not available;" if missing else "OK:"
                 if not self_test_payload_result(data, schema_file, missing, 0, prefix):
+                    return 1
+    return 0
+
+
+def run_search_validation_self_test(payload, schema_file):
+    """Validate literal label keys independently of presentation and schema availability."""
+    import copy
+
+    omitted = object()
+    cases = [
+        (omitted, 0, 0), ({}, 0, 0), ({"label_keys": []}, 0, 0),
+        ({"label_keys": ["_hostname", "_os", "_labels", "app/name", "主机", " ", "\t",
+                         " _hostname ", "é", "e\u0301"]}, 0, 0),
+        (None, 1, 0), ({"enabled": 7}, 1, 0), ({"columns": None}, 1, 0),
+        ({"enabled": False, "label_keys": [""]}, 1, 1),
+    ]
+    cases.extend((value, 1, 1) for value in (False, 7, 1.5, "", []))
+    invalid_keys = (None, False, 7, 1.5, "", {}, [""], ["_hostname", "_hostname"],
+                    [7], [None], [True], [{}], [[]], [" ", " "])
+    cases.extend(({"label_keys": value}, 1, 1) for value in invalid_keys)
+    for search, schema_result, fallback_result in cases:
+        for omit_presentation in (False, True):
+            data = copy.deepcopy(payload)
+            actor_type = data["data"]["types"]["actor_types"]["process"]
+            if omit_presentation:
+                actor_type.pop("presentation", None)
+            if search is omitted:
+                actor_type.pop("search", None)
+            else:
+                actor_type["search"] = search
+            for missing in (False, True):
+                expected = fallback_result if missing else schema_result
+                prefix = "jsonschema not available;" if missing else "OK:"
+                if expected:
+                    prefix = "SEMANTIC FAILURES:" if missing else "SCHEMA FAILURES"
+                if not self_test_payload_result(data, schema_file, missing, expected, prefix):
+                    print("search case:", repr(search), "missing dependency:", missing,
+                          "without presentation:", omit_presentation)
                     return 1
     return 0
 

--- a/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
+++ b/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
@@ -21,6 +21,15 @@ import sys
 import os
 
 
+def schema_validator(schema):
+    """Build the validator selected by the schema's declared draft."""
+    import jsonschema
+
+    validator_class = jsonschema.validators.validator_for(schema)
+    validator_class.check_schema(schema)
+    return validator_class(schema)
+
+
 def load_payload(path):
     raw = io.open(path, encoding='utf-8', errors='replace').read()
     if raw.startswith("FUNCTION_RESULT_BEGIN"):
@@ -42,6 +51,47 @@ def load_payload(path):
     return json.loads(raw)
 
 
+def aggregation_scope_reference_errors(types):
+    """Return actor-type references that have no matching scope definition."""
+    if not isinstance(types, dict):
+        return []
+
+    actor_types = types.get("actor_types")
+    aggregation_scopes = types.get("aggregation_scopes", {})
+    if not isinstance(actor_types, dict) or not isinstance(aggregation_scopes, dict):
+        return []
+
+    errors = []
+    for actor_type_id, actor_type in actor_types.items():
+        if not isinstance(actor_type, dict):
+            continue
+        actor_scopes = actor_type.get("aggregation_scopes", [])
+        if not isinstance(actor_scopes, list):
+            errors.append(
+                f"actor type {actor_type_id!r} aggregation_scopes is not an array")
+            continue
+        for scope_id in actor_scopes:
+            if isinstance(scope_id, str) and scope_id not in aggregation_scopes:
+                errors.append(
+                    f"actor type {actor_type_id!r} references undefined "
+                    f"aggregation scope {scope_id!r}")
+    return errors
+
+
+def network_viewer_actor_type_errors(types):
+    """Enforce network-viewer's endpoint actor contract."""
+    if not isinstance(types, dict) or not isinstance(types.get("actor_types"), dict):
+        return []
+
+    endpoint = types["actor_types"].get("endpoint")
+    if not isinstance(endpoint, dict):
+        return ["missing endpoint actor type"]
+    endpoint_scopes = endpoint.get("aggregation_scopes", [])
+    if isinstance(endpoint_scopes, list) and endpoint_scopes:
+        return ["endpoint actor type must not declare aggregation scopes"]
+    return []
+
+
 def semantic_checks(data, expect_mode=None, expect_group_by=None):
     errors = []
     if data.get("type") != "topology":
@@ -57,6 +107,9 @@ def semantic_checks(data, expect_mode=None, expect_group_by=None):
             errors.append(f"{table} table missing columns/values")
     if "types" not in d or "actor_types" not in d.get("types", {}):
         errors.append("missing types.actor_types registry")
+    else:
+        errors.extend(aggregation_scope_reference_errors(d["types"]))
+        errors.extend(network_viewer_actor_type_errors(d["types"]))
     if "presentation" not in d:
         errors.append("missing presentation")
     view = d.get("view")
@@ -92,6 +145,66 @@ def run_self_test():
         os.unlink(name)
     if parsed["data"]["view"]["scope"] != "FUNCTION_RESULT_END":
         print("self-test FAILED: FUNCTION_RESULT_END inside JSON string was stripped")
+        return 1
+
+    valid_types = {
+        "actor_types": {
+            "process": {"aggregation_scopes": ["process_name"]},
+            "endpoint": {"aggregation_scopes": []},
+            "scope_less": {},
+        },
+        "aggregation_scopes": {"process_name": {}},
+    }
+    if errors := aggregation_scope_reference_errors(valid_types):
+        print("self-test FAILED: valid scoped/scope-less actor types rejected:", errors)
+        return 1
+    if errors := network_viewer_actor_type_errors(valid_types):
+        print("self-test FAILED: valid endpoint actor type rejected:", errors)
+        return 1
+
+    dangling_types = {
+        "actor_types": {"endpoint": {"aggregation_scopes": ["endpoint"]}},
+        "aggregation_scopes": {},
+    }
+    expected = ["actor type 'endpoint' references undefined aggregation scope 'endpoint'"]
+    if aggregation_scope_reference_errors(dangling_types) != expected:
+        print("self-test FAILED: dangling actor aggregation scope was not rejected")
+        return 1
+    expected = ["endpoint actor type must not declare aggregation scopes"]
+    if network_viewer_actor_type_errors(dangling_types) != expected:
+        print("self-test FAILED: endpoint aggregation scope was not rejected")
+        return 1
+
+    if network_viewer_actor_type_errors({"actor_types": {}}) != ["missing endpoint actor type"]:
+        print("self-test FAILED: missing endpoint actor type was not rejected")
+        return 1
+
+    for malformed_scopes in (None, 7, "endpoint", {}):
+        malformed_types = {
+            "actor_types": {"endpoint": {"aggregation_scopes": malformed_scopes}},
+            "aggregation_scopes": {},
+        }
+        expected = ["actor type 'endpoint' aggregation_scopes is not an array"]
+        if aggregation_scope_reference_errors(malformed_types) != expected:
+            print(
+                "self-test FAILED: malformed endpoint aggregation_scopes was not rejected:",
+                repr(malformed_scopes))
+            return 1
+
+    try:
+        import jsonschema
+    except ImportError:
+        print("self-test FAILED: jsonschema is required to test schema draft selection")
+        return 1
+    here = os.path.dirname(os.path.abspath(__file__))
+    schema_file = os.path.join(
+        here, "..", "..", "..", "plugins.d", "FUNCTION_TOPOLOGY_SCHEMA.json")
+    schema = json.load(io.open(schema_file, encoding="utf-8"))
+    validator = schema_validator(schema)
+    if validator.__class__ is not jsonschema.Draft202012Validator:
+        print(
+            "self-test FAILED: topology schema did not select Draft 2020-12; got",
+            validator.__class__.__name__)
         return 1
     print("self-test OK")
     return 0
@@ -139,7 +252,7 @@ def validate_payload(data, schema_file, expect_mode, expect_group_by):
         print("jsonschema not available; semantic checks passed")
         return 0
 
-    validator = jsonschema.Draft7Validator(schema)
+    validator = schema_validator(schema)
     errs = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
     if errs:
         print(f"SCHEMA FAILURES ({len(errs)}):")

--- a/src/go/pkg/topology/v1/aggregation_scopes_test.go
+++ b/src/go/pkg/topology/v1/aggregation_scopes_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActorAggregationScopeReferences(t *testing.T) {
+	tests := map[string]struct {
+		scopes   any
+		registry bool
+		valid    bool
+	}{
+		"scope-less actor":       {scopes: []any{}, valid: true},
+		"registered scope":       {scopes: []any{"node"}, registry: true, valid: true},
+		"undefined endpoint":     {scopes: []any{"endpoint"}, registry: true},
+		"missing scope registry": {scopes: []any{"node"}},
+		"one undefined scope":    {scopes: []any{"node", "endpoint"}, registry: true},
+		"duplicate scope":        {scopes: []any{"node", "node"}, registry: true},
+		"null scope":             {scopes: []any{nil}, registry: true},
+		"empty scope":            {scopes: []any{""}, registry: true},
+		"non-list scopes":        {scopes: "node", registry: true},
+		"null scopes":            {scopes: nil, registry: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data := minimalValidationData(nil)
+			if test.registry {
+				data.Types.AggregationScopes = map[string]AggregationScope{"node": {Columns: []string{"id"}}}
+			}
+			encoded, err := json.Marshal(NewResponse(data))
+			require.NoError(t, err)
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(encoded, &payload))
+			types := payload["data"].(map[string]any)["types"].(map[string]any)
+			actorType := types["actor_types"].(map[string]any)["node"].(map[string]any)
+			actorType["aggregation_scopes"] = test.scopes
+			err = ValidateDecodedResponse(payload)
+			if test.valid {
+				require.NoError(t, err)
+				encoded, err = json.Marshal(payload)
+				require.NoError(t, err)
+				validateAgainstTopologySchema(t, encoded)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "data.types.actor_types.node.aggregation_scopes")
+			}
+		})
+	}
+}

--- a/src/go/pkg/topology/v1/search_test.go
+++ b/src/go/pkg/topology/v1/search_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchLabelKeysSchemaAndSemanticValidation(t *testing.T) {
+	tests := map[string]struct {
+		keys  any
+		valid bool
+	}{
+		"empty list":      {keys: []any{}, valid: true},
+		"ordinary labels": {keys: []any{"hostname", "os"}, valid: true},
+		"built-in labels": {keys: []any{"_hostname", "_os"}, valid: true},
+		"qualified label": {keys: []any{"example.net/rack"}, valid: true},
+		"unicode label":   {keys: []any{"περιοχή"}, valid: true},
+		"space in label":  {keys: []any{"rack name"}, valid: true},
+		"empty key":       {keys: []any{""}},
+		"duplicate key":   {keys: []any{"_hostname", "_hostname"}},
+		"null key":        {keys: []any{nil}},
+		"numeric key":     {keys: []any{1}},
+		"non-list":        {keys: "_hostname"},
+		"null list":       {keys: nil},
+	}
+	for name, test := range tests {
+		for variant, presentation := range map[string]bool{"without presentation": false, "with presentation": true} {
+			t.Run(name+"/"+variant, func(t *testing.T) {
+				payload, actorType := searchTestResponse(t, presentation)
+				actorType["search"] = map[string]any{"label_keys": test.keys}
+				encoded, err := json.Marshal(payload)
+				require.NoError(t, err)
+				assert.Equal(t, test.valid, topologySchemaValidationError(t, encoded) == nil, "schema validity")
+				assert.Equal(t, test.valid, ValidateDecodedResponse(payload) == nil, "semantic validity")
+			})
+		}
+	}
+}
+
+func TestSearchLabelKeyRelaxationPreservesColumnIdentifiers(t *testing.T) {
+	for _, id := range []string{"_hostname", "example.net/rack", "rack name", "περιοχή", ""} {
+		t.Run(id, func(t *testing.T) {
+			payload, actorType := searchTestResponse(t, true)
+			actorType["search"] = map[string]any{"columns": []any{id}}
+			encoded, err := json.Marshal(payload)
+			require.NoError(t, err)
+			require.Error(t, topologySchemaValidationError(t, encoded))
+			require.Error(t, ValidateDecodedResponse(payload))
+		})
+	}
+}
+
+func TestSearchColumnReferencesWithoutPresentation(t *testing.T) {
+	for _, column := range []string{"id", "missing"} {
+		t.Run(column, func(t *testing.T) {
+			payload, actorType := searchTestResponse(t, false)
+			actorType["search"] = map[string]any{"columns": []any{column}}
+			assert.Equal(t, column == "id", ValidateDecodedResponse(payload) == nil)
+		})
+	}
+}
+
+func searchTestResponse(t *testing.T, withPresentation bool) (map[string]any, map[string]any) {
+	t.Helper()
+	var presentation *ActorPresentation
+	if withPresentation {
+		presentation = &ActorPresentation{Label: "Node"}
+	}
+	encoded, err := json.Marshal(NewResponse(minimalValidationData(presentation)))
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &payload))
+	actorTypes := payload["data"].(map[string]any)["types"].(map[string]any)["actor_types"].(map[string]any)
+	return payload, actorTypes["node"].(map[string]any)
+}

--- a/src/go/pkg/topology/v1/validate.go
+++ b/src/go/pkg/topology/v1/validate.go
@@ -23,6 +23,7 @@ type topologyShape struct {
 	actorTypes         map[string]struct{}
 	linkTypes          map[string]struct{}
 	portTypes          map[string]struct{}
+	aggregationScopes  map[string]struct{}
 	evidenceTypes      map[string]map[string]string
 	tableTypes         map[string]map[string]string
 	tableTypeOwners    map[string]string
@@ -679,6 +680,10 @@ func collectTopologyShape(data map[string]any) (topologyShape, error) {
 	if err != nil {
 		return topologyShape{}, err
 	}
+	aggregationScopes, err := optionalObjectKeySet(types["aggregation_scopes"], "data.types.aggregation_scopes")
+	if err != nil {
+		return topologyShape{}, err
+	}
 
 	evidenceTypes, err := columnTypesByRegistryObject(types["evidence_types"], "data.types.evidence_types")
 	if err != nil {
@@ -711,6 +716,7 @@ func collectTopologyShape(data map[string]any) (topologyShape, error) {
 		actorTypes:         actorTypes,
 		linkTypes:          linkTypes,
 		portTypes:          portTypes,
+		aggregationScopes:  aggregationScopes,
 		evidenceTypes:      evidenceTypes,
 		tableTypes:         tableTypes,
 		tableTypeOwners:    tableTypeOwners,
@@ -884,6 +890,21 @@ func validateActorTypePresentation(raw any, shape topologyShape) error {
 		if !ok {
 			return fmt.Errorf("data.types.actor_types.%s is not an object", typeID)
 		}
+		if rawScopes, exists := actorType["aggregation_scopes"]; exists {
+			path := "data.types.actor_types." + typeID + ".aggregation_scopes"
+			scopes, err := collectStringList(path, rawScopes, false)
+			if err != nil {
+				return err
+			}
+			for i, scope := range scopes {
+				if _, ok := shape.aggregationScopes[scope]; !ok {
+					return fmt.Errorf("%s[%d] references unknown aggregation scope %q", path, i, scope)
+				}
+			}
+		}
+		if err := validateActorSearchPolicy("data.types.actor_types."+typeID+".search", actorType["search"], shape.actorColumns); err != nil {
+			return err
+		}
 		presentation, ok := actorType["presentation"].(map[string]any)
 		if !ok {
 			continue
@@ -928,9 +949,6 @@ func validateActorTypePresentation(raw any, shape topologyShape) error {
 			return err
 		}
 		if err := validateModalPresentation(path+".modal", presentation["modal"], shape); err != nil {
-			return err
-		}
-		if err := validateActorSearchPolicy("data.types.actor_types."+typeID+".search", actorType["search"], shape.actorColumns); err != nil {
 			return err
 		}
 	}

--- a/src/go/tools/functions-validation/fixtures/topology-v1/network-connections.json
+++ b/src/go/tools/functions-validation/fixtures/topology-v1/network-connections.json
@@ -55,7 +55,7 @@
           "layer": "process",
           "identity": ["id"],
           "merge_identity": ["machine_guid", "process"],
-          "aggregation_scopes": ["node", "process_name", "pid"],
+          "aggregation_scopes": ["process_name", "pid"],
           "presentation": {
             "label": "Process",
             "color_slot": "primary",
@@ -79,7 +79,7 @@
           "layer": "network",
           "identity": ["id"],
           "merge_identity": ["ip", "address_space"],
-          "aggregation_scopes": ["node"]
+          "aggregation_scopes": []
         }
       },
       "link_types": {
@@ -228,6 +228,24 @@
             {"id": "socket_count", "type": "uint", "role": "metric", "aggregation": "sum"}
           ]
         }
+      },
+      "aggregation_scopes": {
+        "node": {
+          "columns": ["machine_guid", "hostname"],
+          "evidence_policy": "preserve"
+        },
+        "process_name": {
+          "columns": ["process"],
+          "evidence_policy": "preserve"
+        },
+        "pid": {
+          "columns": ["pid", "net_ns_inode"],
+          "evidence_policy": "preserve"
+        },
+        "container": {
+          "columns": ["container_name"],
+          "evidence_policy": "preserve"
+        }
       }
     },
     "presentation": {
@@ -317,7 +335,11 @@
         {"id": "type", "type": "string_ref", "dictionary": "strings"},
         {"id": "id", "type": "string_ref", "dictionary": "strings", "role": "identity"},
         {"id": "machine_guid", "type": "string_ref", "dictionary": "strings", "nullable": true},
+        {"id": "hostname", "type": "string", "nullable": true, "role": "merge_identity", "aggregation": "set"},
         {"id": "process", "type": "string_ref", "dictionary": "strings", "nullable": true},
+        {"id": "pid", "type": "uint", "nullable": true, "role": "identity"},
+        {"id": "net_ns_inode", "type": "uint", "nullable": true, "role": "identity"},
+        {"id": "container_name", "type": "string", "nullable": true, "role": "group_key", "aggregation": "set"},
         {"id": "ip", "type": "ip_ref", "dictionary": "strings", "nullable": true},
         {"id": "address_space", "type": "string_ref", "dictionary": "strings", "nullable": true},
         {"id": "socket_count", "type": "uint", "role": "metric", "aggregation": "sum"}
@@ -326,7 +348,11 @@
         {"codec": "dict", "values": [0, 1, 2], "indexes": [0, 1, 2]},
         {"codec": "values", "values": [3, 5, 6]},
         {"codec": "values", "values": [4, 4, null]},
+        {"codec": "const", "value": null},
         {"codec": "values", "values": [null, 5, null]},
+        {"codec": "const", "value": null},
+        {"codec": "const", "value": null},
+        {"codec": "const", "value": null},
         {"codec": "values", "values": [null, null, 6]},
         {"codec": "values", "values": [null, null, 11]},
         {"codec": "values", "values": [2, 2, 2]}

--- a/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
@@ -355,7 +355,10 @@ fallback.
 Actor type `search` declares exactly what the graph search bar may index for
 that actor type. `search.columns[]` references actor-table scalar columns.
 `search.label_keys[]` references values in the actor label table, normally
-`actor_labels.key`. Set `search.enabled: false` for helper actors that should
+`actor_labels.key`. These keys are unique non-empty strings, not registry IDs;
+built-in keys such as `_hostname` and `_os` are valid. Search validation does not
+depend on the presence of optional actor presentation settings.
+Set `search.enabled: false` for helper actors that should
 not appear in graph search, such as synthetic segment or grouping actors. The
 UI must not traverse producer-specific `details`, `match`, `attributes`, or
 labels paths when rendering a v1 payload.
@@ -365,6 +368,10 @@ generic `segment` type. Each such type must declare its own identity, merge
 identity, presentation, modal sections, legend entry, and aggregation behavior.
 Consumers must use the declared type metadata and must not infer semantics from
 a type id that happens to contain `segment`, `subnet`, or `network`.
+
+Every actor-type `aggregation_scopes[]` entry must name a scope declared in
+`types.aggregation_scopes`. Omit the list or emit an empty list when the actor
+does not participate in a grouping scope; this does not remove it from the graph.
 
 ## Required Link Semantics
 

--- a/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
@@ -292,7 +292,10 @@ Common actor identity columns:
 - `vsphere_moid`
 - `vsphere_inventory_path`
 
-Actor types define source-local identity and cross-source merge identity:
+Actor types define source-local identity and cross-source merge identity. The
+following actor-type excerpt is not a complete payload. The enclosing payload
+must declare the listed scope IDs in `types.aggregation_scopes`, provide the
+referenced actor columns, and define the referenced label and port tables:
 
 ```json
 {

--- a/src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json
@@ -1057,9 +1057,10 @@
         },
         "label_keys": {
           "type": "array",
-          "description": "actor_labels.key values whose label values should be indexed for graph search.",
+          "description": "Non-empty actor_labels.key values whose label values should be indexed for graph search. Label keys are not registry ids; built-in keys such as _hostname are valid.",
           "items": {
-            "$ref": "#/$defs/id"
+            "type": "string",
+            "minLength": 1
           },
           "uniqueItems": true,
           "default": []


### PR DESCRIPTION
## Summary

- Accept unique, non-empty topology search label keys, including built-in labels such as `_hostname`, without relaxing column or registry identifier rules.
- Validate actor search metadata independently of optional presentation, and reject actor aggregation memberships that reference undeclared scopes.
- Remove the network endpoint type's undefined aggregation membership. Preserve actor identities, grouping selectors, links, modals, labels, ports, evidence, and overlays.
- Align the canonical schema, Go validator, network fixture, developer guidance, and Python checks. Select the Python schema validator using the declared draft and exercise the default invocation plus all six mode/grouping combinations in CI.
- Enforce scope-membership and literal search-key checks in the optional Python semantic fallback when `jsonschema` is unavailable.

## Compatibility

This corrects topology metadata validation; it does not change source correlation, observations, request routing, or frontend behavior. Aggregation membership lists may be omitted or empty; when present, every member must name a declared scope.

The Python fallback is a limited semantic checker, not complete JSON Schema validation. It checks selected topology envelope requirements, the network endpoint contract, scope memberships, and literal search-label keys. Omitted or null search policies mean no policy in the fallback, matching the Go helper; installed-schema mode rejects null search. Other search properties, including `enabled` and `columns`, remain schema-only checks. Install `jsonschema` for full validation; the topology CI workflow does so.

The branch is rebased onto `master` at `8a49bad67544fb860277d60c740b5496d66d6840`. The rebase preserves the upstream removal of duplicated skill specifications and retains their relevant contracts in the canonical developer guide. Merged namespace fix #23778 remains an existing prerequisite, not part of this PR's diff.

## Validation

- Rebased revision `f048f2224be0735ab81ac4787cce4b99281caae4`: shared topology and Function CLI tests, race tests and vet; fixture-backed vSphere, Cato Networks and SNMP suites.
- Python self-tests, four container fixtures, and 40 independent search-key probes across optional-presentation and schema-dependency variants.
- All 18 SNMP semantic scenarios and all five full-payload goldens from `netdata/testdata` revision `c4638934ae2345fcd12567d3e60f33cdecff91e5`.
- Independent full-scope review found no blocking defect. Rebase comparison, instruction-reference audit, sensitive-data checks and whitespace checks passed.
- Targeted local Opengrep and Pylint analysis found no issues. Lizard reports complexity/length warnings in validator and test functions; these are not evidence of a correctness failure. The local runner excluded the oversized C translation unit, so this is not a C static-analysis result.
- Linux C build and synthetic namespace/socket/container tests passed on checkpoint `c0b19c69643f0247710b67da2d55097c64d092c0`. The rebase preserves the C change, but a full C rebuild of the rebased revision has not been performed locally.

No live vSphere/Cato environment, privileged namespace execution, installation or deployment is claimed. Hosted checks must qualify the pushed revision; earlier Debian Bullseye failures occurred while downloading Debian security packages (HTTP 404), before building the changes.

Cloud request parsing and aggregation remain separate service components. Frontend integration has its own backend and deployment prerequisites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved topology validation for actor search labels and column references, including support for built-in and Unicode label keys.
  - Added validation for declared aggregation scopes and clearer handling of actors without grouping participation.
  - Search and label validation now works independently of optional actor presentation settings.
  - Updated topology schemas and examples to reflect view-level aggregation scopes and expanded actor metadata.

- **Documentation**
  - Clarified requirements for search labels, aggregation scopes, referenced columns, and complete topology payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->