### PR TITLE
feat(go.d/snmp): publish diagnostics independently of topology collection

### DIFF
--- a/src/go/cmd/godplugin/main.go
+++ b/src/go/cmd/godplugin/main.go
@@ -11,12 +11,6 @@ import (
 
 	"github.com/netdata/netdata/go/plugins/cmd/internal/agenthost"
 	"github.com/netdata/netdata/go/plugins/cmd/internal/discoveryproviders"
-	"github.com/netdata/netdata/go/plugins/plugin/agent"
-	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery"
-	"github.com/netdata/netdata/go/plugins/plugin/agent/policy"
-	"go.uber.org/automaxprocs/maxprocs"
-	"golang.org/x/net/http/httpproxy"
-
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
 	"github.com/netdata/netdata/go/plugins/pkg/cli"
@@ -24,9 +18,15 @@ import (
 	"github.com/netdata/netdata/go/plugins/pkg/hostinfo"
 	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
 	"github.com/netdata/netdata/go/plugins/pkg/terminal"
+	"github.com/netdata/netdata/go/plugins/plugin/agent"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/discovery"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/composition"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/policy"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
-	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext"
+	"go.uber.org/automaxprocs/maxprocs"
+	"golang.org/x/net/http/httpproxy"
 )
 
 func init() {
@@ -59,7 +59,12 @@ func main() {
 	}
 	isTerminal := terminal.IsTerminal()
 	isInsideK8s := hostinfo.IsInsideK8sCluster()
-	moduleRegistry := moduleRegistryWithSystemdPolicy(collectorapi.DefaultRegistry, hostinfo.SystemdVersion)
+	baseRegistry, publisher := collector.NewRegistry(pluginconfig.VarLibDir())
+	moduleRegistry := moduleRegistryWithSystemdPolicy(baseRegistry, hostinfo.SystemdVersion)
+	var services []composition.ProcessService
+	if !isTerminal {
+		services = append(services, publisher)
+	}
 
 	runModePolicy := policy.Agent(isTerminal)
 
@@ -71,6 +76,7 @@ func main() {
 		CollectorsConfigWatchPath: pluginconfig.CollectorsConfigWatchPaths(),
 		VarLibDir:                 pluginconfig.VarLibDir(),
 		ModuleRegistry:            moduleRegistry,
+		Services:                  services,
 		IsInsideK8s:               isInsideK8s,
 		RunModePolicy:             runModePolicy,
 		DiscoveryProviders: []discovery.ProviderFactory{

--- a/src/go/plugin/agent/agent.go
+++ b/src/go/plugin/agent/agent.go
@@ -37,6 +37,7 @@ type Config struct {
 	ServiceDiscoveryConfigDir []string
 	VarLibDir                 string
 
+	Services        []composition.ProcessService
 	ModuleRegistry  collectorapi.Registry
 	RunModule       string
 	RunJob          []string
@@ -78,6 +79,7 @@ type Agent struct {
 
 	DiscoveryProviders []discovery.ProviderFactory
 
+	Services       []composition.ProcessService
 	ModuleRegistry collectorapi.Registry
 	In             io.Reader
 	Out            io.Writer
@@ -107,6 +109,7 @@ func New(cfg Config) *Agent {
 		IsInsideK8s:               cfg.IsInsideK8s,
 		runModePolicy:             cfg.RunModePolicy,
 		ModuleRegistry:            cfg.ModuleRegistry,
+		Services:                  cfg.Services,
 		DiscoveryProviders:        cfg.DiscoveryProviders,
 		In:                        os.Stdin,
 		Out:                       safewriter.Stdout,
@@ -187,6 +190,7 @@ func (a *Agent) run(ctx context.Context) error {
 		InitialSecrets:        a.setupSecretStoreConfigs(),
 		InitialVnodes:         a.setupVnodeRegistry(),
 		Runtime:               a.setupRuntimeService(),
+		Services:              a.Services,
 		KeepAlive:             !a.runModePolicy.IsTerminal,
 		ShutdownTimeout:       a.ShutdownTimeout,
 	})

--- a/src/go/plugin/agent/jobmgr/composition/job_config_lifecycle_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/job_config_lifecycle_test.go
@@ -19,13 +19,39 @@ func TestProcessRetiresCommittedLifecycleOnRestartAndShutdown(t *testing.T) {
 	reader, writer := io.Pipe()
 	defer reader.Close()
 	defer writer.Close()
-	hook := &processLifecycleHook{current: make(map[collectorapi.JobConfigIdentity]bool), changed: make(chan struct{}, 8)}
+	hook := &processLifecycleHook{
+		current: make(map[collectorapi.JobConfigIdentity]bool),
+		changed: make(chan struct{}, 8),
+	}
 	config := testProductionProcessConfig(reader, io.Discard)
 	config.AutoEnable = true
-	config.Modules["test"] = collectorapi.Creator{JobConfigLifecycle: hook, Create: func() collectorapi.CollectorV1 { return &collectorapi.MockCollectorV1{FailOnInit: true} }}
-	config.DiscoveryProviders = []agentdiscovery.ProviderFactory{agentdiscovery.NewProviderFactory("test", func(agentdiscovery.BuildContext) (agentdiscovery.Discoverer, bool, error) {
-		return runTestDiscoverer{configs: []confgroup.Config{{"module": "test", "name": "device", "update_every": 1, "__source__": "test", "__source_type__": "user", "__provider__": "test"}}}, true, nil
-	})}
+	config.Modules["test"] = collectorapi.Creator{
+		JobConfigLifecycle: hook,
+		Create: func() collectorapi.CollectorV1 {
+			return &collectorapi.MockCollectorV1{
+				FailOnInit: true,
+			}
+		},
+	}
+	config.DiscoveryProviders = []agentdiscovery.ProviderFactory{
+		agentdiscovery.NewProviderFactory(
+			"test",
+			func(agentdiscovery.BuildContext) (agentdiscovery.Discoverer, bool, error) {
+				return runTestDiscoverer{
+					configs: []confgroup.Config{
+						{
+							"module":          "test",
+							"name":            "device",
+							"update_every":    1,
+							"__source__":      "test",
+							"__source_type__": "user",
+							"__provider__":    "test",
+						},
+					},
+				}, true, nil
+			},
+		),
+	}
 	process, err := NewProcess(config)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -38,7 +64,12 @@ func TestProcessRetiresCommittedLifecycleOnRestartAndShutdown(t *testing.T) {
 		t.Fatal("no committed lifecycle")
 	}
 	require.NoError(t, process.Restart(ctx))
-	require.Eventually(t, func() bool { hook.mu.Lock(); defer hook.mu.Unlock(); return hook.commits >= 2 }, time.Second, time.Millisecond)
+	require.Eventually(
+		t,
+		func() bool { hook.mu.Lock(); defer hook.mu.Unlock(); return hook.commits >= 2 },
+		time.Second,
+		time.Millisecond,
+	)
 	hook.mu.Lock()
 	removes := hook.removes
 	hook.mu.Unlock()
@@ -63,14 +94,26 @@ type processLifecycleHook struct {
 	changed          chan struct{}
 }
 
-func (*processLifecycleHook) Project(id collectorapi.JobConfigIdentity, _ map[string]any) collectorapi.JobConfigLifecycleSnapshot {
+func (*processLifecycleHook) Project(
+	id collectorapi.JobConfigIdentity,
+	_ map[string]any,
+) collectorapi.JobConfigLifecycleSnapshot {
 	return processLifecycleSnapshot{id}
 }
 func (*processLifecycleHook) Bind(collectorapi.JobConfigIdentity, collectorapi.RuntimeJob) {}
-func (*processLifecycleHook) Capture(id collectorapi.JobConfigIdentity, _ collectorapi.RuntimeJob) collectorapi.JobConfigLifecycleSnapshot {
+
+func (*processLifecycleHook) Capture(
+	id collectorapi.JobConfigIdentity,
+	_ collectorapi.RuntimeJob,
+) collectorapi.JobConfigLifecycleSnapshot {
 	return processLifecycleSnapshot{id}
 }
-func (h *processLifecycleHook) Reconcile(_ collectorapi.JobConfigIdentity, s collectorapi.JobConfigLifecycleSnapshot, _ collectorapi.RuntimeJob) {
+
+func (h *processLifecycleHook) Reconcile(
+	_ collectorapi.JobConfigIdentity,
+	s collectorapi.JobConfigLifecycleSnapshot,
+	_ collectorapi.RuntimeJob,
+) {
 	h.mu.Lock()
 	h.current[s.Identity()] = true
 	h.commits++

--- a/src/go/plugin/agent/jobmgr/composition/job_config_lifecycle_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/job_config_lifecycle_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composition
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	agentdiscovery "github.com/netdata/netdata/go/plugins/plugin/agent/discovery"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessRetiresCommittedLifecycleOnRestartAndShutdown(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+	hook := &processLifecycleHook{current: make(map[collectorapi.JobConfigIdentity]bool), changed: make(chan struct{}, 8)}
+	config := testProductionProcessConfig(reader, io.Discard)
+	config.AutoEnable = true
+	config.Modules["test"] = collectorapi.Creator{JobConfigLifecycle: hook, Create: func() collectorapi.CollectorV1 { return &collectorapi.MockCollectorV1{FailOnInit: true} }}
+	config.DiscoveryProviders = []agentdiscovery.ProviderFactory{agentdiscovery.NewProviderFactory("test", func(agentdiscovery.BuildContext) (agentdiscovery.Discoverer, bool, error) {
+		return runTestDiscoverer{configs: []confgroup.Config{{"module": "test", "name": "device", "update_every": 1, "__source__": "test", "__source_type__": "user", "__provider__": "test"}}}, true, nil
+	})}
+	process, err := NewProcess(config)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- process.Run(ctx) }()
+	select {
+	case <-hook.changed:
+	case <-ctx.Done():
+		t.Fatal("no committed lifecycle")
+	}
+	require.NoError(t, process.Restart(ctx))
+	require.Eventually(t, func() bool { hook.mu.Lock(); defer hook.mu.Unlock(); return hook.commits >= 2 }, time.Second, time.Millisecond)
+	hook.mu.Lock()
+	removes := hook.removes
+	hook.mu.Unlock()
+	require.Equal(t, 1, removes, "restart must retire prior run projection, even for identical config")
+	require.NoError(t, process.Terminate(ctx))
+	require.NoError(t, <-done)
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+	require.Empty(t, hook.current, "shutdown must retire committed lifecycle projections")
+}
+
+type processLifecycleSnapshot struct {
+	id collectorapi.JobConfigIdentity
+}
+
+func (s processLifecycleSnapshot) Identity() collectorapi.JobConfigIdentity { return s.id }
+
+type processLifecycleHook struct {
+	mu               sync.Mutex
+	current          map[collectorapi.JobConfigIdentity]bool
+	commits, removes int
+	changed          chan struct{}
+}
+
+func (*processLifecycleHook) Project(id collectorapi.JobConfigIdentity, _ map[string]any) collectorapi.JobConfigLifecycleSnapshot {
+	return processLifecycleSnapshot{id}
+}
+func (*processLifecycleHook) Bind(collectorapi.JobConfigIdentity, collectorapi.RuntimeJob) {}
+func (*processLifecycleHook) Capture(id collectorapi.JobConfigIdentity, _ collectorapi.RuntimeJob) collectorapi.JobConfigLifecycleSnapshot {
+	return processLifecycleSnapshot{id}
+}
+func (h *processLifecycleHook) Reconcile(_ collectorapi.JobConfigIdentity, s collectorapi.JobConfigLifecycleSnapshot, _ collectorapi.RuntimeJob) {
+	h.mu.Lock()
+	h.current[s.Identity()] = true
+	h.commits++
+	h.mu.Unlock()
+	h.changed <- struct{}{}
+}
+func (h *processLifecycleHook) Remove(id collectorapi.JobConfigIdentity) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.current, id)
+	h.removes++
+}

--- a/src/go/plugin/agent/jobmgr/composition/process.go
+++ b/src/go/plugin/agent/jobmgr/composition/process.go
@@ -54,6 +54,7 @@ type processCoreConfig struct {
 	Jobs            runJobServices            // process-lifetime job services (resolver, catalogs, vnodes)
 	Secrets         runSecretServices         // process-lifetime secret services
 	Discovery       runDiscoveryServices      // discovery services (providers, build context)
+	StopServices    func()                    // cancels and joins before retiring final run evidence
 	FinalizeOutput  func()                    // stops the runtime service at process teardown
 	Diagnostics     jobmgr.DiagnosticObserver // process-wide operational log sink
 }
@@ -615,6 +616,9 @@ func processRestartRequiresProcessExit(err error) bool {
 }
 
 func (pc *processCore) finalize(current *runGeneration, cause error) error {
+	if pc.config.StopServices != nil {
+		pc.config.StopServices()
+	}
 	generation := uint64(0)
 	if current != nil && current.run != nil {
 		generation = current.run.Generation()

--- a/src/go/plugin/agent/jobmgr/composition/process.go
+++ b/src/go/plugin/agent/jobmgr/composition/process.go
@@ -46,17 +46,17 @@ type processInputCompletion struct {
 var errRunDidNotQuiesce = errors.New("jobmgr composition: run did not quiesce")
 
 type processCoreConfig struct {
-	Input           io.Reader                 // plugin stdin
-	Output          io.Writer                 // plugin stdout
-	ShutdownTimeout time.Duration             // per-run shutdown budget
-	KeepAlive       bool                      // emit keepalive frames (long-lived agent mode)
-	Modules         collectorapi.Registry     // collector module registry
-	Jobs            runJobServices            // process-lifetime job services (resolver, catalogs, vnodes)
-	Secrets         runSecretServices         // process-lifetime secret services
-	Discovery       runDiscoveryServices      // discovery services (providers, build context)
-	StopServices    func()                    // cancels and joins before retiring final run evidence
-	FinalizeOutput  func()                    // stops the runtime service at process teardown
-	Diagnostics     jobmgr.DiagnosticObserver // process-wide operational log sink
+	Input           io.Reader                   // plugin stdin
+	Output          io.Writer                   // plugin stdout
+	ShutdownTimeout time.Duration               // per-run shutdown budget
+	KeepAlive       bool                        // emit keepalive frames (long-lived agent mode)
+	Modules         collectorapi.Registry       // collector module registry
+	Jobs            runJobServices              // process-lifetime job services (resolver, catalogs, vnodes)
+	Secrets         runSecretServices           // process-lifetime secret services
+	Discovery       runDiscoveryServices        // discovery services (providers, build context)
+	StopServices    func(context.Context) error // cancels and joins within the shutdown budget
+	FinalizeOutput  func()                      // stops the runtime service at process teardown
+	Diagnostics     jobmgr.DiagnosticObserver   // process-wide operational log sink
 }
 
 type processCore struct {
@@ -616,9 +616,6 @@ func processRestartRequiresProcessExit(err error) bool {
 }
 
 func (pc *processCore) finalize(current *runGeneration, cause error) error {
-	if pc.config.StopServices != nil {
-		pc.config.StopServices()
-	}
 	generation := uint64(0)
 	if current != nil && current.run != nil {
 		generation = current.run.Generation()
@@ -634,12 +631,6 @@ func (pc *processCore) finalize(current *runGeneration, cause error) error {
 	defer cancel()
 	var finishRun *lifecycle.RunSupervisor
 	if current != nil && current.isStarted() {
-		if pc.ingress.State() == functionadapter.ProcessIngressLive {
-			if err := pc.ingress.SealPause(); err != nil {
-				finalErr = errors.Join(finalErr, err)
-			}
-		}
-		current.Stop()
 		budget, err := current.run.BeginShutdown()
 		if err != nil {
 			finalErr = errors.Join(finalErr, err)
@@ -647,6 +638,17 @@ func (pc *processCore) finalize(current *runGeneration, cause error) error {
 			shutdownCtx = budget.Context()
 			finishRun = current.run
 		}
+	}
+	if pc.config.StopServices != nil {
+		finalErr = errors.Join(finalErr, pc.config.StopServices(shutdownCtx))
+	}
+	if current != nil && current.isStarted() {
+		if pc.ingress.State() == functionadapter.ProcessIngressLive {
+			if err := pc.ingress.SealPause(); err != nil {
+				finalErr = errors.Join(finalErr, err)
+			}
+		}
+		current.Stop()
 		if pc.ingress.State() == functionadapter.ProcessIngressLive {
 			if err := pc.ingress.DrainPause(shutdownCtx, 0); err != nil {
 				finalErr = errors.Join(finalErr, err)

--- a/src/go/plugin/agent/jobmgr/composition/public.go
+++ b/src/go/plugin/agent/jobmgr/composition/public.go
@@ -211,9 +211,17 @@ func (p *Process) Run(ctx context.Context) error {
 		})
 	}
 	stopServices := p.startServices(ctx)
+	stop := func() error {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), p.core.config.ShutdownTimeout)
+		defer cancel()
+		return stopServices(shutdownCtx)
+	}
+	defer stop()
 	p.core.config.StopServices = stopServices
 	result := p.core.run(ctx, p.controls)
-	stopServices()
+	if err := stop(); err != nil && !errors.Is(result, err) {
+		result = errors.Join(result, err)
+	}
 	p.mu.Lock()
 	p.result = result
 	close(p.done)
@@ -293,24 +301,48 @@ func cloneSecretConfigs(configs []secretstore.Config) ([]secretstore.Config, err
 	return cloned, nil
 }
 
-func (p *Process) startServices(ctx context.Context) func() {
+func (p *Process) startServices(ctx context.Context) func(context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
-	var joined sync.WaitGroup
+	var completions []<-chan struct{}
 	for _, service := range p.services {
 		if service == nil {
 			continue
 		}
-		joined.Add(1)
+		done := make(chan struct{})
+		completions = append(completions, done)
 		go func() {
-			defer joined.Done()
+			defer close(done)
 			defer func() {
 				if recovered := recover(); recovered != nil {
-					jobmgr.ObserveDiagnostic(p.core.diagnostics, jobmgr.DiagnosticEvent{Level: jobmgr.DiagnosticError, Name: "process service panicked", Err: fmt.Errorf("%v", recovered)})
+					jobmgr.ObserveDiagnostic(p.core.diagnostics, jobmgr.DiagnosticEvent{
+						Level: jobmgr.DiagnosticError,
+						Name:  "process service panicked",
+						Err:   fmt.Errorf("%v", recovered),
+					})
 				}
 			}()
 			service.Run(ctx)
 		}()
 	}
 	var once sync.Once
-	return func() { once.Do(func() { cancel(); joined.Wait() }) }
+	var stopErr error
+	return func(shutdownCtx context.Context) error {
+		once.Do(func() {
+			cancel()
+			for _, done := range completions {
+				select {
+				case <-done:
+					continue
+				default:
+				}
+				select {
+				case <-done:
+				case <-shutdownCtx.Done():
+					stopErr = fmt.Errorf("jobmgr composition: process services shutdown: %w", shutdownCtx.Err())
+					return
+				}
+			}
+		})
+		return stopErr
+	}
 }

--- a/src/go/plugin/agent/jobmgr/composition/public.go
+++ b/src/go/plugin/agent/jobmgr/composition/public.go
@@ -39,6 +39,12 @@ func ContainsOnlyProcessControlErrors(err error, allowed ...error) bool {
 	return jobmgr.ContainsOnlyErrorLeaves(err, allowed...)
 }
 
+// ProcessService runs alongside all run generations. It must return when ctx
+// is canceled and handle its own operational failures without stopping jobs.
+type ProcessService interface {
+	Run(context.Context)
+}
+
 type RuntimeService interface {
 	runtimecomp.Service
 	Start(pluginName string, output io.Writer)
@@ -64,6 +70,8 @@ type Config struct {
 	InitialSecrets []secretstore.Config           // initial secret store configs
 	InitialVnodes  map[string]*vnodes.VirtualNode // file-configured vnodes
 
+	Services []ProcessService // optional process-owned background services
+
 	Runtime RuntimeService // runtime service (charts/host-scope; nil disables runtime charts)
 
 	ShutdownTimeout time.Duration // per-run shutdown budget
@@ -83,6 +91,7 @@ type Process struct {
 	attempted bool       // Run has been attempted (once)
 	result    error      // terminal run result
 
+	services   []ProcessService
 	runtime    RuntimeService // runtime service (started/stopped around Run)
 	pluginName string         // plugin name
 }
@@ -178,6 +187,7 @@ func NewProcess(config Config) (*Process, error) {
 		started:    make(chan struct{}),
 		done:       make(chan struct{}),
 		runtime:    config.Runtime,
+		services:   slices.Clone(config.Services),
 		pluginName: config.PluginName,
 	}, nil
 }
@@ -200,7 +210,10 @@ func (p *Process) Run(ctx context.Context) error {
 			Owner: p.core.frames,
 		})
 	}
+	stopServices := p.startServices(ctx)
+	p.core.config.StopServices = stopServices
 	result := p.core.run(ctx, p.controls)
+	stopServices()
 	p.mu.Lock()
 	p.result = result
 	close(p.done)
@@ -278,4 +291,26 @@ func cloneSecretConfigs(configs []secretstore.Config) ([]secretstore.Config, err
 		cloned[index] = clone
 	}
 	return cloned, nil
+}
+
+func (p *Process) startServices(ctx context.Context) func() {
+	ctx, cancel := context.WithCancel(ctx)
+	var joined sync.WaitGroup
+	for _, service := range p.services {
+		if service == nil {
+			continue
+		}
+		joined.Add(1)
+		go func() {
+			defer joined.Done()
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					jobmgr.ObserveDiagnostic(p.core.diagnostics, jobmgr.DiagnosticEvent{Level: jobmgr.DiagnosticError, Name: "process service panicked", Err: fmt.Errorf("%v", recovered)})
+				}
+			}()
+			service.Run(ctx)
+		}()
+	}
+	var once sync.Once
+	return func() { once.Do(func() { cancel(); joined.Wait() }) }
 }

--- a/src/go/plugin/agent/jobmgr/composition/public_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/public_test.go
@@ -285,3 +285,89 @@ func testProductionProcessConfig(input io.Reader, output io.Writer) Config {
 		ShutdownTimeout:    time.Second,
 	}
 }
+
+func TestProcessServiceSpansRestartsAndJoinsOnTermination(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+	service := &testProcessService{started: make(chan struct{}), stopped: make(chan struct{}), release: make(chan struct{})}
+	config := testProductionProcessConfig(reader, io.Discard)
+	config.Services = []ProcessService{service}
+	process, err := NewProcess(config)
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() { done <- process.Run(t.Context()) }()
+	select {
+	case <-service.started:
+	case <-time.After(time.Second):
+		t.Fatal("service did not start")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	require.NoError(t, process.Restart(ctx))
+	select {
+	case <-service.stopped:
+		t.Fatal("service stopped on restart")
+	default:
+	}
+	terminated := make(chan error, 1)
+	go func() { terminated <- process.Terminate(ctx) }()
+	select {
+	case <-service.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("service was not canceled")
+	}
+	select {
+	case <-terminated:
+		t.Fatal("termination returned before service joined")
+	default:
+	}
+	close(service.release)
+	require.NoError(t, <-terminated)
+	require.NoError(t, <-done)
+}
+
+type testProcessService struct{ started, stopped, release chan struct{} }
+
+func (s *testProcessService) Run(ctx context.Context) {
+	close(s.started)
+	<-ctx.Done()
+	close(s.stopped)
+	<-s.release
+}
+
+func TestProcessServicesJoinOnInputShutdownAndIsolatePanic(t *testing.T) {
+	for _, input := range []string{"", "QUIT\n"} {
+		t.Run(input, func(t *testing.T) {
+			joined := make(chan struct{})
+			panicked := make(chan struct{})
+			config := testProductionProcessConfig(strings.NewReader(input), io.Discard)
+			config.Services = []ProcessService{
+				processServiceFunc(func(ctx context.Context) { <-ctx.Done(); close(joined) }),
+				processServiceFunc(func(context.Context) { defer close(panicked); panic("injected service failure") }),
+			}
+			process, err := NewProcess(config)
+			require.NoError(t, err)
+			err = process.Run(t.Context())
+			if input == "" {
+				require.ErrorContains(t, err, "Function input stopped")
+			} else {
+				require.NoError(t, err)
+			}
+			select {
+			case <-joined:
+			default:
+				t.Fatal("service outlived Process.Run")
+			}
+			select {
+			case <-panicked:
+			default:
+				t.Fatal("panic service was not joined")
+			}
+		})
+	}
+}
+
+type processServiceFunc func(context.Context)
+
+func (f processServiceFunc) Run(ctx context.Context) { f(ctx) }

--- a/src/go/plugin/agent/jobmgr/composition/public_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/public_test.go
@@ -371,3 +371,58 @@ func TestProcessServicesJoinOnInputShutdownAndIsolatePanic(t *testing.T) {
 type processServiceFunc func(context.Context)
 
 func (f processServiceFunc) Run(ctx context.Context) { f(ctx) }
+
+func TestProcessServiceShutdownTimeoutIsReportedWithoutBlockingTeardown(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+	started, canceled, release, exited := make(chan struct{}), make(chan struct{}), make(chan struct{}), make(chan struct{})
+	config := testProductionProcessConfig(reader, io.Discard)
+	config.ShutdownTimeout = 50 * time.Millisecond
+	config.Services = []ProcessService{processServiceFunc(func(ctx context.Context) {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		<-release
+		close(exited)
+	})}
+	process, err := NewProcess(config)
+	require.NoError(t, err)
+	runDone := make(chan error, 1)
+	go func() { runDone <- process.Run(t.Context()) }()
+	<-started
+	terminated := make(chan error, 1)
+	go func() { terminated <- process.Terminate(t.Context()) }()
+	<-canceled
+	var stopErr error
+	timedOut := false
+	select {
+	case stopErr = <-terminated:
+	case <-time.After(time.Second):
+		timedOut = true
+		t.Error("service join bypassed the shutdown budget")
+	}
+	var runErr error
+	runTimedOut := false
+	select {
+	case runErr = <-runDone:
+	case <-time.After(time.Second):
+		runTimedOut = true
+		t.Error("Process.Run re-entered service wait after termination")
+	}
+	close(release)
+	<-exited
+	if timedOut {
+		stopErr = <-terminated
+	}
+	if runTimedOut {
+		runErr = <-runDone
+	}
+	require.ErrorIs(t, stopErr, context.DeadlineExceeded)
+	require.ErrorIs(t, runErr, context.DeadlineExceeded)
+	select {
+	case <-process.done:
+	default:
+		t.Fatal("process completion was not signaled")
+	}
+}

--- a/src/go/plugin/agent/jobmgr/composition/run.go
+++ b/src/go/plugin/agent/jobmgr/composition/run.go
@@ -283,6 +283,7 @@ func newRunGeneration(
 		lifecycle.RealClock{},
 		functions,
 		joinedRunFinalizer{
+			jobs:                dynCfgJobs,
 			functions:           functions,
 			secrets:             secretController,
 			metricsRegistration: metricsRegistration,
@@ -497,6 +498,7 @@ func (rmr *runMetricsRegistration) release() error {
 }
 
 type joinedRunFinalizer struct {
+	jobs                *joboutput.DynCfgJobController
 	functions           *FunctionAssembly
 	secrets             *secretadapter.Controller
 	metricsRegistration *runMetricsRegistration
@@ -506,6 +508,7 @@ func (jrf joinedRunFinalizer) FinalizeRun(ctx context.Context, generation uint64
 	if jrf.functions == nil || jrf.secrets == nil {
 		return errors.New("jobmgr composition: incomplete run finalizer")
 	}
+	jrf.jobs.FinalizeJobConfigLifecycles()
 	return errors.Join(
 		jrf.metricsRegistration.release(),
 		jrf.functions.FinalizeRun(ctx, generation),

--- a/src/go/plugin/agent/jobmgr/joboutput/job_config_lifecycle.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/job_config_lifecycle.go
@@ -209,3 +209,17 @@ func (dcjc *DynCfgJobController) jobConfigLifecycleHook(
 	}
 	return creator.JobConfigLifecycle
 }
+
+// FinalizeJobConfigLifecycles retires committed projections after all jobs and
+// graph mutations in this run have joined. Successor runs must not inherit them.
+func (dcjc *DynCfgJobController) FinalizeJobConfigLifecycles() {
+	if dcjc == nil || dcjc.graph == nil {
+		return
+	}
+	for _, id := range dcjc.graph.IDs() {
+		state := dcjc.currentJobConfigLifecycleGraphState(id)
+		if state.valid && state.hook != nil {
+			callJobConfigLifecycle(func() { state.hook.Remove(state.identity) })
+		}
+	}
+}

--- a/src/go/plugin/go.d/collector/diagnostics_integration_test.go
+++ b/src/go/plugin/go.d/collector/diagnostics_integration_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package collector
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	agentdiscovery "github.com/netdata/netdata/go/plugins/plugin/agent/discovery"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/composition"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalSNMPFailedReadinessPublishesWithoutTopology(t *testing.T) {
+	dir := t.TempDir()
+	registry, publisher := NewRegistry(dir)
+	// Exercise the real normal-SNMP Creator and failed Init commit with the
+	// topology module entirely absent from enabled modules.
+	modules := collectorapi.Registry{"snmp": registry["snmp"]}
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+	process, err := composition.NewProcess(composition.Config{
+		Input: reader, Output: io.Discard, PluginName: "go.d", Modules: modules,
+		Defaults: confgroup.Registry{"snmp": {}}, AutoEnable: true, ShutdownTimeout: time.Second,
+		Services: []composition.ProcessService{publisher},
+		DiscoveryProviders: []agentdiscovery.ProviderFactory{agentdiscovery.NewProviderFactory("test", func(agentdiscovery.BuildContext) (agentdiscovery.Discoverer, bool, error) {
+			return diagnosticTestDiscovery{}, true, nil
+		})},
+	})
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- process.Run(ctx) }()
+	var document snmpdiag.Document
+	require.Eventually(t, func() bool {
+		file, err := os.Open(snmpdiag.ArchivePath(dir))
+		if err != nil {
+			return false
+		}
+		defer file.Close()
+		document, err = snmpdiag.Read(file, snmpdiag.DefaultReadLimits())
+		return err == nil && len(document.Snapshot.Lifecycle.Cut.Entries) == 1
+	}, 3*time.Second, 5*time.Millisecond)
+	require.Nil(t, document.Snapshot.Topology)
+	row := document.Snapshot.Lifecycle.Cut.Entries[0]
+	require.Equal(t, "init", row.LastCompleted.Phase)
+	require.Equal(t, "failed", row.LastCompleted.Outcome)
+	require.False(t, row.TopologyReady)
+	archive, err := snmptopology.InspectDiagnosticDocument(document)
+	require.NoError(t, err)
+	_, err = archive.Summary()
+	require.NoError(t, err)
+	_, err = archive.Replay(snmptopology.DefaultDiagnosticQueryOptions())
+	require.ErrorContains(t, err, "no replayable topology")
+	before, err := os.ReadFile(snmpdiag.ArchivePath(dir))
+	require.NoError(t, err)
+	require.NoError(t, process.Terminate(ctx))
+	require.NoError(t, <-done)
+	after, err := os.ReadFile(snmpdiag.ArchivePath(dir))
+	require.NoError(t, err)
+	require.Equal(t, before, after, "shutdown must preserve useful evidence, not publish cleared state")
+}
+
+type diagnosticTestDiscovery struct{}
+
+func (diagnosticTestDiscovery) Run(ctx context.Context, out chan<- []*confgroup.Group) {
+	config := confgroup.Config{"module": "snmp", "name": "invalid-device", "hostname": "", "update_every": 10}
+	config.SetProvider("test")
+	config.SetSourceType(confgroup.TypeUser)
+	config.SetSource("file=test")
+	select {
+	case out <- []*confgroup.Group{{Source: "test", Configs: []confgroup.Config{config}}}:
+	case <-ctx.Done():
+		return
+	}
+	<-ctx.Done()
+}
+
+func TestSNMPRegistryInstancesHaveIndependentState(t *testing.T) {
+	first, firstPublisher := NewRegistry(t.TempDir())
+	second, secondPublisher := NewRegistry(t.TempDir())
+	require.NotSame(t, firstPublisher, secondPublisher)
+	require.NotEqual(t, pointerField(t, first["snmp"].Create(), "deviceStore"), pointerField(t, second["snmp"].Create(), "deviceStore"))
+	require.NotContains(t, collectorapi.DefaultRegistry, "snmp")
+}

--- a/src/go/plugin/go.d/collector/diagnostics_integration_test.go
+++ b/src/go/plugin/go.d/collector/diagnostics_integration_test.go
@@ -23,17 +23,31 @@ func TestNormalSNMPFailedReadinessPublishesWithoutTopology(t *testing.T) {
 	registry, publisher := NewRegistry(dir)
 	// Exercise the real normal-SNMP Creator and failed Init commit with the
 	// topology module entirely absent from enabled modules.
-	modules := collectorapi.Registry{"snmp": registry["snmp"]}
+	modules := collectorapi.Registry{
+		"snmp": registry["snmp"],
+	}
 	reader, writer := io.Pipe()
 	defer reader.Close()
 	defer writer.Close()
 	process, err := composition.NewProcess(composition.Config{
-		Input: reader, Output: io.Discard, PluginName: "go.d", Modules: modules,
-		Defaults: confgroup.Registry{"snmp": {}}, AutoEnable: true, ShutdownTimeout: time.Second,
-		Services: []composition.ProcessService{publisher},
-		DiscoveryProviders: []agentdiscovery.ProviderFactory{agentdiscovery.NewProviderFactory("test", func(agentdiscovery.BuildContext) (agentdiscovery.Discoverer, bool, error) {
-			return diagnosticTestDiscovery{}, true, nil
-		})},
+		Input:      reader,
+		Output:     io.Discard,
+		PluginName: "go.d",
+		Modules:    modules,
+		Defaults: confgroup.Registry{
+			"snmp": {},
+		},
+		AutoEnable:      true,
+		ShutdownTimeout: time.Second,
+		Services:        []composition.ProcessService{publisher},
+		DiscoveryProviders: []agentdiscovery.ProviderFactory{
+			agentdiscovery.NewProviderFactory(
+				"test",
+				func(agentdiscovery.BuildContext) (agentdiscovery.Discoverer, bool, error) {
+					return diagnosticTestDiscovery{}, true, nil
+				},
+			),
+		},
 	})
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -73,7 +87,12 @@ func TestNormalSNMPFailedReadinessPublishesWithoutTopology(t *testing.T) {
 type diagnosticTestDiscovery struct{}
 
 func (diagnosticTestDiscovery) Run(ctx context.Context, out chan<- []*confgroup.Group) {
-	config := confgroup.Config{"module": "snmp", "name": "invalid-device", "hostname": "", "update_every": 10}
+	config := confgroup.Config{
+		"module":       "snmp",
+		"name":         "invalid-device",
+		"hostname":     "",
+		"update_every": 10,
+	}
 	config.SetProvider("test")
 	config.SetSourceType(confgroup.TypeUser)
 	config.SetSource("file=test")
@@ -89,6 +108,10 @@ func TestSNMPRegistryInstancesHaveIndependentState(t *testing.T) {
 	first, firstPublisher := NewRegistry(t.TempDir())
 	second, secondPublisher := NewRegistry(t.TempDir())
 	require.NotSame(t, firstPublisher, secondPublisher)
-	require.NotEqual(t, pointerField(t, first["snmp"].Create(), "deviceStore"), pointerField(t, second["snmp"].Create(), "deviceStore"))
+	require.NotEqual(
+		t,
+		pointerField(t, first["snmp"].Create(), "deviceStore"),
+		pointerField(t, second["snmp"].Create(), "deviceStore"),
+	)
 	require.NotContains(t, collectorapi.DefaultRegistry, "snmp")
 }

--- a/src/go/plugin/go.d/collector/init.go
+++ b/src/go/plugin/go.d/collector/init.go
@@ -3,11 +3,14 @@
 package collector
 
 import (
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 	snmptraps "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/reversedns"
+	"maps"
 
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/activemq"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/adaptecraid"
@@ -144,7 +147,9 @@ import (
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/zookeeper"
 )
 
-func init() {
+// NewRegistry gives each Agent its own shared SNMP state and publisher.
+func NewRegistry(varLibDir string) (collectorapi.Registry, *snmpdiag.Publisher) {
+	registry := maps.Clone(collectorapi.DefaultRegistry)
 	// These collectors share SNMP state; wire them together here instead of
 	// exposing package-global registries from the individual collector packages.
 	deviceStore := ddsnmp.NewDeviceStore()
@@ -157,7 +162,9 @@ func init() {
 		MaxConcurrent: reversedns.DefaultMaxConcurrent,
 	})
 
-	snmp.Register(deviceStore)
-	snmptopology.Register(deviceStore, trapEnrichment, reverseDNS)
-	snmptraps.Register(deviceStore, trapEnrichment, reverseDNS)
+	publisher := snmpdiag.NewPublisher(deviceStore, varLibDir)
+	registry["snmp"] = snmp.Creator(deviceStore)
+	registry["snmp_topology"] = snmptopology.Creator(deviceStore, trapEnrichment, reverseDNS, publisher)
+	registry["snmp_traps"] = snmptraps.Creator(deviceStore, trapEnrichment, reverseDNS)
+	return registry, publisher
 }

--- a/src/go/plugin/go.d/collector/init.go
+++ b/src/go/plugin/go.d/collector/init.go
@@ -3,6 +3,8 @@
 package collector
 
 import (
+	"maps"
+
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
@@ -10,7 +12,6 @@ import (
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 	snmptraps "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/reversedns"
-	"maps"
 
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/activemq"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/adaptecraid"
@@ -18,6 +19,7 @@ import (
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/apache"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/apcupsd"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/azure_monitor"
+
 	// _ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/as400" // Moved to ibm.d.plugin (requires CGO)
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/beanstalk"
 	_ "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/bind"

--- a/src/go/plugin/go.d/collector/init_test.go
+++ b/src/go/plugin/go.d/collector/init_test.go
@@ -24,6 +24,7 @@ import (
 var serviceModulePattern = regexp.MustCompile(`(?m)^\s*(?:-\s*)?module:\s*([A-Za-z0-9_.-]+)\s*$`)
 
 func TestStockServiceDiscoveryRulesTargetRegisteredCollectors(t *testing.T) {
+	registry, _ := NewRegistry(t.TempDir())
 	files, err := filepath.Glob("../config/go.d/sd/*.conf")
 	require.NoError(t, err)
 	require.NotEmpty(t, files)
@@ -50,7 +51,7 @@ func TestStockServiceDiscoveryRulesTargetRegisteredCollectors(t *testing.T) {
 				modules = [][]string{{"", rule.ID}}
 			}
 			for _, match := range modules {
-				_, ok := collectorapi.DefaultRegistry.Lookup(match[1])
+				_, ok := registry.Lookup(match[1])
 				assert.Truef(t, ok, "%s service rule %q targets unregistered collector %q", filepath.Base(file), rule.ID, match[1])
 			}
 		}
@@ -58,9 +59,11 @@ func TestStockServiceDiscoveryRulesTargetRegisteredCollectors(t *testing.T) {
 }
 
 func TestSNMPFamilyRegistrationUsesSharedDependencies(t *testing.T) {
-	snmpCreator := requireCreator(t, "snmp")
-	topologyCreator := requireCreator(t, "snmp_topology")
-	trapsCreator := requireCreator(t, "snmp_traps")
+	registry, publisher := NewRegistry(t.TempDir())
+	require.NotNil(t, publisher)
+	snmpCreator := requireCreator(t, registry, "snmp")
+	topologyCreator := requireCreator(t, registry, "snmp_topology")
+	trapsCreator := requireCreator(t, registry, "snmp_traps")
 
 	assert.NotNil(t, snmpCreator.Create)
 	assert.Nil(t, snmpCreator.CreateV2)
@@ -109,9 +112,9 @@ func TestSNMPFamilyRegistrationUsesSharedDependencies(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, negativeTTL)
 }
 
-func requireCreator(t *testing.T, module string) collectorapi.Creator {
+func requireCreator(t *testing.T, registry collectorapi.Registry, module string) collectorapi.Creator {
 	t.Helper()
-	creator, ok := collectorapi.DefaultRegistry.Lookup(module)
+	creator, ok := registry.Lookup(module)
 	require.True(t, ok, "collector %q is not registered", module)
 	return creator
 }

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -10,11 +10,10 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
-
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/pinger"
@@ -24,14 +23,10 @@ import (
 //go:embed "config_schema.json"
 var configSchema string
 
-// Register registers the SNMP collector with its shared SNMP-family device store.
-func Register(store *ddsnmp.DeviceStore) {
-	collectorapi.Register("snmp", newCreator(store))
-}
-
-func newCreator(store *ddsnmp.DeviceStore) collectorapi.Creator {
+// Creator constructs registration with explicit SNMP-family dependencies.
+func Creator(store *ddsnmp.DeviceStore) collectorapi.Creator {
 	if store == nil {
-		panic("snmp Register requires a non-nil device store")
+		panic("snmp Creator requires a non-nil device store")
 	}
 	return collectorapi.Creator{
 		JobConfigSchema: configSchema,
@@ -120,6 +115,7 @@ type (
 		seenProfiles             map[string]bool
 		deviceStore              *ddsnmp.DeviceStore
 		deviceLifecycleStore     deviceLifecycleStore
+		deviceWriter             *ddsnmp.DeviceWriter
 		deviceLifecycleMu        sync.Mutex
 		deviceLifecycleOwner     string
 		deviceLifecycleInfo      ddsnmp.DeviceLifecycleInfo

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -14,6 +14,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/gosnmp/gosnmp"
+	snmpmock "github.com/gosnmp/gosnmp/mocks"
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
@@ -22,10 +25,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/collecttest"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/pinger"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
-
-	"github.com/golang/mock/gomock"
-	"github.com/gosnmp/gosnmp"
-	snmpmock "github.com/gosnmp/gosnmp/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,8 +48,8 @@ func TestCollector_ConfigurationSerialize(t *testing.T) {
 }
 
 func TestCollectorCreatorRequiresDeviceStore(t *testing.T) {
-	require.PanicsWithValue(t, "snmp Register requires a non-nil device store", func() {
-		_ = newCreator(nil)
+	require.PanicsWithValue(t, "snmp Creator requires a non-nil device store", func() {
+		_ = Creator(nil)
 	})
 }
 
@@ -267,7 +266,7 @@ func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilReconcile(t *testi
 	collr := New(store)
 	collr.Hostname = ""
 	job := snmpLifecycleTestRuntimeJob{collector: collr}
-	hook := newCreator(store).JobConfigLifecycle
+	hook := Creator(store).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
 	hook.Bind(identity, job)
@@ -286,7 +285,7 @@ func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilReconcile(t *testi
 
 func TestSNMPJobConfigLifecycleProjectsCredentialFreeBaseline(t *testing.T) {
 	store := ddsnmp.NewDeviceStore()
-	hook := newCreator(store).JobConfigLifecycle
+	hook := Creator(store).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 	config := map[string]any{
 		"hostname":  "switch-a.example",
@@ -323,7 +322,7 @@ func TestCollectorRejectedManagedCandidateDoesNotRemoveIncumbentConnection(t *te
 	store.Register(identity.String(), ddsnmp.DeviceConnectionInfo{Hostname: "incumbent.example"})
 	collr := New(store)
 	job := snmpLifecycleTestRuntimeJob{collector: collr}
-	hook := newCreator(store).JobConfigLifecycle
+	hook := Creator(store).JobConfigLifecycle
 
 	hook.Bind(identity, job)
 	collr.Cleanup(context.Background())
@@ -337,7 +336,7 @@ func TestCollectorManagedLifecycleSnapshotIsDetachedAtCapture(t *testing.T) {
 	collr := New(store)
 	collr.Config = prepareV2Config()
 	job := snmpLifecycleTestRuntimeJob{collector: collr}
-	hook := newCreator(store).JobConfigLifecycle
+	hook := Creator(store).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
 	hook.Bind(identity, job)
@@ -405,7 +404,7 @@ func TestCollectorManagedConnectionCollectedBeforeReconcileIsPublishedAtReconcil
 	collr.Config = prepareV2Config()
 	collr.ManualProfiles = []string{"profile-a"}
 	job := snmpLifecycleTestRuntimeJob{collector: collr}
-	hook := newCreator(store).JobConfigLifecycle
+	hook := Creator(store).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
 	hook.Bind(identity, job)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -119,6 +119,7 @@ type deviceLifecycleRecord struct {
 // NewDeviceStore returns an empty SNMP device connection-state store.
 func NewDeviceStore() *DeviceStore {
 	return &DeviceStore{
+		changes:            make(chan struct{}, 1),
 		ownerRegistrations: make(map[string]DeviceRegistrationID),
 		devices:            make(map[DeviceRegistrationID]DeviceConnectionInfo),
 		lifecycles:         make(map[DeviceRegistrationID]deviceLifecycleRecord),
@@ -128,13 +129,16 @@ func NewDeviceStore() *DeviceStore {
 
 // DeviceStore holds SNMP device connection state shared between SNMP-family modules.
 type DeviceStore struct {
-	mu                 sync.RWMutex
-	ownerRegistrations map[string]DeviceRegistrationID
-	devices            map[DeviceRegistrationID]DeviceConnectionInfo
-	lifecycles         map[DeviceRegistrationID]deviceLifecycleRecord
-	byHostname         map[string]map[string]struct{}
-	lastRegistrationID DeviceRegistrationID
-	lifecycleSequence  uint64
+	mu                    sync.RWMutex
+	changes               chan struct{}
+	writers               map[string]*DeviceWriter
+	ownerRegistrations    map[string]DeviceRegistrationID
+	devices               map[DeviceRegistrationID]DeviceConnectionInfo
+	lifecycles            map[DeviceRegistrationID]deviceLifecycleRecord
+	byHostname            map[string]map[string]struct{}
+	lastRegistrationID    DeviceRegistrationID
+	configurationRevision uint64
+	lifecycleSequence     uint64
 }
 
 // RegisterJob starts or updates the credential-free lifecycle row for a
@@ -201,15 +205,16 @@ func (s *DeviceStore) LifecycleCut() DeviceLifecycleCut {
 
 // ReplaceJob atomically removes a prior configuration incarnation, when
 // different, and publishes the current lifecycle plus any topology-ready state.
+// The returned writer replaces the prior runtime's update authority.
 func (s *DeviceStore) ReplaceJob(
 	previousOwnerKey string,
 	ownerKey string,
 	info DeviceLifecycleInfo,
 	status DeviceLifecycleStatus,
 	device *DeviceConnectionInfo,
-) {
+) *DeviceWriter {
 	if ownerKey == "" {
-		return
+		return nil
 	}
 	s.mu.Lock()
 	s.ensureMapsLocked()
@@ -234,7 +239,15 @@ func (s *DeviceStore) ReplaceJob(
 		s.addHostnameIndexLocked(ownerKey, cloned.Hostname)
 	}
 	s.lifecycleSequence++
+	s.configurationRevision++
+	s.notifyConfigurationChangedLocked()
+	writer := &DeviceWriter{store: s, owner: ownerKey}
+	if s.writers == nil {
+		s.writers = make(map[string]*DeviceWriter)
+	}
+	s.writers[ownerKey] = writer
 	s.mu.Unlock()
+	return writer
 }
 
 // Register adds or updates a device by its caller-owned lookup key. An update
@@ -242,6 +255,11 @@ func (s *DeviceStore) ReplaceJob(
 // Reference types are deep-copied to prevent data races with the caller.
 func (s *DeviceStore) Register(ownerKey string, info DeviceConnectionInfo) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.registerLocked(ownerKey, info)
+}
+
+func (s *DeviceStore) registerLocked(ownerKey string, info DeviceConnectionInfo) {
 	s.ensureMapsLocked()
 	registrationID, exists := s.ownerRegistrations[ownerKey]
 	if exists {
@@ -256,7 +274,6 @@ func (s *DeviceStore) Register(ownerKey string, info DeviceConnectionInfo) {
 	s.lifecycles[registrationID] = record
 	s.addHostnameIndexLocked(ownerKey, info.Hostname)
 	s.lifecycleSequence++
-	s.mu.Unlock()
 }
 
 // Unregister removes a complete job incarnation from the store.
@@ -264,6 +281,8 @@ func (s *DeviceStore) Unregister(ownerKey string) {
 	s.mu.Lock()
 	if _, ok := s.ownerRegistrations[ownerKey]; ok {
 		s.removeRegistrationLocked(ownerKey)
+		s.configurationRevision++
+		s.notifyConfigurationChangedLocked()
 		s.lifecycleSequence++
 	}
 	s.mu.Unlock()
@@ -280,6 +299,7 @@ func (s *DeviceStore) removeRegistrationLocked(ownerKey string) {
 	delete(s.devices, registrationID)
 	delete(s.lifecycles, registrationID)
 	delete(s.ownerRegistrations, ownerKey)
+	delete(s.writers, ownerKey)
 }
 
 // Entries returns a deterministic, deep-copied snapshot of all registered jobs.
@@ -442,4 +462,55 @@ func deviceHostnameIndexKey(hostname string) string {
 	}
 
 	return strings.ToLower(hostname)
+}
+
+// DeviceWriter is authority for one accepted runtime. Replacement/removal
+// revokes old writers even when the exact configuration identity is reused.
+type DeviceWriter struct {
+	store *DeviceStore
+	owner string
+}
+
+func (w *DeviceWriter) UpdateDevice(info DeviceConnectionInfo) {
+	if w == nil {
+		return
+	}
+	s := w.store
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writers[w.owner] == w {
+		s.registerLocked(w.owner, info)
+	}
+}
+
+func (w *DeviceWriter) RecordLifecycle(status DeviceLifecycleStatus) {
+	if w == nil {
+		return
+	}
+	s := w.store
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writers[w.owner] != w {
+		return
+	}
+	id := s.ownerRegistrations[w.owner]
+	record := s.lifecycles[id]
+	record.lastCompleted = status
+	s.lifecycles[id] = record
+	s.lifecycleSequence++
+}
+
+// ConfigurationRevision fences snapshots across accepted job replacement/removal.
+func (s *DeviceStore) ConfigurationRevision() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.configurationRevision
+}
+
+func (s *DeviceStore) ConfigurationChanges() <-chan struct{} { return s.changes }
+func (s *DeviceStore) notifyConfigurationChangedLocked() {
+	select {
+	case s.changes <- struct{}{}:
+	default:
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -3,7 +3,6 @@
 package ddsnmp
 
 import (
-	"errors"
 	"maps"
 	"net/netip"
 	"slices"
@@ -130,7 +129,6 @@ func NewDeviceStore() *DeviceStore {
 
 // DeviceStore holds SNMP device connection state shared between SNMP-family modules.
 type DeviceStore struct {
-	configurationMu       sync.Mutex
 	mu                    sync.RWMutex
 	changes               chan struct{}
 	writers               map[string]*DeviceWriter
@@ -218,8 +216,6 @@ func (s *DeviceStore) ReplaceJob(
 	if ownerKey == "" {
 		return nil
 	}
-	s.configurationMu.Lock()
-	defer s.configurationMu.Unlock()
 	s.mu.Lock()
 	s.ensureMapsLocked()
 	if previousOwnerKey != "" && previousOwnerKey != ownerKey {
@@ -282,8 +278,6 @@ func (s *DeviceStore) registerLocked(ownerKey string, info DeviceConnectionInfo)
 
 // Unregister removes a complete job incarnation from the store.
 func (s *DeviceStore) Unregister(ownerKey string) {
-	s.configurationMu.Lock()
-	defer s.configurationMu.Unlock()
 	s.mu.Lock()
 	if _, ok := s.ownerRegistrations[ownerKey]; ok {
 		s.removeRegistrationLocked(ownerKey)
@@ -519,15 +513,4 @@ func (s *DeviceStore) notifyConfigurationChangedLocked() {
 	case s.changes <- struct{}{}:
 	default:
 	}
-}
-
-// WithConfigurationRevision serializes a snapshot commit with accepted inventory
-// changes. Its callback does not hold the lock used by polling or metadata updates.
-func (s *DeviceStore) WithConfigurationRevision(revision uint64, commit func() error) error {
-	s.configurationMu.Lock()
-	defer s.configurationMu.Unlock()
-	if s.ConfigurationRevision() != revision {
-		return errors.New("device configuration changed during snapshot publication")
-	}
-	return commit()
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -3,6 +3,7 @@
 package ddsnmp
 
 import (
+	"errors"
 	"maps"
 	"net/netip"
 	"slices"
@@ -129,6 +130,7 @@ func NewDeviceStore() *DeviceStore {
 
 // DeviceStore holds SNMP device connection state shared between SNMP-family modules.
 type DeviceStore struct {
+	configurationMu       sync.Mutex
 	mu                    sync.RWMutex
 	changes               chan struct{}
 	writers               map[string]*DeviceWriter
@@ -216,6 +218,8 @@ func (s *DeviceStore) ReplaceJob(
 	if ownerKey == "" {
 		return nil
 	}
+	s.configurationMu.Lock()
+	defer s.configurationMu.Unlock()
 	s.mu.Lock()
 	s.ensureMapsLocked()
 	if previousOwnerKey != "" && previousOwnerKey != ownerKey {
@@ -278,6 +282,8 @@ func (s *DeviceStore) registerLocked(ownerKey string, info DeviceConnectionInfo)
 
 // Unregister removes a complete job incarnation from the store.
 func (s *DeviceStore) Unregister(ownerKey string) {
+	s.configurationMu.Lock()
+	defer s.configurationMu.Unlock()
 	s.mu.Lock()
 	if _, ok := s.ownerRegistrations[ownerKey]; ok {
 		s.removeRegistrationLocked(ownerKey)
@@ -513,4 +519,15 @@ func (s *DeviceStore) notifyConfigurationChangedLocked() {
 	case s.changes <- struct{}{}:
 	default:
 	}
+}
+
+// WithConfigurationRevision serializes a snapshot commit with accepted inventory
+// changes. Its callback does not hold the lock used by polling or metadata updates.
+func (s *DeviceStore) WithConfigurationRevision(revision uint64, commit func() error) error {
+	s.configurationMu.Lock()
+	defer s.configurationMu.Unlock()
+	if s.ConfigurationRevision() != revision {
+		return errors.New("device configuration changed during snapshot publication")
+	}
+	return commit()
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store_test.go
@@ -3,6 +3,7 @@
 package ddsnmp
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -265,4 +266,41 @@ func TestDeviceStoreRegistrationIdentityChangesOnlyAfterUnregister(t *testing.T)
 	entries = store.Entries()
 	require.Len(t, entries, 1)
 	require.Greater(t, entries[0].RegistrationID, initialIdentity, "replacement registrations must receive a new identity")
+}
+
+func TestDeviceWriterCannotReviveRemovedOrReplaceSuccessor(t *testing.T) {
+	store := NewDeviceStore()
+	first := store.ReplaceJob("", "same-config", DeviceLifecycleInfo{Hostname: "first"}, DeviceLifecycleStatus{}, nil)
+	first.UpdateDevice(DeviceConnectionInfo{Hostname: "first"})
+	require.Len(t, store.Entries(), 1)
+	successor := store.ReplaceJob("same-config", "same-config", DeviceLifecycleInfo{Hostname: "successor"}, DeviceLifecycleStatus{}, nil)
+	first.UpdateDevice(DeviceConnectionInfo{Hostname: "retired"})
+	first.RecordLifecycle(DeviceLifecycleStatus{Phase: DeviceLifecyclePhaseCollect, Outcome: DeviceLifecycleOutcomeFailed})
+	require.Empty(t, store.Entries())
+	require.Equal(t, "successor", store.LifecycleCut().Entries[0].Info.Hostname)
+	require.Equal(t, DeviceLifecyclePhaseUnknown, store.LifecycleCut().Entries[0].LastCompleted.Phase)
+	successor.UpdateDevice(DeviceConnectionInfo{Hostname: "successor"})
+	require.Equal(t, "successor", store.Entries()[0].Info.Hostname)
+	store.Unregister("same-config")
+	successor.UpdateDevice(DeviceConnectionInfo{Hostname: "retired"})
+	successor.RecordLifecycle(DeviceLifecycleStatus{Phase: DeviceLifecyclePhaseCollect})
+	require.Empty(t, store.Entries())
+	require.Empty(t, store.LifecycleCut().Entries)
+}
+
+func BenchmarkDeviceWriterLifecycle(b *testing.B) {
+	for _, count := range []int{1, 10000} {
+		b.Run(strconv.Itoa(count), func(b *testing.B) {
+			store := NewDeviceStore()
+			var writer *DeviceWriter
+			for i := range count {
+				writer = store.ReplaceJob("", strconv.Itoa(i), DeviceLifecycleInfo{Hostname: "switch.example"}, DeviceLifecycleStatus{}, nil)
+			}
+			status := DeviceLifecycleStatus{Phase: DeviceLifecyclePhaseCollect, Outcome: DeviceLifecycleOutcomeSuccess}
+			b.ReportAllocs()
+			for b.Loop() {
+				writer.RecordLifecycle(status)
+			}
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
@@ -23,7 +23,7 @@ func (c *Collector) beginDeviceLifecycle() {
 	}
 	c.deviceLifecycleMu.Lock()
 	c.deviceLifecycleInfo = info
-	publish := !c.deviceLifecycleManaged || c.deviceLifecycleCommitted
+	publish := !c.deviceLifecycleManaged
 	c.deviceLifecycleMu.Unlock()
 	if !publish {
 		return
@@ -52,9 +52,11 @@ func (c *Collector) recordDeviceLifecycle(
 	}
 	c.deviceLifecycleMu.Lock()
 	c.deviceLifecycleStatus = status
-	publish := !c.deviceLifecycleManaged || c.deviceLifecycleCommitted
+	managed := c.deviceLifecycleManaged
+	writer := c.deviceWriter
 	c.deviceLifecycleMu.Unlock()
-	if !publish {
+	if managed {
+		writer.RecordLifecycle(status)
 		return
 	}
 	c.reportDeviceLifecycle(func(store deviceLifecycleStore) {
@@ -88,7 +90,7 @@ func (c *Collector) commitDeviceLifecycle(previousOwner string) {
 				Warningf("failed to update SNMP job lifecycle diagnostics")
 		}
 	}()
-	c.deviceStore.ReplaceJob(
+	c.deviceWriter = c.deviceStore.ReplaceJob(
 		previousOwner,
 		c.deviceLifecycleOwner,
 		c.deviceLifecycleInfo,

--- a/src/go/plugin/go.d/collector/snmp/device_state.go
+++ b/src/go/plugin/go.d/collector/snmp/device_state.go
@@ -115,6 +115,12 @@ func (c *Collector) publishDeviceState(info ddsnmp.DeviceConnectionInfo) {
 		c.deviceLifecycleMu.Unlock()
 		return
 	}
+	if c.deviceLifecycleManaged {
+		writer := c.deviceWriter
+		c.deviceLifecycleMu.Unlock()
+		writer.UpdateDevice(info)
+		return
+	}
 	ownerKey := c.deviceLifecycleOwner
 	if ownerKey == "" {
 		ownerKey = fmt.Sprintf("%p:%s:%d", c, c.Hostname, c.Options.Port)

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
@@ -34,11 +34,20 @@ func Write(w io.Writer, document Document) error {
 	if w == nil {
 		return errors.New("write SNMP diagnostic archive: nil writer")
 	}
-	encoder, err := zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.SpeedDefault), zstd.WithEncoderConcurrency(1), zstd.WithEncoderCRC(true))
+	encoder, err := zstd.NewWriter(
+		w,
+		zstd.WithEncoderLevel(zstd.SpeedDefault),
+		zstd.WithEncoderConcurrency(1),
+		zstd.WithEncoderCRC(true),
+	)
 	if err != nil {
 		return fmt.Errorf("create diagnostic zstd encoder: %w", err)
 	}
-	encodeErr := jsonv2.MarshalWrite(encoder, document, jsonv2.JoinOptions(jsonv1.DefaultOptionsV1(), jsontext.EscapeForHTML(false)))
+	encodeErr := jsonv2.MarshalWrite(
+		encoder,
+		document,
+		jsonv2.JoinOptions(jsonv1.DefaultOptionsV1(), jsontext.EscapeForHTML(false)),
+	)
 	closeErr := encoder.Close()
 	return errors.Join(encodeErr, closeErr)
 }
@@ -55,7 +64,10 @@ func Read(r io.Reader, limits ReadLimits) (Document, error) {
 	if limits.MaxDecodedBytes <= 0 || limits.MaxDecodedBytes == math.MaxInt64 {
 		return Document{}, errors.New("invalid decoded-byte limit")
 	}
-	compressed := &io.LimitedReader{R: r, N: limits.MaxCompressedBytes + 1}
+	compressed := &io.LimitedReader{
+		R: r,
+		N: limits.MaxCompressedBytes + 1,
+	}
 	decoder, err := zstd.NewReader(compressed, zstd.WithDecoderConcurrency(1))
 	if err != nil {
 		if compressed.N == 0 {
@@ -63,9 +75,16 @@ func Read(r io.Reader, limits ReadLimits) (Document, error) {
 		}
 		return Document{}, fmt.Errorf("create diagnostic zstd decoder: %w", err)
 	}
-	decoded := &io.LimitedReader{R: decoder, N: limits.MaxDecodedBytes + 1}
+	decoded := &io.LimitedReader{
+		R: decoder,
+		N: limits.MaxDecodedBytes + 1,
+	}
 	var document Document
-	err = jsonv2.UnmarshalRead(decoded, &document, jsonv2.JoinOptions(jsonv1.DefaultOptionsV1(), jsontext.AllowInvalidUTF8(false)))
+	err = jsonv2.UnmarshalRead(
+		decoded,
+		&document,
+		jsonv2.JoinOptions(jsonv1.DefaultOptionsV1(), jsontext.AllowInvalidUTF8(false)),
+	)
 	decoder.Close()
 	if compressed.N == 0 {
 		return Document{}, ErrCompressedLimit

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	jsonv1 "encoding/json"
+	"encoding/json/jsontext"
+	jsonv2 "encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+const Format = "netdata.snmp_topology.diagnostics"
+const Version = 1
+
+var (
+	ErrCompressedLimit = errors.New("SNMP topology diagnostic archive compressed-byte limit exceeded")
+	ErrDecodedLimit    = errors.New("SNMP topology diagnostic archive decoded-byte limit exceeded")
+)
+
+type ReadLimits struct {
+	MaxCompressedBytes int64
+	MaxDecodedBytes    int64
+}
+
+func DefaultReadLimits() ReadLimits { return ReadLimits{128 << 20, 512 << 20} }
+
+// Write encodes one complete document. The caller owns its immutable snapshot.
+func Write(w io.Writer, document Document) error {
+	if w == nil {
+		return errors.New("write SNMP diagnostic archive: nil writer")
+	}
+	encoder, err := zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.SpeedDefault), zstd.WithEncoderConcurrency(1), zstd.WithEncoderCRC(true))
+	if err != nil {
+		return fmt.Errorf("create diagnostic zstd encoder: %w", err)
+	}
+	encodeErr := jsonv2.MarshalWrite(encoder, document, jsonv2.JoinOptions(jsonv1.DefaultOptionsV1(), jsontext.EscapeForHTML(false)))
+	closeErr := encoder.Close()
+	return errors.Join(encodeErr, closeErr)
+}
+
+// Read checks the transport and envelope. Domain consumers validate their
+// typed sections before inspection or replay.
+func Read(r io.Reader, limits ReadLimits) (Document, error) {
+	if r == nil {
+		return Document{}, errors.New("read SNMP diagnostic archive: nil reader")
+	}
+	if limits.MaxCompressedBytes <= 0 || limits.MaxCompressedBytes == math.MaxInt64 {
+		return Document{}, errors.New("invalid compressed-byte limit")
+	}
+	if limits.MaxDecodedBytes <= 0 || limits.MaxDecodedBytes == math.MaxInt64 {
+		return Document{}, errors.New("invalid decoded-byte limit")
+	}
+	compressed := &io.LimitedReader{R: r, N: limits.MaxCompressedBytes + 1}
+	decoder, err := zstd.NewReader(compressed, zstd.WithDecoderConcurrency(1))
+	if err != nil {
+		if compressed.N == 0 {
+			return Document{}, ErrCompressedLimit
+		}
+		return Document{}, fmt.Errorf("create diagnostic zstd decoder: %w", err)
+	}
+	decoded := &io.LimitedReader{R: decoder, N: limits.MaxDecodedBytes + 1}
+	var document Document
+	err = jsonv2.UnmarshalRead(decoded, &document, jsonv2.JoinOptions(jsonv1.DefaultOptionsV1(), jsontext.AllowInvalidUTF8(false)))
+	decoder.Close()
+	if compressed.N == 0 {
+		return Document{}, ErrCompressedLimit
+	}
+	if decoded.N == 0 {
+		return Document{}, ErrDecodedLimit
+	}
+	if err != nil {
+		return Document{}, fmt.Errorf("decode diagnostic JSON: %w", err)
+	}
+	if document.Format != Format {
+		return Document{}, fmt.Errorf("unsupported format %q", document.Format)
+	}
+	if document.Version != Version {
+		return Document{}, fmt.Errorf("unsupported version %d", document.Version)
+	}
+	return document, nil
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/document.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/document.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import "time"
+
+type Document struct {
+	Format   string   `json:"format"`
+	Version  uint64   `json:"version"`
+	Producer Producer `json:"producer"`
+	Snapshot Snapshot `json:"snapshot"`
+}
+
+type Producer struct {
+	AgentVersion string `json:"agent_version"`
+}
+
+type Snapshot struct {
+	Lifecycle       Lifecycle `json:"job_lifecycle_cut"`
+	ProducerScopeID string    `json:"producer_scope_id"`
+	Topology        *Sweep    `json:"topology_sweep_cut,omitempty"`
+	LastAborted     *Abort    `json:"last_aborted_sweep,omitempty"`
+}
+
+type Lifecycle struct {
+	State  string       `json:"capture_state"`
+	Reason string       `json:"capture_reason"`
+	Cut    LifecycleCut `json:"cut"`
+}
+
+type LifecycleCut struct {
+	Sequence   uint64           `json:"sequence"`
+	CapturedAt time.Time        `json:"captured_at"`
+	Entries    []LifecycleEntry `json:"entries,omitempty"`
+}
+
+type LifecycleEntry struct {
+	RegistrationID uint64          `json:"registration_id"`
+	Hostname       string          `json:"hostname"`
+	Port           int             `json:"port"`
+	SNMPVersion    string          `json:"snmp_version"`
+	LastCompleted  LifecycleStatus `json:"last_completed"`
+	TopologyReady  bool            `json:"topology_ready"`
+}
+
+type LifecycleStatus struct {
+	Phase       string    `json:"phase"`
+	Outcome     string    `json:"outcome"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+type Sweep struct {
+	Sequence      uint64    `json:"sequence"`
+	StartedAt     time.Time `json:"started_at"`
+	PublishedAt   time.Time `json:"published_at"`
+	CaptureState  string    `json:"capture_state"`
+	CaptureReason string    `json:"capture_reason"`
+	RecordCount   uint64    `json:"record_count"`
+	LogicalBytes  uint64    `json:"logical_bytes"`
+	Devices       []Device  `json:"devices,omitempty"`
+	Removed       []Removed `json:"removed_devices,omitempty"`
+}
+
+type Device struct {
+	RegistrationID  uint64       `json:"registration_id"`
+	Selected        bool         `json:"selected"`
+	Outcome         string       `json:"outcome"`
+	LastAttempt     time.Time    `json:"last_attempt"`
+	LastSuccess     time.Time    `json:"last_success"`
+	NextRetry       time.Time    `json:"next_retry"`
+	RetainedSuccess *EvidenceRef `json:"retained_success,omitempty"`
+	Captures        []Capture    `json:"captures,omitempty"`
+	HasObservation  bool         `json:"has_observation"`
+	ExpiresAt       time.Time    `json:"expires_at"`
+	Renderable      bool         `json:"renderable"`
+	Expired         bool         `json:"expired"`
+}
+
+type Removed struct {
+	RegistrationID  uint64       `json:"registration_id"`
+	RetainedSuccess *EvidenceRef `json:"retained_success,omitempty"`
+}
+
+type EvidenceRef struct {
+	RegistrationID uint64 `json:"registration_id"`
+	Generation     uint64 `json:"generation"`
+}
+
+type Capture struct {
+	Roles          []string             `json:"roles"`
+	AttemptOrdinal uint64               `json:"attempt_ordinal"`
+	State          string               `json:"capture_state"`
+	Reason         string               `json:"capture_reason"`
+	RecordCount    uint64               `json:"record_count"`
+	LogicalBytes   uint64               `json:"logical_bytes"`
+	Evidence       *AcquisitionEvidence `json:"evidence,omitempty"`
+}
+
+type Abort struct {
+	Sequence              uint64    `json:"sequence"`
+	StartedAt             time.Time `json:"started_at"`
+	AbortedAt             time.Time `json:"aborted_at"`
+	Reason                string    `json:"reason"`
+	Phase                 string    `json:"phase"`
+	ActiveRegistrationID  uint64    `json:"active_registration_id,omitempty"`
+	HasActiveRegistration bool      `json:"has_active_registration"`
+	RegistrationCount     int       `json:"registration_count"`
+	SelectedCount         int       `json:"selected_count"`
+}
+
+type AcquisitionEvidence struct {
+	Device             DeviceInput       `json:"device"`
+	Target             Target            `json:"target"`
+	Client             Phase             `json:"client"`
+	Connect            Phase             `json:"connect"`
+	Profiles           Phase             `json:"profiles"`
+	Collection         Phase             `json:"collection"`
+	SysUptime          Phase             `json:"sys_uptime"`
+	VLANProfiles       Phase             `json:"vlan_profiles"`
+	CollectedAt        time.Time         `json:"collected_at"`
+	FreshForNanos      int64             `json:"fresh_for_ns"`
+	SysUptimeValue     int64             `json:"sys_uptime_value"`
+	CollectionContexts []ContextEvidence `json:"collection_contexts,omitempty"`
+}
+
+type DeviceInput struct {
+	Hostname    string            `json:"hostname"`
+	SysObjectID string            `json:"sys_object_id"`
+	SysName     string            `json:"sys_name"`
+	SysDescr    string            `json:"sys_descr"`
+	SysContact  string            `json:"sys_contact"`
+	SysLocation string            `json:"sys_location"`
+	Vendor      string            `json:"vendor"`
+	Model       string            `json:"model"`
+	VnodeGUID   string            `json:"vnode_guid"`
+	VnodeLabels map[string]string `json:"vnode_labels,omitempty"`
+}
+
+type Target struct {
+	Outcome   string   `json:"outcome"`
+	Addresses []string `json:"addresses,omitempty"`
+}
+
+type Phase struct {
+	Outcome string `json:"outcome"`
+	Failure string `json:"failure"`
+}
+
+type ContextEvidence struct {
+	Ordinal    uint32            `json:"ordinal"`
+	VLANID     string            `json:"vlan_id"`
+	VLANName   string            `json:"vlan_name"`
+	Client     Phase             `json:"client"`
+	Connect    Phase             `json:"connect"`
+	Collection Phase             `json:"collection"`
+	Profiles   []ProfileEvidence `json:"profiles,omitempty"`
+}
+
+type ProfileEvidence struct {
+	Identity     ProfileIdentity `json:"identity"`
+	Outcome      string          `json:"outcome"`
+	FailurePhase string          `json:"failure_phase"`
+	Stats        CollectionStats `json:"stats"`
+	Execution    *Execution      `json:"execution,omitempty"`
+	Routes       []Route         `json:"routes,omitempty"`
+	Values       ProfileValues   `json:"values"`
+}
+
+type ProfileIdentity struct {
+	Ordinal     uint32 `json:"ordinal"`
+	RouteDigest string `json:"route_digest"`
+}
+
+type Route struct {
+	Ordinal      uint32 `json:"ordinal"`
+	Kind         string `json:"kind"`
+	RootOID      string `json:"root_oid"`
+	Source       string `json:"source"`
+	Outcome      string `json:"outcome"`
+	FailureClass string `json:"failure_class"`
+	Rows         uint64 `json:"rows"`
+	Values       uint64 `json:"values"`
+	Missing      uint64 `json:"missing"`
+	Rejected     uint64 `json:"rejected"`
+}
+
+type ProfileValues struct {
+	Metadata  map[string]MetaTag `json:"metadata,omitempty"`
+	Tags      map[string]string  `json:"tags,omitempty"`
+	Metrics   []MetricValue      `json:"metrics,omitempty"`
+	BGPRows   []BGPRowValue      `json:"bgp_rows,omitempty"`
+	BGPFailed bool               `json:"bgp_failed"`
+}
+
+type MetaTag struct {
+	Value        string `json:"value"`
+	IsExactMatch bool   `json:"is_exact_match"`
+}
+
+type MetricValue struct {
+	RouteOrdinal uint32            `json:"route_ordinal"`
+	RowOrdinal   uint32            `json:"row_ordinal"`
+	ValueOrdinal uint32            `json:"value_ordinal"`
+	Kind         string            `json:"kind"`
+	Tags         map[string]string `json:"tags,omitempty"`
+}
+
+type BGPRowValue struct {
+	RouteOrdinal uint32 `json:"route_ordinal"`
+	RowOrdinal   uint32 `json:"row_ordinal"`
+	ValueOrdinal uint32 `json:"value_ordinal"`
+
+	OriginProfileID string `json:"origin_profile_id"`
+	Table           string `json:"table"`
+	RowKey          string `json:"row_key"`
+	StructuralID    string `json:"structural_id"`
+	Kind            string `json:"kind"`
+
+	RoutingInstance string `json:"routing_instance"`
+	Neighbor        string `json:"neighbor"`
+	RemoteAS        string `json:"remote_as"`
+	LocalAddress    string `json:"local_address"`
+	LocalAS         string `json:"local_as"`
+	LocalIdentifier string `json:"local_identifier"`
+	PeerIdentifier  string `json:"peer_identifier"`
+	PeerType        string `json:"peer_type"`
+	BGPVersion      string `json:"bgp_version"`
+	Description     string `json:"description"`
+
+	AdminHas       bool              `json:"admin_has"`
+	AdminEnabled   bool              `json:"admin_enabled"`
+	StateHas       bool              `json:"state_has"`
+	State          string            `json:"state"`
+	StateRaw       string            `json:"state_raw"`
+	EstablishedHas bool              `json:"established_has"`
+	Established    int64             `json:"established"`
+	UpdateAgeHas   bool              `json:"update_age_has"`
+	UpdateAge      int64             `json:"update_age"`
+	Tags           map[string]string `json:"tags,omitempty"`
+}
+
+type CollectionStats struct {
+	Timing     TimingStats     `json:"timing"`
+	SNMP       SNMPStats       `json:"snmp"`
+	Metrics    MetricStats     `json:"metrics"`
+	TableCache TableCacheStats `json:"table_cache"`
+	Errors     ErrorStats      `json:"errors"`
+}
+
+type TimingStats struct {
+	PreparationNanos    int64 `json:"preparation_ns,omitempty"`
+	ScalarNanos         int64 `json:"scalar_ns"`
+	TableNanos          int64 `json:"table_ns"`
+	LicensingNanos      int64 `json:"licensing_ns"`
+	BGPNanos            int64 `json:"bgp_ns"`
+	VirtualMetricsNanos int64 `json:"virtual_metrics_ns"`
+}
+
+type SNMPStats struct {
+	GetRequests  int64 `json:"get_requests"`
+	GetOIDs      int64 `json:"get_oids"`
+	WalkRequests int64 `json:"walk_requests"`
+	WalkPDUs     int64 `json:"walk_pdus"`
+	TablesWalked int64 `json:"tables_walked"`
+	TablesCached int64 `json:"tables_cached"`
+}
+
+type MetricStats struct {
+	Scalar    int64 `json:"scalar"`
+	Table     int64 `json:"table"`
+	Virtual   int64 `json:"virtual"`
+	Licensing int64 `json:"licensing"`
+	BGP       int64 `json:"bgp"`
+	Tables    int64 `json:"tables"`
+	Rows      int64 `json:"rows"`
+}
+
+type TableCacheStats struct {
+	Hits   int64 `json:"hits"`
+	Misses int64 `json:"misses"`
+}
+
+type ErrorStats struct {
+	ProcessingPreparation int64 `json:"processing_preparation,omitempty"`
+	SNMP                  int64 `json:"snmp"`
+	ProcessingScalar      int64 `json:"processing_scalar"`
+	ProcessingTable       int64 `json:"processing_table"`
+	ProcessingLicensing   int64 `json:"processing_licensing"`
+	ProcessingBGP         int64 `json:"processing_bgp"`
+	MissingOIDs           int64 `json:"missing_oids"`
+}
+
+type Execution struct {
+	Preparation Preparation `json:"preparation"`
+	Walks       []Walk      `json:"walks"`
+}
+
+type Preparation struct {
+	ElapsedNanos     int64 `json:"elapsed_ns"`
+	GetRequests      int64 `json:"get_requests"`
+	GetOIDs          int64 `json:"get_oids"`
+	SNMPErrors       int64 `json:"snmp_errors"`
+	MissingOIDs      int64 `json:"missing_oids"`
+	ProcessingErrors int64 `json:"processing_errors"`
+}
+
+type Walk struct {
+	RootOID      string `json:"root_oid"`
+	ElapsedNanos int64  `json:"elapsed_ns"`
+	Failed       bool   `json:"failed"`
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/lifecycle.go
@@ -41,7 +41,15 @@ func ParseLifecycleOutcome(v string) (ddsnmp.DeviceLifecycleOutcome, error) {
 }
 
 func NewLifecycle(cut ddsnmp.DeviceLifecycleCut) (Lifecycle, error) {
-	result := Lifecycle{State: "available", Reason: "none", Cut: LifecycleCut{Sequence: cut.Sequence, CapturedAt: cut.CapturedAt, Entries: make([]LifecycleEntry, 0, len(cut.Entries))}}
+	result := Lifecycle{
+		State:  "available",
+		Reason: "none",
+		Cut: LifecycleCut{
+			Sequence:   cut.Sequence,
+			CapturedAt: cut.CapturedAt,
+			Entries:    make([]LifecycleEntry, 0, len(cut.Entries)),
+		},
+	}
 	for _, entry := range cut.Entries {
 		phase, err := LifecyclePhaseName(entry.LastCompleted.Phase)
 		if err != nil {
@@ -51,7 +59,21 @@ func NewLifecycle(cut ddsnmp.DeviceLifecycleCut) (Lifecycle, error) {
 		if err != nil {
 			return Lifecycle{}, err
 		}
-		result.Cut.Entries = append(result.Cut.Entries, LifecycleEntry{RegistrationID: uint64(entry.RegistrationID), Hostname: entry.Info.Hostname, Port: entry.Info.Port, SNMPVersion: entry.Info.SNMPVersion, LastCompleted: LifecycleStatus{Phase: phase, Outcome: outcome, CompletedAt: entry.LastCompleted.CompletedAt}, TopologyReady: entry.TopologyReady})
+		result.Cut.Entries = append(
+			result.Cut.Entries,
+			LifecycleEntry{
+				RegistrationID: uint64(entry.RegistrationID),
+				Hostname:       entry.Info.Hostname,
+				Port:           entry.Info.Port,
+				SNMPVersion:    entry.Info.SNMPVersion,
+				LastCompleted: LifecycleStatus{
+					Phase:       phase,
+					Outcome:     outcome,
+					CompletedAt: entry.LastCompleted.CompletedAt,
+				},
+				TopologyReady: entry.TopologyReady,
+			},
+		)
 	}
 	return result, nil
 }
@@ -65,10 +87,16 @@ type LifecycleSource interface {
 }
 
 func CaptureLifecycle(source LifecycleSource, maxRecords, maxBytes uint64) (result Lifecycle) {
-	result = Lifecycle{State: "unavailable", Reason: "projection_error"}
+	result = Lifecycle{
+		State:  "unavailable",
+		Reason: "projection_error",
+	}
 	defer func() {
 		if recover() != nil {
-			result = Lifecycle{State: "unavailable", Reason: "projection_panic"}
+			result = Lifecycle{
+				State:  "unavailable",
+				Reason: "projection_panic",
+			}
 		}
 	}()
 	if source == nil {
@@ -81,7 +109,14 @@ func CaptureLifecycle(source LifecycleSource, maxRecords, maxBytes uint64) (resu
 		size += uint64(64 + len(entry.Info.Hostname) + len(entry.Info.SNMPVersion))
 	}
 	if records > maxRecords || size > maxBytes {
-		result = Lifecycle{State: "limit_exceeded", Reason: "global_byte_limit", Cut: LifecycleCut{Sequence: cut.Sequence, CapturedAt: cut.CapturedAt}}
+		result = Lifecycle{
+			State:  "limit_exceeded",
+			Reason: "global_byte_limit",
+			Cut: LifecycleCut{
+				Sequence:   cut.Sequence,
+				CapturedAt: cut.CapturedAt,
+			},
+		}
 		if records > maxRecords {
 			result.Reason = "global_record_limit"
 		}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/lifecycle.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"fmt"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+var lifecyclePhases = []string{"unknown", "init", "check", "collect"}
+var lifecycleOutcomes = []string{"unknown", "success", "failed"}
+
+func LifecyclePhaseName(v ddsnmp.DeviceLifecyclePhase) (string, error) {
+	if int(v) >= len(lifecyclePhases) {
+		return "", fmt.Errorf("unknown value %d", v)
+	}
+	return lifecyclePhases[v], nil
+}
+func ParseLifecyclePhase(v string) (ddsnmp.DeviceLifecyclePhase, error) {
+	for i, n := range lifecyclePhases {
+		if n == v {
+			return ddsnmp.DeviceLifecyclePhase(i), nil
+		}
+	}
+	return 0, fmt.Errorf("unknown value %q", v)
+}
+func LifecycleOutcomeName(v ddsnmp.DeviceLifecycleOutcome) (string, error) {
+	if int(v) >= len(lifecycleOutcomes) {
+		return "", fmt.Errorf("unknown value %d", v)
+	}
+	return lifecycleOutcomes[v], nil
+}
+func ParseLifecycleOutcome(v string) (ddsnmp.DeviceLifecycleOutcome, error) {
+	for i, n := range lifecycleOutcomes {
+		if n == v {
+			return ddsnmp.DeviceLifecycleOutcome(i), nil
+		}
+	}
+	return 0, fmt.Errorf("unknown value %q", v)
+}
+
+func NewLifecycle(cut ddsnmp.DeviceLifecycleCut) (Lifecycle, error) {
+	result := Lifecycle{State: "available", Reason: "none", Cut: LifecycleCut{Sequence: cut.Sequence, CapturedAt: cut.CapturedAt, Entries: make([]LifecycleEntry, 0, len(cut.Entries))}}
+	for _, entry := range cut.Entries {
+		phase, err := LifecyclePhaseName(entry.LastCompleted.Phase)
+		if err != nil {
+			return Lifecycle{}, err
+		}
+		outcome, err := LifecycleOutcomeName(entry.LastCompleted.Outcome)
+		if err != nil {
+			return Lifecycle{}, err
+		}
+		result.Cut.Entries = append(result.Cut.Entries, LifecycleEntry{RegistrationID: uint64(entry.RegistrationID), Hostname: entry.Info.Hostname, Port: entry.Info.Port, SNMPVersion: entry.Info.SNMPVersion, LastCompleted: LifecycleStatus{Phase: phase, Outcome: outcome, CompletedAt: entry.LastCompleted.CompletedAt}, TopologyReady: entry.TopologyReady})
+	}
+	return result, nil
+}
+
+const MaxRecords uint64 = 250_000
+const MaxLogicalBytes uint64 = 64 << 20
+const LifecycleCutLogicalBytes uint64 = 32
+
+type LifecycleSource interface {
+	LifecycleCut() ddsnmp.DeviceLifecycleCut
+}
+
+func CaptureLifecycle(source LifecycleSource, maxRecords, maxBytes uint64) (result Lifecycle) {
+	result = Lifecycle{State: "unavailable", Reason: "projection_error"}
+	defer func() {
+		if recover() != nil {
+			result = Lifecycle{State: "unavailable", Reason: "projection_panic"}
+		}
+	}()
+	if source == nil {
+		return result
+	}
+	cut := source.LifecycleCut()
+	records := uint64(1 + len(cut.Entries))
+	size := LifecycleCutLogicalBytes
+	for _, entry := range cut.Entries {
+		size += uint64(64 + len(entry.Info.Hostname) + len(entry.Info.SNMPVersion))
+	}
+	if records > maxRecords || size > maxBytes {
+		result = Lifecycle{State: "limit_exceeded", Reason: "global_byte_limit", Cut: LifecycleCut{Sequence: cut.Sequence, CapturedAt: cut.CapturedAt}}
+		if records > maxRecords {
+			result.Reason = "global_record_limit"
+		}
+		return result
+	}
+	projected, err := NewLifecycle(cut)
+	if err != nil {
+		return result
+	}
+	return projected
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/lifecycle_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/lifecycle_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLifecyclePhasesAreCompleteAndRoundTrip(t *testing.T) {
+	require.Len(t, lifecyclePhases, int(ddsnmp.DeviceLifecyclePhaseCollect)+1)
+	for i, want := range []string{"unknown", "init", "check", "collect"} {
+		phase := ddsnmp.DeviceLifecyclePhase(i)
+		name, err := LifecyclePhaseName(phase)
+		require.NoError(t, err)
+		require.Equal(t, want, name)
+		restored, err := ParseLifecyclePhase(name)
+		require.NoError(t, err)
+		require.Equal(t, phase, restored)
+	}
+	_, err := LifecyclePhaseName(ddsnmp.DeviceLifecyclePhase(255))
+	require.Error(t, err)
+	_, err = ParseLifecyclePhase("invalid")
+	require.Error(t, err)
+}
+
+func TestLifecycleOutcomesAreCompleteAndRoundTrip(t *testing.T) {
+	require.Len(t, lifecycleOutcomes, int(ddsnmp.DeviceLifecycleOutcomeFailed)+1)
+	for i, want := range []string{"unknown", "success", "failed"} {
+		outcome := ddsnmp.DeviceLifecycleOutcome(i)
+		name, err := LifecycleOutcomeName(outcome)
+		require.NoError(t, err)
+		require.Equal(t, want, name)
+		restored, err := ParseLifecycleOutcome(name)
+		require.NoError(t, err)
+		require.Equal(t, outcome, restored)
+	}
+	_, err := LifecycleOutcomeName(ddsnmp.DeviceLifecycleOutcome(255))
+	require.Error(t, err)
+	_, err = ParseLifecycleOutcome("invalid")
+	require.Error(t, err)
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
@@ -36,6 +36,7 @@ func defaultArchivePath(varLibDir string) string {
 type Source interface {
 	LifecycleSource
 	ConfigurationRevision() uint64
+	WithConfigurationRevision(uint64, func() error) error
 	ConfigurationChanges() <-chan struct{}
 }
 
@@ -53,11 +54,20 @@ type Publisher struct {
 	publishedTopologyRevision uint64
 	interval                  time.Duration
 	changed                   chan struct{}
+	rename                    func(string, string) error
 	writeFile                 func(context.Context, string, Document, func(string, string) error) error
 }
 
 func NewPublisher(source Source, varLibDir string) *Publisher {
-	return &Publisher{Logger: logger.New(), source: source, path: defaultArchivePath(varLibDir), interval: DefaultInterval, changed: make(chan struct{}, 1), writeFile: writeArchiveFile}
+	return &Publisher{
+		Logger:    logger.New(),
+		source:    source,
+		path:      defaultArchivePath(varLibDir),
+		interval:  DefaultInterval,
+		changed:   make(chan struct{}, 1),
+		writeFile: writeArchiveFile,
+		rename:    os.Rename,
+	}
 }
 
 // SetTopology is called only for an accepted configuration. Candidate captures
@@ -96,14 +106,10 @@ func (p *Publisher) ReleaseTopology(source TopologySource) {
 	p.mu.Unlock()
 	p.notify()
 }
-func (p *Publisher) TopologyUpdated(source TopologySource) {
-	p.mu.Lock()
-	current := p.topology == source && p.publishedTopologyRevision != p.revision
-	p.mu.Unlock()
-	if current {
-		p.notify()
-	}
-}
+
+// TopologyUpdated must remain independent of file replacement: collectors call
+// it while committing a generation. The writer filters coalesced notifications.
+func (p *Publisher) TopologyUpdated() { p.notify() }
 func (p *Publisher) needsInitialTopology() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -192,23 +198,32 @@ func (p *Publisher) publish(ctx context.Context, requireMeaningful bool) (meanin
 	if requireMeaningful && !meaningful {
 		return false
 	}
-	document := Document{Format: Format, Version: Version, Producer: Producer{AgentVersion: buildinfo.Version}, Snapshot: snapshot}
+	document := Document{
+		Format:  Format,
+		Version: Version,
+		Producer: Producer{
+			AgentVersion: buildinfo.Version,
+		},
+		Snapshot: snapshot,
+	}
 	err := p.writeFile(ctx, p.path, document, func(from, to string) error {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if p.revision != revision || p.source.ConfigurationRevision() != configRevision {
+		if p.revision != revision {
 			return errors.New("diagnostic ownership changed during publication")
 		}
-		if err := os.Rename(from, to); err != nil {
-			return err
-		}
-		if snapshot.Topology != nil {
-			p.publishedTopologyRevision = revision
-		}
-		return nil
+		return p.source.WithConfigurationRevision(configRevision, func() error {
+			if err := p.rename(from, to); err != nil {
+				return err
+			}
+			if snapshot.Topology != nil {
+				p.publishedTopologyRevision = revision
+			}
+			return nil
+		})
 	})
 	if err != nil {
 		p.warn(err)
@@ -223,7 +238,14 @@ func (p *Publisher) warn(err error) {
 func writeArchiveFile(ctx context.Context, path string, document Document, replace func(string, string) error) error {
 	return writeArchiveFileWithClose(ctx, path, document, (*os.File).Close, replace)
 }
-func writeArchiveFileWithClose(ctx context.Context, path string, document Document, closeFile func(*os.File) error, replace func(string, string) error) error {
+
+func writeArchiveFileWithClose(
+	ctx context.Context,
+	path string,
+	document Document,
+	closeFile func(*os.File) error,
+	replace func(string, string) error,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
@@ -36,7 +36,6 @@ func defaultArchivePath(varLibDir string) string {
 type Source interface {
 	LifecycleSource
 	ConfigurationRevision() uint64
-	WithConfigurationRevision(uint64, func() error) error
 	ConfigurationChanges() <-chan struct{}
 }
 
@@ -207,23 +206,27 @@ func (p *Publisher) publish(ctx context.Context, requireMeaningful bool) (meanin
 		Snapshot: snapshot,
 	}
 	err := p.writeFile(ctx, p.path, document, func(from, to string) error {
-		p.mu.Lock()
-		defer p.mu.Unlock()
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if p.revision != revision {
+		p.mu.Lock()
+		current := p.revision == revision
+		p.mu.Unlock()
+		if !current || p.source.ConfigurationRevision() != configRevision {
 			return errors.New("diagnostic ownership changed during publication")
 		}
-		return p.source.WithConfigurationRevision(configRevision, func() error {
-			if err := p.rename(from, to); err != nil {
-				return err
-			}
-			if snapshot.Topology != nil {
-				p.publishedTopologyRevision = revision
-			}
-			return nil
-		})
+		// This is a historical checkpoint, not a live inventory pointer. A
+		// concurrent configuration change may leave this cut on disk; no
+		// collection or activation lock may be held during filesystem I/O.
+		if err := p.rename(from, to); err != nil {
+			return err
+		}
+		p.mu.Lock()
+		if p.revision == revision && snapshot.Topology != nil {
+			p.publishedTopologyRevision = revision
+		}
+		p.mu.Unlock()
+		return nil
 	})
 	if err != nil {
 		p.warn(err)

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
+)
+
+const DefaultInterval = 30 * time.Minute
+const firstEvidenceCheckEvery = time.Minute
+
+func ArchivePath(varLibDir string) string {
+	return filepath.Join(varLibDir, "snmp-topology", "diagnostics", "netdata-snmp-topology-diagnostics.zst")
+}
+func defaultArchivePath(varLibDir string) string {
+	dir := strings.TrimSpace(varLibDir)
+	if dir == "" {
+		dir = strings.TrimSpace(buildinfo.VarLibDir)
+	}
+	if dir == "" {
+		dir = buildinfo.DefaultVarLibDir
+	}
+	return ArchivePath(filepath.Clean(dir))
+}
+
+type Source interface {
+	LifecycleSource
+	ConfigurationRevision() uint64
+	ConfigurationChanges() <-chan struct{}
+}
+
+// TopologySource exposes only diagnostic snapshots, without connection state.
+type TopologySource interface{ Capture() (Snapshot, error) }
+
+type Publisher struct {
+	*logger.Logger
+	source                    Source
+	path                      string
+	mu                        sync.Mutex
+	topology                  TopologySource
+	owner                     string
+	revision                  uint64
+	publishedTopologyRevision uint64
+	interval                  time.Duration
+	changed                   chan struct{}
+	writeFile                 func(context.Context, string, Document, func(string, string) error) error
+}
+
+func NewPublisher(source Source, varLibDir string) *Publisher {
+	return &Publisher{Logger: logger.New(), source: source, path: defaultArchivePath(varLibDir), interval: DefaultInterval, changed: make(chan struct{}, 1), writeFile: writeArchiveFile}
+}
+
+// SetTopology is called only for an accepted configuration. Candidate captures
+// stay private until this boundary.
+func (p *Publisher) SetTopology(owner string, source TopologySource, interval time.Duration) {
+	p.mu.Lock()
+	p.owner = owner
+	p.topology = source
+	p.revision++
+	p.interval = DefaultInterval
+	if source != nil && interval > 0 {
+		p.interval = interval
+	}
+	p.mu.Unlock()
+	p.notify()
+}
+func (p *Publisher) RemoveTopology(owner string) {
+	p.mu.Lock()
+	if p.owner == owner {
+		p.owner = ""
+		p.topology = nil
+		p.interval = DefaultInterval
+		p.revision++
+	}
+	p.mu.Unlock()
+	p.notify()
+}
+func (p *Publisher) ReleaseTopology(source TopologySource) {
+	p.mu.Lock()
+	if p.topology == source {
+		p.owner = ""
+		p.topology = nil
+		p.interval = DefaultInterval
+		p.revision++
+	}
+	p.mu.Unlock()
+	p.notify()
+}
+func (p *Publisher) TopologyUpdated(source TopologySource) {
+	p.mu.Lock()
+	current := p.topology == source && p.publishedTopologyRevision != p.revision
+	p.mu.Unlock()
+	if current {
+		p.notify()
+	}
+}
+func (p *Publisher) needsInitialTopology() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.topology != nil && p.publishedTopologyRevision != p.revision
+}
+func (p *Publisher) notify() {
+	select {
+	case p.changed <- struct{}{}:
+	default:
+	}
+}
+func (p *Publisher) currentInterval() time.Duration {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.interval
+}
+
+func (p *Publisher) Run(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	meaningful := p.publish(ctx, false)
+	p.mu.Lock()
+	scheduleRevision := p.revision
+	p.mu.Unlock()
+	periodic := time.NewTimer(p.currentInterval())
+	defer periodic.Stop()
+	first := time.NewTicker(firstEvidenceCheckEvery)
+	defer first.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.changed:
+			p.mu.Lock()
+			revision := p.revision
+			p.mu.Unlock()
+			if scheduleRevision != revision {
+				periodic.Reset(p.currentInterval())
+				scheduleRevision = revision
+			}
+			if !meaningful || p.needsInitialTopology() {
+				meaningful = p.publish(ctx, true) || meaningful
+			}
+		case <-p.source.ConfigurationChanges():
+			if !meaningful || p.needsInitialTopology() {
+				meaningful = p.publish(ctx, true) || meaningful
+			}
+		case <-first.C:
+			if !meaningful || p.needsInitialTopology() {
+				meaningful = p.publish(ctx, true) || meaningful
+			}
+		case <-periodic.C:
+			meaningful = p.publish(ctx, false) || meaningful
+			periodic.Reset(p.currentInterval())
+		}
+	}
+}
+
+func (p *Publisher) publish(ctx context.Context, requireMeaningful bool) (meaningful bool) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			meaningful = false
+			p.warn(fmt.Errorf("capture panic: %v", recovered))
+		}
+	}()
+	if ctx.Err() != nil {
+		return false
+	}
+	configRevision := p.source.ConfigurationRevision()
+	p.mu.Lock()
+	source, revision := p.topology, p.revision
+	p.mu.Unlock()
+	snapshot := Snapshot{}
+	if source != nil {
+		var err error
+		snapshot, err = source.Capture()
+		if err != nil {
+			p.warn(err)
+			return false
+		}
+	} else {
+		snapshot.Lifecycle = CaptureLifecycle(p.source, MaxRecords, MaxLogicalBytes)
+	}
+	meaningful = len(snapshot.Lifecycle.Cut.Entries) > 0
+	if requireMeaningful && !meaningful {
+		return false
+	}
+	document := Document{Format: Format, Version: Version, Producer: Producer{AgentVersion: buildinfo.Version}, Snapshot: snapshot}
+	err := p.writeFile(ctx, p.path, document, func(from, to string) error {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if p.revision != revision || p.source.ConfigurationRevision() != configRevision {
+			return errors.New("diagnostic ownership changed during publication")
+		}
+		if err := os.Rename(from, to); err != nil {
+			return err
+		}
+		if snapshot.Topology != nil {
+			p.publishedTopologyRevision = revision
+		}
+		return nil
+	})
+	if err != nil {
+		p.warn(err)
+		return false
+	}
+	return meaningful
+}
+func (p *Publisher) warn(err error) {
+	p.Limit("snmp:diagnostic-archive", 1, time.Hour).Warningf("failed to publish SNMP diagnostic archive: %v", err)
+}
+
+func writeArchiveFile(ctx context.Context, path string, document Document, replace func(string, string) error) error {
+	return writeArchiveFileWithClose(ctx, path, document, (*os.File).Close, replace)
+}
+func writeArchiveFileWithClose(ctx context.Context, path string, document Document, closeFile func(*os.File) error, replace func(string, string) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return err
+	}
+	temp := path + ".tmp"
+	if err := os.Remove(temp); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	file, err := os.OpenFile(temp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(temp)
+	if err := file.Chmod(0o600); err != nil {
+		_ = closeFile(file)
+		return err
+	}
+	encodeErr := Write(file, document)
+	closeErr := closeFile(file)
+	if err := errors.Join(encodeErr, closeErr); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return replace(temp, path)
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_test.go
@@ -282,24 +282,49 @@ func TestPublisherReplacementDoesNotBlockCollection(t *testing.T) {
 	}
 }
 
-func TestPublisherReplacementSerializesConfigurationCommit(t *testing.T) {
+func TestPublisherReplacementDoesNotBlockOwnershipChanges(t *testing.T) {
 	p, store := testPublisher(t)
 	store.ReplaceJob("", "device", ddsnmp.DeviceLifecycleInfo{}, ddsnmp.DeviceLifecycleStatus{}, nil)
+	incumbent := &testTopologySource{
+		snapshot: Snapshot{
+			ProducerScopeID: "incumbent",
+			Topology:        &Sweep{},
+			Lifecycle:       CaptureLifecycle(store, MaxRecords, MaxLogicalBytes),
+		},
+	}
+	successor := &testTopologySource{
+		snapshot: Snapshot{
+			ProducerScopeID: "successor",
+			Topology:        &Sweep{},
+		},
+	}
+	p.SetTopology("same-config", incumbent, DefaultInterval)
 	entered, release := make(chan struct{}), make(chan struct{})
 	p.rename = func(from, to string) error { close(entered); <-release; return os.Rename(from, to) }
 	published := make(chan struct{})
 	go func() { p.publish(t.Context(), false); close(published) }()
 	<-entered
-	replaced := make(chan struct{})
-	go func() { store.Unregister("device"); close(replaced) }()
-	select {
-	case <-replaced:
-		t.Error("configuration retired between revision validation and rename")
-	case <-time.After(50 * time.Millisecond):
+	removed, replaced := make(chan struct{}), make(chan struct{})
+	go func() { store.Unregister("device"); close(removed) }()
+	go func() { p.SetTopology("same-config", successor, DefaultInterval); close(replaced) }()
+	for _, done := range []<-chan struct{}{removed, replaced} {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("ownership transition blocked behind filesystem replacement")
+		}
 	}
 	close(release)
 	<-published
+	<-removed
 	<-replaced
-	require.Len(t, readFile(t, p.path).Snapshot.Lifecycle.Cut.Entries, 1)
+	// The file is a historical checkpoint. An ownership change during rename
+	// does not mark the successor's first checkpoint as already published.
+	require.Equal(t, "incumbent", readFile(t, p.path).Snapshot.ProducerScopeID)
 	require.Empty(t, store.LifecycleCut().Entries)
+	require.True(t, p.needsInitialTopology())
+	p.rename = os.Rename
+	p.publish(t.Context(), false)
+	require.Equal(t, "successor", readFile(t, p.path).Snapshot.ProducerScopeID)
+	require.False(t, p.needsInitialTopology())
 }

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/stretchr/testify/require"
+)
+
+func testDocument(sequence uint64) Document {
+	return Document{Format: Format, Version: Version, Snapshot: Snapshot{Lifecycle: Lifecycle{State: "available", Reason: "none", Cut: LifecycleCut{Sequence: sequence}}}}
+}
+func readFile(t *testing.T, path string) Document {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	d, err := Read(f, DefaultReadLimits())
+	require.NoError(t, err)
+	return d
+}
+func TestArchivePublicationPathPermissionsReplacement(t *testing.T) {
+	require.Equal(t, filepath.Join("varlib", "snmp-topology", "diagnostics", "netdata-snmp-topology-diagnostics.zst"), ArchivePath("varlib"))
+	path := filepath.Join(t.TempDir(), "diagnostics", "latest.zst")
+	for _, seq := range []uint64{1, 2} {
+		require.NoError(t, writeArchiveFile(t.Context(), path, testDocument(seq), os.Rename))
+		require.Equal(t, seq, readFile(t, path).Snapshot.Lifecycle.Cut.Sequence)
+	}
+	files, err := os.ReadDir(filepath.Dir(path))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+		info, err = os.Stat(filepath.Dir(path))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+	}
+	require.NoError(t, os.WriteFile(path+".tmp", []byte("stale"), 0o600))
+	require.NoError(t, writeArchiveFile(t.Context(), path, testDocument(3), os.Rename))
+	require.NoFileExists(t, path+".tmp")
+}
+func TestArchivePublicationFailuresPreservePreviousFile(t *testing.T) {
+	for _, failure := range []string{"encode", "close", "replace", "cancel"} {
+		t.Run(failure, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "latest.zst")
+			require.NoError(t, writeArchiveFile(t.Context(), path, testDocument(1), os.Rename))
+			before, err := os.ReadFile(path)
+			require.NoError(t, err)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			injected := errors.New("injected failure")
+			closeFile := func(f *os.File) error {
+				require.NoError(t, f.Close())
+				if failure == "close" {
+					return injected
+				}
+				if failure == "cancel" {
+					cancel()
+				}
+				return nil
+			}
+			replace := func(a, b string) error {
+				if failure == "replace" {
+					return injected
+				}
+				return os.Rename(a, b)
+			}
+			document := testDocument(2)
+			if failure == "encode" {
+				document.Snapshot.Lifecycle.Cut.CapturedAt = time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC)
+			}
+			require.Error(t, writeArchiveFileWithClose(ctx, path, document, closeFile, replace))
+			after, err := os.ReadFile(path)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+			require.NoFileExists(t, path+".tmp")
+		})
+	}
+}
+
+type testTopologySource struct {
+	snapshot Snapshot
+	capture  func() (Snapshot, error)
+}
+
+func (s *testTopologySource) Capture() (Snapshot, error) {
+	if s.capture != nil {
+		return s.capture()
+	}
+	return s.snapshot, nil
+}
+func testPublisher(t *testing.T) (*Publisher, *ddsnmp.DeviceStore) {
+	t.Helper()
+	store := ddsnmp.NewDeviceStore()
+	p := NewPublisher(store, t.TempDir())
+	p.path = filepath.Join(t.TempDir(), "latest.zst")
+	return p, store
+}
+func TestPublisherWorksWithoutTopologyAndRetainsPreviousOnProviderFailure(t *testing.T) {
+	p, store := testPublisher(t)
+	require.False(t, p.publish(t.Context(), false))
+	require.FileExists(t, p.path)
+	store.ReplaceJob("", "device", ddsnmp.DeviceLifecycleInfo{Hostname: "switch.example", Port: 161, SNMPVersion: "2c"}, ddsnmp.DeviceLifecycleStatus{Phase: ddsnmp.DeviceLifecyclePhaseInit, Outcome: ddsnmp.DeviceLifecycleOutcomeFailed}, nil)
+	require.True(t, p.publish(t.Context(), true))
+	d := readFile(t, p.path)
+	require.Nil(t, d.Snapshot.Topology)
+	require.Len(t, d.Snapshot.Lifecycle.Cut.Entries, 1)
+	require.Equal(t, "failed", d.Snapshot.Lifecycle.Cut.Entries[0].LastCompleted.Outcome)
+	before, err := os.ReadFile(p.path)
+	require.NoError(t, err)
+	for _, panicCapture := range []bool{false, true} {
+		source := &testTopologySource{capture: func() (Snapshot, error) {
+			if panicCapture {
+				panic("failure")
+			}
+			return Snapshot{}, errors.New("failure")
+		}}
+		p.SetTopology("topology", source, time.Minute)
+		require.False(t, p.publish(t.Context(), false))
+		after, err := os.ReadFile(p.path)
+		require.NoError(t, err)
+		require.Equal(t, before, after)
+	}
+}
+func TestPublisherFencesReplacementRemovalAndRetiredCleanup(t *testing.T) {
+	p, store := testPublisher(t)
+	store.RegisterJob("device", ddsnmp.DeviceLifecycleInfo{Hostname: "switch.example"})
+	snapshot := Snapshot{Lifecycle: CaptureLifecycle(store, MaxRecords, MaxLogicalBytes), ProducerScopeID: "incumbent"}
+	incumbent := &testTopologySource{snapshot: snapshot}
+	p.SetTopology("same-config", incumbent, DefaultInterval)
+	require.True(t, p.publish(t.Context(), false))
+	successor := &testTopologySource{snapshot: snapshot}
+	successor.snapshot.ProducerScopeID = "successor"
+	// No SetTopology for a rejected candidate: incumbent remains selected.
+	p.ReleaseTopology(successor)
+	require.True(t, p.publish(t.Context(), false))
+	require.Equal(t, "incumbent", readFile(t, p.path).Snapshot.ProducerScopeID)
+	p.SetTopology("same-config", successor, 2*time.Minute)
+	p.ReleaseTopology(incumbent)
+	require.True(t, p.publish(t.Context(), false))
+	require.Equal(t, "successor", readFile(t, p.path).Snapshot.ProducerScopeID)
+	p.RemoveTopology("different-config")
+	require.Equal(t, 2*time.Minute, p.currentInterval())
+	p.RemoveTopology("same-config")
+	require.True(t, p.publish(t.Context(), false))
+	require.Empty(t, readFile(t, p.path).Snapshot.ProducerScopeID)
+	require.Equal(t, DefaultInterval, p.currentInterval())
+}
+func TestPublisherRejectsOwnershipChangeBeforeRename(t *testing.T) {
+	for _, change := range []string{"provider", "inventory"} {
+		t.Run(change, func(t *testing.T) {
+			p, store := testPublisher(t)
+			p.publish(t.Context(), false)
+			before, err := os.ReadFile(p.path)
+			require.NoError(t, err)
+			p.writeFile = func(ctx context.Context, path string, d Document, replace func(string, string) error) error {
+				if change == "provider" {
+					p.SetTopology("new", &testTopologySource{}, DefaultInterval)
+				} else {
+					store.ReplaceJob("", "new", ddsnmp.DeviceLifecycleInfo{}, ddsnmp.DeviceLifecycleStatus{}, nil)
+				}
+				return writeArchiveFile(ctx, path, d, replace)
+			}
+			require.False(t, p.publish(t.Context(), false))
+			after, err := os.ReadFile(p.path)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+		})
+	}
+}
+func TestPublisherRunSerializesAndStopsAfterCancellation(t *testing.T) {
+	p, _ := testPublisher(t)
+	var active, maximum, calls atomic.Int32
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	p.writeFile = func(ctx context.Context, _ string, _ Document, _ func(string, string) error) error {
+		n := active.Add(1)
+		defer active.Add(-1)
+		maximum.Store(max(maximum.Load(), n))
+		calls.Add(1)
+		entered <- struct{}{}
+		<-release
+		return ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { p.Run(ctx); close(done) }()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("publisher not started")
+	}
+	for range 10 {
+		p.notify()
+	}
+	cancel()
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("publisher did not join")
+	}
+	require.EqualValues(t, 1, maximum.Load())
+	require.EqualValues(t, 1, calls.Load())
+	p.Run(ctx)
+	require.EqualValues(t, 1, calls.Load())
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_test.go
@@ -17,7 +17,19 @@ import (
 )
 
 func testDocument(sequence uint64) Document {
-	return Document{Format: Format, Version: Version, Snapshot: Snapshot{Lifecycle: Lifecycle{State: "available", Reason: "none", Cut: LifecycleCut{Sequence: sequence}}}}
+	return Document{
+		Format:  Format,
+		Version: Version,
+		Snapshot: Snapshot{
+			Lifecycle: Lifecycle{
+				State:  "available",
+				Reason: "none",
+				Cut: LifecycleCut{
+					Sequence: sequence,
+				},
+			},
+		},
+	}
 }
 func readFile(t *testing.T, path string) Document {
 	t.Helper()
@@ -29,7 +41,11 @@ func readFile(t *testing.T, path string) Document {
 	return d
 }
 func TestArchivePublicationPathPermissionsReplacement(t *testing.T) {
-	require.Equal(t, filepath.Join("varlib", "snmp-topology", "diagnostics", "netdata-snmp-topology-diagnostics.zst"), ArchivePath("varlib"))
+	require.Equal(
+		t,
+		filepath.Join("varlib", "snmp-topology", "diagnostics", "netdata-snmp-topology-diagnostics.zst"),
+		ArchivePath("varlib"),
+	)
 	path := filepath.Join(t.TempDir(), "diagnostics", "latest.zst")
 	for _, seq := range []uint64{1, 2} {
 		require.NoError(t, writeArchiveFile(t.Context(), path, testDocument(seq), os.Rename))
@@ -111,7 +127,20 @@ func TestPublisherWorksWithoutTopologyAndRetainsPreviousOnProviderFailure(t *tes
 	p, store := testPublisher(t)
 	require.False(t, p.publish(t.Context(), false))
 	require.FileExists(t, p.path)
-	store.ReplaceJob("", "device", ddsnmp.DeviceLifecycleInfo{Hostname: "switch.example", Port: 161, SNMPVersion: "2c"}, ddsnmp.DeviceLifecycleStatus{Phase: ddsnmp.DeviceLifecyclePhaseInit, Outcome: ddsnmp.DeviceLifecycleOutcomeFailed}, nil)
+	store.ReplaceJob(
+		"",
+		"device",
+		ddsnmp.DeviceLifecycleInfo{
+			Hostname:    "switch.example",
+			Port:        161,
+			SNMPVersion: "2c",
+		},
+		ddsnmp.DeviceLifecycleStatus{
+			Phase:   ddsnmp.DeviceLifecyclePhaseInit,
+			Outcome: ddsnmp.DeviceLifecycleOutcomeFailed,
+		},
+		nil,
+	)
 	require.True(t, p.publish(t.Context(), true))
 	d := readFile(t, p.path)
 	require.Nil(t, d.Snapshot.Topology)
@@ -120,12 +149,14 @@ func TestPublisherWorksWithoutTopologyAndRetainsPreviousOnProviderFailure(t *tes
 	before, err := os.ReadFile(p.path)
 	require.NoError(t, err)
 	for _, panicCapture := range []bool{false, true} {
-		source := &testTopologySource{capture: func() (Snapshot, error) {
-			if panicCapture {
-				panic("failure")
-			}
-			return Snapshot{}, errors.New("failure")
-		}}
+		source := &testTopologySource{
+			capture: func() (Snapshot, error) {
+				if panicCapture {
+					panic("failure")
+				}
+				return Snapshot{}, errors.New("failure")
+			},
+		}
 		p.SetTopology("topology", source, time.Minute)
 		require.False(t, p.publish(t.Context(), false))
 		after, err := os.ReadFile(p.path)
@@ -135,12 +166,21 @@ func TestPublisherWorksWithoutTopologyAndRetainsPreviousOnProviderFailure(t *tes
 }
 func TestPublisherFencesReplacementRemovalAndRetiredCleanup(t *testing.T) {
 	p, store := testPublisher(t)
-	store.RegisterJob("device", ddsnmp.DeviceLifecycleInfo{Hostname: "switch.example"})
-	snapshot := Snapshot{Lifecycle: CaptureLifecycle(store, MaxRecords, MaxLogicalBytes), ProducerScopeID: "incumbent"}
-	incumbent := &testTopologySource{snapshot: snapshot}
+	store.RegisterJob("device", ddsnmp.DeviceLifecycleInfo{
+		Hostname: "switch.example",
+	})
+	snapshot := Snapshot{
+		Lifecycle:       CaptureLifecycle(store, MaxRecords, MaxLogicalBytes),
+		ProducerScopeID: "incumbent",
+	}
+	incumbent := &testTopologySource{
+		snapshot: snapshot,
+	}
 	p.SetTopology("same-config", incumbent, DefaultInterval)
 	require.True(t, p.publish(t.Context(), false))
-	successor := &testTopologySource{snapshot: snapshot}
+	successor := &testTopologySource{
+		snapshot: snapshot,
+	}
 	successor.snapshot.ProducerScopeID = "successor"
 	// No SetTopology for a rejected candidate: incumbent remains selected.
 	p.ReleaseTopology(successor)
@@ -215,4 +255,51 @@ func TestPublisherRunSerializesAndStopsAfterCancellation(t *testing.T) {
 	require.EqualValues(t, 1, calls.Load())
 	p.Run(ctx)
 	require.EqualValues(t, 1, calls.Load())
+}
+
+func TestPublisherReplacementDoesNotBlockCollection(t *testing.T) {
+	p, store := testPublisher(t)
+	writer := store.ReplaceJob("", "device", ddsnmp.DeviceLifecycleInfo{}, ddsnmp.DeviceLifecycleStatus{}, nil)
+	entered, release := make(chan struct{}), make(chan struct{})
+	p.rename = func(from, to string) error { close(entered); <-release; return os.Rename(from, to) }
+	done := make(chan struct{})
+	go func() { p.publish(t.Context(), false); close(done) }()
+	<-entered
+	defer func() { close(release); <-done }()
+	notified := make(chan struct{})
+	go func() { p.TopologyUpdated(); close(notified) }()
+	select {
+	case <-notified:
+	case <-time.After(time.Second):
+		t.Error("topology notification blocked behind filesystem replacement")
+	}
+	polled := make(chan struct{})
+	go func() { writer.RecordLifecycle(ddsnmp.DeviceLifecycleStatus{}); close(polled) }()
+	select {
+	case <-polled:
+	case <-time.After(time.Second):
+		t.Error("normal poll blocked behind filesystem replacement")
+	}
+}
+
+func TestPublisherReplacementSerializesConfigurationCommit(t *testing.T) {
+	p, store := testPublisher(t)
+	store.ReplaceJob("", "device", ddsnmp.DeviceLifecycleInfo{}, ddsnmp.DeviceLifecycleStatus{}, nil)
+	entered, release := make(chan struct{}), make(chan struct{})
+	p.rename = func(from, to string) error { close(entered); <-release; return os.Rename(from, to) }
+	published := make(chan struct{})
+	go func() { p.publish(t.Context(), false); close(published) }()
+	<-entered
+	replaced := make(chan struct{})
+	go func() { store.Unregister("device"); close(replaced) }()
+	select {
+	case <-replaced:
+		t.Error("configuration retired between revision validation and rename")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	<-published
+	<-replaced
+	require.Len(t, readFile(t, p.path).Snapshot.Lifecycle.Cut.Entries, 1)
+	require.Empty(t, store.LifecycleCut().Entries)
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -94,7 +94,12 @@ func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmen
 		store:                        metricStore,
 		metrics:                      newCollectorMetrics(metricStore),
 	}
-	c.diagnosticProvider = &topologyDiagnosticProvider{registry: c.topologyRegistry, aborted: &c.lastAbortedTopologyDiagnostic, source: deviceStore, limits: defaultTopologyDiagnosticGlobalLimits}
+	c.diagnosticProvider = &topologyDiagnosticProvider{
+		registry: c.topologyRegistry,
+		aborted:  &c.lastAbortedTopologyDiagnostic,
+		source:   deviceStore,
+		limits:   c.currentTopologyDiagnosticGlobalLimits(),
+	}
 	return c
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -158,6 +158,7 @@ func (c *Collector) Collect(context.Context) error {
 func (c *Collector) MetricStore() metrix.CollectorStore { return c.store }
 
 func (c *Collector) Run(ctx context.Context) error {
+	defer c.releaseDiagnosticProvider()
 	if err := ctx.Err(); err != nil {
 		return nil
 	}
@@ -238,6 +239,7 @@ func (c *Collector) refreshEvery() time.Duration {
 }
 
 func (c *Collector) Cleanup(context.Context) {
+	c.releaseDiagnosticProvider()
 	c.unpublishTrapTopologyEnrichment()
 
 	c.refreshMu.Lock()
@@ -431,7 +433,7 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 	})
 	c.topologyRegistry.publishGeneration(generation)
 	if c.diagnosticPublisher != nil {
-		c.diagnosticPublisher.TopologyUpdated(c.diagnosticProvider)
+		c.diagnosticPublisher.TopologyUpdated()
 	}
 	stats.cachedDevices = generation.deviceCount()
 	stats.completedAt = c.currentTime()

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -75,12 +75,11 @@ func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmen
 	}
 	metricStore := metrix.NewCollectorStore()
 	c := &Collector{
-		deviceStates:          make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState),
-		topologyRegistry:      newTopologyRegistryWithResolver(reverseDNS),
-		deviceSource:          deviceStore,
-		deviceLifecycleSource: deviceStore,
-		trapEnrichment:        trapEnrichment,
-		newSnmpClient:         gosnmp.NewHandler,
+		deviceStates:     make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState),
+		topologyRegistry: newTopologyRegistryWithResolver(reverseDNS),
+		deviceSource:     deviceStore,
+		trapEnrichment:   trapEnrichment,
+		newSnmpClient:    gosnmp.NewHandler,
 		newDdSnmpColl: func(cfg ddsnmpcollector.Config) ddCollector {
 			return ddsnmpcollector.New(cfg)
 		},
@@ -112,7 +111,6 @@ type (
 		generationSequence              uint64
 		topologyRegistry                *topologyRegistry
 		deviceSource                    deviceSource
-		deviceLifecycleSource           deviceLifecycleSource
 		trapEnrichment                  *TrapEnrichmentHandle
 		lastAbortedTopologyDiagnostic   atomic.Pointer[topologyAbortedSweepDiagnostic]
 		topologyDiagnosticAbortSequence atomic.Uint64

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -18,13 +18,12 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
-
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
-	"github.com/netdata/netdata/go/plugins/pkg/terminal"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/reversedns"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 )
@@ -32,29 +31,30 @@ import (
 //go:embed "config_schema.json"
 var configSchema string
 
-// Register registers the SNMP topology collector with shared SNMP-family state.
-func Register(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle, reverseDNS *reversedns.Resolver) {
-	collectorapi.Register("snmp_topology", newCreator(deviceStore, trapEnrichment, reverseDNS))
-}
-
-func newCreator(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle, reverseDNS *reversedns.Resolver) collectorapi.Creator {
+// Creator constructs registration with explicit SNMP-family dependencies.
+func Creator(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmentHandle, reverseDNS *reversedns.Resolver, publisher *snmpdiag.Publisher) collectorapi.Creator {
 	if deviceStore == nil {
-		panic("snmp_topology Register requires a non-nil device store")
+		panic("snmp_topology Creator requires a non-nil device store")
 	}
 	if trapEnrichment == nil {
-		panic("snmp_topology Register requires a non-nil trap enrichment handle")
+		panic("snmp_topology Creator requires a non-nil trap enrichment handle")
 	}
 	if reverseDNS == nil {
-		panic("snmp_topology Register requires a non-nil reverse DNS resolver")
+		panic("snmp_topology Creator requires a non-nil reverse DNS resolver")
 	}
 	return collectorapi.Creator{
 		JobConfigSchema: configSchema,
 		UpdateEvery:     60,
-		CreateV2:        func() collectorapi.CollectorV2 { return newCollector(deviceStore, trapEnrichment, reverseDNS) },
-		Config:          func() any { return &Config{} },
-		InstancePolicy:  collectorapi.InstancePolicySingle,
-		SharedFunctions: topologyMethods,
-		MethodHandler:   topologyFunctionHandler,
+		CreateV2: func() collectorapi.CollectorV2 {
+			c := newCollector(deviceStore, trapEnrichment, reverseDNS)
+			c.diagnosticPublisher = publisher
+			return c
+		},
+		JobConfigLifecycle: &topologyJobConfigLifecycle{publisher: publisher},
+		Config:             func() any { return &Config{} },
+		InstancePolicy:     collectorapi.InstancePolicySingle,
+		SharedFunctions:    topologyMethods,
+		MethodHandler:      topologyFunctionHandler,
 	}
 }
 
@@ -74,7 +74,7 @@ func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmen
 		panic("snmp_topology New requires a non-nil reverse DNS resolver")
 	}
 	metricStore := metrix.NewCollectorStore()
-	return &Collector{
+	c := &Collector{
 		deviceStates:          make(map[ddsnmp.DeviceRegistrationID]deviceRefreshState),
 		topologyRegistry:      newTopologyRegistryWithResolver(reverseDNS),
 		deviceSource:          deviceStore,
@@ -91,12 +91,11 @@ func newCollector(deviceStore *ddsnmp.DeviceStore, trapEnrichment *TrapEnrichmen
 		acquisitionLimits:            defaultTopologyAcquisitionLimits,
 		diagnosticGlobalLimits:       defaultTopologyDiagnosticGlobalLimits,
 		projectTopologyDiagnosticCut: projectTopologyDiagnosticCut,
-		publishDiagnosticArchive:     !terminal.IsTerminal(),
-		diagnosticArchivePath:        defaultTopologyDiagnosticArchivePath(),
-		publishDiagnosticArchiveFile: publishTopologyDiagnosticArchiveFile,
 		store:                        metricStore,
 		metrics:                      newCollectorMetrics(metricStore),
 	}
+	c.diagnosticProvider = &topologyDiagnosticProvider{registry: c.topologyRegistry, aborted: &c.lastAbortedTopologyDiagnostic, source: deviceStore, limits: defaultTopologyDiagnosticGlobalLimits}
+	return c
 }
 
 type (
@@ -128,9 +127,8 @@ type (
 		acquisitionLimits            topologyAcquisitionLimits
 		diagnosticGlobalLimits       topologyAcquisitionLimits
 		projectTopologyDiagnosticCut topologyDiagnosticCutProjector
-		publishDiagnosticArchive     bool
-		diagnosticArchivePath        string
-		publishDiagnosticArchiveFile func(string, topologyDiagnostics) error
+		diagnosticPublisher          *snmpdiag.Publisher
+		diagnosticProvider           *topologyDiagnosticProvider
 	}
 	deviceSource interface {
 		Entries() []ddsnmp.DeviceEntry
@@ -170,16 +168,6 @@ func (c *Collector) Run(ctx context.Context) error {
 
 	c.refreshTopologyRecovering(ctx)
 	c.topologyRegistry.enqueueReverseDNSWarmFromDefaultSnapshot()
-	var diagnosticArchiveRefreshes chan struct{}
-	if c.publishDiagnosticArchive {
-		diagnosticArchiveRefreshes = make(chan struct{}, 1)
-		publisherDone := make(chan struct{})
-		go func() {
-			defer close(publisherDone)
-			c.runTopologyDiagnosticArchivePublisher(ctx, diagnosticArchiveRefreshes)
-		}()
-		defer func() { <-publisherDone }()
-	}
 
 	ticker := time.NewTicker(c.deviceCheckEvery())
 	defer ticker.Stop()
@@ -191,12 +179,6 @@ func (c *Collector) Run(ctx context.Context) error {
 		case <-ticker.C:
 			c.refreshTopologyRecovering(ctx)
 			c.topologyRegistry.enqueueReverseDNSWarmFromDefaultSnapshot()
-			if diagnosticArchiveRefreshes != nil {
-				select {
-				case diagnosticArchiveRefreshes <- struct{}{}:
-				default:
-				}
-			}
 		}
 	}
 }
@@ -448,6 +430,9 @@ func (c *Collector) refreshTopology(ctx context.Context) refreshStats {
 		limits:         c.currentTopologyDiagnosticGlobalLimits(),
 	})
 	c.topologyRegistry.publishGeneration(generation)
+	if c.diagnosticPublisher != nil {
+		c.diagnosticPublisher.TopologyUpdated(c.diagnosticProvider)
+	}
 	stats.cachedDevices = generation.deviceCount()
 	stats.completedAt = c.currentTime()
 	stats.duration = stats.completedAt.Sub(start)

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
-	"github.com/netdata/netdata/go/plugins/pkg/terminal"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/snmptopologyfunc"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestSNMPTopologyCreatorOwnsTopologyFunction(t *testing.T) {
-	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	creator := Creator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), newTestReverseDNSResolver(), nil)
 	require.Nil(t, creator.Create)
 	require.NotNil(t, creator.CreateV2)
 	require.Equal(t, collectorapi.InstancePolicySingle, creator.InstancePolicy)
@@ -48,34 +47,29 @@ func TestSNMPTopologyCreatorRequiresSharedDependencies(t *testing.T) {
 		"nil-device-store": {
 			store:     nil,
 			traps:     NewTrapEnrichmentHandle(),
-			wantPanic: "snmp_topology Register requires a non-nil device store",
+			wantPanic: "snmp_topology Creator requires a non-nil device store",
 		},
 		"nil-trap-handle": {
 			store:     ddsnmp.NewDeviceStore(),
 			traps:     nil,
-			wantPanic: "snmp_topology Register requires a non-nil trap enrichment handle",
+			wantPanic: "snmp_topology Creator requires a non-nil trap enrichment handle",
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			require.PanicsWithValue(t, tc.wantPanic, func() {
-				_ = newCreator(tc.store, tc.traps, newTestReverseDNSResolver())
+				_ = Creator(tc.store, tc.traps, newTestReverseDNSResolver(), nil)
 			})
 		})
 	}
-	require.PanicsWithValue(t, "snmp_topology Register requires a non-nil reverse DNS resolver", func() {
-		_ = newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), nil)
+	require.PanicsWithValue(t, "snmp_topology Creator requires a non-nil reverse DNS resolver", func() {
+		_ = Creator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), nil, nil)
 	})
 }
 
-func TestSNMPTopologyDiagnosticArchivePublicationFollowsTerminalMode(t *testing.T) {
-	coll := New(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
-	require.Equal(t, !terminal.IsTerminal(), coll.publishDiagnosticArchive)
-}
-
 func TestSNMPTopologyFunctionAvailabilityBecomesReadyAfterRenderableObservation(t *testing.T) {
-	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	creator := Creator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), newTestReverseDNSResolver(), nil)
 	methods := creator.SharedFunctions()
 	require.Len(t, methods, 1)
 	require.Nil(t, methods[0].Available)
@@ -120,14 +114,14 @@ func TestSNMPTopologyFunctionAvailabilityChangesOnlyWithPublishedGeneration(t *t
 }
 
 func TestSNMPTopologyFunctionAvailabilityResetsWhenCollectorRuns(t *testing.T) {
-	creator := newCreator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	creator := Creator(ddsnmp.NewDeviceStore(), NewTrapEnrichmentHandle(), newTestReverseDNSResolver(), nil)
 	methods := creator.SharedFunctions()
 	require.Len(t, methods, 1)
 	require.Nil(t, methods[0].Available)
 
 	coll, ok := creator.CreateV2().(*Collector)
 	require.True(t, ok)
-	coll.publishDiagnosticArchiveFile = func(string, topologyDiagnostics) error { return nil }
+
 	builder := newTopologyBuilder()
 	seedPublishedEndpointSnapshot(builder)
 	publishTestTopologyBuilder(coll.topologyRegistry, builder)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api.go
@@ -35,7 +35,12 @@ func InspectDiagnosticDocument(document snmpdiag.Document) (*DiagnosticArchive, 
 	if err != nil {
 		return nil, fmt.Errorf("inspect SNMP diagnostic archive: %w", err)
 	}
-	return &DiagnosticArchive{archive: topologyDiagnosticArchive{producerVersion: document.Producer.AgentVersion, diagnostics: diagnostics}}, nil
+	return &DiagnosticArchive{
+		archive: topologyDiagnosticArchive{
+			producerVersion: document.Producer.AgentVersion,
+			diagnostics:     diagnostics,
+		},
+	}, nil
 }
 
 func (a *DiagnosticArchive) Identity() DiagnosticArchiveIdentity {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api.go
@@ -5,7 +5,6 @@ package snmptopology
 import (
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"slices"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 
 	topologyapi "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
 )
@@ -23,35 +23,19 @@ type DiagnosticArchive struct {
 	archive topologyDiagnosticArchive
 }
 
-// DefaultDiagnosticArchiveReadLimits returns the generous defaults measured for
-// archives produced by the Agent.
-func DefaultDiagnosticArchiveReadLimits() DiagnosticReadLimits {
-	limits := defaultTopologyDiagnosticArchiveReadLimits()
-	return DiagnosticReadLimits{
-		MaxCompressedBytes: limits.maxCompressedBytes,
-		MaxDecodedBytes:    limits.maxDecodedBytes,
-	}
-}
-
 // DefaultDiagnosticQueryOptions returns the production topology query defaults.
 func DefaultDiagnosticQueryOptions() DiagnosticQueryOptions {
 	return diagnosticQueryOptionsFromInternal(topologyoptions.DefaultQueryOptions())
 }
 
-// ReadDiagnosticArchive validates and reconstructs one archive through the
-// same reader used by all offline diagnostic operations.
-func ReadDiagnosticArchive(
-	r io.Reader,
-	limits DiagnosticReadLimits,
-) (*DiagnosticArchive, error) {
-	archive, err := readTopologyDiagnosticArchive(r, topologyDiagnosticArchiveReadLimits{
-		maxCompressedBytes: limits.MaxCompressedBytes,
-		maxDecodedBytes:    limits.MaxDecodedBytes,
-	})
+// InspectDiagnosticDocument validates the typed evidence before exposing
+// lifecycle inspection or topology replay. The caller has decoded it once.
+func InspectDiagnosticDocument(document snmpdiag.Document) (*DiagnosticArchive, error) {
+	diagnostics, err := restoreArchiveDocument(document)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("inspect SNMP diagnostic archive: %w", err)
 	}
-	return &DiagnosticArchive{archive: archive}, nil
+	return &DiagnosticArchive{archive: topologyDiagnosticArchive{producerVersion: document.Producer.AgentVersion, diagnostics: diagnostics}}, nil
 }
 
 func (a *DiagnosticArchive) Identity() DiagnosticArchiveIdentity {
@@ -59,8 +43,8 @@ func (a *DiagnosticArchive) Identity() DiagnosticArchiveIdentity {
 		return DiagnosticArchiveIdentity{}
 	}
 	return DiagnosticArchiveIdentity{
-		Format:               topologyDiagnosticArchiveFormat,
-		Version:              topologyDiagnosticArchiveVersion,
+		Format:               snmpdiag.Format,
+		Version:              snmpdiag.Version,
 		ProducerAgentVersion: a.archive.producerVersion,
 	}
 }
@@ -360,11 +344,11 @@ func newDiagnosticTopologyCutSummary(
 func newDiagnosticLifecycleRegistration(
 	entry ddsnmp.DeviceLifecycleEntry,
 ) (diagnosticLifecycleRegistration, error) {
-	phase, err := topologyDiagnosticArchiveLifecyclePhaseName(entry.LastCompleted.Phase)
+	phase, err := snmpdiag.LifecyclePhaseName(entry.LastCompleted.Phase)
 	if err != nil {
 		return diagnosticLifecycleRegistration{}, fmt.Errorf("lifecycle phase: %w", err)
 	}
-	outcome, err := topologyDiagnosticArchiveLifecycleOutcomeName(entry.LastCompleted.Outcome)
+	outcome, err := snmpdiag.LifecycleOutcomeName(entry.LastCompleted.Outcome)
 	if err != nil {
 		return diagnosticLifecycleRegistration{}, fmt.Errorf("lifecycle outcome: %w", err)
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api_inspection.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api_inspection.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	topologyv1renderer "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyv1"
 )
@@ -200,7 +201,7 @@ func newDiagnosticDeviceCaptureInspection(result topologyInspectionCaptureResult
 				return diagnosticDeviceCaptureInspection{}, err
 			}
 			accounting.Profiles = append(accounting.Profiles, diagnosticProfileAccounting{
-				Identity: topologyDiagnosticArchiveProfileIdentityV1{
+				Identity: snmpdiag.ProfileIdentity{
 					Ordinal: profile.identity.Ordinal, RouteDigest: hex.EncodeToString(profile.identity.RouteDigest[:]),
 				},
 				Outcome: outcome, FailurePhase: phase,

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_api_test.go
@@ -4,8 +4,10 @@ package snmptopology
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyv1test"
 	"github.com/stretchr/testify/require"
 )
@@ -18,14 +20,14 @@ func TestDiagnosticArchiveAPIReusesArchiveReplayAndInspection(t *testing.T) {
 	var encoded bytes.Buffer
 	require.NoError(t, writeTopologyDiagnosticArchiveWithProducerVersion(&encoded, diagnostics, "v-test"))
 
-	archive, err := ReadDiagnosticArchive(
+	archive, err := readTestDiagnosticArchive(
 		bytes.NewReader(encoded.Bytes()),
-		DefaultDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, DiagnosticArchiveIdentity{
-		Format:               topologyDiagnosticArchiveFormat,
-		Version:              topologyDiagnosticArchiveVersion,
+		Format:               snmpdiag.Format,
+		Version:              snmpdiag.Version,
 		ProducerAgentVersion: "v-test",
 	}, archive.Identity())
 
@@ -99,7 +101,7 @@ func TestDiagnosticArchiveAPIRejectsInvalidExactLinkIndexes(t *testing.T) {
 
 	var encoded bytes.Buffer
 	require.NoError(t, writeTopologyDiagnosticArchive(&encoded, diagnostics))
-	archive, err := ReadDiagnosticArchive(bytes.NewReader(encoded.Bytes()), DefaultDiagnosticArchiveReadLimits())
+	archive, err := readTestDiagnosticArchive(bytes.NewReader(encoded.Bytes()), snmpdiag.DefaultReadLimits())
 	require.NoError(t, err)
 
 	query := diagnosticQueryOptionsFromInternal(newLLDPDirectScenario().opts)
@@ -115,7 +117,7 @@ func TestDiagnosticArchiveAPIRejectsInvalidExternalSelectors(t *testing.T) {
 
 	var encoded bytes.Buffer
 	require.NoError(t, writeTopologyDiagnosticArchive(&encoded, diagnostics))
-	archive, err := ReadDiagnosticArchive(bytes.NewReader(encoded.Bytes()), DefaultDiagnosticArchiveReadLimits())
+	archive, err := readTestDiagnosticArchive(bytes.NewReader(encoded.Bytes()), snmpdiag.DefaultReadLimits())
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -178,4 +180,12 @@ func TestDiagnosticArchiveAPIRejectsInvalidExternalSelectors(t *testing.T) {
 			require.ErrorContains(t, err, tc.want)
 		})
 	}
+}
+
+func readTestDiagnosticArchive(r io.Reader, limits snmpdiag.ReadLimits) (*DiagnosticArchive, error) {
+	d, err := snmpdiag.Read(r, limits)
+	if err != nil {
+		return nil, err
+	}
+	return InspectDiagnosticDocument(d)
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive.go
@@ -3,54 +3,11 @@
 package snmptopology
 
 import (
-	jsonv1 "encoding/json"
-	"encoding/json/jsontext"
-	jsonv2 "encoding/json/v2"
 	"errors"
 	"fmt"
-	"io"
-	"math"
-	"time"
 
-	"github.com/klauspost/compress/zstd"
-	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
-)
-
-const (
-	topologyDiagnosticArchiveFormat  = "netdata.snmp_topology.diagnostics"
-	topologyDiagnosticArchiveVersion = 1
-
-	// The defaults leave substantial headroom over the largest measured producer shapes.
-	topologyDiagnosticArchiveDefaultMaxCompressedBytes = 128 << 20
-	topologyDiagnosticArchiveDefaultMaxDecodedBytes    = 512 << 20
-)
-
-var (
-	errTopologyDiagnosticArchiveCompressedLimit = errors.New("SNMP topology diagnostic archive compressed-byte limit exceeded")
-	errTopologyDiagnosticArchiveDecodedLimit    = errors.New("SNMP topology diagnostic archive decoded-byte limit exceeded")
-)
-
-type topologyDiagnosticArchiveReadLimits struct {
-	maxCompressedBytes int64
-	maxDecodedBytes    int64
-}
-
-func defaultTopologyDiagnosticArchiveReadLimits() topologyDiagnosticArchiveReadLimits {
-	return topologyDiagnosticArchiveReadLimits{
-		maxCompressedBytes: topologyDiagnosticArchiveDefaultMaxCompressedBytes,
-		maxDecodedBytes:    topologyDiagnosticArchiveDefaultMaxDecodedBytes,
-	}
-}
-
-var topologyDiagnosticArchiveWriterJSONOptions = jsonv2.JoinOptions(
-	jsonv1.DefaultOptionsV1(),
-	jsontext.EscapeForHTML(false),
-)
-
-var topologyDiagnosticArchiveReaderJSONOptions = jsonv2.JoinOptions(
-	jsonv1.DefaultOptionsV1(),
-	jsontext.AllowInvalidUTF8(false),
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
 
 type topologyDiagnosticArchive struct {
@@ -58,237 +15,33 @@ type topologyDiagnosticArchive struct {
 	diagnostics     topologyDiagnostics
 }
 
-type topologyDiagnosticArchiveDocumentV1 struct {
-	Format   string                              `json:"format"`
-	Version  uint64                              `json:"version"`
-	Producer topologyDiagnosticArchiveProducerV1 `json:"producer"`
-	Snapshot topologyDiagnosticArchiveSnapshotV1 `json:"snapshot"`
-}
-
-type topologyDiagnosticArchiveProducerV1 struct {
-	AgentVersion string `json:"agent_version"`
-}
-
-type topologyDiagnosticArchiveSnapshotV1 struct {
-	Lifecycle       topologyDiagnosticArchiveLifecycleV1 `json:"job_lifecycle_cut"`
-	ProducerScopeID string                               `json:"producer_scope_id"`
-	Topology        *topologyDiagnosticArchiveSweepV1    `json:"topology_sweep_cut,omitempty"`
-	LastAborted     *topologyDiagnosticArchiveAbortV1    `json:"last_aborted_sweep,omitempty"`
-}
-
-type topologyDiagnosticArchiveLifecycleV1 struct {
-	State  string                                  `json:"capture_state"`
-	Reason string                                  `json:"capture_reason"`
-	Cut    topologyDiagnosticArchiveLifecycleCutV1 `json:"cut"`
-}
-
-type topologyDiagnosticArchiveLifecycleCutV1 struct {
-	Sequence   uint64                                      `json:"sequence"`
-	CapturedAt time.Time                                   `json:"captured_at"`
-	Entries    []topologyDiagnosticArchiveLifecycleEntryV1 `json:"entries,omitempty"`
-}
-
-type topologyDiagnosticArchiveLifecycleEntryV1 struct {
-	RegistrationID uint64                                     `json:"registration_id"`
-	Hostname       string                                     `json:"hostname"`
-	Port           int                                        `json:"port"`
-	SNMPVersion    string                                     `json:"snmp_version"`
-	LastCompleted  topologyDiagnosticArchiveLifecycleStatusV1 `json:"last_completed"`
-	TopologyReady  bool                                       `json:"topology_ready"`
-}
-
-type topologyDiagnosticArchiveLifecycleStatusV1 struct {
-	Phase       string    `json:"phase"`
-	Outcome     string    `json:"outcome"`
-	CompletedAt time.Time `json:"completed_at"`
-}
-
-type topologyDiagnosticArchiveSweepV1 struct {
-	Sequence      uint64                               `json:"sequence"`
-	StartedAt     time.Time                            `json:"started_at"`
-	PublishedAt   time.Time                            `json:"published_at"`
-	CaptureState  string                               `json:"capture_state"`
-	CaptureReason string                               `json:"capture_reason"`
-	RecordCount   uint64                               `json:"record_count"`
-	LogicalBytes  uint64                               `json:"logical_bytes"`
-	Devices       []topologyDiagnosticArchiveDeviceV1  `json:"devices,omitempty"`
-	Removed       []topologyDiagnosticArchiveRemovedV1 `json:"removed_devices,omitempty"`
-}
-
-type topologyDiagnosticArchiveDeviceV1 struct {
-	RegistrationID  uint64                                  `json:"registration_id"`
-	Selected        bool                                    `json:"selected"`
-	Outcome         string                                  `json:"outcome"`
-	LastAttempt     time.Time                               `json:"last_attempt"`
-	LastSuccess     time.Time                               `json:"last_success"`
-	NextRetry       time.Time                               `json:"next_retry"`
-	RetainedSuccess *topologyDiagnosticArchiveEvidenceRefV1 `json:"retained_success,omitempty"`
-	Captures        []topologyDiagnosticArchiveCaptureV1    `json:"captures,omitempty"`
-	HasObservation  bool                                    `json:"has_observation"`
-	ExpiresAt       time.Time                               `json:"expires_at"`
-	Renderable      bool                                    `json:"renderable"`
-	Expired         bool                                    `json:"expired"`
-}
-
-type topologyDiagnosticArchiveRemovedV1 struct {
-	RegistrationID  uint64                                  `json:"registration_id"`
-	RetainedSuccess *topologyDiagnosticArchiveEvidenceRefV1 `json:"retained_success,omitempty"`
-}
-
-type topologyDiagnosticArchiveEvidenceRefV1 struct {
-	RegistrationID uint64 `json:"registration_id"`
-	Generation     uint64 `json:"generation"`
-}
-
-type topologyDiagnosticArchiveCaptureV1 struct {
-	Roles          []string                                        `json:"roles"`
-	AttemptOrdinal uint64                                          `json:"attempt_ordinal"`
-	State          string                                          `json:"capture_state"`
-	Reason         string                                          `json:"capture_reason"`
-	RecordCount    uint64                                          `json:"record_count"`
-	LogicalBytes   uint64                                          `json:"logical_bytes"`
-	Evidence       *topologyDiagnosticArchiveAcquisitionEvidenceV1 `json:"evidence,omitempty"`
-}
-
-type topologyDiagnosticArchiveAbortV1 struct {
-	Sequence              uint64    `json:"sequence"`
-	StartedAt             time.Time `json:"started_at"`
-	AbortedAt             time.Time `json:"aborted_at"`
-	Reason                string    `json:"reason"`
-	Phase                 string    `json:"phase"`
-	ActiveRegistrationID  uint64    `json:"active_registration_id,omitempty"`
-	HasActiveRegistration bool      `json:"has_active_registration"`
-	RegistrationCount     int       `json:"registration_count"`
-	SelectedCount         int       `json:"selected_count"`
-}
-
 const (
 	topologyDiagnosticArchiveCaptureRoleLatestAttempt   = "latest_attempt"
 	topologyDiagnosticArchiveCaptureRoleRetainedSuccess = "retained_success"
 )
 
-func writeTopologyDiagnosticArchive(w io.Writer, diagnostics topologyDiagnostics) error {
-	return writeTopologyDiagnosticArchiveWithProducerVersion(w, diagnostics, buildinfo.Version)
-}
-
-func writeTopologyDiagnosticArchiveWithProducerVersion(
-	w io.Writer,
-	diagnostics topologyDiagnostics,
-	producerVersion string,
-) error {
-	if w == nil {
-		return errors.New("write SNMP topology diagnostic archive: nil writer")
-	}
-	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, producerVersion)
-	if err != nil {
-		return fmt.Errorf("write SNMP topology diagnostic archive: %w", err)
-	}
-	encoder, err := zstd.NewWriter(
-		w,
-		zstd.WithEncoderLevel(zstd.SpeedDefault),
-		zstd.WithEncoderConcurrency(1),
-		zstd.WithEncoderCRC(true),
-	)
-	if err != nil {
-		return fmt.Errorf("write SNMP topology diagnostic archive: create zstd encoder: %w", err)
-	}
-	encodeErr := jsonv2.MarshalWrite(encoder, document, topologyDiagnosticArchiveWriterJSONOptions)
-	closeErr := encoder.Close()
-	if encodeErr != nil {
-		return fmt.Errorf("write SNMP topology diagnostic archive: encode JSON: %w", encodeErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("write SNMP topology diagnostic archive: close zstd encoder: %w", closeErr)
-	}
-	return nil
-}
-
-func readTopologyDiagnosticArchive(
-	r io.Reader,
-	limits topologyDiagnosticArchiveReadLimits,
-) (topologyDiagnosticArchive, error) {
-	if r == nil {
-		return topologyDiagnosticArchive{}, errors.New("read SNMP topology diagnostic archive: nil reader")
-	}
-	if limits.maxCompressedBytes <= 0 || limits.maxCompressedBytes == math.MaxInt64 {
-		return topologyDiagnosticArchive{}, errors.New("read SNMP topology diagnostic archive: invalid compressed-byte limit")
-	}
-	if limits.maxDecodedBytes <= 0 || limits.maxDecodedBytes == math.MaxInt64 {
-		return topologyDiagnosticArchive{}, errors.New("read SNMP topology diagnostic archive: invalid decoded-byte limit")
-	}
-
-	compressed := &io.LimitedReader{R: r, N: limits.maxCompressedBytes + 1}
-	decoder, err := zstd.NewReader(compressed, zstd.WithDecoderConcurrency(1))
-	if err != nil {
-		if compressed.N == 0 {
-			return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveCompressedLimit
-		}
-		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: create zstd decoder: %w", err)
-	}
-
-	decoded := &io.LimitedReader{R: decoder, N: limits.maxDecodedBytes + 1}
-	var document topologyDiagnosticArchiveDocumentV1
-	err = jsonv2.UnmarshalRead(decoded, &document, topologyDiagnosticArchiveReaderJSONOptions)
-	decoder.Close()
-	if compressed.N == 0 {
-		return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveCompressedLimit
-	}
-	if decoded.N == 0 {
-		return topologyDiagnosticArchive{}, errTopologyDiagnosticArchiveDecodedLimit
-	}
-	if err != nil {
-		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: decode JSON: %w", err)
-	}
-	diagnostics, err := document.diagnostics()
-	if err != nil {
-		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: %w", err)
-	}
-	return topologyDiagnosticArchive{
-		producerVersion: document.Producer.AgentVersion,
-		diagnostics:     diagnostics,
-	}, nil
-}
-
-func newTopologyDiagnosticArchiveDocumentV1(
-	diagnostics topologyDiagnostics,
-	producerVersion string,
-) (topologyDiagnosticArchiveDocumentV1, error) {
-	snapshot, err := newTopologyDiagnosticArchiveSnapshotV1(diagnostics)
-	if err != nil {
-		return topologyDiagnosticArchiveDocumentV1{}, err
-	}
-	return topologyDiagnosticArchiveDocumentV1{
-		Format:  topologyDiagnosticArchiveFormat,
-		Version: topologyDiagnosticArchiveVersion,
-		Producer: topologyDiagnosticArchiveProducerV1{
-			AgentVersion: producerVersion,
-		},
-		Snapshot: snapshot,
-	}, nil
-}
-
 func newTopologyDiagnosticArchiveSnapshotV1(
 	diagnostics topologyDiagnostics,
-) (topologyDiagnosticArchiveSnapshotV1, error) {
+) (snmpdiag.Snapshot, error) {
 	lifecycle, err := newTopologyDiagnosticArchiveLifecycleV1(diagnostics.lifecycle)
 	if err != nil {
-		return topologyDiagnosticArchiveSnapshotV1{}, err
+		return snmpdiag.Snapshot{}, err
 	}
-	result := topologyDiagnosticArchiveSnapshotV1{
+	result := snmpdiag.Snapshot{
 		Lifecycle:       lifecycle,
 		ProducerScopeID: diagnostics.producerScopeID,
 	}
 	if diagnostics.topology != nil {
 		cut, err := newTopologyDiagnosticArchiveSweepV1(diagnostics.topology)
 		if err != nil {
-			return topologyDiagnosticArchiveSnapshotV1{}, err
+			return snmpdiag.Snapshot{}, err
 		}
 		result.Topology = &cut
 	}
 	if diagnostics.lastAborted != nil {
 		abort, err := newTopologyDiagnosticArchiveAbortV1(diagnostics.lastAborted)
 		if err != nil {
-			return topologyDiagnosticArchiveSnapshotV1{}, err
+			return snmpdiag.Snapshot{}, err
 		}
 		result.LastAborted = &abort
 	}
@@ -297,59 +50,34 @@ func newTopologyDiagnosticArchiveSnapshotV1(
 
 func newTopologyDiagnosticArchiveLifecycleV1(
 	lifecycle topologyJobLifecycleDiagnosticCut,
-) (topologyDiagnosticArchiveLifecycleV1, error) {
+) (snmpdiag.Lifecycle, error) {
 	state, err := topologyDiagnosticArchiveCaptureStateName(lifecycle.state)
 	if err != nil {
-		return topologyDiagnosticArchiveLifecycleV1{}, fmt.Errorf("job lifecycle capture state: %w", err)
+		return snmpdiag.Lifecycle{}, fmt.Errorf("job lifecycle capture state: %w", err)
 	}
 	reason, err := topologyDiagnosticArchiveCaptureReasonName(lifecycle.reason)
 	if err != nil {
-		return topologyDiagnosticArchiveLifecycleV1{}, fmt.Errorf("job lifecycle capture reason: %w", err)
+		return snmpdiag.Lifecycle{}, fmt.Errorf("job lifecycle capture reason: %w", err)
 	}
-	result := topologyDiagnosticArchiveLifecycleV1{
-		State:  state,
-		Reason: reason,
-		Cut: topologyDiagnosticArchiveLifecycleCutV1{
-			Sequence:   lifecycle.cut.Sequence,
-			CapturedAt: lifecycle.cut.CapturedAt,
-			Entries:    make([]topologyDiagnosticArchiveLifecycleEntryV1, 0, len(lifecycle.cut.Entries)),
-		},
+	result, err := snmpdiag.NewLifecycle(lifecycle.cut)
+	if err != nil {
+		return snmpdiag.Lifecycle{}, err
 	}
-	for _, entry := range lifecycle.cut.Entries {
-		phase, err := topologyDiagnosticArchiveLifecyclePhaseName(entry.LastCompleted.Phase)
-		if err != nil {
-			return topologyDiagnosticArchiveLifecycleV1{}, fmt.Errorf("job lifecycle registration %d phase: %w", entry.RegistrationID, err)
-		}
-		outcome, err := topologyDiagnosticArchiveLifecycleOutcomeName(entry.LastCompleted.Outcome)
-		if err != nil {
-			return topologyDiagnosticArchiveLifecycleV1{}, fmt.Errorf("job lifecycle registration %d outcome: %w", entry.RegistrationID, err)
-		}
-		result.Cut.Entries = append(result.Cut.Entries, topologyDiagnosticArchiveLifecycleEntryV1{
-			RegistrationID: uint64(entry.RegistrationID),
-			Hostname:       entry.Info.Hostname,
-			Port:           entry.Info.Port,
-			SNMPVersion:    entry.Info.SNMPVersion,
-			LastCompleted: topologyDiagnosticArchiveLifecycleStatusV1{
-				Phase:       phase,
-				Outcome:     outcome,
-				CompletedAt: entry.LastCompleted.CompletedAt,
-			},
-			TopologyReady: entry.TopologyReady,
-		})
-	}
+	result.State = state
+	result.Reason = reason
 	return result, nil
 }
 
-func newTopologyDiagnosticArchiveSweepV1(cut *topologySweepDiagnosticCut) (topologyDiagnosticArchiveSweepV1, error) {
+func newTopologyDiagnosticArchiveSweepV1(cut *topologySweepDiagnosticCut) (snmpdiag.Sweep, error) {
 	state, err := topologyDiagnosticArchiveCaptureStateName(cut.captureState)
 	if err != nil {
-		return topologyDiagnosticArchiveSweepV1{}, fmt.Errorf("topology sweep capture state: %w", err)
+		return snmpdiag.Sweep{}, fmt.Errorf("topology sweep capture state: %w", err)
 	}
 	reason, err := topologyDiagnosticArchiveCaptureReasonName(cut.captureReason)
 	if err != nil {
-		return topologyDiagnosticArchiveSweepV1{}, fmt.Errorf("topology sweep capture reason: %w", err)
+		return snmpdiag.Sweep{}, fmt.Errorf("topology sweep capture reason: %w", err)
 	}
-	result := topologyDiagnosticArchiveSweepV1{
+	result := snmpdiag.Sweep{
 		Sequence:      cut.sequence,
 		StartedAt:     cut.startedAt,
 		PublishedAt:   cut.publishedAt,
@@ -357,18 +85,18 @@ func newTopologyDiagnosticArchiveSweepV1(cut *topologySweepDiagnosticCut) (topol
 		CaptureReason: reason,
 		RecordCount:   cut.recordCount,
 		LogicalBytes:  cut.logicalBytes,
-		Devices:       make([]topologyDiagnosticArchiveDeviceV1, 0, len(cut.devices)),
-		Removed:       make([]topologyDiagnosticArchiveRemovedV1, 0, len(cut.removed)),
+		Devices:       make([]snmpdiag.Device, 0, len(cut.devices)),
+		Removed:       make([]snmpdiag.Removed, 0, len(cut.removed)),
 	}
 	for _, device := range cut.devices {
 		row, err := newTopologyDiagnosticArchiveDeviceV1(device)
 		if err != nil {
-			return topologyDiagnosticArchiveSweepV1{}, err
+			return snmpdiag.Sweep{}, err
 		}
 		result.Devices = append(result.Devices, row)
 	}
 	for _, removed := range cut.removed {
-		result.Removed = append(result.Removed, topologyDiagnosticArchiveRemovedV1{
+		result.Removed = append(result.Removed, snmpdiag.Removed{
 			RegistrationID:  uint64(removed.registrationID),
 			RetainedSuccess: topologyDiagnosticArchiveEvidenceRef(removed.retainedSuccess, removed.hasRetainedSuccess),
 		})
@@ -378,12 +106,12 @@ func newTopologyDiagnosticArchiveSweepV1(cut *topologySweepDiagnosticCut) (topol
 
 func newTopologyDiagnosticArchiveDeviceV1(
 	device topologySweepDeviceDiagnostic,
-) (topologyDiagnosticArchiveDeviceV1, error) {
+) (snmpdiag.Device, error) {
 	outcome, err := topologyDiagnosticArchiveDeviceOutcomeName(device.outcome)
 	if err != nil {
-		return topologyDiagnosticArchiveDeviceV1{}, fmt.Errorf("topology sweep registration %d outcome: %w", device.registrationID, err)
+		return snmpdiag.Device{}, fmt.Errorf("topology sweep registration %d outcome: %w", device.registrationID, err)
 	}
-	result := topologyDiagnosticArchiveDeviceV1{
+	result := snmpdiag.Device{
 		RegistrationID:  uint64(device.registrationID),
 		Selected:        device.selected,
 		Outcome:         outcome,
@@ -403,7 +131,7 @@ func newTopologyDiagnosticArchiveDeviceV1(
 			[]string{topologyDiagnosticArchiveCaptureRoleRetainedSuccess},
 		)
 		if err != nil {
-			return topologyDiagnosticArchiveDeviceV1{}, err
+			return snmpdiag.Device{}, err
 		}
 		result.Captures = append(result.Captures, capture)
 	}
@@ -420,7 +148,7 @@ func newTopologyDiagnosticArchiveDeviceV1(
 				[]string{topologyDiagnosticArchiveCaptureRoleLatestAttempt},
 			)
 			if err != nil {
-				return topologyDiagnosticArchiveDeviceV1{}, err
+				return snmpdiag.Device{}, err
 			}
 			result.Captures = append(result.Captures, capture)
 		}
@@ -432,32 +160,32 @@ func newTopologyDiagnosticArchiveCaptureV1(
 	registrationID ddsnmp.DeviceRegistrationID,
 	capture *topologyAcquisitionCapture,
 	roles []string,
-) (topologyDiagnosticArchiveCaptureV1, error) {
+) (snmpdiag.Capture, error) {
 	state, err := topologyDiagnosticArchiveCaptureStateName(capture.state)
 	if err != nil {
-		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture state: %w", registrationID, err)
+		return snmpdiag.Capture{}, fmt.Errorf("topology sweep registration %d capture state: %w", registrationID, err)
 	}
 	reason, err := topologyDiagnosticArchiveCaptureReasonName(capture.reason)
 	if err != nil {
-		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture reason: %w", registrationID, err)
+		return snmpdiag.Capture{}, fmt.Errorf("topology sweep registration %d capture reason: %w", registrationID, err)
 	}
 	if capture.attemptID.registrationID != registrationID {
-		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf(
+		return snmpdiag.Capture{}, fmt.Errorf(
 			"topology sweep registration %d capture belongs to registration %d",
 			registrationID,
 			capture.attemptID.registrationID,
 		)
 	}
 	if capture.attemptID.ordinal == 0 {
-		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture attempt ordinal is zero", registrationID)
+		return snmpdiag.Capture{}, fmt.Errorf("topology sweep registration %d capture attempt ordinal is zero", registrationID)
 	}
 	if capture.state == diagnosticCaptureAvailable && capture.evidence == nil {
-		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d available capture has no evidence", registrationID)
+		return snmpdiag.Capture{}, fmt.Errorf("topology sweep registration %d available capture has no evidence", registrationID)
 	}
 	if capture.state != diagnosticCaptureAvailable && capture.evidence != nil {
-		return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d unavailable capture has evidence", registrationID)
+		return snmpdiag.Capture{}, fmt.Errorf("topology sweep registration %d unavailable capture has evidence", registrationID)
 	}
-	result := topologyDiagnosticArchiveCaptureV1{
+	result := snmpdiag.Capture{
 		Roles:          roles,
 		AttemptOrdinal: capture.attemptID.ordinal,
 		State:          state,
@@ -467,11 +195,11 @@ func newTopologyDiagnosticArchiveCaptureV1(
 	}
 	if capture.evidence != nil {
 		if capture.evidence.id != capture.attemptID {
-			return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture/evidence attempt mismatch", registrationID)
+			return snmpdiag.Capture{}, fmt.Errorf("topology sweep registration %d capture/evidence attempt mismatch", registrationID)
 		}
 		evidence, err := newTopologyDiagnosticArchiveAcquisitionEvidenceV1(capture.evidence)
 		if err != nil {
-			return topologyDiagnosticArchiveCaptureV1{}, fmt.Errorf("topology sweep registration %d capture evidence: %w", registrationID, err)
+			return snmpdiag.Capture{}, fmt.Errorf("topology sweep registration %d capture evidence: %w", registrationID, err)
 		}
 		result.Evidence = &evidence
 	}
@@ -481,11 +209,11 @@ func newTopologyDiagnosticArchiveCaptureV1(
 func topologyDiagnosticArchiveEvidenceRef(
 	ref topologyEvidenceRef,
 	present bool,
-) *topologyDiagnosticArchiveEvidenceRefV1 {
+) *snmpdiag.EvidenceRef {
 	if !present {
 		return nil
 	}
-	return &topologyDiagnosticArchiveEvidenceRefV1{
+	return &snmpdiag.EvidenceRef{
 		RegistrationID: uint64(ref.registrationID),
 		Generation:     ref.generation,
 	}
@@ -493,16 +221,16 @@ func topologyDiagnosticArchiveEvidenceRef(
 
 func newTopologyDiagnosticArchiveAbortV1(
 	abort *topologyAbortedSweepDiagnostic,
-) (topologyDiagnosticArchiveAbortV1, error) {
+) (snmpdiag.Abort, error) {
 	reason, err := topologyDiagnosticArchiveAbortReasonName(abort.reason)
 	if err != nil {
-		return topologyDiagnosticArchiveAbortV1{}, err
+		return snmpdiag.Abort{}, err
 	}
 	phase, err := topologyDiagnosticArchiveSweepPhaseName(abort.phase)
 	if err != nil {
-		return topologyDiagnosticArchiveAbortV1{}, err
+		return snmpdiag.Abort{}, err
 	}
-	return topologyDiagnosticArchiveAbortV1{
+	return snmpdiag.Abort{
 		Sequence:              abort.sequence,
 		StartedAt:             abort.startedAt,
 		AbortedAt:             abort.abortedAt,
@@ -515,18 +243,18 @@ func newTopologyDiagnosticArchiveAbortV1(
 	}, nil
 }
 
-func (d topologyDiagnosticArchiveDocumentV1) diagnostics() (topologyDiagnostics, error) {
-	if d.Format != topologyDiagnosticArchiveFormat {
+func restoreArchiveDocument(d snmpdiag.Document) (topologyDiagnostics, error) {
+	if d.Format != snmpdiag.Format {
 		return topologyDiagnostics{}, fmt.Errorf("unsupported format %q", d.Format)
 	}
-	if d.Version != topologyDiagnosticArchiveVersion {
+	if d.Version != snmpdiag.Version {
 		return topologyDiagnostics{}, fmt.Errorf("unsupported version %d", d.Version)
 	}
-	return d.Snapshot.diagnostics()
+	return restoreArchiveSnapshot(d.Snapshot)
 }
 
-func (s topologyDiagnosticArchiveSnapshotV1) diagnostics() (topologyDiagnostics, error) {
-	lifecycle, err := s.Lifecycle.lifecycle()
+func restoreArchiveSnapshot(s snmpdiag.Snapshot) (topologyDiagnostics, error) {
+	lifecycle, err := restoreArchiveLifecycle(s.Lifecycle)
 	if err != nil {
 		return topologyDiagnostics{}, err
 	}
@@ -535,14 +263,14 @@ func (s topologyDiagnosticArchiveSnapshotV1) diagnostics() (topologyDiagnostics,
 		producerScopeID: s.ProducerScopeID,
 	}
 	if s.Topology != nil {
-		cut, err := s.Topology.sweep()
+		cut, err := restoreArchiveSweep(*s.Topology)
 		if err != nil {
 			return topologyDiagnostics{}, err
 		}
 		result.topology = cut
 	}
 	if s.LastAborted != nil {
-		abort, err := s.LastAborted.abort()
+		abort, err := restoreArchiveAbort(*s.LastAborted)
 		if err != nil {
 			return topologyDiagnostics{}, err
 		}
@@ -551,7 +279,7 @@ func (s topologyDiagnosticArchiveSnapshotV1) diagnostics() (topologyDiagnostics,
 	return result, nil
 }
 
-func (l topologyDiagnosticArchiveLifecycleV1) lifecycle() (topologyJobLifecycleDiagnosticCut, error) {
+func restoreArchiveLifecycle(l snmpdiag.Lifecycle) (topologyJobLifecycleDiagnosticCut, error) {
 	state, err := topologyDiagnosticArchiveParseCaptureState(l.State)
 	if err != nil {
 		return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("job lifecycle capture state: %w", err)
@@ -579,11 +307,11 @@ func (l topologyDiagnosticArchiveLifecycleV1) lifecycle() (topologyJobLifecycleD
 			return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("duplicate job lifecycle registration ID %d", registrationID)
 		}
 		seen[registrationID] = struct{}{}
-		phase, err := topologyDiagnosticArchiveParseLifecyclePhase(entry.LastCompleted.Phase)
+		phase, err := snmpdiag.ParseLifecyclePhase(entry.LastCompleted.Phase)
 		if err != nil {
 			return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("job lifecycle registration %d phase: %w", registrationID, err)
 		}
-		outcome, err := topologyDiagnosticArchiveParseLifecycleOutcome(entry.LastCompleted.Outcome)
+		outcome, err := snmpdiag.ParseLifecycleOutcome(entry.LastCompleted.Outcome)
 		if err != nil {
 			return topologyJobLifecycleDiagnosticCut{}, fmt.Errorf("job lifecycle registration %d outcome: %w", registrationID, err)
 		}
@@ -605,7 +333,7 @@ func (l topologyDiagnosticArchiveLifecycleV1) lifecycle() (topologyJobLifecycleD
 	return result, nil
 }
 
-func (s topologyDiagnosticArchiveSweepV1) sweep() (*topologySweepDiagnosticCut, error) {
+func restoreArchiveSweep(s snmpdiag.Sweep) (*topologySweepDiagnosticCut, error) {
 	state, err := topologyDiagnosticArchiveParseCaptureState(s.CaptureState)
 	if err != nil {
 		return nil, fmt.Errorf("topology sweep capture state: %w", err)
@@ -627,7 +355,7 @@ func (s topologyDiagnosticArchiveSweepV1) sweep() (*topologySweepDiagnosticCut, 
 	}
 	seen := make(map[ddsnmp.DeviceRegistrationID]struct{}, len(s.Devices)+len(s.Removed))
 	for _, device := range s.Devices {
-		row, err := device.device(s.Sequence)
+		row, err := restoreArchiveDevice(device, s.Sequence)
 		if err != nil {
 			return nil, err
 		}
@@ -646,7 +374,7 @@ func (s topologyDiagnosticArchiveSweepV1) sweep() (*topologySweepDiagnosticCut, 
 			return nil, fmt.Errorf("duplicate topology sweep registration ID %d", registrationID)
 		}
 		seen[registrationID] = struct{}{}
-		ref, hasRef, err := removed.RetainedSuccess.evidenceRef(registrationID)
+		ref, hasRef, err := restoreArchiveEvidenceRef(removed.RetainedSuccess, registrationID)
 		if err != nil {
 			return nil, fmt.Errorf("removed topology registration %d: %w", registrationID, err)
 		}
@@ -667,7 +395,7 @@ func (s topologyDiagnosticArchiveSweepV1) sweep() (*topologySweepDiagnosticCut, 
 	return result, nil
 }
 
-func (d topologyDiagnosticArchiveDeviceV1) device(sweepGeneration uint64) (topologySweepDeviceDiagnostic, error) {
+func restoreArchiveDevice(d snmpdiag.Device, sweepGeneration uint64) (topologySweepDeviceDiagnostic, error) {
 	registrationID := ddsnmp.DeviceRegistrationID(d.RegistrationID)
 	if registrationID == 0 {
 		return topologySweepDeviceDiagnostic{}, errors.New("topology sweep registration ID is zero")
@@ -676,7 +404,7 @@ func (d topologyDiagnosticArchiveDeviceV1) device(sweepGeneration uint64) (topol
 	if err != nil {
 		return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d outcome: %w", registrationID, err)
 	}
-	ref, hasRef, err := d.RetainedSuccess.evidenceRef(registrationID)
+	ref, hasRef, err := restoreArchiveEvidenceRef(d.RetainedSuccess, registrationID)
 	if err != nil {
 		return topologySweepDeviceDiagnostic{}, fmt.Errorf("topology sweep registration %d: %w", registrationID, err)
 	}
@@ -697,7 +425,7 @@ func (d topologyDiagnosticArchiveDeviceV1) device(sweepGeneration uint64) (topol
 	seenRoles := make(map[string]struct{}, 2)
 	seenAttemptOrdinals := make(map[uint64]struct{}, len(d.Captures))
 	for _, archivedCapture := range d.Captures {
-		capture, err := archivedCapture.capture(registrationID)
+		capture, err := restoreArchiveCapture(archivedCapture, registrationID)
 		if err != nil {
 			return topologySweepDeviceDiagnostic{}, err
 		}
@@ -753,7 +481,7 @@ func (d topologyDiagnosticArchiveDeviceV1) device(sweepGeneration uint64) (topol
 	return result, nil
 }
 
-func (c topologyDiagnosticArchiveCaptureV1) capture(
+func restoreArchiveCapture(c snmpdiag.Capture,
 	registrationID ddsnmp.DeviceRegistrationID,
 ) (*topologyAcquisitionCapture, error) {
 	state, err := topologyDiagnosticArchiveParseCaptureState(c.State)
@@ -776,7 +504,7 @@ func (c topologyDiagnosticArchiveCaptureV1) capture(
 		logicalBytes: c.LogicalBytes,
 	}
 	if c.Evidence != nil {
-		evidence, err := c.Evidence.evidence(attemptID)
+		evidence, err := restoreArchiveAcquisitionEvidence(*c.Evidence, attemptID)
 		if err != nil {
 			return nil, fmt.Errorf("topology sweep registration %d capture evidence: %w", registrationID, err)
 		}
@@ -791,7 +519,7 @@ func (c topologyDiagnosticArchiveCaptureV1) capture(
 	return result, nil
 }
 
-func (r *topologyDiagnosticArchiveEvidenceRefV1) evidenceRef(
+func restoreArchiveEvidenceRef(r *snmpdiag.EvidenceRef,
 	owner ddsnmp.DeviceRegistrationID,
 ) (topologyEvidenceRef, bool, error) {
 	if r == nil {
@@ -807,7 +535,7 @@ func (r *topologyDiagnosticArchiveEvidenceRefV1) evidenceRef(
 	return topologyEvidenceRef{registrationID: registrationID, generation: r.Generation}, true, nil
 }
 
-func (a topologyDiagnosticArchiveAbortV1) abort() (*topologyAbortedSweepDiagnostic, error) {
+func restoreArchiveAbort(a snmpdiag.Abort) (*topologyAbortedSweepDiagnostic, error) {
 	reason, err := topologyDiagnosticArchiveParseAbortReason(a.Reason)
 	if err != nil {
 		return nil, err
@@ -846,12 +574,6 @@ var (
 	topologyDiagnosticArchiveCaptureReasonNames = []string{
 		"none", "record_limit", "byte_limit", "projection_error", "projection_panic",
 		"global_record_limit", "global_byte_limit",
-	}
-	topologyDiagnosticArchiveLifecyclePhaseNames = []string{
-		"unknown", "init", "check", "collect",
-	}
-	topologyDiagnosticArchiveLifecycleOutcomeNames = []string{
-		"unknown", "success", "failed",
 	}
 	topologyDiagnosticArchiveDeviceOutcomeNames = []string{
 		"unknown", "success", "no_profiles", "failed",
@@ -895,22 +617,6 @@ func topologyDiagnosticArchiveCaptureReasonName(value diagnosticCaptureReason) (
 
 func topologyDiagnosticArchiveParseCaptureReason(value string) (diagnosticCaptureReason, error) {
 	return topologyDiagnosticArchiveParseEnum[diagnosticCaptureReason](value, topologyDiagnosticArchiveCaptureReasonNames)
-}
-
-func topologyDiagnosticArchiveLifecyclePhaseName(value ddsnmp.DeviceLifecyclePhase) (string, error) {
-	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveLifecyclePhaseNames)
-}
-
-func topologyDiagnosticArchiveParseLifecyclePhase(value string) (ddsnmp.DeviceLifecyclePhase, error) {
-	return topologyDiagnosticArchiveParseEnum[ddsnmp.DeviceLifecyclePhase](value, topologyDiagnosticArchiveLifecyclePhaseNames)
-}
-
-func topologyDiagnosticArchiveLifecycleOutcomeName(value ddsnmp.DeviceLifecycleOutcome) (string, error) {
-	return topologyDiagnosticArchiveEnumName(value, topologyDiagnosticArchiveLifecycleOutcomeNames)
-}
-
-func topologyDiagnosticArchiveParseLifecycleOutcome(value string) (ddsnmp.DeviceLifecycleOutcome, error) {
-	return topologyDiagnosticArchiveParseEnum[ddsnmp.DeviceLifecycleOutcome](value, topologyDiagnosticArchiveLifecycleOutcomeNames)
 }
 
 func topologyDiagnosticArchiveDeviceOutcomeName(value deviceRefreshOutcome) (string, error) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_acquisition.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_acquisition.go
@@ -12,223 +12,42 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
-
-type topologyDiagnosticArchiveAcquisitionEvidenceV1 struct {
-	Device             topologyDiagnosticArchiveDeviceInputV1       `json:"device"`
-	Target             topologyDiagnosticArchiveTargetV1            `json:"target"`
-	Client             topologyDiagnosticArchivePhaseV1             `json:"client"`
-	Connect            topologyDiagnosticArchivePhaseV1             `json:"connect"`
-	Profiles           topologyDiagnosticArchivePhaseV1             `json:"profiles"`
-	Collection         topologyDiagnosticArchivePhaseV1             `json:"collection"`
-	SysUptime          topologyDiagnosticArchivePhaseV1             `json:"sys_uptime"`
-	VLANProfiles       topologyDiagnosticArchivePhaseV1             `json:"vlan_profiles"`
-	CollectedAt        time.Time                                    `json:"collected_at"`
-	FreshForNanos      int64                                        `json:"fresh_for_ns"`
-	SysUptimeValue     int64                                        `json:"sys_uptime_value"`
-	CollectionContexts []topologyDiagnosticArchiveContextEvidenceV1 `json:"collection_contexts,omitempty"`
-}
-
-type topologyDiagnosticArchiveDeviceInputV1 struct {
-	Hostname    string            `json:"hostname"`
-	SysObjectID string            `json:"sys_object_id"`
-	SysName     string            `json:"sys_name"`
-	SysDescr    string            `json:"sys_descr"`
-	SysContact  string            `json:"sys_contact"`
-	SysLocation string            `json:"sys_location"`
-	Vendor      string            `json:"vendor"`
-	Model       string            `json:"model"`
-	VnodeGUID   string            `json:"vnode_guid"`
-	VnodeLabels map[string]string `json:"vnode_labels,omitempty"`
-}
-
-type topologyDiagnosticArchiveTargetV1 struct {
-	Outcome   string   `json:"outcome"`
-	Addresses []string `json:"addresses,omitempty"`
-}
-
-type topologyDiagnosticArchivePhaseV1 struct {
-	Outcome string `json:"outcome"`
-	Failure string `json:"failure"`
-}
-
-type topologyDiagnosticArchiveContextEvidenceV1 struct {
-	Ordinal    uint32                                       `json:"ordinal"`
-	VLANID     string                                       `json:"vlan_id"`
-	VLANName   string                                       `json:"vlan_name"`
-	Client     topologyDiagnosticArchivePhaseV1             `json:"client"`
-	Connect    topologyDiagnosticArchivePhaseV1             `json:"connect"`
-	Collection topologyDiagnosticArchivePhaseV1             `json:"collection"`
-	Profiles   []topologyDiagnosticArchiveProfileEvidenceV1 `json:"profiles,omitempty"`
-}
-
-type topologyDiagnosticArchiveProfileEvidenceV1 struct {
-	Identity     topologyDiagnosticArchiveProfileIdentityV1 `json:"identity"`
-	Outcome      string                                     `json:"outcome"`
-	FailurePhase string                                     `json:"failure_phase"`
-	Stats        topologyDiagnosticArchiveCollectionStatsV1 `json:"stats"`
-	Execution    *topologyDiagnosticArchiveExecutionV1      `json:"execution,omitempty"`
-	Routes       []topologyDiagnosticArchiveRouteV1         `json:"routes,omitempty"`
-	Values       topologyDiagnosticArchiveProfileValuesV1   `json:"values"`
-}
-
-type topologyDiagnosticArchiveProfileIdentityV1 struct {
-	Ordinal     uint32 `json:"ordinal"`
-	RouteDigest string `json:"route_digest"`
-}
-
-type topologyDiagnosticArchiveRouteV1 struct {
-	Ordinal      uint32 `json:"ordinal"`
-	Kind         string `json:"kind"`
-	RootOID      string `json:"root_oid"`
-	Source       string `json:"source"`
-	Outcome      string `json:"outcome"`
-	FailureClass string `json:"failure_class"`
-	Rows         uint64 `json:"rows"`
-	Values       uint64 `json:"values"`
-	Missing      uint64 `json:"missing"`
-	Rejected     uint64 `json:"rejected"`
-}
-
-type topologyDiagnosticArchiveProfileValuesV1 struct {
-	Metadata  map[string]topologyDiagnosticArchiveMetaTagV1 `json:"metadata,omitempty"`
-	Tags      map[string]string                             `json:"tags,omitempty"`
-	Metrics   []topologyDiagnosticArchiveMetricValueV1      `json:"metrics,omitempty"`
-	BGPRows   []topologyDiagnosticArchiveBGPRowValueV1      `json:"bgp_rows,omitempty"`
-	BGPFailed bool                                          `json:"bgp_failed"`
-}
-
-type topologyDiagnosticArchiveMetaTagV1 struct {
-	Value        string `json:"value"`
-	IsExactMatch bool   `json:"is_exact_match"`
-}
-
-type topologyDiagnosticArchiveMetricValueV1 struct {
-	RouteOrdinal uint32            `json:"route_ordinal"`
-	RowOrdinal   uint32            `json:"row_ordinal"`
-	ValueOrdinal uint32            `json:"value_ordinal"`
-	Kind         string            `json:"kind"`
-	Tags         map[string]string `json:"tags,omitempty"`
-}
-
-type topologyDiagnosticArchiveBGPRowValueV1 struct {
-	RouteOrdinal uint32 `json:"route_ordinal"`
-	RowOrdinal   uint32 `json:"row_ordinal"`
-	ValueOrdinal uint32 `json:"value_ordinal"`
-
-	OriginProfileID string `json:"origin_profile_id"`
-	Table           string `json:"table"`
-	RowKey          string `json:"row_key"`
-	StructuralID    string `json:"structural_id"`
-	Kind            string `json:"kind"`
-
-	RoutingInstance string `json:"routing_instance"`
-	Neighbor        string `json:"neighbor"`
-	RemoteAS        string `json:"remote_as"`
-	LocalAddress    string `json:"local_address"`
-	LocalAS         string `json:"local_as"`
-	LocalIdentifier string `json:"local_identifier"`
-	PeerIdentifier  string `json:"peer_identifier"`
-	PeerType        string `json:"peer_type"`
-	BGPVersion      string `json:"bgp_version"`
-	Description     string `json:"description"`
-
-	AdminHas       bool              `json:"admin_has"`
-	AdminEnabled   bool              `json:"admin_enabled"`
-	StateHas       bool              `json:"state_has"`
-	State          string            `json:"state"`
-	StateRaw       string            `json:"state_raw"`
-	EstablishedHas bool              `json:"established_has"`
-	Established    int64             `json:"established"`
-	UpdateAgeHas   bool              `json:"update_age_has"`
-	UpdateAge      int64             `json:"update_age"`
-	Tags           map[string]string `json:"tags,omitempty"`
-}
-
-type topologyDiagnosticArchiveCollectionStatsV1 struct {
-	Timing     topologyDiagnosticArchiveTimingStatsV1     `json:"timing"`
-	SNMP       topologyDiagnosticArchiveSNMPStatsV1       `json:"snmp"`
-	Metrics    topologyDiagnosticArchiveMetricStatsV1     `json:"metrics"`
-	TableCache topologyDiagnosticArchiveTableCacheStatsV1 `json:"table_cache"`
-	Errors     topologyDiagnosticArchiveErrorStatsV1      `json:"errors"`
-}
-
-type topologyDiagnosticArchiveTimingStatsV1 struct {
-	PreparationNanos    int64 `json:"preparation_ns,omitempty"`
-	ScalarNanos         int64 `json:"scalar_ns"`
-	TableNanos          int64 `json:"table_ns"`
-	LicensingNanos      int64 `json:"licensing_ns"`
-	BGPNanos            int64 `json:"bgp_ns"`
-	VirtualMetricsNanos int64 `json:"virtual_metrics_ns"`
-}
-
-type topologyDiagnosticArchiveSNMPStatsV1 struct {
-	GetRequests  int64 `json:"get_requests"`
-	GetOIDs      int64 `json:"get_oids"`
-	WalkRequests int64 `json:"walk_requests"`
-	WalkPDUs     int64 `json:"walk_pdus"`
-	TablesWalked int64 `json:"tables_walked"`
-	TablesCached int64 `json:"tables_cached"`
-}
-
-type topologyDiagnosticArchiveMetricStatsV1 struct {
-	Scalar    int64 `json:"scalar"`
-	Table     int64 `json:"table"`
-	Virtual   int64 `json:"virtual"`
-	Licensing int64 `json:"licensing"`
-	BGP       int64 `json:"bgp"`
-	Tables    int64 `json:"tables"`
-	Rows      int64 `json:"rows"`
-}
-
-type topologyDiagnosticArchiveTableCacheStatsV1 struct {
-	Hits   int64 `json:"hits"`
-	Misses int64 `json:"misses"`
-}
-
-type topologyDiagnosticArchiveErrorStatsV1 struct {
-	ProcessingPreparation int64 `json:"processing_preparation,omitempty"`
-	SNMP                  int64 `json:"snmp"`
-	ProcessingScalar      int64 `json:"processing_scalar"`
-	ProcessingTable       int64 `json:"processing_table"`
-	ProcessingLicensing   int64 `json:"processing_licensing"`
-	ProcessingBGP         int64 `json:"processing_bgp"`
-	MissingOIDs           int64 `json:"missing_oids"`
-}
 
 func newTopologyDiagnosticArchiveAcquisitionEvidenceV1(
 	evidence *topologyAcquisitionAttemptEvidence,
-) (topologyDiagnosticArchiveAcquisitionEvidenceV1, error) {
+) (snmpdiag.AcquisitionEvidence, error) {
 	targetOutcome, err := topologyDiagnosticArchiveTargetOutcomeName(evidence.target.outcome)
 	if err != nil {
-		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, err
+		return snmpdiag.AcquisitionEvidence{}, err
 	}
 	client, err := newTopologyDiagnosticArchivePhaseV1(evidence.client)
 	if err != nil {
-		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("client phase: %w", err)
+		return snmpdiag.AcquisitionEvidence{}, fmt.Errorf("client phase: %w", err)
 	}
 	connect, err := newTopologyDiagnosticArchivePhaseV1(evidence.connect)
 	if err != nil {
-		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("connect phase: %w", err)
+		return snmpdiag.AcquisitionEvidence{}, fmt.Errorf("connect phase: %w", err)
 	}
 	profiles, err := newTopologyDiagnosticArchivePhaseV1(evidence.profiles)
 	if err != nil {
-		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("profiles phase: %w", err)
+		return snmpdiag.AcquisitionEvidence{}, fmt.Errorf("profiles phase: %w", err)
 	}
 	collection, err := newTopologyDiagnosticArchivePhaseV1(evidence.collection)
 	if err != nil {
-		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("collection phase: %w", err)
+		return snmpdiag.AcquisitionEvidence{}, fmt.Errorf("collection phase: %w", err)
 	}
 	sysUptime, err := newTopologyDiagnosticArchivePhaseV1(evidence.sysUptime)
 	if err != nil {
-		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("sys_uptime phase: %w", err)
+		return snmpdiag.AcquisitionEvidence{}, fmt.Errorf("sys_uptime phase: %w", err)
 	}
 	vlanProfiles, err := newTopologyDiagnosticArchivePhaseV1(evidence.vlanProfiles)
 	if err != nil {
-		return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("vlan_profiles phase: %w", err)
+		return snmpdiag.AcquisitionEvidence{}, fmt.Errorf("vlan_profiles phase: %w", err)
 	}
-	result := topologyDiagnosticArchiveAcquisitionEvidenceV1{
-		Device: topologyDiagnosticArchiveDeviceInputV1{
+	result := snmpdiag.AcquisitionEvidence{
+		Device: snmpdiag.DeviceInput{
 			Hostname:    evidence.device.hostname,
 			SysObjectID: evidence.device.sysObjectID,
 			SysName:     evidence.device.sysName,
@@ -240,7 +59,7 @@ func newTopologyDiagnosticArchiveAcquisitionEvidenceV1(
 			VnodeGUID:   evidence.device.vnodeGUID,
 			VnodeLabels: evidence.device.vnodeLabels,
 		},
-		Target: topologyDiagnosticArchiveTargetV1{
+		Target: snmpdiag.Target{
 			Outcome:   targetOutcome,
 			Addresses: make([]string, 0, len(evidence.target.addresses)),
 		},
@@ -253,7 +72,7 @@ func newTopologyDiagnosticArchiveAcquisitionEvidenceV1(
 		CollectedAt:        evidence.collectedAt,
 		FreshForNanos:      int64(evidence.freshFor),
 		SysUptimeValue:     evidence.sysUptimeValue,
-		CollectionContexts: make([]topologyDiagnosticArchiveContextEvidenceV1, 0, len(evidence.collectionContexts)),
+		CollectionContexts: make([]snmpdiag.ContextEvidence, 0, len(evidence.collectionContexts)),
 	}
 	for _, address := range evidence.target.addresses {
 		result.Target.Addresses = append(result.Target.Addresses, address.String())
@@ -261,7 +80,7 @@ func newTopologyDiagnosticArchiveAcquisitionEvidenceV1(
 	for _, context := range evidence.collectionContexts {
 		archived, err := newTopologyDiagnosticArchiveContextEvidenceV1(context)
 		if err != nil {
-			return topologyDiagnosticArchiveAcquisitionEvidenceV1{}, fmt.Errorf("collection context %d: %w", context.ordinal, err)
+			return snmpdiag.AcquisitionEvidence{}, fmt.Errorf("collection context %d: %w", context.ordinal, err)
 		}
 		result.CollectionContexts = append(result.CollectionContexts, archived)
 	}
@@ -270,32 +89,32 @@ func newTopologyDiagnosticArchiveAcquisitionEvidenceV1(
 
 func newTopologyDiagnosticArchiveContextEvidenceV1(
 	context topologyAcquisitionContextEvidence,
-) (topologyDiagnosticArchiveContextEvidenceV1, error) {
+) (snmpdiag.ContextEvidence, error) {
 	client, err := newTopologyDiagnosticArchivePhaseV1(context.client)
 	if err != nil {
-		return topologyDiagnosticArchiveContextEvidenceV1{}, fmt.Errorf("client phase: %w", err)
+		return snmpdiag.ContextEvidence{}, fmt.Errorf("client phase: %w", err)
 	}
 	connect, err := newTopologyDiagnosticArchivePhaseV1(context.connect)
 	if err != nil {
-		return topologyDiagnosticArchiveContextEvidenceV1{}, fmt.Errorf("connect phase: %w", err)
+		return snmpdiag.ContextEvidence{}, fmt.Errorf("connect phase: %w", err)
 	}
 	collection, err := newTopologyDiagnosticArchivePhaseV1(context.collection)
 	if err != nil {
-		return topologyDiagnosticArchiveContextEvidenceV1{}, fmt.Errorf("collection phase: %w", err)
+		return snmpdiag.ContextEvidence{}, fmt.Errorf("collection phase: %w", err)
 	}
-	result := topologyDiagnosticArchiveContextEvidenceV1{
+	result := snmpdiag.ContextEvidence{
 		Ordinal:    context.ordinal,
 		VLANID:     context.vlanID,
 		VLANName:   context.vlanName,
 		Client:     client,
 		Connect:    connect,
 		Collection: collection,
-		Profiles:   make([]topologyDiagnosticArchiveProfileEvidenceV1, 0, len(context.profiles)),
+		Profiles:   make([]snmpdiag.ProfileEvidence, 0, len(context.profiles)),
 	}
 	for _, profile := range context.profiles {
 		archived, err := newTopologyDiagnosticArchiveProfileEvidenceV1(profile)
 		if err != nil {
-			return topologyDiagnosticArchiveContextEvidenceV1{}, fmt.Errorf("profile %d: %w", profile.identity.Ordinal, err)
+			return snmpdiag.ContextEvidence{}, fmt.Errorf("profile %d: %w", profile.identity.Ordinal, err)
 		}
 		result.Profiles = append(result.Profiles, archived)
 	}
@@ -304,17 +123,17 @@ func newTopologyDiagnosticArchiveContextEvidenceV1(
 
 func newTopologyDiagnosticArchiveProfileEvidenceV1(
 	profile topologyAcquisitionProfileEvidence,
-) (topologyDiagnosticArchiveProfileEvidenceV1, error) {
+) (snmpdiag.ProfileEvidence, error) {
 	outcome, err := topologyDiagnosticArchiveProfileOutcomeName(profile.outcome)
 	if err != nil {
-		return topologyDiagnosticArchiveProfileEvidenceV1{}, err
+		return snmpdiag.ProfileEvidence{}, err
 	}
 	failurePhase, err := topologyDiagnosticArchiveProfileFailurePhaseName(profile.failurePhase)
 	if err != nil {
-		return topologyDiagnosticArchiveProfileEvidenceV1{}, err
+		return snmpdiag.ProfileEvidence{}, err
 	}
-	result := topologyDiagnosticArchiveProfileEvidenceV1{
-		Identity: topologyDiagnosticArchiveProfileIdentityV1{
+	result := snmpdiag.ProfileEvidence{
+		Identity: snmpdiag.ProfileIdentity{
 			Ordinal:     profile.identity.Ordinal,
 			RouteDigest: hex.EncodeToString(profile.identity.RouteDigest[:]),
 		},
@@ -322,13 +141,13 @@ func newTopologyDiagnosticArchiveProfileEvidenceV1(
 		FailurePhase: failurePhase,
 		Stats:        newTopologyDiagnosticArchiveCollectionStatsV1(profile.stats),
 		Execution:    newTopologyDiagnosticArchiveExecutionV1(profile.execution),
-		Routes:       make([]topologyDiagnosticArchiveRouteV1, 0, len(profile.routes)),
+		Routes:       make([]snmpdiag.Route, 0, len(profile.routes)),
 		Values:       newTopologyDiagnosticArchiveProfileValuesV1(profile.values),
 	}
 	for _, route := range profile.routes {
 		archived, err := newTopologyDiagnosticArchiveRouteV1(route)
 		if err != nil {
-			return topologyDiagnosticArchiveProfileEvidenceV1{}, fmt.Errorf("route %d: %w", route.Ordinal, err)
+			return snmpdiag.ProfileEvidence{}, fmt.Errorf("route %d: %w", route.Ordinal, err)
 		}
 		result.Routes = append(result.Routes, archived)
 	}
@@ -337,24 +156,24 @@ func newTopologyDiagnosticArchiveProfileEvidenceV1(
 
 func newTopologyDiagnosticArchiveRouteV1(
 	route ddsnmpcollector.AcquisitionRouteReport,
-) (topologyDiagnosticArchiveRouteV1, error) {
+) (snmpdiag.Route, error) {
 	kind, err := topologyDiagnosticArchiveRouteKindName(route.Kind)
 	if err != nil {
-		return topologyDiagnosticArchiveRouteV1{}, err
+		return snmpdiag.Route{}, err
 	}
 	source, err := topologyDiagnosticArchiveRouteSourceName(route.Source)
 	if err != nil {
-		return topologyDiagnosticArchiveRouteV1{}, err
+		return snmpdiag.Route{}, err
 	}
 	outcome, err := topologyDiagnosticArchiveRouteOutcomeName(route.Outcome)
 	if err != nil {
-		return topologyDiagnosticArchiveRouteV1{}, err
+		return snmpdiag.Route{}, err
 	}
 	failureClass, err := topologyDiagnosticArchiveRouteFailureClassName(route.FailureClass)
 	if err != nil {
-		return topologyDiagnosticArchiveRouteV1{}, err
+		return snmpdiag.Route{}, err
 	}
-	return topologyDiagnosticArchiveRouteV1{
+	return snmpdiag.Route{
 		Ordinal:      route.Ordinal,
 		Kind:         kind,
 		RootOID:      route.RootOID,
@@ -370,24 +189,24 @@ func newTopologyDiagnosticArchiveRouteV1(
 
 func newTopologyDiagnosticArchiveProfileValuesV1(
 	values topologyAcquisitionProfileValues,
-) topologyDiagnosticArchiveProfileValuesV1 {
-	result := topologyDiagnosticArchiveProfileValuesV1{
+) snmpdiag.ProfileValues {
+	result := snmpdiag.ProfileValues{
 		Tags:      values.tags,
-		Metrics:   make([]topologyDiagnosticArchiveMetricValueV1, 0, len(values.metrics)),
-		BGPRows:   make([]topologyDiagnosticArchiveBGPRowValueV1, 0, len(values.bgpRows)),
+		Metrics:   make([]snmpdiag.MetricValue, 0, len(values.metrics)),
+		BGPRows:   make([]snmpdiag.BGPRowValue, 0, len(values.bgpRows)),
 		BGPFailed: values.bgpFailed,
 	}
 	if values.metadata != nil {
-		result.Metadata = make(map[string]topologyDiagnosticArchiveMetaTagV1, len(values.metadata))
+		result.Metadata = make(map[string]snmpdiag.MetaTag, len(values.metadata))
 		for key, value := range values.metadata {
-			result.Metadata[key] = topologyDiagnosticArchiveMetaTagV1{
+			result.Metadata[key] = snmpdiag.MetaTag{
 				Value:        value.Value,
 				IsExactMatch: value.IsExactMatch,
 			}
 		}
 	}
 	for _, metric := range values.metrics {
-		result.Metrics = append(result.Metrics, topologyDiagnosticArchiveMetricValueV1{
+		result.Metrics = append(result.Metrics, snmpdiag.MetricValue{
 			RouteOrdinal: metric.routeOrdinal,
 			RowOrdinal:   metric.rowOrdinal,
 			ValueOrdinal: metric.valueOrdinal,
@@ -396,7 +215,7 @@ func newTopologyDiagnosticArchiveProfileValuesV1(
 		})
 	}
 	for _, row := range values.bgpRows {
-		result.BGPRows = append(result.BGPRows, topologyDiagnosticArchiveBGPRowValueV1{
+		result.BGPRows = append(result.BGPRows, snmpdiag.BGPRowValue{
 			RouteOrdinal:    row.routeOrdinal,
 			RowOrdinal:      row.rowOrdinal,
 			ValueOrdinal:    row.valueOrdinal,
@@ -432,9 +251,9 @@ func newTopologyDiagnosticArchiveProfileValuesV1(
 
 func newTopologyDiagnosticArchiveCollectionStatsV1(
 	stats ddsnmp.CollectionStats,
-) topologyDiagnosticArchiveCollectionStatsV1 {
-	return topologyDiagnosticArchiveCollectionStatsV1{
-		Timing: topologyDiagnosticArchiveTimingStatsV1{
+) snmpdiag.CollectionStats {
+	return snmpdiag.CollectionStats{
+		Timing: snmpdiag.TimingStats{
 			PreparationNanos:    int64(stats.Timing.Preparation),
 			ScalarNanos:         int64(stats.Timing.Scalar),
 			TableNanos:          int64(stats.Timing.Table),
@@ -442,7 +261,7 @@ func newTopologyDiagnosticArchiveCollectionStatsV1(
 			BGPNanos:            int64(stats.Timing.BGP),
 			VirtualMetricsNanos: int64(stats.Timing.VirtualMetrics),
 		},
-		SNMP: topologyDiagnosticArchiveSNMPStatsV1{
+		SNMP: snmpdiag.SNMPStats{
 			GetRequests:  stats.SNMP.GetRequests,
 			GetOIDs:      stats.SNMP.GetOIDs,
 			WalkRequests: stats.SNMP.WalkRequests,
@@ -450,7 +269,7 @@ func newTopologyDiagnosticArchiveCollectionStatsV1(
 			TablesWalked: stats.SNMP.TablesWalked,
 			TablesCached: stats.SNMP.TablesCached,
 		},
-		Metrics: topologyDiagnosticArchiveMetricStatsV1{
+		Metrics: snmpdiag.MetricStats{
 			Scalar:    stats.Metrics.Scalar,
 			Table:     stats.Metrics.Table,
 			Virtual:   stats.Metrics.Virtual,
@@ -459,11 +278,11 @@ func newTopologyDiagnosticArchiveCollectionStatsV1(
 			Tables:    stats.Metrics.Tables,
 			Rows:      stats.Metrics.Rows,
 		},
-		TableCache: topologyDiagnosticArchiveTableCacheStatsV1{
+		TableCache: snmpdiag.TableCacheStats{
 			Hits:   stats.TableCache.Hits,
 			Misses: stats.TableCache.Misses,
 		},
-		Errors: topologyDiagnosticArchiveErrorStatsV1{
+		Errors: snmpdiag.ErrorStats{
 			ProcessingPreparation: stats.Errors.Processing.Preparation,
 			SNMP:                  stats.Errors.SNMP,
 			ProcessingScalar:      stats.Errors.Processing.Scalar,
@@ -475,7 +294,7 @@ func newTopologyDiagnosticArchiveCollectionStatsV1(
 	}
 }
 
-func (e topologyDiagnosticArchiveAcquisitionEvidenceV1) evidence(
+func restoreArchiveAcquisitionEvidence(e snmpdiag.AcquisitionEvidence,
 	id topologyAcquisitionAttemptID,
 ) (*topologyAcquisitionAttemptEvidence, error) {
 	targetOutcome, err := topologyDiagnosticArchiveParseTargetOutcome(e.Target.Outcome)
@@ -493,27 +312,27 @@ func (e topologyDiagnosticArchiveAcquisitionEvidenceV1) evidence(
 		}
 		addresses = append(addresses, address)
 	}
-	client, err := e.Client.phase()
+	client, err := restoreArchivePhase(e.Client)
 	if err != nil {
 		return nil, fmt.Errorf("client phase: %w", err)
 	}
-	connect, err := e.Connect.phase()
+	connect, err := restoreArchivePhase(e.Connect)
 	if err != nil {
 		return nil, fmt.Errorf("connect phase: %w", err)
 	}
-	profiles, err := e.Profiles.phase()
+	profiles, err := restoreArchivePhase(e.Profiles)
 	if err != nil {
 		return nil, fmt.Errorf("profiles phase: %w", err)
 	}
-	collection, err := e.Collection.phase()
+	collection, err := restoreArchivePhase(e.Collection)
 	if err != nil {
 		return nil, fmt.Errorf("collection phase: %w", err)
 	}
-	sysUptime, err := e.SysUptime.phase()
+	sysUptime, err := restoreArchivePhase(e.SysUptime)
 	if err != nil {
 		return nil, fmt.Errorf("sys_uptime phase: %w", err)
 	}
-	vlanProfiles, err := e.VLANProfiles.phase()
+	vlanProfiles, err := restoreArchivePhase(e.VLANProfiles)
 	if err != nil {
 		return nil, fmt.Errorf("vlan_profiles phase: %w", err)
 	}
@@ -547,7 +366,7 @@ func (e topologyDiagnosticArchiveAcquisitionEvidenceV1) evidence(
 		collectionContexts: make([]topologyAcquisitionContextEvidence, 0, len(e.CollectionContexts)),
 	}
 	for _, context := range e.CollectionContexts {
-		reconstructed, err := context.context()
+		reconstructed, err := restoreArchiveContextEvidence(context)
 		if err != nil {
 			return nil, fmt.Errorf("collection context %d: %w", context.Ordinal, err)
 		}
@@ -556,16 +375,16 @@ func (e topologyDiagnosticArchiveAcquisitionEvidenceV1) evidence(
 	return result, nil
 }
 
-func (c topologyDiagnosticArchiveContextEvidenceV1) context() (topologyAcquisitionContextEvidence, error) {
-	client, err := c.Client.phase()
+func restoreArchiveContextEvidence(c snmpdiag.ContextEvidence) (topologyAcquisitionContextEvidence, error) {
+	client, err := restoreArchivePhase(c.Client)
 	if err != nil {
 		return topologyAcquisitionContextEvidence{}, fmt.Errorf("client phase: %w", err)
 	}
-	connect, err := c.Connect.phase()
+	connect, err := restoreArchivePhase(c.Connect)
 	if err != nil {
 		return topologyAcquisitionContextEvidence{}, fmt.Errorf("connect phase: %w", err)
 	}
-	collection, err := c.Collection.phase()
+	collection, err := restoreArchivePhase(c.Collection)
 	if err != nil {
 		return topologyAcquisitionContextEvidence{}, fmt.Errorf("collection phase: %w", err)
 	}
@@ -579,7 +398,7 @@ func (c topologyDiagnosticArchiveContextEvidenceV1) context() (topologyAcquisiti
 		profiles:   make([]topologyAcquisitionProfileEvidence, 0, len(c.Profiles)),
 	}
 	for _, profile := range c.Profiles {
-		reconstructed, err := profile.profile()
+		reconstructed, err := restoreArchiveProfileEvidence(profile)
 		if err != nil {
 			return topologyAcquisitionContextEvidence{}, fmt.Errorf("profile %d: %w", profile.Identity.Ordinal, err)
 		}
@@ -588,7 +407,7 @@ func (c topologyDiagnosticArchiveContextEvidenceV1) context() (topologyAcquisiti
 	return result, nil
 }
 
-func (p topologyDiagnosticArchiveProfileEvidenceV1) profile() (topologyAcquisitionProfileEvidence, error) {
+func restoreArchiveProfileEvidence(p snmpdiag.ProfileEvidence) (topologyAcquisitionProfileEvidence, error) {
 	digest, err := hex.DecodeString(p.Identity.RouteDigest)
 	if err != nil || len(digest) != 32 {
 		return topologyAcquisitionProfileEvidence{}, errors.New("route digest must be 32 bytes of hexadecimal")
@@ -610,10 +429,10 @@ func (p topologyDiagnosticArchiveProfileEvidenceV1) profile() (topologyAcquisiti
 		},
 		outcome:      outcome,
 		failurePhase: failurePhase,
-		stats:        p.Stats.stats(),
+		stats:        restoreArchiveCollectionStats(p.Stats),
 		routes:       make([]ddsnmpcollector.AcquisitionRouteReport, 0, len(p.Routes)),
 	}
-	result.execution, err = p.Execution.execution()
+	result.execution, err = restoreArchiveExecution(p.Execution)
 	if err != nil {
 		return topologyAcquisitionProfileEvidence{}, err
 	}
@@ -622,14 +441,14 @@ func (p topologyDiagnosticArchiveProfileEvidenceV1) profile() (topologyAcquisiti
 		if _, ok := routeOrdinals[route.Ordinal]; ok {
 			return topologyAcquisitionProfileEvidence{}, fmt.Errorf("duplicate route ordinal %d", route.Ordinal)
 		}
-		reconstructed, err := route.route()
+		reconstructed, err := restoreArchiveRoute(route)
 		if err != nil {
 			return topologyAcquisitionProfileEvidence{}, fmt.Errorf("route %d: %w", route.Ordinal, err)
 		}
 		routeOrdinals[route.Ordinal] = struct{}{}
 		result.routes = append(result.routes, reconstructed)
 	}
-	values, err := p.Values.values(routeOrdinals)
+	values, err := restoreArchiveProfileValues(p.Values, routeOrdinals)
 	if err != nil {
 		return topologyAcquisitionProfileEvidence{}, err
 	}
@@ -637,7 +456,7 @@ func (p topologyDiagnosticArchiveProfileEvidenceV1) profile() (topologyAcquisiti
 	return result, nil
 }
 
-func (r topologyDiagnosticArchiveRouteV1) route() (ddsnmpcollector.AcquisitionRouteReport, error) {
+func restoreArchiveRoute(r snmpdiag.Route) (ddsnmpcollector.AcquisitionRouteReport, error) {
 	kind, err := topologyDiagnosticArchiveParseRouteKind(r.Kind)
 	if err != nil {
 		return ddsnmpcollector.AcquisitionRouteReport{}, err
@@ -668,7 +487,7 @@ func (r topologyDiagnosticArchiveRouteV1) route() (ddsnmpcollector.AcquisitionRo
 	}, nil
 }
 
-func (v topologyDiagnosticArchiveProfileValuesV1) values(
+func restoreArchiveProfileValues(v snmpdiag.ProfileValues,
 	routeOrdinals map[uint32]struct{},
 ) (topologyAcquisitionProfileValues, error) {
 	result := topologyAcquisitionProfileValues{
@@ -742,7 +561,7 @@ func (v topologyDiagnosticArchiveProfileValuesV1) values(
 	return result, nil
 }
 
-func (s topologyDiagnosticArchiveCollectionStatsV1) stats() ddsnmp.CollectionStats {
+func restoreArchiveCollectionStats(s snmpdiag.CollectionStats) ddsnmp.CollectionStats {
 	var result ddsnmp.CollectionStats
 	result.Timing.Preparation = time.Duration(s.Timing.PreparationNanos)
 	result.Timing.Scalar = time.Duration(s.Timing.ScalarNanos)
@@ -777,19 +596,19 @@ func (s topologyDiagnosticArchiveCollectionStatsV1) stats() ddsnmp.CollectionSta
 
 func newTopologyDiagnosticArchivePhaseV1(
 	phase topologyAcquisitionPhaseEvidence,
-) (topologyDiagnosticArchivePhaseV1, error) {
+) (snmpdiag.Phase, error) {
 	outcome, err := topologyDiagnosticArchivePhaseOutcomeName(phase.outcome)
 	if err != nil {
-		return topologyDiagnosticArchivePhaseV1{}, err
+		return snmpdiag.Phase{}, err
 	}
 	failure, err := topologyDiagnosticArchivePhaseFailureName(phase.failure)
 	if err != nil {
-		return topologyDiagnosticArchivePhaseV1{}, err
+		return snmpdiag.Phase{}, err
 	}
-	return topologyDiagnosticArchivePhaseV1{Outcome: outcome, Failure: failure}, nil
+	return snmpdiag.Phase{Outcome: outcome, Failure: failure}, nil
 }
 
-func (p topologyDiagnosticArchivePhaseV1) phase() (topologyAcquisitionPhaseEvidence, error) {
+func restoreArchivePhase(p snmpdiag.Phase) (topologyAcquisitionPhaseEvidence, error) {
 	outcome, err := topologyDiagnosticArchiveParsePhaseOutcome(p.Outcome)
 	if err != nil {
 		return topologyAcquisitionPhaseEvidence{}, err

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_benchmark_test.go
@@ -4,6 +4,8 @@ package snmptopology
 
 import (
 	"bytes"
+	jsonv1 "encoding/json"
+	"encoding/json/jsontext"
 	jsonv2 "encoding/json/v2"
 	"fmt"
 	"io"
@@ -15,6 +17,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
 
 func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
@@ -70,7 +73,7 @@ func BenchmarkSNMPTopologyDiagnosticArchive(b *testing.B) {
 				for b.Loop() {
 					if _, err := readTopologyDiagnosticArchive(
 						bytes.NewReader(encoded.Bytes()),
-						defaultTopologyDiagnosticArchiveReadLimits(),
+						snmpdiag.DefaultReadLimits(),
 					); err != nil {
 						b.Fatal(err)
 					}
@@ -284,3 +287,5 @@ func benchmarkTopologyArchiveDiagnosticsWithMetric(
 		topology:        cut,
 	}
 }
+
+var topologyDiagnosticArchiveWriterJSONOptions = jsonv2.JoinOptions(jsonv1.DefaultOptionsV1(), jsontext.EscapeForHTML(false))

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
@@ -389,8 +389,6 @@ func TestTopologyDiagnosticArchiveEnumTablesAreCompleteAndRoundTrip(t *testing.T
 	}{
 		{"capture state", topologyDiagnosticArchiveCaptureStateNames, uint8(diagnosticCaptureUnavailable)},
 		{"capture reason", topologyDiagnosticArchiveCaptureReasonNames, uint8(diagnosticCaptureReasonGlobalByteLimit)},
-		{"lifecycle phase", []string{"unknown", "init", "check", "collect"}, uint8(ddsnmp.DeviceLifecyclePhaseCollect)},
-		{"lifecycle outcome", []string{"unknown", "success", "failed"}, uint8(ddsnmp.DeviceLifecycleOutcomeFailed)},
 		{"device outcome", topologyDiagnosticArchiveDeviceOutcomeNames, uint8(deviceRefreshOutcomeFailed)},
 		{"abort reason", topologyDiagnosticArchiveAbortReasonNames, uint8(topologyDiagnosticAbortPanic)},
 		{"sweep phase", topologyDiagnosticArchiveSweepPhaseNames, uint8(topologyDiagnosticSweepPhaseCommit)},

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_archive_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyv1test"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +41,7 @@ func TestTopologyDiagnosticArchiveRoundTripPreservesReplayAndInspection(t *testi
 	))
 	archive, err := readTopologyDiagnosticArchive(
 		bytes.NewReader(encoded.Bytes()),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "v-test", archive.producerVersion)
@@ -91,7 +92,7 @@ func TestTopologyDiagnosticArchiveV1GoldenDocument(t *testing.T) {
 
 	archive, err := readTopologyDiagnosticArchive(
 		bytes.NewReader(compressArchiveJSON(t, string(raw))),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "v1.2.3", archive.producerVersion)
@@ -123,31 +124,31 @@ func TestTopologyDiagnosticArchiveRejectsMalformedAndUnsupportedInput(t *testing
 	require.NoError(t, err)
 
 	tests := map[string]struct {
-		mutate func(*topologyDiagnosticArchiveDocumentV1)
+		mutate func(*snmpdiag.Document)
 		want   string
 	}{
 		"format": {
-			mutate: func(document *topologyDiagnosticArchiveDocumentV1) { document.Format = "other" },
+			mutate: func(document *snmpdiag.Document) { document.Format = "other" },
 			want:   "unsupported format",
 		},
 		"version": {
-			mutate: func(document *topologyDiagnosticArchiveDocumentV1) { document.Version++ },
+			mutate: func(document *snmpdiag.Document) { document.Version++ },
 			want:   "unsupported version",
 		},
 		"retained reference": {
-			mutate: func(document *topologyDiagnosticArchiveDocumentV1) {
+			mutate: func(document *snmpdiag.Document) {
 				document.Snapshot.Topology.Devices[0].RetainedSuccess.RegistrationID++
 			},
 			want: "does not match owner",
 		},
 		"capture role": {
-			mutate: func(document *topologyDiagnosticArchiveDocumentV1) {
+			mutate: func(document *snmpdiag.Document) {
 				document.Snapshot.Topology.Devices[0].Captures[0].Roles[0] = "other"
 			},
 			want: "unknown capture role",
 		},
 		"route reference": {
-			mutate: func(document *topologyDiagnosticArchiveDocumentV1) {
+			mutate: func(document *snmpdiag.Document) {
 				profile := &document.Snapshot.Topology.Devices[0].Captures[0].Evidence.CollectionContexts[0].Profiles[0]
 				require.NotEmpty(t, profile.Values.Metrics)
 				profile.Values.Metrics[0].RouteOrdinal = ^uint32(0)
@@ -155,7 +156,7 @@ func TestTopologyDiagnosticArchiveRejectsMalformedAndUnsupportedInput(t *testing
 			want: "references unknown route ordinal",
 		},
 		"target address": {
-			mutate: func(document *topologyDiagnosticArchiveDocumentV1) {
+			mutate: func(document *snmpdiag.Document) {
 				document.Snapshot.Topology.Devices[0].Captures[0].Evidence.Target.Addresses = []string{"not-an-address"}
 			},
 			want: "target address",
@@ -165,13 +166,13 @@ func TestTopologyDiagnosticArchiveRejectsMalformedAndUnsupportedInput(t *testing
 		t.Run(name, func(t *testing.T) {
 			encoded, err := json.Marshal(document)
 			require.NoError(t, err)
-			var mutated topologyDiagnosticArchiveDocumentV1
+			var mutated snmpdiag.Document
 			require.NoError(t, json.Unmarshal(encoded, &mutated))
 			tc.mutate(&mutated)
 
 			_, err = readTopologyDiagnosticArchive(
 				bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, mutated))),
-				defaultTopologyDiagnosticArchiveReadLimits(),
+				snmpdiag.DefaultReadLimits(),
 			)
 			require.ErrorContains(t, err, tc.want)
 		})
@@ -190,7 +191,7 @@ func TestTopologyDiagnosticArchivePreservesOpenBGPPeerState(t *testing.T) {
 
 	archive, err := readTopologyDiagnosticArchive(
 		bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, document))),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.NoError(t, err)
 	restored, err := newTopologyDiagnosticArchiveDocumentV1(archive.diagnostics, archive.producerVersion)
@@ -206,11 +207,11 @@ func TestTopologyDiagnosticArchiveRejectsRetainedReferenceCaptureMismatch(t *tes
 	require.GreaterOrEqual(t, len(document.Snapshot.Topology.Devices), 2)
 
 	tests := map[string]struct {
-		mutate func(*topologyDiagnosticArchiveDeviceV1, uint64)
+		mutate func(*snmpdiag.Device, uint64)
 		want   string
 	}{
 		"reference without role": {
-			mutate: func(device *topologyDiagnosticArchiveDeviceV1, _ uint64) {
+			mutate: func(device *snmpdiag.Device, _ uint64) {
 				require.NotNil(t, device.RetainedSuccess)
 				require.Len(t, device.Captures, 1)
 				device.Captures[0].Roles = []string{topologyDiagnosticArchiveCaptureRoleLatestAttempt}
@@ -218,14 +219,14 @@ func TestTopologyDiagnosticArchiveRejectsRetainedReferenceCaptureMismatch(t *tes
 			want: "retained-success reference and capture role disagree",
 		},
 		"role without reference": {
-			mutate: func(device *topologyDiagnosticArchiveDeviceV1, _ uint64) {
+			mutate: func(device *snmpdiag.Device, _ uint64) {
 				require.NotNil(t, device.RetainedSuccess)
 				device.RetainedSuccess = nil
 			},
 			want: "retained-success reference and capture role disagree",
 		},
 		"generation newer than sweep": {
-			mutate: func(device *topologyDiagnosticArchiveDeviceV1, sequence uint64) {
+			mutate: func(device *snmpdiag.Device, sequence uint64) {
 				require.NotNil(t, device.RetainedSuccess)
 				device.RetainedSuccess.Generation = sequence + 1
 			},
@@ -241,7 +242,7 @@ func TestTopologyDiagnosticArchiveRejectsRetainedReferenceCaptureMismatch(t *tes
 
 			_, err := readTopologyDiagnosticArchive(
 				bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, mutated))),
-				defaultTopologyDiagnosticArchiveReadLimits(),
+				snmpdiag.DefaultReadLimits(),
 			)
 			require.ErrorContains(t, err, mutate.want)
 		})
@@ -259,7 +260,7 @@ func TestTopologyDiagnosticArchiveRejectsDuplicateCaptureAttemptOrdinal(t *testi
 
 	_, err = readTopologyDiagnosticArchive(
 		bytes.NewReader(compressArchiveJSON(t, archiveDocumentJSON(t, document))),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.ErrorContains(t, err, "duplicate capture attempt ordinal")
 }
@@ -272,7 +273,7 @@ func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.
 
 	_, err = readTopologyDiagnosticArchive(
 		bytes.NewReader(compressArchiveJSON(t, validJSON+"{}")),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.Error(t, err)
 
@@ -280,7 +281,7 @@ func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.
 	require.Greater(t, len(encoded), 8)
 	_, err = readTopologyDiagnosticArchive(
 		bytes.NewReader(encoded[:len(encoded)-4]),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.Error(t, err)
 
@@ -288,15 +289,15 @@ func TestTopologyDiagnosticArchiveRejectsTrailingAndTruncatedContent(t *testing.
 	corrupt[len(corrupt)-1] ^= 0xff
 	_, err = readTopologyDiagnosticArchive(
 		bytes.NewReader(corrupt),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.Error(t, err)
 }
 
 func TestTopologyDiagnosticArchiveReadLimitsHaveGenerousDefaults(t *testing.T) {
-	limits := defaultTopologyDiagnosticArchiveReadLimits()
-	require.Equal(t, int64(128<<20), limits.maxCompressedBytes)
-	require.Equal(t, int64(512<<20), limits.maxDecodedBytes)
+	limits := snmpdiag.DefaultReadLimits()
+	require.Equal(t, int64(128<<20), limits.MaxCompressedBytes)
+	require.Equal(t, int64(512<<20), limits.MaxDecodedBytes)
 }
 
 func TestTopologyDiagnosticArchiveEnforcesCallerByteLimits(t *testing.T) {
@@ -307,16 +308,16 @@ func TestTopologyDiagnosticArchiveEnforcesCallerByteLimits(t *testing.T) {
 	encoded := compressArchiveJSON(t, archiveDocumentJSON(t, document))
 
 	for _, limit := range []int64{1, int64(len(encoded) - 1)} {
-		limits := defaultTopologyDiagnosticArchiveReadLimits()
-		limits.maxCompressedBytes = limit
+		limits := snmpdiag.DefaultReadLimits()
+		limits.MaxCompressedBytes = limit
 		_, err = readTopologyDiagnosticArchive(bytes.NewReader(encoded), limits)
-		require.ErrorIs(t, err, errTopologyDiagnosticArchiveCompressedLimit)
+		require.ErrorIs(t, err, snmpdiag.ErrCompressedLimit)
 	}
 
-	limits := defaultTopologyDiagnosticArchiveReadLimits()
-	limits.maxDecodedBytes = 64
+	limits := snmpdiag.DefaultReadLimits()
+	limits.MaxDecodedBytes = 64
 	_, err = readTopologyDiagnosticArchive(bytes.NewReader(encoded), limits)
-	require.ErrorIs(t, err, errTopologyDiagnosticArchiveDecodedLimit)
+	require.ErrorIs(t, err, snmpdiag.ErrDecodedLimit)
 }
 
 func TestTopologyDiagnosticArchiveWriterPropagatesDestinationFailure(t *testing.T) {
@@ -342,7 +343,7 @@ func TestTopologyDiagnosticArchiveUsesStandardJSONFieldSemantics(t *testing.T) {
 
 	_, err = readTopologyDiagnosticArchive(
 		bytes.NewReader(compressArchiveJSON(t, raw)),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.NoError(t, err)
 }
@@ -356,7 +357,7 @@ func TestTopologyDiagnosticArchiveRejectsInvalidWireUTF8(t *testing.T) {
 	invalidUTF8 := strings.Replace(raw, `"v-test"`, `"`+string([]byte{0xff})+`"`, 1)
 	_, err = readTopologyDiagnosticArchive(
 		bytes.NewReader(compressArchiveJSON(t, invalidUTF8)),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.ErrorContains(t, err, "invalid UTF-8")
 }
@@ -374,7 +375,7 @@ func TestTopologyDiagnosticArchiveWriterPreservesV1StringSemantics(t *testing.T)
 	require.NotContains(t, raw, `\u0026`)
 	archive, err := readTopologyDiagnosticArchive(
 		bytes.NewReader(encoded.Bytes()),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "v<&>\ufffd", archive.producerVersion)
@@ -388,8 +389,8 @@ func TestTopologyDiagnosticArchiveEnumTablesAreCompleteAndRoundTrip(t *testing.T
 	}{
 		{"capture state", topologyDiagnosticArchiveCaptureStateNames, uint8(diagnosticCaptureUnavailable)},
 		{"capture reason", topologyDiagnosticArchiveCaptureReasonNames, uint8(diagnosticCaptureReasonGlobalByteLimit)},
-		{"lifecycle phase", topologyDiagnosticArchiveLifecyclePhaseNames, uint8(ddsnmp.DeviceLifecyclePhaseCollect)},
-		{"lifecycle outcome", topologyDiagnosticArchiveLifecycleOutcomeNames, uint8(ddsnmp.DeviceLifecycleOutcomeFailed)},
+		{"lifecycle phase", []string{"unknown", "init", "check", "collect"}, uint8(ddsnmp.DeviceLifecyclePhaseCollect)},
+		{"lifecycle outcome", []string{"unknown", "success", "failed"}, uint8(ddsnmp.DeviceLifecycleOutcomeFailed)},
 		{"device outcome", topologyDiagnosticArchiveDeviceOutcomeNames, uint8(deviceRefreshOutcomeFailed)},
 		{"abort reason", topologyDiagnosticArchiveAbortReasonNames, uint8(topologyDiagnosticAbortPanic)},
 		{"sweep phase", topologyDiagnosticArchiveSweepPhaseNames, uint8(topologyDiagnosticSweepPhaseCommit)},
@@ -435,9 +436,9 @@ func FuzzReadTopologyDiagnosticArchive(f *testing.F) {
 	}`)
 	f.Add(seed)
 	f.Fuzz(func(t *testing.T, input []byte) {
-		limits := topologyDiagnosticArchiveReadLimits{
-			maxCompressedBytes: 1 << 20,
-			maxDecodedBytes:    4 << 20,
+		limits := snmpdiag.ReadLimits{
+			MaxCompressedBytes: 1 << 20,
+			MaxDecodedBytes:    4 << 20,
 		}
 		_, _ = readTopologyDiagnosticArchive(bytes.NewReader(input), limits)
 	})
@@ -537,8 +538,8 @@ func decompressArchiveJSON(t testing.TB, encoded []byte) string {
 
 func firstTopologyDiagnosticArchiveBGPRow(
 	t testing.TB,
-	document *topologyDiagnosticArchiveDocumentV1,
-) *topologyDiagnosticArchiveBGPRowValueV1 {
+	document *snmpdiag.Document,
+) *snmpdiag.BGPRowValue {
 	t.Helper()
 	require.NotNil(t, document)
 	require.NotNil(t, document.Snapshot.Topology)
@@ -566,13 +567,13 @@ func firstTopologyDiagnosticArchiveBGPRow(
 
 func cloneTopologyDiagnosticArchiveSweepV1(
 	t testing.TB,
-	sweep *topologyDiagnosticArchiveSweepV1,
-) *topologyDiagnosticArchiveSweepV1 {
+	sweep *snmpdiag.Sweep,
+) *snmpdiag.Sweep {
 	t.Helper()
 	require.NotNil(t, sweep)
 	raw, err := json.Marshal(sweep)
 	require.NoError(t, err)
-	var cloned topologyDiagnosticArchiveSweepV1
+	var cloned snmpdiag.Sweep
 	require.NoError(t, json.Unmarshal(raw, &cloned))
 	return &cloned
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_codec_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_codec_test.go
@@ -39,7 +39,10 @@ func readTopologyDiagnosticArchive(r io.Reader, limits snmpdiag.ReadLimits) (top
 	if err != nil {
 		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: %w", err)
 	}
-	return topologyDiagnosticArchive{producerVersion: document.Producer.AgentVersion, diagnostics: diagnostics}, nil
+	return topologyDiagnosticArchive{
+		producerVersion: document.Producer.AgentVersion,
+		diagnostics:     diagnostics,
+	}, nil
 }
 
 func newTopologyDiagnosticArchiveDocumentV1(
@@ -61,15 +64,26 @@ func newTopologyDiagnosticArchiveDocumentV1(
 }
 
 func (c *Collector) acquireTopologyDiagnostics() topologyDiagnostics {
-	diagnostics, limits := captureTopologyCut(c.topologyRegistry, c.lastAbortedTopologyDiagnostic.Load(), c.currentTopologyDiagnosticGlobalLimits())
+	diagnostics, limits := captureTopologyCut(
+		c.topologyRegistry,
+		c.lastAbortedTopologyDiagnostic.Load(),
+		c.currentTopologyDiagnosticGlobalLimits(),
+	)
 	diagnostics.lifecycle = acquireTopologyJobLifecycleCut(c.deviceLifecycleSource, limits)
 	return diagnostics
 }
-func acquireTopologyJobLifecycleCut(source deviceLifecycleSource, limits topologyAcquisitionLimits) topologyJobLifecycleDiagnosticCut {
+
+func acquireTopologyJobLifecycleCut(
+	source deviceLifecycleSource,
+	limits topologyAcquisitionLimits,
+) topologyJobLifecycleDiagnosticCut {
 	projected := snmpdiag.CaptureLifecycle(source, limits.maxRecords, limits.maxLogicalBytes)
 	result, err := restoreArchiveLifecycle(projected)
 	if err != nil {
-		return topologyJobLifecycleDiagnosticCut{state: diagnosticCaptureUnavailable, reason: diagnosticCaptureReasonProjectionError}
+		return topologyJobLifecycleDiagnosticCut{
+			state:  diagnosticCaptureUnavailable,
+			reason: diagnosticCaptureReasonProjectionError,
+		}
 	}
 	return result
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_codec_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_codec_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmptopology
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+)
+
+func writeTopologyDiagnosticArchive(w io.Writer, diagnostics topologyDiagnostics) error {
+	return writeTopologyDiagnosticArchiveWithProducerVersion(w, diagnostics, buildinfo.Version)
+}
+
+func writeTopologyDiagnosticArchiveWithProducerVersion(
+	w io.Writer,
+	diagnostics topologyDiagnostics,
+	producerVersion string,
+) error {
+	if w == nil {
+		return errors.New("write SNMP topology diagnostic archive: nil writer")
+	}
+	document, err := newTopologyDiagnosticArchiveDocumentV1(diagnostics, producerVersion)
+	if err != nil {
+		return fmt.Errorf("write SNMP topology diagnostic archive: %w", err)
+	}
+	return snmpdiag.Write(w, document)
+}
+
+func readTopologyDiagnosticArchive(r io.Reader, limits snmpdiag.ReadLimits) (topologyDiagnosticArchive, error) {
+	document, err := snmpdiag.Read(r, limits)
+	if err != nil {
+		return topologyDiagnosticArchive{}, err
+	}
+	diagnostics, err := restoreArchiveDocument(document)
+	if err != nil {
+		return topologyDiagnosticArchive{}, fmt.Errorf("read SNMP topology diagnostic archive: %w", err)
+	}
+	return topologyDiagnosticArchive{producerVersion: document.Producer.AgentVersion, diagnostics: diagnostics}, nil
+}
+
+func newTopologyDiagnosticArchiveDocumentV1(
+	diagnostics topologyDiagnostics,
+	producerVersion string,
+) (snmpdiag.Document, error) {
+	snapshot, err := newTopologyDiagnosticArchiveSnapshotV1(diagnostics)
+	if err != nil {
+		return snmpdiag.Document{}, err
+	}
+	return snmpdiag.Document{
+		Format:  snmpdiag.Format,
+		Version: snmpdiag.Version,
+		Producer: snmpdiag.Producer{
+			AgentVersion: producerVersion,
+		},
+		Snapshot: snapshot,
+	}, nil
+}
+
+func (c *Collector) acquireTopologyDiagnostics() topologyDiagnostics {
+	diagnostics, limits := captureTopologyCut(c.topologyRegistry, c.lastAbortedTopologyDiagnostic.Load(), c.currentTopologyDiagnosticGlobalLimits())
+	diagnostics.lifecycle = acquireTopologyJobLifecycleCut(c.deviceLifecycleSource, limits)
+	return diagnostics
+}
+func acquireTopologyJobLifecycleCut(source deviceLifecycleSource, limits topologyAcquisitionLimits) topologyJobLifecycleDiagnosticCut {
+	projected := snmpdiag.CaptureLifecycle(source, limits.maxRecords, limits.maxLogicalBytes)
+	result, err := restoreArchiveLifecycle(projected)
+	if err != nil {
+		return topologyJobLifecycleDiagnosticCut{state: diagnosticCaptureUnavailable, reason: diagnosticCaptureReasonProjectionError}
+	}
+	return result
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_codec_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_codec_test.go
@@ -63,13 +63,14 @@ func newTopologyDiagnosticArchiveDocumentV1(
 	}, nil
 }
 
+// Native-cut tests inspect immutability and retention before wire conversion.
 func (c *Collector) acquireTopologyDiagnostics() topologyDiagnostics {
 	diagnostics, limits := captureTopologyCut(
 		c.topologyRegistry,
 		c.lastAbortedTopologyDiagnostic.Load(),
 		c.currentTopologyDiagnosticGlobalLimits(),
 	)
-	diagnostics.lifecycle = acquireTopologyJobLifecycleCut(c.deviceLifecycleSource, limits)
+	diagnostics.lifecycle = acquireTopologyJobLifecycleCut(c.diagnosticProvider.source, limits)
 	return diagnostics
 }
 

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_execution.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_execution.go
@@ -7,39 +7,20 @@ import (
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
 
 // Presence distinguishes recorded zero work from archives predating accounting.
 // This allowlist is shared by the archive and selected-device inspection.
-type topologyDiagnosticArchiveExecutionV1 struct {
-	Preparation topologyDiagnosticArchivePreparationV1 `json:"preparation"`
-	Walks       []topologyDiagnosticArchiveWalkV1      `json:"walks"`
-}
-
-type topologyDiagnosticArchivePreparationV1 struct {
-	ElapsedNanos     int64 `json:"elapsed_ns"`
-	GetRequests      int64 `json:"get_requests"`
-	GetOIDs          int64 `json:"get_oids"`
-	SNMPErrors       int64 `json:"snmp_errors"`
-	MissingOIDs      int64 `json:"missing_oids"`
-	ProcessingErrors int64 `json:"processing_errors"`
-}
-
-type topologyDiagnosticArchiveWalkV1 struct {
-	RootOID      string `json:"root_oid"`
-	ElapsedNanos int64  `json:"elapsed_ns"`
-	Failed       bool   `json:"failed"`
-}
-
 func newTopologyDiagnosticArchiveExecutionV1(
 	execution *ddsnmpcollector.AcquisitionExecutionReport,
-) *topologyDiagnosticArchiveExecutionV1 {
+) *snmpdiag.Execution {
 	if execution == nil {
 		return nil
 	}
 	p := execution.Preparation
-	result := &topologyDiagnosticArchiveExecutionV1{
-		Preparation: topologyDiagnosticArchivePreparationV1{
+	result := &snmpdiag.Execution{
+		Preparation: snmpdiag.Preparation{
 			ElapsedNanos:     int64(p.Elapsed),
 			GetRequests:      p.GetRequests,
 			GetOIDs:          p.GetOIDs,
@@ -47,10 +28,10 @@ func newTopologyDiagnosticArchiveExecutionV1(
 			MissingOIDs:      p.MissingOIDs,
 			ProcessingErrors: p.ProcessingErrors,
 		},
-		Walks: make([]topologyDiagnosticArchiveWalkV1, 0, len(execution.Walks)),
+		Walks: make([]snmpdiag.Walk, 0, len(execution.Walks)),
 	}
 	for _, walk := range execution.Walks {
-		result.Walks = append(result.Walks, topologyDiagnosticArchiveWalkV1{
+		result.Walks = append(result.Walks, snmpdiag.Walk{
 			RootOID:      walk.RootOID,
 			ElapsedNanos: int64(walk.Elapsed),
 			Failed:       walk.Failed,
@@ -59,7 +40,7 @@ func newTopologyDiagnosticArchiveExecutionV1(
 	return result
 }
 
-func (e *topologyDiagnosticArchiveExecutionV1) execution() (*ddsnmpcollector.AcquisitionExecutionReport, error) {
+func restoreArchiveExecution(e *snmpdiag.Execution) (*ddsnmpcollector.AcquisitionExecutionReport, error) {
 	if e == nil {
 		return nil, nil
 	}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_execution_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_execution_test.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
-	"github.com/stretchr/testify/require"
-
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+	"github.com/stretchr/testify/require"
 )
 
 type executionTestHandler struct {
@@ -113,7 +113,7 @@ func TestTopologyExecutionAccountingRetentionArchiveInspection(t *testing.T) {
 	require.NoError(t, writeTopologyDiagnosticArchiveWithProducerVersion(&encoded, diagnostics, "v-test"))
 	archive, err := readTopologyDiagnosticArchive(
 		bytes.NewReader(encoded.Bytes()),
-		defaultTopologyDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	require.NoError(t, err)
 	restored := archive.diagnostics.topology.devices[0].latestAttempt.evidence.collectionContexts[0].profiles[0]
@@ -201,9 +201,9 @@ func TestTopologyExecutionAccountingPresence(t *testing.T) {
 			require.NoError(t, err)
 			raw, err := json.Marshal(dto)
 			require.NoError(t, err)
-			var decoded topologyDiagnosticArchiveProfileEvidenceV1
+			var decoded snmpdiag.ProfileEvidence
 			require.NoError(t, json.Unmarshal(raw, &decoded))
-			restored, err := decoded.profile()
+			restored, err := restoreArchiveProfileEvidence(decoded)
 			require.NoError(t, err)
 			require.Equal(t, recorded, restored.execution != nil)
 			again, err := newTopologyDiagnosticArchiveProfileEvidenceV1(restored)
@@ -214,17 +214,17 @@ func TestTopologyExecutionAccountingPresence(t *testing.T) {
 }
 
 func TestTopologyExecutionAccountingRejectsInvalidMeasurements(t *testing.T) {
-	for _, e := range []*topologyDiagnosticArchiveExecutionV1{
-		{Preparation: topologyDiagnosticArchivePreparationV1{
+	for _, e := range []*snmpdiag.Execution{
+		{Preparation: snmpdiag.Preparation{
 			ElapsedNanos: -1,
 		}},
-		{Preparation: topologyDiagnosticArchivePreparationV1{
+		{Preparation: snmpdiag.Preparation{
 			SNMPErrors: -1,
 		}},
-		{Walks: []topologyDiagnosticArchiveWalkV1{{RootOID: "1.3", ElapsedNanos: -1}}},
-		{Walks: []topologyDiagnosticArchiveWalkV1{{ElapsedNanos: int64(time.Second)}}},
+		{Walks: []snmpdiag.Walk{{RootOID: "1.3", ElapsedNanos: -1}}},
+		{Walks: []snmpdiag.Walk{{ElapsedNanos: int64(time.Second)}}},
 	} {
-		_, err := e.execution()
+		_, err := restoreArchiveExecution(e)
 		require.Error(t, err)
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication.go
@@ -57,3 +57,9 @@ func (h *topologyJobConfigLifecycle) Remove(id collectorapi.JobConfigIdentity) {
 		h.publisher.RemoveTopology(id.String())
 	}
 }
+
+func (c *Collector) releaseDiagnosticProvider() {
+	if c.diagnosticPublisher != nil {
+		c.diagnosticPublisher.ReleaseTopology(c.diagnosticProvider)
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication.go
@@ -3,163 +3,57 @@
 package snmptopology
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
+	"sync/atomic"
 
-	"github.com/netdata/netdata/go/plugins/pkg/buildinfo"
-	"github.com/netdata/netdata/go/plugins/pkg/pluginconfig"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
 
-const topologyDiagnosticArchiveFailureLogKey = "snmp_topology:diagnostic-archive"
-
-func topologyDiagnosticArchivePath(varLibDir string) string {
-	return filepath.Join(varLibDir, "snmp-topology", "diagnostics", "netdata-snmp-topology-diagnostics.zst")
+type topologyDiagnosticProvider struct {
+	registry *topologyRegistry
+	aborted  *atomic.Pointer[topologyAbortedSweepDiagnostic]
+	source   deviceLifecycleSource
+	limits   topologyAcquisitionLimits
 }
 
-func defaultTopologyDiagnosticArchivePath() string {
-	varLibDir := strings.TrimSpace(pluginconfig.VarLibDir())
-	if varLibDir == "" {
-		varLibDir = strings.TrimSpace(buildinfo.VarLibDir)
-	}
-	if varLibDir == "" {
-		varLibDir = buildinfo.DefaultVarLibDir
-	}
-	return topologyDiagnosticArchivePath(filepath.Clean(varLibDir))
-}
-
-func publishTopologyDiagnosticArchiveFile(path string, diagnostics topologyDiagnostics) error {
-	return writeTopologyDiagnosticArchiveFile(path, diagnostics, replaceTopologyDiagnosticArchiveFile)
-}
-
-func writeTopologyDiagnosticArchiveFile(
-	path string,
-	diagnostics topologyDiagnostics,
-	replace func(string, string) error,
-) error {
-	return writeTopologyDiagnosticArchiveFileWithClose(path, diagnostics, (*os.File).Close, replace)
-}
-
-func writeTopologyDiagnosticArchiveFileWithClose(
-	path string,
-	diagnostics topologyDiagnostics,
-	closeFile func(*os.File) error,
-	replace func(string, string) error,
-) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("create SNMP topology diagnostic archive directory: %w", err)
-	}
-	if err := os.Chmod(dir, 0o700); err != nil {
-		return fmt.Errorf("set SNMP topology diagnostic archive directory permissions: %w", err)
-	}
-
-	tempPath := path + ".tmp"
-	if err := os.Remove(tempPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove stale SNMP topology diagnostic archive temporary file: %w", err)
-	}
-
-	file, err := os.OpenFile(tempPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+func (p *topologyDiagnosticProvider) Capture() (snmpdiag.Snapshot, error) {
+	diagnostics, limits := captureTopologyCut(p.registry, p.aborted.Load(), p.limits)
+	diagnostics.lifecycle.state = diagnosticCaptureAvailable
+	snapshot, err := newTopologyDiagnosticArchiveSnapshotV1(diagnostics)
 	if err != nil {
-		return fmt.Errorf("create temporary SNMP topology diagnostic archive: %w", err)
+		return snmpdiag.Snapshot{}, err
 	}
-	keepTemp := true
-	defer func() {
-		if keepTemp {
-			_ = os.Remove(tempPath)
-		}
-	}()
-
-	if err := file.Chmod(0o600); err != nil {
-		_ = closeFile(file)
-		return fmt.Errorf("set temporary SNMP topology diagnostic archive permissions: %w", err)
-	}
-	if err := writeTopologyDiagnosticArchive(file, diagnostics); err != nil {
-		_ = closeFile(file)
-		return fmt.Errorf("write temporary SNMP topology diagnostic archive: %w", err)
-	}
-	if err := closeFile(file); err != nil {
-		return fmt.Errorf("close temporary SNMP topology diagnostic archive: %w", err)
-	}
-	if err := replace(tempPath, path); err != nil {
-		return fmt.Errorf("replace SNMP topology diagnostic archive: %w", err)
-	}
-	keepTemp = false
-	return nil
+	snapshot.Lifecycle = snmpdiag.CaptureLifecycle(p.source, limits.maxRecords, limits.maxLogicalBytes)
+	return snapshot, nil
 }
 
-func replaceTopologyDiagnosticArchiveFile(from, to string) error {
-	return os.Rename(from, to)
+type topologyJobConfigLifecycle struct{ publisher *snmpdiag.Publisher }
+type topologyConfigSnapshot struct {
+	id collectorapi.JobConfigIdentity
 }
 
-func runTopologyDiagnosticArchivePublisher(
-	ctx context.Context,
-	ticks <-chan time.Time,
-	refreshes <-chan struct{},
-	publish func(requireMeaningful bool) bool,
-) {
-	if ctx.Err() != nil {
+func (s topologyConfigSnapshot) Identity() collectorapi.JobConfigIdentity { return s.id }
+func (*topologyJobConfigLifecycle) Project(id collectorapi.JobConfigIdentity, _ map[string]any) collectorapi.JobConfigLifecycleSnapshot {
+	return topologyConfigSnapshot{id}
+}
+func (*topologyJobConfigLifecycle) Bind(collectorapi.JobConfigIdentity, collectorapi.RuntimeJob) {}
+func (*topologyJobConfigLifecycle) Capture(id collectorapi.JobConfigIdentity, _ collectorapi.RuntimeJob) collectorapi.JobConfigLifecycleSnapshot {
+	return topologyConfigSnapshot{id}
+}
+func (h *topologyJobConfigLifecycle) Reconcile(_ collectorapi.JobConfigIdentity, snapshot collectorapi.JobConfigLifecycleSnapshot, job collectorapi.RuntimeJob) {
+	if h.publisher == nil {
 		return
 	}
-	if publish(false) {
-		refreshes = nil
-	}
-	for {
-		select {
-		case <-ctx.Done():
+	if job != nil {
+		if c, ok := job.Collector().(*Collector); ok {
+			h.publisher.SetTopology(snapshot.Identity().String(), c.diagnosticProvider, max(c.deviceCheckEvery(), c.refreshEvery()))
 			return
-		case <-refreshes:
-			if ctx.Err() != nil {
-				return
-			}
-			if publish(true) {
-				refreshes = nil
-			}
-		case <-ticks:
-			if ctx.Err() != nil {
-				return
-			}
-			if publish(false) {
-				refreshes = nil
-			}
 		}
 	}
+	h.publisher.SetTopology(snapshot.Identity().String(), nil, snmpdiag.DefaultInterval)
 }
-
-func (c *Collector) diagnosticArchiveEvery() time.Duration {
-	return max(c.deviceCheckEvery(), c.refreshEvery())
-}
-
-func (c *Collector) runTopologyDiagnosticArchivePublisher(ctx context.Context, refreshes <-chan struct{}) {
-	ticker := time.NewTicker(c.diagnosticArchiveEvery())
-	defer ticker.Stop()
-	runTopologyDiagnosticArchivePublisher(ctx, ticker.C, refreshes, c.publishTopologyDiagnosticArchiveRecovering)
-}
-
-func (c *Collector) publishTopologyDiagnosticArchiveRecovering(requireMeaningful bool) (meaningful bool) {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			meaningful = false
-			c.Limit(topologyDiagnosticArchiveFailureLogKey, 1, topologyRefreshWarningEvery).
-				Warningf("failed to publish SNMP topology diagnostic archive: panic: %v", recovered)
-		}
-	}()
-	if c.publishDiagnosticArchiveFile == nil {
-		return false
+func (h *topologyJobConfigLifecycle) Remove(id collectorapi.JobConfigIdentity) {
+	if h.publisher != nil {
+		h.publisher.RemoveTopology(id.String())
 	}
-	diagnostics := c.acquireTopologyDiagnostics()
-	meaningful = len(diagnostics.lifecycle.cut.Entries) > 0
-	if requireMeaningful && !meaningful {
-		return false
-	}
-	if err := c.publishDiagnosticArchiveFile(c.diagnosticArchivePath, diagnostics); err != nil {
-		c.Limit(topologyDiagnosticArchiveFailureLogKey, 1, topologyRefreshWarningEvery).
-			Warningf("failed to publish SNMP topology diagnostic archive: %v", err)
-		return false
-	}
-	return meaningful
 }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication_test.go
@@ -41,8 +41,9 @@ func TestTopologyDiagnosticHookPublishesOnlyAcceptedProvider(t *testing.T) {
 	id := collectorapi.JobConfigIdentity{1}
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	start := func() (*Collector, context.CancelFunc, <-chan error) {
+	start := func(scope string) (*Collector, context.CancelFunc, <-chan error) {
 		c := creator.CreateV2().(*Collector)
+		c.topologyRegistry.producerScopeID = scope
 		c.UpdateEvery = 1
 		c.RefreshEvery = confopt.LongDuration(time.Second)
 		require.NoError(t, c.Init(ctx))
@@ -55,7 +56,7 @@ func TestTopologyDiagnosticHookPublishesOnlyAcceptedProvider(t *testing.T) {
 		}, time.Second, time.Millisecond)
 		return c, stop, done
 	}
-	incumbent, stopIncumbent, incumbentDone := start()
+	incumbent, stopIncumbent, incumbentDone := start("incumbent")
 	hook.Reconcile(collectorapi.JobConfigIdentity{}, hook.Capture(id, topologyLifecycleTestJob{incumbent}), topologyLifecycleTestJob{incumbent})
 	publisherDone := make(chan struct{})
 	go func() { publisher.Run(ctx); close(publisherDone) }()
@@ -73,7 +74,11 @@ func TestTopologyDiagnosticHookPublishesOnlyAcceptedProvider(t *testing.T) {
 	}, time.Second, time.Millisecond)
 	before, err := read()
 	require.NoError(t, err)
-	candidate, stopCandidate, candidateDone := start()
+	candidate, stopCandidate, candidateDone := start("candidate")
+	require.NotEqual(t,
+		incumbent.topologyRegistry.producerScope(), candidate.topologyRegistry.producerScope(),
+		"ownership assertions need distinct producer scopes",
+	)
 	hook.Bind(id, topologyLifecycleTestJob{candidate})
 	hook.Capture(id, topologyLifecycleTestJob{candidate})
 	// Wait for another real disk publication to prove that merely running the

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication_test.go
@@ -4,10 +4,11 @@ package snmptopology
 
 import (
 	"context"
-	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
@@ -92,12 +93,23 @@ func TestTopologyDiagnosticHookPublishesOnlyAcceptedProvider(t *testing.T) {
 		d, err := read()
 		return err == nil && d.Snapshot.ProducerScopeID == candidate.topologyRegistry.producerScope()
 	}, time.Second, time.Millisecond)
-	hook.Remove(id)
-	stopCandidate()
-	require.NoError(t, <-candidateDone)
-	candidate.Cleanup(ctx)
+	// Stop the selected runner without config removal. A fresh publisher run
+	// forces a checkpoint without waiting for the 30-minute fallback interval.
 	cancel()
 	<-publisherDone
+	stopCandidate()
+	require.NoError(t, <-candidateDone)
+	nextCtx, nextCancel := context.WithCancel(t.Context())
+	defer nextCancel()
+	nextDone := make(chan struct{})
+	go func() { publisher.Run(nextCtx); close(nextDone) }()
+	require.Eventually(t, func() bool {
+		d, err := read()
+		return err == nil && d.Snapshot.ProducerScopeID == "" && d.Snapshot.Topology == nil
+	}, time.Second, time.Millisecond)
+	nextCancel()
+	<-nextDone
+	candidate.Cleanup(ctx)
 }
 
 type topologyLifecycleTestJob struct{ c *Collector }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_publication_test.go
@@ -3,473 +3,107 @@
 package snmptopology
 
 import (
-	"bytes"
 	"context"
-	"errors"
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"os"
-	"path/filepath"
-	"runtime"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTopologyDiagnosticArchivePathUsesAgentVarLib(t *testing.T) {
-	path := topologyDiagnosticArchivePath(filepath.Join("agent", "varlib"))
-	require.Equal(
-		t,
-		filepath.Join("agent", "varlib", "snmp-topology", "diagnostics", "netdata-snmp-topology-diagnostics.zst"),
-		path,
-	)
-}
-
-func TestWriteTopologyDiagnosticArchiveFileCreatesValidatedArchiveWithPlatformPermissions(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "nested", "latest.zst")
-	diagnostics := publicationTestDiagnostics(7)
-
-	require.NoError(t, writeTopologyDiagnosticArchiveFile(path, diagnostics, replaceTopologyDiagnosticArchiveFile))
-
-	file, err := os.Open(path)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, file.Close()) })
-	archive, err := ReadDiagnosticArchive(file, DefaultDiagnosticArchiveReadLimits())
-	require.NoError(t, err)
-	summary, err := archive.Summary()
-	require.NoError(t, err)
-	require.EqualValues(t, 7, summary.Lifecycle.Sequence)
-	require.NoFileExists(t, path+".tmp")
-
-	if runtime.GOOS != "windows" {
-		dirInfo, err := os.Stat(filepath.Dir(path))
-		require.NoError(t, err)
-		require.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
-		fileInfo, err := os.Stat(path)
-		require.NoError(t, err)
-		require.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm())
-	}
-}
-
-func TestWriteTopologyDiagnosticArchiveFileReplacesOneStableFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "latest.zst")
-	require.NoError(t, writeTopologyDiagnosticArchiveFile(
-		path,
-		publicationTestDiagnostics(1),
-		replaceTopologyDiagnosticArchiveFile,
-	))
-
-	require.NoError(t, writeTopologyDiagnosticArchiveFile(
-		path,
-		publicationTestDiagnostics(2),
-		replaceTopologyDiagnosticArchiveFile,
-	))
-
-	files, err := os.ReadDir(filepath.Dir(path))
-	require.NoError(t, err)
-	require.Len(t, files, 1)
-	require.Equal(t, "latest.zst", files[0].Name())
-
-	file, err := os.Open(path)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, file.Close()) })
-	archive, err := ReadDiagnosticArchive(file, DefaultDiagnosticArchiveReadLimits())
-	require.NoError(t, err)
-	summary, err := archive.Summary()
-	require.NoError(t, err)
-	require.EqualValues(t, 2, summary.Lifecycle.Sequence)
-}
-
-func TestWriteTopologyDiagnosticArchiveFilePreservesPreviousArchiveOnFailure(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "latest.zst")
-	require.NoError(t, writeTopologyDiagnosticArchiveFile(
-		path,
-		publicationTestDiagnostics(1),
-		replaceTopologyDiagnosticArchiveFile,
-	))
-	want, err := os.ReadFile(path)
-	require.NoError(t, err)
-
-	t.Run("archive writer", func(t *testing.T) {
-		invalid := publicationTestDiagnostics(2)
-		invalid.lifecycle.state = diagnosticCaptureState(255)
-		err := writeTopologyDiagnosticArchiveFile(path, invalid, replaceTopologyDiagnosticArchiveFile)
-		require.ErrorContains(t, err, "write temporary SNMP topology diagnostic archive")
-		requirePreviousDiagnosticArchive(t, path, want)
-	})
-
-	t.Run("close", func(t *testing.T) {
-		closeErr := errors.New("close failed")
-		replaceCalled := false
-		err := writeTopologyDiagnosticArchiveFileWithClose(
-			path,
-			publicationTestDiagnostics(2),
-			func(file *os.File) error {
-				require.NoError(t, file.Close())
-				return closeErr
-			},
-			func(_, _ string) error {
-				replaceCalled = true
-				return nil
-			},
-		)
-		require.ErrorIs(t, err, closeErr)
-		require.False(t, replaceCalled)
-		requirePreviousDiagnosticArchive(t, path, want)
-	})
-
-	t.Run("replace", func(t *testing.T) {
-		replaceErr := errors.New("replace failed")
-		err := writeTopologyDiagnosticArchiveFile(path, publicationTestDiagnostics(2), func(_, _ string) error {
-			return replaceErr
-		})
-		require.ErrorIs(t, err, replaceErr)
-		requirePreviousDiagnosticArchive(t, path, want)
-	})
-}
-
-func TestWriteTopologyDiagnosticArchiveFileRemovesStaleTemporaryFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "latest.zst")
-	require.NoError(t, os.WriteFile(path+".tmp", []byte("stale"), 0o600))
-
-	require.NoError(t, writeTopologyDiagnosticArchiveFile(
-		path,
-		publicationTestDiagnostics(1),
-		replaceTopologyDiagnosticArchiveFile,
-	))
-	require.NoFileExists(t, path+".tmp")
-}
-
-func TestRunTopologyDiagnosticArchivePublisherPublishesImmediatelyAndSerially(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	ticks := make(chan time.Time)
-	refreshes := make(chan struct{}, 1)
-	started := make(chan struct{}, 2)
-	release := make(chan struct{}, 2)
-	done := make(chan struct{})
-	var calls atomic.Int32
-	var active atomic.Int32
-	var maximum atomic.Int32
-
-	go func() {
-		defer close(done)
-		runTopologyDiagnosticArchivePublisher(ctx, ticks, refreshes, func(bool) bool {
-			calls.Add(1)
-			current := active.Add(1)
-			for {
-				previous := maximum.Load()
-				if current <= previous || maximum.CompareAndSwap(previous, current) {
-					break
-				}
-			}
-			started <- struct{}{}
-			<-release
-			active.Add(-1)
-			return calls.Load() > 1
-		})
-	}()
-
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("initial publication did not start")
-	}
-	refreshes <- struct{}{}
-	select {
-	case refreshes <- struct{}{}:
-		t.Fatal("more than one refresh event must not queue while publication is blocked")
-	default:
-	}
-	release <- struct{}{}
-
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("coalesced publication did not start")
-	}
-	cancel()
-	release <- struct{}{}
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("publisher did not stop")
-	}
-	require.EqualValues(t, 2, calls.Load())
-	require.EqualValues(t, 1, maximum.Load())
-}
-
-func TestRunTopologyDiagnosticArchivePublisherDoesNotPublishAfterCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	var calls atomic.Int32
-
-	runTopologyDiagnosticArchivePublisher(ctx, make(chan time.Time), make(chan struct{}), func(bool) bool {
-		calls.Add(1)
-		return true
-	})
-
-	require.Zero(t, calls.Load())
-}
-
-func TestRunTopologyDiagnosticArchivePublisherRetriesRefreshesUntilMeaningfulSuccess(t *testing.T) {
-	ctx := t.Context()
-	ticks := make(chan time.Time)
-	refreshes := make(chan struct{}, 1)
-	called := make(chan publicationCall, 4)
-	var calls atomic.Int32
-
-	go runTopologyDiagnosticArchivePublisher(ctx, ticks, refreshes, func(requireMeaningful bool) bool {
-		call := int(calls.Add(1))
-		called <- publicationCall{number: call, requireMeaningful: requireMeaningful}
-		return call == 3
-	})
-
-	require.Equal(t, publicationCall{number: 1}, receivePublicationCall(t, called))
-	refreshes <- struct{}{}
-	require.Equal(t, publicationCall{number: 2, requireMeaningful: true}, receivePublicationCall(t, called))
-	refreshes <- struct{}{}
-	require.Equal(t, publicationCall{number: 3, requireMeaningful: true}, receivePublicationCall(t, called))
-
-	refreshes <- struct{}{}
-	select {
-	case call := <-called:
-		t.Fatalf("refresh publication remained enabled after meaningful success: call %d", call.number)
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	ticks <- time.Now()
-	require.Equal(t, publicationCall{number: 4}, receivePublicationCall(t, called))
-}
-
-func TestCollectorDiagnosticArchiveEveryUsesEffectiveRefreshCadence(t *testing.T) {
-	coll := newTestSNMPTopologyCollector()
-	coll.UpdateEvery = 60
-	coll.RefreshEvery = confopt.LongDuration(30 * time.Minute)
-	require.Equal(t, 30*time.Minute, coll.diagnosticArchiveEvery())
-
-	coll.UpdateEvery = 120
-	coll.RefreshEvery = confopt.LongDuration(time.Minute)
-	require.Equal(t, 2*time.Minute, coll.diagnosticArchiveEvery())
-}
-
-func TestPublishTopologyDiagnosticArchiveDoesNotUseRefreshLock(t *testing.T) {
-	coll := newTestSNMPTopologyCollector()
-	published := make(chan struct{})
-	coll.publishDiagnosticArchiveFile = func(string, topologyDiagnostics) error {
-		close(published)
-		return nil
-	}
-
-	coll.refreshMu.Lock()
-	defer coll.refreshMu.Unlock()
-	done := make(chan struct{})
-	meaningful := make(chan bool, 1)
-	go func() {
-		defer close(done)
-		meaningful <- coll.publishTopologyDiagnosticArchiveRecovering(false)
-	}()
-
-	select {
-	case <-published:
-	case <-time.After(time.Second):
-		t.Fatal("diagnostic publication waited for the refresh lock")
-	}
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("diagnostic publication did not complete")
-	}
-	require.False(t, <-meaningful)
-}
-
-func TestPublishTopologyDiagnosticArchiveReportsOnlyMeaningfulSuccessfulWrites(t *testing.T) {
-	coll, store := newTestSNMPTopologyCollectorWithStore()
-	var writes atomic.Int32
-	coll.publishDiagnosticArchiveFile = func(string, topologyDiagnostics) error {
-		writes.Add(1)
-		return nil
-	}
-
-	require.False(t, coll.publishTopologyDiagnosticArchiveRecovering(false))
-	require.EqualValues(t, 1, writes.Load())
-	require.False(t, coll.publishTopologyDiagnosticArchiveRecovering(true))
-	require.EqualValues(t, 1, writes.Load())
-
-	store.RegisterJob("job", ddsnmp.DeviceLifecycleInfo{Hostname: "switch.example"})
-	require.True(t, coll.publishTopologyDiagnosticArchiveRecovering(true))
-	require.EqualValues(t, 2, writes.Load())
-
-	coll.publishDiagnosticArchiveFile = func(string, topologyDiagnostics) error {
-		return errors.New("write failed")
-	}
-	require.False(t, coll.publishTopologyDiagnosticArchiveRecovering(true))
-}
-
-func TestCollectorDoesNotPublishDiagnosticArchiveWhenDisabled(t *testing.T) {
-	coll := newTestSNMPTopologyCollector()
-	coll.publishDiagnosticArchive = false
-	coll.UpdateEvery = 1
-	coll.RefreshEvery = confopt.LongDuration(time.Hour)
-
-	refreshes := make(chan struct{}, 2)
-	coll.projectTopologyDiagnosticCut = func(input topologyDiagnosticCutInput) (*topologySweepDiagnosticCut, error) {
-		refreshes <- struct{}{}
-		return projectTopologyDiagnosticCut(input)
-	}
-	var writes atomic.Int32
-	coll.publishDiagnosticArchiveFile = func(_ string, _ topologyDiagnostics) error {
-		writes.Add(1)
-		return nil
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
+func TestDiagnosticProviderAcquiresImmutableGenerationWithoutRefreshLock(t *testing.T) {
+	c := newTestSNMPTopologyCollector()
+	c.refreshTopologyRecovering(context.Background())
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
 	done := make(chan error, 1)
-	go func() { done <- coll.Run(ctx) }()
+	go func() { _, err := c.diagnosticProvider.Capture(); done <- err }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("diagnostic capture acquired refresh lock")
+	}
+}
 
-	for range 2 {
-		select {
-		case <-refreshes:
-		case <-time.After(2 * time.Second):
-			t.Fatal("topology refresh did not run")
+func TestTopologyDiagnosticHookPublishesOnlyAcceptedProvider(t *testing.T) {
+	_, store := newTestSNMPTopologyCollectorWithStore()
+	store.RegisterJob("device", ddsnmp.DeviceLifecycleInfo{Hostname: "switch.example"})
+	dir := t.TempDir()
+	publisher := snmpdiag.NewPublisher(store, dir)
+	creator := Creator(store, NewTrapEnrichmentHandle(), newTestReverseDNSResolver(), publisher)
+	hook := creator.JobConfigLifecycle
+	id := collectorapi.JobConfigIdentity{1}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	start := func() (*Collector, context.CancelFunc, <-chan error) {
+		c := creator.CreateV2().(*Collector)
+		c.UpdateEvery = 1
+		c.RefreshEvery = confopt.LongDuration(time.Second)
+		require.NoError(t, c.Init(ctx))
+		runCtx, stop := context.WithCancel(ctx)
+		done := make(chan error, 1)
+		go func() { done <- c.Run(runCtx) }()
+		require.Eventually(t, func() bool {
+			generation := c.topologyRegistry.acquireGeneration()
+			return generation != nil && generation.sequence > 0
+		}, time.Second, time.Millisecond)
+		return c, stop, done
+	}
+	incumbent, stopIncumbent, incumbentDone := start()
+	hook.Reconcile(collectorapi.JobConfigIdentity{}, hook.Capture(id, topologyLifecycleTestJob{incumbent}), topologyLifecycleTestJob{incumbent})
+	publisherDone := make(chan struct{})
+	go func() { publisher.Run(ctx); close(publisherDone) }()
+	read := func() (snmpdiag.Document, error) {
+		f, err := os.Open(snmpdiag.ArchivePath(dir))
+		if err != nil {
+			return snmpdiag.Document{}, err
 		}
+		defer f.Close()
+		return snmpdiag.Read(f, snmpdiag.DefaultReadLimits())
 	}
-	require.Zero(t, writes.Load())
-
-	cancel()
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("collector did not stop")
-	}
-}
-
-func TestCollectorStartsDiagnosticPublisherAfterInitialRefresh(t *testing.T) {
-	coll := newTestSNMPTopologyCollector()
-	coll.UpdateEvery = 3600
-	coll.RefreshEvery = confopt.LongDuration(time.Hour)
-
-	refreshStarted := make(chan struct{})
-	releaseRefresh := make(chan struct{})
-	published := make(chan struct{}, 1)
-	coll.projectTopologyDiagnosticCut = func(input topologyDiagnosticCutInput) (*topologySweepDiagnosticCut, error) {
-		close(refreshStarted)
-		<-releaseRefresh
-		return projectTopologyDiagnosticCut(input)
-	}
-	coll.publishDiagnosticArchiveFile = func(_ string, _ topologyDiagnostics) error {
-		published <- struct{}{}
-		return nil
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- coll.Run(ctx) }()
-
-	select {
-	case <-refreshStarted:
-	case <-time.After(time.Second):
-		t.Fatal("initial refresh did not start")
-	}
-	select {
-	case <-published:
-		t.Fatal("diagnostic archive was published before the initial refresh completed")
-	default:
-	}
-	close(releaseRefresh)
-	select {
-	case <-published:
-	case <-time.After(time.Second):
-		t.Fatal("diagnostic archive was not published after the initial refresh")
-	}
-
-	cancel()
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("collector did not stop")
-	}
-}
-
-func TestCollectorPublishesFirstLifecycleRegistrationAfterRefresh(t *testing.T) {
-	coll, store := newTestSNMPTopologyCollectorWithStore()
-	coll.UpdateEvery = 1
-	coll.RefreshEvery = confopt.LongDuration(time.Hour)
-	published := make(chan topologyDiagnostics, 4)
-	coll.publishDiagnosticArchiveFile = func(_ string, diagnostics topologyDiagnostics) error {
-		published <- diagnostics
-		return nil
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- coll.Run(ctx) }()
-
-	initial := receivePublishedDiagnostics(t, published)
-	require.Empty(t, initial.lifecycle.cut.Entries)
-
-	store.RegisterJob("job", ddsnmp.DeviceLifecycleInfo{Hostname: "switch.example"})
-	meaningful := receivePublishedDiagnostics(t, published)
-	require.Len(t, meaningful.lifecycle.cut.Entries, 1)
-	require.False(t, meaningful.lifecycle.cut.Entries[0].TopologyReady)
-
-	cancel()
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("collector did not stop")
-	}
-}
-
-func publicationTestDiagnostics(sequence uint64) topologyDiagnostics {
-	return topologyDiagnostics{
-		lifecycle: topologyJobLifecycleDiagnosticCut{
-			state:  diagnosticCaptureAvailable,
-			reason: diagnosticCaptureReasonNone,
-			cut: ddsnmp.DeviceLifecycleCut{
-				Sequence:   sequence,
-				CapturedAt: time.Unix(int64(sequence), 0).UTC(),
-			},
-		},
-		producerScopeID: "publication-test",
-	}
-}
-
-func requirePreviousDiagnosticArchive(t *testing.T, path string, want []byte) {
-	t.Helper()
-	got, err := os.ReadFile(path)
+	require.Eventually(t, func() bool {
+		d, err := read()
+		return err == nil && d.Snapshot.ProducerScopeID == incumbent.topologyRegistry.producerScope()
+	}, time.Second, time.Millisecond)
+	before, err := read()
 	require.NoError(t, err)
-	require.True(t, bytes.Equal(want, got))
-	require.NoFileExists(t, path+".tmp")
+	candidate, stopCandidate, candidateDone := start()
+	hook.Bind(id, topologyLifecycleTestJob{candidate})
+	hook.Capture(id, topologyLifecycleTestJob{candidate})
+	// Wait for another real disk publication to prove that merely running the
+	// candidate did not select it as the diagnostic provider.
+	require.Eventually(t, func() bool {
+		d, err := read()
+		return err == nil && d.Snapshot.Lifecycle.Cut.CapturedAt.After(before.Snapshot.Lifecycle.Cut.CapturedAt)
+	}, 3*time.Second, 5*time.Millisecond)
+	actual, err := read()
+	require.NoError(t, err)
+	require.Equal(t, incumbent.topologyRegistry.producerScope(), actual.Snapshot.ProducerScopeID)
+	hook.Reconcile(id, hook.Capture(id, topologyLifecycleTestJob{candidate}), topologyLifecycleTestJob{candidate})
+	stopIncumbent()
+	require.NoError(t, <-incumbentDone)
+	incumbent.Cleanup(ctx)
+	require.Eventually(t, func() bool {
+		d, err := read()
+		return err == nil && d.Snapshot.ProducerScopeID == candidate.topologyRegistry.producerScope()
+	}, time.Second, time.Millisecond)
+	hook.Remove(id)
+	stopCandidate()
+	require.NoError(t, <-candidateDone)
+	candidate.Cleanup(ctx)
+	cancel()
+	<-publisherDone
 }
 
-type publicationCall struct {
-	number            int
-	requireMeaningful bool
-}
+type topologyLifecycleTestJob struct{ c *Collector }
 
-func receivePublicationCall(t *testing.T, calls <-chan publicationCall) publicationCall {
-	t.Helper()
-	select {
-	case call := <-calls:
-		return call
-	case <-time.After(time.Second):
-		t.Fatal("diagnostic publication did not run")
-		return publicationCall{}
-	}
-}
-
-func receivePublishedDiagnostics(t *testing.T, published <-chan topologyDiagnostics) topologyDiagnostics {
-	t.Helper()
-	select {
-	case diagnostics := <-published:
-		return diagnostics
-	case <-time.After(2 * time.Second):
-		t.Fatal("diagnostic archive was not published")
-		return topologyDiagnostics{}
-	}
-}
+func (topologyLifecycleTestJob) FullName() string   { return "snmp_topology_test" }
+func (topologyLifecycleTestJob) ModuleName() string { return "snmp_topology" }
+func (topologyLifecycleTestJob) Name() string       { return "test" }
+func (topologyLifecycleTestJob) IsRunning() bool    { return true }
+func (j topologyLifecycleTestJob) Collector() any   { return j.c }

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_types.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/pkg/topology/graph"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
 
 const (
@@ -13,11 +14,6 @@ const (
 	diagnosticStatePresent      = "present"
 	diagnosticStateAbsent       = "absent"
 )
-
-type DiagnosticReadLimits struct {
-	MaxCompressedBytes int64
-	MaxDecodedBytes    int64
-}
 
 type DiagnosticQueryOptions struct {
 	CollapseActorsByIP     bool   `json:"collapse_actors_by_ip"`
@@ -219,11 +215,11 @@ type diagnosticContextAccounting struct {
 }
 
 type diagnosticProfileAccounting struct {
-	Identity     topologyDiagnosticArchiveProfileIdentityV1 `json:"identity"`
-	Outcome      string                                     `json:"outcome"`
-	FailurePhase string                                     `json:"failure_phase"`
-	Stats        topologyDiagnosticArchiveCollectionStatsV1 `json:"stats"`
-	Execution    *topologyDiagnosticArchiveExecutionV1      `json:"execution,omitempty"`
+	Identity     snmpdiag.ProfileIdentity `json:"identity"`
+	Outcome      string                   `json:"outcome"`
+	FailurePhase string                   `json:"failure_phase"`
+	Stats        snmpdiag.CollectionStats `json:"stats"`
+	Execution    *snmpdiag.Execution      `json:"execution,omitempty"`
 }
 
 type diagnosticGraphActor struct {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics.go
@@ -111,10 +111,9 @@ type topologyDiagnosticCutInput struct {
 
 type topologyDiagnosticCutProjector func(topologyDiagnosticCutInput) (*topologySweepDiagnosticCut, error)
 
-func (c *Collector) acquireTopologyDiagnostics() topologyDiagnostics {
-	limits := c.currentTopologyDiagnosticGlobalLimits()
-	diagnostics := topologyDiagnostics{lastAborted: c.lastAbortedTopologyDiagnostic.Load()}
-	if generation := c.topologyRegistry.acquireGeneration(); generation != nil {
+func captureTopologyCut(registry *topologyRegistry, aborted *topologyAbortedSweepDiagnostic, limits topologyAcquisitionLimits) (topologyDiagnostics, topologyAcquisitionLimits) {
+	diagnostics := topologyDiagnostics{lastAborted: aborted}
+	if generation := registry.acquireGeneration(); generation != nil {
 		diagnostics.producerScopeID = generation.producerScopeID
 		diagnostics.topology = generation.diagnostic
 	}
@@ -126,43 +125,7 @@ func (c *Collector) acquireTopologyDiagnostics() topologyDiagnostics {
 			limits.maxLogicalBytes -= diagnostics.topology.logicalBytes
 		}
 	}
-	diagnostics.lifecycle = acquireTopologyJobLifecycleCut(c.deviceLifecycleSource, limits)
-	return diagnostics
-}
-
-func acquireTopologyJobLifecycleCut(source deviceLifecycleSource, limits topologyAcquisitionLimits) (result topologyJobLifecycleDiagnosticCut) {
-	result.state = diagnosticCaptureAvailable
-	defer func() {
-		if recover() != nil {
-			result = topologyJobLifecycleDiagnosticCut{
-				state:  diagnosticCaptureUnavailable,
-				reason: diagnosticCaptureReasonProjectionPanic,
-			}
-		}
-	}()
-	if source == nil {
-		result.state = diagnosticCaptureUnavailable
-		result.reason = diagnosticCaptureReasonProjectionError
-		return result
-	}
-	result.cut = source.LifecycleCut()
-	records := uint64(1 + len(result.cut.Entries))
-	logicalBytes := uint64(topologyDiagnosticCutLogicalBytes)
-	for _, entry := range result.cut.Entries {
-		logicalBytes += uint64(64 + len(entry.Info.Hostname) + len(entry.Info.SNMPVersion))
-	}
-	if records > limits.maxRecords {
-		result.state = diagnosticCaptureLimitExceeded
-		result.reason = diagnosticCaptureReasonGlobalRecordLimit
-		result.cut.Entries = nil
-		return result
-	}
-	if logicalBytes > limits.maxLogicalBytes {
-		result.state = diagnosticCaptureLimitExceeded
-		result.reason = diagnosticCaptureReasonGlobalByteLimit
-		result.cut.Entries = nil
-	}
-	return result
+	return diagnostics, limits
 }
 
 func (c *Collector) projectCommittedTopologyDiagnosticCut(input topologyDiagnosticCutInput) (cut *topologySweepDiagnosticCut) {

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostics_test.go
@@ -287,7 +287,7 @@ func TestProjectTopologyDiagnosticCutMarksExpiredRetainedGeneration(t *testing.T
 
 func TestAcquireTopologyDiagnosticsContainsLifecyclePanic(t *testing.T) {
 	coll := newTestSNMPTopologyCollector()
-	coll.deviceLifecycleSource = panickingTopologyLifecycleSource{}
+	coll.diagnosticProvider.source = panickingTopologyLifecycleSource{}
 
 	diagnostics := coll.acquireTopologyDiagnostics()
 	require.Equal(t, diagnosticCaptureUnavailable, diagnostics.lifecycle.state)

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_semantic.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
 
 type topologySemanticEventKind uint8
@@ -120,8 +121,8 @@ var defaultTopologyAcquisitionLimits = topologyAcquisitionLimits{
 }
 
 var defaultTopologyDiagnosticGlobalLimits = topologyAcquisitionLimits{
-	maxRecords:      250_000,
-	maxLogicalBytes: 64 << 20,
+	maxRecords:      snmpdiag.MaxRecords,
+	maxLogicalBytes: snmpdiag.MaxLogicalBytes,
 }
 
 type diagnosticCaptureState uint8

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_test_helpers_test.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologymodel"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyoptions"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology/internal/topologyutil"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/reversedns"
-
-	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 )
 
 func newTestSNMPTopologyCollector() *Collector {
@@ -22,8 +21,7 @@ func newTestSNMPTopologyCollector() *Collector {
 func newTestSNMPTopologyCollectorWithStore() (*Collector, *ddsnmp.DeviceStore) {
 	store := ddsnmp.NewDeviceStore()
 	coll := New(store, NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
-	coll.publishDiagnosticArchive = true
-	coll.publishDiagnosticArchiveFile = func(string, topologyDiagnostics) error { return nil }
+
 	return coll, store
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/func_logs_test.go
@@ -10,12 +10,11 @@ import (
 	"testing"
 	"time"
 
-	sdkjournal "github.com/netdata/systemd-journal-sdk/go/journal"
-
 	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_traps/internal/snmptrapsfunc"
+	sdkjournal "github.com/netdata/systemd-journal-sdk/go/journal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,8 +70,8 @@ func TestSNMPTrapsLogsMethodAvailabilityTracksAllJournalLeases(t *testing.T) {
 }
 
 func TestSNMPTrapsLogsMethodAvailabilityIsCreatorScoped(t *testing.T) {
-	firstCreator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
-	secondCreator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	firstCreator := Creator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	secondCreator := Creator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
 	firstLogs := firstCreator.AgentFunctions()[0]
 	secondLogs := secondCreator.AgentFunctions()[0]
 

--- a/src/go/plugin/go.d/collector/snmp_traps/init_test.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/init_test.go
@@ -149,12 +149,12 @@ func TestCollectorInitBuildsEnabledProfileMetricRuntime(t *testing.T) {
 }
 
 func TestCollectorCreatorDefaults(t *testing.T) {
-	creator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	creator := Creator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
 	assert.False(t, creator.Defaults.Disabled)
 }
 
 func TestCollectorCreatorSharesPluginDependencies(t *testing.T) {
-	creator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	creator := Creator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
 	first := creator.CreateV2().(*Collector)
 	second := creator.CreateV2().(*Collector)
 
@@ -184,7 +184,7 @@ func TestCollectorCreatorResolvesProfilePathsOnFirstCollector(t *testing.T) {
 	earlyDir := filepath.Join(t.TempDir(), "before-plugin-config")
 	require.NoError(t, os.MkdirAll(earlyDir, 0o755))
 	executable.Directory = earlyDir
-	creator := newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	creator := Creator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
 
 	root := t.TempDir()
 	executableDir := filepath.Join(root, "plugins.d")
@@ -269,14 +269,14 @@ func TestCollectorNewUsesIndependentHostIdentityService(t *testing.T) {
 }
 
 func TestCollectorCreatorRequiresSharedDependencies(t *testing.T) {
-	require.PanicsWithValue(t, "snmp_traps Register requires a non-nil device store", func() {
-		_ = newCreator(nil, snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
+	require.PanicsWithValue(t, "snmp_traps Creator requires a non-nil device store", func() {
+		_ = Creator(nil, snmptopology.NewTrapEnrichmentHandle(), newTestReverseDNSResolver())
 	})
-	require.PanicsWithValue(t, "snmp_traps Register requires a non-nil trap enrichment handle", func() {
-		_ = newCreator(ddsnmp.NewDeviceStore(), nil, newTestReverseDNSResolver())
+	require.PanicsWithValue(t, "snmp_traps Creator requires a non-nil trap enrichment handle", func() {
+		_ = Creator(ddsnmp.NewDeviceStore(), nil, newTestReverseDNSResolver())
 	})
-	require.PanicsWithValue(t, "snmp_traps Register requires a non-nil reverse DNS resolver", func() {
-		_ = newCreator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), nil)
+	require.PanicsWithValue(t, "snmp_traps Creator requires a non-nil reverse DNS resolver", func() {
+		_ = Creator(ddsnmp.NewDeviceStore(), snmptopology.NewTrapEnrichmentHandle(), nil)
 	})
 }
 

--- a/src/go/plugin/go.d/collector/snmp_traps/register.go
+++ b/src/go/plugin/go.d/collector/snmp_traps/register.go
@@ -15,13 +15,9 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/reversedns"
 )
 
-// Register registers the SNMP traps collector with shared SNMP-family enrichment state.
-func Register(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnrichmentHandle, reverseDNS *reversedns.Resolver) {
-	collectorapi.Register("snmp_traps", newCreator(deviceStore, topologyEnricher, reverseDNS))
-}
-
-func newCreator(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnrichmentHandle, reverseDNS *reversedns.Resolver) collectorapi.Creator {
-	services := requiredPluginServices("Register", deviceStore, topologyEnricher, reverseDNS)
+// Creator constructs registration with explicit SNMP-family dependencies.
+func Creator(deviceStore *ddsnmp.DeviceStore, topologyEnricher *snmptopology.TrapEnrichmentHandle, reverseDNS *reversedns.Resolver) collectorapi.Creator {
+	services := requiredPluginServices("Creator", deviceStore, topologyEnricher, reverseDNS)
 	return collectorapi.Creator{
 		JobConfigSchema: configSchema,
 		Defaults: collectorapi.Defaults{

--- a/src/go/tools/snmp-topology-diagnostics/main.go
+++ b/src/go/tools/snmp-topology-diagnostics/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/go-units"
 	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 )
 
@@ -36,7 +37,7 @@ type diagnosticArchive interface {
 	InspectLinkAt(snmptopology.DiagnosticQueryOptions, int) (snmptopology.DiagnosticLinkInspection, error)
 }
 
-type archiveOpener func(io.Reader, snmptopology.DiagnosticReadLimits) (diagnosticArchive, error)
+type archiveOpener func(io.Reader, snmpdiag.ReadLimits) (diagnosticArchive, error)
 
 type commandOptions struct {
 	archivePath       string
@@ -56,9 +57,9 @@ func main() {
 func run(arguments []string, stdout, stderr io.Writer) int {
 	return runWithOpener(arguments, stdout, stderr, func(
 		reader io.Reader,
-		limits snmptopology.DiagnosticReadLimits,
+		limits snmpdiag.ReadLimits,
 	) (diagnosticArchive, error) {
-		return snmptopology.ReadDiagnosticArchive(reader, limits)
+		return openDiagnosticArchive(reader, limits)
 	})
 }
 
@@ -113,7 +114,7 @@ func runWithOpener(arguments []string, stdout, stderr io.Writer, openArchive arc
 }
 
 func parseCommandOptions(operation string, arguments []string, stderr io.Writer) (commandOptions, int) {
-	defaults := snmptopology.DefaultDiagnosticArchiveReadLimits()
+	defaults := snmpdiag.DefaultReadLimits()
 	options := commandOptions{
 		maxCompressedSize: formatDefaultSize(defaults.MaxCompressedBytes),
 		maxDecodedSize:    formatDefaultSize(defaults.MaxDecodedBytes),
@@ -249,18 +250,18 @@ func executeOperation(operation string, archive diagnosticArchive, options comma
 	}
 }
 
-func readLimits(compressed, decoded string) (snmptopology.DiagnosticReadLimits, error) {
-	maxCompressedBytes, err := units.RAMInBytes(compressed)
-	if err != nil || maxCompressedBytes <= 0 {
-		return snmptopology.DiagnosticReadLimits{}, fmt.Errorf("invalid maximum compressed size %q", compressed)
+func readLimits(compressed, decoded string) (snmpdiag.ReadLimits, error) {
+	MaxCompressedBytes, err := units.RAMInBytes(compressed)
+	if err != nil || MaxCompressedBytes <= 0 {
+		return snmpdiag.ReadLimits{}, fmt.Errorf("invalid maximum compressed size %q", compressed)
 	}
-	maxDecodedBytes, err := units.RAMInBytes(decoded)
-	if err != nil || maxDecodedBytes <= 0 {
-		return snmptopology.DiagnosticReadLimits{}, fmt.Errorf("invalid maximum decoded size %q", decoded)
+	MaxDecodedBytes, err := units.RAMInBytes(decoded)
+	if err != nil || MaxDecodedBytes <= 0 {
+		return snmpdiag.ReadLimits{}, fmt.Errorf("invalid maximum decoded size %q", decoded)
 	}
-	return snmptopology.DiagnosticReadLimits{
-		MaxCompressedBytes: maxCompressedBytes,
-		MaxDecodedBytes:    maxDecodedBytes,
+	return snmpdiag.ReadLimits{
+		MaxCompressedBytes: MaxCompressedBytes,
+		MaxDecodedBytes:    MaxDecodedBytes,
 	}, nil
 }
 
@@ -288,4 +289,12 @@ func usage(writer io.Writer) {
 
 func operationUsage(writer io.Writer, operation string) {
 	fmt.Fprintf(writer, "usage: snmp-topology-diagnostics %s --archive PATH [options]\n", operation)
+}
+
+func openDiagnosticArchive(r io.Reader, limits snmpdiag.ReadLimits) (*snmptopology.DiagnosticArchive, error) {
+	document, err := snmpdiag.Read(r, limits)
+	if err != nil {
+		return nil, err
+	}
+	return snmptopology.InspectDiagnosticDocument(document)
 }

--- a/src/go/tools/snmp-topology-diagnostics/main_test.go
+++ b/src/go/tools/snmp-topology-diagnostics/main_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
-	"github.com/netdata/netdata/go/plugins/pkg/topology/v1"
+	topologyv1 "github.com/netdata/netdata/go/plugins/pkg/topology/v1"
 	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 )

--- a/src/go/tools/snmp-topology-diagnostics/main_test.go
+++ b/src/go/tools/snmp-topology-diagnostics/main_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/netdata/netdata/go/plugins/pkg/topology/v1"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	snmptopology "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp_topology"
 )
 
@@ -108,7 +109,7 @@ func TestRunDispatchesReplayAndInspectionOnce(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fake := &fakeDiagnosticArchive{}
 			openCalls := 0
-			opener := func(_ io.Reader, limits snmptopology.DiagnosticReadLimits) (diagnosticArchive, error) {
+			opener := func(_ io.Reader, limits snmpdiag.ReadLimits) (diagnosticArchive, error) {
 				openCalls++
 				fake.limits = limits
 				return fake, nil
@@ -369,7 +370,7 @@ func TestRunRejectsUsageArchiveAndSelectors(t *testing.T) {
 type fakeDiagnosticArchive struct {
 	operation      string
 	operationCalls int
-	limits         snmptopology.DiagnosticReadLimits
+	limits         snmpdiag.ReadLimits
 	query          snmptopology.DiagnosticQueryOptions
 	linkIndex      int
 }
@@ -470,9 +471,9 @@ func readReplayableDiagnosticArchive(t testing.TB) *snmptopology.DiagnosticArchi
 	if err != nil {
 		t.Fatal(err)
 	}
-	archive, err := snmptopology.ReadDiagnosticArchive(
+	archive, err := openDiagnosticArchive(
 		bytes.NewReader(fixture),
-		snmptopology.DefaultDiagnosticArchiveReadLimits(),
+		snmpdiag.DefaultReadLimits(),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
##### Summary

Make built-in SNMP diagnostics available even when topology collection is disabled or unavailable. Preserve existing topology troubleshooting and replay, while keeping diagnostic ownership correct across collector restarts and configuration changes.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes built-in SNMP diagnostics independently of topology collection, so troubleshooting data stays available when topology collection is disabled or unavailable. Previously diagnostics were tied to the `snmp_topology` collector; now a process-owned service manages publication across collector restarts and configuration changes.

- The archive codec, document schema, and read limits moved into the shared `snmp/diagnostics` package; the archive format and version are unchanged.
- Committed job-config lifecycle projections are retired at run finalization, so successor runs don't inherit stale entries.
- The device store rejects writes from retired writer handles, so a removed device can't be revived by a lingering writer.

<sup>Written for commit eb5462233f82ab512a159e20ac73ab0f91907e37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SNMP topology diagnostics with compressed archives covering lifecycle, topology, collection, and execution details.
  * Diagnostics now publish automatically as configuration and topology changes occur, including failed readiness states.
  * Updated the diagnostics command-line tool to inspect archives with configurable size limits.

* **Bug Fixes**
  * Prevented retired device and topology runs from restoring outdated data.
  * Improved cleanup and error reporting for background services during restarts and shutdowns.
  * Ensured diagnostics remain isolated between plugin instances.
  * Preserved previously published diagnostics when new capture attempts fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->