### PR TITLE
Validate typed set cells in topology scalar columns

### DIFF
--- a/.agents/skills/topology-authoring/SKILL.md
+++ b/.agents/skills/topology-authoring/SKILL.md
@@ -67,6 +67,9 @@ State these as facts in reviews; do not re-derive them, and do not claim enforce
   `--schema ../plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json` from `src/go`
   (`src/go/tools/functions-validation/README.md#validate-topology-v1-fixtures`); it then calls
   `ValidateDecodedResponse`.
+- Go builders (`Table.Validate`) and the decoded semantic validator enforce typed-set member types and nullability
+  as errors across the compact-table codecs. Contract: `src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md#compact-tables`;
+  validation workflow: `src/go/tools/functions-validation/README.md#validate-topology-v1-fixtures`.
 - The CLI tool (`src/go/tools/functions-validation`) counts a topology payload's rows as
   `max(actor rows, link rows)` (`topologyv1.GraphRowsFromDecodedData`) for its `--min-rows` and `--require-rows`
   gates, so an actor-only payload passes; nothing in `pkg/topology` caps row counts.

--- a/.agents/skills/topology-authoring/SKILL.md
+++ b/.agents/skills/topology-authoring/SKILL.md
@@ -67,8 +67,9 @@ State these as facts in reviews; do not re-derive them, and do not claim enforce
   `--schema ../plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json` from `src/go`
   (`src/go/tools/functions-validation/README.md#validate-topology-v1-fixtures`); it then calls
   `ValidateDecodedResponse`.
-- Go builders (`Table.Validate`) and the decoded semantic validator enforce typed-set member types and nullability
-  as errors across the compact-table codecs. Contract: `src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md#compact-tables`;
+- Go builders (`Table.Validate`) and the decoded semantic validator enforce scalar numeric validity, typed-set member
+  types, and nullability as errors across the compact-table codecs.
+  Contract: `src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md#compact-tables`;
   validation workflow: `src/go/tools/functions-validation/README.md#validate-topology-v1-fixtures`.
 - The CLI tool (`src/go/tools/functions-validation`) counts a topology payload's rows as
   `max(actor rows, link rows)` (`topologyv1.GraphRowsFromDecodedData`) for its `--min-rows` and `--require-rows`

--- a/.agents/skills/topology-authoring/SKILL.md
+++ b/.agents/skills/topology-authoring/SKILL.md
@@ -53,7 +53,8 @@ State these as facts in reviews; do not re-derive them, and do not claim enforce
 - Go semantic validator (`topologyv1.ValidateDecodedData` on `data`, `topologyv1.ValidateDecodedResponse` on a whole
   envelope; both return an error, there is no warning level): actor and link reference bounds (evidence references
   only where the table type declares `source_evidence`), column-length equality with `rows`,
-  dictionary indexes, label-policy display types, search columns, the `ports.sources[]` rules except the
+  dictionary indexes, label-policy display types, search columns and label-key shape independently of optional actor
+  presentation, declared actor aggregation-scope memberships, the `ports.sources[]` rules except the
   `actor_table` carve-out below (and `show_bullets` is read untyped, so only the schema rejects a non-boolean),
   highlight-path column types (including that a `path_table` not under `data.tables.actor` is owned by `actor`, the
   one use the validator makes of `table_type.owner`), every overlay-refs convention rule except the id-pattern rule (schema-only), correlation rules

--- a/.github/workflows/topology-container-tests.yml
+++ b/.github/workflows/topology-container-tests.yml
@@ -145,9 +145,13 @@ jobs:
             fi
             python3 src/collectors/network-viewer.plugin/tests/validate_topology_payload.py "$out" "$@"
           }
-          validate aggregated '{}' --mode aggregated --group-by process_name
-          validate pid '{"selections":{"group_by":"pid"}}' --mode aggregated --group-by pid
-          validate detailed '{"selections":{"__topology_mode":"detailed","mode":"detailed"}}' --mode detailed
+          validate default '{}' --mode aggregated --group-by process_name
+          validate aggregated-process-name '{"selections":{"__topology_mode":"aggregated","mode":"aggregated","group_by":"process_name"}}' --mode aggregated --group-by process_name
+          validate aggregated-pid '{"selections":{"__topology_mode":"aggregated","mode":"aggregated","group_by":"pid"}}' --mode aggregated --group-by pid
+          validate aggregated-container '{"selections":{"__topology_mode":"aggregated","mode":"aggregated","group_by":"container"}}' --mode aggregated --group-by container
+          validate detailed-process-name '{"selections":{"__topology_mode":"detailed","mode":"detailed","group_by":"process_name"}}' --mode detailed --group-by process_name
+          validate detailed-pid '{"selections":{"__topology_mode":"detailed","mode":"detailed","group_by":"pid"}}' --mode detailed --group-by pid
+          validate detailed-container '{"selections":{"__topology_mode":"detailed","mode":"detailed","group_by":"container"}}' --mode detailed --group-by container
 
   asan-tests:
     name: Unit Tests (ASAN)

--- a/src/collectors/network-viewer.plugin/network-viewer-topology.c
+++ b/src/collectors/network-viewer.plugin/network-viewer-topology.c
@@ -4120,7 +4120,6 @@ static void topology_v1_emit_type_registry(
     static const char *const self_scopes[] = { "node" };
     static const char *const process_scopes[] = { "process_name", "pid" };
     static const char *const container_scopes[] = { "container" };
-    static const char *const endpoint_scopes[] = { "endpoint" };
     const char *process_merge_a = "process";
     const char *process_merge_b = NULL;
 
@@ -4149,7 +4148,7 @@ static void topology_v1_emit_type_registry(
                 topology_v1_emit_runtime_actor_type(
                     wb, payload, &topology_runtime_actor_types[i], container_scopes, _countof(container_scopes), group_by, detailed);
             topology_v1_emit_actor_type(
-                wb, payload, "endpoint", "ip", "address_space", endpoint_scopes, _countof(endpoint_scopes),
+                wb, payload, "endpoint", "ip", "address_space", NULL, 0,
                 "Correlation endpoint", "derived", "remote-endpoint", "endpoint", true, "fixed", NULL, "compact", "weaker", false, NULL,
                 group_by,
                 detailed,

--- a/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
+++ b/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
@@ -52,26 +52,37 @@ def load_payload(path):
 
 
 def aggregation_scope_reference_errors(types):
-    """Return actor-type references that have no matching scope definition."""
+    """Require well-formed actor scope memberships and declared scope IDs."""
     if not isinstance(types, dict):
-        return []
+        return ["types is not an object"]
 
     actor_types = types.get("actor_types")
     aggregation_scopes = types.get("aggregation_scopes", {})
-    if not isinstance(actor_types, dict) or not isinstance(aggregation_scopes, dict):
-        return []
+    if not isinstance(actor_types, dict):
+        return ["types.actor_types is not an object"]
+    if not isinstance(aggregation_scopes, dict):
+        return ["types.aggregation_scopes is not an object"]
 
     errors = []
     for actor_type_id, actor_type in actor_types.items():
         if not isinstance(actor_type, dict):
+            errors.append(f"actor type {actor_type_id!r} is not an object")
             continue
         actor_scopes = actor_type.get("aggregation_scopes", [])
         if not isinstance(actor_scopes, list):
             errors.append(
                 f"actor type {actor_type_id!r} aggregation_scopes is not an array")
             continue
+        seen = set()
         for scope_id in actor_scopes:
-            if isinstance(scope_id, str) and scope_id not in aggregation_scopes:
+            if not isinstance(scope_id, str) or not scope_id:
+                errors.append(
+                    f"actor type {actor_type_id!r} aggregation_scopes members must be non-empty strings")
+                continue
+            if scope_id in seen:
+                errors.append(f"actor type {actor_type_id!r} repeats aggregation scope {scope_id!r}")
+            seen.add(scope_id)
+            if scope_id not in aggregation_scopes:
                 errors.append(
                     f"actor type {actor_type_id!r} references undefined "
                     f"aggregation scope {scope_id!r}")
@@ -105,7 +116,7 @@ def semantic_checks(data, expect_mode=None, expect_group_by=None):
         t = d.get(table)
         if not isinstance(t, dict) or "columns" not in t or "values" not in t:
             errors.append(f"{table} table missing columns/values")
-    if "types" not in d or "actor_types" not in d.get("types", {}):
+    if not isinstance(d.get("types"), dict) or "actor_types" not in d["types"]:
         errors.append("missing types.actor_types registry")
     else:
         errors.extend(aggregation_scope_reference_errors(d["types"]))
@@ -206,7 +217,121 @@ def run_self_test():
             "self-test FAILED: topology schema did not select Draft 2020-12; got",
             validator.__class__.__name__)
         return 1
+    if run_payload_validation_self_test(schema_file):
+        return 1
     print("self-test OK")
+    return 0
+
+
+def self_test_payload_result(data, schema_file, missing_dependency, expected, prefix):
+    """Check status and diagnostic prefix to pin validation-branch precedence."""
+    from contextlib import redirect_stdout
+    from unittest.mock import patch
+
+    unavailable = {"jsonschema": None} if missing_dependency else {}
+    with patch.dict(sys.modules, unavailable), redirect_stdout(io.StringIO()) as output:
+        result = validate_payload(data, schema_file, None, None)
+    if result != expected or not output.getvalue().startswith(prefix):
+        print("self-test FAILED: payload validation result", result, output.getvalue())
+        return False
+    return True
+
+
+def run_payload_validation_self_test(schema_file):
+    """Exercise the actual validator with and without its optional dependency."""
+    fixture = os.path.join(
+        os.path.dirname(schema_file), "..", "go", "tools", "functions-validation",
+        "fixtures", "topology-v1", "network-connections.json")
+    payload = load_payload(fixture)
+    payload["v"] = 3
+    for missing in (False, True):
+        cases = (
+            (payload, 0, "jsonschema not available;" if missing else "OK:"),
+            (dict(payload, v=2), 1, "SEMANTIC FAILURES:"),
+            (dict(payload, unexpected=True), 0 if missing else 1,
+             "jsonschema not available;" if missing else "SCHEMA FAILURES"),
+            (dict(payload, v=2, unexpected=True), 1,
+             "SEMANTIC FAILURES:" if missing else "SCHEMA FAILURES"),
+        )
+        for data, expected, prefix in cases:
+            if not self_test_payload_result(data, schema_file, missing, expected, prefix):
+                return 1
+    return (run_scope_validation_self_test(payload, schema_file)
+            or run_schema_errors_self_test(payload))
+
+
+def run_scope_validation_self_test(payload, schema_file):
+    """Reject malformed scope metadata even when JSON Schema is unavailable."""
+    import copy
+
+    bad_objects = (None, True, 7, 1.5, "scope", [])
+    cases = (
+        (("types",), bad_objects, True),
+        (("types", "actor_types"), bad_objects, True),
+        (("types", "aggregation_scopes"), bad_objects, True),
+        (("types", "actor_types", "process"), bad_objects, True),
+        (("types", "actor_types", "process", "aggregation_scopes"),
+         (None, True, 7, 1.5, "pid", {}, [None], [True], [7], [1.5], [{}], [[]], [""],
+          ["pid", "pid"]), True),
+        (("types", "actor_types", "process", "aggregation_scopes"), (["undefined_scope"],), False),
+    )
+    for path, values, schema_rejects in cases:
+        for value in values:
+            data = copy.deepcopy(payload)
+            target = data["data"]
+            for key in path[:-1]:
+                target = target[key]
+            target[path[-1]] = value
+            for missing in (False, True):
+                prefix = "SCHEMA FAILURES" if schema_rejects and not missing else "SEMANTIC FAILURES:"
+                if not self_test_payload_result(data, schema_file, missing, 1, prefix):
+                    print("scope case:", path, repr(value), "missing dependency:", missing)
+                    return 1
+
+    for omit_memberships in (False, True):
+        for omit_registry in (False, True):
+            data = copy.deepcopy(payload)
+            types = data["data"]["types"]
+            for actor_type in types["actor_types"].values():
+                actor_type["aggregation_scopes"] = []
+                if omit_memberships:
+                    actor_type.pop("aggregation_scopes")
+            types["aggregation_scopes"] = {}
+            if omit_registry:
+                types.pop("aggregation_scopes")
+            for missing in (False, True):
+                prefix = "jsonschema not available;" if missing else "OK:"
+                if not self_test_payload_result(data, schema_file, missing, 0, prefix):
+                    return 1
+    return 0
+
+
+def run_schema_errors_self_test(payload):
+    """Schema file errors must not be mistaken for a missing optional library."""
+    import tempfile
+    from contextlib import redirect_stdout
+    from unittest.mock import patch
+    from jsonschema.exceptions import SchemaError
+
+    cases = (("{", False, json.JSONDecodeError), ("{", True, json.JSONDecodeError),
+             ('{"type":"invalid"}', False, SchemaError), ('{"type":"invalid"}', True, None))
+    for content, missing, exception in cases:
+        with tempfile.TemporaryDirectory() as directory:
+            schema_file = os.path.join(directory, "schema.json")
+            with io.open(schema_file, "w", encoding="utf-8") as output:
+                output.write(content)
+            if exception is None:
+                if not self_test_payload_result(payload, schema_file, missing, 0, "jsonschema not available;"):
+                    return 1
+                continue
+            unavailable = {"jsonschema": None} if missing else {}
+            try:
+                with patch.dict(sys.modules, unavailable), redirect_stdout(io.StringIO()):
+                    validate_payload(payload, schema_file, None, None)
+            except exception:
+                continue
+            print("self-test FAILED: schema file did not raise", exception.__name__)
+            return 1
     return 0
 
 
@@ -241,7 +366,7 @@ def validate_payload(data, schema_file, expect_mode, expect_group_by):
     schema = json.load(io.open(schema_file, encoding='utf-8'))
 
     try:
-        import jsonschema
+        validator = schema_validator(schema)
     except ImportError:
         errors = semantic_checks(data, expect_mode, expect_group_by)
         if errors:
@@ -252,7 +377,6 @@ def validate_payload(data, schema_file, expect_mode, expect_group_by):
         print("jsonschema not available; semantic checks passed")
         return 0
 
-    validator = schema_validator(schema)
     errs = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
     if errs:
         print(f"SCHEMA FAILURES ({len(errs)}):")

--- a/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
+++ b/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
@@ -89,6 +89,40 @@ def aggregation_scope_reference_errors(types):
     return errors
 
 
+def actor_search_label_key_errors(types):
+    """Validate optional search label keys without normalizing literal keys."""
+    if not isinstance(types, dict) or not isinstance(types.get("actor_types"), dict):
+        return []
+
+    errors = []
+    for actor_type_id, actor_type in types["actor_types"].items():
+        if not isinstance(actor_type, dict):
+            continue
+        search = actor_type.get("search")
+        # A null policy is absent in semantic-only validation, matching the Go helper.
+        if search is None:
+            continue
+        path = f"actor type {actor_type_id!r} search"
+        if not isinstance(search, dict):
+            errors.append(f"{path} is not an object")
+            continue
+        if "label_keys" not in search:
+            continue
+        keys = search["label_keys"]
+        if not isinstance(keys, list):
+            errors.append(f"{path}.label_keys is not an array")
+            continue
+        seen = set()
+        for key in keys:
+            if not isinstance(key, str) or not key:
+                errors.append(f"{path}.label_keys members must be non-empty strings")
+                continue
+            if key in seen:
+                errors.append(f"{path}.label_keys repeats {key!r}")
+            seen.add(key)
+    return errors
+
+
 def network_viewer_actor_type_errors(types):
     """Enforce network-viewer's endpoint actor contract."""
     if not isinstance(types, dict) or not isinstance(types.get("actor_types"), dict):
@@ -121,6 +155,7 @@ def semantic_checks(data, expect_mode=None, expect_group_by=None):
     else:
         errors.extend(aggregation_scope_reference_errors(d["types"]))
         errors.extend(network_viewer_actor_type_errors(d["types"]))
+        errors.extend(actor_search_label_key_errors(d["types"]))
     if "presentation" not in d:
         errors.append("missing presentation")
     view = d.get("view")
@@ -257,6 +292,7 @@ def run_payload_validation_self_test(schema_file):
             if not self_test_payload_result(data, schema_file, missing, expected, prefix):
                 return 1
     return (run_scope_validation_self_test(payload, schema_file)
+            or run_search_validation_self_test(payload, schema_file)
             or run_schema_errors_self_test(payload))
 
 
@@ -302,6 +338,44 @@ def run_scope_validation_self_test(payload, schema_file):
             for missing in (False, True):
                 prefix = "jsonschema not available;" if missing else "OK:"
                 if not self_test_payload_result(data, schema_file, missing, 0, prefix):
+                    return 1
+    return 0
+
+
+def run_search_validation_self_test(payload, schema_file):
+    """Validate literal label keys independently of presentation and schema availability."""
+    import copy
+
+    omitted = object()
+    cases = [
+        (omitted, 0, 0), ({}, 0, 0), ({"label_keys": []}, 0, 0),
+        ({"label_keys": ["_hostname", "_os", "_labels", "app/name", "主机", " ", "\t",
+                         " _hostname ", "é", "e\u0301"]}, 0, 0),
+        (None, 1, 0), ({"enabled": 7}, 1, 0), ({"columns": None}, 1, 0),
+        ({"enabled": False, "label_keys": [""]}, 1, 1),
+    ]
+    cases.extend((value, 1, 1) for value in (False, 7, 1.5, "", []))
+    invalid_keys = (None, False, 7, 1.5, "", {}, [""], ["_hostname", "_hostname"],
+                    [7], [None], [True], [{}], [[]], [" ", " "])
+    cases.extend(({"label_keys": value}, 1, 1) for value in invalid_keys)
+    for search, schema_result, fallback_result in cases:
+        for omit_presentation in (False, True):
+            data = copy.deepcopy(payload)
+            actor_type = data["data"]["types"]["actor_types"]["process"]
+            if omit_presentation:
+                actor_type.pop("presentation", None)
+            if search is omitted:
+                actor_type.pop("search", None)
+            else:
+                actor_type["search"] = search
+            for missing in (False, True):
+                expected = fallback_result if missing else schema_result
+                prefix = "jsonschema not available;" if missing else "OK:"
+                if expected:
+                    prefix = "SEMANTIC FAILURES:" if missing else "SCHEMA FAILURES"
+                if not self_test_payload_result(data, schema_file, missing, expected, prefix):
+                    print("search case:", repr(search), "missing dependency:", missing,
+                          "without presentation:", omit_presentation)
                     return 1
     return 0
 

--- a/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
+++ b/src/collectors/network-viewer.plugin/tests/validate_topology_payload.py
@@ -21,6 +21,15 @@ import sys
 import os
 
 
+def schema_validator(schema):
+    """Build the validator selected by the schema's declared draft."""
+    import jsonschema
+
+    validator_class = jsonschema.validators.validator_for(schema)
+    validator_class.check_schema(schema)
+    return validator_class(schema)
+
+
 def load_payload(path):
     raw = io.open(path, encoding='utf-8', errors='replace').read()
     if raw.startswith("FUNCTION_RESULT_BEGIN"):
@@ -42,6 +51,47 @@ def load_payload(path):
     return json.loads(raw)
 
 
+def aggregation_scope_reference_errors(types):
+    """Return actor-type references that have no matching scope definition."""
+    if not isinstance(types, dict):
+        return []
+
+    actor_types = types.get("actor_types")
+    aggregation_scopes = types.get("aggregation_scopes", {})
+    if not isinstance(actor_types, dict) or not isinstance(aggregation_scopes, dict):
+        return []
+
+    errors = []
+    for actor_type_id, actor_type in actor_types.items():
+        if not isinstance(actor_type, dict):
+            continue
+        actor_scopes = actor_type.get("aggregation_scopes", [])
+        if not isinstance(actor_scopes, list):
+            errors.append(
+                f"actor type {actor_type_id!r} aggregation_scopes is not an array")
+            continue
+        for scope_id in actor_scopes:
+            if isinstance(scope_id, str) and scope_id not in aggregation_scopes:
+                errors.append(
+                    f"actor type {actor_type_id!r} references undefined "
+                    f"aggregation scope {scope_id!r}")
+    return errors
+
+
+def network_viewer_actor_type_errors(types):
+    """Enforce network-viewer's endpoint actor contract."""
+    if not isinstance(types, dict) or not isinstance(types.get("actor_types"), dict):
+        return []
+
+    endpoint = types["actor_types"].get("endpoint")
+    if not isinstance(endpoint, dict):
+        return ["missing endpoint actor type"]
+    endpoint_scopes = endpoint.get("aggregation_scopes", [])
+    if isinstance(endpoint_scopes, list) and endpoint_scopes:
+        return ["endpoint actor type must not declare aggregation scopes"]
+    return []
+
+
 def semantic_checks(data, expect_mode=None, expect_group_by=None):
     errors = []
     if data.get("type") != "topology":
@@ -57,6 +107,9 @@ def semantic_checks(data, expect_mode=None, expect_group_by=None):
             errors.append(f"{table} table missing columns/values")
     if "types" not in d or "actor_types" not in d.get("types", {}):
         errors.append("missing types.actor_types registry")
+    else:
+        errors.extend(aggregation_scope_reference_errors(d["types"]))
+        errors.extend(network_viewer_actor_type_errors(d["types"]))
     if "presentation" not in d:
         errors.append("missing presentation")
     view = d.get("view")
@@ -92,6 +145,66 @@ def run_self_test():
         os.unlink(name)
     if parsed["data"]["view"]["scope"] != "FUNCTION_RESULT_END":
         print("self-test FAILED: FUNCTION_RESULT_END inside JSON string was stripped")
+        return 1
+
+    valid_types = {
+        "actor_types": {
+            "process": {"aggregation_scopes": ["process_name"]},
+            "endpoint": {"aggregation_scopes": []},
+            "scope_less": {},
+        },
+        "aggregation_scopes": {"process_name": {}},
+    }
+    if errors := aggregation_scope_reference_errors(valid_types):
+        print("self-test FAILED: valid scoped/scope-less actor types rejected:", errors)
+        return 1
+    if errors := network_viewer_actor_type_errors(valid_types):
+        print("self-test FAILED: valid endpoint actor type rejected:", errors)
+        return 1
+
+    dangling_types = {
+        "actor_types": {"endpoint": {"aggregation_scopes": ["endpoint"]}},
+        "aggregation_scopes": {},
+    }
+    expected = ["actor type 'endpoint' references undefined aggregation scope 'endpoint'"]
+    if aggregation_scope_reference_errors(dangling_types) != expected:
+        print("self-test FAILED: dangling actor aggregation scope was not rejected")
+        return 1
+    expected = ["endpoint actor type must not declare aggregation scopes"]
+    if network_viewer_actor_type_errors(dangling_types) != expected:
+        print("self-test FAILED: endpoint aggregation scope was not rejected")
+        return 1
+
+    if network_viewer_actor_type_errors({"actor_types": {}}) != ["missing endpoint actor type"]:
+        print("self-test FAILED: missing endpoint actor type was not rejected")
+        return 1
+
+    for malformed_scopes in (None, 7, "endpoint", {}):
+        malformed_types = {
+            "actor_types": {"endpoint": {"aggregation_scopes": malformed_scopes}},
+            "aggregation_scopes": {},
+        }
+        expected = ["actor type 'endpoint' aggregation_scopes is not an array"]
+        if aggregation_scope_reference_errors(malformed_types) != expected:
+            print(
+                "self-test FAILED: malformed endpoint aggregation_scopes was not rejected:",
+                repr(malformed_scopes))
+            return 1
+
+    try:
+        import jsonschema
+    except ImportError:
+        print("self-test FAILED: jsonschema is required to test schema draft selection")
+        return 1
+    here = os.path.dirname(os.path.abspath(__file__))
+    schema_file = os.path.join(
+        here, "..", "..", "..", "plugins.d", "FUNCTION_TOPOLOGY_SCHEMA.json")
+    schema = json.load(io.open(schema_file, encoding="utf-8"))
+    validator = schema_validator(schema)
+    if validator.__class__ is not jsonschema.Draft202012Validator:
+        print(
+            "self-test FAILED: topology schema did not select Draft 2020-12; got",
+            validator.__class__.__name__)
         return 1
     print("self-test OK")
     return 0
@@ -139,7 +252,7 @@ def validate_payload(data, schema_file, expect_mode, expect_group_by):
         print("jsonschema not available; semantic checks passed")
         return 0
 
-    validator = jsonschema.Draft7Validator(schema)
+    validator = schema_validator(schema)
     errs = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
     if errs:
         print(f"SCHEMA FAILURES ({len(errs)}):")

--- a/src/go/pkg/topology/v1/aggregation_scopes_test.go
+++ b/src/go/pkg/topology/v1/aggregation_scopes_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActorAggregationScopeReferences(t *testing.T) {
+	tests := map[string]struct {
+		scopes   any
+		registry bool
+		valid    bool
+	}{
+		"scope-less actor":       {scopes: []any{}, valid: true},
+		"registered scope":       {scopes: []any{"node"}, registry: true, valid: true},
+		"undefined endpoint":     {scopes: []any{"endpoint"}, registry: true},
+		"missing scope registry": {scopes: []any{"node"}},
+		"one undefined scope":    {scopes: []any{"node", "endpoint"}, registry: true},
+		"duplicate scope":        {scopes: []any{"node", "node"}, registry: true},
+		"null scope":             {scopes: []any{nil}, registry: true},
+		"empty scope":            {scopes: []any{""}, registry: true},
+		"non-list scopes":        {scopes: "node", registry: true},
+		"null scopes":            {scopes: nil, registry: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data := minimalValidationData(nil)
+			if test.registry {
+				data.Types.AggregationScopes = map[string]AggregationScope{"node": {Columns: []string{"id"}}}
+			}
+			encoded, err := json.Marshal(NewResponse(data))
+			require.NoError(t, err)
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(encoded, &payload))
+			types := payload["data"].(map[string]any)["types"].(map[string]any)
+			actorType := types["actor_types"].(map[string]any)["node"].(map[string]any)
+			actorType["aggregation_scopes"] = test.scopes
+			err = ValidateDecodedResponse(payload)
+			if test.valid {
+				require.NoError(t, err)
+				encoded, err = json.Marshal(payload)
+				require.NoError(t, err)
+				validateAgainstTopologySchema(t, encoded)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "data.types.actor_types.node.aggregation_scopes")
+			}
+		})
+	}
+}

--- a/src/go/pkg/topology/v1/scalar_numeric_test.go
+++ b/src/go/pkg/topology/v1/scalar_numeric_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNumericScalarCells(t *testing.T) {
+	cases := map[string]struct {
+		value                     any
+		number, integer, unsigned bool
+	}{
+		"int zero":                   {0, true, true, true},
+		"int negative":               {-2, true, true, false},
+		"int64 minimum":              {int64(math.MinInt64), true, true, false},
+		"int64 maximum":              {int64(math.MaxInt64), true, true, true},
+		"int64 above uint32":         {int64(1 << 32), true, true, true},
+		"negative int64 low zero":    {int64(-1 << 32), true, true, false},
+		"uint64 above machine int":   {uint64(maxInt()) + 1, true, true, true},
+		"uint64 maximum":             {uint64(math.MaxUint64), true, true, true},
+		"float zero":                 {float64(0), true, true, true},
+		"float negative zero":        {math.Copysign(0, -1), true, true, true},
+		"float negative integer":     {float64(-2), true, true, false},
+		"float fraction":             {1.5, true, false, false},
+		"float negative fraction":    {-1.5, true, false, false},
+		"float subnormal":            {math.SmallestNonzeroFloat64, true, false, false},
+		"float above signed range":   {float64(1 << 63), true, true, true},
+		"float uint64 roundtrip":     {float64(uint64(math.MaxUint64)), true, true, true},
+		"float maximum":              {math.MaxFloat64, true, true, true},
+		"NaN":                        {math.NaN(), false, false, false},
+		"positive infinity":          {math.Inf(1), false, false, false},
+		"negative infinity":          {math.Inf(-1), false, false, false},
+		"JSON zero":                  {json.Number("0"), true, true, true},
+		"JSON negative zero":         {json.Number("-0"), true, true, true},
+		"JSON negative integer":      {json.Number("-2"), true, true, false},
+		"JSON int64 minimum":         {json.Number("-9223372036854775808"), true, true, false},
+		"JSON int64 maximum":         {json.Number("9223372036854775807"), true, true, true},
+		"JSON uint64 maximum":        {json.Number("18446744073709551615"), true, true, true},
+		"JSON below int64":           {json.Number("-9223372036854775809"), true, false, false},
+		"JSON above uint64":          {json.Number("18446744073709551616"), true, false, false},
+		"JSON fraction":              {json.Number("1.5"), true, false, false},
+		"JSON rounded fraction":      {json.Number("9007199254740993.1"), true, false, false},
+		"JSON decimal integer":       {json.Number("1.0"), true, false, false},
+		"JSON exponent integer":      {json.Number("1e3"), true, false, false},
+		"JSON exponent sign":         {json.Number("1e+3"), true, false, false},
+		"JSON overflow":              {json.Number("1e400"), false, false, false},
+		"JSON NaN":                   {json.Number("NaN"), false, false, false},
+		"JSON infinity":              {json.Number("Inf"), false, false, false},
+		"JSON negative infinity":     {json.Number("-Infinity"), false, false, false},
+		"JSON leading plus":          {json.Number("+1"), false, false, false},
+		"JSON leading zero":          {json.Number("01"), false, false, false},
+		"JSON negative leading zero": {json.Number("-01"), false, false, false},
+		"JSON hexadecimal":           {json.Number("0x1p4"), false, false, false},
+		"JSON underscore":            {json.Number("1_0"), false, false, false},
+		"JSON incomplete fraction":   {json.Number("1."), false, false, false},
+		"JSON incomplete exponent":   {json.Number("1e"), false, false, false},
+		"JSON empty":                 {json.Number(""), false, false, false},
+		"JSON whitespace":            {json.Number(" 1 "), false, false, false},
+		"JSON string":                {json.Number(`"1"`), false, false, false},
+		"JSON boolean":               {json.Number("true"), false, false, false},
+		"JSON array":                 {json.Number("[1]"), false, false, false},
+		"numeric string":             {"1", false, false, false},
+		"boolean":                    {true, false, false, false},
+		"unsupported int32":          {int32(1), false, false, false},
+		"unsupported uint":           {uint(1), false, false, false},
+		"unsupported float32":        {float32(1), false, false, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			for typ, valid := range map[string]bool{"int": tc.integer, "uint": tc.unsigned, "float": tc.number, "duration": tc.number} {
+				t.Run(typ, func(t *testing.T) {
+					for _, aggregation := range []string{"none", "set"} {
+						t.Run(aggregation, func(t *testing.T) {
+							value := tc.value
+							if aggregation == "set" {
+								value = []any{1, value}
+							}
+							assertNumericCellCodecs(t, Column{ID: "sample", Type: typ, Aggregation: aggregation}, value, valid)
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func assertNumericCellCodecs(t *testing.T, column Column, value any, valid bool) {
+	t.Helper()
+	for codec, tc := range map[string]struct {
+		encoding ColumnEncoding
+		wire     map[string]any
+	}{
+		"const":  {Const(value), map[string]any{"codec": "const", "value": value}},
+		"values": {Values(1, value), map[string]any{"codec": "values", "values": []any{1, value}}},
+		"dict": {Dict([]any{1, value}, 1, 0), map[string]any{
+			"codec": "dict", "values": []any{1, value}, "indexes": []any{1, 0},
+		}},
+	} {
+		t.Run(codec, func(t *testing.T) {
+			columns := []Column{column}
+			encodings := []ColumnEncoding{tc.encoding}
+			table, builderErr := NewTable(2, columns, encodings)
+			wire := map[string]any{
+				"rows":    2,
+				"columns": []any{map[string]any{"id": column.ID, "type": column.Type, "aggregation": column.Aggregation}},
+				"values":  []any{tc.wire},
+			}
+			_, decodedErr := validateCompactTable("table", wire, validationContext{})
+			if !valid {
+				assert.Error(t, builderErr, "builder must reject the numeric cell")
+				assert.Error(t, decodedErr, "decoded validation must reject the numeric cell")
+				return
+			}
+			require.NoError(t, builderErr)
+			require.NoError(t, decodedErr)
+			before, err := json.Marshal(Table{Rows: 2, Columns: columns, Values: encodings})
+			require.NoError(t, err)
+			after, err := json.Marshal(table)
+			require.NoError(t, err)
+			assert.Equal(t, before, after, "numeric validation must preserve cell representation")
+			for _, useNumber := range []bool{false, true} {
+				decoder := json.NewDecoder(strings.NewReader(string(after)))
+				if useNumber {
+					decoder.UseNumber()
+				}
+				var decoded any
+				require.NoError(t, decoder.Decode(&decoded))
+				// UseNumber retains decimal/exponent syntax, which integer cells do not accept.
+				if useNumber && (column.Type == "int" || column.Type == "uint") {
+					continue
+				}
+				_, err = validateCompactTable("table", decoded, validationContext{})
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNumericScalarErrorIdentifiesRowAndMember(t *testing.T) {
+	column := Column{ID: "sample", Type: "float", Aggregation: "set"}
+	_, err := NewTable(2, []Column{column}, []ColumnEncoding{Values(1, []any{2, math.Inf(1)})})
+	require.EqualError(t, err, "values[0][1][1] is not a number")
+	err = validateColumnValues("table.sample", map[string]any{"aggregation": "set"}, "float",
+		[]any{1, []any{2, math.Inf(1)}}, validationContext{})
+	require.EqualError(t, err, "table.sample[1][1] is not a number")
+}
+
+func TestNumericScalarRangeDoesNotBroadenReferences(t *testing.T) {
+	for _, typ := range []string{"string_ref", "ip_ref", "mac_ref", "actor_ref", "link_ref", "evidence_ref"} {
+		t.Run(typ, func(t *testing.T) {
+			column := Column{ID: "sample", Type: typ, Aggregation: "set"}
+			if typ == "string_ref" || typ == "ip_ref" || typ == "mac_ref" {
+				column.Dictionary = "items"
+			}
+			ctx := validationContext{dictionaries: map[string]any{"items": []any{"item"}}, actorRows: 1, linkRows: 1, evidenceRows: 1}
+			for _, value := range []any{uint64(math.MaxUint64), json.Number("18446744073709551615")} {
+				_, err := NewTable(1, []Column{column}, []ColumnEncoding{Const(value)})
+				require.Error(t, err)
+				err = validateColumnValues("table.sample", map[string]any{"aggregation": "set", "dictionary": column.Dictionary},
+					typ, []any{value}, ctx)
+				require.Error(t, err)
+			}
+		})
+	}
+	_, err := decodeColumn("table", 0, 1, map[string]any{
+		"codec": "dict", "values": []any{1}, "indexes": []any{uint64(math.MaxUint64)},
+	})
+	require.Error(t, err)
+	_, err = decodedTableRows(map[string]any{"rows": uint64(math.MaxUint64)})
+	require.Error(t, err)
+}
+
+func TestNumericScalarValidationAllocations(t *testing.T) {
+	for typ, value := range map[string]any{"int": int64(-2), "uint": uint64(math.MaxUint64), "float": 1.25, "duration": 1.25} {
+		for _, aggregation := range []string{"none", "set"} {
+			t.Run(typ+"/"+aggregation, func(t *testing.T) {
+				cell := value
+				if aggregation == "set" {
+					cell = []any{value, value}
+				}
+				column := Column{ID: "sample", Type: typ, Aggregation: aggregation}
+				metadata := map[string]any{"aggregation": aggregation}
+				values := []any{cell}
+				builderAllocs := testing.AllocsPerRun(100, func() {
+					require.NoError(t, validateEncodedColumnValue(0, 0, column, cell))
+				})
+				decodedAllocs := testing.AllocsPerRun(100, func() {
+					require.NoError(t, validateColumnValues("table.sample", metadata, typ, values, validationContext{}))
+				})
+				assert.Zero(t, builderAllocs, "valid native numeric cells require no builder allocations")
+				assert.Zero(t, decodedAllocs, "valid native numeric cells require no decoded-validation allocations")
+			})
+		}
+	}
+}
+
+// Timings are workstation trends, not CI gates; successful native cells allocate nothing.
+func BenchmarkNumericScalarValidation(b *testing.B) {
+	for typ, value := range map[string]any{"int": int64(-2), "uint": uint64(42), "float": 1.25, "duration": 1.25} {
+		for _, aggregation := range []string{"none", "set"} {
+			b.Run(typ+"/"+aggregation, func(b *testing.B) {
+				cell := value
+				if aggregation == "set" {
+					cell = []any{value, value}
+				}
+				column := Column{ID: "sample", Type: typ, Aggregation: aggregation}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					if err := validateEncodedColumnValue(0, 0, column, cell); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/src/go/pkg/topology/v1/scalar_set_test.go
+++ b/src/go/pkg/topology/v1/scalar_set_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypedSetScalarColumns(t *testing.T) {
+	types := map[string]struct {
+		first, second, invalid any
+	}{
+		"bool":      {true, false, "true"},
+		"int":       {int64(-2), json.Number("3"), 1.5},
+		"uint":      {uint64(0), uint64(3), -1},
+		"float":     {1.25, json.Number("2.5"), "1.25"},
+		"duration":  {1.25, int64(3), "1s"},
+		"string":    {"alpha", "beta", true},
+		"timestamp": {"2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z", 123},
+		"ip":        {"192.0.2.1", "2001:db8::1", 123},
+		"mac":       {"02:00:00:00:00:01", "02:00:00:00:00:02", 123},
+	}
+	for typ, values := range types {
+		t.Run(typ, func(t *testing.T) {
+			cases := map[string]struct {
+				value    any
+				nullable bool
+				wantErr  string
+			}{
+				"scalar":                 {value: values.first},
+				"set":                    {value: []any{values.first, values.second}},
+				"empty set":              {value: []any{}},
+				"nullable cell":          {nullable: true},
+				"nonnullable cell":       {wantErr: "is null but column is not nullable"},
+				"nullable member":        {value: []any{values.first, nil}, nullable: true},
+				"nonnullable member":     {value: []any{values.first, nil}, wantErr: "is null but column is not nullable"},
+				"nullable nil slice":     {value: []any(nil), nullable: true},
+				"nonnullable nil slice":  {value: []any(nil), wantErr: "is null but column is not nullable"},
+				"wrong member":           {value: []any{values.first, values.invalid}, wantErr: "is not"},
+				"nested member":          {value: []any{values.first, []any{values.second}}, wantErr: "is not"},
+				"nested nullable member": {value: []any{values.first, []any{nil}}, nullable: true, wantErr: "is not"},
+				"object member":          {value: []any{map[string]any{"value": values.first}}, wantErr: "is not"},
+				"typed slice":            {value: []string{"alpha"}, wantErr: "is not"},
+			}
+			for name, tc := range cases {
+				t.Run(name, func(t *testing.T) {
+					column := Column{ID: "sample", Type: typ, Nullable: tc.nullable, Role: "attribute", Aggregation: "set"}
+					if name == "typed slice" {
+						// Builders accept decoded []any arrays, not arbitrary Go slices.
+						_, err := NewTable(1, []Column{column}, []ColumnEncoding{Const(tc.value)})
+						require.ErrorContains(t, err, tc.wantErr)
+						return
+					}
+					assertScalarSetCodecs(t, column, values.first, tc.value, tc.wantErr)
+				})
+			}
+			for _, aggregation := range []string{"", "none", "first", "last", "sum", "min", "max", "avg", "count"} {
+				t.Run("non-set/"+aggregation, func(t *testing.T) {
+					column := Column{ID: "sample", Type: typ, Aggregation: aggregation}
+					assertScalarSetCodecs(t, column, values.first, values.second, "")
+					assertScalarSetCodecs(t, column, values.first, []any{values.first}, "is not")
+				})
+			}
+		})
+	}
+}
+
+func assertScalarSetCodecs(t *testing.T, column Column, scalar, value any, wantErr string) {
+	t.Helper()
+	encodings := map[string]struct {
+		rows     int
+		encoding ColumnEncoding
+	}{
+		"const":  {rows: 2, encoding: Const(value)},
+		"values": {rows: 2, encoding: Values(scalar, value)},
+		"dict":   {rows: 3, encoding: Dict([]any{scalar, value}, 1, 0, 1)},
+	}
+	for name, tc := range encodings {
+		t.Run(name, func(t *testing.T) {
+			columns := []Column{column}
+			encodings := []ColumnEncoding{tc.encoding}
+			before, err := json.Marshal(Table{Rows: tc.rows, Columns: columns, Values: encodings})
+			require.NoError(t, err)
+			table, builderErr := NewTable(tc.rows, columns, encodings)
+			var decoded any
+			require.NoError(t, json.Unmarshal(before, &decoded))
+			_, decodedErr := validateCompactTable("table", decoded, validationContext{})
+			if wantErr != "" {
+				require.ErrorContains(t, builderErr, wantErr)
+				require.ErrorContains(t, decodedErr, wantErr)
+				return
+			}
+			require.NoError(t, builderErr)
+			require.NoError(t, decodedErr)
+			after, err := json.Marshal(table)
+			require.NoError(t, err)
+			assert.Equal(t, before, after, "validation must preserve metadata and cell representation")
+		})
+	}
+}
+
+func TestTypedSetReferenceColumnsKeepIndexValidation(t *testing.T) {
+	for _, typ := range []string{"string_ref", "ip_ref", "mac_ref", "actor_ref", "link_ref", "evidence_ref"} {
+		t.Run(typ, func(t *testing.T) {
+			column := Column{ID: "sample", Type: typ, Aggregation: "set"}
+			if typ == "string_ref" || typ == "ip_ref" || typ == "mac_ref" {
+				column.Dictionary = "items"
+			}
+			ctx := validationContext{
+				dictionaries: map[string]any{"items": []any{"scalar", []any{"alpha", "beta"}}},
+				actorRows:    2, linkRows: 2, evidenceRows: 2,
+			}
+			for name, tc := range map[string]struct {
+				value   any
+				wantErr bool
+			}{
+				"scalar":        {value: 0},
+				"second scalar": {value: 1},
+				"array":         {value: []any{0, 1}, wantErr: true},
+				"negative":      {value: -1, wantErr: true},
+				"fractional":    {value: 0.5, wantErr: true},
+			} {
+				t.Run(name, func(t *testing.T) {
+					_, builderErr := NewTable(1, []Column{column}, []ColumnEncoding{Const(tc.value)})
+					wireColumn := map[string]any{"type": typ, "dictionary": column.Dictionary, "aggregation": "set"}
+					decodedErr := validateColumnValues("table.sample", wireColumn, typ, []any{tc.value}, ctx)
+					if tc.wantErr {
+						require.Error(t, builderErr)
+						require.Error(t, decodedErr)
+					} else {
+						require.NoError(t, builderErr)
+						require.NoError(t, decodedErr)
+					}
+				})
+			}
+			wireColumn := map[string]any{"type": typ, "dictionary": column.Dictionary, "aggregation": "set"}
+			require.ErrorContains(t, validateColumnValues("table.sample", wireColumn, typ, []any{2}, ctx), "out of bounds")
+			if column.Dictionary != "" {
+				require.ErrorContains(t, validateColumnValues("table.sample", wireColumn, typ, []any{0}, validationContext{}), "missing dictionary")
+				delete(wireColumn, "dictionary")
+				require.ErrorContains(t, validateColumnValues("table.sample", wireColumn, typ, []any{0}, ctx), "without dictionary")
+			}
+		})
+	}
+}
+
+func TestTypedSetArrayAndJSONColumnsKeepTheirShape(t *testing.T) {
+	for _, typ := range []string{"array", "json"} {
+		t.Run(typ, func(t *testing.T) {
+			column := Column{ID: "sample", Type: typ, Role: "identity", Aggregation: "set"}
+			value := []any{[]any{"nested"}, map[string]any{"attribute": "value"}}
+			assertScalarSetCodecs(t, column, value, value, "")
+		})
+	}
+}
+
+func TestTypedSetBuilderAndResponsePreserveMixedRows(t *testing.T) {
+	columns := []Column{
+		{ID: "id", Type: "string", Role: "identity", Aggregation: "set"},
+		{ID: "type", Type: "string"},
+		{ID: "sample", Type: "string", Role: "merge_identity", Aggregation: "set"},
+	}
+	builder := NewTableBuilder(columns...)
+	builder.Add("node-a", "node", "key-a")
+	builder.Add("process-a", "process", []any{"alpha", "beta"})
+	actors, err := builder.Table()
+	require.NoError(t, err)
+	assert.Equal(t, columns, actors.Columns)
+	data := minimalValidationData(&ActorPresentation{LabelPolicy: &LabelPolicy{Columns: []string{"sample"}, Array: "first"}})
+	nodeType := data.Types.ActorTypes["node"]
+	nodeType.MergeIdentity = []string{"sample"}
+	data.Types.ActorTypes["node"] = nodeType
+	data.Types.ActorTypes["process"] = ActorType{Layer: "process", Identity: []string{"id"}}
+	data.Actors = actors
+	payload, err := json.Marshal(NewResponse(data))
+	require.NoError(t, err)
+	validateAgainstTopologySchema(t, payload)
+	var decoded any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	require.NoError(t, ValidateDecodedResponse(decoded))
+	decodedActors := decoded.(map[string]any)["data"].(map[string]any)["actors"].(map[string]any)
+	values := decodedActors["values"].([]any)
+	assert.Equal(t, []any{"node-a", "process-a"}, values[0].(map[string]any)["values"])
+	assert.Equal(t, []any{"key-a", []any{"alpha", "beta"}}, values[2].(map[string]any)["values"])
+}
+
+func TestTypedSetErrorIdentifiesRowAndMember(t *testing.T) {
+	column := Column{ID: "sample", Type: "uint", Aggregation: "set"}
+	_, err := NewTable(2, []Column{column}, []ColumnEncoding{Values(1, []any{2, -1})})
+	require.EqualError(t, err, "values[0][1][1] is not a non-negative integer")
+	err = validateColumnValues("table.sample", map[string]any{"aggregation": "set"}, "uint", []any{1, []any{2, -1}}, validationContext{})
+	require.EqualError(t, err, "table.sample[1][1] is not a non-negative integer")
+}
+
+func TestTypedSetCellValidationDoesNotAllocate(t *testing.T) {
+	column := Column{ID: "sample", Type: "string", Aggregation: "set"}
+	wireColumn := map[string]any{"aggregation": "set"}
+	for name, value := range map[string]any{
+		"scalar": "alpha",
+		"set":    []any{"alpha", "beta"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			values := []any{value}
+			var validationErr error
+			builderAllocs := testing.AllocsPerRun(100, func() {
+				validationErr = validateEncodedColumnValue(0, 0, column, value)
+			})
+			require.NoError(t, validationErr)
+			assert.Zero(t, builderAllocs, "successful cell validation needs no intermediate representation")
+			decodedAllocs := testing.AllocsPerRun(100, func() {
+				validationErr = validateColumnValues("table.sample", wireColumn, "string", values, validationContext{})
+			})
+			require.NoError(t, validationErr)
+			assert.Zero(t, decodedAllocs, "successful cell validation needs no intermediate representation")
+		})
+	}
+}

--- a/src/go/pkg/topology/v1/scalar_value.go
+++ b/src/go/pkg/topology/v1/scalar_value.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+// scalarColumnValueError preserves the item type when set aggregation produces
+// an array. A negative index identifies the cell itself rather than a member.
+func scalarColumnValueError(typ, aggregation string, nullable bool, value any) (int, string) {
+	if aggregation == "set" {
+		if members, ok := value.([]any); ok {
+			if members == nil {
+				// A typed nil slice encodes as null, not as an empty JSON array.
+				return -1, scalarItemError(typ, nullable, nil)
+			}
+			for i, member := range members {
+				if reason := scalarItemError(typ, nullable, member); reason != "" {
+					return i, reason
+				}
+			}
+			return -1, ""
+		}
+	}
+	return -1, scalarItemError(typ, nullable, value)
+}
+
+func scalarItemError(typ string, nullable bool, value any) string {
+	if value == nil {
+		if nullable {
+			return ""
+		}
+		return "is null but column is not nullable"
+	}
+	switch typ {
+	case "bool":
+		if _, ok := value.(bool); !ok {
+			return "is not a bool"
+		}
+	case "int":
+		if _, ok := integerValue(value); !ok {
+			return "is not an integer"
+		}
+	case "uint":
+		if n, ok := integerValue(value); !ok || n < 0 {
+			return "is not a non-negative integer"
+		}
+	case "float", "duration":
+		if _, ok := numberValue(value); !ok {
+			return "is not a number"
+		}
+	case "string", "ip", "mac", "timestamp":
+		if _, ok := value.(string); !ok {
+			return "is not a string"
+		}
+	default:
+		return "has unsupported scalar column type"
+	}
+	return ""
+}

--- a/src/go/pkg/topology/v1/scalar_value.go
+++ b/src/go/pkg/topology/v1/scalar_value.go
@@ -2,6 +2,12 @@
 
 package topologyv1
 
+import (
+	"encoding/json"
+	"math"
+	"strconv"
+)
+
 // scalarColumnValueError preserves the item type when set aggregation produces
 // an array. A negative index identifies the cell itself rather than a member.
 func scalarColumnValueError(typ, aggregation string, nullable bool, value any) (int, string) {
@@ -35,15 +41,15 @@ func scalarItemError(typ string, nullable bool, value any) string {
 			return "is not a bool"
 		}
 	case "int":
-		if _, ok := integerValue(value); !ok {
+		if _, ok := scalarNumberValue(value, true); !ok {
 			return "is not an integer"
 		}
 	case "uint":
-		if n, ok := integerValue(value); !ok || n < 0 {
+		if n, ok := scalarNumberValue(value, true); !ok || n < 0 {
 			return "is not a non-negative integer"
 		}
 	case "float", "duration":
-		if _, ok := numberValue(value); !ok {
+		if _, ok := scalarNumberValue(value, false); !ok {
 			return "is not a number"
 		}
 	case "string", "ip", "mac", "timestamp":
@@ -54,4 +60,41 @@ func scalarItemError(typ string, nullable bool, value any) string {
 		return "has unsupported scalar column type"
 	}
 	return ""
+}
+
+// scalarNumberValue validates cells independently of machine-sized indexes.
+// The returned number is only for sign checks; the stored value is unchanged.
+func scalarNumberValue(raw any, integral bool) (float64, bool) {
+	var n float64
+	switch value := raw.(type) {
+	case int:
+		return float64(value), true
+	case int64:
+		return float64(value), true
+	case uint64:
+		return float64(value), true
+	case float64:
+		n = value
+	case json.Number:
+		if !json.Valid([]byte(value)) {
+			return 0, false
+		}
+		if integral {
+			// Integer-form literals retain exact parsing, including the unsigned range.
+			if len(value) > 0 && value[0] == '-' {
+				integer, err := value.Int64()
+				return float64(integer), err == nil
+			}
+			integer, err := strconv.ParseUint(string(value), 10, 64)
+			return float64(integer), err == nil
+		}
+		var err error
+		n, err = value.Float64()
+		if err != nil {
+			return 0, false
+		}
+	default:
+		return 0, false
+	}
+	return n, !math.IsNaN(n) && !math.IsInf(n, 0) && (!integral || math.Trunc(n) == n)
 }

--- a/src/go/pkg/topology/v1/search_test.go
+++ b/src/go/pkg/topology/v1/search_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package topologyv1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchLabelKeysSchemaAndSemanticValidation(t *testing.T) {
+	tests := map[string]struct {
+		keys  any
+		valid bool
+	}{
+		"empty list":      {keys: []any{}, valid: true},
+		"ordinary labels": {keys: []any{"hostname", "os"}, valid: true},
+		"built-in labels": {keys: []any{"_hostname", "_os"}, valid: true},
+		"qualified label": {keys: []any{"example.net/rack"}, valid: true},
+		"unicode label":   {keys: []any{"περιοχή"}, valid: true},
+		"space in label":  {keys: []any{"rack name"}, valid: true},
+		"empty key":       {keys: []any{""}},
+		"duplicate key":   {keys: []any{"_hostname", "_hostname"}},
+		"null key":        {keys: []any{nil}},
+		"numeric key":     {keys: []any{1}},
+		"non-list":        {keys: "_hostname"},
+		"null list":       {keys: nil},
+	}
+	for name, test := range tests {
+		for variant, presentation := range map[string]bool{"without presentation": false, "with presentation": true} {
+			t.Run(name+"/"+variant, func(t *testing.T) {
+				payload, actorType := searchTestResponse(t, presentation)
+				actorType["search"] = map[string]any{"label_keys": test.keys}
+				encoded, err := json.Marshal(payload)
+				require.NoError(t, err)
+				assert.Equal(t, test.valid, topologySchemaValidationError(t, encoded) == nil, "schema validity")
+				assert.Equal(t, test.valid, ValidateDecodedResponse(payload) == nil, "semantic validity")
+			})
+		}
+	}
+}
+
+func TestSearchLabelKeyRelaxationPreservesColumnIdentifiers(t *testing.T) {
+	for _, id := range []string{"_hostname", "example.net/rack", "rack name", "περιοχή", ""} {
+		t.Run(id, func(t *testing.T) {
+			payload, actorType := searchTestResponse(t, true)
+			actorType["search"] = map[string]any{"columns": []any{id}}
+			encoded, err := json.Marshal(payload)
+			require.NoError(t, err)
+			require.Error(t, topologySchemaValidationError(t, encoded))
+			require.Error(t, ValidateDecodedResponse(payload))
+		})
+	}
+}
+
+func TestSearchColumnReferencesWithoutPresentation(t *testing.T) {
+	for _, column := range []string{"id", "missing"} {
+		t.Run(column, func(t *testing.T) {
+			payload, actorType := searchTestResponse(t, false)
+			actorType["search"] = map[string]any{"columns": []any{column}}
+			assert.Equal(t, column == "id", ValidateDecodedResponse(payload) == nil)
+		})
+	}
+}
+
+func searchTestResponse(t *testing.T, withPresentation bool) (map[string]any, map[string]any) {
+	t.Helper()
+	var presentation *ActorPresentation
+	if withPresentation {
+		presentation = &ActorPresentation{Label: "Node"}
+	}
+	encoded, err := json.Marshal(NewResponse(minimalValidationData(presentation)))
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &payload))
+	actorTypes := payload["data"].(map[string]any)["types"].(map[string]any)["actor_types"].(map[string]any)
+	return payload, actorTypes["node"].(map[string]any)
+}

--- a/src/go/pkg/topology/v1/table.go
+++ b/src/go/pkg/topology/v1/table.go
@@ -240,25 +240,12 @@ func validateEncodedColumnValue(columnIndex, rowIndex int, column Column, value 
 		if _, ok := value.([]any); !ok {
 			return fmt.Errorf("values[%d][%d] is not an array", columnIndex, rowIndex)
 		}
-	case "bool":
-		if _, ok := value.(bool); !ok {
-			return fmt.Errorf("values[%d][%d] is not a bool", columnIndex, rowIndex)
-		}
-	case "int":
-		if _, ok := integerValue(value); !ok {
-			return fmt.Errorf("values[%d][%d] is not an integer", columnIndex, rowIndex)
-		}
-	case "uint":
-		if n, ok := integerValue(value); !ok || n < 0 {
-			return fmt.Errorf("values[%d][%d] is not a non-negative integer", columnIndex, rowIndex)
-		}
-	case "float", "duration":
-		if _, ok := numberValue(value); !ok {
-			return fmt.Errorf("values[%d][%d] is not a number", columnIndex, rowIndex)
-		}
-	case "string", "ip", "mac", "timestamp":
-		if _, ok := value.(string); !ok {
-			return fmt.Errorf("values[%d][%d] is not a string", columnIndex, rowIndex)
+	case "bool", "int", "uint", "float", "duration", "string", "ip", "mac", "timestamp":
+		if member, reason := scalarColumnValueError(column.Type, column.Aggregation, column.Nullable, value); reason != "" {
+			if member >= 0 {
+				return fmt.Errorf("values[%d][%d][%d] %s", columnIndex, rowIndex, member, reason)
+			}
+			return fmt.Errorf("values[%d][%d] %s", columnIndex, rowIndex, reason)
 		}
 	case "json":
 		return nil

--- a/src/go/pkg/topology/v1/validate.go
+++ b/src/go/pkg/topology/v1/validate.go
@@ -23,6 +23,7 @@ type topologyShape struct {
 	actorTypes         map[string]struct{}
 	linkTypes          map[string]struct{}
 	portTypes          map[string]struct{}
+	aggregationScopes  map[string]struct{}
 	evidenceTypes      map[string]map[string]string
 	tableTypes         map[string]map[string]string
 	tableTypeOwners    map[string]string
@@ -679,6 +680,10 @@ func collectTopologyShape(data map[string]any) (topologyShape, error) {
 	if err != nil {
 		return topologyShape{}, err
 	}
+	aggregationScopes, err := optionalObjectKeySet(types["aggregation_scopes"], "data.types.aggregation_scopes")
+	if err != nil {
+		return topologyShape{}, err
+	}
 
 	evidenceTypes, err := columnTypesByRegistryObject(types["evidence_types"], "data.types.evidence_types")
 	if err != nil {
@@ -711,6 +716,7 @@ func collectTopologyShape(data map[string]any) (topologyShape, error) {
 		actorTypes:         actorTypes,
 		linkTypes:          linkTypes,
 		portTypes:          portTypes,
+		aggregationScopes:  aggregationScopes,
 		evidenceTypes:      evidenceTypes,
 		tableTypes:         tableTypes,
 		tableTypeOwners:    tableTypeOwners,
@@ -884,6 +890,21 @@ func validateActorTypePresentation(raw any, shape topologyShape) error {
 		if !ok {
 			return fmt.Errorf("data.types.actor_types.%s is not an object", typeID)
 		}
+		if rawScopes, exists := actorType["aggregation_scopes"]; exists {
+			path := "data.types.actor_types." + typeID + ".aggregation_scopes"
+			scopes, err := collectStringList(path, rawScopes, false)
+			if err != nil {
+				return err
+			}
+			for i, scope := range scopes {
+				if _, ok := shape.aggregationScopes[scope]; !ok {
+					return fmt.Errorf("%s[%d] references unknown aggregation scope %q", path, i, scope)
+				}
+			}
+		}
+		if err := validateActorSearchPolicy("data.types.actor_types."+typeID+".search", actorType["search"], shape.actorColumns); err != nil {
+			return err
+		}
 		presentation, ok := actorType["presentation"].(map[string]any)
 		if !ok {
 			continue
@@ -928,9 +949,6 @@ func validateActorTypePresentation(raw any, shape topologyShape) error {
 			return err
 		}
 		if err := validateModalPresentation(path+".modal", presentation["modal"], shape); err != nil {
-			return err
-		}
-		if err := validateActorSearchPolicy("data.types.actor_types."+typeID+".search", actorType["search"], shape.actorColumns); err != nil {
 			return err
 		}
 	}

--- a/src/go/pkg/topology/v1/validate.go
+++ b/src/go/pkg/topology/v1/validate.go
@@ -2582,27 +2582,6 @@ func integerValue(raw any) (int, bool) {
 	}
 }
 
-func numberValue(raw any) (float64, bool) {
-	switch value := raw.(type) {
-	case int:
-		return float64(value), true
-	case int64:
-		return float64(value), true
-	case uint64:
-		return float64(value), true
-	case float64:
-		return value, true
-	case json.Number:
-		n, err := value.Float64()
-		if err != nil {
-			return 0, false
-		}
-		return n, true
-	default:
-		return 0, false
-	}
-}
-
 func maxInt() int {
 	return int(^uint(0) >> 1)
 }

--- a/src/go/pkg/topology/v1/validate.go
+++ b/src/go/pkg/topology/v1/validate.go
@@ -580,6 +580,7 @@ func decodeColumn(path string, columnIndex int, rows int, raw any) ([]any, error
 
 func validateColumnValues(path string, column map[string]any, columnType string, values []any, ctx validationContext) error {
 	nullable, _ := column["nullable"].(bool)
+	aggregation, _ := column["aggregation"].(string)
 	for i, value := range values {
 		if value == nil {
 			if nullable {
@@ -625,26 +626,12 @@ func validateColumnValues(path string, column map[string]any, columnType string,
 			if _, ok := value.([]any); !ok {
 				return fmt.Errorf("%s[%d] is not an array", path, i)
 			}
-		case "bool":
-			if _, ok := value.(bool); !ok {
-				return fmt.Errorf("%s[%d] is not a bool", path, i)
-			}
-		case "int":
-			if _, ok := integerValue(value); !ok {
-				return fmt.Errorf("%s[%d] is not an integer", path, i)
-			}
-		case "uint":
-			n, ok := integerValue(value)
-			if !ok || n < 0 {
-				return fmt.Errorf("%s[%d] is not a non-negative integer", path, i)
-			}
-		case "float", "duration":
-			if _, ok := numberValue(value); !ok {
-				return fmt.Errorf("%s[%d] is not a number", path, i)
-			}
-		case "string", "ip", "mac", "timestamp":
-			if _, ok := value.(string); !ok {
-				return fmt.Errorf("%s[%d] is not a string", path, i)
+		case "bool", "int", "uint", "float", "duration", "string", "ip", "mac", "timestamp":
+			if member, reason := scalarColumnValueError(columnType, aggregation, nullable, value); reason != "" {
+				if member >= 0 {
+					return fmt.Errorf("%s[%d][%d] %s", path, i, member, reason)
+				}
+				return fmt.Errorf("%s[%d] %s", path, i, reason)
 			}
 		case "json":
 			// Any decoded JSON value is valid for a json column.

--- a/src/go/tools/functions-validation/README.md
+++ b/src/go/tools/functions-validation/README.md
@@ -60,6 +60,11 @@ unchanged reference/array/json behavior. Validate producer-derived aggregates
 with this CLI; generic JSON Schema and optional Python fallback checks alone
 do not prove typed-member validation.
 
+Numeric regressions must also exercise builders before JSON marshaling, which
+otherwise rejects non-finite values and malformed `json.Number` literals before
+the topology validator sees them. Cover large unsigned cells, finite/integral
+checks, and unchanged index bounds in both scalar and set form.
+
 ## Validate output (require rows)
 ```
 src/go/go.d.plugin \

--- a/src/go/tools/functions-validation/README.md
+++ b/src/go/tools/functions-validation/README.md
@@ -47,6 +47,19 @@ must be in range, actor/link references must point to existing rows, and
 correlation rules must reference existing actor/link types and point/claim key
 columns.
 
+For direct scalar columns declaring `aggregation: "set"`, semantic validation
+accepts scalar cells and one-dimensional arrays of correctly typed members.
+Null cells and null members require `nullable: true`; empty sets are valid.
+Nested arrays and wrong-typed members are rejected with a row/member location.
+Column metadata and integer reference encoding remain unchanged. Generic JSON
+Schema validation alone does not enforce the column-to-member relationship.
+
+When changing typed-set validation, test all codecs, mixed scalar/set rows,
+member types, empty sets, nullability, nil Go slices, nested direct sets, and
+unchanged reference/array/json behavior. Validate producer-derived aggregates
+with this CLI; generic JSON Schema and optional Python fallback checks alone
+do not prove typed-member validation.
+
 ## Validate output (require rows)
 ```
 src/go/go.d.plugin \

--- a/src/go/tools/functions-validation/fixtures/topology-v1/network-connections.json
+++ b/src/go/tools/functions-validation/fixtures/topology-v1/network-connections.json
@@ -55,7 +55,7 @@
           "layer": "process",
           "identity": ["id"],
           "merge_identity": ["machine_guid", "process"],
-          "aggregation_scopes": ["node", "process_name", "pid"],
+          "aggregation_scopes": ["process_name", "pid"],
           "presentation": {
             "label": "Process",
             "color_slot": "primary",
@@ -79,7 +79,7 @@
           "layer": "network",
           "identity": ["id"],
           "merge_identity": ["ip", "address_space"],
-          "aggregation_scopes": ["node"]
+          "aggregation_scopes": []
         }
       },
       "link_types": {
@@ -228,6 +228,24 @@
             {"id": "socket_count", "type": "uint", "role": "metric", "aggregation": "sum"}
           ]
         }
+      },
+      "aggregation_scopes": {
+        "node": {
+          "columns": ["machine_guid", "hostname"],
+          "evidence_policy": "preserve"
+        },
+        "process_name": {
+          "columns": ["process"],
+          "evidence_policy": "preserve"
+        },
+        "pid": {
+          "columns": ["pid", "net_ns_inode"],
+          "evidence_policy": "preserve"
+        },
+        "container": {
+          "columns": ["container_name"],
+          "evidence_policy": "preserve"
+        }
       }
     },
     "presentation": {
@@ -317,7 +335,11 @@
         {"id": "type", "type": "string_ref", "dictionary": "strings"},
         {"id": "id", "type": "string_ref", "dictionary": "strings", "role": "identity"},
         {"id": "machine_guid", "type": "string_ref", "dictionary": "strings", "nullable": true},
+        {"id": "hostname", "type": "string", "nullable": true, "role": "merge_identity", "aggregation": "set"},
         {"id": "process", "type": "string_ref", "dictionary": "strings", "nullable": true},
+        {"id": "pid", "type": "uint", "nullable": true, "role": "identity"},
+        {"id": "net_ns_inode", "type": "uint", "nullable": true, "role": "identity"},
+        {"id": "container_name", "type": "string", "nullable": true, "role": "group_key", "aggregation": "set"},
         {"id": "ip", "type": "ip_ref", "dictionary": "strings", "nullable": true},
         {"id": "address_space", "type": "string_ref", "dictionary": "strings", "nullable": true},
         {"id": "socket_count", "type": "uint", "role": "metric", "aggregation": "sum"}
@@ -326,7 +348,11 @@
         {"codec": "dict", "values": [0, 1, 2], "indexes": [0, 1, 2]},
         {"codec": "values", "values": [3, 5, 6]},
         {"codec": "values", "values": [4, 4, null]},
+        {"codec": "const", "value": null},
         {"codec": "values", "values": [null, 5, null]},
+        {"codec": "const", "value": null},
+        {"codec": "const", "value": null},
+        {"codec": "const", "value": null},
         {"codec": "values", "values": [null, null, 6]},
         {"codec": "values", "values": [null, null, 11]},
         {"codec": "values", "values": [2, 2, 2]}

--- a/src/go/tools/functions-validation/validate/numeric_cell_test.go
+++ b/src/go/tools/functions-validation/validate/numeric_cell_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopologyNumericCellFixture(t *testing.T) {
+	schema := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_TOPOLOGY_SCHEMA.json"))
+	fixture := readTestFile(t, filepath.Join("..", "fixtures", "topology-v1", "network-connections.json"))
+	for name, tc := range map[string]struct {
+		typ     string
+		value   json.Number
+		wantErr string
+	}{
+		"unsigned maximum":         {typ: "uint", value: "18446744073709551615"},
+		"integer unsigned maximum": {typ: "int", value: "18446744073709551615"},
+		"integer minimum":          {typ: "int", value: "-9223372036854775808"},
+		"unsigned negative":        {typ: "uint", value: "-1", wantErr: "is not a non-negative integer"},
+		"unsigned fraction":        {typ: "uint", value: "1.5", wantErr: "is not a non-negative integer"},
+		"integer fraction":         {typ: "int", value: "1.5", wantErr: "is not an integer"},
+	} {
+		for _, aggregation := range []string{"none", "set"} {
+			t.Run(name+"/"+aggregation, func(t *testing.T) {
+				var payload map[string]any
+				require.NoError(t, json.Unmarshal(fixture, &payload))
+				actors := payload["data"].(map[string]any)["actors"].(map[string]any)
+				var cell any = tc.value
+				if aggregation == "set" {
+					cell = []any{1, tc.value}
+				}
+				actors["columns"] = append(actors["columns"].([]any), map[string]any{
+					"id": "numeric_sample", "type": tc.typ, "aggregation": aggregation,
+				})
+				actors["values"] = append(actors["values"].([]any), map[string]any{"codec": "const", "value": cell})
+				input, err := json.Marshal(payload)
+				require.NoError(t, err)
+				result, err := validateJSON(schema, input)
+				if tc.wantErr != "" {
+					path := "data.actors.numeric_sample[0]"
+					if aggregation == "set" {
+						path += "[1]"
+					}
+					require.ErrorContains(t, err, path+" "+tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				var expected any
+				require.NoError(t, json.Unmarshal(input, &expected))
+				assert.Equal(t, expected, result, "validation preserves the default decoder's numeric representation")
+			})
+		}
+	}
+}

--- a/src/go/tools/functions-validation/validate/typed_set_test.go
+++ b/src/go/tools/functions-validation/validate/typed_set_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopologyTypedSetFixture(t *testing.T) {
+	schemaBytes := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_TOPOLOGY_SCHEMA.json"))
+	fixture := readTestFile(t, filepath.Join("..", "fixtures", "topology-v1", "network-connections.json"))
+	for name, tc := range map[string]struct {
+		value    any
+		nullable bool
+		wantErr  string
+	}{
+		"typed set":          {value: []any{"alpha", "beta"}},
+		"nullable member":    {value: []any{"alpha", nil}, nullable: true},
+		"nonnullable member": {value: []any{"alpha", nil}, wantErr: "is null but column is not nullable"},
+		"wrong member":       {value: []any{"alpha", 3}, wantErr: "is not a string"},
+		"nested member":      {value: []any{"alpha", []any{"beta"}}, wantErr: "is not a string"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(fixture, &payload))
+			actors := payload["data"].(map[string]any)["actors"].(map[string]any)
+			rowCount := int(actors["rows"].(float64))
+			require.Greater(t, rowCount, 1)
+			values := make([]any, rowCount)
+			for row := range values {
+				values[row] = "scalar-key"
+			}
+			values[1] = tc.value
+			actors["columns"] = append(actors["columns"].([]any), map[string]any{
+				"id": "set_sample", "type": "string", "role": "merge_identity", "aggregation": "set", "nullable": tc.nullable,
+			})
+			actors["values"] = append(actors["values"].([]any), map[string]any{"codec": "values", "values": values})
+			input, err := json.Marshal(payload)
+			require.NoError(t, err)
+			validated, err := validateJSON(schemaBytes, input)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, "data.actors.set_sample[1][1] "+tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, payload, validated, "the CLI must preserve scalar and set cell representations")
+		})
+	}
+}
+
+func TestNetworkViewerProducerSetFixtures(t *testing.T) {
+	schemaBytes := readTestFile(t, filepath.Join("..", "..", "..", "..", "plugins.d", "FUNCTION_TOPOLOGY_SCHEMA.json"))
+	fixtureDir := filepath.Join("..", "..", "..", "..", "collectors", "network-viewer.plugin", "tests", "fixtures", "topology")
+	// These synthetic producer fixtures also shipped in v2.11.0. Their cells
+	// are scalar/null; the array mutation below models a Cloud aggregate.
+	for _, fixture := range []string{"with-containers.json", "zero-containers.json", "mixed-containers.json", "whitelist-allow-all.json"} {
+		t.Run(fixture, func(t *testing.T) {
+			input := readTestFile(t, filepath.Join(fixtureDir, fixture))
+			validated, err := validateJSON(schemaBytes, input)
+			require.NoError(t, err)
+			actors := validated.(map[string]any)["data"].(map[string]any)["actors"].(map[string]any)
+			for i, rawColumn := range actors["columns"].([]any) {
+				column := rawColumn.(map[string]any)
+				if column["id"] != "orchestrator" {
+					continue
+				}
+				require.Equal(t, "string", column["type"])
+				require.Equal(t, "set", column["aggregation"])
+				encoding := actors["values"].([]any)[i].(map[string]any)
+				require.Equal(t, "values", encoding["codec"])
+				values := encoding["values"].([]any)
+				require.NotEmpty(t, values)
+				values[0] = []any{"docker", "k8s"}
+				aggregated, err := json.Marshal(validated)
+				require.NoError(t, err)
+				result, err := validateJSON(schemaBytes, aggregated)
+				require.NoError(t, err)
+				assert.Equal(t, validated, result, "aggregate validation must preserve producer metadata")
+				return
+			}
+			t.Fatal("fixture has no orchestrator column")
+		})
+	}
+}

--- a/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
@@ -268,6 +268,19 @@ for sets. A nil slice serializes as null and follows nullability; a non-nil
 empty slice represents an empty set. These rules apply after decoding any of
 the three column codecs.
 
+Numeric cells and set members must be finite. Types `int` and `uint` require
+integral values, and `uint` also requires a nonnegative value. Go validation
+accepts `int`, `int64`, `uint64`, `float64`, and `json.Number`, including the
+full native `uint64` range; numeric cells are not narrowed to machine-sized
+row or dictionary indexes. Validation preserves the supplied value.
+
+`json.Number` must contain a valid JSON numeric literal. For `int` and `uint`,
+it must use integer-form syntax (no fraction or exponent), fitting `int64`
+when negative or `uint64` when nonnegative. For `float` and `duration`, it must
+parse as a finite `float64`. Callers using the default JSON decoder retain its
+`float64` precision limits; validation does not recover digits already rounded
+during decoding.
+
 Set aggregation does not turn reference cells into arrays of references:
 `string_ref`, `ip_ref`, and `mac_ref` still carry one global dictionary index,
 and row-reference columns still carry one row index. A global dictionary entry

--- a/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
@@ -253,6 +253,29 @@ For string-heavy columns, prefer `string_ref` with `dictionary: "strings"` and
 integer values. This is how production socket evidence reached about 22 raw
 bytes per socket evidence row in the measured corpus.
 
+For direct scalar columns with `aggregation: "set"`, `type` describes each
+member: `bool`, `int`, `uint`, `float`, `string`, `timestamp`, `duration`, `ip`,
+or `mac`. A cell may contain a scalar or a one-dimensional array of that type,
+including an empty array. The same column can contain scalar identity cells
+and set-valued attributes for different actor types; aggregators preserve key
+values rather than wrapping them into sets. Keep the column type, role, unit,
+and presentation metadata when emitting an aggregate.
+
+Every set member follows the ordinary scalar type and `nullable` checks. Null
+cells and null members require `nullable: true`; nested arrays, objects, and
+wrong-typed members are rejected without coercion. In Go builders, use `[]any`
+for sets. A nil slice serializes as null and follows nullability; a non-nil
+empty slice represents an empty set. These rules apply after decoding any of
+the three column codecs.
+
+Set aggregation does not turn reference cells into arrays of references:
+`string_ref`, `ip_ref`, and `mac_ref` still carry one global dictionary index,
+and row-reference columns still carry one row index. A global dictionary entry
+may contain a set where its existing dictionary contract permits arrays.
+Non-set scalar columns and explicit `array`/`json` columns retain their existing
+validation rules. JSON Schema checks the generic wire shape; the topology Go
+builder and semantic validator also check the typed-set member contract.
+
 Use column type `json` only for actor/custom detail cells that must preserve
 nested producer-owned data, such as SNMP port `neighbors` or `vlans`. Do not
 use `json` for high-cardinality relationship evidence when a typed scalar,

--- a/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
@@ -355,7 +355,10 @@ fallback.
 Actor type `search` declares exactly what the graph search bar may index for
 that actor type. `search.columns[]` references actor-table scalar columns.
 `search.label_keys[]` references values in the actor label table, normally
-`actor_labels.key`. Set `search.enabled: false` for helper actors that should
+`actor_labels.key`. These keys are unique non-empty strings, not registry IDs;
+built-in keys such as `_hostname` and `_os` are valid. Search validation does not
+depend on the presence of optional actor presentation settings.
+Set `search.enabled: false` for helper actors that should
 not appear in graph search, such as synthetic segment or grouping actors. The
 UI must not traverse producer-specific `details`, `match`, `attributes`, or
 labels paths when rendering a v1 payload.
@@ -365,6 +368,10 @@ generic `segment` type. Each such type must declare its own identity, merge
 identity, presentation, modal sections, legend entry, and aggregation behavior.
 Consumers must use the declared type metadata and must not infer semantics from
 a type id that happens to contain `segment`, `subnet`, or `network`.
+
+Every actor-type `aggregation_scopes[]` entry must name a scope declared in
+`types.aggregation_scopes`. Omit the list or emit an empty list when the actor
+does not participate in a grouping scope; this does not remove it from the graph.
 
 ## Required Link Semantics
 

--- a/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md
@@ -292,7 +292,10 @@ Common actor identity columns:
 - `vsphere_moid`
 - `vsphere_inventory_path`
 
-Actor types define source-local identity and cross-source merge identity:
+Actor types define source-local identity and cross-source merge identity. The
+following actor-type excerpt is not a complete payload. The enclosing payload
+must declare the listed scope IDs in `types.aggregation_scopes`, provide the
+referenced actor columns, and define the referenced label and port tables:
 
 ```json
 {

--- a/src/plugins.d/FUNCTION_TOPOLOGY_IMPLEMENTATION_SCOPE.md
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_IMPLEMENTATION_SCOPE.md
@@ -471,6 +471,11 @@ Suggested package split:
 Required behavior:
 
 - merge actors by the requested scope and actor type identity;
+- preserve scalar/item column metadata for `aggregation: set`: direct scalar
+  cells and one-dimensional typed sets may share a column. Preserve key cells,
+  validate each set member with the column's type/nullability rules, and retain
+  integer reference encoding. Canonical Go builders and semantic validation
+  accept these aggregate cells without changing installed Agent producer output;
 - apply `data.correlation.rules` without hardcoding topology-kind-specific key
   names in the aggregator;
 - remove pure correlation actors only for exact unambiguous `absorb` matches,

--- a/src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json
@@ -1057,9 +1057,10 @@
         },
         "label_keys": {
           "type": "array",
-          "description": "actor_labels.key values whose label values should be indexed for graph search.",
+          "description": "Non-empty actor_labels.key values whose label values should be indexed for graph search. Label keys are not registry ids; built-in keys such as _hostname are valid.",
           "items": {
-            "$ref": "#/$defs/id"
+            "type": "string",
+            "minLength": 1
           },
           "uniqueItems": true,
           "default": []

--- a/src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json
+++ b/src/plugins.d/FUNCTION_TOPOLOGY_SCHEMA.json
@@ -2474,7 +2474,8 @@
             "evidence_ref",
             "array",
             "json"
-          ]
+          ],
+          "description": "Cell type; for direct scalar columns with aggregation set, also the item type of a one-dimensional set-valued cell. Scalar cells remain valid. Reference cells retain their integer-index encoding."
         },
         "dictionary": {
           "$ref": "#/$defs/id"
@@ -2500,7 +2501,8 @@
           ]
         },
         "aggregation": {
-          "$ref": "#/$defs/aggregation_rule"
+          "$ref": "#/$defs/aggregation_rule",
+          "description": "Column reduction. With set on a direct scalar type, cells may be scalars or one-dimensional arrays whose members satisfy that type and nullable. Empty sets are valid; nested arrays and coercion are not. This relationship is checked by semantic validation; array, json, and reference types retain their existing rules."
         }
       }
     },


### PR DESCRIPTION
## Summary

- Accept scalar or one-dimensional typed-set cells in direct scalar columns that explicitly declare `aggregation: "set"`.
- Share scalar type and nullability checks between topology builders and decoded validation. Reject nested arrays and wrong-typed members with their element location.
- Reject non-finite numeric cells and malformed `json.Number` literals. Accept the full native `uint64` range without narrowing cells to machine-sized indexes.
- Preserve reference/index bounds, column metadata, existing array/JSON behavior and producer output. Document numeric representation and decoder-precision limits in the developer guide.

## Compatibility

This corrects validation of CTS aggregate output. Stable v2.11.0 producers already declare typed scalar set columns. No collector response, request, configuration, metric or chart changes are required; existing installed Agents and direct per-node views continue operating without this validator update.

Older developer validation tools reject array-valued scalar sets until updated. Row and global dictionary references remain integer indexes. Preserving actual actor key values is a CTS aggregation responsibility; this PR does not introduce a separate Agent identity policy.

Numeric `int` and `uint` cells require integral values; `uint` also requires nonnegative values. `json.Number` integer cells retain integer-form syntax, with positive values supported through `uint64`. The CLI retains its existing JSON decoder; this change does not recover precision already lost to `float64` decoding.

## Dependencies

Stacked on #23788. Merge #23788 first, then retarget this PR to `master`. Corresponding CTS components are netdata/cloud-topology-service#20 and netdata/cloud-topology-service#21. Frontend enablement remains gated on the complete CTS dependency set and integration validation.

## Validation

- Topology and Function CLI tests on amd64 and 386, plus race tests and vet for topology, CLI, vSphere, Cato Networks, SNMP topology and job-management packages.
- All direct scalar types, const/values/dict codecs, scalar/set mixed rows, nullability, empty sets, malformed members and unchanged reference/array/JSON cases.
- Numeric regressions reproduce non-finite acceptance and the unsigned ceiling before the fix; the corrected matrix covers native and decoded values, all numeric types and all codecs. CLI fixture tests cover large unsigned values and signed/fractional rejection.
- Four canonical CLI fixtures, four network container fixtures, Python self-tests, 18 SNMP semantic scenarios and five pinned external full-payload goldens.
- Successful native-number validation retains zero allocations for scalar and two-member set cells. Local statement coverage of the numeric helper is 100%; this is not a claim about hosted coverage or end-to-end topology coverage.
- Independent full-scope review found no blocking defects. A separate oracle checked 40,020 numeric representations on amd64 and 386; pointer/value codec checks and set-size benchmarks also passed. The reviewed tree is `7c1059a652371b08851772fc5618ff4e196538b3`, committed as `e34abd5c2979f829e0012a56abb5b33f72c70b55`.
- Targeted local Opengrep analysis reports no findings or tool errors. Lizard reports complexity/length warnings in validator and test functions, not proven correctness defects.

Hosted checks must qualify the pushed revision. Earlier source-build failures were Debian security package HTTP 404 errors, not validator failures. Fixture checks do not establish browser or production qualification; no deployment or installation is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation support for typed set values in topology compact tables, including member types, nullability, numeric formats, and empty sets.
  - Supports direct scalar values and one-dimensional typed sets in the same column.

- **Bug Fixes**
  - Numeric validation now consistently rejects invalid, non-integral, negative unsigned, non-finite, and malformed values.
  - Validation errors identify the affected row and set member where applicable.

- **Documentation**
  - Expanded topology schema and developer guidance for typed sets, numeric constraints, nullability, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->