### PR TITLE
chore(skills): add repo-skill-authoring

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -27,8 +27,9 @@ published contract and are exempt from the naming rule below.
   reduced to their text; then lowercase; letters, digits, spaces, hyphens, and underscores kept, everything else
   dropped; spaces become hyphens; a repeated heading gets `-1`, `-2`, and this repository's check gives a further
   suffix to a generated slug that collides with a literal title, which GitHub may not). Cite only such headings:
-  non-ASCII titles, setext headings, and titles that collide with generated suffixes are outside the convention. Paths are repo-relative (with or without a leading
-  `/`), or relative to the citing file when they start with `./` or `../`. URLs are written with their scheme.
+  non-ASCII titles, setext headings, and titles that collide with generated suffixes are outside the convention. Paths
+  are repo-relative (with or without a leading `/`), or relative to the citing file when they start with `./` or
+  `../`. URLs are written with their scheme.
 - `.agents/sow/audit.sh` fails when the cited file or a heading with that slug is missing, so renaming or removing a
   heading in an owner document is caught until every citing skill is updated. Headings and citations inside fenced
   code blocks or multi-line HTML comments are not scanned.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -59,5 +59,5 @@ published contract and are exempt from the naming rule below.
 
 The per-skill grouped index is the "Skills index" in the root `AGENTS.md`: skills under their area, an area's entry
 point marked where it has one, and a skill that serves two areas cross-referenced from the other. A skill's frontmatter
-description is its trigger. How to create, edit, slim, or review a skill, and the rot signals to watch for:
-`repo-skill-authoring`.
+description is its trigger. How to create, edit, slim, split, or review a skill, and the rot signals to watch for:
+`repo-skill-authoring`, which cites sections of this file and of the root `AGENTS.md` by heading anchor.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -59,4 +59,5 @@ published contract and are exempt from the naming rule below.
 
 The per-skill grouped index is the "Skills index" in the root `AGENTS.md`: skills under their area, an area's entry
 point marked where it has one, and a skill that serves two areas cross-referenced from the other. A skill's frontmatter
-description is its trigger.
+description is its trigger. How to create, edit, slim, or review a skill, and the rot signals to watch for:
+`repo-skill-authoring`.

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -79,7 +79,9 @@ Ownership and pointing:
 
 Citations and claims:
 
-- Cite symbols and paths, never line numbers; never promise that line numbers track a branch.
+- Cite symbols and paths, never line numbers of this repository; a `path:line` appears only inside an
+  `owner/repo @ commit` citation, where the commit pins it (`AGENTS.md#open-source-reference-evidence`). Never promise
+  that line numbers track a branch.
 - No PR, issue, or SOW identifiers of this repository, no commit hashes of this repository, and no session labels
   (option letters, inventory ids) in a skill. A commit hash appears only inside an `owner/repo @ commit` citation of an
   out-of-repo owner.
@@ -143,8 +145,8 @@ Structure and routing:
 Run this over a skill periodically and before extending it (an owner document is judged only by being hand-maintained
 and current). A cluster of hits is a slim; a single hit is a one-line fix in the same change.
 
-- Line-number citations; PR, commit, issue, or SOW identifiers; a promise that line numbers track a branch. Grep for
-  them; the audit automates only its legacy SOW-identifier check.
+- Line-number citations into this repository; PR, commit, issue, or SOW identifiers; a promise that line numbers track
+  a branch. Grep for them; the audit automates only its legacy SOW-identifier check.
 - A code-side document now exists for facts the skill states.
 - "Authoritative design", "Spec -", Status, Migration Notes, Schema Additions Required, phase history, open review
   questions.

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -56,7 +56,7 @@ Ownership and pointing:
   generated output (`git ls-files -s <path>` shows mode `120000`; `readlink <path>`) is never an owner or an authority.
 - When the only owner of a fact is a script or a workflow (`.agents/sow/audit.sh`, `.github/workflows/sow.yml`),
   attribute the fact to that file, not to the prose section that names the script: a section that does not state the
-  fact cannot be checked against it, and renaming the section never exposes the drift.
+  fact cannot be checked against it.
 - Cite the repository path, never a bare filename; several documents in this tree share a basename. A one-segment
   path names a repository-root file. Inside a skill, cite a section of its own files as `./<file>.md#<anchor>`.
 - An owner outside this repository cannot be an anchor citation: read it from the local mirror (`repo-mirror-sources`)
@@ -67,8 +67,8 @@ Ownership and pointing:
   section, not just the file.
 - A pointer row carries one clause naming the subject; copying the requirement text creates a second owner.
 - A keep-list fact with no owner is a user-owned fork: keep it in the skill, add it to the section of an existing
-  code-side document that already covers the mechanism, or open a separate change for a new developer document.
-  Present the options; never mint a second owner inside the skill.
+  code-side document that covers the mechanism, or open a separate change for a new developer document. Never mint a
+  second owner inside the skill.
 - Developer procedure stays in the skill; a shipped operator document keeps only the operator form.
 - Do not transcribe schemas, enum members, finding codes, or code; the reader opens the file.
 - Design records rot once the code ships its own document. Propose retiring them, with the relocation target and the

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -16,7 +16,7 @@ change.
 |---|---|
 | create a skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`, `./SKILL.md#creating-a-skill`; `./change-method.md#review-round`, `./change-method.md#mechanical-hygiene`, `./change-method.md#close` |
 | add or change rules in an existing skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`; `./change-method.md#recorded-findings-and-owners`, `./change-method.md#mechanical-hygiene`, `./change-method.md#close` |
-| slim, split, or restructure a skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`, then all of `./change-method.md#changing-a-skill`; the method is not optional |
+| slim, split, or restructure a skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`, `./SKILL.md#rot-signals`, then all of `./change-method.md#changing-a-skill`; the method is not optional |
 | periodic rot pass | `./SKILL.md#rot-signals` |
 | review a skill change | `./change-method.md#review-round`: the two lenses and what each reviewer receives |
 
@@ -29,7 +29,7 @@ names.
 |---|---|
 | `AGENTS.md#project-skills` | where runtime skills live; the same-PR rule for gap-closing and pointer-fixing updates; the slimming pass every skill change ends with and what it reports; the public-skill convention (audience boundary, symlinks, script shape, token safety, the live how-tos catalog); output/reference skill trees and their no-rename rule; the grouped skills index |
 | `AGENTS.md#durable-ai-facing-artifact-formatting` | retrieval structure, requirement words next to the action, prose width, reflow-only commits |
-| `AGENTS.md#sensitive-data-in-durable-artifacts` | the public-artifact assumption and the sanitized-evidence requirement |
+| `AGENTS.md#sensitive-data-in-durable-artifacts`, `.agents/sensitive-data-discipline.md#allowed-alternatives` | the public-artifact assumption and the sanitized-evidence requirement; the `<repo>/`-prefixed path form for prose (an anchor citation stays repo-relative without it) |
 | `AGENTS.md#enforcement` | what `.agents/sow/audit.sh` hard-fails on and what the PR gate `.github/workflows/sow.yml` re-checks |
 | `AGENTS.md#local-only-working-directory` | where skill-change evidence goes, and how this skill's `<dir>` (the `<subject>` in `./change-method.md#changing-a-skill`) is named |
 | `AGENTS.md#clean-end-state-over-less-churn` | the target is recorded before options are generated; the disclosure of what is removed and what is excluded; the reference search when a path is replaced; how coupled cleanup is handled |
@@ -74,7 +74,8 @@ Ownership and pointing:
 - Design records rot once the code ships its own document. Propose retiring them, with the relocation target and the
   rejected alternatives; deletion is the user's call; history stays in git. Unshipped design that must survive goes
   to the owning subsystem's scope or architecture document, labelled as not shipped; when none exists, that is the
-  user-owned fork above.
+  user-owned fork above. A rule a skill declares mandatory or durable that a repo-wide owner contradicts is demoted
+  the same way: proposed with the superseding owner named, decided by the user.
 
 Citations and claims:
 
@@ -139,8 +140,8 @@ Structure and routing:
 
 ## Rot Signals
 
-Run this over a skill periodically and before extending it. A cluster of hits is a slim; a single hit is a one-line fix
-in the same change.
+Run this over a skill periodically and before extending it (an owner document is judged only by being hand-maintained
+and current). A cluster of hits is a slim; a single hit is a one-line fix in the same change.
 
 - Line-number citations; PR, commit, issue, or SOW identifiers; a promise that line numbers track a branch. Grep for
   them; the audit automates only its legacy SOW-identifier check.

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -13,10 +13,10 @@ home. When an owner document and this skill disagree, the owner wins and this fi
 
 | Task | Read |
 |---|---|
-| create a skill | Where The Rules Live, Authoring Rules, Creating A Skill |
-| add or change rules in an existing skill | Authoring Rules; then `change-method.md` "Close" |
+| create a skill | Where The Rules Live, Authoring Rules, Creating A Skill; `change-method.md` "Mechanical Hygiene" |
+| add or change rules in an existing skill | Authoring Rules; `change-method.md` "Recorded Findings And Owners", "Mechanical Hygiene", "Close" |
 | slim, split, or restructure a skill | Authoring Rules, then all of `change-method.md`; the method is not optional |
-| periodic rot pass | Rot Signals; a cluster of hits becomes a slim, a single hit a one-line fix |
+| periodic rot pass | Rot Signals |
 | review a skill change | `change-method.md` "Review Round": the two lenses and what each reviewer receives |
 
 ## Where The Rules Live
@@ -26,33 +26,37 @@ names the subject and never copies the requirement text.
 
 | Owner section | What you must get from it |
 |---|---|
-| `AGENTS.md#project-skills` | where runtime skills live; a gap-closing skill update ships in the PR that exposed it; the slimming pass every skill change ends with (keep every rule, report line counts before and after); the public-skill convention (audience boundary, symlinks, script shape, token safety, the live how-tos catalog); the grouped index, whose entries the audit parses as a bullet whose first token is the backticked skill name followed by a colon |
-| `AGENTS.md#durable-ai-facing-artifact-formatting` | retrieval structure, requirement words next to the action, ~120 columns, reflow-only commits kept separate |
+| `AGENTS.md#project-skills` | where runtime skills live; the same-PR rule for gap-closing and pointer-fixing updates; the slimming pass every skill change ends with and what it reports; the public-skill convention (audience boundary, symlinks, script shape, token safety, the live how-tos catalog); the grouped skills index |
+| `AGENTS.md#durable-ai-facing-artifact-formatting` | retrieval structure, requirement words next to the action, prose width, reflow-only commits |
 | `AGENTS.md#sensitive-data-in-durable-artifacts` | a skill is public even when local; sanitized evidence only |
-| `AGENTS.md#enforcement` | what `.agents/sow/audit.sh` hard-fails on: skills layout, `.agents/skills/` paths named in any tracked file, index agreement, owner-section anchors, legacy SOW identifiers, relocated spec paths, the sensitive scan |
-| `AGENTS.md#local-only-working-directory` | evidence goes under `.local/audits/<dir>/`; this skill's row uses the name of the skill or SOW topic under change |
-| `AGENTS.md#clean-end-state-over-less-churn` | record the target before generating options; disclose what is removed and what is excluded; the reference search when a path is replaced; coupled cleanup is included and disclosed |
-| `AGENTS.md#working-with-the-user` | how a user decision is presented: evidence, numbered options, pros and cons, a recommendation |
-| `AGENTS.md#review` | the blocker bar, verify findings before acting, red test first, checkpoint commits, one round by default, repeat only after a material change, the recurrence guard |
-| `AGENTS.md#when-a-sow-is-required`, `AGENTS.md#followup-discipline`, `AGENTS.md#artifact-maintenance-gate` | a skill change is non-trivial work with a SOW; deferred items are tracked; every close records the artifact gate |
-| `AGENTS.md#git-and-pr-workflow` | stage specific files; deleting a file, checking one out, or resetting needs explicit approval |
-| `AGENTS.md#open-source-reference-evidence` | an owner outside this repository is cited as `owner/repo @ commit` plus a repository-relative path |
-| `.agents/skills/README.md#naming`, `.agents/skills/README.md#areas` | the name form, frontmatter `name` equals the directory, the area minting rule; the no-nesting rule is in the README's opening paragraph |
-| `.agents/skills/README.md#owner-section-citations` | the anchor form and slug rules; the marker paragraph for a private owner document, none for a Learn-published one; the anchor check scans skill files only |
-| `.agents/skills/README.md#finding-a-skill` | the index is the map; the frontmatter description is the trigger |
+| `AGENTS.md#enforcement` | what `.agents/sow/audit.sh` hard-fails on and what the PR gate `.github/workflows/sow.yml` re-checks. Facts the audit script itself owns: its path and anchor scans read tracked files (`git grep`, `git ls-files`), the anchor collector reads only files under `.agents/skills/` and `docs/netdata-ai/skills/`, and index entries resolve to directories only when written as a bullet whose first token is the backticked skill name followed by a colon, inside the block that ends at the `Public skills (` line |
+| `AGENTS.md#local-only-working-directory` | evidence goes under `.local/audits/<dir>/`; this skill's row names the directory after the skill or SOW topic under change |
+| `AGENTS.md#clean-end-state-over-less-churn` | the target is recorded before options are generated; the disclosure of what is removed and what is excluded; the reference search when a path is replaced; how coupled cleanup is handled |
+| `AGENTS.md#working-with-the-user` | the user-decision format and when a decision is recorded |
+| `AGENTS.md#review` | the blocker bar, what to do with a finding before acting, red test first, checkpoint commits, when a round repeats, the recurrence guard |
+| `AGENTS.md#when-a-sow-is-required`, `AGENTS.md#followup-discipline`, `AGENTS.md#artifact-maintenance-gate` | a skill change is non-trivial work with a SOW; how deferred items are tracked; what every close records |
+| `AGENTS.md#git-and-pr-workflow` | staging, and which git actions need explicit approval (deleting a file among them) |
+| `AGENTS.md#open-source-reference-evidence` | the citation form for an owner outside this repository |
+| `.agents/skills/README.md#naming`, `.agents/skills/README.md#areas` | the name form, frontmatter `name` equals the directory, the area minting rule and its same-change obligation; the no-nesting rule is in the README's opening paragraph |
+| `.agents/skills/README.md#owner-section-citations` | pointing at a fact's owner rather than restating it is a MUST there; the anchor form and slug rules; the marker paragraph for a private owner document, none for a Learn-published one |
+| `.agents/skills/README.md#finding-a-skill` | the index is the map; the frontmatter description is the trigger; the cross-reference for a skill serving two areas |
 
 ## Authoring Rules
+
+Every bullet is a MUST unless it says SHOULD or MAY.
 
 Ownership and pointing:
 
 - Search for the owner before writing a fact: the shipped format document, an `ARCHITECTURE.md`, a tool `README.md`,
   a published operator page, a code-tree `README.md`, a sibling skill. A skill that restates any of them rots.
-- An owner is a hand-maintained file. A generated page, or a symlink into generated output (check with
-  `git ls-files -s` and `readlink`), is never an owner or an authority.
+- An owner is a hand-maintained file. A generated page (generator banner, or listed as a generator's output) or a
+  symlink into generated output (`git ls-files -s <path>` shows mode `120000`; `readlink <path>`) is never an owner or
+  an authority.
 - Cite the repository path, never a bare filename; several documents in this tree share a basename.
-- An owner outside this repository cannot be an anchor citation: cite it as `owner/repo @ commit`. A fact whose only
-  owner is out of repo stays in the skill, labelled with what verified it or as unverifiable; never delete what you
-  cannot re-home.
+- An owner outside this repository cannot be an anchor citation: read it from the local mirror (`repo-mirror-sources`)
+  and cite it as `owner/repo @ commit` (`AGENTS.md#open-source-reference-evidence`). A fact whose only owner is out of
+  repo stays in the skill, labelled with what verified it and when, or as unverifiable; never delete what you cannot
+  re-home.
 - One owner per fact. When a fact moves into its owner, delete every copy in the same commit and record the owner
   section, not just the file.
 - A pointer row carries one clause naming the subject; copying the requirement text creates a second owner.
@@ -63,7 +67,8 @@ Ownership and pointing:
 - Do not transcribe schemas, enum members, finding codes, or code; the reader opens the file.
 - Design records rot once the code ships its own document. Propose retiring them, with the relocation target and the
   rejected alternatives; deletion is the user's call; history stays in git. Unshipped design that must survive goes
-  to the code-side scope document, labelled as not shipped.
+  to the owning subsystem's scope or architecture document, labelled as not shipped; when none exists, that is the
+  user-owned fork above.
 
 Citations and claims:
 
@@ -76,7 +81,8 @@ Citations and claims:
 - Keep the permissive half of a rule: a MAY clause is a rule, inventoried and preserved on its own.
 - A documented command runs as written: repository-root paths, where to run it from, the interpreter or environment
   it needs. A launcher's internal path resolution is a separate fact.
-- No hard-coded counts or percentages that regeneration or the next slim changes; give the recompute command.
+- No hard-coded aggregates, counts, or percentages that regeneration or the next slim changes; give the recompute
+  command.
 - A relocated fact adopts the receiving document's existing convention (requirement words, mood) and names it; a
   developer document written in lowercase indicative keeps that register. This never removes requirement force from
   an AI-facing artifact.
@@ -87,49 +93,53 @@ Structure and routing:
 - Every file is routed from `SKILL.md`; a router or index lists only files that exist (a bare name is invisible to the
   audit's path scan); no stubs.
 - When a skill serves more than one audience, `SKILL.md` routes by audience and a topic file SHOULD serve one.
-- Repo-wide `AGENTS.md` rules are pointed at, never restated. The live how-tos catalog MUST binds public skills only;
-  a runtime skill's `how-tos/INDEX.md` is optional: keep it when `SKILL.md` routes it and every listed file exists,
-  otherwise list the how-tos in `SKILL.md`.
-- A peer skill gets one routing sentence and is never a required reference (that is circular). When two skills claim
-  one directory, each carries one boundary line.
+- The live how-tos catalog MUST binds public skills only; a runtime skill's `how-tos/INDEX.md` is optional: keep it
+  when `SKILL.md` routes it and every listed file exists, otherwise list the how-tos in `SKILL.md`.
+- A peer skill gets one routing sentence. A one-way prerequisite MAY be declared (an entry-point skill, a
+  read-this-first skill); two skills never require each other. When two skills claim one directory, each carries one
+  boundary line.
 - The trigger (the frontmatter description) enumerates the phrases users type and carries "not for" clauses toward
   neighbouring skills; the `AGENTS.md` index entry matches it, including every producer, subcommand, or binary name.
-- The shape that has held: frontmatter trigger; an owners table with anchors and clauses; a task router; a rule sheet
-  split into what the code enforces and rules with no code owner; workflow; validation commands; the how-to list.
-  Precedents: `collectors-snmp-trap-profiles`, `collectors-prometheus-profiles`, `topology-authoring`.
+- Recommended skeleton, each element with the skill that shows it: frontmatter trigger (all); an owners block with
+  anchors and one clause per owner (`topology-authoring` as a table, `collectors-snmp-trap-profiles` as bullets); a
+  task router (`collectors-prometheus-profiles`); a rule sheet split into what the code enforces and rules with no
+  code owner (`collectors-prometheus-profiles`, `topology-authoring`); a workflow (all); validation commands
+  (`collectors-snmp-trap-profiles`); a how-to list (`collectors-prometheus-profiles`, `topology-authoring`); a one-file
+  rule sheet when there is one audience (`collectors-snmp-profiles`, `collectors-snmp-trap-profiles`).
 
 ## Creating A Skill
 
-1. Decide runtime or public (`AGENTS.md#project-skills`): a workflow that reads source files, updates schemas, or
-   changes collectors is a runtime skill; a public skill teaches operators and gets its relative symlink.
-2. Pick the area from `.agents/skills/README.md#areas`, or add its row in the same change; name the directory
-   `<area>-<topic>` and set frontmatter `name` to the directory name.
-3. Write the trigger with the phrases users type and the "not for" clauses; write `SKILL.md` in the shape above; add a
-   supporting file only when `SKILL.md` routes it.
+1. Resolve the runtime-vs-public fork before the first file exists (`AGENTS.md#project-skills` has the criteria and
+   the audience boundary); a public skill also gets its relative symlink.
+2. Pick the area (`.agents/skills/README.md#areas`); name the directory `<area>-<topic>` and set frontmatter `name` to
+   the directory name (`.agents/skills/README.md#naming`).
+3. Write the trigger with the phrases users type and the "not for" clauses; write `SKILL.md` on the skeleton above; add
+   a supporting file only when `SKILL.md` routes it.
 4. If the skill writes output, add its row to the table in `AGENTS.md#local-only-working-directory`.
-5. Add the index entry under its area in `AGENTS.md#project-skills`, in the bullet form the audit parses, and a
-   cross-reference from any second area it serves.
-6. Run `bash .agents/sow/audit.sh`; then one review round with the correctness lens plus a trigger-coverage check
-   (there is no inventory yet, so no preservation lens).
+5. Add the index entry under its area in `AGENTS.md#project-skills`, in the form the audit resolves (Where The Rules
+   Live, the `AGENTS.md#enforcement` row), and the cross-reference `.agents/skills/README.md#finding-a-skill` asks for.
+6. `git add` the new files (the audit's path and anchor scans read tracked files; nothing in CI runs the audit), run
+   `bash .agents/sow/audit.sh`, then one review round with the correctness lens plus a trigger-coverage check (there
+   is no inventory yet, so no preservation lens).
 
 ## Rot Signals
 
-Run this over a skill before extending it, and periodically. A cluster of hits is a slim; a single hit is a one-line
-fix in the same change.
+Run this over a skill periodically and before extending it. A cluster of hits is a slim; a single hit is a one-line fix
+in the same change.
 
 - Line-number citations; PR, commit, issue, or SOW identifiers; a promise that line numbers track a branch (grep for
-  them; nothing automates this yet).
+  them; only legacy four-digit SOW identifiers are automated, by the audit).
 - A code-side document now exists for facts the skill states.
 - "Authoritative design", "Spec -", Status, Migration Notes, Schema Additions Required, phase history, open review
   questions.
 - The same fact in two or more files; transcribed enum members, finding codes, schema fields.
 - Unqualified "the loader enforces", "validates", "rejects".
-- An index nothing routes, or one listing files that do not exist; stubs; dead paths; a peer skill as a required
-  reference.
+- An index nothing routes, or one listing files that do not exist; stubs; dead paths; two skills requiring each other.
 - Hard-coded counts or percentages.
 - Index entry and frontmatter disagree; a new producer, subcommand, or flag the trigger does not name.
 - No task router: every task opens most of the skill; `SKILL.md` narrative paid on every trigger.
-- Audit anchor failures after an owner document edit; a code-tree relative link whose `../` depth no longer resolves.
+- Audit anchor failures after an owner document edit; a relative link the audit does not check that no longer
+  resolves (`change-method.md` "Recorded Findings And Owners" lists what it checks).
 - A generated page or symlink in an authority list.
 - An owner section named in prose instead of cited by anchor.
 
@@ -138,4 +148,4 @@ fix in the same change.
 This skill has no code-side owner; nothing feeds it but skill work. A lesson or rot signal learned while changing any
 skill lands here in the same SOW, and that SOW's Artifact Maintenance Gate says so. When the method itself changes, a
 fresh-context agent runs the method from this skill, `AGENTS.md`, and the README alone; what it misses is the
-under-specified line.
+under-specified line, fixed in the same SOW.

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -5,15 +5,16 @@ description: How to create, edit, slim, split, or review a skill under .agents/s
 
 # Skill Authoring
 
-Developer skill for assistants changing this repository's skills. The MUSTs live in the root `AGENTS.md` and
-`.agents/skills/README.md`; this skill points at them and states only the rules and the method that have no other
-home. When an owner document and this skill disagree, the owner wins and this file is fixed in the same change.
+Developer skill for assistants changing this repository's skills. The MUSTs that have another home live in the root
+`AGENTS.md` and `.agents/skills/README.md`; this skill points at them and states only the rules and the method that
+have no other home. When an owner document and this skill disagree, the owner wins and this file is fixed in the same
+change.
 
 ## Pick Your Task
 
 | Task | Read |
 |---|---|
-| create a skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`, `./SKILL.md#creating-a-skill`; `./change-method.md#review-round`, `./change-method.md#mechanical-hygiene` |
+| create a skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`, `./SKILL.md#creating-a-skill`; `./change-method.md#review-round`, `./change-method.md#mechanical-hygiene`, `./change-method.md#close` |
 | add or change rules in an existing skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`; `./change-method.md#recorded-findings-and-owners`, `./change-method.md#mechanical-hygiene`, `./change-method.md#close` |
 | slim, split, or restructure a skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`, then all of `./change-method.md#changing-a-skill`; the method is not optional |
 | periodic rot pass | `./SKILL.md#rot-signals` |
@@ -21,7 +22,8 @@ home. When an owner document and this skill disagree, the owner wins and this fi
 
 ## Where The Rules Live
 
-Owner sections, cited by anchor so the audit catches a renamed heading. Read the row for the obligation it names.
+Owner sections, cited by anchor (`.agents/skills/README.md#owner-section-citations`). Read the row for the obligation it
+names.
 
 | Owner section | What you must get from it |
 |---|---|
@@ -29,21 +31,20 @@ Owner sections, cited by anchor so the audit catches a renamed heading. Read the
 | `AGENTS.md#durable-ai-facing-artifact-formatting` | retrieval structure, requirement words next to the action, prose width, reflow-only commits |
 | `AGENTS.md#sensitive-data-in-durable-artifacts` | the public-artifact assumption and the sanitized-evidence requirement |
 | `AGENTS.md#enforcement` | what `.agents/sow/audit.sh` hard-fails on and what the PR gate `.github/workflows/sow.yml` re-checks |
-| `AGENTS.md#local-only-working-directory` | evidence goes under `.local/audits/<dir>/`; this skill's row names the directory after the skill or SOW topic under change |
+| `AGENTS.md#local-only-working-directory` | where skill-change evidence goes, and how this skill's `<dir>` (the `<subject>` in `./change-method.md#changing-a-skill`) is named |
 | `AGENTS.md#clean-end-state-over-less-churn` | the target is recorded before options are generated; the disclosure of what is removed and what is excluded; the reference search when a path is replaced; how coupled cleanup is handled |
 | `AGENTS.md#working-with-the-user` | the user-decision format and when a decision is recorded |
 | `AGENTS.md#review` | the blocker bar, what to do with a finding before acting, red test first, checkpoint commits, when a round repeats, the recurrence guard |
-| `AGENTS.md#when-a-sow-is-required`, `AGENTS.md#followup-discipline`, `AGENTS.md#artifact-maintenance-gate` | a skill change is non-trivial work with a SOW; how deferred items are tracked; what every close records |
+| `AGENTS.md#when-a-sow-is-required`, `AGENTS.md#followup-discipline`, `AGENTS.md#validation-gate`, `AGENTS.md#artifact-maintenance-gate` | a skill change is non-trivial work with a SOW; how deferred items are tracked; what Validation must hold and what every close records |
 | `AGENTS.md#git-and-pr-workflow` | staging, and which git actions need explicit approval (deleting a file among them) |
 | `AGENTS.md#open-source-reference-evidence` | the citation form for an owner outside this repository |
-| `.agents/skills/README.md#naming`, `.agents/skills/README.md#areas` | the name form and the area minting rule with its same-change obligation; the no-nesting rule is in the README's opening paragraph |
+| `.agents/skills/README.md#skills`, `.agents/skills/README.md#naming`, `.agents/skills/README.md#areas` | the no-nesting rule; the name form; the area minting rule with its same-change obligation |
 | `.agents/skills/README.md#owner-section-citations` | the point-rather-than-restate rule and the anchor form (a MUST) with its slug rules; the marker paragraph for a private owner document, none for a Learn-published one |
 | `.agents/skills/README.md#finding-a-skill` | the index is the map; the frontmatter description is the trigger; the cross-reference for a skill serving two areas |
 
 ## Authoring Rules
 
-Every requirement below is a MUST unless it says SHOULD or MAY; a sentence stating a fact or a consequence is marked as
-such by its wording.
+Every requirement below is a MUST unless it says SHOULD or MAY.
 
 Ownership and pointing:
 
@@ -56,8 +57,8 @@ Ownership and pointing:
 - When the only owner of a fact is a script or a workflow (`.agents/sow/audit.sh`, `.github/workflows/sow.yml`),
   attribute the fact to that file, not to the prose section that names the script: a section that does not state the
   fact cannot be checked against it, and renaming the section never exposes the drift.
-- Cite the repository path, never a bare filename; several documents in this tree share a basename. Inside a skill,
-  cite a section of its own files as `./<file>.md#<anchor>` so the audit checks it.
+- Cite the repository path, never a bare filename; several documents in this tree share a basename. A one-segment
+  path names a repository-root file. Inside a skill, cite a section of its own files as `./<file>.md#<anchor>`.
 - An owner outside this repository cannot be an anchor citation: read it from the local mirror (`repo-mirror-sources`)
   and cite it as `owner/repo @ commit` (`AGENTS.md#open-source-reference-evidence`). A fact whose only owner is out of
   repo stays in the skill, labelled with what verified it and when, or as unverifiable; never delete what you cannot
@@ -131,9 +132,10 @@ Structure and routing:
 4. If the skill writes output, add its row to the table in `AGENTS.md#local-only-working-directory`.
 5. Add the index entry under its area in `AGENTS.md#project-skills`, in the bullet form the existing entries use, and,
    when the skill serves two areas, the cross-reference `.agents/skills/README.md#finding-a-skill` asks for.
-6. `git add` the new files first (the audit reads tracked files), run `bash .agents/sow/audit.sh` (nothing in CI
-   replaces it), then one review round with the correctness lens of `./change-method.md#review-round` plus a
-   trigger-coverage check. A creation has no inventory, so no preservation map and no preservation lens.
+6. Run the audit and close per `./change-method.md#close`, then one review round with the correctness lens of
+   `./change-method.md#review-round` plus a trigger-coverage check: the description names a phrase a user would type
+   for every task the router lists, and the index entry names every producer, subcommand, or binary the skill covers.
+   A creation has no inventory, so no preservation map and no preservation lens.
 
 ## Rot Signals
 
@@ -141,7 +143,7 @@ Run this over a skill periodically and before extending it. A cluster of hits is
 in the same change.
 
 - Line-number citations; PR, commit, issue, or SOW identifiers; a promise that line numbers track a branch. Grep for
-  them; do not assume the audit does.
+  them; the audit automates only its legacy SOW-identifier check.
 - A code-side document now exists for facts the skill states.
 - "Authoritative design", "Spec -", Status, Migration Notes, Schema Additions Required, phase history, open review
   questions.

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -98,8 +98,8 @@ Citations and claims:
 
 Structure and routing:
 
-- Every file is routed from `SKILL.md`; a router or index lists only files that exist (a bare name is invisible to the
-  audit's path scan); no stubs.
+- Every file is routed from `SKILL.md`; a router or index lists only files that exist, checked by hand (a bare
+  filename is not a path the audit resolves); no stubs.
 - When a skill serves more than one audience, `SKILL.md` routes by audience and a topic file SHOULD serve one. Split
   into two skills only when the audiences differ and the seam cuts no shared step and no facts that change together;
   otherwise one skill with a router.
@@ -129,13 +129,11 @@ Structure and routing:
 3. Write the trigger with the phrases users type and the "not for" clauses; write `SKILL.md` on the skeleton above; add
    a supporting file only when `SKILL.md` routes it.
 4. If the skill writes output, add its row to the table in `AGENTS.md#local-only-working-directory`.
-5. Add the index entry under its area in `AGENTS.md#project-skills`. The audit (`.agents/sow/audit.sh`) resolves an
-   entry to its directory only when it is a bullet whose first token is the backticked skill name followed by a colon,
-   inside the block between the `Skills index (` and `Public skills (` lines. When the skill serves two areas, add the
-   cross-reference `.agents/skills/README.md#finding-a-skill` asks for.
-6. `git add` the new files (the audit's path and anchor scans read tracked files; CI runs no skills check), run
-   `bash .agents/sow/audit.sh`, then one review round with the correctness lens of `./change-method.md#review-round`
-   plus a trigger-coverage check. A creation has no inventory, so no preservation map and no preservation lens.
+5. Add the index entry under its area in `AGENTS.md#project-skills`, in the bullet form the existing entries use, and,
+   when the skill serves two areas, the cross-reference `.agents/skills/README.md#finding-a-skill` asks for.
+6. `git add` the new files first (the audit reads tracked files), run `bash .agents/sow/audit.sh` (nothing in CI
+   replaces it), then one review round with the correctness lens of `./change-method.md#review-round` plus a
+   trigger-coverage check. A creation has no inventory, so no preservation map and no preservation lens.
 
 ## Rot Signals
 
@@ -143,8 +141,7 @@ Run this over a skill periodically and before extending it. A cluster of hits is
 in the same change.
 
 - Line-number citations; PR, commit, issue, or SOW identifiers; a promise that line numbers track a branch. Grep for
-  them: the audit automates only legacy four-digit SOW identifiers, not dated SOW ids, line numbers, or PR and commit
-  references.
+  them; do not assume the audit does.
 - A code-side document now exists for facts the skill states.
 - "Authoritative design", "Spec -", Status, Migration Notes, Schema Additions Required, phase history, open review
   questions.
@@ -154,8 +151,8 @@ in the same change.
 - Hard-coded counts or percentages.
 - Index entry and frontmatter disagree; a new producer, subcommand, or flag the trigger does not name.
 - No task router: every task opens most of the skill; `SKILL.md` narrative paid on every trigger.
-- Audit anchor failures after an owner document edit; a link the audit does not check that no longer resolves
-  (`./change-method.md#recorded-findings-and-owners` lists what it checks).
+- Audit anchor failures after an owner document edit; a relative link or bare filename that no longer resolves
+  (`./change-method.md#recorded-findings-and-owners` says what is verified by hand).
 - A generated page or symlink in an authority list.
 - An owner section named in prose instead of cited by anchor.
 

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -13,23 +13,22 @@ home. When an owner document and this skill disagree, the owner wins and this fi
 
 | Task | Read |
 |---|---|
-| create a skill | Where The Rules Live, Authoring Rules, Creating A Skill; `change-method.md` "Mechanical Hygiene" |
-| add or change rules in an existing skill | Authoring Rules; `change-method.md` "Recorded Findings And Owners", "Mechanical Hygiene", "Close" |
-| slim, split, or restructure a skill | Authoring Rules, then all of `change-method.md`; the method is not optional |
-| periodic rot pass | Rot Signals |
-| review a skill change | `change-method.md` "Review Round": the two lenses and what each reviewer receives |
+| create a skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`, `./SKILL.md#creating-a-skill`; `./change-method.md#review-round`, `./change-method.md#mechanical-hygiene` |
+| add or change rules in an existing skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`; `./change-method.md#recorded-findings-and-owners`, `./change-method.md#mechanical-hygiene`, `./change-method.md#close` |
+| slim, split, or restructure a skill | `./SKILL.md#where-the-rules-live`, `./SKILL.md#authoring-rules`, then all of `./change-method.md#changing-a-skill`; the method is not optional |
+| periodic rot pass | `./SKILL.md#rot-signals` |
+| review a skill change | `./change-method.md#review-round`: the two lenses and what each reviewer receives |
 
 ## Where The Rules Live
 
-Owner sections, cited by anchor so the audit catches a renamed heading. Read the row for the obligation it names; a row
-names the subject and never copies the requirement text.
+Owner sections, cited by anchor so the audit catches a renamed heading. Read the row for the obligation it names.
 
 | Owner section | What you must get from it |
 |---|---|
-| `AGENTS.md#project-skills` | where runtime skills live; the same-PR rule for gap-closing and pointer-fixing updates; the slimming pass every skill change ends with and what it reports; the public-skill convention (audience boundary, symlinks, script shape, token safety, the live how-tos catalog); the grouped skills index |
+| `AGENTS.md#project-skills` | where runtime skills live; the same-PR rule for gap-closing and pointer-fixing updates; the slimming pass every skill change ends with and what it reports; the public-skill convention (audience boundary, symlinks, script shape, token safety, the live how-tos catalog); output/reference skill trees and their no-rename rule; the grouped skills index |
 | `AGENTS.md#durable-ai-facing-artifact-formatting` | retrieval structure, requirement words next to the action, prose width, reflow-only commits |
-| `AGENTS.md#sensitive-data-in-durable-artifacts` | a skill is public even when local; sanitized evidence only |
-| `AGENTS.md#enforcement` | what `.agents/sow/audit.sh` hard-fails on and what the PR gate `.github/workflows/sow.yml` re-checks. Facts the audit script itself owns: its path and anchor scans read tracked files (`git grep`, `git ls-files`), the anchor collector reads only files under `.agents/skills/` and `docs/netdata-ai/skills/`, and index entries resolve to directories only when written as a bullet whose first token is the backticked skill name followed by a colon, inside the block that ends at the `Public skills (` line |
+| `AGENTS.md#sensitive-data-in-durable-artifacts` | the public-artifact assumption and the sanitized-evidence requirement |
+| `AGENTS.md#enforcement` | what `.agents/sow/audit.sh` hard-fails on and what the PR gate `.github/workflows/sow.yml` re-checks |
 | `AGENTS.md#local-only-working-directory` | evidence goes under `.local/audits/<dir>/`; this skill's row names the directory after the skill or SOW topic under change |
 | `AGENTS.md#clean-end-state-over-less-churn` | the target is recorded before options are generated; the disclosure of what is removed and what is excluded; the reference search when a path is replaced; how coupled cleanup is handled |
 | `AGENTS.md#working-with-the-user` | the user-decision format and when a decision is recorded |
@@ -37,22 +36,28 @@ names the subject and never copies the requirement text.
 | `AGENTS.md#when-a-sow-is-required`, `AGENTS.md#followup-discipline`, `AGENTS.md#artifact-maintenance-gate` | a skill change is non-trivial work with a SOW; how deferred items are tracked; what every close records |
 | `AGENTS.md#git-and-pr-workflow` | staging, and which git actions need explicit approval (deleting a file among them) |
 | `AGENTS.md#open-source-reference-evidence` | the citation form for an owner outside this repository |
-| `.agents/skills/README.md#naming`, `.agents/skills/README.md#areas` | the name form, frontmatter `name` equals the directory, the area minting rule and its same-change obligation; the no-nesting rule is in the README's opening paragraph |
-| `.agents/skills/README.md#owner-section-citations` | pointing at a fact's owner rather than restating it is a MUST there; the anchor form and slug rules; the marker paragraph for a private owner document, none for a Learn-published one |
+| `.agents/skills/README.md#naming`, `.agents/skills/README.md#areas` | the name form and the area minting rule with its same-change obligation; the no-nesting rule is in the README's opening paragraph |
+| `.agents/skills/README.md#owner-section-citations` | the point-rather-than-restate rule and the anchor form (a MUST) with its slug rules; the marker paragraph for a private owner document, none for a Learn-published one |
 | `.agents/skills/README.md#finding-a-skill` | the index is the map; the frontmatter description is the trigger; the cross-reference for a skill serving two areas |
 
 ## Authoring Rules
 
-Every bullet is a MUST unless it says SHOULD or MAY.
+Every requirement below is a MUST unless it says SHOULD or MAY; a sentence stating a fact or a consequence is marked as
+such by its wording.
 
 Ownership and pointing:
 
 - Search for the owner before writing a fact: the shipped format document, an `ARCHITECTURE.md`, a tool `README.md`,
-  a published operator page, a code-tree `README.md`, a sibling skill. A skill that restates any of them rots.
-- An owner is a hand-maintained file. A generated page (generator banner, or listed as a generator's output) or a
-  symlink into generated output (`git ls-files -s <path>` shows mode `120000`; `readlink <path>`) is never an owner or
-  an authority.
-- Cite the repository path, never a bare filename; several documents in this tree share a basename.
+  a published operator page, a code-tree `README.md`, a sibling skill, a script or workflow. A skill that restates any
+  of them rots.
+- An owner is a hand-maintained file. A generated page (an opening HTML comment carrying `startmeta` and
+  `meta_yaml:`, a `DO NOT EDIT` banner, or a file `integrations-lifecycle` lists as generator output) or a symlink into
+  generated output (`git ls-files -s <path>` shows mode `120000`; `readlink <path>`) is never an owner or an authority.
+- When the only owner of a fact is a script or a workflow (`.agents/sow/audit.sh`, `.github/workflows/sow.yml`),
+  attribute the fact to that file, not to the prose section that names the script: a section that does not state the
+  fact cannot be checked against it, and renaming the section never exposes the drift.
+- Cite the repository path, never a bare filename; several documents in this tree share a basename. Inside a skill,
+  cite a section of its own files as `./<file>.md#<anchor>` so the audit checks it.
 - An owner outside this repository cannot be an anchor citation: read it from the local mirror (`repo-mirror-sources`)
   and cite it as `owner/repo @ commit` (`AGENTS.md#open-source-reference-evidence`). A fact whose only owner is out of
   repo stays in the skill, labelled with what verified it and when, or as unverifiable; never delete what you cannot
@@ -73,12 +78,15 @@ Ownership and pointing:
 Citations and claims:
 
 - Cite symbols and paths, never line numbers; never promise that line numbers track a branch.
-- No PR, commit, issue, or SOW identifiers and no session labels (option letters, inventory ids) in a skill.
+- No PR, issue, or SOW identifiers of this repository, no commit hashes of this repository, and no session labels
+  (option letters, inventory ids) in a skill. A commit hash appears only inside an `owner/repo @ commit` citation of an
+  out-of-repo owner.
 - Write each code-dependent sentence from the symbol, not from old skill text or a quick read, and state what a
   consumer relies on rather than how the producer gets there.
 - Qualify every "the code enforces" claim with the tool, the mode, and the severity (error or warning); keep enforced
   checks and hand-reviewed rules in separate lists.
-- Keep the permissive half of a rule: a MAY clause is a rule, inventoried and preserved on its own.
+- Keep the permissive half of a rule: a MAY clause is a rule, inventoried as its own row and mapped separately from
+  its prohibition.
 - A documented command runs as written: repository-root paths, where to run it from, the interpreter or environment
   it needs. A launcher's internal path resolution is a separate fact.
 - No hard-coded aggregates, counts, or percentages that regeneration or the next slim changes; give the recompute
@@ -92,20 +100,25 @@ Structure and routing:
 
 - Every file is routed from `SKILL.md`; a router or index lists only files that exist (a bare name is invisible to the
   audit's path scan); no stubs.
-- When a skill serves more than one audience, `SKILL.md` routes by audience and a topic file SHOULD serve one.
-- The live how-tos catalog MUST binds public skills only; a runtime skill's `how-tos/INDEX.md` is optional: keep it
-  when `SKILL.md` routes it and every listed file exists, otherwise list the how-tos in `SKILL.md`.
+- When a skill serves more than one audience, `SKILL.md` routes by audience and a topic file SHOULD serve one. Split
+  into two skills only when the audiences differ and the seam cuts no shared step and no facts that change together;
+  otherwise one skill with a router.
+- The live how-tos catalog requirement (`AGENTS.md#project-skills`) binds public skills only. In a runtime skill an
+  index file in any subdirectory (`how-tos/INDEX.md`, `recipes/INDEX.md`) is optional: keep it when `SKILL.md` routes
+  it and every listed file exists, otherwise list the files in `SKILL.md`.
 - A peer skill gets one routing sentence. A one-way prerequisite MAY be declared (an entry-point skill, a
-  read-this-first skill); two skills never require each other. When two skills claim one directory, each carries one
-  boundary line.
+  read-this-first skill).
+- Two skills MUST NOT require each other. When two skills claim one directory, each carries one boundary line.
 - The trigger (the frontmatter description) enumerates the phrases users type and carries "not for" clauses toward
   neighbouring skills; the `AGENTS.md` index entry matches it, including every producer, subcommand, or binary name.
-- Recommended skeleton, each element with the skill that shows it: frontmatter trigger (all); an owners block with
-  anchors and one clause per owner (`topology-authoring` as a table, `collectors-snmp-trap-profiles` as bullets); a
-  task router (`collectors-prometheus-profiles`); a rule sheet split into what the code enforces and rules with no
-  code owner (`collectors-prometheus-profiles`, `topology-authoring`); a workflow (all); validation commands
-  (`collectors-snmp-trap-profiles`); a how-to list (`collectors-prometheus-profiles`, `topology-authoring`); a one-file
-  rule sheet when there is one audience (`collectors-snmp-profiles`, `collectors-snmp-trap-profiles`).
+- Recommended skeleton, each element with the skill that shows it: frontmatter trigger (all); an owners block with one
+  row per owner and anchors where a section is meant (`topology-authoring` as a table, `collectors-snmp-trap-profiles`
+  as anchored bullets); a task router (`collectors-prometheus-profiles`); a rule sheet split into what the code
+  enforces and rules with no code owner (`collectors-prometheus-profiles`, `topology-authoring`); a workflow section
+  (`collectors-prometheus-profiles`, `topology-authoring`) or ordered required-checks lists (`collectors-snmp-profiles`,
+  `collectors-snmp-trap-profiles`); validation commands (`collectors-snmp-profiles`, `collectors-snmp-trap-profiles`);
+  a how-to list (`collectors-prometheus-profiles`, `topology-authoring`); a one-file rule sheet when there is one
+  audience (`collectors-snmp-profiles`, `collectors-snmp-trap-profiles`).
 
 ## Creating A Skill
 
@@ -116,19 +129,22 @@ Structure and routing:
 3. Write the trigger with the phrases users type and the "not for" clauses; write `SKILL.md` on the skeleton above; add
    a supporting file only when `SKILL.md` routes it.
 4. If the skill writes output, add its row to the table in `AGENTS.md#local-only-working-directory`.
-5. Add the index entry under its area in `AGENTS.md#project-skills`, in the form the audit resolves (Where The Rules
-   Live, the `AGENTS.md#enforcement` row), and the cross-reference `.agents/skills/README.md#finding-a-skill` asks for.
-6. `git add` the new files (the audit's path and anchor scans read tracked files; nothing in CI runs the audit), run
-   `bash .agents/sow/audit.sh`, then one review round with the correctness lens plus a trigger-coverage check (there
-   is no inventory yet, so no preservation lens).
+5. Add the index entry under its area in `AGENTS.md#project-skills`. The audit (`.agents/sow/audit.sh`) resolves an
+   entry to its directory only when it is a bullet whose first token is the backticked skill name followed by a colon,
+   inside the block between the `Skills index (` and `Public skills (` lines. When the skill serves two areas, add the
+   cross-reference `.agents/skills/README.md#finding-a-skill` asks for.
+6. `git add` the new files (the audit's path and anchor scans read tracked files; CI runs no skills check), run
+   `bash .agents/sow/audit.sh`, then one review round with the correctness lens of `./change-method.md#review-round`
+   plus a trigger-coverage check. A creation has no inventory, so no preservation map and no preservation lens.
 
 ## Rot Signals
 
 Run this over a skill periodically and before extending it. A cluster of hits is a slim; a single hit is a one-line fix
 in the same change.
 
-- Line-number citations; PR, commit, issue, or SOW identifiers; a promise that line numbers track a branch (grep for
-  them; only legacy four-digit SOW identifiers are automated, by the audit).
+- Line-number citations; PR, commit, issue, or SOW identifiers; a promise that line numbers track a branch. Grep for
+  them: the audit automates only legacy four-digit SOW identifiers, not dated SOW ids, line numbers, or PR and commit
+  references.
 - A code-side document now exists for facts the skill states.
 - "Authoritative design", "Spec -", Status, Migration Notes, Schema Additions Required, phase history, open review
   questions.
@@ -138,14 +154,14 @@ in the same change.
 - Hard-coded counts or percentages.
 - Index entry and frontmatter disagree; a new producer, subcommand, or flag the trigger does not name.
 - No task router: every task opens most of the skill; `SKILL.md` narrative paid on every trigger.
-- Audit anchor failures after an owner document edit; a relative link the audit does not check that no longer
-  resolves (`change-method.md` "Recorded Findings And Owners" lists what it checks).
+- Audit anchor failures after an owner document edit; a link the audit does not check that no longer resolves
+  (`./change-method.md#recorded-findings-and-owners` lists what it checks).
 - A generated page or symlink in an authority list.
 - An owner section named in prose instead of cited by anchor.
 
 ## Maintaining This Skill
 
-This skill has no code-side owner; nothing feeds it but skill work. A lesson or rot signal learned while changing any
-skill lands here in the same SOW, and that SOW's Artifact Maintenance Gate says so. When the method itself changes, a
-fresh-context agent runs the method from this skill, `AGENTS.md`, and the README alone; what it misses is the
-under-specified line, fixed in the same SOW.
+Nothing feeds this skill but skill work. A lesson or rot signal learned while changing any skill lands here in the
+same SOW, and that SOW's Artifact Maintenance Gate says so. When the method itself changes, a fresh-context agent runs
+the method from this skill, `AGENTS.md`, and the README alone; what it misses is the under-specified line, fixed in the
+same SOW.

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: repo-skill-authoring
+description: How to create, edit, slim, split, or review a skill under .agents/skills/ or docs/netdata-ai/skills/, and how to spot skill rot. Use when asked to write a new skill, add or change rules in an existing skill, slim or split a bloated or duplicated skill, run a staleness or rot pass over a skill, or review a skill change; on phrases like "write a skill for X", "slim this skill", "this skill is too long", "the skill is stale or wrong", "skill rot", "skill authoring". Covers the authoring rules (point at the owner document instead of restating it, one owner per fact, symbols and paths rather than line numbers, qualified enforcement claims), the change method (evidence round, numbered options, row-level preservation map, two-lens review), and the rot signals. Not for normalizing the skills layout across CLI tools or bootstrapping the SOW framework, not for PR comment mechanics (repo-pr-reviews), and not for authoring a collector (collectors-authoring).
+---
+
+# Skill Authoring
+
+Developer skill for assistants changing this repository's skills. The MUSTs live in the root `AGENTS.md` and
+`.agents/skills/README.md`; this skill points at them and states only the rules and the method that have no other
+home. When an owner document and this skill disagree, the owner wins and this file is fixed in the same change.
+
+## Pick Your Task
+
+| Task | Read |
+|---|---|
+| create a skill | Where The Rules Live, Authoring Rules, Creating A Skill |
+| add or change rules in an existing skill | Authoring Rules; then `change-method.md` "Close" |
+| slim, split, or restructure a skill | Authoring Rules, then all of `change-method.md`; the method is not optional |
+| periodic rot pass | Rot Signals; a cluster of hits becomes a slim, a single hit a one-line fix |
+| review a skill change | `change-method.md` "Review Round": the two lenses and what each reviewer receives |
+
+## Where The Rules Live
+
+Owner sections, cited by anchor so the audit catches a renamed heading. Read the row for the obligation it names; a row
+names the subject and never copies the requirement text.
+
+| Owner section | What you must get from it |
+|---|---|
+| `AGENTS.md#project-skills` | where runtime skills live; a gap-closing skill update ships in the PR that exposed it; the slimming pass every skill change ends with (keep every rule, report line counts before and after); the public-skill convention (audience boundary, symlinks, script shape, token safety, the live how-tos catalog); the grouped index, whose entries the audit parses as a bullet whose first token is the backticked skill name followed by a colon |
+| `AGENTS.md#durable-ai-facing-artifact-formatting` | retrieval structure, requirement words next to the action, ~120 columns, reflow-only commits kept separate |
+| `AGENTS.md#sensitive-data-in-durable-artifacts` | a skill is public even when local; sanitized evidence only |
+| `AGENTS.md#enforcement` | what `.agents/sow/audit.sh` hard-fails on: skills layout, `.agents/skills/` paths named in any tracked file, index agreement, owner-section anchors, legacy SOW identifiers, relocated spec paths, the sensitive scan |
+| `AGENTS.md#local-only-working-directory` | evidence goes under `.local/audits/<dir>/`; this skill's row uses the name of the skill or SOW topic under change |
+| `AGENTS.md#clean-end-state-over-less-churn` | record the target before generating options; disclose what is removed and what is excluded; the reference search when a path is replaced; coupled cleanup is included and disclosed |
+| `AGENTS.md#working-with-the-user` | how a user decision is presented: evidence, numbered options, pros and cons, a recommendation |
+| `AGENTS.md#review` | the blocker bar, verify findings before acting, red test first, checkpoint commits, one round by default, repeat only after a material change, the recurrence guard |
+| `AGENTS.md#when-a-sow-is-required`, `AGENTS.md#followup-discipline`, `AGENTS.md#artifact-maintenance-gate` | a skill change is non-trivial work with a SOW; deferred items are tracked; every close records the artifact gate |
+| `AGENTS.md#git-and-pr-workflow` | stage specific files; deleting a file, checking one out, or resetting needs explicit approval |
+| `AGENTS.md#open-source-reference-evidence` | an owner outside this repository is cited as `owner/repo @ commit` plus a repository-relative path |
+| `.agents/skills/README.md#naming`, `.agents/skills/README.md#areas` | the name form, frontmatter `name` equals the directory, the area minting rule; the no-nesting rule is in the README's opening paragraph |
+| `.agents/skills/README.md#owner-section-citations` | the anchor form and slug rules; the marker paragraph for a private owner document, none for a Learn-published one; the anchor check scans skill files only |
+| `.agents/skills/README.md#finding-a-skill` | the index is the map; the frontmatter description is the trigger |
+
+## Authoring Rules
+
+Ownership and pointing:
+
+- Search for the owner before writing a fact: the shipped format document, an `ARCHITECTURE.md`, a tool `README.md`,
+  a published operator page, a code-tree `README.md`, a sibling skill. A skill that restates any of them rots.
+- An owner is a hand-maintained file. A generated page, or a symlink into generated output (check with
+  `git ls-files -s` and `readlink`), is never an owner or an authority.
+- Cite the repository path, never a bare filename; several documents in this tree share a basename.
+- An owner outside this repository cannot be an anchor citation: cite it as `owner/repo @ commit`. A fact whose only
+  owner is out of repo stays in the skill, labelled with what verified it or as unverifiable; never delete what you
+  cannot re-home.
+- One owner per fact. When a fact moves into its owner, delete every copy in the same commit and record the owner
+  section, not just the file.
+- A pointer row carries one clause naming the subject; copying the requirement text creates a second owner.
+- A keep-list fact with no owner is a user-owned fork: keep it in the skill, add it to the section of an existing
+  code-side document that already covers the mechanism, or open a separate change for a new developer document.
+  Present the options; never mint a second owner inside the skill.
+- Developer procedure stays in the skill; a shipped operator document keeps only the operator form.
+- Do not transcribe schemas, enum members, finding codes, or code; the reader opens the file.
+- Design records rot once the code ships its own document. Propose retiring them, with the relocation target and the
+  rejected alternatives; deletion is the user's call; history stays in git. Unshipped design that must survive goes
+  to the code-side scope document, labelled as not shipped.
+
+Citations and claims:
+
+- Cite symbols and paths, never line numbers; never promise that line numbers track a branch.
+- No PR, commit, issue, or SOW identifiers and no session labels (option letters, inventory ids) in a skill.
+- Write each code-dependent sentence from the symbol, not from old skill text or a quick read, and state what a
+  consumer relies on rather than how the producer gets there.
+- Qualify every "the code enforces" claim with the tool, the mode, and the severity (error or warning); keep enforced
+  checks and hand-reviewed rules in separate lists.
+- Keep the permissive half of a rule: a MAY clause is a rule, inventoried and preserved on its own.
+- A documented command runs as written: repository-root paths, where to run it from, the interpreter or environment
+  it needs. A launcher's internal path resolution is a separate fact.
+- No hard-coded counts or percentages that regeneration or the next slim changes; give the recompute command.
+- A relocated fact adopts the receiving document's existing convention (requirement words, mood) and names it; a
+  developer document written in lowercase indicative keeps that register. This never removes requirement force from
+  an AI-facing artifact.
+- Tests never pin skill prose.
+
+Structure and routing:
+
+- Every file is routed from `SKILL.md`; a router or index lists only files that exist (a bare name is invisible to the
+  audit's path scan); no stubs.
+- When a skill serves more than one audience, `SKILL.md` routes by audience and a topic file SHOULD serve one.
+- Repo-wide `AGENTS.md` rules are pointed at, never restated. The live how-tos catalog MUST binds public skills only;
+  a runtime skill's `how-tos/INDEX.md` is optional: keep it when `SKILL.md` routes it and every listed file exists,
+  otherwise list the how-tos in `SKILL.md`.
+- A peer skill gets one routing sentence and is never a required reference (that is circular). When two skills claim
+  one directory, each carries one boundary line.
+- The trigger (the frontmatter description) enumerates the phrases users type and carries "not for" clauses toward
+  neighbouring skills; the `AGENTS.md` index entry matches it, including every producer, subcommand, or binary name.
+- The shape that has held: frontmatter trigger; an owners table with anchors and clauses; a task router; a rule sheet
+  split into what the code enforces and rules with no code owner; workflow; validation commands; the how-to list.
+  Precedents: `collectors-snmp-trap-profiles`, `collectors-prometheus-profiles`, `topology-authoring`.
+
+## Creating A Skill
+
+1. Decide runtime or public (`AGENTS.md#project-skills`): a workflow that reads source files, updates schemas, or
+   changes collectors is a runtime skill; a public skill teaches operators and gets its relative symlink.
+2. Pick the area from `.agents/skills/README.md#areas`, or add its row in the same change; name the directory
+   `<area>-<topic>` and set frontmatter `name` to the directory name.
+3. Write the trigger with the phrases users type and the "not for" clauses; write `SKILL.md` in the shape above; add a
+   supporting file only when `SKILL.md` routes it.
+4. If the skill writes output, add its row to the table in `AGENTS.md#local-only-working-directory`.
+5. Add the index entry under its area in `AGENTS.md#project-skills`, in the bullet form the audit parses, and a
+   cross-reference from any second area it serves.
+6. Run `bash .agents/sow/audit.sh`; then one review round with the correctness lens plus a trigger-coverage check
+   (there is no inventory yet, so no preservation lens).
+
+## Rot Signals
+
+Run this over a skill before extending it, and periodically. A cluster of hits is a slim; a single hit is a one-line
+fix in the same change.
+
+- Line-number citations; PR, commit, issue, or SOW identifiers; a promise that line numbers track a branch (grep for
+  them; nothing automates this yet).
+- A code-side document now exists for facts the skill states.
+- "Authoritative design", "Spec -", Status, Migration Notes, Schema Additions Required, phase history, open review
+  questions.
+- The same fact in two or more files; transcribed enum members, finding codes, schema fields.
+- Unqualified "the loader enforces", "validates", "rejects".
+- An index nothing routes, or one listing files that do not exist; stubs; dead paths; a peer skill as a required
+  reference.
+- Hard-coded counts or percentages.
+- Index entry and frontmatter disagree; a new producer, subcommand, or flag the trigger does not name.
+- No task router: every task opens most of the skill; `SKILL.md` narrative paid on every trigger.
+- Audit anchor failures after an owner document edit; a code-tree relative link whose `../` depth no longer resolves.
+- A generated page or symlink in an authority list.
+- An owner section named in prose instead of cited by anchor.
+
+## Maintaining This Skill
+
+This skill has no code-side owner; nothing feeds it but skill work. A lesson or rot signal learned while changing any
+skill lands here in the same SOW, and that SOW's Artifact Maintenance Gate says so. When the method itself changes, a
+fresh-context agent runs the method from this skill, `AGENTS.md`, and the README alone; what it misses is the
+under-specified line.

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -51,10 +51,9 @@ Then re-verify every Tier-1 item yourself against the code before presenting any
   read from the local mirror and cited as `./SKILL.md#authoring-rules` says.
 - Reference search for every file you may rename or delete (`AGENTS.md#clean-end-state-over-less-churn`): root
   `AGENTS.md`, sibling skills, `src/**/AGENTS.md`, developer documents, CI path filters and test discovery, code-tree
-  README links, tests, audit globs. The audit checks repository-relative `.agents/skills/` paths in tracked files
-  (`CHANGELOG.md` excluded), `../` markdown links and `source` lines inside skill files, and anchor citations inside
-  skill files. Everything else is verified by hand: `./`, sibling, and subdirectory links, bare filenames,
-  `docs/netdata-ai/skills/` paths anywhere, and the hop depth of a relative link from a non-skill file.
+  README links, tests, audit globs. The skills-layout section of `.agents/sow/audit.sh` says which path and anchor
+  forms it resolves; everything else is verified by hand, in particular `./`, sibling, and subdirectory links, bare
+  filenames, public-skill paths under `docs/netdata-ai/skills/`, and links from files outside a skill.
 
 ## Options Round
 
@@ -113,18 +112,16 @@ bitten, for the throwaway scripts:
           if len(l.rstrip("\n")) > 120 and not l.startswith("|"): print(f"{f}:{n}")' <files>
   ```
 
-- never write an HTML comment opener literally in prose or a code span: the audit's anchor scan treats it as the start
-  of a comment and stops seeing headings until a closer appears;
+- never write an HTML comment opener literally in prose or a code span inside a skill: the anchor scan stops seeing
+  headings after it;
 - `git diff HEAD` before each commit;
-- the sensitive scanner (`.agents/sow/scan-sensitive.sh`) flags an SNMP community keyword followed by a colon or an
-  equals sign and a value; its placeholder exemption is a short whole-word list, so a redaction token is still
-  flagged. Phrase around the keyword rather than relying on a placeholder.
+- on a sensitive-scan hit, phrase around the keyword, not around the value (a redaction placeholder does not clear an
+  SNMP community hit); `.agents/sow/scan-sensitive.sh` defines the hits.
 
 ## Close
 
-- `bash .agents/sow/audit.sh` before every commit and at close, after `git add` of every new file: it is the only check
-  for the skills items `AGENTS.md#enforcement` lists; CI (`.github/workflows/sow.yml`) re-runs the sensitive scan and
-  the committed-working-files check and no skills check.
+- `bash .agents/sow/audit.sh` before every commit and at close, after `git add` of every new file; nothing in CI
+  replaces it (`.github/workflows/sow.yml` is what CI runs).
 - Line counts before and after per touched file; a symbol sweep (grep the tree for every backticked identifier and
   path the skill cites); the reference search re-run; the slimming pass over every touched skill
   (`AGENTS.md#project-skills`).

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -1,21 +1,23 @@
 # Changing A Skill
 
-The method for editing, slimming, splitting, or restructuring an existing skill. It exists because four slims each
+The method for editing, slimming, splitting, or restructuring an existing skill. It exists because past slims each
 lost rules through the same gaps: inventories that hid sub-clauses and MAY halves, preservation maps with range rows,
 facts relocated from prose instead of from the symbol, and enforcement claims nobody qualified. Every step below
-closes one of those gaps. Evidence lives under `.local/audits/<subject>/`, where the subject is the skill under
-change (`AGENTS.md#local-only-working-directory`). The rules the rewrite must satisfy are in `SKILL.md` "Authoring
-Rules".
+closes one of those gaps. Evidence lives under `.local/audits/<subject>/` (`AGENTS.md#local-only-working-directory`);
+throwaway tooling written for a change (width check, rewrap, symbol sweep) lives there too. The rules the rewrite must
+satisfy are in `SKILL.md` "Authoring Rules". There is no size target: the end state is defined by those rules, and
+line counts are reported, not aimed at.
 
 ## Evidence Round
 
-Before proposing anything, run two independent read-only passes with fresh context, each writing its output file
-before its summary turn. If a pass dies, read its file before re-running; it usually finished the file first.
+Before proposing anything, run two independent read-only passes with fresh context (subagents or external
+assistants), each given the skill directory, the owner candidates found so far, and the output format below, and each
+writing its output file before its summary turn. If a pass dies, read its file before re-running; it usually finished
+the file first.
 
-Census first: per-file line counts, lines over 120 columns, provenance (`git log --follow`). A maintained design
-record and an abandoned one get different options.
-
-`inventory.md`, the preservation baseline:
+`inventory.md`, the preservation baseline, opens with a census: per-file line counts, lines over 120 columns,
+provenance (`git log --follow -- <path>`). A maintained design record and an abandoned one get different options.
+Then:
 
 - one row per rule with a stable id per file; a compound bullet is split into sub-clauses, one row each;
 - the permissive half of a rule (MAY) is its own row, separate from its prohibition;
@@ -38,23 +40,27 @@ Then re-verify every Tier-1 item yourself against the code before presenting any
 
 ## Recorded Findings And Owners
 
-- Collect the findings already recorded against the skill (the project's follow-up store, past PR bot reviews, open
-  issues) and triage each before proposing scope: fixed here, or rejected with evidence. Close the entry.
+- Collect the findings already recorded against the skill (GitHub issues per `AGENTS.md#followup-discipline`, the
+  local stores under `.local/`, past PR bot reviews) and triage each before proposing scope: fixed here, or rejected
+  with evidence. Close the entry.
 - Owner search: the candidate owners and the generated-file check in `SKILL.md` "Authoring Rules"; the Learn status of
   each candidate via `docs/.map/map.yaml` (a private owner document gets the marker paragraph of
-  `.agents/skills/README.md#owner-section-citations`, a Learn-published one none); the cross-repo branch when the owner
-  is in another repository.
+  `.agents/skills/README.md#owner-section-citations`, a Learn-published one none); an owner in another repository is
+  read from the local mirror and cited as `SKILL.md` "Authoring Rules" says.
 - Reference search for every file you may rename or delete (`AGENTS.md#clean-end-state-over-less-churn`): root
   `AGENTS.md`, sibling skills, `src/**/AGENTS.md`, developer documents, CI path filters and test discovery, code-tree
-  README links, tests, audit globs. The audit catches `.agents/skills/` paths named in any tracked file; only the `../`
-  hop depth of a relative link from a non-skill file is unchecked, so verify the rendered link.
+  README links, tests, audit globs. The audit checks repository-relative `.agents/skills/` paths in tracked files
+  (`CHANGELOG.md` excluded), `../` links written as markdown links or `source` lines inside skill files, and anchor
+  citations inside skill files. Everything else is verified by hand: `./`, sibling, and subdirectory links, bare
+  filenames, `docs/netdata-ai/skills/` paths named outside a skill file, and the hop depth of a relative link from a
+  non-skill file.
 
 ## Options Round
 
 Record the clean-end-state target first (`AGENTS.md#clean-end-state-over-less-churn`), then present numbered options
 with a recommendation (`AGENTS.md#working-with-the-user`): slim in place, split, keep; and, for every keep-list fact
 with no owner, the fork in `SKILL.md` "Authoring Rules". No step plan before the evidence round. The user decides
-scope and design; record the decisions in the SOW before touching an implementation file.
+scope and design.
 
 ## Rewrite And Preservation Map
 
@@ -64,12 +70,12 @@ Write to the authoring rules. Keep `preservation-map.md` up to date as you write
   `<path>.md#<anchor>` the skill now cites), DROPPED (the reason: false against the code at a named symbol, superseded
   by a named owner, or a numbered user decision);
 - a range row only when every id in the range was opened, and never for a disposition that claims a pre-existing
-  owner: every leak in three review rounds hid inside such a range;
+  owner: every leak the topology slim's review rounds found hid inside such a range;
 - every keep-list item maps to the section that now holds it.
 
-Relocating a fact into a shipped document: write each sentence from the symbol, contract-level, with the symbol named,
-in the receiving document's register. A coupled fix in an owner document (a dangling reference, a one-word
-correction) is included when low-risk and disclosed.
+Relocating a fact into a shipped document follows the citation and register rules in `SKILL.md` "Authoring Rules". A
+coupled fix in an owner document (a dangling reference, a one-word correction) is included when low-risk and
+disclosed.
 
 ## Review Round
 
@@ -92,19 +98,21 @@ contract-only text with a symbol per sentence, not another round of patches.
 ## Mechanical Hygiene
 
 The width and reflow-commit rules are `AGENTS.md#durable-ai-facing-artifact-formatting`. The tooling rules that have
-bitten:
+bitten, for the throwaway scripts under `.local/audits/<subject>/`:
 
 - rewrap whole paragraphs with fence-, table-, and list-aware logic; a line starting with `- ` begins a paragraph;
-- assert token-stream equality after every rewrap; never auto-join short lines;
-- count characters, not bytes; re-run the width check on every touched file, including files outside the skill;
+- assert that the whitespace-split token stream is unchanged after every rewrap; never auto-join short lines;
+- count characters, not bytes (Python `len`, not `awk length`); re-run the width check on every touched file,
+  including files outside the skill;
 - `git diff HEAD` before each commit;
-- the sensitive scanner treats the word community followed by a colon and a value as an SNMP credential; phrase
-  around it.
+- the sensitive scanner treats the word community (also with an `snmp`, `ro`, `rw`, or `string` affix) followed by a
+  colon or an equals sign and a value of three or more characters as an SNMP credential unless the value is a
+  placeholder such as `[REDACTED_SECRET]`; phrase around it.
 
 ## Close
 
-- `bash .agents/sow/audit.sh` before every commit and at close: it is the only check for names, index agreement, skill
-  paths, owner-section anchors, legacy identifiers, and the sensitive scan.
+- `bash .agents/sow/audit.sh` before every commit and at close, after `git add` of every new file: it is the only local
+  check for the items `AGENTS.md#enforcement` lists, and CI re-runs only the sensitive scan.
 - Line counts before and after per touched file; a symbol sweep of every cited identifier and path; the reference
   search re-run; the slimming pass over every touched skill (`AGENTS.md#project-skills`).
 - Follow-ups tracked and the artifact gate recorded (`AGENTS.md#followup-discipline`,

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -6,25 +6,28 @@ relocated from prose instead of from the symbol, and enforcement claims nobody q
 of those gaps. The rules the rewrite must satisfy are in `./SKILL.md#authoring-rules`. There is no size
 target: the end state is defined by those rules, and line counts are reported, not aimed at.
 
-Where things go: decisions, the recorded target, dispositions, and validation evidence go in the SOW; the evidence
-files named below, the review reports (`review-r<n>-<lens>.md`), and any throwaway tooling written for the change go
-under `.local/audits/<subject>/` (`AGENTS.md#local-only-working-directory`).
+Where things go: the SOW is opened first (`planning`; the evidence round is analysis, not implementation) and holds
+the decisions, the recorded target, dispositions, and validation evidence; the evidence files named below, the review
+reports (`review-r<n>-preservation.md`, `review-r<n>-correctness.md`; a PR bot round is `review-bot<n>.md`), and any
+throwaway tooling written for the change go under `.local/audits/<subject>/`, where `<subject>` is the directory name
+of the skill under change (`AGENTS.md#local-only-working-directory`).
 
 ## Evidence Round
 
 Before proposing anything, run two independent read-only passes with fresh context (subagents or external
-assistants, one per pass, one output file each), each given the skill directory, the owner candidates from a first
-sweep of `./change-method.md#recorded-findings-and-owners` (an empty list is acceptable; the passes extend it), and
-the output format below, and each writing its output file before its summary turn. If a pass dies, read its file
-before re-running; a dying pass has usually written it. When the passes disagree on a claim, the code decides:
-re-verify it yourself.
+assistants; one writes `inventory.md`, the other `staleness.md`), each given the skill directory, the owner candidates
+from a first sweep of `./change-method.md#recorded-findings-and-owners` (an empty list is acceptable; the passes extend
+it), and the output format below, and each writing its output file before its summary turn. If a pass dies, read its
+file before re-running; a dying pass has usually written it. When the passes disagree on a claim, the code decides:
+re-verify it yourself; when they disagree on how to split a rule, take the finer split.
 
 `inventory.md`, the preservation baseline, opens with a census: per-file line counts, lines over 120 columns,
-provenance (`git log --follow -- <path>`). A maintained design record and an abandoned one get different options.
-Then:
+provenance (`git log --follow -- <path>`: first and last change dates and commit count; hashes belong in this local
+evidence, never in the skill). A maintained design record and an abandoned one get different options. Then:
 
-- one row per rule with a stable id per file (`<file>-R<n>`, assigned in document order); a compound bullet is split
-  into sub-clauses, one row each;
+- one row per rule or hard-won fact, with a stable id per file (`<file>-R<n>` in document order, the stem
+  directory-qualified when basenames repeat); narrative and examples are counted in the classification only, and
+  dropping them needs no row; a compound bullet is split into sub-clauses, one row each;
 - the permissive half of a rule (MAY) is its own row, separate from its prohibition;
 - a closed list (enum, token vocabulary) is one row naming its members and their count;
 - a kind per row: MUST, MUST NOT, SHOULD, MAY, fact, enum, pointer, procedure, history, rationale, example, status;
@@ -40,7 +43,10 @@ Then:
   can get it from the owner), or UNVERIFIABLE (say why);
 - a Tier-1 list: claims that would cause wrong work today;
 - code facts the skill lacks; an authority check (every named authority exists and is hand-maintained); a keep list
-  with stable ids.
+  with its own stable ids (`K<n>`), mapped to inventory ids in the preservation map.
+- When an owner lives in another repository and its mirror is absent on the machine, its claims are UNVERIFIABLE and
+  whether to touch them at all is a numbered user decision in the options round; a verified out-of-repo fact is
+  labelled `owner/repo @ commit`.
 
 Then re-verify every Tier-1 item yourself against the code before presenting anything.
 
@@ -48,8 +54,9 @@ Then re-verify every Tier-1 item yourself against the code before presenting any
 
 - Collect the findings already recorded against the skill and triage each before proposing scope: fixed here, or
   rejected with evidence; close the entry. Stores: GitHub issues (`gh issue list --search "<skill name>"`,
-  `AGENTS.md#followup-discipline`), the local stores `.local/sow/` and `.local/audits/<subject>/followups.md`, and past
-  PR bot reviews (fetched as `repo-pr-reviews` describes).
+  `AGENTS.md#followup-discipline`), the local stores `.local/sow/` and `.local/audits/<subject>/followups.md`, past PR
+  bot reviews (fetched as `repo-pr-reviews` describes), and a tree-wide grep for the skill's name (sibling skills carry
+  findings in prose).
 - Owner search: the candidate owners and the generated-file check in `./SKILL.md#authoring-rules`; the Learn status of
   each candidate via `docs/.map/map.yaml` decides the marker paragraph
   (`.agents/skills/README.md#owner-section-citations`; repository instruction files such as the root `AGENTS.md` and
@@ -65,9 +72,11 @@ Then re-verify every Tier-1 item yourself against the code before presenting any
 ## Options Round
 
 Record the clean-end-state target first (`AGENTS.md#clean-end-state-over-less-churn`), then present numbered options
-with a recommendation (`AGENTS.md#working-with-the-user`): slim in place, split (the split test is in
-`./SKILL.md#authoring-rules`), keep; and, for every keep-list fact with no owner, the fork in the same section. No
-step plan before the evidence round. The user decides scope and design.
+with a recommendation (`AGENTS.md#working-with-the-user`), one numbered decision per fork: scope (slim in place, split
+per the test in `./SKILL.md#authoring-rules`, keep); each keep-list cluster with no owner; each file deletion (the
+approval `AGENTS.md#git-and-pr-workflow` requires, staged later with `git rm <path>`); each self-declared rule to
+demote; each unverifiable out-of-repo cluster. No step plan before the evidence round. The user decides scope and
+design.
 
 ## Rewrite And Preservation Map
 
@@ -92,10 +101,12 @@ finding, CRITICAL vs TODO. The blocker bar, verify-before-acting, the one-round 
 
 - Preservation lens: receives `inventory.md`, the keep list, and `preservation-map.md`; checks that every row and keep
   item is reachable from the new skill or the cited owner section; flags dropped permissive clauses and range rows.
-- Correctness lens: receives the code and the owner documents, never the old skill text; checks every fact at its
-  symbol, every enforcement qualifier, every command as written, every anchor.
+- Correctness lens: receives the new skill text, the code, and the owner documents, never the pre-change skill text;
+  checks every fact at its symbol, every enforcement qualifier, every command as written, every anchor; marks claims
+  whose owner is unavailable on the machine as unverifiable.
 
-Probe every fix wrong-to-right and on the normal case; hold user edit requests until the round closes, or tell the
+Probe every fix wrong-to-right and on the normal case (for prose: run the documented commands and re-resolve the
+cited anchors and paths); hold user edit requests until the round closes, or tell the
 reviewers to review the tree as it is. A PR bot review is triaged
 the same way: fix real issues, add no machinery for unlikely edge cases; the mechanics are in `repo-pr-reviews`.
 
@@ -105,8 +116,9 @@ round of patches.
 
 ## Mechanical Hygiene
 
-The width and reflow-commit rules are `AGENTS.md#durable-ai-facing-artifact-formatting`. The tooling rules that have
-bitten, for the throwaway scripts:
+The width and reflow-commit rules are `AGENTS.md#durable-ai-facing-artifact-formatting`: a rewritten paragraph is
+wrapped in its content commit; surviving prose at another width is rewrapped in a separate whitespace-only commit. The
+tooling rules that have bitten, for the throwaway scripts:
 
 - rewrap whole paragraphs with fence-, table-, and list-aware logic; a line starting with `- ` begins a paragraph;
 - assert that the whitespace-split token stream is unchanged after every rewrap; never auto-join short lines;
@@ -132,7 +144,7 @@ bitten, for the throwaway scripts:
 - `bash .agents/sow/audit.sh` before every commit and at close, after `git add` of every new file (its citation and
   path scans read tracked files); nothing in CI replaces it (`.github/workflows/sow.yml` is the PR gate).
 - Line counts before and after per touched file; a symbol sweep (grep the tree for every backticked identifier and
-  path the skill cites); the reference search re-run; the slimming pass over every touched skill
-  (`AGENTS.md#project-skills`).
+  path the skill cites); the reference search re-run for every file or heading removed or renamed; the slimming pass
+  over every touched skill file (`AGENTS.md#project-skills`).
 - Follow-ups tracked and the artifact gate recorded (`AGENTS.md#followup-discipline`,
   `AGENTS.md#artifact-maintenance-gate`); a lesson about the method goes into `./SKILL.md#maintaining-this-skill`.

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -1,9 +1,9 @@
 # Changing A Skill
 
-The method for editing, slimming, splitting, or restructuring an existing skill. It exists because past slims each
-lost rules through the same gaps: inventories that hid sub-clauses and MAY halves, preservation maps with range rows,
-facts relocated from prose instead of from the symbol, and enforcement claims nobody qualified. Every step below
-closes one of those gaps. The rules the rewrite must satisfy are in `./SKILL.md#authoring-rules`. There is no size
+The method for editing, slimming, splitting, or restructuring an existing skill. It exists because past slims lost
+rules through the same gaps: inventories that hid sub-clauses and MAY halves, preservation maps with range rows, facts
+relocated from prose instead of from the symbol, and enforcement claims nobody qualified. Every step below closes one
+of those gaps. The rules the rewrite must satisfy are in `./SKILL.md#authoring-rules`. There is no size
 target: the end state is defined by those rules, and line counts are reported, not aimed at.
 
 Where things go: decisions, the recorded target, dispositions, and validation evidence go in the SOW; the evidence
@@ -13,21 +13,25 @@ under `.local/audits/<subject>/` (`AGENTS.md#local-only-working-directory`).
 ## Evidence Round
 
 Before proposing anything, run two independent read-only passes with fresh context (subagents or external
-assistants, one per pass), each given the skill directory, the owner candidates found so far, and the output format
-below, and each writing its output file before its summary turn. If a pass dies, read its file before re-running; it
-usually finished the file first. When the passes disagree on a claim, the code decides: re-verify it yourself.
+assistants, one per pass, one output file each), each given the skill directory, the owner candidates from a first
+sweep of `./change-method.md#recorded-findings-and-owners` (an empty list is acceptable; the passes extend it), and
+the output format below, and each writing its output file before its summary turn. If a pass dies, read its file
+before re-running; a dying pass has usually written it. When the passes disagree on a claim, the code decides:
+re-verify it yourself.
 
 `inventory.md`, the preservation baseline, opens with a census: per-file line counts, lines over 120 columns,
 provenance (`git log --follow -- <path>`). A maintained design record and an abandoned one get different options.
 Then:
 
-- one row per rule with a stable id per file; a compound bullet is split into sub-clauses, one row each;
+- one row per rule with a stable id per file (`<file>-R<n>`, assigned in document order); a compound bullet is split
+  into sub-clauses, one row each;
 - the permissive half of a rule (MAY) is its own row, separate from its prohibition;
 - a closed list (enum, token vocabulary) is one row naming its members and their count;
 - a kind per row: MUST, MUST NOT, SHOULD, MAY, fact, enum, pointer, procedure, history, rationale, example, status;
-- aggregate sections: line classification (rules, hard-won facts, restatement, narrative, examples), internal
-  duplication, ownership overlap with code-side documents, cross-skill overlap, task clusters (which files each task
-  opens), reachability (what `SKILL.md` routes), structural facts (external references, CI coupling, audit coupling);
+- aggregate sections: line classification as per-file line counts per bucket (rules; hard-won facts, stated nowhere
+  else; restatement, stated in a named owner; narrative; examples), internal duplication, ownership overlap with
+  code-side documents, cross-skill overlap, task clusters (which files each task opens), reachability (what `SKILL.md`
+  routes), structural facts (external references, CI coupling, audit coupling);
 - the reported row count equals the enumerated ids; fix a mismatch before the map is written.
 
 `staleness.md`, truth against the code:
@@ -42,18 +46,21 @@ Then re-verify every Tier-1 item yourself against the code before presenting any
 
 ## Recorded Findings And Owners
 
-- Collect the findings already recorded against the skill (GitHub issues per `AGENTS.md#followup-discipline`, the
-  local stores `.local/sow/` and `.local/audits/<subject>/followups.md`, past PR bot reviews) and triage each before
-  proposing scope: fixed here, or rejected with evidence. Close the entry.
+- Collect the findings already recorded against the skill and triage each before proposing scope: fixed here, or
+  rejected with evidence; close the entry. Stores: GitHub issues (`gh issue list --search "<skill name>"`,
+  `AGENTS.md#followup-discipline`), the local stores `.local/sow/` and `.local/audits/<subject>/followups.md`, and past
+  PR bot reviews (fetched as `repo-pr-reviews` describes).
 - Owner search: the candidate owners and the generated-file check in `./SKILL.md#authoring-rules`; the Learn status of
-  each candidate via `docs/.map/map.yaml` (a private owner document gets the marker paragraph of
-  `.agents/skills/README.md#owner-section-citations`, a Learn-published one none); an owner in another repository is
-  read from the local mirror and cited as `./SKILL.md#authoring-rules` says.
+  each candidate via `docs/.map/map.yaml` decides the marker paragraph
+  (`.agents/skills/README.md#owner-section-citations`; repository instruction files such as the root `AGENTS.md` and
+  the skills README carry the citing sentence inline instead); an owner in another repository is read from the local
+  mirror and cited as `./SKILL.md#authoring-rules` says.
 - Reference search for every file you may rename or delete (`AGENTS.md#clean-end-state-over-less-churn`): root
   `AGENTS.md`, sibling skills, `src/**/AGENTS.md`, developer documents, CI path filters and test discovery, code-tree
   README links, tests, audit globs. The skills-layout section of `.agents/sow/audit.sh` says which path and anchor
-  forms it resolves; everything else is verified by hand, in particular `./`, sibling, and subdirectory links, bare
-  filenames, public-skill paths under `docs/netdata-ai/skills/`, and links from files outside a skill.
+  forms it resolves; everything else is verified by hand, in particular links without an anchor (`./`, sibling, and
+  subdirectory forms), bare filenames, path strings under `docs/netdata-ai/skills/`, and links from files outside a
+  skill.
 
 ## Options Round
 
@@ -70,7 +77,7 @@ Write to the authoring rules. Keep `preservation-map.md` up to date as you write
   `<path>.md#<anchor>` the skill now cites), DROPPED (the reason: false against the code at a named symbol, superseded
   by a named owner, or a numbered user decision);
 - a range row only when every id in the range was opened, and never for a disposition that claims a pre-existing
-  owner: every leak the topology slim's review rounds found hid inside such a range;
+  owner: leaks found in past review rounds hid inside such ranges;
 - every keep-list item maps to the section that now holds it.
 
 Relocating a fact into a shipped document follows the citation and register rules in `./SKILL.md#authoring-rules`. A
@@ -88,12 +95,13 @@ finding, CRITICAL vs TODO. The blocker bar, verify-before-acting, the one-round 
 - Correctness lens: receives the code and the owner documents, never the old skill text; checks every fact at its
   symbol, every enforcement qualifier, every command as written, every anchor.
 
-Verify every finding against the code before acting; probe every fix wrong-to-right and on the normal case; hold user
-edit requests until the round closes, or tell the reviewers to review the tree as it is. A PR bot review is triaged
+Probe every fix wrong-to-right and on the normal case; hold user edit requests until the round closes, or tell the
+reviewers to review the tree as it is. A PR bot review is triaged
 the same way: fix real issues, add no machinery for unlikely edge cases; the mechanics are in `repo-pr-reviews`.
 
-Recurrence seen in skills: findings clustering in relocated prose that was written from documents. The class fix is
-contract-only text with a symbol per sentence, not another round of patches.
+Recurrence seen in skills: findings clustering in relocated prose written from documents, and in descriptions of what
+a tool does. The class fix is contract-only text with a symbol per sentence, or a pointer at the tool, not another
+round of patches.
 
 ## Mechanical Hygiene
 
@@ -103,25 +111,26 @@ bitten, for the throwaway scripts:
 - rewrap whole paragraphs with fence-, table-, and list-aware logic; a line starting with `- ` begins a paragraph;
 - assert that the whitespace-split token stream is unchanged after every rewrap; never auto-join short lines;
 - count characters, not bytes: BSD `awk length` counts bytes, so use Python; re-run the width check on every touched
-  file, including files outside the skill:
+  file, including files outside the skill. From the repository root (it reports every non-table line; judge fenced
+  and frontmatter hits by the owner rule instead of rewrapping them):
 
   ```bash
-  .venv/bin/python3 -c 'import sys
+  python3 -c 'import sys
   for f in sys.argv[1:]:
       for n, l in enumerate(open(f), 1):
           if len(l.rstrip("\n")) > 120 and not l.startswith("|"): print(f"{f}:{n}")' <files>
   ```
 
-- never write an HTML comment opener literally in prose or a code span inside a skill: the anchor scan stops seeing
-  headings after it;
+- never write an HTML comment opener literally in prose or a code span inside a skill: the headings after it stop
+  being scanned (`.agents/skills/README.md#owner-section-citations`);
 - `git diff HEAD` before each commit;
-- on a sensitive-scan hit, phrase around the keyword, not around the value (a redaction placeholder does not clear an
-  SNMP community hit); `.agents/sow/scan-sensitive.sh` defines the hits.
+- on a sensitive-scan hit, phrase around the keyword, not around the value; `.agents/sow/scan-sensitive.sh` defines
+  the hits.
 
 ## Close
 
-- `bash .agents/sow/audit.sh` before every commit and at close, after `git add` of every new file; nothing in CI
-  replaces it (`.github/workflows/sow.yml` is what CI runs).
+- `bash .agents/sow/audit.sh` before every commit and at close, after `git add` of every new file (its citation and
+  path scans read tracked files); nothing in CI replaces it (`.github/workflows/sow.yml` is the PR gate).
 - Line counts before and after per touched file; a symbol sweep (grep the tree for every backticked identifier and
   path the skill cites); the reference search re-run; the slimming pass over every touched skill
   (`AGENTS.md#project-skills`).

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -1,10 +1,10 @@
 # Changing A Skill
 
-The method for editing, slimming, splitting, or restructuring an existing skill. It exists because past slims lost
-rules through the same gaps: inventories that hid sub-clauses and MAY halves, preservation maps with range rows, facts
-relocated from prose instead of from the symbol, and enforcement claims nobody qualified. Every step below closes one
-of those gaps. The rules the rewrite must satisfy are in `./SKILL.md#authoring-rules`. There is no size
-target: the end state is defined by those rules, and line counts are reported, not aimed at.
+The method for editing, slimming, splitting, or restructuring an existing skill. Past slims lost rules through
+inventories that hid sub-clauses and MAY halves, preservation maps with range rows, facts relocated from prose instead
+of the symbol, and unqualified enforcement claims; each step below closes one of those gaps. The rules the rewrite must
+satisfy are in `./SKILL.md#authoring-rules`. There is no size target: the end state is defined by those rules, and
+line counts are reported, not aimed at.
 
 Where things go: the SOW is opened first (`planning`; the evidence round is analysis, not implementation) and holds
 the decisions, the recorded target, dispositions, and validation evidence; the evidence files named below, the review
@@ -106,9 +106,9 @@ finding, CRITICAL vs TODO. The blocker bar, verify-before-acting, the one-round 
   whose owner is unavailable on the machine as unverifiable.
 
 Probe every fix wrong-to-right and on the normal case (for prose: run the documented commands and re-resolve the
-cited anchors and paths); hold user edit requests until the round closes, or tell the
-reviewers to review the tree as it is. A PR bot review is triaged
-the same way: fix real issues, add no machinery for unlikely edge cases; the mechanics are in `repo-pr-reviews`.
+cited anchors and paths); hold user edit requests until the round closes, or tell the reviewers to review the tree as
+it is. A PR bot review is triaged the same way: fix real issues, add no machinery for unlikely edge cases; the
+mechanics are in `repo-pr-reviews`.
 
 Recurrence seen in skills: findings clustering in relocated prose written from documents, and in descriptions of what
 a tool does. The class fix is contract-only text with a symbol per sentence, or a pointer at the tool, not another

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -132,7 +132,7 @@ tooling rules that have bitten, for the throwaway scripts:
   python3 -c 'import sys
   for f in sys.argv[1:]:
       for n, l in enumerate(open(f), 1):
-          if len(l.rstrip("\n")) > 120 and not l.startswith("|"): print(f"{f}:{n}")' $(git diff --name-only HEAD -- '*.md')
+          if len(l.rstrip("\n")) > 120 and not l.startswith("|"): print(f"{f}:{n}")' $(git diff --name-only --diff-filter=d HEAD -- '*.md')
   ```
 
 - never write an HTML comment opener literally in prose or a code span inside a skill: the headings after it stop

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -120,24 +120,26 @@ The width and reflow-commit rules are `AGENTS.md#durable-ai-facing-artifact-form
 wrapped in its content commit; surviving prose at another width is rewrapped in a separate whitespace-only commit. The
 tooling rules that have bitten, for the throwaway scripts:
 
-- rewrap whole paragraphs with fence-, table-, and list-aware logic; a line starting with `- ` begins a paragraph;
+- rewrap whole paragraphs with fence-, table-, and list-aware logic; a line starting with a dash and a space (a
+  bullet) begins a paragraph;
 - assert that the whitespace-split token stream is unchanged after every rewrap; never auto-join short lines;
 - count characters, not bytes: BSD `awk length` counts bytes, so use Python; re-run the width check on every touched
-  file, including files outside the skill. From the repository root (it reports every non-table line; judge fenced
-  and frontmatter hits by the owner rule instead of rewrapping them):
+  file, including files outside the skill. From the repository root, after staging new files (it checks every
+  changed markdown file and reports every non-table line; judge fenced and frontmatter hits by the owner rule instead
+  of rewrapping them):
 
   ```bash
   python3 -c 'import sys
   for f in sys.argv[1:]:
       for n, l in enumerate(open(f), 1):
-          if len(l.rstrip("\n")) > 120 and not l.startswith("|"): print(f"{f}:{n}")' <files>
+          if len(l.rstrip("\n")) > 120 and not l.startswith("|"): print(f"{f}:{n}")' $(git diff --name-only HEAD -- '*.md')
   ```
 
 - never write an HTML comment opener literally in prose or a code span inside a skill: the headings after it stop
   being scanned (`.agents/skills/README.md#owner-section-citations`);
 - `git diff HEAD` before each commit;
-- on a sensitive-scan hit, phrase around the keyword, not around the value; `.agents/sow/scan-sensitive.sh` defines
-  the hits.
+- on a sensitive-scan hit, use the bracketed placeholders `AGENTS.md#sensitive-data-in-durable-artifacts` prescribes
+  and phrase around the keyword; `.agents/sow/scan-sensitive.sh` defines the hits.
 
 ## Close
 

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -1,0 +1,111 @@
+# Changing A Skill
+
+The method for editing, slimming, splitting, or restructuring an existing skill. It exists because four slims each
+lost rules through the same gaps: inventories that hid sub-clauses and MAY halves, preservation maps with range rows,
+facts relocated from prose instead of from the symbol, and enforcement claims nobody qualified. Every step below
+closes one of those gaps. Evidence lives under `.local/audits/<subject>/`, where the subject is the skill under
+change (`AGENTS.md#local-only-working-directory`). The rules the rewrite must satisfy are in `SKILL.md` "Authoring
+Rules".
+
+## Evidence Round
+
+Before proposing anything, run two independent read-only passes with fresh context, each writing its output file
+before its summary turn. If a pass dies, read its file before re-running; it usually finished the file first.
+
+Census first: per-file line counts, lines over 120 columns, provenance (`git log --follow`). A maintained design
+record and an abandoned one get different options.
+
+`inventory.md`, the preservation baseline:
+
+- one row per rule with a stable id per file; a compound bullet is split into sub-clauses, one row each;
+- the permissive half of a rule (MAY) is its own row, separate from its prohibition;
+- a closed list (enum, token vocabulary) is one row naming its members and their count;
+- a kind per row: MUST, MUST NOT, SHOULD, MAY, fact, enum, pointer, procedure, history, rationale, example, status;
+- aggregate sections: line classification (rules, hard-won facts, restatement, narrative, examples), internal
+  duplication, ownership overlap with code-side documents, cross-skill overlap, task clusters (which files each task
+  opens), reachability (what `SKILL.md` routes), structural facts (external references, CI coupling, audit coupling);
+- the reported row count equals the enumerated ids; fix a mismatch before the map is written.
+
+`staleness.md`, truth against the code:
+
+- every checkable claim labelled FALSE, STALE, DEAD, TRUE-HIGH-VALUE (stated nowhere else), TRUE-DERIVABLE (the reader
+  can get it from the owner), or UNVERIFIABLE (say why);
+- a Tier-1 list: claims that would cause wrong work today;
+- code facts the skill lacks; an authority check (every named authority exists and is hand-maintained); a keep list
+  with stable ids.
+
+Then re-verify every Tier-1 item yourself against the code before presenting anything.
+
+## Recorded Findings And Owners
+
+- Collect the findings already recorded against the skill (the project's follow-up store, past PR bot reviews, open
+  issues) and triage each before proposing scope: fixed here, or rejected with evidence. Close the entry.
+- Owner search: the candidate owners and the generated-file check in `SKILL.md` "Authoring Rules"; the Learn status of
+  each candidate via `docs/.map/map.yaml` (a private owner document gets the marker paragraph of
+  `.agents/skills/README.md#owner-section-citations`, a Learn-published one none); the cross-repo branch when the owner
+  is in another repository.
+- Reference search for every file you may rename or delete (`AGENTS.md#clean-end-state-over-less-churn`): root
+  `AGENTS.md`, sibling skills, `src/**/AGENTS.md`, developer documents, CI path filters and test discovery, code-tree
+  README links, tests, audit globs. The audit catches `.agents/skills/` paths named in any tracked file; only the `../`
+  hop depth of a relative link from a non-skill file is unchecked, so verify the rendered link.
+
+## Options Round
+
+Record the clean-end-state target first (`AGENTS.md#clean-end-state-over-less-churn`), then present numbered options
+with a recommendation (`AGENTS.md#working-with-the-user`): slim in place, split, keep; and, for every keep-list fact
+with no owner, the fork in `SKILL.md` "Authoring Rules". No step plan before the evidence round. The user decides
+scope and design; record the decisions in the SOW before touching an implementation file.
+
+## Rewrite And Preservation Map
+
+Write to the authoring rules. Keep `preservation-map.md` up to date as you write:
+
+- one row per inventory id with a disposition: KEPT (where), CORRECTED (what was wrong, at which symbol), OWNER (the
+  `<path>.md#<anchor>` the skill now cites), DROPPED (the reason: false against the code at a named symbol, superseded
+  by a named owner, or a numbered user decision);
+- a range row only when every id in the range was opened, and never for a disposition that claims a pre-existing
+  owner: every leak in three review rounds hid inside such a range;
+- every keep-list item maps to the section that now holds it.
+
+Relocating a fact into a shipped document: write each sentence from the symbol, contract-level, with the symbol named,
+in the receiving document's register. A coupled fix in an owner document (a dangling reference, a one-word
+correction) is included when low-risk and disclosed.
+
+## Review Round
+
+One reviewer per lens, fresh context, full scope, the working tree as it is at round start, one proposed fix per
+finding, CRITICAL vs TODO. The blocker bar, verify-before-acting, the one-round default, and the recurrence guard are
+`AGENTS.md#review`.
+
+- Preservation lens: receives `inventory.md`, the keep list, and `preservation-map.md`; checks that every row and keep
+  item is reachable from the new skill or the cited owner section; flags dropped permissive clauses and range rows.
+- Correctness lens: receives the code and the owner documents, never the old skill text; checks every fact at its
+  symbol, every enforcement qualifier, every command as written, every anchor.
+
+Verify every finding against the code before acting; probe every fix wrong-to-right and on the normal case; hold user
+edit requests until the round closes, or tell the reviewers to review the tree as it is. A PR bot review is triaged
+the same way: fix real issues, add no machinery for unlikely edge cases; the mechanics are in `repo-pr-reviews`.
+
+Recurrence seen in skills: findings clustering in relocated prose that was written from documents. The class fix is
+contract-only text with a symbol per sentence, not another round of patches.
+
+## Mechanical Hygiene
+
+The width and reflow-commit rules are `AGENTS.md#durable-ai-facing-artifact-formatting`. The tooling rules that have
+bitten:
+
+- rewrap whole paragraphs with fence-, table-, and list-aware logic; a line starting with `- ` begins a paragraph;
+- assert token-stream equality after every rewrap; never auto-join short lines;
+- count characters, not bytes; re-run the width check on every touched file, including files outside the skill;
+- `git diff HEAD` before each commit;
+- the sensitive scanner treats the word community followed by a colon and a value as an SNMP credential; phrase
+  around it.
+
+## Close
+
+- `bash .agents/sow/audit.sh` before every commit and at close: it is the only check for names, index agreement, skill
+  paths, owner-section anchors, legacy identifiers, and the sensitive scan.
+- Line counts before and after per touched file; a symbol sweep of every cited identifier and path; the reference
+  search re-run; the slimming pass over every touched skill (`AGENTS.md#project-skills`).
+- Follow-ups tracked and the artifact gate recorded (`AGENTS.md#followup-discipline`,
+  `AGENTS.md#artifact-maintenance-gate`); a lesson about the method goes into `SKILL.md` "Maintaining This Skill".

--- a/.agents/skills/repo-skill-authoring/change-method.md
+++ b/.agents/skills/repo-skill-authoring/change-method.md
@@ -3,17 +3,19 @@
 The method for editing, slimming, splitting, or restructuring an existing skill. It exists because past slims each
 lost rules through the same gaps: inventories that hid sub-clauses and MAY halves, preservation maps with range rows,
 facts relocated from prose instead of from the symbol, and enforcement claims nobody qualified. Every step below
-closes one of those gaps. Evidence lives under `.local/audits/<subject>/` (`AGENTS.md#local-only-working-directory`);
-throwaway tooling written for a change (width check, rewrap, symbol sweep) lives there too. The rules the rewrite must
-satisfy are in `SKILL.md` "Authoring Rules". There is no size target: the end state is defined by those rules, and
-line counts are reported, not aimed at.
+closes one of those gaps. The rules the rewrite must satisfy are in `./SKILL.md#authoring-rules`. There is no size
+target: the end state is defined by those rules, and line counts are reported, not aimed at.
+
+Where things go: decisions, the recorded target, dispositions, and validation evidence go in the SOW; the evidence
+files named below, the review reports (`review-r<n>-<lens>.md`), and any throwaway tooling written for the change go
+under `.local/audits/<subject>/` (`AGENTS.md#local-only-working-directory`).
 
 ## Evidence Round
 
 Before proposing anything, run two independent read-only passes with fresh context (subagents or external
-assistants), each given the skill directory, the owner candidates found so far, and the output format below, and each
-writing its output file before its summary turn. If a pass dies, read its file before re-running; it usually finished
-the file first.
+assistants, one per pass), each given the skill directory, the owner candidates found so far, and the output format
+below, and each writing its output file before its summary turn. If a pass dies, read its file before re-running; it
+usually finished the file first. When the passes disagree on a claim, the code decides: re-verify it yourself.
 
 `inventory.md`, the preservation baseline, opens with a census: per-file line counts, lines over 120 columns,
 provenance (`git log --follow -- <path>`). A maintained design record and an abandoned one get different options.
@@ -41,26 +43,25 @@ Then re-verify every Tier-1 item yourself against the code before presenting any
 ## Recorded Findings And Owners
 
 - Collect the findings already recorded against the skill (GitHub issues per `AGENTS.md#followup-discipline`, the
-  local stores under `.local/`, past PR bot reviews) and triage each before proposing scope: fixed here, or rejected
-  with evidence. Close the entry.
-- Owner search: the candidate owners and the generated-file check in `SKILL.md` "Authoring Rules"; the Learn status of
+  local stores `.local/sow/` and `.local/audits/<subject>/followups.md`, past PR bot reviews) and triage each before
+  proposing scope: fixed here, or rejected with evidence. Close the entry.
+- Owner search: the candidate owners and the generated-file check in `./SKILL.md#authoring-rules`; the Learn status of
   each candidate via `docs/.map/map.yaml` (a private owner document gets the marker paragraph of
   `.agents/skills/README.md#owner-section-citations`, a Learn-published one none); an owner in another repository is
-  read from the local mirror and cited as `SKILL.md` "Authoring Rules" says.
+  read from the local mirror and cited as `./SKILL.md#authoring-rules` says.
 - Reference search for every file you may rename or delete (`AGENTS.md#clean-end-state-over-less-churn`): root
   `AGENTS.md`, sibling skills, `src/**/AGENTS.md`, developer documents, CI path filters and test discovery, code-tree
   README links, tests, audit globs. The audit checks repository-relative `.agents/skills/` paths in tracked files
-  (`CHANGELOG.md` excluded), `../` links written as markdown links or `source` lines inside skill files, and anchor
-  citations inside skill files. Everything else is verified by hand: `./`, sibling, and subdirectory links, bare
-  filenames, `docs/netdata-ai/skills/` paths named outside a skill file, and the hop depth of a relative link from a
-  non-skill file.
+  (`CHANGELOG.md` excluded), `../` markdown links and `source` lines inside skill files, and anchor citations inside
+  skill files. Everything else is verified by hand: `./`, sibling, and subdirectory links, bare filenames,
+  `docs/netdata-ai/skills/` paths anywhere, and the hop depth of a relative link from a non-skill file.
 
 ## Options Round
 
 Record the clean-end-state target first (`AGENTS.md#clean-end-state-over-less-churn`), then present numbered options
-with a recommendation (`AGENTS.md#working-with-the-user`): slim in place, split, keep; and, for every keep-list fact
-with no owner, the fork in `SKILL.md` "Authoring Rules". No step plan before the evidence round. The user decides
-scope and design.
+with a recommendation (`AGENTS.md#working-with-the-user`): slim in place, split (the split test is in
+`./SKILL.md#authoring-rules`), keep; and, for every keep-list fact with no owner, the fork in the same section. No
+step plan before the evidence round. The user decides scope and design.
 
 ## Rewrite And Preservation Map
 
@@ -73,7 +74,7 @@ Write to the authoring rules. Keep `preservation-map.md` up to date as you write
   owner: every leak the topology slim's review rounds found hid inside such a range;
 - every keep-list item maps to the section that now holds it.
 
-Relocating a fact into a shipped document follows the citation and register rules in `SKILL.md` "Authoring Rules". A
+Relocating a fact into a shipped document follows the citation and register rules in `./SKILL.md#authoring-rules`. A
 coupled fix in an owner document (a dangling reference, a one-word correction) is included when low-risk and
 disclosed.
 
@@ -98,22 +99,34 @@ contract-only text with a symbol per sentence, not another round of patches.
 ## Mechanical Hygiene
 
 The width and reflow-commit rules are `AGENTS.md#durable-ai-facing-artifact-formatting`. The tooling rules that have
-bitten, for the throwaway scripts under `.local/audits/<subject>/`:
+bitten, for the throwaway scripts:
 
 - rewrap whole paragraphs with fence-, table-, and list-aware logic; a line starting with `- ` begins a paragraph;
 - assert that the whitespace-split token stream is unchanged after every rewrap; never auto-join short lines;
-- count characters, not bytes (Python `len`, not `awk length`); re-run the width check on every touched file,
-  including files outside the skill;
+- count characters, not bytes: BSD `awk length` counts bytes, so use Python; re-run the width check on every touched
+  file, including files outside the skill:
+
+  ```bash
+  .venv/bin/python3 -c 'import sys
+  for f in sys.argv[1:]:
+      for n, l in enumerate(open(f), 1):
+          if len(l.rstrip("\n")) > 120 and not l.startswith("|"): print(f"{f}:{n}")' <files>
+  ```
+
+- never write an HTML comment opener literally in prose or a code span: the audit's anchor scan treats it as the start
+  of a comment and stops seeing headings until a closer appears;
 - `git diff HEAD` before each commit;
-- the sensitive scanner treats the word community (also with an `snmp`, `ro`, `rw`, or `string` affix) followed by a
-  colon or an equals sign and a value of three or more characters as an SNMP credential unless the value is a
-  placeholder such as `[REDACTED_SECRET]`; phrase around it.
+- the sensitive scanner (`.agents/sow/scan-sensitive.sh`) flags an SNMP community keyword followed by a colon or an
+  equals sign and a value; its placeholder exemption is a short whole-word list, so a redaction token is still
+  flagged. Phrase around the keyword rather than relying on a placeholder.
 
 ## Close
 
-- `bash .agents/sow/audit.sh` before every commit and at close, after `git add` of every new file: it is the only local
-  check for the items `AGENTS.md#enforcement` lists, and CI re-runs only the sensitive scan.
-- Line counts before and after per touched file; a symbol sweep of every cited identifier and path; the reference
-  search re-run; the slimming pass over every touched skill (`AGENTS.md#project-skills`).
+- `bash .agents/sow/audit.sh` before every commit and at close, after `git add` of every new file: it is the only check
+  for the skills items `AGENTS.md#enforcement` lists; CI (`.github/workflows/sow.yml`) re-runs the sensitive scan and
+  the committed-working-files check and no skills check.
+- Line counts before and after per touched file; a symbol sweep (grep the tree for every backticked identifier and
+  path the skill cites); the reference search re-run; the slimming pass over every touched skill
+  (`AGENTS.md#project-skills`).
 - Follow-ups tracked and the artifact gate recorded (`AGENTS.md#followup-discipline`,
-  `AGENTS.md#artifact-maintenance-gate`); a lesson about the method goes into `SKILL.md` "Maintaining This Skill".
+  `AGENTS.md#artifact-maintenance-gate`); a lesson about the method goes into `./SKILL.md#maintaining-this-skill`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,7 +523,7 @@ relative/path/inside/repo:line
 ```
 
 Resolve `owner/repo` from the repository remote, record the checked commit, keep paths relative to the upstream
-root. Never write absolute paths into SOW evidence.
+root. Never write absolute paths into SOW or skill evidence.
 
 ### Specs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,6 +554,8 @@ Project skills are memory of HOW to work here.
 - Every change to a skill MUST end with a slimming pass over the touched files: remove restatements, merged-in
   duplicates, and rules that now live elsewhere, keeping every rule (a removed directive is moved or superseded by a
   recorded decision, never dropped). Skills accrete bloat with each update; report line counts before and after.
+- How to create, edit, slim, split, or review a skill, and the rot signals to watch for: the runtime skill
+  `repo-skill-authoring`.
 
 Public skill convention (`docs/netdata-ai/skills/`):
 
@@ -656,6 +658,9 @@ and the rule for adding one; each skill's frontmatter description is the authori
   - `repo-pr-reviews`: PR comment and review iteration
   - `repo-mirror-sources`: setting up or syncing the local mirror of Netdata-org repos at `${NETDATA_REPOS_DIR}`;
     reset-to-default safety; `--repo` scoping
+  - `repo-skill-authoring`: creating, editing, slimming, splitting, or reviewing a skill; skill rot; the authoring
+    rules (point at the owner, one owner per fact, symbols not line numbers, qualified enforcement claims), the change
+    method (evidence round, numbered options, row-level preservation map, two-lens review), the rot signals
 
 Public skills (canonical under `docs/netdata-ai/skills/<name>/`, symlinked at `.agents/skills/<name>`):
 
@@ -724,6 +729,7 @@ renames:
 | `triage-agent-events` | `query-agent-events/` | fetched event batches |
 | `repo-pr-reviews` | `pr-reviews/` | per-PR comment and review caches |
 | `collectors-prometheus-profiles` | `prometheus-profiles/` | captured exposition dumps |
+| `repo-skill-authoring` | `<subject>/` | inventory, staleness, preservation map, and review reports of a skill change, in a directory named after the skill or SOW topic under change |
 | `query-netdata-agents` (public) | `query-netdata-agents/` | output of the agent-query wrappers and the bearer cache |
 | `query-netdata-cloud` (public) | `query-netdata-cloud/` | saved Cloud API responses from its how-tos |
 | `query-snmp-traps` (public) | `query-snmp-traps/` | saved trap query results from its how-tos |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,8 +514,8 @@ files, and other docs written so future AI agents can execute repository rules c
 
 ### Open-Source Reference Evidence
 
-When SOW evidence comes from another open-source repository, cite the upstream repository and the checked commit,
-never the workstation path:
+When evidence in a SOW or a skill comes from another open-source repository, cite the upstream repository and the
+checked commit, never the workstation path:
 
 ```text
 owner/repo @ commit
@@ -659,9 +659,9 @@ and the rule for adding one; each skill's frontmatter description is the authori
   - `repo-pr-reviews`: PR comment and review iteration
   - `repo-mirror-sources`: setting up or syncing the local mirror of Netdata-org repos at `${NETDATA_REPOS_DIR}`;
     reset-to-default safety; `--repo` scoping
-  - `repo-skill-authoring`: creating, editing, slimming, splitting, or reviewing a skill; skill rot; the authoring
-    rules (point at the owner, one owner per fact, symbols not line numbers, qualified enforcement claims), the change
-    method (evidence round, numbered options, row-level preservation map, two-lens review), the rot signals
+  - `repo-skill-authoring`: creating, editing, slimming, splitting, or reviewing a skill; the authoring rules (point
+    at the owner, one owner per fact, symbols not line numbers, qualified enforcement claims), the change method
+    (evidence round, numbered options, row-level preservation map, two-lens review), the rot signals
 
 Public skills (canonical under `docs/netdata-ai/skills/<name>/`, symlinked at `.agents/skills/<name>`):
 
@@ -730,13 +730,14 @@ renames:
 | `triage-agent-events` | `query-agent-events/` | fetched event batches |
 | `repo-pr-reviews` | `pr-reviews/` | per-PR comment and review caches |
 | `collectors-prometheus-profiles` | `prometheus-profiles/` | captured exposition dumps |
-| `repo-skill-authoring` | `<subject>/` | inventory, staleness, preservation map, review reports, and throwaway tooling of a skill change; `<subject>` is the directory name of the skill under change (distinct from that skill's own pinned output directory) or the SOW topic |
+| `repo-skill-authoring` | `<subject>/` | inventory, staleness, preservation map, review reports, and throwaway tooling of a skill change |
 | `query-netdata-agents` (public) | `query-netdata-agents/` | output of the agent-query wrappers and the bearer cache |
 | `query-netdata-cloud` (public) | `query-netdata-cloud/` | saved Cloud API responses from its how-tos |
 | `query-snmp-traps` (public) | `query-snmp-traps/` | saved trap query results from its how-tos |
 
 A new runtime skill picks a `<dir>` equal to its topic; a public skill uses its skill name; `repo-skill-authoring` is
-the exception, writing under the name of the skill it changes. All record the row here.
+the exception: its `<subject>` is the directory name of the skill under change (distinct from that skill's own pinned
+directory) or the SOW topic. All record the row here.
 
 ### Per-User Secrets
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -555,7 +555,8 @@ Project skills are memory of HOW to work here.
   duplicates, and rules that now live elsewhere, keeping every rule (a removed directive is moved or superseded by a
   recorded decision, never dropped). Skills accrete bloat with each update; report line counts before and after.
 - How to create, edit, slim, split, or review a skill, and the rot signals to watch for: the runtime skill
-  `repo-skill-authoring`.
+  `repo-skill-authoring`. It cites sections of this file and of `.agents/skills/README.md` by heading anchor, so a
+  heading rename in either fails the audit until that skill is updated.
 
 Public skill convention (`docs/netdata-ai/skills/`):
 
@@ -729,12 +730,13 @@ renames:
 | `triage-agent-events` | `query-agent-events/` | fetched event batches |
 | `repo-pr-reviews` | `pr-reviews/` | per-PR comment and review caches |
 | `collectors-prometheus-profiles` | `prometheus-profiles/` | captured exposition dumps |
-| `repo-skill-authoring` | `<subject>/` | inventory, staleness, preservation map, and review reports of a skill change, in a directory named after the skill or SOW topic under change |
+| `repo-skill-authoring` | `<subject>/` | inventory, staleness, preservation map, review reports, and throwaway tooling of a skill change; `<subject>` is the directory name of the skill under change (distinct from that skill's own pinned output directory) or the SOW topic |
 | `query-netdata-agents` (public) | `query-netdata-agents/` | output of the agent-query wrappers and the bearer cache |
 | `query-netdata-cloud` (public) | `query-netdata-cloud/` | saved Cloud API responses from its how-tos |
 | `query-snmp-traps` (public) | `query-snmp-traps/` | saved trap query results from its how-tos |
 
-A new runtime skill picks a `<dir>` equal to its topic; a public skill uses its skill name. Both record the row here.
+A new runtime skill picks a `<dir>` equal to its topic; a public skill uses its skill name; `repo-skill-authoring` is
+the exception, writing under the name of the skill it changes. All record the row here.
 
 ### Per-User Secrets
 


### PR DESCRIPTION
##### Summary

The how-to for creating, editing, slimming, and reviewing skills.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `repo-skill-authoring` skill that documents how to create, edit, slim, split, or review skills, including the authoring rules, change method, and rot signals. It points to existing owner documents instead of restating facts, and updates the index, audit table, and open-source evidence rule in `AGENTS.md` plus the skills README.

**Key points**
- The change method requires an evidence round, numbered options, a preservation map, and a two-lens review to prevent rule loss.
- The skill cites `AGENTS.md` and `.agents/skills/README.md` by heading anchor, so a heading rename fails the audit until the skill is updated.
- Facts about the audit, CI, and scanner scripts are attributed to those scripts, not described, since descriptions kept regressing.

<sup>Written for commit 4b8273cb7fc604edef15fd68136dc88d580a7874. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for creating, editing, slimming, splitting, reviewing, and maintaining repository skills.
  - Added a structured workflow for modifying existing skills, including evidence collection, review, validation, and follow-up tracking.
  - Updated skill ownership, citation, indexing, and local working-directory guidance.
  - Clarified that open-source references must identify the upstream repository and checked commit.
  - Improved navigation with anchored references and added checks for citation accuracy, documentation quality, and maintenance issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->