### PR TITLE
Add Signalgrid Push Notifications

### DIFF
--- a/src/health/notifications/alarm-notify.sh.in
+++ b/src/health/notifications/alarm-notify.sh.in
@@ -1253,13 +1253,12 @@ send_signalgrid() {
     esac
 
     for channel in ${channels}; do
-      httpcode=$(docurl \
-        --form-string "client_key=${client_key}" \
+      httpcode=$(printf '%s' "${client_key}" | docurl \
+        --form "client_key=<-" \
         --form-string "channel=${channel}" \
         --form-string "type=${type}" \
         --form-string "title=${title}" \
         --form-string "body=${message}" \
-        --form-string "critical=false" \
         https://api.signalgrid.co/v1/push)
 
       if [ "${httpcode}" = "200" ]; then

--- a/src/health/notifications/alarm-notify.sh.in
+++ b/src/health/notifications/alarm-notify.sh.in
@@ -34,6 +34,7 @@
 #  - Opsgenie by @thiaoftsm #9858
 #  - Gotify by @coffeegrind123
 #  - ntfy.sh by @Dim-P
+#  - signalgrid.co notifications by @signalgridco
 #shellcheck source=/dev/null disable=SC2086,SC2154
 
 # -----------------------------------------------------------------------------
@@ -266,6 +267,7 @@ prowl
 pushbullet
 pushover
 rocketchat
+signalgrid
 slack
 sms
 syslog
@@ -422,6 +424,9 @@ DISCORD_WEBHOOK_URL=
 
 # pushover configs
 PUSHOVER_APP_TOKEN=
+
+# signalgrid configs
+SIGNALGRID_CLIENT_KEY=
 
 # pushbullet configs
 PUSHBULLET_ACCESS_TOKEN=
@@ -719,6 +724,9 @@ fi
 # check pushover
 [ -z "${PUSHOVER_APP_TOKEN}" ] && SEND_PUSHOVER="NO"
 
+# check signalgrid
+[ -z "${SIGNALGRID_CLIENT_KEY}" ] && SEND_SIGNALGRID="NO"
+
 # check pushbullet
 [ -z "${PUSHBULLET_ACCESS_TOKEN}" ] && SEND_PUSHBULLET="NO"
 
@@ -795,6 +803,7 @@ check_supported_targets() {
   shift
 
   if [ "${SEND_PUSHOVER}" = "YES" ] ||
+    [ "${SEND_SIGNALGRID}" = "YES" ] ||
     [ "${SEND_SLACK}" = "YES" ] ||
     [ "${SEND_ROCKETCHAT}" = "YES" ] ||
     [ "${SEND_ALERTA}" = "YES" ] ||
@@ -827,6 +836,7 @@ check_supported_targets() {
     if [ -z "${curl}" ]; then
       $log "Cannot find curl command in the system path. Disabling all curl based notifications."
       SEND_PUSHOVER="NO"
+      SEND_SIGNALGRID="NO"
       SEND_PUSHBULLET="NO"
       SEND_TELEGRAM="NO"
       SEND_SLACK="NO"
@@ -982,6 +992,7 @@ fi
 proceed=0
 for method in "${SEND_EMAIL}" \
   "${SEND_PUSHOVER}" \
+  "${SEND_SIGNALGRID}" \
   "${SEND_TELEGRAM}" \
   "${SEND_SLACK}" \
   "${SEND_ROCKETCHAT}" \
@@ -1218,6 +1229,44 @@ send_pushover() {
         sent=$((sent + 1))
       else
         error "failed to send pushover notification to '${user}' for ${notification_description}, with HTTP response status code ${httpcode}."
+      fi
+    done
+
+    [ ${sent} -gt 0 ] && return 0
+  fi
+
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# signalgrid sender
+
+send_signalgrid() {
+  local client_key="${1}" channels="${2}" status="${3}" title="${4}" message="${5}" httpcode sent=0 channel type
+
+  if [ "${SEND_SIGNALGRID}" = "YES" ] && [ -n "${client_key}" ] && [ -n "${channels}" ] && [ -n "${title}" ] && [ -n "${message}" ]; then
+    case "${status}" in
+    WARNING) type="WARN" ;;
+    CRITICAL) type="CRIT" ;;
+    CLEAR) type="SUCCESS" ;;
+    *) type="INFO" ;;
+    esac
+
+    for channel in ${channels}; do
+      httpcode=$(docurl \
+        --form-string "client_key=${client_key}" \
+        --form-string "channel=${channel}" \
+        --form-string "type=${type}" \
+        --form-string "title=${title}" \
+        --form-string "body=${message}" \
+        --form-string "critical=false" \
+        https://api.signalgrid.co/v1/push)
+
+      if [ "${httpcode}" = "200" ]; then
+        info "sent signalgrid notification to '${channel}' for ${notification_description}"
+        sent=$((sent + 1))
+      else
+        error "failed to send signalgrid notification to '${channel}' for ${notification_description}, with HTTP response status code ${httpcode}."
       fi
     done
 
@@ -2818,6 +2867,15 @@ send_pushover "${PUSHOVER_APP_TOKEN}" "${to_pushover}" "${when}" "${goto_url}" "
 SENT_PUSHOVER=$?
 
 # -----------------------------------------------------------------------------
+# send the signalgrid notification
+
+send_signalgrid "${SIGNALGRID_CLIENT_KEY}" "${to_signalgrid}" "${status}" "${host} ${status_message} - ${name//_/ } - ${chart}" "${alarm}
+Severity: ${severity}
+Chart: ${chart}
+${info}"
+SENT_SIGNALGRID=$?
+
+# -----------------------------------------------------------------------------
 # send the pushbullet notification
 
 send_pushbullet "${PUSHBULLET_ACCESS_TOKEN}" "${PUSHBULLET_SOURCE_DEVICE}" "${to_pushbullet}" "${goto_url}" "${host} ${status_message} - ${name//_/ } - ${chart}" "${alarm}\\n
@@ -3813,6 +3871,7 @@ SENT_SIGNL4=$?
 # let netdata know
 for state in "${SENT_EMAIL}" \
   "${SENT_PUSHOVER}" \
+  "${SENT_SIGNALGRID}" \
   "${SENT_TELEGRAM}" \
   "${SENT_SLACK}" \
   "${SENT_ROCKETCHAT}" \

--- a/src/health/notifications/health_alarm_notify.conf
+++ b/src/health/notifications/health_alarm_notify.conf
@@ -23,6 +23,7 @@
 # - message to Microsoft Teams (through webhook)
 # - message to Rocket.Chat (through webhook)
 # - push notifications to your mobile phone or desktop (ntfy.sh)
+# - push notifications via Signalgrid (signalgrid.co)
 #
 # The 'to' line given at netdata alarms defines a *role*, so that many
 # people can be notified for each role.
@@ -34,7 +35,7 @@
 # proxy configuration
 #
 # If you need to send curl based notifications (pushover, pushbullet, slack, alerta,
-# flock, discord, telegram) via a proxy, set these to your proxy address:
+# flock, discord, telegram, signalgrid) via a proxy, set these to your proxy address:
 #export http_proxy="http://10.0.0.1:3128/"
 #export https_proxy="http://10.0.0.1:3128/"
 
@@ -151,6 +152,7 @@ sendsms=""
 #
 #  - emails addresses
 #  - pushover user tokens
+#  - signalgrid channels
 #  - telegram chat ids
 #  - slack channels
 #  - alerta environment
@@ -175,6 +177,7 @@ sendsms=""
 #
 #  email      : "user1@example.com user2@example.com|critical"
 #  pushover   : "2987343...9437837 8756278...2362736|critical"
+#  signalgrid : "CHANNEL1 CHANNEL2|critical"
 #  telegram   : "111827421 112746832|critical"
 #  slack      : "alarms disasters|critical"
 #  alerta     : "alarms disasters|critical"
@@ -317,6 +320,23 @@ PUSHOVER_APP_TOKEN=""
 # this pushover user token (empty = do not send a notification for unconfigured
 # roles):
 DEFAULT_RECIPIENT_PUSHOVER=""
+
+#------------------------------------------------------------------------------
+# signalgrid (signalgrid.co) global notification options
+
+# multiple recipients can be given like this:
+#                  "CHANNEL1 CHANNEL2 ..."
+
+# enable/disable sending signalgrid notifications
+SEND_SIGNALGRID="YES"
+
+# Signalgrid client key
+SIGNALGRID_CLIENT_KEY=""
+
+# if a role's recipients are not configured, a notification will be sent to
+# this signalgrid channel (empty = do not send a notification for unconfigured
+# roles):
+DEFAULT_RECIPIENT_SIGNALGRID=""
 
 
 #------------------------------------------------------------------------------
@@ -990,6 +1010,8 @@ custom_sender() {
 
 # role_recipients_pushover[sysadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
+# role_recipients_signalgrid[sysadmin]="${DEFAULT_RECIPIENT_SIGNALGRID}"
+
 # role_recipients_pushbullet[sysadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
 # role_recipients_telegram[sysadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
@@ -1050,6 +1072,8 @@ custom_sender() {
 # role_recipients_email[domainadmin]="${DEFAULT_RECIPIENT_EMAIL}"
 
 # role_recipients_pushover[domainadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
+
+# role_recipients_signalgrid[domainadmin]="${DEFAULT_RECIPIENT_SIGNALGRID}"
 
 # role_recipients_pushbullet[domainadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
@@ -1115,6 +1139,8 @@ custom_sender() {
 
 # role_recipients_pushover[dba]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
+# role_recipients_signalgrid[dba]="${DEFAULT_RECIPIENT_SIGNALGRID}"
+
 # role_recipients_pushbullet[dba]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
 # role_recipients_telegram[dba]="${DEFAULT_RECIPIENT_TELEGRAM}"
@@ -1178,6 +1204,8 @@ custom_sender() {
 # role_recipients_email[webmaster]="${DEFAULT_RECIPIENT_EMAIL}"
 
 # role_recipients_pushover[webmaster]="${DEFAULT_RECIPIENT_PUSHOVER}"
+
+# role_recipients_signalgrid[webmaster]="${DEFAULT_RECIPIENT_SIGNALGRID}"
 
 # role_recipients_pushbullet[webmaster]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
@@ -1243,6 +1271,8 @@ custom_sender() {
 
 # role_recipients_pushover[proxyadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
+# role_recipients_signalgrid[proxyadmin]="${DEFAULT_RECIPIENT_SIGNALGRID}"
+
 # role_recipients_pushbullet[proxyadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
 # role_recipients_telegram[proxyadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
@@ -1306,6 +1336,8 @@ custom_sender() {
 # role_recipients_email[sitemgr]="${DEFAULT_RECIPIENT_EMAIL}"
 
 # role_recipients_pushover[sitemgr]="${DEFAULT_RECIPIENT_PUSHOVER}"
+
+# role_recipients_signalgrid[sitemgr]="${DEFAULT_RECIPIENT_SIGNALGRID}"
 
 # role_recipients_pushbullet[sitemgr]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 

--- a/src/health/notifications/signalgrid/metadata.yaml
+++ b/src/health/notifications/signalgrid/metadata.yaml
@@ -1,0 +1,76 @@
+# yamllint disable rule:line-length
+---
+- id: 'notify-signalgrid'
+  meta:
+    name: 'Signalgrid'
+    link: 'https://signalgrid.co/'
+    categories:
+      - notify.agent
+    icon_filename: 'signalgrid.png'
+  keywords:
+    - Signalgrid
+  overview:
+    notification_description: |
+      Send Netdata alert notifications to Signalgrid channels.
+      Warning, critical, and recovery notifications are mapped to the corresponding Signalgrid notification types.
+    notification_limitations: ''
+  setup:
+    prerequisites:
+      list:
+        - title: ''
+          description: |
+            - A Signalgrid client key.
+            - A Signalgrid channel to receive the notifications.
+            - Access to the terminal where Netdata Agent is running.
+    configuration:
+      file:
+        name: 'health_alarm_notify.conf'
+      options:
+        description: 'The following options can be defined for this notification'
+        folding:
+          title: 'Config Options'
+          enabled: true
+        list:
+          - name: 'SEND_SIGNALGRID'
+            default_value: 'YES'
+            description: "Set `SEND_SIGNALGRID` to YES to enable Signalgrid notifications."
+            required: true
+          - name: 'SIGNALGRID_CLIENT_KEY'
+            default_value: ''
+            description: "Set `SIGNALGRID_CLIENT_KEY` to your Signalgrid client key."
+            required: true
+          - name: 'DEFAULT_RECIPIENT_SIGNALGRID'
+            default_value: ''
+            description: "Set `DEFAULT_RECIPIENT_SIGNALGRID` to the Signalgrid channel that should receive alert notifications. Multiple channels can be separated by spaces."
+            required: true
+            detailed_description: |
+              If no recipient is configured for a role, Netdata uses `DEFAULT_RECIPIENT_SIGNALGRID`.
+
+              You can route different Netdata roles to different Signalgrid channels:
+              ```text
+              role_recipients_signalgrid[sysadmin]="CHANNEL1"
+              role_recipients_signalgrid[domainadmin]="CHANNEL2"
+              role_recipients_signalgrid[dba]="CHANNEL3"
+              role_recipients_signalgrid[webmaster]="CHANNEL4"
+              role_recipients_signalgrid[proxyadmin]="CHANNEL5"
+              role_recipients_signalgrid[sitemgr]="CHANNEL6"
+              ```
+      examples:
+        folding:
+          enabled: true
+          title: ''
+        list:
+          - name: 'Basic Configuration'
+            folding:
+              enabled: false
+            description: ''
+            config: |
+              #------------------------------------------------------------------------------
+              # signalgrid (signalgrid.co) global notification options
+
+              SEND_SIGNALGRID="YES"
+              SIGNALGRID_CLIENT_KEY="YOUR_CLIENT_KEY"
+              DEFAULT_RECIPIENT_SIGNALGRID="YOUR_CHANNEL"
+  troubleshooting:
+    problems:
+      list: []


### PR DESCRIPTION
##### Summary

Adds Signalgrid as an alert notification method for the Netdata Agent.

The integration supports warning, critical, and recovery notifications and maps them to the corresponding Signalgrid notification types.

Signalgrid can be configured in `health_alarm_notify.conf` using a client key and channel, with support for default and role-specific channels.

##### Test Plan

Tested using Netdata's notification test flow.

Verified successful delivery of:
- warning notifications
- critical notifications
- recovery notifications

Also verified the notification script syntax and Signalgrid integration metadata.

##### Additional Information

Signalgrid is a push notification service that can be used to receive Netdata alerts on iOS, Android, Web.

<details> <summary>For users: How does this change affect me?</summary>

Users can configure Signalgrid as an additional notification method for Netdata Agent alerts.

Signalgrid notifications can be routed to a default channel or configured separately for individual Netdata roles.

</details>

I hope this matches the project’s contribution guidelines. If anything needs to be adjusted, I’m happy to make the necessary changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Signalgrid push notifications as an alert notification method for the Netdata Agent, passing the client key via stdin so it isn't exposed in process listings.

- Maps warning, critical, and recovery alerts to Signalgrid WARN, CRIT, and SUCCESS notification types.
- Adds `SEND_SIGNALGRID`, `SIGNALGRID_CLIENT_KEY`, and `DEFAULT_RECIPIENT_SIGNALGRID` options to `health_alarm_notify.conf`.
- Supports routing alerts to a default channel or role-specific channels via `role_recipients_signalgrid[...]`.
- Includes the Signalgrid integration metadata for the notifications reference.

<sup>Written for commit c2146dbb412753cbe72f103e04df99feed466c1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SignalGrid as a notification delivery option for health alarms.
  * Supports warning, critical, and recovery notifications through SignalGrid channels.
  * Added configuration for the SignalGrid client key, default recipient, and role-based routing.
  * Added setup guidance, configuration examples, and recipient settings for common alarm roles.
  * SignalGrid notifications can be enabled or disabled alongside existing notification methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->