### PR TITLE
feat(go.d/snmp): add recurring per-device diagnostics

### DIFF
--- a/src/go/plugin/agent/jobmgr/composition/public.go
+++ b/src/go/plugin/agent/jobmgr/composition/public.go
@@ -348,7 +348,7 @@ func (p *Process) startServices(ctx context.Context) func(context.Context) error
 				completions = append(completions, result)
 				go func() { result <- finalizeProcessService(shutdownCtx, entry.service, entry.done) }()
 			}
-			for _, done := range completions {
+			for index, done := range completions {
 				select {
 				case err := <-done:
 					stopErr = errors.Join(stopErr, err)
@@ -360,6 +360,14 @@ func (p *Process) startServices(ctx context.Context) func(context.Context) error
 					stopErr = errors.Join(stopErr, err)
 				case <-shutdownCtx.Done():
 					stopErr = errors.Join(stopErr, fmt.Errorf("jobmgr composition: process services shutdown: %w", shutdownCtx.Err()))
+					// Preserve completed failures without waiting beyond the shared budget.
+					for _, pending := range completions[index:] {
+						select {
+						case err := <-pending:
+							stopErr = errors.Join(stopErr, err)
+						default:
+						}
+					}
 					return
 				}
 			}

--- a/src/go/plugin/agent/jobmgr/composition/public.go
+++ b/src/go/plugin/agent/jobmgr/composition/public.go
@@ -45,6 +45,13 @@ type ProcessService interface {
 	Run(context.Context)
 }
 
+// ProcessServiceFinalizer optionally saves pending state after Run has joined,
+// before jobs are retired. Finalize is called once with the process shutdown
+// budget. It must honor cancellation; the process stops waiting at the deadline.
+type ProcessServiceFinalizer interface {
+	Finalize(context.Context) error
+}
+
 type RuntimeService interface {
 	runtimecomp.Service
 	Start(pluginName string, output io.Writer)
@@ -303,13 +310,17 @@ func cloneSecretConfigs(configs []secretstore.Config) ([]secretstore.Config, err
 
 func (p *Process) startServices(ctx context.Context) func(context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
-	var completions []<-chan struct{}
+	type runningService struct {
+		service ProcessService
+		done    <-chan struct{}
+	}
+	var running []runningService
 	for _, service := range p.services {
 		if service == nil {
 			continue
 		}
 		done := make(chan struct{})
-		completions = append(completions, done)
+		running = append(running, runningService{service, done})
 		go func() {
 			defer close(done)
 			defer func() {
@@ -329,20 +340,56 @@ func (p *Process) startServices(ctx context.Context) func(context.Context) error
 	return func(shutdownCtx context.Context) error {
 		once.Do(func() {
 			cancel()
+			// Finalize independent services concurrently under the same budget.
+			// A stuck Run must never overlap its own finalizer.
+			var completions []<-chan error
+			for _, entry := range running {
+				result := make(chan error, 1)
+				completions = append(completions, result)
+				go func() { result <- finalizeProcessService(shutdownCtx, entry.service, entry.done) }()
+			}
 			for _, done := range completions {
 				select {
-				case <-done:
+				case err := <-done:
+					stopErr = errors.Join(stopErr, err)
 					continue
 				default:
 				}
 				select {
-				case <-done:
+				case err := <-done:
+					stopErr = errors.Join(stopErr, err)
 				case <-shutdownCtx.Done():
-					stopErr = fmt.Errorf("jobmgr composition: process services shutdown: %w", shutdownCtx.Err())
+					stopErr = errors.Join(stopErr, fmt.Errorf("jobmgr composition: process services shutdown: %w", shutdownCtx.Err()))
 					return
 				}
 			}
 		})
 		return stopErr
 	}
+}
+
+// A finalizer never overlaps its own Run; the caller bounds the wait even for
+// service code or filesystem operations that do not respond to cancellation.
+func finalizeProcessService(ctx context.Context, service ProcessService, done <-chan struct{}) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("process service finalization panicked: %v", recovered)
+		}
+	}()
+	select {
+	case <-done:
+	default:
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return fmt.Errorf("jobmgr composition: process services shutdown: %w", ctx.Err())
+		}
+	}
+	if finalizer, ok := service.(ProcessServiceFinalizer); ok {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return finalizer.Finalize(ctx)
+	}
+	return nil
 }

--- a/src/go/plugin/agent/jobmgr/composition/service_finalization_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/service_finalization_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composition
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type finalizingTestService struct {
+	started, joined chan struct{}
+	runRelease      <-chan struct{}
+	finalize        func(context.Context) error
+	calls           atomic.Int32
+}
+
+func (s *finalizingTestService) Run(ctx context.Context) {
+	close(s.started)
+	<-ctx.Done()
+	if s.runRelease != nil {
+		<-s.runRelease
+	}
+	close(s.joined)
+}
+
+func (s *finalizingTestService) Finalize(ctx context.Context) error {
+	s.calls.Add(1)
+	select {
+	case <-s.joined:
+	default:
+		return errors.New("finalization overlapped Run")
+	}
+	return s.finalize(ctx)
+}
+
+func TestProcessServiceFinalization(t *testing.T) {
+	for name, tc := range map[string]struct {
+		stop                        string
+		blockRun, blockFinal, panic bool
+		failure                     bool
+	}{
+		"termination finalizes once":             {stop: "terminate"},
+		"parent cancellation":                    {stop: "cancel"},
+		"input quit":                             {stop: "quit"},
+		"input EOF":                              {stop: "eof"},
+		"failed finalizer is reported":           {stop: "terminate", failure: true},
+		"panic is isolated":                      {stop: "terminate", panic: true},
+		"blocked finalizer respects wait budget": {stop: "terminate", blockFinal: true},
+		"unjoined Run is never finalized":        {stop: "terminate", blockRun: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			reader, writer := io.Pipe()
+			defer reader.Close()
+			defer writer.Close()
+			release := make(chan struct{})
+			finalDone := make(chan struct{})
+			service := &finalizingTestService{started: make(chan struct{}), joined: make(chan struct{})}
+			if tc.blockRun {
+				service.runRelease = release
+			}
+			injected := errors.New("finalization failure")
+			service.finalize = func(ctx context.Context) error {
+				defer close(finalDone)
+				if _, ok := ctx.Deadline(); !ok || ctx.Err() != nil {
+					return errors.New("missing live shutdown budget")
+				}
+				if tc.blockFinal {
+					<-release
+				}
+				if tc.panic {
+					panic("injected finalizer panic")
+				}
+				if tc.failure {
+					return injected
+				}
+				return nil
+			}
+			// A stalled service must not prevent an independent service's finalizer.
+			healthyDone := make(chan struct{})
+			healthy := &finalizingTestService{started: make(chan struct{}), joined: make(chan struct{}), finalize: func(context.Context) error {
+				close(healthyDone)
+				return nil
+			}}
+			config := testProductionProcessConfig(reader, io.Discard)
+			config.ShutdownTimeout = 100 * time.Millisecond
+			config.Services = []ProcessService{service, healthy}
+			process, err := NewProcess(config)
+			require.NoError(t, err)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- process.Run(ctx) }()
+			<-service.started
+			<-healthy.started
+			require.NoError(t, process.Restart(t.Context()))
+			require.Zero(t, service.calls.Load(), "restart must preserve the process service")
+			switch tc.stop {
+			case "terminate":
+				go func() { _ = process.Terminate(t.Context()) }()
+			case "cancel":
+				cancel()
+			case "quit":
+				_, err = io.WriteString(writer, "QUIT\n")
+				require.NoError(t, err)
+			case "eof":
+				require.NoError(t, writer.Close())
+			}
+			select {
+			case err = <-done:
+			case <-time.After(3 * time.Second):
+				t.Error("process exceeded the service finalization wait budget")
+			}
+			close(release)
+			<-service.joined
+			if tc.blockRun {
+				assert.Zero(t, service.calls.Load())
+			} else {
+				<-finalDone
+				assert.EqualValues(t, 1, service.calls.Load())
+			}
+			<-healthyDone
+			assert.EqualValues(t, 1, healthy.calls.Load())
+			switch {
+			case tc.blockRun || tc.blockFinal:
+				assert.ErrorIs(t, err, context.DeadlineExceeded)
+			case tc.failure:
+				assert.ErrorIs(t, err, injected)
+			case tc.panic:
+				assert.ErrorContains(t, err, "injected finalizer panic")
+			case tc.stop == "eof":
+				assert.ErrorContains(t, err, "Function input stopped")
+			case tc.stop != "cancel":
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/composition/service_finalization_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/service_finalization_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -139,6 +140,58 @@ func TestProcessServiceFinalization(t *testing.T) {
 			case tc.stop != "cancel":
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestProcessServiceFinalizationRetainsReadyErrors(t *testing.T) {
+	for name, tc := range map[string]struct{ blockRun bool }{
+		"earlier Run stalls":       {blockRun: true},
+		"earlier finalizer stalls": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				reader, writer := io.Pipe()
+				defer reader.Close()
+				defer writer.Close()
+				release := make(chan struct{})
+				defer close(release)
+				stalled := &finalizingTestService{started: make(chan struct{}), joined: make(chan struct{}), finalize: func(context.Context) error {
+					<-release
+					return nil
+				}}
+				if tc.blockRun {
+					stalled.runRelease = release
+				}
+				injected := errors.New("independent finalization failure")
+				failed := &finalizingTestService{started: make(chan struct{}), joined: make(chan struct{}), finalize: func(context.Context) error {
+					return injected
+				}}
+				config := testProductionProcessConfig(reader, io.Discard)
+				config.ShutdownTimeout = time.Second
+				config.Services = []ProcessService{stalled, failed}
+				process, err := NewProcess(config)
+				require.NoError(t, err)
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				done := make(chan error, 1)
+				go func() { done <- process.Run(ctx) }()
+				<-stalled.started
+				<-failed.started
+				cancel()
+				synctest.Wait()
+				// All runnable finalizers finish before advancing the shared deadline.
+				require.EqualValues(t, 1, failed.calls.Load())
+				time.Sleep(config.ShutdownTimeout)
+				synctest.Wait()
+				select {
+				case err := <-done:
+					assert.ErrorIs(t, err, context.DeadlineExceeded)
+					assert.ErrorIs(t, err, injected)
+				default:
+					t.Fatal("process exceeded its shutdown budget")
+				}
+			})
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/init.go
+++ b/src/go/plugin/go.d/collector/init.go
@@ -165,7 +165,7 @@ func NewRegistry(varLibDir string) (collectorapi.Registry, *snmpdiag.Publisher) 
 	})
 
 	publisher := snmpdiag.NewPublisher(deviceStore, varLibDir)
-	registry["snmp"] = snmp.Creator(deviceStore)
+	registry["snmp"] = snmp.Creator(deviceStore, publisher)
 	registry["snmp_topology"] = snmptopology.Creator(deviceStore, trapEnrichment, reverseDNS, publisher)
 	registry["snmp_traps"] = snmptraps.Creator(deviceStore, trapEnrichment, reverseDNS)
 	return registry, publisher

--- a/src/go/plugin/go.d/collector/snmp/bgp_chart_filter.go
+++ b/src/go/plugin/go.d/collector/snmp/bgp_chart_filter.go
@@ -4,7 +4,7 @@ package snmp
 
 import "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 
-func filterChartMetrics(metrics []ddsnmp.Metric) []ddsnmp.Metric {
+func filterChartMetrics(metrics []ddsnmp.Metric, onFiltered func(ddsnmp.Metric)) []ddsnmp.Metric {
 	if len(metrics) == 0 {
 		return nil
 	}
@@ -12,6 +12,9 @@ func filterChartMetrics(metrics []ddsnmp.Metric) []ddsnmp.Metric {
 	filtered := make([]ddsnmp.Metric, 0, len(metrics))
 	for _, metric := range metrics {
 		if shouldHideBGPDiagnosticMetric(metric.Name) {
+			if onFiltered != nil {
+				onFiltered(metric)
+			}
 			continue
 		}
 		filtered = append(filtered, metric)

--- a/src/go/plugin/go.d/collector/snmp/bgp_integration.go
+++ b/src/go/plugin/go.d/collector/snmp/bgp_integration.go
@@ -61,10 +61,10 @@ func (c *Collector) prepareProfileMetrics(pms []*ddsnmp.ProfileMetrics) []ddsnmp
 	if c.bgp == nil {
 		return flattenProfileMetrics(pms)
 	}
-	return c.bgp.prepareProfileMetrics(pms)
+	return c.bgp.prepareProfileMetrics(pms, func(metric ddsnmp.Metric) { c.recordNormalMetric(metric, "bgp_chart_filter", nil) })
 }
 
-func (b *bgpIntegration) prepareProfileMetrics(pms []*ddsnmp.ProfileMetrics) []ddsnmp.Metric {
+func (b *bgpIntegration) prepareProfileMetrics(pms []*ddsnmp.ProfileMetrics, filtered func(ddsnmp.Metric)) []ddsnmp.Metric {
 	b.collectError, b.collectFailedSources = bgpCollectErrorsBySource(pms)
 
 	metrics := flattenProfileMetrics(pms)
@@ -80,7 +80,7 @@ func (b *bgpIntegration) prepareProfileMetrics(pms []*ddsnmp.ProfileMetrics) []d
 
 	metrics = append(metrics, typedBGPMetricsFromProfileMetrics(successfulBGPProfileMetrics(pms))...)
 
-	return filterChartMetrics(metrics)
+	return filterChartMetrics(metrics, filtered)
 }
 
 func (c *Collector) finalizeProfileMetrics() {

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -26,8 +26,15 @@ func (c *Collector) collect(ctx context.Context) (map[string]int64, error) {
 		ctx = context.Background()
 	}
 
+	initializing := !c.initialized
 	if err := c.ensureInitialized(); err != nil {
 		return nil, err
+	}
+
+	if initializing && c.normal.recorder != nil {
+		for ordinal := uint64(1); ordinal <= c.normal.recorder.Cursor(); ordinal++ {
+			c.normal.initialization = append(c.normal.initialization, c.normal.recorder.Operation(ordinal))
+		}
 	}
 
 	if c.PingOnly {
@@ -106,11 +113,12 @@ func (c *Collector) ensureInitialized() error {
 
 	if c.ddSnmpColl == nil && len(c.snmpProfiles) > 0 {
 		c.ddSnmpColl = c.newDdSnmpColl(ddsnmpcollector.Config{
-			SnmpClient:      c.snmpClient,
-			Profiles:        c.snmpProfiles,
-			Log:             c.Logger,
-			SysObjectID:     si.SysObjectID,
-			DisableBulkWalk: c.disableBulkWalk,
+			SnmpClient:          c.snmpClient,
+			Profiles:            c.snmpProfiles,
+			Log:                 c.Logger,
+			SysObjectID:         si.SysObjectID,
+			DisableBulkWalk:     c.disableBulkWalk,
+			AcquisitionObserver: ddsnmpcollector.AcquisitionObserverFunc(c.observeNormalProfile),
 		})
 	}
 
@@ -209,7 +217,11 @@ func (c *Collector) initAndConnectSNMPClient() (gosnmp.Handler, error) {
 	if c.adjMaxRepetitions != 0 {
 		snmpClient.SetMaxRepetitions(c.adjMaxRepetitions)
 	} else {
-		ok, err := c.adjustMaxRepetitions(snmpClient)
+		probeClient := snmpClient
+		if c.normal != nil && c.normal.recorder != nil {
+			probeClient = c.normal.recorder.Wrap(snmpClient)
+		}
+		ok, err := c.adjustMaxRepetitions(probeClient)
 		if err != nil {
 			return nil, snmputils.WithFailure(fmt.Errorf("re-adjust max repetitions SNMP client: %w", err), "max_repetitions", "")
 		}

--- a/src/go/plugin/go.d/collector/snmp/collect_snmp.go
+++ b/src/go/plugin/go.d/collector/snmp/collect_snmp.go
@@ -37,13 +37,18 @@ func (c *Collector) collectSNMP(mx map[string]int64) error {
 
 	c.finalizeIfaceCache()
 	c.finalizeProfileMetrics()
+	c.commitNormalConsumers(pms)
 
 	return nil
 }
 
 func (c *Collector) collectProfileScalarMetrics(mx map[string]int64, metrics []ddsnmp.Metric) {
 	for _, m := range metrics {
-		if m.IsTable || m.Name == "" {
+		if m.IsTable {
+			continue
+		}
+		if m.Name == "" {
+			c.recordNormalMetric(m, "missing_name", nil)
 			continue
 		}
 
@@ -53,13 +58,19 @@ func (c *Collector) collectProfileScalarMetrics(mx map[string]int64, metrics []d
 		}
 
 		if len(m.MultiValue) == 0 {
-			mx[metricIDFromName(m.Name)] = m.Value
+			id := metricIDFromName(m.Name)
+			mx[id] = m.Value
+			c.recordNormalMetric(m, "set", []string{id})
 			continue
 		}
 
+		var ids []string
 		for k, v := range m.MultiValue {
-			mx[metricIDFromName(m.Name, k)] = v
+			id := metricIDFromName(m.Name, k)
+			mx[id] = v
+			ids = append(ids, id)
 		}
+		c.recordNormalMetric(m, "set", ids)
 	}
 }
 
@@ -67,12 +78,21 @@ func (c *Collector) collectProfileTableMetrics(mx map[string]int64, metrics []dd
 	seen := make(map[string]bool)
 
 	for _, m := range metrics {
-		if !m.IsTable || m.Name == "" || len(m.Tags) == 0 {
+		if !m.IsTable {
+			continue
+		}
+		if m.Name == "" || len(m.Tags) == 0 {
+			reason := "missing_tags"
+			if m.Name == "" {
+				reason = "missing_name"
+			}
+			c.recordNormalMetric(m, reason, nil)
 			continue
 		}
 
 		key := tableMetricKey(m)
 		if key == "" {
+			c.recordNormalMetric(m, "missing_table_key", nil)
 			continue
 		}
 
@@ -84,11 +104,17 @@ func (c *Collector) collectProfileTableMetrics(mx map[string]int64, metrics []dd
 		}
 
 		if len(m.MultiValue) == 0 {
-			mx[metricIDFromKey(key)] += m.Value
+			id := metricIDFromKey(key)
+			mx[id] += m.Value
+			c.recordNormalMetric(m, "sum", []string{id})
 		} else {
+			var ids []string
 			for k, v := range m.MultiValue {
-				mx[metricIDFromKey(key, k)] = v
+				id := metricIDFromKey(key, k)
+				mx[id] = v
+				ids = append(ids, id)
 			}
+			c.recordNormalMetric(m, "set", ids)
 		}
 
 		if isIfaceMetric(m.Name) {

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/pinger"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 )
@@ -24,7 +25,7 @@ import (
 var configSchema string
 
 // Creator constructs registration with explicit SNMP-family dependencies.
-func Creator(store *ddsnmp.DeviceStore) collectorapi.Creator {
+func Creator(store *ddsnmp.DeviceStore, publisher *diagnostics.Publisher) collectorapi.Creator {
 	if store == nil {
 		panic("snmp Creator requires a non-nil device store")
 	}
@@ -33,9 +34,9 @@ func Creator(store *ddsnmp.DeviceStore) collectorapi.Creator {
 		Defaults: collectorapi.Defaults{
 			UpdateEvery: 10,
 		},
-		Create:             func() collectorapi.CollectorV1 { return New(store) },
+		Create:             func() collectorapi.CollectorV1 { c := New(store); c.diagnosticPublisher = publisher; return c },
 		Config:             func() any { return &Config{} },
-		JobConfigLifecycle: newSNMPJobConfigLifecycle(store),
+		JobConfigLifecycle: newSNMPJobConfigLifecycle(store, publisher),
 		SharedFunctions:    snmpMethods,
 		MethodHandler:      snmpFunctionHandler,
 	}
@@ -78,6 +79,7 @@ func New(store *ddsnmp.DeviceStore) *Collector {
 	}
 	c := &Collector{
 		Config: defaultConfig(),
+		normal: &normalDiagnostics{},
 
 		charts:               &collectorapi.Charts{},
 		seenScalarMetrics:    make(map[string]bool),
@@ -105,7 +107,10 @@ func New(store *ddsnmp.DeviceStore) *Collector {
 type (
 	Collector struct {
 		collectorapi.Base
-		Config `yaml:",inline" json:""`
+		normal              *normalDiagnostics
+		diagnosticPublisher *diagnostics.Publisher
+		normalWriter        *diagnostics.NormalWriter
+		Config              `yaml:",inline" json:""`
 
 		vnode *vnodes.VirtualNode
 
@@ -191,8 +196,11 @@ func (c *Collector) Init(context.Context) (err error) {
 }
 
 func (c *Collector) Check(ctx context.Context) (err error) {
+	c.beginNormalAttempt("check")
+	defer func() { c.finishNormalAttempt(err, nil) }()
 	defer func() {
 		if recovered := recover(); recovered != nil {
+			err = snmputils.WithFailureDetail(fmt.Errorf("SNMP check interrupted"), snmputils.Failure{Reason: "panic"})
 			c.recordDeviceLifecycle(
 				ddsnmp.DeviceLifecyclePhaseCheck,
 				ddsnmp.DeviceLifecycleOutcomeFailed,
@@ -208,6 +216,7 @@ func (c *Collector) Check(ctx context.Context) (err error) {
 			return lifecycleFailureError(fmt.Errorf("failed to init and connect SNMP client: %v", err), err, "connect", "")
 		}
 		c.snmpClient = snmpClient
+		c.wrapNormalClient()
 	}
 
 	if err := c.ensureDeviceProfile(); err != nil {
@@ -228,17 +237,20 @@ func (c *Collector) Charts() *collectorapi.Charts {
 }
 
 func (c *Collector) Collect(ctx context.Context) map[string]int64 {
+	c.beginNormalAttempt("collect")
 	c.deviceLifecycleMu.Lock()
 	c.deviceCollectionFailures = ddsnmp.CollectionFailures{}
 	c.deviceLifecycleMu.Unlock()
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			c.recordDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseCollect, ddsnmp.DeviceLifecycleOutcomeFailed)
+			c.finishNormalAttempt(snmputils.WithFailureDetail(fmt.Errorf("SNMP collection interrupted"), snmputils.Failure{Reason: "panic"}), nil)
 			panic(recovered)
 		}
 	}()
 	mx, err := c.collect(ctx)
 	c.completeDeviceLifecycle(ddsnmp.DeviceLifecyclePhaseCollect, err)
+	c.finishNormalAttempt(err, mx)
 	if err != nil {
 		c.Error(err)
 	}

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -50,7 +50,7 @@ func TestCollector_ConfigurationSerialize(t *testing.T) {
 
 func TestCollectorCreatorRequiresDeviceStore(t *testing.T) {
 	require.PanicsWithValue(t, "snmp Creator requires a non-nil device store", func() {
-		_ = Creator(nil)
+		_ = Creator(nil, nil)
 	})
 }
 
@@ -267,7 +267,7 @@ func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilReconcile(t *testi
 	collr := New(store)
 	collr.Hostname = ""
 	job := snmpLifecycleTestRuntimeJob{collector: collr}
-	hook := Creator(store).JobConfigLifecycle
+	hook := Creator(store, nil).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
 	hook.Bind(identity, job)
@@ -286,7 +286,7 @@ func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilReconcile(t *testi
 
 func TestSNMPJobConfigLifecycleProjectsCredentialFreeBaseline(t *testing.T) {
 	store := ddsnmp.NewDeviceStore()
-	hook := Creator(store).JobConfigLifecycle
+	hook := Creator(store, nil).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 	config := map[string]any{
 		"hostname":  "switch-a.example",
@@ -323,7 +323,7 @@ func TestCollectorRejectedManagedCandidateDoesNotRemoveIncumbentConnection(t *te
 	store.Register(identity.String(), ddsnmp.DeviceConnectionInfo{Hostname: "incumbent.example"})
 	collr := New(store)
 	job := snmpLifecycleTestRuntimeJob{collector: collr}
-	hook := Creator(store).JobConfigLifecycle
+	hook := Creator(store, nil).JobConfigLifecycle
 
 	hook.Bind(identity, job)
 	collr.Cleanup(context.Background())
@@ -337,7 +337,7 @@ func TestCollectorManagedLifecycleSnapshotIsDetachedAtCapture(t *testing.T) {
 	collr := New(store)
 	collr.Config = prepareV2Config()
 	job := snmpLifecycleTestRuntimeJob{collector: collr}
-	hook := Creator(store).JobConfigLifecycle
+	hook := Creator(store, nil).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
 	hook.Bind(identity, job)
@@ -405,7 +405,7 @@ func TestCollectorManagedConnectionCollectedBeforeReconcileIsPublishedAtReconcil
 	collr.Config = prepareV2Config()
 	collr.ManualProfiles = []string{"profile-a"}
 	job := snmpLifecycleTestRuntimeJob{collector: collr}
-	hook := Creator(store).JobConfigLifecycle
+	hook := Creator(store, nil).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
 	hook.Bind(identity, job)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_cache.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_cache.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"cmp"
+	"slices"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+// AcquisitionCacheInput belongs to one committed cache generation. Its maps
+// and source objects are immutable, allowing a poll to retain references only.
+type AcquisitionCacheInput struct {
+	Kind      string
+	Profile   string
+	RootOID   string
+	ConfigID  string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	Marker    bool
+	OIDs      map[string]map[string]string
+	TableTags map[string]map[string]string
+	Tags      map[string]string
+	Metadata  map[string]ddsnmp.MetaTag
+	Sources   []*ddsnmp.SourceOperation
+}
+
+// CachedInputs snapshots cache owners, not their historical raw payloads.
+// Like Collect, only the synchronous collector owner calls this method.
+func (c *Collector) CachedInputs() []AcquisitionCacheInput {
+	var result []AcquisitionCacheInput
+	for _, profile := range c.sortedProfileStates() {
+		if input := profile.cache.tagEvidence; input != nil {
+			item := *input
+			item.Profile = profile.profile.SourceFile
+			result = append(result, item)
+		}
+		if input := profile.cache.metadataEvidence; input != nil {
+			item := *input
+			item.Profile = profile.profile.SourceFile
+			result = append(result, item)
+		}
+	}
+	c.tableCache.mu.RLock()
+	for root, configs := range c.tableCache.tables {
+		for configID, entry := range configs {
+			if entry.evidence == nil {
+				continue
+			}
+			input := *entry.evidence
+			input.RootOID, input.ConfigID = root, configID
+			input.ExpiresAt = c.tableCache.timestamps[root].Add(c.tableCache.tableTTLs[root])
+			result = append(result, input)
+		}
+	}
+	c.tableCache.mu.RUnlock()
+	slices.SortFunc(result, func(a, b AcquisitionCacheInput) int {
+		return cmp.Or(cmp.Compare(a.Kind, b.Kind), cmp.Compare(a.Profile, b.Profile), cmp.Compare(a.RootOID, b.RootOID), cmp.Compare(a.ConfigID, b.ConfigID))
+	})
+	return result
+}
+
+func (s *tableCollectionSession) cacheSources(req *tableCollectionRequest) []*ddsnmp.SourceOperation {
+	recorder := sourceRecorder(s.collector.snmpClient)
+	if recorder == nil {
+		return nil
+	}
+	var sources []*ddsnmp.SourceOperation
+	seen := make(map[*ddsnmp.SourceOperation]bool)
+	if operation := recorder.Operation(req.route.sourceOperation); operation != nil {
+		sources = append(sources, operation)
+		seen[operation] = true
+	}
+	for _, dependency := range req.dependencies {
+		if operation := recorder.Operation(dependency.sourceOperation); operation != nil && !seen[operation] {
+			sources = append(sources, operation)
+			seen[operation] = true
+		}
+	}
+	return sources
+}
+
+func (c *acquisitionProfileCollection) retainInputRoutes(recorder *SourceRecorder) []AcquisitionRouteReport {
+	if c == nil {
+		return nil
+	}
+	var result []AcquisitionRouteReport
+	for _, route := range c.routes {
+		if route.Kind != AcquisitionRouteKindProfileTagScalar && route.Kind != AcquisitionRouteKindMetadataScalar {
+			continue
+		}
+		route.Sources = slices.Clone(route.Sources)
+		if recorder != nil {
+			for i := range route.Sources {
+				route.Sources[i].ContextID = recorder.ContextID
+			}
+		}
+		result = append(result, route)
+	}
+	return result
+}
+
+func (c *acquisitionProfileCollection) restoreInputRoutes(routes []AcquisitionRouteReport) {
+	if c == nil {
+		return
+	}
+	for _, route := range routes {
+		route.Source = AcquisitionRouteSourceCache
+		c.routes[route.Ordinal] = route
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_cache.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_cache.go
@@ -108,6 +108,7 @@ func (c *acquisitionProfileCollection) restoreInputRoutes(routes []AcquisitionRo
 	}
 	for _, route := range routes {
 		route.Source = AcquisitionRouteSourceCache
+		route.Reused = true
 		c.routes[route.Ordinal] = route
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_licensing.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_licensing.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+
+func failAcquisitionRoute(route *AcquisitionRouteReport, class AcquisitionFailureClass) {
+	if route != nil {
+		route.Outcome, route.FailureClass = AcquisitionRouteOutcomeFailed, class
+	}
+}
+
+func rejectAcquisitionRoute(route *AcquisitionRouteReport) {
+	if route != nil {
+		route.Rejected++
+		route.Outcome, route.FailureClass = AcquisitionRouteOutcomeRejected, AcquisitionFailureClassProcessing
+	}
+}
+
+func startLicenseScalarRoute(route *AcquisitionRouteReport, oids, missing []string) {
+	if route == nil {
+		return
+	}
+	route.Missing = uint64(len(missing))
+	if len(oids) > 0 {
+		route.Source = AcquisitionRouteSourceGET
+	} else if len(missing) > 0 {
+		route.Source = AcquisitionRouteSourceCache
+	}
+}
+
+func finishLicenseScalarRoute(route *AcquisitionRouteReport, requested []string, missing map[string]bool) {
+	if route == nil {
+		return
+	}
+	for _, oid := range requested {
+		if missing[oid] {
+			route.Missing++
+		}
+	}
+	setAcquisitionRouteCounts(route, 1, route.Values, route.Rejected)
+}
+
+func (c *acquisitionProfileCollection) addLicenseReference(route *AcquisitionRouteReport, row string) {
+	if c == nil || route == nil {
+		return
+	}
+	c.addValueReference(&c.licenseValueReferences, AcquisitionValueReference{RouteOrdinal: route.Ordinal, RowIndex: row, RowOrdinal: uint32(route.Values)})
+	route.Values++
+}
+
+func firstLicenseRouteOID(cfg ddprofiledefinition.LicensingConfig) string {
+	var first string
+	add := func(oid string) {
+		if oid = trimOID(oid); oid != "" && (first == "" || oid < first) {
+			first = oid
+		}
+	}
+	forEachLicenseValue(cfg, func(value ddprofiledefinition.LicenseValueConfig) { add(licenseValueSymbol(value).OID) })
+	for _, tag := range cfg.MetricTags {
+		add(tag.Symbol.OID)
+	}
+	return first
+}
+
+func (ctx licenseValueContext) record(cfg ddprofiledefinition.LicenseValueConfig, oid, reason string) {
+	ctx.processing.record(licenseValueSymbol(cfg).Name, oid, reason)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_metrics.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_metrics.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+func (c *acquisitionProfileCollection) metricScalarObserver() *acquisitionScalarObserver {
+	if c == nil {
+		return nil
+	}
+	return &acquisitionScalarObserver{collection: c, routeIndexes: c.metricScalarRoutes}
+}
+
+func (c *acquisitionProfileCollection) metricTableScope() *acquisitionTableScope {
+	if c == nil {
+		return nil
+	}
+	return &acquisitionTableScope{collection: c, routeIndexes: c.metricTableRoutes}
+}
+
+func (c *acquisitionProfileCollection) addMetricValueReference(ordinal uint32, reference AcquisitionValueReference) {
+	if c == nil {
+		return
+	}
+	switch c.routes[ordinal].Kind {
+	case AcquisitionRouteKindTopologyScalar, AcquisitionRouteKindTopologyTable:
+		c.addTopologyValueReference(reference)
+	default:
+		c.addValueReference(&c.metricValueReferences, reference)
+	}
+}
+
+func (c *acquisitionProfileCollection) licenseRoute(index int) *AcquisitionRouteReport {
+	if c == nil {
+		return nil
+	}
+	return c.route(c.licenseRoutes[index])
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+// AcquisitionNegativeCause explains a permanent missing-OID entry without
+// retaining unrelated values from the GET that established it.
+type AcquisitionNegativeCause struct {
+	ContextID  uint64
+	Operation  uint64
+	ObservedAt time.Time
+	PDU        ddsnmp.SourcePDU
+}
+
+func (c *diagnosticClient) recordMissing(pdu gosnmp.SnmpPDU) {
+	source := c.SourceRecorder()
+	if source == nil || c.negativeCauses == nil {
+		return
+	}
+	oid := trimOID(pdu.Name)
+	if _, exists := (*c.negativeCauses)[oid]; exists {
+		return
+	}
+	operation := source.Operation(source.Cursor())
+	if operation == nil {
+		return
+	}
+	if *c.negativeCauses == nil {
+		*c.negativeCauses = make(map[string]AcquisitionNegativeCause)
+	}
+	(*c.negativeCauses)[oid] = AcquisitionNegativeCause{
+		ContextID: operation.ContextID, Operation: operation.Ordinal, ObservedAt: operation.StartedAt,
+		PDU: ddsnmp.SourcePDU{OID: strings.Clone(pdu.Name), Type: uint8(pdu.Type), Value: sourceValue(pdu.Value)},
+	}
+}
+
+func (c *Collector) NegativeCauses() []AcquisitionNegativeCause {
+	result := make([]AcquisitionNegativeCause, 0, len(c.negativeCauses))
+	for _, cause := range c.negativeCauses {
+		result = append(result, cause)
+	}
+	slices.SortFunc(result, func(a, b AcquisitionNegativeCause) int { return strings.Compare(a.PDU.OID, b.PDU.OID) })
+	return result
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
@@ -20,31 +20,51 @@ type AcquisitionNegativeCause struct {
 	PDU        ddsnmp.SourcePDU
 }
 
+type negativeEvidence struct {
+	eligible map[string]bool
+	causes   map[string]AcquisitionNegativeCause
+}
+
+// Only production suppression reads establish eligibility. Dynamic instance
+// GETs bypass this map, so their churn cannot grow retained diagnostic history.
+func isMissingOID(client gosnmp.Handler, missing map[string]bool, oid string) bool {
+	if observer, ok := client.(*diagnosticClient); ok && observer.negative != nil && observer.SourceRecorder() != nil {
+		if observer.negative.eligible == nil {
+			observer.negative.eligible = make(map[string]bool)
+		}
+		observer.negative.eligible[oid] = true
+	}
+	return missing[oid]
+}
+
 func (c *diagnosticClient) recordMissing(pdu gosnmp.SnmpPDU) {
 	source := c.SourceRecorder()
-	if source == nil || c.negativeCauses == nil {
+	if source == nil || c.negative == nil {
 		return
 	}
 	oid := trimOID(pdu.Name)
-	if _, exists := (*c.negativeCauses)[oid]; exists {
+	if !c.negative.eligible[oid] {
+		return
+	}
+	if _, exists := c.negative.causes[oid]; exists {
 		return
 	}
 	operation := source.Operation(source.Cursor())
 	if operation == nil {
 		return
 	}
-	if *c.negativeCauses == nil {
-		*c.negativeCauses = make(map[string]AcquisitionNegativeCause)
+	if c.negative.causes == nil {
+		c.negative.causes = make(map[string]AcquisitionNegativeCause)
 	}
-	(*c.negativeCauses)[oid] = AcquisitionNegativeCause{
+	c.negative.causes[oid] = AcquisitionNegativeCause{
 		ContextID: operation.ContextID, Operation: operation.Ordinal, ObservedAt: operation.StartedAt,
 		PDU: ddsnmp.SourcePDU{OID: strings.Clone(pdu.Name), Type: uint8(pdu.Type), Value: sourceValue(pdu.Value)},
 	}
 }
 
 func (c *Collector) NegativeCauses() []AcquisitionNegativeCause {
-	result := make([]AcquisitionNegativeCause, 0, len(c.negativeCauses))
-	for _, cause := range c.negativeCauses {
+	result := make([]AcquisitionNegativeCause, 0, len(c.negative.causes))
+	for _, cause := range c.negative.causes {
 		result = append(result, cause)
 	}
 	slices.SortFunc(result, func(a, b AcquisitionNegativeCause) int { return strings.Compare(a.PDU.OID, b.PDU.OID) })

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
@@ -14,10 +14,10 @@ import (
 // AcquisitionNegativeCause explains a permanent missing-OID entry without
 // retaining unrelated values from the GET that established it.
 type AcquisitionNegativeCause struct {
-	ContextID  uint64
-	Operation  uint64
-	ObservedAt time.Time
-	PDU        ddsnmp.SourcePDU
+	ContextID  uint64           `json:"context_id"`
+	Operation  uint64           `json:"operation"`
+	ObservedAt time.Time        `json:"observed_at"`
+	PDU        ddsnmp.SourcePDU `json:"pdu"`
 }
 
 type negativeEvidence struct {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_processing.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_processing.go
@@ -50,7 +50,7 @@ func (o *acquisitionTableObservation) processing(row string) *processingObserver
 	return processingFor(o.collection.route(int(o.routeOrdinal)), row)
 }
 
-func (o *acquisitionTopologyScalarObserver) processing(index int) *processingObserver {
+func (o *acquisitionScalarObserver) processing(index int) *processingObserver {
 	return processingFor(o.route(index), "")
 }
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_processing_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_processing_test.go
@@ -19,26 +19,31 @@ func TestBGPProcessingEvidenceFollowsCollection(t *testing.T) {
 		configure func(*ddprofiledefinition.BGPConfig)
 		want      ddsnmp.ProcessingEvent
 		rows      int
+		failed    bool
 	}{
 		"optional descriptor omission": {
+			failed: true,
 			configure: func(c *ddprofiledefinition.BGPConfig) {
 				c.Descriptors.Description.Symbol = ddprofiledefinition.SymbolConfig{OID: root + ".4", ExtractValueCompiled: regexp.MustCompile("^never(.)$")}
 			},
 			want: ddsnmp.ProcessingEvent{RowIndex: "42", Field: "descriptors.description", OID: root + ".4.42", Reason: "extract_mismatch"}, rows: 1,
 		},
 		"boolean conversion rejects row": {
+			failed: true,
 			configure: func(c *ddprofiledefinition.BGPConfig) {
 				c.Admin.Enabled = ddprofiledefinition.BGPValueConfig{Value: "invalid"}
 			},
 			want: ddsnmp.ProcessingEvent{RowIndex: "42", Field: "admin.enabled", Reason: "conversion"},
 		},
 		"raw enrichment omission preserves numeric value": {
+			failed: true,
 			configure: func(c *ddprofiledefinition.BGPConfig) {
 				c.Connection.EstablishedUptime.Symbol.ExtractValueCompiled = regexp.MustCompile("^never(.)$")
 			},
 			want: ddsnmp.ProcessingEvent{RowIndex: "42", Field: "connection.established_uptime", OID: root + ".4.42", Reason: "extract_mismatch", Stage: "raw_text"}, rows: 1,
 		},
 		"device state identifies exact field": {
+			failed: true,
 			configure: func(c *ddprofiledefinition.BGPConfig) {
 				c.Device.States.Idle = ddprofiledefinition.BGPValueConfig{Value: "invalid"}
 			},
@@ -68,6 +73,7 @@ func TestBGPProcessingEvidenceFollowsCollection(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 			require.Len(t, results[0].BGPRows, tc.rows)
+			require.Equal(t, tc.failed, report.HasFailures())
 			require.Len(t, report.Routes, 1)
 			require.Contains(t, report.Routes[0].Processing, tc.want)
 			require.NoError(t, ddsnmp.ValidateProcessingEvents(report.Routes[0].Processing))
@@ -119,6 +125,7 @@ func TestCrossTableProcessingEvidenceFollowsCollection(t *testing.T) {
 			require.Contains(t, route.Processing, ddsnmp.ProcessingEvent{RowIndex: "7", Field: metricTagDisplayName(primary.MetricTags[0]), OID: primary.MetricTags[0].Symbol.OID + ".7", Reason: tc.reason})
 			require.Len(t, route.Sources, 2)
 			require.Equal(t, dependency.Table.Name, primary.MetricTags[0].Table)
+			require.Equal(t, !tc.missing, report.HasFailures(), "absent dependency data differs from a failed transform")
 			require.Len(t, source.Finish(), 2)
 		})
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_processing_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_processing_test.go
@@ -63,7 +63,7 @@ func TestBGPProcessingEvidenceFollowsCollection(t *testing.T) {
 			handler := &sourceTestHandler{walk: func(string) ([]gosnmp.SnmpPDU, error) { return pdus, nil }}
 			source := &SourceRecorder{}
 			var report AcquisitionProfileReport
-			collector := New(Config{SnmpClient: source.Wrap(handler), Log: logger.New(), Profiles: []*ddsnmp.Profile{{SourceFile: "synthetic.yaml", Definition: &ddprofiledefinition.ProfileDefinition{BGP: []ddprofiledefinition.BGPConfig{cfg}}}}, InitialAcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = r })})
+			collector := New(Config{SnmpClient: source.Wrap(handler), Log: logger.New(), Profiles: []*ddsnmp.Profile{{SourceFile: "synthetic.yaml", Definition: &ddprofiledefinition.ProfileDefinition{BGP: []ddprofiledefinition.BGPConfig{cfg}}}}, AcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = r })})
 			results, err := collector.Collect()
 			require.NoError(t, err)
 			require.Len(t, results, 1)
@@ -103,7 +103,7 @@ func TestCrossTableProcessingEvidenceFollowsCollection(t *testing.T) {
 			}}
 			source := &SourceRecorder{}
 			var report AcquisitionProfileReport
-			collector := New(Config{SnmpClient: source.Wrap(handler), Log: logger.New(), Profiles: []*ddsnmp.Profile{profile}, InitialAcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = r })})
+			collector := New(Config{SnmpClient: source.Wrap(handler), Log: logger.New(), Profiles: []*ddsnmp.Profile{profile}, AcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = r })})
 			results, err := collector.Collect()
 			require.NoError(t, err)
 			require.Len(t, results, 1)
@@ -194,7 +194,7 @@ func TestMetadataProcessingEvidenceUsesLogicalField(t *testing.T) {
 				SnmpClient: new(SourceRecorder).Wrap(handler),
 				Profiles:   []*ddsnmp.Profile{profile},
 				Log:        logger.New(),
-				InitialAcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+				AcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 					report = r
 				}),
 			})

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_recurring_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_recurring_test.go
@@ -4,6 +4,7 @@ package ddsnmpcollector
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/gosnmp/gosnmp"
@@ -184,6 +185,45 @@ func TestRecurringDependencySettlementEvidence(t *testing.T) {
 					assert.NotEqual(t, "get", operation.Method)
 				}
 			}
+		})
+	}
+}
+
+func TestRecurringNegativeEvidenceIgnoresDynamicInstances(t *testing.T) {
+	for name, tc := range map[string]struct{ polls int }{"short churn": {3}, "longer churn": {20}} {
+		t.Run(name, func(t *testing.T) {
+			const root, scalar = "1.3.6.1.4.1.99999.82", "1.3.6.1.4.1.99999.83.0"
+			poll := 0
+			handler := &sourceTestHandler{
+				get: func(oids []string) (*gosnmp.SnmpPacket, error) {
+					packet := &gosnmp.SnmpPacket{}
+					for _, oid := range oids {
+						packet.Variables = append(packet.Variables, gosnmp.SnmpPDU{Name: oid, Type: gosnmp.NoSuchInstance})
+					}
+					return packet, nil
+				},
+				walk: func(string) ([]gosnmp.SnmpPDU, error) {
+					return []gosnmp.SnmpPDU{createGauge32PDU(fmt.Sprintf("%s.1.%d", root, poll), 7)}, nil
+				},
+			}
+			profile := createTestProfile("churn.yaml", []ddprofiledefinition.MetricsConfig{
+				{Symbol: ddprofiledefinition.SymbolConfig{OID: scalar, Name: "unsupported"}},
+				{Table: ddprofiledefinition.SymbolConfig{OID: root, Name: "table"}, Symbols: []ddprofiledefinition.SymbolConfig{{OID: root + ".1", Name: "value"}}},
+			})
+			collector := New(Config{SnmpClient: handler, Profiles: []*ddsnmp.Profile{profile}, Log: logger.New()})
+			for poll = 1; poll <= tc.polls; poll++ {
+				recorder := &SourceRecorder{ContextID: uint64(poll)}
+				collector.SetSNMPClient(recorder.Wrap(handler))
+				metrics, err := collector.Collect()
+				require.NoError(t, err)
+				require.Len(t, metrics[0].Metrics, 1)
+				recorder.Finish()
+			}
+			require.Greater(t, len(collector.missingOIDs), 1, "production cache still records dynamic missing instances")
+			causes := collector.NegativeCauses()
+			require.Len(t, causes, 1, "only the configured scalar suppresses future acquisition")
+			assert.Equal(t, scalar, causes[0].PDU.OID)
+			assert.EqualValues(t, 1, causes[0].ContextID)
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_recurring_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_recurring_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+func TestRecurringTableEvidence(t *testing.T) {
+	const root = "1.3.6.1.4.1.99999.80"
+	for name, tc := range map[string]struct{ fallback bool }{
+		"cached GET retains original structure":   {},
+		"failed candidate GET falls back to WALK": {fallback: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			handler := &sourceTestHandler{
+				walk: func(string) ([]gosnmp.SnmpPDU, error) {
+					return []gosnmp.SnmpPDU{createGauge32PDU(root+".1.1", 7)}, nil
+				},
+				get: func(oids []string) (*gosnmp.SnmpPacket, error) {
+					if tc.fallback {
+						return nil, errors.New("candidate timeout")
+					}
+					return &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{createGauge32PDU(oids[0], 9)}}, nil
+				},
+			}
+			profile := createTestProfile("table.yaml", []ddprofiledefinition.MetricsConfig{{
+				Table:   ddprofiledefinition.SymbolConfig{OID: root, Name: "table"},
+				Symbols: []ddprofiledefinition.SymbolConfig{{OID: root + ".1", Name: "value"}},
+			}})
+			var reports []AcquisitionProfileReport
+			first := &SourceRecorder{ContextID: 1}
+			collector := New(Config{SnmpClient: first.Wrap(handler), Profiles: []*ddsnmp.Profile{profile}, Log: logger.New(),
+				AcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { reports = append(reports, report) }),
+			})
+			_, err := collector.Collect()
+			require.NoError(t, err)
+			firstSources := first.Finish()
+			require.Len(t, firstSources, 1)
+			require.EqualValues(t, 1, firstSources[0].ContextID)
+			require.False(t, firstSources[0].StartedAt.IsZero())
+			second := &SourceRecorder{ContextID: 2}
+			collector.SetSNMPClient(second.Wrap(handler))
+			metrics, err := collector.Collect()
+			require.NoError(t, err)
+			sources := second.Finish()
+			require.Len(t, reports, 2)
+			require.Len(t, reports[1].MetricValueReferences, 1)
+			require.Len(t, reports[1].Routes, 1)
+			route := reports[1].Routes[0]
+			var tableInput *AcquisitionCacheInput
+			for _, input := range collector.CachedInputs() {
+				if input.Kind == "table" {
+					tableInput = &input
+				}
+			}
+			require.NotNil(t, tableInput)
+			require.Len(t, tableInput.Sources, 1)
+			if tc.fallback {
+				require.Len(t, sources, 2)
+				assert.Equal(t, AcquisitionRouteSourceWalk, route.Source)
+				require.Len(t, route.DiscardedSources, 1)
+				assert.EqualValues(t, 1, route.DiscardedSources[0].Operation)
+				require.Len(t, route.Sources, 1)
+				assert.EqualValues(t, 2, route.Sources[0].Operation)
+				assert.Same(t, sources[1], tableInput.Sources[0])
+				assert.EqualValues(t, 7, metrics[0].Metrics[0].Value)
+			} else {
+				require.Len(t, sources, 1)
+				assert.Equal(t, AcquisitionRouteSourceCache, route.Source)
+				assert.Empty(t, route.DiscardedSources)
+				require.Len(t, route.Sources, 1)
+				assert.EqualValues(t, 1, route.Sources[0].Operation)
+				assert.Same(t, firstSources[0], tableInput.Sources[0])
+				assert.EqualValues(t, 9, metrics[0].Metrics[0].Value)
+			}
+			assert.EqualValues(t, 1, firstSources[0].ContextID)
+		})
+	}
+}
+
+func TestRecurringNegativeEvidence(t *testing.T) {
+	for name, tc := range map[string]struct{ kind gosnmp.Asn1BER }{
+		"no such object":   {gosnmp.NoSuchObject},
+		"no such instance": {gosnmp.NoSuchInstance},
+	} {
+		t.Run(name, func(t *testing.T) {
+			const oid = "1.3.6.1.4.1.99999.90.0"
+			handler := &sourceTestHandler{get: func([]string) (*gosnmp.SnmpPacket, error) {
+				return &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{{Name: oid, Type: tc.kind}}}, nil
+			}}
+			profile := createTestProfile("scalar.yaml", []ddprofiledefinition.MetricsConfig{{Symbol: ddprofiledefinition.SymbolConfig{OID: oid, Name: "missing"}}})
+			var report AcquisitionProfileReport
+			first := &SourceRecorder{ContextID: 11}
+			collector := New(Config{SnmpClient: first.Wrap(handler), Profiles: []*ddsnmp.Profile{profile}, Log: logger.New(),
+				AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = value }),
+			})
+			_, err := collector.Collect()
+			require.NoError(t, err)
+			first.Finish()
+			second := &SourceRecorder{ContextID: 12}
+			collector.SetSNMPClient(second.Wrap(handler))
+			_, err = collector.Collect()
+			require.NoError(t, err)
+			assert.Empty(t, second.Finish())
+			assert.Equal(t, 1, handler.gets)
+			assert.Equal(t, AcquisitionRouteSourceCache, report.Routes[0].Source)
+			assert.Equal(t, AcquisitionRouteOutcomeMissing, report.Routes[0].Outcome)
+			causes := collector.NegativeCauses()
+			require.Len(t, causes, 1)
+			assert.EqualValues(t, 11, causes[0].ContextID)
+			assert.EqualValues(t, 1, causes[0].Operation)
+			assert.Equal(t, uint8(tc.kind), causes[0].PDU.Type)
+		})
+	}
+}
+
+func TestRecurringDependencySettlementEvidence(t *testing.T) {
+	for name, tc := range map[string]struct{ dependencyFailure bool }{
+		"dependency refresh discards successful candidate": {},
+		"failed dependency discards successful candidate":  {true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dependency, source := crossTableDependencyTestConfigs("1.3.6.1.4.1.99999.81")
+			poll := 1
+			handler := &sourceTestHandler{
+				get: func(oids []string) (*gosnmp.SnmpPacket, error) {
+					if oids[0] == dependency.Symbols[0].OID+".1" {
+						return nil, errors.New("dependency cache miss")
+					}
+					return &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{createGauge32PDU(oids[0], 99)}}, nil
+				},
+				walk: func(root string) ([]gosnmp.SnmpPDU, error) {
+					if poll == 2 && tc.dependencyFailure && root == dependency.Table.OID {
+						return nil, errors.New("dependency unavailable")
+					}
+					return []gosnmp.SnmpPDU{createGauge32PDU(root+".1.1", uint(poll*10))}, nil
+				},
+			}
+			profile := createTestProfile("dependencies.yaml", []ddprofiledefinition.MetricsConfig{source, dependency})
+			var report AcquisitionProfileReport
+			first := &SourceRecorder{ContextID: 1}
+			collector := New(Config{SnmpClient: first.Wrap(handler), Profiles: []*ddsnmp.Profile{profile}, Log: logger.New(),
+				AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = value }),
+			})
+			_, err := collector.Collect()
+			require.NoError(t, err)
+			first.Finish()
+			poll = 2
+			second := &SourceRecorder{ContextID: 2}
+			collector.SetSNMPClient(second.Wrap(handler))
+			_, err = collector.Collect()
+			require.NoError(t, err)
+			operations := second.Finish()
+			require.Len(t, operations, 4)
+			var sourceRoute *AcquisitionRouteReport
+			for i := range report.Routes {
+				if report.Routes[i].RootOID == source.Table.OID {
+					sourceRoute = &report.Routes[i]
+					break
+				}
+			}
+			require.NotNil(t, sourceRoute)
+			require.Len(t, sourceRoute.DiscardedSources, 1)
+			assert.EqualValues(t, 1, sourceRoute.DiscardedSources[0].Operation)
+			for _, binding := range sourceRoute.Sources {
+				assert.Greater(t, binding.Operation, uint64(2))
+			}
+			for _, cache := range collector.CachedInputs() {
+				if cache.Kind != "table" {
+					continue
+				}
+				for _, operation := range cache.Sources {
+					assert.EqualValues(t, 2, operation.ContextID)
+					assert.NotEqual(t, "get", operation.Method)
+				}
+			}
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report.go
@@ -123,6 +123,9 @@ type AcquisitionValueReference struct {
 // and processing omissions. It contains no profile path, packet, decoded value
 // or error text.
 type AcquisitionRouteReport struct {
+	// Reused means the complete outcome belongs to an earlier attempt, not a
+	// fresh value GET that merely used cached table structure.
+	Reused           bool
 	Sources          []ddsnmp.SourceBinding
 	DiscardedSources []ddsnmp.SourceBinding
 	Processing       []ddsnmp.ProcessingEvent
@@ -857,7 +860,7 @@ func (c *acquisitionProfileCollection) report(
 	report.BGPValueReferences = c.bgpValueReferences
 	report.MetricValueReferences = c.metricValueReferences
 	report.LicenseValueReferences = c.licenseValueReferences
-	if outcome == AcquisitionProfileOutcomeSuccess && routesHaveFailures(report.Routes) {
+	if outcome == AcquisitionProfileOutcomeSuccess && report.HasFailures() {
 		report.Outcome = AcquisitionProfileOutcomePartial
 	}
 	c.releaseReportStorage()
@@ -885,11 +888,27 @@ func (c *acquisitionProfileCollection) releaseReportStorage() {
 	c.metadata = nil
 }
 
-func routesHaveFailures(routes []AcquisitionRouteReport) bool {
-	for _, route := range routes {
-		switch route.Outcome {
-		case AcquisitionRouteOutcomeFailed, AcquisitionRouteOutcomeRejected, AcquisitionRouteOutcomePartial:
+// HasFailures classifies work in this attempt. Reused outcomes and ordinary
+// omissions stay visible in the report without creating a new failed attempt.
+func (r AcquisitionProfileReport) HasFailures() bool {
+	if r.Outcome == AcquisitionProfileOutcomeFailed {
+		return true
+	}
+	p := r.Stats.Errors.Processing
+	if r.Stats.Errors.SNMP > 0 || p.Preparation+p.Scalar+p.Table+p.BGP+p.Licensing > 0 {
+		return true
+	}
+	for _, route := range r.Routes {
+		if route.Reused {
+			continue
+		}
+		if route.Outcome == AcquisitionRouteOutcomeFailed {
 			return true
+		}
+		for _, event := range route.Processing {
+			if event.IsFailure() {
+				return true
+			}
 		}
 	}
 	return false

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report.go
@@ -108,8 +108,9 @@ type AcquisitionProfileReport struct {
 }
 
 // AcquisitionValueReference identifies one borrowed decoded value within its
-// profile route. Slice position joins it to the corresponding ProfileMetrics
-// topology metric or BGP row supplied to the observer.
+// profile route. Topology, BGP and licensing references follow their observed
+// output slices. Ordinary metric references describe acquisition output before
+// normalization, duplicate selection, virtual derivation and hidden filtering.
 type AcquisitionValueReference struct {
 	RowIndex     string
 	Field        string

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report.go
@@ -14,7 +14,7 @@ import (
 )
 
 // AcquisitionObserver receives one terminal report for every selected profile
-// during the initial Collect call. The report and its Routes remain valid after
+// during each Collect call. The report and its Routes remain valid after
 // the call; ProfileMetrics is borrowed only for the duration of the call.
 type AcquisitionObserver interface {
 	ObserveProfile(AcquisitionProfileReport, *ddsnmp.ProfileMetrics)
@@ -53,6 +53,10 @@ const (
 	AcquisitionRouteKindTopologyTable
 	AcquisitionRouteKindBGPScalar
 	AcquisitionRouteKindBGPTable
+	AcquisitionRouteKindMetricScalar
+	AcquisitionRouteKindMetricTable
+	AcquisitionRouteKindLicenseScalar
+	AcquisitionRouteKindLicenseTable
 )
 
 type AcquisitionRouteSource uint8
@@ -99,6 +103,8 @@ type AcquisitionProfileReport struct {
 	Routes                  []AcquisitionRouteReport
 	TopologyValueReferences []AcquisitionValueReference
 	BGPValueReferences      []AcquisitionValueReference
+	MetricValueReferences   []AcquisitionValueReference
+	LicenseValueReferences  []AcquisitionValueReference
 }
 
 // AcquisitionValueReference identifies one borrowed decoded value within its
@@ -116,18 +122,19 @@ type AcquisitionValueReference struct {
 // and processing omissions. It contains no profile path, packet, decoded value
 // or error text.
 type AcquisitionRouteReport struct {
-	Sources      []ddsnmp.SourceBinding
-	Processing   []ddsnmp.ProcessingEvent
-	Ordinal      uint32
-	Kind         AcquisitionRouteKind
-	RootOID      string
-	Source       AcquisitionRouteSource
-	Outcome      AcquisitionRouteOutcome
-	FailureClass AcquisitionFailureClass
-	Rows         uint64
-	Values       uint64
-	Missing      uint64
-	Rejected     uint64
+	Sources          []ddsnmp.SourceBinding
+	DiscardedSources []ddsnmp.SourceBinding
+	Processing       []ddsnmp.ProcessingEvent
+	Ordinal          uint32
+	Kind             AcquisitionRouteKind
+	RootOID          string
+	Source           AcquisitionRouteSource
+	Outcome          AcquisitionRouteOutcome
+	FailureClass     AcquisitionFailureClass
+	Rows             uint64
+	Values           uint64
+	Missing          uint64
+	Rejected         uint64
 }
 
 func (r AcquisitionProfileReport) String() string {
@@ -142,6 +149,11 @@ type acquisitionProfileCollection struct {
 	topologyScalarRoutes    []int
 	topologyTableRoutes     map[int]int
 	bgpRoutes               []int
+	metricScalarRoutes      []int
+	metricTableRoutes       map[int]int
+	licenseRoutes           []int
+	metricValueReferences   []AcquisitionValueReference
+	licenseValueReferences  []AcquisitionValueReference
 	tableBindings           []acquisitionTableBinding
 	topologyValueReferences []AcquisitionValueReference
 	bgpValueReferences      []AcquisitionValueReference
@@ -156,16 +168,20 @@ type acquisitionTableBinding struct {
 }
 
 type acquisitionTableObservation struct {
-	collection         *acquisitionProfileCollection
-	routeOrdinal       uint32
-	processed          bool
-	rows               uint64
-	values             uint64
-	rejected           uint64
-	dependencyRejected uint64
+	collection          *acquisitionProfileCollection
+	routeOrdinal        uint32
+	processed           bool
+	rows                uint64
+	values              uint64
+	rejected            uint64
+	dependencyRejected  uint64
+	staging             bool
+	valueReferences     []AcquisitionValueReference
+	candidateReferences []AcquisitionValueReference
+	candidateSources    []ddsnmp.SourceBinding
 }
 
-type acquisitionTopologyTableScope struct {
+type acquisitionTableScope struct {
 	collection   *acquisitionProfileCollection
 	routeIndexes map[int]int
 }
@@ -175,16 +191,21 @@ func (o *acquisitionTableObservation) addValueReferences(rowOrdinal uint32, rowI
 		return
 	}
 	for valueOrdinal, metric := range metrics {
-		o.collection.addTopologyValueReference(AcquisitionValueReference{
+		reference := AcquisitionValueReference{
 			RowIndex: rowIndex, Field: metric.Name,
 			RouteOrdinal: o.routeOrdinal,
 			RowOrdinal:   rowOrdinal,
 			ValueOrdinal: uint32(valueOrdinal),
-		})
+		}
+		if o.staging {
+			o.candidateReferences = append(o.candidateReferences, reference)
+		} else {
+			o.valueReferences = append(o.valueReferences, reference)
+		}
 	}
 }
 
-type acquisitionTopologyScalarObserver struct {
+type acquisitionScalarObserver struct {
 	collection   *acquisitionProfileCollection
 	routeIndexes []int
 }
@@ -205,7 +226,7 @@ type acquisitionMetadataRoute struct {
 	field      ddprofiledefinition.MetadataField
 }
 
-func (o *acquisitionTopologyScalarObserver) start(
+func (o *acquisitionScalarObserver) start(
 	configs []ddprofiledefinition.MetricsConfig,
 	missingOIDs map[string]bool,
 ) {
@@ -231,7 +252,7 @@ func (o *acquisitionTopologyScalarObserver) start(
 	}
 }
 
-func (o *acquisitionTopologyScalarObserver) failUnfinished(class AcquisitionFailureClass) {
+func (o *acquisitionScalarObserver) failUnfinished(class AcquisitionFailureClass) {
 	if o == nil {
 		return
 	}
@@ -245,26 +266,26 @@ func (o *acquisitionTopologyScalarObserver) failUnfinished(class AcquisitionFail
 	}
 }
 
-func (o *acquisitionTopologyScalarObserver) rejected(index int) {
+func (o *acquisitionScalarObserver) rejected(index int) {
 	if route := o.route(index); route != nil {
 		setAcquisitionScalarRouteRejected(route)
 	}
 }
 
-func (o *acquisitionTopologyScalarObserver) value(index int, field string) {
+func (o *acquisitionScalarObserver) value(index int, field string) {
 	if route := o.route(index); route != nil {
 		setAcquisitionScalarRouteValue(route)
-		o.collection.addTopologyValueReference(AcquisitionValueReference{RouteOrdinal: route.Ordinal, Field: field})
+		o.collection.addMetricValueReference(route.Ordinal, AcquisitionValueReference{RouteOrdinal: route.Ordinal, Field: field})
 	}
 }
 
-func (o *acquisitionTopologyScalarObserver) empty(index int) {
+func (o *acquisitionScalarObserver) empty(index int) {
 	if route := o.route(index); route != nil && route.Outcome == AcquisitionRouteOutcomeNotObserved {
 		route.Outcome = AcquisitionRouteOutcomeEmpty
 	}
 }
 
-func (o *acquisitionTopologyScalarObserver) route(configIndex int) *AcquisitionRouteReport {
+func (o *acquisitionScalarObserver) route(configIndex int) *AcquisitionRouteReport {
 	if o == nil || configIndex < 0 || configIndex >= len(o.routeIndexes) {
 		return nil
 	}
@@ -459,7 +480,7 @@ func newAcquisitionProfileCollection(
 	for _, cfg := range def.Topology {
 		topologyMetrics = append(topologyMetrics, cfg.MetricsConfig)
 	}
-	collection.topologyScalarRoutes, collection.topologyTableRoutes = collection.addTopologyRoutes(topologyMetrics)
+	collection.topologyScalarRoutes, collection.topologyTableRoutes = collection.addMetricRoutes(topologyMetrics, AcquisitionRouteKindTopologyScalar, AcquisitionRouteKindTopologyTable)
 
 	collection.bgpRoutes = make([]int, len(def.BGP))
 	for i := range collection.bgpRoutes {
@@ -474,6 +495,14 @@ func newAcquisitionProfileCollection(
 		if cfg.Table.OID != "" {
 			collection.bgpRoutes[i] = collection.addRoute(AcquisitionRouteKindBGPTable, trimOID(cfg.Table.OID))
 		}
+	}
+	collection.metricScalarRoutes, collection.metricTableRoutes = collection.addMetricRoutes(def.Metrics, AcquisitionRouteKindMetricScalar, AcquisitionRouteKindMetricTable)
+	for _, cfg := range def.Licensing {
+		kind, root := AcquisitionRouteKindLicenseTable, trimOID(cfg.Table.OID)
+		if root == "" {
+			kind, root = AcquisitionRouteKindLicenseScalar, firstLicenseRouteOID(cfg)
+		}
+		collection.licenseRoutes = append(collection.licenseRoutes, collection.addRoute(kind, root))
 	}
 	collection.prepareProfileInputRoutes(profile, sysObjectID)
 	return collection
@@ -501,8 +530,9 @@ func (c *acquisitionProfileCollection) prepareProfileInputRoutes(profile *ddsnmp
 	}
 }
 
-func (c *acquisitionProfileCollection) addTopologyRoutes(
+func (c *acquisitionProfileCollection) addMetricRoutes(
 	configs []ddprofiledefinition.MetricsConfig,
+	scalarKind, tableKind AcquisitionRouteKind,
 ) (scalarRoutes []int, tableRoutes map[int]int) {
 	if c == nil {
 		return nil, nil
@@ -513,7 +543,7 @@ func (c *acquisitionProfileCollection) addTopologyRoutes(
 	}
 	for i, cfg := range configs {
 		if cfg.IsScalar() {
-			scalarRoutes[i] = c.addRoute(AcquisitionRouteKindTopologyScalar, trimOID(cfg.Symbol.OID))
+			scalarRoutes[i] = c.addRoute(scalarKind, trimOID(cfg.Symbol.OID))
 		}
 	}
 	for i, cfg := range configs {
@@ -521,7 +551,7 @@ func (c *acquisitionProfileCollection) addTopologyRoutes(
 			if tableRoutes == nil {
 				tableRoutes = make(map[int]int)
 			}
-			tableRoutes[i] = c.addRoute(AcquisitionRouteKindTopologyTable, trimOID(cfg.Table.OID))
+			tableRoutes[i] = c.addRoute(tableKind, trimOID(cfg.Table.OID))
 		}
 	}
 	return scalarRoutes, tableRoutes
@@ -573,21 +603,21 @@ func (c *acquisitionProfileCollection) bgpRoute(configIndex int) *AcquisitionRou
 	return c.route(c.bgpRoutes[configIndex])
 }
 
-func (c *acquisitionProfileCollection) topologyScalarObserver() *acquisitionTopologyScalarObserver {
+func (c *acquisitionProfileCollection) topologyScalarObserver() *acquisitionScalarObserver {
 	if c == nil {
 		return nil
 	}
-	return &acquisitionTopologyScalarObserver{
+	return &acquisitionScalarObserver{
 		collection:   c,
 		routeIndexes: c.topologyScalarRoutes,
 	}
 }
 
-func (c *acquisitionProfileCollection) topologyTableScope() *acquisitionTopologyTableScope {
+func (c *acquisitionProfileCollection) topologyTableScope() *acquisitionTableScope {
 	if c == nil {
 		return nil
 	}
-	return &acquisitionTopologyTableScope{
+	return &acquisitionTableScope{
 		collection:   c,
 		routeIndexes: c.topologyTableRoutes,
 	}
@@ -698,7 +728,7 @@ func acquisitionMetadataFieldRootOID(field ddprofiledefinition.MetadataField) st
 	return ""
 }
 
-func (s *acquisitionTopologyTableScope) bind(
+func (s *acquisitionTableScope) bind(
 	configIndex int,
 	request *tableCollectionRequest,
 ) *acquisitionTableObservation {
@@ -733,6 +763,17 @@ func (c *acquisitionProfileCollection) syncTableRoutes() {
 		}
 
 		if request.route != nil {
+			if request.route.state == tableRouteCached {
+				route.Sources = append(route.Sources, observation.candidateSources...)
+				for _, ref := range observation.candidateReferences {
+					c.addMetricValueReference(route.Ordinal, ref)
+				}
+			} else {
+				route.DiscardedSources = observation.candidateSources
+				for _, ref := range observation.valueReferences {
+					c.addMetricValueReference(route.Ordinal, ref)
+				}
+			}
 			bindSourceWalk(route, request.route.sourceOperation, request.route.oid, "primary")
 			for _, dependency := range request.dependencies {
 				bindSourceWalk(route, dependency.sourceOperation, dependency.oid, "dependency")
@@ -813,6 +854,8 @@ func (c *acquisitionProfileCollection) report(
 	report.Routes = c.routes
 	report.TopologyValueReferences = c.topologyValueReferences
 	report.BGPValueReferences = c.bgpValueReferences
+	report.MetricValueReferences = c.metricValueReferences
+	report.LicenseValueReferences = c.licenseValueReferences
 	if outcome == AcquisitionProfileOutcomeSuccess && routesHaveFailures(report.Routes) {
 		report.Outcome = AcquisitionProfileOutcomePartial
 	}
@@ -829,6 +872,11 @@ func (c *acquisitionProfileCollection) releaseReportStorage() {
 	c.topologyScalarRoutes = nil
 	c.topologyTableRoutes = nil
 	c.bgpRoutes = nil
+	c.metricScalarRoutes = nil
+	c.metricTableRoutes = nil
+	c.licenseRoutes = nil
+	c.metricValueReferences = nil
+	c.licenseValueReferences = nil
 	c.tableBindings = nil
 	c.topologyValueReferences = nil
 	c.bgpValueReferences = nil
@@ -870,6 +918,12 @@ func acquisitionProfileRouteDigest(profile *ddsnmp.Profile) [32]byte {
 	}
 	def := profile.Definition
 
+	for _, cfg := range def.Metrics {
+		d.addMetric("metric", cfg)
+	}
+	for _, cfg := range def.Licensing {
+		d.addMetric("licensing", licensingConfigAsMetricsConfig(cfg))
+	}
 	for _, cfg := range def.Topology {
 		d.addMetric("topology:"+string(cfg.Kind), cfg.MetricsConfig)
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_report_test.go
@@ -43,7 +43,7 @@ func TestCollector_AcquisitionObserverReportsEveryProfileInExecutionOrder(t *tes
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{succeeded, failed},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, metrics *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, metrics *ddsnmp.ProfileMetrics) {
 			got = append(got, observation{report: report, hasMetrics: metrics != nil})
 		}),
 	})
@@ -77,7 +77,7 @@ func TestCollector_AcquisitionObserverReportsEveryProfileInExecutionOrder(t *tes
 	}
 }
 
-func TestCollector_InitialAcquisitionObserverReportsProfileInputsOnce(t *testing.T) {
+func TestCollector_AcquisitionObserverReportsCachedProfileInputs(t *testing.T) {
 	ctrl, mockHandler := setupMockHandler(t)
 	defer ctrl.Finish()
 
@@ -111,7 +111,7 @@ func TestCollector_InitialAcquisitionObserverReportsProfileInputsOnce(t *testing
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			reports = append(reports, report)
 		}),
 	})
@@ -138,7 +138,13 @@ func TestCollector_InitialAcquisitionObserverReportsProfileInputsOnce(t *testing
 	require.Len(t, metrics, 1)
 	assert.Equal(t, "lab", metrics[0].Tags["site"], "normal collection must continue to reuse its live cache")
 	assert.NotContains(t, metrics[0].DeviceMetadata, "serial_number")
-	assert.Len(t, reports, 1, "acquisition evidence is produced only by the initial Collect call")
+	require.Len(t, reports, 2, "every poll has its own acquisition report")
+	second := acquisitionRoutesByKind(reports[1].Routes)
+	assert.Equal(t, AcquisitionRouteSourceCache, second[AcquisitionRouteKindProfileTagScalar].Source)
+	assert.Equal(t, AcquisitionRouteOutcomeValues, second[AcquisitionRouteKindProfileTagScalar].Outcome)
+	assert.Equal(t, AcquisitionRouteSourceCache, second[AcquisitionRouteKindMetadataScalar].Source)
+	assert.Equal(t, AcquisitionRouteOutcomeMissing, second[AcquisitionRouteKindMetadataScalar].Outcome)
+	assert.Zero(t, metrics[0].Stats.SNMP.GetRequests)
 }
 
 func TestCollector_AcquisitionObserverReportsLaterRoutesAsNotObservedAfterPrepareFailure(t *testing.T) {
@@ -174,7 +180,7 @@ func TestCollector_AcquisitionObserverReportsLaterRoutesAsNotObservedAfterPrepar
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -211,7 +217,7 @@ func TestCollector_AcquisitionObserverReportsPatternTagValue(t *testing.T) {
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -233,7 +239,7 @@ func TestCollector_AcquisitionObserverPanicDoesNotChangeCollection(t *testing.T)
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{createTestProfile("profile.yaml", nil)},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(AcquisitionProfileReport, *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(AcquisitionProfileReport, *ddsnmp.ProfileMetrics) {
 			panic("observer failure")
 		}),
 	})
@@ -271,7 +277,7 @@ func TestCollector_AcquisitionProfileDigestUsesRoutesNotSourcePath(t *testing.T)
 			SnmpClient: mockHandler,
 			Profiles:   []*ddsnmp.Profile{profile},
 			Log:        logger.New(),
-			InitialAcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+			AcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 				reports = append(reports, report)
 			}),
 		})
@@ -289,7 +295,7 @@ func TestCollector_AcquisitionProfileDigestUsesRoutesNotSourcePath(t *testing.T)
 	assert.NotEqual(t, digestA, digestChangedRoute)
 }
 
-func TestAcquisitionProfileRouteDigestIgnoresOrdinaryMetrics(t *testing.T) {
+func TestAcquisitionProfileRouteDigestIncludesOrdinaryMetrics(t *testing.T) {
 	profile := &ddsnmp.Profile{Definition: &ddprofiledefinition.ProfileDefinition{
 		Topology: []ddprofiledefinition.TopologyConfig{{
 			Kind: ddsnmp.KindArpEntry,
@@ -304,7 +310,7 @@ func TestAcquisitionProfileRouteDigestIgnoresOrdinaryMetrics(t *testing.T) {
 		Symbol: ddprofiledefinition.SymbolConfig{OID: "1.3.6.1.4.1.99999.4", Name: "ordinaryValue"},
 	}}
 
-	assert.Equal(t, want, acquisitionProfileRouteDigest(profile))
+	assert.NotEqual(t, want, acquisitionProfileRouteDigest(profile))
 }
 
 func TestCollector_AcquisitionObserverReportsSyntheticDependencyAndTagFailure(t *testing.T) {
@@ -339,7 +345,7 @@ func TestCollector_AcquisitionObserverReportsSyntheticDependencyAndTagFailure(t 
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -399,7 +405,7 @@ func TestCollector_AcquisitionObserverReportsSyntheticDependencyVarbindCounts(t 
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -444,7 +450,7 @@ func TestCollector_AcquisitionObserverLeavesDormantDependencyUnobserved(t *testi
 		SnmpClient: new(SourceRecorder).Wrap(mockHandler),
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -501,7 +507,7 @@ func TestCollector_AcquisitionObserverFiltersSharedWalkToSyntheticDependencyRoot
 		SnmpClient: new(SourceRecorder).Wrap(mockHandler),
 		Profiles:   []*ddsnmp.Profile{topology, owner},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(report AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			reports = append(reports, report)
 		}),
 	})
@@ -566,7 +572,7 @@ func TestCollector_AcquisitionObserverLeavesTopologyRouteUnobservedWhenRegularTa
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -575,7 +581,9 @@ func TestCollector_AcquisitionObserverLeavesTopologyRouteUnobservedWhenRegularTa
 
 	assert.Equal(t, AcquisitionProfileOutcomeFailed, report.Outcome)
 	assert.Equal(t, AcquisitionFailurePhaseTables, report.FailurePhase)
-	require.Len(t, report.Routes, 1)
+	require.Len(t, report.Routes, 2)
+	assert.Equal(t, AcquisitionRouteKindMetricTable, report.Routes[1].Kind)
+	assert.Equal(t, AcquisitionRouteOutcomeFailed, report.Routes[1].Outcome)
 	assert.Equal(t, topologyTableOID, report.Routes[0].RootOID)
 	assert.Equal(t, AcquisitionRouteSourceWalk, report.Routes[0].Source)
 	assert.Equal(t, AcquisitionRouteOutcomeNotObserved, report.Routes[0].Outcome)
@@ -620,7 +628,7 @@ func TestCollector_AcquisitionObserverAssociatesTopologyValuesWithRoutes(t *test
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -653,7 +661,7 @@ func TestCollector_AcquisitionObserverDistinguishesCurrentAndInheritedMissingSou
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{second, first},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			reports = append(reports, value)
 		}),
 	})
@@ -683,7 +691,7 @@ func TestCollector_AcquisitionObserverReportsScalarsDiscoveredMissingInCurrentGE
 			SnmpClient: mockHandler,
 			Profiles:   []*ddsnmp.Profile{profile},
 			Log:        logger.New(),
-			InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+			AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 				report = value
 			}),
 		})
@@ -718,7 +726,7 @@ func TestCollector_AcquisitionObserverReportsScalarsDiscoveredMissingInCurrentGE
 			SnmpClient: mockHandler,
 			Profiles:   []*ddsnmp.Profile{profile},
 			Log:        logger.New(),
-			InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+			AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 				report = value
 			}),
 		})
@@ -756,7 +764,7 @@ func TestCollector_AcquisitionObserverReportsPartialBGPCollection(t *testing.T) 
 		SnmpClient: new(SourceRecorder).Wrap(mockHandler),
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -804,7 +812,7 @@ func TestCollector_AcquisitionObserverReportsMixedBGPScalarMissingInputs(t *test
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -908,7 +916,7 @@ func TestCollector_AcquisitionObserverClassifiesBGPTableLookupFailureAsDependenc
 			},
 		}},
 		Log: logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -944,7 +952,7 @@ func TestCollector_AcquisitionObserverClassifiesMissingRequiredBGPTableCellAsDep
 			},
 		}},
 		Log: logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -990,7 +998,7 @@ func TestCollector_AcquisitionObserverIgnoresMissingOptionalBGPTableDescriptor(t
 			},
 		}},
 		Log: logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})
@@ -1039,7 +1047,7 @@ func TestCollector_AcquisitionObserverAssociatesBGPTableValuesWithRoutes(t *test
 		SnmpClient: mockHandler,
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = value
 		}),
 	})

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_source.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_source.go
@@ -18,8 +18,11 @@ import (
 
 // SourceRecorder belongs to one synchronous collection context. Finish transfers
 // its immutable evidence to the attempt; it retains neither clients nor profiles.
+// Each operation has independent ownership so a cache reference cannot pin the
+// other operations and payloads from its original collection.
 type SourceRecorder struct {
-	operations []ddsnmp.SourceOperation
+	ContextID  uint64
+	operations []*ddsnmp.SourceOperation
 	finished   bool
 }
 
@@ -48,7 +51,23 @@ func (r *SourceRecorder) Cursor() uint64 {
 	return uint64(len(r.operations))
 }
 
-func (r *SourceRecorder) Finish() []ddsnmp.SourceOperation {
+// Operation returns an immutable independently owned source, not a pointer into
+// the recorder's operation array. Cache generations can retain it directly.
+func (r *SourceRecorder) Operation(ordinal uint64) *ddsnmp.SourceOperation {
+	if r == nil || ordinal == 0 || ordinal > uint64(len(r.operations)) {
+		return nil
+	}
+	return r.operations[ordinal-1]
+}
+
+func (r *SourceRecorder) operationsSince(cursor uint64) []*ddsnmp.SourceOperation {
+	if r == nil || cursor >= uint64(len(r.operations)) {
+		return nil
+	}
+	return slices.Clone(r.operations[cursor:])
+}
+
+func (r *SourceRecorder) Finish() []*ddsnmp.SourceOperation {
 	if r == nil {
 		return nil
 	}
@@ -80,37 +99,37 @@ func (c *sourceClient) Get(oids []string) (*gosnmp.SnmpPacket, error) {
 	if packet != nil {
 		pdus = packet.Variables
 	}
-	c.recorder.record("get", oids, elapsed, packet != nil, pdus, snmputils.ClassifyGetFailure(packet, err))
+	c.recorder.record("get", oids, start, elapsed, packet != nil, pdus, snmputils.ClassifyGetFailure(packet, err))
 	return packet, err
 }
 
 func (c *sourceClient) WalkAll(oid string) ([]gosnmp.SnmpPDU, error) {
 	start := time.Now()
 	values, err := c.Handler.WalkAll(oid)
-	c.recorder.recordWalk("walk", oid, time.Since(start), values, err)
+	c.recorder.recordWalk("walk", oid, start, time.Since(start), values, err)
 	return values, err
 }
 
 func (c *sourceClient) BulkWalkAll(oid string) ([]gosnmp.SnmpPDU, error) {
 	start := time.Now()
 	values, err := c.Handler.BulkWalkAll(oid)
-	c.recorder.recordWalk("bulk_walk", oid, time.Since(start), values, err)
+	c.recorder.recordWalk("bulk_walk", oid, start, time.Since(start), values, err)
 	return values, err
 }
 
-func (r *SourceRecorder) recordWalk(method, oid string, elapsed time.Duration, values []gosnmp.SnmpPDU, err error) {
+func (r *SourceRecorder) recordWalk(method, oid string, started time.Time, elapsed time.Duration, values []gosnmp.SnmpPDU, err error) {
 	failure := snmputils.ClassifyFailure(err)
 	if err != nil {
 		failure.Operation = "walk"
 	}
-	r.record(method, []string{oid}, elapsed, values != nil, values, failure)
+	r.record(method, []string{oid}, started, elapsed, values != nil, values, failure)
 }
 
-func (r *SourceRecorder) record(method string, oids []string, elapsed time.Duration, present bool, pdus []gosnmp.SnmpPDU, failure snmputils.Failure) {
+func (r *SourceRecorder) record(method string, oids []string, started time.Time, elapsed time.Duration, present bool, pdus []gosnmp.SnmpPDU, failure snmputils.Failure) {
 	if r == nil || r.finished {
 		return
 	}
-	operation := ddsnmp.SourceOperation{Method: method, ElapsedNanos: int64(elapsed), Failure: failure, ResultPresent: present,
+	operation := &ddsnmp.SourceOperation{ContextID: r.ContextID, Ordinal: uint64(len(r.operations)) + 1, StartedAt: started.UTC(), Method: method, ElapsedNanos: int64(elapsed), Failure: failure, ResultPresent: present,
 		RequestedOIDs: make([]string, len(oids)), PDUs: make([]ddsnmp.SourcePDU, len(pdus))}
 	for i, oid := range oids {
 		operation.RequestedOIDs[i] = strings.Clone(oid)
@@ -187,7 +206,7 @@ func bindSourceWalk(route *AcquisitionRouteReport, operation uint64, oid, role s
 	route.Sources = append(route.Sources, ddsnmp.SourceBinding{Operation: operation, OID: trimOID(oid), Role: role})
 }
 
-func (o *acquisitionTopologyScalarObserver) bindSource(requests map[string][]uint64, configs []ddprofiledefinition.MetricsConfig) {
+func (o *acquisitionScalarObserver) bindSource(requests map[string][]uint64, configs []ddprofiledefinition.MetricsConfig) {
 	if o == nil {
 		return
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_source_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_source_test.go
@@ -72,7 +72,7 @@ func TestSourceValuesPreserveDecodedData(t *testing.T) {
 			encoded, err := json.Marshal(evidence)
 			require.NoError(t, err)
 			require.NotContains(t, string(encoded), "never retain this")
-			var restored []ddsnmp.SourceOperation
+			var restored []*ddsnmp.SourceOperation
 			require.NoError(t, json.Unmarshal(encoded, &restored))
 			require.NoError(t, ddsnmp.ValidateSourceOperations(restored))
 			require.Equal(t, tc.want.Kind, restored[0].PDUs[0].Value.Kind)
@@ -125,7 +125,7 @@ func TestSourceEvidenceFollowsActualCollection(t *testing.T) {
 			}
 			source := &SourceRecorder{}
 			var reports []AcquisitionProfileReport
-			collector := New(Config{SnmpClient: source.Wrap(handler), Profiles: []*ddsnmp.Profile{{SourceFile: "synthetic.yaml", Definition: tc.profile}}, Log: logger.New(), InitialAcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { reports = append(reports, r) })})
+			collector := New(Config{SnmpClient: source.Wrap(handler), Profiles: []*ddsnmp.Profile{{SourceFile: "synthetic.yaml", Definition: tc.profile}}, Log: logger.New(), AcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { reports = append(reports, r) })})
 			values, err := collector.Collect()
 			if tc.wantErr {
 				require.Error(t, err)
@@ -164,10 +164,10 @@ func TestSourceEvidenceFollowsActualCollection(t *testing.T) {
 	}
 }
 
-func testWalkSources(t *testing.T, collector *Collector, execution *AcquisitionExecutionReport) []ddsnmp.SourceOperation {
+func testWalkSources(t *testing.T, collector *Collector, execution *AcquisitionExecutionReport) []*ddsnmp.SourceOperation {
 	t.Helper()
 	require.NotNil(t, execution)
-	var result []ddsnmp.SourceOperation
+	var result []*ddsnmp.SourceOperation
 	for _, id := range execution.WalkOperations {
 		r := sourceRecorder(collector.tableCollector.snmpClient)
 		require.NotNil(t, r)
@@ -190,7 +190,7 @@ func TestSourceRecorderLifecycleAndClientReplacement(t *testing.T) {
 			}}
 			source := &SourceRecorder{}
 			client := source.Wrap(handler)
-			collector := New(Config{SnmpClient: client, Log: logger.New(), Profiles: []*ddsnmp.Profile{{SourceFile: "synthetic.yaml", Definition: &ddprofiledefinition.ProfileDefinition{BGP: []ddprofiledefinition.BGPConfig{cfg}}}}, InitialAcquisitionObserver: AcquisitionObserverFunc(func(AcquisitionProfileReport, *ddsnmp.ProfileMetrics) {})})
+			collector := New(Config{SnmpClient: client, Log: logger.New(), Profiles: []*ddsnmp.Profile{{SourceFile: "synthetic.yaml", Definition: &ddprofiledefinition.ProfileDefinition{BGP: []ddprofiledefinition.BGPConfig{cfg}}}}, AcquisitionObserver: AcquisitionObserverFunc(func(AcquisitionProfileReport, *ddsnmp.ProfileMetrics) {})})
 			if tc.replace {
 				collector.SetSNMPClient(client)
 			}
@@ -232,7 +232,7 @@ func BenchmarkCollectorSourceEvidence(b *testing.B) {
 						client = source.Wrap(client)
 						observer = AcquisitionObserverFunc(func(AcquisitionProfileReport, *ddsnmp.ProfileMetrics) {})
 					}
-					collector := New(Config{SnmpClient: client, Log: log, Profiles: []*ddsnmp.Profile{profile}, InitialAcquisitionObserver: observer})
+					collector := New(Config{SnmpClient: client, Log: log, Profiles: []*ddsnmp.Profile{profile}, AcquisitionObserver: observer})
 					results, err := collector.Collect()
 					if err != nil {
 						b.Fatal(err)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collection_failures.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collection_failures.go
@@ -14,8 +14,8 @@ func (c *Collector) CollectionFailures() ddsnmp.CollectionFailures { return c.fa
 
 type diagnosticClient struct {
 	gosnmp.Handler
-	failures       *ddsnmp.CollectionFailures
-	negativeCauses *map[string]AcquisitionNegativeCause
+	failures *ddsnmp.CollectionFailures
+	negative *negativeEvidence
 }
 
 func (c *diagnosticClient) Get(oids []string) (*gosnmp.SnmpPacket, error) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collection_failures.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collection_failures.go
@@ -14,7 +14,8 @@ func (c *Collector) CollectionFailures() ddsnmp.CollectionFailures { return c.fa
 
 type diagnosticClient struct {
 	gosnmp.Handler
-	failures *ddsnmp.CollectionFailures
+	failures       *ddsnmp.CollectionFailures
+	negativeCauses *map[string]AcquisitionNegativeCause
 }
 
 func (c *diagnosticClient) Get(oids []string) (*gosnmp.SnmpPacket, error) {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -21,12 +21,12 @@ import (
 )
 
 type Config struct {
-	SnmpClient                 gosnmp.Handler
-	Profiles                   []*ddsnmp.Profile
-	Log                        *logger.Logger
-	SysObjectID                string
-	DisableBulkWalk            bool
-	InitialAcquisitionObserver AcquisitionObserver
+	SnmpClient          gosnmp.Handler
+	Profiles            []*ddsnmp.Profile
+	Log                 *logger.Logger
+	SysObjectID         string
+	DisableBulkWalk     bool
+	AcquisitionObserver AcquisitionObserver
 }
 
 func New(cfg Config) *Collector {
@@ -39,13 +39,13 @@ func New(cfg Config) *Collector {
 		tableIdentity:             buildTableIdentity(cfg.Profiles),
 	}
 
-	cfg.SnmpClient = &diagnosticClient{Handler: cfg.SnmpClient, failures: &coll.failures}
+	cfg.SnmpClient = &diagnosticClient{Handler: cfg.SnmpClient, failures: &coll.failures, negativeCauses: &coll.negativeCauses}
 
 	for _, prof := range cfg.Profiles {
 		coll.profiles[prof.SourceFile] = &profileState{profile: prof}
 	}
-	if cfg.InitialAcquisitionObserver != nil {
-		coll.initialAcquisitionObserver = cfg.InitialAcquisitionObserver
+	if cfg.AcquisitionObserver != nil {
+		coll.acquisitionObserver = cfg.AcquisitionObserver
 	}
 
 	coll.globalTagsCollector = newGlobalTagsCollector(cfg.SnmpClient, coll.missingOIDs, coll.log)
@@ -59,14 +59,15 @@ func New(cfg Config) *Collector {
 
 type (
 	Collector struct {
-		failures                   ddsnmp.CollectionFailures
-		log                        *logger.Logger
-		profiles                   map[string]*profileState
-		missingOIDs                map[string]bool
-		regularScalarNamesScratch  map[string]struct{}
-		tableCache                 *tableCache
-		tableIdentity              *tableIdentity
-		initialAcquisitionObserver AcquisitionObserver
+		failures                  ddsnmp.CollectionFailures
+		log                       *logger.Logger
+		profiles                  map[string]*profileState
+		missingOIDs               map[string]bool
+		negativeCauses            map[string]AcquisitionNegativeCause
+		regularScalarNamesScratch map[string]struct{}
+		tableCache                *tableCache
+		tableIdentity             *tableIdentity
+		acquisitionObserver       AcquisitionObserver
 
 		globalTagsCollector     *globalTagsCollector
 		deviceMetadataCollector *deviceMetadataCollector
@@ -76,10 +77,14 @@ type (
 	}
 	profileState struct {
 		profile     *ddsnmp.Profile
+		identity    *AcquisitionProfileIdentity
 		initialized bool
 		cache       struct {
-			globalTags     map[string]string
-			deviceMetadata map[string]ddsnmp.MetaTag
+			globalTags       map[string]string
+			deviceMetadata   map[string]ddsnmp.MetaTag
+			tagEvidence      *AcquisitionCacheInput
+			metadataEvidence *AcquisitionCacheInput
+			inputRoutes      []AcquisitionRouteReport
 		}
 	}
 	preparedProfileCollection struct {
@@ -119,9 +124,6 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 	c.failures = ddsnmp.CollectionFailures{}
 	var prepared []*preparedProfileCollection
 	var errs []error
-	if c.initialAcquisitionObserver != nil {
-		defer c.releaseInitialAcquisition()
-	}
 
 	expired := c.tableCache.clearExpired()
 	if len(expired) > 0 {
@@ -141,10 +143,11 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 
 	session := newTableCollectionSession(c.tableCollector, c.tableIdentity)
 	for _, profile := range prepared {
-		profile.regularScope = session.addScope(
+		profile.regularScope = session.addObservedScope(
 			profile.state.profile,
 			tableSymbolModeValue,
 			&profile.metrics.Stats,
+			profile.acquisition.metricTableScope(),
 		)
 		profile.regularScope.execution = profile.acquisition.executionReport()
 		if profile.topologyProfile != nil {
@@ -179,6 +182,7 @@ func (c *Collector) Collect() ([]*ddsnmp.ProfileMetrics, error) {
 		if len(vmetrics) > 0 {
 			for i := range vmetrics {
 				vmetrics[i].Profile = profile.metrics
+				vmetrics[i].IsVirtual = true
 			}
 
 			profile.metrics.Metrics = append(profile.metrics.Metrics, vmetrics...)
@@ -215,7 +219,7 @@ func (c *Collector) observeAcquisitionProfile(
 		c.failures.Processing.BGP += p.BGP
 		c.failures.Processing.Licensing += p.Licensing
 	}
-	if c.initialAcquisitionObserver == nil || profile == nil || profile.acquisition == nil {
+	if c.acquisitionObserver == nil || profile == nil || profile.acquisition == nil {
 		return
 	}
 	profile.acquisition.syncTableRoutes()
@@ -223,11 +227,7 @@ func (c *Collector) observeAcquisitionProfile(
 	defer func() {
 		_ = recover()
 	}()
-	c.initialAcquisitionObserver.ObserveProfile(report, profile.metrics)
-}
-
-func (c *Collector) releaseInitialAcquisition() {
-	c.initialAcquisitionObserver = nil
+	c.acquisitionObserver.ObserveProfile(report, profile.metrics)
 }
 
 func (c *Collector) sortedProfileStates() []*profileState {
@@ -274,7 +274,7 @@ func collectHiddenMetrics(metrics []ddsnmp.Metric) []ddsnmp.Metric {
 }
 
 func (c *Collector) SetSNMPClient(snmpClient gosnmp.Handler) {
-	snmpClient = &diagnosticClient{Handler: snmpClient, failures: &c.failures}
+	snmpClient = &diagnosticClient{Handler: snmpClient, failures: &c.failures, negativeCauses: &c.negativeCauses}
 	if c.globalTagsCollector != nil {
 		c.globalTagsCollector.snmpClient = snmpClient
 	}
@@ -295,9 +295,13 @@ func (c *Collector) prepareProfileCollection(ps *profileState, ordinal uint32) (
 		state:   ps,
 		metrics: pm,
 	}
-	if c.initialAcquisitionObserver != nil {
+	if c.acquisitionObserver != nil {
+		if ps.identity == nil {
+			identity := buildAcquisitionProfileIdentity(ps.profile, ordinal)
+			ps.identity = &identity
+		}
 		prepared.acquisition = newAcquisitionProfileCollection(
-			buildAcquisitionProfileIdentity(ps.profile, ordinal),
+			*ps.identity,
 			ps.profile,
 			c.deviceMetadataCollector.sysobjectid,
 		)
@@ -308,7 +312,7 @@ func (c *Collector) prepareProfileCollection(ps *profileState, ordinal uint32) (
 	}
 
 	now := time.Now()
-	scalarMetrics, err := c.scalarCollector.collect(ps.profile, &pm.Stats)
+	scalarMetrics, err := c.scalarCollector.collectObserved(ps.profile, &pm.Stats, prepared.acquisition.metricScalarObserver())
 	pm.Stats.Timing.Scalar = time.Since(now)
 	if err != nil {
 		return prepared, err
@@ -360,18 +364,30 @@ func (c *Collector) prepareProfileInputs(prepared *preparedProfileCollection) er
 			}
 		}
 	}()
-	if !ps.initialized {
+	if ps.initialized {
+		prepared.acquisition.restoreInputRoutes(ps.cache.inputRoutes)
+	} else {
+		recorder := sourceRecorder(c.globalTagsCollector.snmpClient)
+		cursor := recorder.Cursor()
 		globalTags, err := c.globalTagsCollector.collectObserved(ps.profile, &pm.Stats, prepared.acquisition)
 		if err != nil {
 			return fmt.Errorf("failed to collect global tags: %w", err)
 		}
 		ps.cache.globalTags = globalTags
+		if recorder != nil {
+			ps.cache.tagEvidence = &AcquisitionCacheInput{Kind: "profile_tags", CreatedAt: time.Now().UTC(), Tags: globalTags, Sources: recorder.operationsSince(cursor)}
+		}
+		cursor = recorder.Cursor()
 		metadata, err := c.deviceMetadataCollector.collectObserved(ps.profile, &pm.Stats, prepared.acquisition)
 		if err != nil {
 			return fmt.Errorf("failed to collect device metadata: %w", err)
 		}
 		ps.cache.deviceMetadata = metadata
+		if recorder != nil {
+			ps.cache.metadataEvidence = &AcquisitionCacheInput{Kind: "profile_metadata", CreatedAt: time.Now().UTC(), Metadata: metadata, Sources: recorder.operationsSince(cursor)}
+		}
 		ps.initialized = true
+		ps.cache.inputRoutes = prepared.acquisition.retainInputRoutes(recorder)
 	}
 	pm.Tags = maps.Clone(ps.cache.globalTags)
 	pm.DeviceMetadata = maps.Clone(ps.cache.deviceMetadata)
@@ -410,7 +426,7 @@ func (c *Collector) collectPreparedProfileRows(profile *preparedProfileCollectio
 	pm := profile.metrics
 
 	now := time.Now()
-	licenseRows, err := c.collectLicenseRowsObserved(ps.profile, &pm.Stats, profile.acquisition.executionReport())
+	licenseRows, err := c.collectLicenseRowsObserved(ps.profile, &pm.Stats, profile.acquisition)
 	if err != nil {
 		c.log.Limit(licenseRowsFailedLogKey+ps.profile.SourceFile, 1, licenseRowsErrorLogEvery).
 			Warningf("failed to collect licensing rows for profile %q: %v", ps.profile.SourceFile, err)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector.go
@@ -39,7 +39,7 @@ func New(cfg Config) *Collector {
 		tableIdentity:             buildTableIdentity(cfg.Profiles),
 	}
 
-	cfg.SnmpClient = &diagnosticClient{Handler: cfg.SnmpClient, failures: &coll.failures, negativeCauses: &coll.negativeCauses}
+	cfg.SnmpClient = &diagnosticClient{Handler: cfg.SnmpClient, failures: &coll.failures, negative: &coll.negative}
 
 	for _, prof := range cfg.Profiles {
 		coll.profiles[prof.SourceFile] = &profileState{profile: prof}
@@ -63,7 +63,7 @@ type (
 		log                       *logger.Logger
 		profiles                  map[string]*profileState
 		missingOIDs               map[string]bool
-		negativeCauses            map[string]AcquisitionNegativeCause
+		negative                  negativeEvidence
 		regularScalarNamesScratch map[string]struct{}
 		tableCache                *tableCache
 		tableIdentity             *tableIdentity
@@ -274,7 +274,7 @@ func collectHiddenMetrics(metrics []ddsnmp.Metric) []ddsnmp.Metric {
 }
 
 func (c *Collector) SetSNMPClient(snmpClient gosnmp.Handler) {
-	snmpClient = &diagnosticClient{Handler: snmpClient, failures: &c.failures, negativeCauses: &c.negativeCauses}
+	snmpClient = &diagnosticClient{Handler: snmpClient, failures: &c.failures, negative: &c.negative}
 	if c.globalTagsCollector != nil {
 		c.globalTagsCollector.snmpClient = snmpClient
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_acquisition_timing_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_acquisition_timing_test.go
@@ -41,7 +41,7 @@ func TestCollector_AcquisitionScalarFailureTiming(t *testing.T) {
 				SnmpClient: handler,
 				Profiles:   []*ddsnmp.Profile{profile},
 				Log:        logger.New(),
-				InitialAcquisitionObserver: AcquisitionObserverFunc(
+				AcquisitionObserver: AcquisitionObserverFunc(
 					func(value AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = value },
 				),
 			})
@@ -82,13 +82,14 @@ func TestCollector_AcquisitionPreparationBatchesFailureAndRetry(t *testing.T) {
 		SnmpClient: new(SourceRecorder).Wrap(handler),
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(
+		AcquisitionObserver: AcquisitionObserverFunc(
 			func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = r },
 		),
 	})
 	_, err := collector.Collect()
 	require.Error(t, err)
 	require.NotNil(t, report.Execution)
+	firstReport := report
 	p := report.Execution.Preparation
 	assert.EqualValues(t, 2, p.GetRequests)
 	assert.EqualValues(t, 11, p.GetOIDs)
@@ -111,7 +112,8 @@ func TestCollector_AcquisitionPreparationBatchesFailureAndRetry(t *testing.T) {
 	metrics, err = collector.Collect()
 	require.NoError(t, err)
 	assert.Zero(t, metrics[0].Stats.SNMP.GetRequests, "initialized inputs are cached")
-	assert.Equal(t, p, report.Execution.Preparation, "later collections must not mutate retained evidence")
+	assert.Equal(t, p, firstReport.Execution.Preparation, "later collections must not mutate retained evidence")
+	assert.Zero(t, report.Execution.Preparation.GetRequests)
 }
 
 func TestCollector_AcquisitionPreparationNonfatalMetadataErrors(t *testing.T) {
@@ -149,7 +151,7 @@ func TestCollector_AcquisitionPreparationNonfatalMetadataErrors(t *testing.T) {
 			Profiles:    []*ddsnmp.Profile{profile},
 			SysObjectID: base,
 			Log:         logger.New(),
-			InitialAcquisitionObserver: AcquisitionObserverFunc(
+			AcquisitionObserver: AcquisitionObserverFunc(
 				func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = r },
 			),
 		},
@@ -208,7 +210,7 @@ func TestCollector_AcquisitionSharedWalkAccounting(t *testing.T) {
 					createTestProfile("a.yaml", []ddprofiledefinition.MetricsConfig{metric}),
 					createTestProfile("b.yaml", []ddprofiledefinition.MetricsConfig{metric}),
 				},
-				InitialAcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { reports = append(reports, r) }),
+				AcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { reports = append(reports, r) }),
 			})
 			_, err := collector.Collect()
 			assert.Equal(t, failed, err != nil)
@@ -249,7 +251,7 @@ func TestCollector_AcquisitionBGPWalkPassAccounting(t *testing.T) {
 		SnmpClient: new(SourceRecorder).Wrap(handler),
 		Log:        logger.New(),
 		Profiles:   []*ddsnmp.Profile{profile},
-		InitialAcquisitionObserver: AcquisitionObserverFunc(
+		AcquisitionObserver: AcquisitionObserverFunc(
 			func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) { report = r },
 		),
 	})

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_bgp.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_bgp.go
@@ -155,7 +155,7 @@ func (c *Collector) collectScalarBGPRows(
 			remainingOIDCount := len(oids)
 			currentMissingOIDCount := len(missingOIDs)
 			for _, oid := range oids {
-				if c.missingOIDs[oid] {
+				if isMissingOID(c.scalarCollector.snmpClient, c.missingOIDs, oid) {
 					remainingOIDCount--
 					currentMissingOIDCount++
 				}
@@ -1284,7 +1284,7 @@ func (c *Collector) bgpScalarOIDs(cfg ddprofiledefinition.BGPConfig) ([]string, 
 		sym := bgpValueSymbol(valueCfg)
 		if sym.OID != "" {
 			oid := trimOID(sym.OID)
-			if c.missingOIDs[oid] {
+			if isMissingOID(c.scalarCollector.snmpClient, c.missingOIDs, oid) {
 				missingOIDs = append(missingOIDs, oid)
 				return
 			}
@@ -1296,7 +1296,7 @@ func (c *Collector) bgpScalarOIDs(cfg ddprofiledefinition.BGPConfig) ([]string, 
 	for _, tagCfg := range cfg.MetricTags {
 		if tagCfg.Symbol.OID != "" {
 			oid := trimOID(tagCfg.Symbol.OID)
-			if c.missingOIDs[oid] {
+			if isMissingOID(c.scalarCollector.snmpClient, c.missingOIDs, oid) {
 				missingOIDs = append(missingOIDs, oid)
 				continue
 			}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
@@ -128,7 +128,7 @@ func (dc *deviceMetadataCollector) collectStaticAndIdentifyOIDs(fields map[strin
 		case field.Value != "":
 			ddsnmp.MergeMetaTag(metadata, name, ddsnmp.MetaTag{Value: field.Value, IsExactMatch: isExactMatch})
 		case field.Symbol.OID != "":
-			if !dc.missingOIDs[trimOID(field.Symbol.OID)] {
+			if !isMissingOID(dc.snmpClient, dc.missingOIDs, trimOID(field.Symbol.OID)) {
 				oids = append(oids, field.Symbol.OID)
 			} else {
 				stats.Errors.MissingOIDs++
@@ -138,7 +138,7 @@ func (dc *deviceMetadataCollector) collectStaticAndIdentifyOIDs(fields map[strin
 				if sym.OID == "" {
 					continue
 				}
-				if !dc.missingOIDs[trimOID(sym.OID)] {
+				if !isMissingOID(dc.snmpClient, dc.missingOIDs, trimOID(sym.OID)) {
 					oids = append(oids, sym.OID)
 				} else {
 					stats.Errors.MissingOIDs++

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_global_tags.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_global_tags.go
@@ -148,7 +148,7 @@ func (gc *globalTagsCollector) identifyTagOIDs(metricTags []ddprofiledefinition.
 		}
 
 		oid := trimOID(cfg.Symbol.OID)
-		if gc.missingOIDs[oid] {
+		if isMissingOID(gc.snmpClient, gc.missingOIDs, oid) {
 			missingOIDs = append(missingOIDs, cfg.Symbol.OID)
 			continue
 		}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
@@ -645,7 +645,7 @@ func (c *Collector) licenseRawTextValue(cfg ddprofiledefinition.LicenseValueConf
 	if sym.ExtractValueCompiled != nil {
 		sm := sym.ExtractValueCompiled.FindStringSubmatch(value)
 		if len(sm) < 2 {
-			ctx.record(cfg, pdu.Name, "extract_value")
+			ctx.record(cfg, pdu.Name, "extract_mismatch")
 			return "", false, fmt.Errorf("extract_value did not match value %q", value)
 		}
 		value = sm[1]
@@ -653,7 +653,7 @@ func (c *Collector) licenseRawTextValue(cfg ddprofiledefinition.LicenseValueConf
 	if sym.MatchPatternCompiled != nil {
 		sm := sym.MatchPatternCompiled.FindStringSubmatch(value)
 		if len(sm) == 0 {
-			ctx.record(cfg, pdu.Name, "match_pattern")
+			ctx.record(cfg, pdu.Name, "pattern_mismatch")
 			return "", false, fmt.Errorf("match_pattern %q did not match value %q", sym.MatchPattern, value)
 		}
 		value = replaceSubmatches(sym.MatchValue, sm)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
@@ -855,7 +855,7 @@ func (c *Collector) licensingScalarOIDs(cfg ddprofiledefinition.LicensingConfig)
 		sym := licenseValueSymbol(valueCfg)
 		if sym.OID != "" {
 			oid := trimOID(sym.OID)
-			if c.missingOIDs[oid] {
+			if isMissingOID(c.scalarCollector.snmpClient, c.missingOIDs, oid) {
 				missingOIDs = append(missingOIDs, sym.OID)
 				return
 			}
@@ -867,7 +867,7 @@ func (c *Collector) licensingScalarOIDs(cfg ddprofiledefinition.LicensingConfig)
 	for _, tagCfg := range cfg.MetricTags {
 		if tagCfg.Symbol.OID != "" {
 			oid := trimOID(tagCfg.Symbol.OID)
-			if c.missingOIDs[oid] {
+			if isMissingOID(c.scalarCollector.snmpClient, c.missingOIDs, oid) {
 				missingOIDs = append(missingOIDs, tagCfg.Symbol.OID)
 				continue
 			}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing.go
@@ -26,9 +26,10 @@ const (
 )
 
 type licenseValueContext struct {
-	rowIndex string
-	rowPDUs  map[string]gosnmp.SnmpPDU
-	pdus     map[string]gosnmp.SnmpPDU
+	rowIndex   string
+	processing *processingObserver
+	rowPDUs    map[string]gosnmp.SnmpPDU
+	pdus       map[string]gosnmp.SnmpPDU
 }
 
 func (c *Collector) collectLicenseRows(prof *ddsnmp.Profile, stats *ddsnmp.CollectionStats) ([]ddsnmp.LicenseRow, error) {
@@ -38,7 +39,7 @@ func (c *Collector) collectLicenseRows(prof *ddsnmp.Profile, stats *ddsnmp.Colle
 func (c *Collector) collectLicenseRowsObserved(
 	prof *ddsnmp.Profile,
 	stats *ddsnmp.CollectionStats,
-	execution *AcquisitionExecutionReport,
+	acquisition *acquisitionProfileCollection,
 ) ([]ddsnmp.LicenseRow, error) {
 	if prof.Definition == nil || len(prof.Definition.Licensing) == 0 {
 		return nil, nil
@@ -47,13 +48,13 @@ func (c *Collector) collectLicenseRowsObserved(
 	var rows []ddsnmp.LicenseRow
 	var errs []error
 
-	scalarRows, err := c.collectScalarLicenseRows(prof.Definition.Licensing, stats)
+	scalarRows, err := c.collectScalarLicenseRows(prof.Definition.Licensing, stats, acquisition)
 	if err != nil {
 		errs = append(errs, err)
 	}
 	rows = append(rows, scalarRows...)
 
-	tableRows, err := c.collectTableLicenseRows(prof.Definition.Licensing, stats, execution)
+	tableRows, err := c.collectTableLicenseRows(prof.Definition.Licensing, stats, acquisition)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -73,16 +74,19 @@ func (c *Collector) collectLicenseRowsObserved(
 func (c *Collector) collectScalarLicenseRows(
 	configs []ddprofiledefinition.LicensingConfig,
 	stats *ddsnmp.CollectionStats,
+	acquisition *acquisitionProfileCollection,
 ) ([]ddsnmp.LicenseRow, error) {
 	var rows []ddsnmp.LicenseRow
 	var errs []error
 
-	for _, cfg := range configs {
+	for i, cfg := range configs {
 		if cfg.Table.OID != "" {
 			continue
 		}
 
+		route := acquisition.licenseRoute(i)
 		oids, missingOIDs := c.licensingScalarOIDs(cfg)
+		startLicenseScalarRoute(route, oids, missingOIDs)
 		if len(missingOIDs) > 0 {
 			c.log.Debugf("licensing scalar row %q missing OIDs: %v", licensingConfigDisplayName(cfg), missingOIDs)
 			stats.Errors.MissingOIDs += int64(len(missingOIDs))
@@ -91,16 +95,26 @@ func (c *Collector) collectScalarLicenseRows(
 		var pdus map[string]gosnmp.SnmpPDU
 		var err error
 		if len(oids) > 0 {
+			source := sourceRecorder(c.scalarCollector.snmpClient)
+			cursor := source.Cursor()
 			pdus, err = c.scalarCollector.getScalarValues(oids, stats)
+			if source != nil && route != nil {
+				requests := source.requestsSince(cursor)
+				for _, oid := range oids {
+					bindSourceGETs(route, requests, oid, "primary")
+				}
+			}
 			if err != nil {
+				failAcquisitionRoute(route, AcquisitionFailureClassTransport)
 				recordCollectionFailure(&c.failures.Licensing, err, "licensing", "")
 				errs = append(errs, fmt.Errorf("licensing scalar row %q: %w", licensingConfigDisplayName(cfg), err))
 				continue
 			}
 		}
 
-		row, ok, err := c.buildScalarLicenseRow(cfg, pdus)
+		row, ok, err := c.buildScalarLicenseRowObserved(cfg, pdus, route)
 		if err != nil {
+			rejectAcquisitionRoute(route)
 			stats.Errors.Processing.Licensing++
 			recordCollectionFailure(&c.failures.Licensing, err, "licensing", "processing")
 			errs = append(errs, fmt.Errorf("licensing scalar row %q: %w", licensingConfigDisplayName(cfg), err))
@@ -108,7 +122,9 @@ func (c *Collector) collectScalarLicenseRows(
 		}
 		if ok {
 			rows = append(rows, row)
+			acquisition.addLicenseReference(route, "")
 		}
+		finishLicenseScalarRoute(route, oids, c.missingOIDs)
 	}
 
 	if len(rows) == 0 && len(errs) > 0 {
@@ -120,41 +136,52 @@ func (c *Collector) collectScalarLicenseRows(
 func (c *Collector) collectTableLicenseRows(
 	configs []ddprofiledefinition.LicensingConfig,
 	stats *ddsnmp.CollectionStats,
-	execution *AcquisitionExecutionReport,
+	acquisition *acquisitionProfileCollection,
 ) ([]ddsnmp.LicenseRow, error) {
 	var rows []ddsnmp.LicenseRow
 	var errs []error
-	walkPass := newTableWalkPass(execution)
+	walkPass := newTableWalkPass(acquisition.executionReport())
 	tableNameToOID := licensingTableNameToOID(configs)
 
-	for _, cfg := range configs {
+	for i, cfg := range configs {
 		if cfg.Table.OID == "" {
 			continue
+		}
+		route := acquisition.licenseRoute(i)
+		if route != nil {
+			route.Source = AcquisitionRouteSourceWalk
 		}
 		metricsCfg := licensingConfigAsMetricsConfig(cfg)
 
 		outcome := walkPass.walk(c.tableCollector, cfg.Table.OID, stats)
+		bindSourceWalk(route, outcome.sourceOperation, cfg.Table.OID, "primary")
 		if outcome.err != nil {
+			failAcquisitionRoute(route, AcquisitionFailureClassTransport)
 			recordCollectionFailure(&c.failures.Licensing, outcome.err, "licensing", "")
 			errs = append(errs, fmt.Errorf("licensing table %q: %w", licensingConfigDisplayName(cfg), outcome.err))
 			continue
 		}
 		pdus := outcome.pdus
 		if len(pdus) == 0 {
+			if route != nil {
+				route.Outcome = AcquisitionRouteOutcomeEmpty
+			}
 			continue
 		}
 
-		if err := c.walkLicenseTableDependencies(metricsCfg, tableNameToOID, walkPass, stats); err != nil {
+		if err := c.walkLicenseTableDependencies(metricsCfg, tableNameToOID, walkPass, stats, route); err != nil {
+			failAcquisitionRoute(route, AcquisitionFailureClassDependency)
 			recordCollectionFailure(&c.failures.Licensing, err, "licensing", "dependency")
 			errs = append(errs, fmt.Errorf("licensing table %q dependencies: %w", licensingConfigDisplayName(cfg), err))
 			continue
 		}
 
 		ctx := &tableProcessingContext{
-			config:         metricsCfg,
-			pdus:           pdus,
-			walkedData:     walkPass.walkedData,
-			tableNameToOID: tableNameToOID,
+			processingRoute: route,
+			config:          metricsCfg,
+			pdus:            pdus,
+			walkedData:      walkPass.walkedData,
+			tableNameToOID:  tableNameToOID,
 		}
 		ctx.columnOIDs = buildColumnOIDs(metricsCfg)
 		ctx.orderedTags = buildOrderedTags(metricsCfg)
@@ -162,9 +189,13 @@ func (c *Collector) collectTableLicenseRows(
 		crossTableCtx := newCrossTableContext(ctx.walkedData, ctx.tableNameToOID)
 		staticTags := parseStaticTags(cfg.StaticTags)
 
+		if route != nil {
+			route.Rows = uint64(len(ctx.rows))
+		}
 		for rowIndex, rowPDUs := range ctx.rows {
 			row, ok, err := c.buildTableLicenseRow(cfg, rowIndex, rowPDUs, ctx, crossTableCtx, staticTags)
 			if err != nil {
+				rejectAcquisitionRoute(route)
 				stats.Errors.Processing.Licensing++
 				recordCollectionFailure(&c.failures.Licensing, err, "licensing", "processing")
 				errs = append(errs, fmt.Errorf("licensing table %q row %q: %w", licensingConfigDisplayName(cfg), rowIndex, err))
@@ -172,7 +203,11 @@ func (c *Collector) collectTableLicenseRows(
 			}
 			if ok {
 				rows = append(rows, row)
+				acquisition.addLicenseReference(route, rowIndex)
 			}
+		}
+		if route != nil {
+			setAcquisitionRouteCounts(route, route.Rows, route.Values, route.Rejected)
 		}
 	}
 
@@ -187,10 +222,12 @@ func (c *Collector) walkLicenseTableDependencies(
 	tableNameToOID map[string]string,
 	walkPass *tableWalkPass,
 	stats *ddsnmp.CollectionStats,
+	route *AcquisitionRouteReport,
 ) error {
 	var errs []error
 	for _, depOID := range extractTableDependencies(cfg, tableNameToOID) {
 		outcome := walkPass.walk(c.tableCollector, depOID, stats)
+		bindSourceWalk(route, outcome.sourceOperation, depOID, "dependency")
 		if outcome.err != nil {
 			errs = append(errs, fmt.Errorf("table OID %q: %w", trimOID(depOID), outcome.err))
 		}
@@ -202,6 +239,10 @@ func (c *Collector) buildScalarLicenseRow(
 	cfg ddprofiledefinition.LicensingConfig,
 	pdus map[string]gosnmp.SnmpPDU,
 ) (ddsnmp.LicenseRow, bool, error) {
+	return c.buildScalarLicenseRowObserved(cfg, pdus, nil)
+}
+
+func (c *Collector) buildScalarLicenseRowObserved(cfg ddprofiledefinition.LicensingConfig, pdus map[string]gosnmp.SnmpPDU, route *AcquisitionRouteReport) (ddsnmp.LicenseRow, bool, error) {
 	rowKey := scalarLicenseRowKey(cfg)
 	row := ddsnmp.LicenseRow{
 		OriginProfileID: cfg.OriginProfileID,
@@ -210,7 +251,7 @@ func (c *Collector) buildScalarLicenseRow(
 		Tags:            parseStaticTags(cfg.StaticTags),
 	}
 
-	licenseCtx := licenseValueContext{pdus: pdus}
+	licenseCtx := licenseValueContext{pdus: pdus, processing: processingFor(route, "")}
 	if err := c.populateLicenseRow(&row, cfg, licenseCtx); err != nil {
 		return ddsnmp.LicenseRow{}, false, err
 	}
@@ -220,7 +261,7 @@ func (c *Collector) buildScalarLicenseRow(
 
 	if len(cfg.MetricTags) > 0 {
 		tags := make(map[string]string)
-		ta := tagAdder{tags: tags}
+		ta := tagAdder{tags: tags, processing: processingFor(route, "")}
 		for _, tagCfg := range cfg.MetricTags {
 			if tagCfg.Symbol.OID == "" {
 				continue
@@ -257,6 +298,7 @@ func (c *Collector) buildTableLicenseRow(
 	}
 	crossTableCtx.rowTags = rowData.tags
 	rowCtx := &tableRowProcessingContext{
+		processing:    processingFor(ctx.processingRoute, rowIndex),
 		config:        ctx.config,
 		columnOIDs:    ctx.columnOIDs,
 		crossTableCtx: crossTableCtx,
@@ -275,7 +317,7 @@ func (c *Collector) buildTableLicenseRow(
 	}
 	mergeStringMaps(row.Tags, rowData.tags)
 
-	licenseCtx := licenseValueContext{rowIndex: rowIndex, rowPDUs: rowPDUs}
+	licenseCtx := licenseValueContext{rowIndex: rowIndex, rowPDUs: rowPDUs, processing: processingFor(ctx.processingRoute, rowIndex)}
 	if err := c.populateLicenseRow(&row, cfg, licenseCtx); err != nil {
 		return ddsnmp.LicenseRow{}, false, err
 	}
@@ -425,6 +467,7 @@ func (c *Collector) populateLicenseTimerTimestamp(
 	name string,
 ) error {
 	if sourceOID, ok := licenseTimerZeroDateAndTimePlaceholder(cfg, ctx); ok {
+		ctx.record(cfg, sourceOID, "empty_date")
 		c.log.Limit(licenseTimerNoValueLogKey+sourceOID, 1, licenseRowsErrorLogEvery).
 			Warningf("license timer %q returned zero DateAndTime placeholder; treating timer as absent", sourceOID)
 		return nil
@@ -433,11 +476,16 @@ func (c *Collector) populateLicenseTimerTimestamp(
 	value, sourceOID, ok, err := c.licenseNumericValue(cfg, ctx)
 	if err != nil {
 		source := licenseTimerSource(cfg, name)
+		ctx.record(cfg, source, "conversion")
 		c.log.Limit(licenseTimerMalformedLogKey+source, 1, licenseRowsErrorLogEvery).
 			Warningf("license timer %q is malformed: %v; treating timer as absent", source, err)
 		return nil
 	}
-	if !ok || licenseValueRejectedBySentinel(value, cfg.Sentinel) {
+	if !ok {
+		return nil
+	}
+	if licenseValueRejectedBySentinel(value, cfg.Sentinel) {
+		ctx.record(cfg, sourceOID, "sentinel")
 		return nil
 	}
 
@@ -456,11 +504,16 @@ func (c *Collector) populateLicenseTimerRemaining(
 	value, sourceOID, ok, err := c.licenseNumericValue(cfg, ctx)
 	if err != nil {
 		source := licenseTimerSource(cfg, name)
+		ctx.record(cfg, source, "conversion")
 		c.log.Limit(licenseTimerMalformedLogKey+source, 1, licenseRowsErrorLogEvery).
 			Warningf("license timer %q is malformed: %v; treating timer as absent", source, err)
 		return nil
 	}
-	if !ok || licenseValueRejectedBySentinel(value, cfg.Sentinel) {
+	if !ok {
+		return nil
+	}
+	if licenseValueRejectedBySentinel(value, cfg.Sentinel) {
+		ctx.record(cfg, sourceOID, "sentinel")
 		return nil
 	}
 
@@ -538,6 +591,7 @@ func (c *Collector) populateLicenseUsageValue(
 		return nil
 	}
 	if licenseValueRejectedBySentinel(value, cfg.Sentinel) {
+		ctx.record(cfg, licenseValueSymbol(cfg).OID, "sentinel")
 		return nil
 	}
 	*has = true
@@ -575,12 +629,14 @@ func (c *Collector) licenseRawTextValue(cfg ddprofiledefinition.LicenseValueConf
 	}
 	pdu, ok := ctx.lookupPDU(sym.OID)
 	if !ok {
+		ctx.record(cfg, sym.OID, "missing_input")
 		return "", false, nil
 	}
 
 	value, err := convPduToStringf(pdu, sym.Format)
 	if err != nil {
 		if errors.Is(err, errNoTextDateValue) {
+			ctx.record(cfg, pdu.Name, "empty_date")
 			return "", false, nil
 		}
 		return "", false, err
@@ -589,6 +645,7 @@ func (c *Collector) licenseRawTextValue(cfg ddprofiledefinition.LicenseValueConf
 	if sym.ExtractValueCompiled != nil {
 		sm := sym.ExtractValueCompiled.FindStringSubmatch(value)
 		if len(sm) < 2 {
+			ctx.record(cfg, pdu.Name, "extract_value")
 			return "", false, fmt.Errorf("extract_value did not match value %q", value)
 		}
 		value = sm[1]
@@ -596,6 +653,7 @@ func (c *Collector) licenseRawTextValue(cfg ddprofiledefinition.LicenseValueConf
 	if sym.MatchPatternCompiled != nil {
 		sm := sym.MatchPatternCompiled.FindStringSubmatch(value)
 		if len(sm) == 0 {
+			ctx.record(cfg, pdu.Name, "match_pattern")
 			return "", false, fmt.Errorf("match_pattern %q did not match value %q", sym.MatchPattern, value)
 		}
 		value = replaceSubmatches(sym.MatchValue, sm)
@@ -629,12 +687,14 @@ func (c *Collector) licenseNumericValue(
 	}
 	pdu, ok := ctx.lookupPDU(sym.OID)
 	if !ok {
+		ctx.record(cfg, sym.OID, "missing_input")
 		return 0, "", false, nil
 	}
 
 	value, err = c.scalarCollector.valProc.processValue(sym, pdu)
 	if err != nil {
 		if errors.Is(err, errNoTextDateValue) {
+			ctx.record(cfg, pdu.Name, "empty_date")
 			return 0, "", false, nil
 		}
 		return 0, "", false, err

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_licensing_test.go
@@ -370,7 +370,7 @@ func TestCollector_Collect_LicenseRowsFromTableLicensingConfig(t *testing.T) {
 		SnmpClient: new(SourceRecorder).Wrap(mockHandler),
 		Profiles:   []*ddsnmp.Profile{profile},
 		Log:        logger.New(),
-		InitialAcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
+		AcquisitionObserver: AcquisitionObserverFunc(func(r AcquisitionProfileReport, _ *ddsnmp.ProfileMetrics) {
 			report = r
 		}),
 	})

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
@@ -88,7 +88,7 @@ func (sc *scalarCollector) identifyScalarOIDs(configs []ddprofiledefinition.Metr
 		}
 
 		oid := trimOID(cfg.Symbol.OID)
-		if sc.missingOIDs[oid] {
+		if isMissingOID(sc.snmpClient, sc.missingOIDs, oid) {
 			missingOIDs = append(missingOIDs, cfg.Symbol.OID)
 			continue
 		}
@@ -101,7 +101,7 @@ func (sc *scalarCollector) identifyScalarOIDs(configs []ddprofiledefinition.Metr
 			}
 
 			tagOID := trimOID(tagCfg.Symbol.OID)
-			if sc.missingOIDs[tagOID] {
+			if isMissingOID(sc.snmpClient, sc.missingOIDs, tagOID) {
 				missingOIDs = append(missingOIDs, tagCfg.Symbol.OID)
 				continue
 			}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar.go
@@ -41,7 +41,7 @@ func (sc *scalarCollector) collect(prof *ddsnmp.Profile, stats *ddsnmp.Collectio
 func (sc *scalarCollector) collectObserved(
 	prof *ddsnmp.Profile,
 	stats *ddsnmp.CollectionStats,
-	observer *acquisitionTopologyScalarObserver,
+	observer *acquisitionScalarObserver,
 ) ([]ddsnmp.Metric, error) {
 	oids, missingOIDs := sc.identifyScalarOIDs(prof.Definition.Metrics)
 	if observer != nil {
@@ -130,7 +130,7 @@ func (sc *scalarCollector) processScalarMetricsObserved(
 	configs []ddprofiledefinition.MetricsConfig,
 	pdus map[string]gosnmp.SnmpPDU,
 	stats *ddsnmp.CollectionStats,
-	observer *acquisitionTopologyScalarObserver,
+	observer *acquisitionScalarObserver,
 ) ([]ddsnmp.Metric, error) {
 	var metrics []ddsnmp.Metric
 	var errs []error
@@ -174,7 +174,7 @@ func (sc *scalarCollector) processScalarMetricsObserved(
 func (sc *scalarCollector) processScalarMetric(
 	cfg ddprofiledefinition.MetricsConfig,
 	pdus map[string]gosnmp.SnmpPDU,
-	observer *acquisitionTopologyScalarObserver,
+	observer *acquisitionScalarObserver,
 	configIndex int,
 ) (*ddsnmp.Metric, error) {
 	processing := observer.processing(configIndex)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_fallback_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_scalar_fallback_test.go
@@ -57,7 +57,7 @@ func TestCollector_Collect_RegularScalarFallbackKeepsFirstSuccessfulMetric(t *te
 	pm := results[0]
 	require.Len(t, pm.Metrics, 2)
 	assert.Equal(t, ddsnmp.Metric{Name: "systemUptime", Value: 10, MetricType: "gauge", Profile: pm}, pm.Metrics[0])
-	assert.Equal(t, ddsnmp.Metric{Name: "selectedUptime", Value: 10, MetricType: "gauge", Profile: pm}, pm.Metrics[1])
+	assert.Equal(t, ddsnmp.Metric{Name: "selectedUptime", Value: 10, MetricType: "gauge", Profile: pm, IsVirtual: true}, pm.Metrics[1])
 	assert.Equal(t, int64(1), pm.Stats.Metrics.Scalar)
 	assert.Equal(t, int64(1), pm.Stats.Metrics.Virtual)
 	assert.Equal(t, int64(2), pm.Stats.SNMP.GetOIDs)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp.go
@@ -30,6 +30,9 @@ func getSNMPValues(
 			if !isPduWithData(pdu) {
 				stats.Errors.MissingOIDs++
 				missingOIDs[trimOID(pdu.Name)] = true
+				if observer, ok := client.(interface{ recordMissing(gosnmp.SnmpPDU) }); ok {
+					observer.recordMissing(pdu)
+				}
 				continue
 			}
 			pdus[trimOID(pdu.Name)] = pdu

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table.go
@@ -72,6 +72,7 @@ type (
 	}
 
 	tableProcessingContext struct {
+		cacheEvidence   *AcquisitionCacheInput
 		processingRoute *AcquisitionRouteReport
 		// === Input data (set when context is created) ===
 
@@ -239,7 +240,7 @@ func (tc *tableCollector) processTableData(ctx *tableProcessingContext, collecti
 		switch {
 		case len(ctx.rows) > 0 && dependenciesReady:
 			deps := extractTableDependencies(ctx.config, collectionCtx.tableNameToOID)
-			tc.tableCache.cacheRows(ctx.config, ctx.oidCache, ctx.tagCache, deps)
+			tc.tableCache.cacheRows(ctx.config, ctx.oidCache, ctx.tagCache, deps, ctx.cacheEvidence)
 			tc.log.Debugf("Cached table %s structure with %d rows", ctx.config.Table.Name, len(ctx.oidCache))
 		case len(ctx.rows) > 0:
 			tc.tableCache.invalidateConfig(ctx.config)
@@ -393,7 +394,17 @@ func (tc *tableCollector) collectWithCache(ctx *cacheProcessingContext, stats *d
 	}
 
 	// GET current values
+	source := sourceRecorder(tc.snmpClient)
+	cursor := source.Cursor()
 	pdus, err := tc.snmpGet(oidsToGet, stats)
+	if source != nil && ctx.acquisition != nil {
+		requests := source.requestsSince(cursor)
+		for _, oid := range oidsToGet {
+			for _, operation := range requests[trimOID(oid)] {
+				ctx.acquisition.candidateSources = append(ctx.acquisition.candidateSources, ddsnmp.SourceBinding{Operation: operation, OID: trimOID(oid), Role: "primary"})
+			}
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cached OIDs: %w", err)
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
@@ -143,7 +143,7 @@ func (s *tableCollectionSession) addObservedScope(
 	prof *ddsnmp.Profile,
 	mode tableSymbolMode,
 	stats *ddsnmp.CollectionStats,
-	acquisition *acquisitionTopologyTableScope,
+	acquisition *acquisitionTableScope,
 ) *tableCollectionScope {
 	scope := &tableCollectionScope{
 		profileSource:  prof.SourceFile,
@@ -383,6 +383,10 @@ func (s *tableCollectionSession) stageCached(route *tableCollectionRoute) *table
 		}
 
 		started := time.Now()
+		observation := req.scope.acquisition[req]
+		if observation != nil {
+			observation.staging = true
+		}
 		req.candidateMetrics = s.collector.tryCollectFromCache(
 			req.config,
 			req.scope.profileSource,
@@ -390,6 +394,9 @@ func (s *tableCollectionSession) stageCached(route *tableCollectionRoute) *table
 			&req.candidateStats,
 			req.scope.acquisition[req],
 		)
+		if observation != nil {
+			observation.staging = false
+		}
 		req.candidateStats.Timing.Table += time.Since(started)
 		if req.candidateMetrics == nil {
 			return req
@@ -548,17 +555,22 @@ func (s *tableCollectionSession) collectScope(scope *tableCollectionScope) ([]dd
 			tablesSeen[req.route.oid] = true
 			// A current WALK is successful even when it is empty or auxiliary-only.
 			successful = true
+			var cacheEvidence *AcquisitionCacheInput
+			if req.cacheEligible && sourceRecorder(s.collector.snmpClient) != nil {
+				cacheEvidence = &AcquisitionCacheInput{Kind: "table", RootOID: req.route.oid, CreatedAt: time.Now().UTC(), Marker: len(req.config.Symbols) == 0, Sources: s.cacheSources(req)}
+			}
 			if len(req.config.Symbols) == 0 {
 				if acquisition != nil {
 					acquisition.processed = true
 					acquisition.values = req.route.acquisitionValuesWithin(req.config.Table.OID)
 				}
 				if req.cacheEligible && !req.sharesRouteCache {
-					s.collector.tableCache.cacheMarker(req.config)
+					s.collector.tableCache.cacheMarker(req.config, cacheEvidence)
 				}
 				continue
 			}
 			ctx := &tableProcessingContext{
+				cacheEvidence:  cacheEvidence,
 				config:         req.config,
 				pdus:           req.route.pdus,
 				walkedData:     s.freshData,

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session.go
@@ -255,7 +255,7 @@ func (s *tableCollectionSession) buildRoutes() {
 				}
 			}
 
-			if s.collector.missingOIDs[trimOID(req.config.Table.OID)] {
+			if isMissingOID(s.collector.snmpClient, s.collector.missingOIDs, trimOID(req.config.Table.OID)) {
 				req.missing = true
 				req.scope.stats.Errors.MissingOIDs++
 				continue

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_table_session_test.go
@@ -102,7 +102,7 @@ func BenchmarkTableCollectorCachedAuxiliaryRoutingScaling(b *testing.B) {
 					},
 				}
 				configs = append(configs, cfg)
-				cache.cacheMarker(cfg)
+				cache.cacheMarker(cfg, nil)
 			}
 
 			profile := createTestProfile("cached-auxiliary-scaling.yaml", configs)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_topology_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_topology_benchmark_test.go
@@ -118,7 +118,7 @@ func BenchmarkCollector_AcquisitionAccounting(b *testing.B) {
 				cfg := Config{SnmpClient: &benchmarkAcquisitionSNMPHandler{}, Profiles: profiles, Log: logger.New()}
 				b.ReportAllocs()
 				for b.Loop() {
-					cfg.InitialAcquisitionObserver = mode.new()
+					cfg.AcquisitionObserver = mode.new()
 					results, err := New(cfg).Collect()
 					if err != nil || len(results) != len(profiles) {
 						b.Fatalf("profiles=%d err=%v", len(results), err)
@@ -164,10 +164,10 @@ func BenchmarkCollector_NewTopologyProfiles(b *testing.B) {
 		for _, mode := range benchmarkAcquisitionObserverModes()[:2] {
 			b.Run(fmt.Sprintf("profiles=%d/observer=%s", profileCount, mode.name), func(b *testing.B) {
 				cfg := Config{
-					SnmpClient:                 &benchmarkTopologySNMPHandler{},
-					Profiles:                   profiles,
-					Log:                        logger.New(),
-					InitialAcquisitionObserver: mode.new(),
+					SnmpClient:          &benchmarkTopologySNMPHandler{},
+					Profiles:            profiles,
+					Log:                 logger.New(),
+					AcquisitionObserver: mode.new(),
 				}
 				b.ReportAllocs()
 				for b.Loop() {
@@ -197,10 +197,10 @@ func BenchmarkCollector_InitialCollectTopologyRows(b *testing.B) {
 				for b.Loop() {
 					observer := mode.new()
 					collector := New(Config{
-						SnmpClient:                 &benchmarkTopologySNMPHandler{pdus: pdus},
-						Profiles:                   []*ddsnmp.Profile{profile},
-						Log:                        log,
-						InitialAcquisitionObserver: observer,
+						SnmpClient:          &benchmarkTopologySNMPHandler{pdus: pdus},
+						Profiles:            []*ddsnmp.Profile{profile},
+						Log:                 log,
+						AcquisitionObserver: observer,
 					})
 					results, err := collector.Collect()
 					topologyCount := -1

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_cache.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_cache.go
@@ -49,7 +49,8 @@ const (
 )
 
 type tableCacheEntry struct {
-	kind tableCacheEntryKind
+	kind     tableCacheEntryKind
+	evidence *AcquisitionCacheInput
 
 	// Index -> column OID -> full OID
 	oidMap map[string]map[string]string
@@ -116,7 +117,7 @@ func (tc *tableCache) getCachedData(cfg ddprofiledefinition.MetricsConfig) (oids
 	return entry.oidMap, entry.tagValues, true
 }
 
-func (tc *tableCache) cacheRows(cfg ddprofiledefinition.MetricsConfig, oidMap map[string]map[string]string, tagValues map[string]map[string]string, dependencies []string) {
+func (tc *tableCache) cacheRows(cfg ddprofiledefinition.MetricsConfig, oidMap map[string]map[string]string, tagValues map[string]map[string]string, dependencies []string, evidence *AcquisitionCacheInput) {
 	if len(oidMap) == 0 {
 		return
 	}
@@ -152,11 +153,18 @@ func (tc *tableCache) cacheRows(cfg ddprofiledefinition.MetricsConfig, oidMap ma
 	}
 
 	// Store the entry
-	tc.tables[tableOID][configID] = tableCacheEntry{
+	entry := tableCacheEntry{
 		kind:      tableCacheEntryRows,
 		oidMap:    oidsCopy,
 		tagValues: tagsCopy,
 	}
+	if evidence != nil {
+		item := *evidence
+		item.CreatedAt = time.Now().UTC()
+		item.OIDs, item.TableTags = oidsCopy, tagsCopy
+		entry.evidence = &item
+	}
+	tc.tables[tableOID][configID] = entry
 
 	// Update table-level metadata only if this is the first config for this table
 	if _, exists := tc.timestamps[tableOID]; !exists {
@@ -183,7 +191,7 @@ func (tc *tableCache) cacheRows(cfg ddprofiledefinition.MetricsConfig, oidMap ma
 
 // cacheMarker records a successful symbol-free auxiliary walk for route
 // planning. Markers never provide row data to cached collection.
-func (tc *tableCache) cacheMarker(cfg ddprofiledefinition.MetricsConfig) {
+func (tc *tableCache) cacheMarker(cfg ddprofiledefinition.MetricsConfig, evidence *AcquisitionCacheInput) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
@@ -195,7 +203,13 @@ func (tc *tableCache) cacheMarker(cfg ddprofiledefinition.MetricsConfig) {
 	if tc.tables[tableOID] == nil {
 		tc.tables[tableOID] = make(map[string]tableCacheEntry)
 	}
-	tc.tables[tableOID][tc.generateConfigID(cfg)] = tableCacheEntry{kind: tableCacheEntryMarker}
+	entry := tableCacheEntry{kind: tableCacheEntryMarker}
+	if evidence != nil {
+		item := *evidence
+		item.CreatedAt = time.Now().UTC()
+		entry.evidence = &item
+	}
+	tc.tables[tableOID][tc.generateConfigID(cfg)] = entry
 
 	if _, exists := tc.timestamps[tableOID]; !exists {
 		tc.timestamps[tableOID] = time.Now()

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_cache_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/table_cache_test.go
@@ -59,7 +59,7 @@ func TestTableCache(t *testing.T) {
 			}
 
 			// Cache data
-			cache.cacheRows(cfg, oidMap, tagValues, nil)
+			cache.cacheRows(cfg, oidMap, tagValues, nil, nil)
 
 			// Retrieve cached data - should work
 			cachedOIDs, cachedTags, found := cache.getCachedData(cfg)
@@ -107,10 +107,10 @@ func TestTableCacheEntryKinds(t *testing.T) {
 		Table: ddprofiledefinition.SymbolConfig{OID: "1.2.4", Name: "auxiliaryTable"},
 	}
 
-	cache.cacheRows(rowConfig, nil, nil, nil)
+	cache.cacheRows(rowConfig, nil, nil, nil, nil)
 	assert.False(t, cache.isConfigCached(rowConfig), "empty row snapshots must not become cache entries")
 
-	cache.cacheMarker(markerConfig)
+	cache.cacheMarker(markerConfig, nil)
 	assert.True(t, cache.isConfigCached(markerConfig), "markers must satisfy route planning")
 	_, _, found := cache.getCachedData(markerConfig)
 	assert.False(t, found, "markers must never be readable as row snapshots")
@@ -146,9 +146,9 @@ func BenchmarkTableCacheDiscardDependentsScaling(b *testing.B) {
 			for range b.N {
 				b.StopTimer()
 				cache := newTableCache(time.Hour, 0)
-				cache.cacheRows(configs[0], data, nil, nil)
+				cache.cacheRows(configs[0], data, nil, nil, nil)
 				for i := 1; i < len(configs); i++ {
-					cache.cacheRows(configs[i], data, nil, []string{configs[i-1].Table.OID})
+					cache.cacheRows(configs[i], data, nil, []string{configs[i-1].Table.OID}, nil)
 				}
 				b.StartTimer()
 
@@ -219,8 +219,8 @@ func TestTableCacheMultipleConfigs(t *testing.T) {
 	}
 
 	// Cache both configs
-	cache.cacheRows(cfg1, oidMap1, tagValues1, nil)
-	cache.cacheRows(cfg2, oidMap2, tagValues2, nil)
+	cache.cacheRows(cfg1, oidMap1, tagValues1, nil, nil)
+	cache.cacheRows(cfg2, oidMap2, tagValues2, nil, nil)
 
 	// Both should be retrievable
 	cachedOIDs1, cachedTags1, found1 := cache.getCachedData(cfg1)
@@ -271,8 +271,8 @@ func TestTableCacheInvalidateConfig(t *testing.T) {
 		cache := newTableCache(time.Hour, 0)
 		cfg1 := newConfig("1.3.6.1.2.1.2.2", "ifTable", "ifInOctets")
 		cfg2 := newConfig("1.3.6.1.2.1.2.2", "ifTable", "ifOutOctets")
-		cache.cacheRows(cfg1, data, nil, nil)
-		cache.cacheRows(cfg2, data, nil, nil)
+		cache.cacheRows(cfg1, data, nil, nil, nil)
+		cache.cacheRows(cfg2, data, nil, nil, nil)
 
 		cache.invalidateConfig(cfg1)
 
@@ -287,8 +287,8 @@ func TestTableCacheInvalidateConfig(t *testing.T) {
 		cache := newTableCache(time.Hour, 0)
 		cfg1 := newConfig("1.3.6.1.2.1.2.2", "ifTable", "ifInOctets")
 		cfg2 := newConfig("1.3.6.1.2.1.31.1.1", "ifXTable", "ifHCInOctets")
-		cache.cacheRows(cfg1, data, nil, []string{cfg2.Table.OID})
-		cache.cacheRows(cfg2, data, nil, nil)
+		cache.cacheRows(cfg1, data, nil, []string{cfg2.Table.OID}, nil)
+		cache.cacheRows(cfg2, data, nil, nil, nil)
 
 		cache.invalidateConfig(cfg1)
 
@@ -304,9 +304,9 @@ func TestTableCacheInvalidateConfig(t *testing.T) {
 		cfg1 := newConfig("1.3.6.1.2.1.2.2", "ifTable", "ifInOctets")
 		cfg2 := newConfig("1.3.6.1.2.1.2.2", "ifTable", "ifOutOctets")
 		cfg3 := newConfig("1.3.6.1.2.1.31.1.1", "ifXTable", "ifHCInOctets")
-		cache.cacheRows(cfg1, data, nil, []string{cfg3.Table.OID})
-		cache.cacheRows(cfg2, data, nil, nil)
-		cache.cacheRows(cfg3, data, nil, nil)
+		cache.cacheRows(cfg1, data, nil, []string{cfg3.Table.OID}, nil)
+		cache.cacheRows(cfg2, data, nil, nil, nil)
+		cache.cacheRows(cfg3, data, nil, nil, nil)
 
 		cache.invalidateTable(cfg1.Table.OID)
 
@@ -335,10 +335,10 @@ func TestTableCacheDiscardTables(t *testing.T) {
 		unrelated := newConfig("1.3.6.1.2.1.4", "unrelated")
 		data := map[string]map[string]string{"1": {"column": "column.1"}}
 
-		cache.cacheRows(dependency, data, nil, nil)
-		cache.cacheRows(source, data, nil, []string{dependency.Table.OID})
-		cache.cacheRows(dependent, data, nil, []string{source.Table.OID})
-		cache.cacheRows(unrelated, data, nil, nil)
+		cache.cacheRows(dependency, data, nil, nil, nil)
+		cache.cacheRows(source, data, nil, []string{dependency.Table.OID}, nil)
+		cache.cacheRows(dependent, data, nil, []string{source.Table.OID}, nil)
+		cache.cacheRows(unrelated, data, nil, nil, nil)
 		return cache, dependency, source, dependent, unrelated
 	}
 
@@ -421,11 +421,11 @@ func TestTableCacheDependencies(t *testing.T) {
 
 	// Cache tables with dependencies
 	// table1 and table2 depend on each other
-	cache.cacheRows(cfg1, oidMap, tagValues, []string{cfg2.Table.OID})
-	cache.cacheRows(cfg2, oidMap, tagValues, []string{cfg1.Table.OID})
+	cache.cacheRows(cfg1, oidMap, tagValues, []string{cfg2.Table.OID}, nil)
+	cache.cacheRows(cfg2, oidMap, tagValues, []string{cfg1.Table.OID}, nil)
 
 	// table3 depends on table2
-	cache.cacheRows(cfg3, oidMap, nil, []string{cfg2.Table.OID})
+	cache.cacheRows(cfg3, oidMap, nil, []string{cfg2.Table.OID}, nil)
 
 	// All tables should be cached
 	assert.True(t, cache.areTablesCached([]string{cfg1.Table.OID, cfg2.Table.OID, cfg3.Table.OID}))
@@ -516,10 +516,10 @@ func TestTableCacheDependenciesCascade(t *testing.T) {
 	data := map[string]map[string]string{"1": {"col": "val"}}
 
 	// Cache with chain dependencies
-	cache.cacheRows(cfgA, data, nil, []string{cfgB.Table.OID})
-	cache.cacheRows(cfgB, data, nil, []string{cfgA.Table.OID, cfgC.Table.OID})
-	cache.cacheRows(cfgC, data, nil, []string{cfgB.Table.OID, cfgD.Table.OID})
-	cache.cacheRows(cfgD, data, nil, []string{cfgC.Table.OID})
+	cache.cacheRows(cfgA, data, nil, []string{cfgB.Table.OID}, nil)
+	cache.cacheRows(cfgB, data, nil, []string{cfgA.Table.OID, cfgC.Table.OID}, nil)
+	cache.cacheRows(cfgC, data, nil, []string{cfgB.Table.OID, cfgD.Table.OID}, nil)
+	cache.cacheRows(cfgD, data, nil, []string{cfgC.Table.OID}, nil)
 
 	// All should be cached
 	assert.True(t, cache.areTablesCached([]string{cfgA.Table.OID, cfgB.Table.OID, cfgC.Table.OID, cfgD.Table.OID}))
@@ -576,9 +576,9 @@ func TestTableCacheMixedDependencies(t *testing.T) {
 	data := map[string]map[string]string{"1": {"col": "val"}}
 
 	// Cache tables
-	cache.cacheRows(cfg1, data, nil, []string{cfg2.Table.OID})
-	cache.cacheRows(cfg2, data, nil, []string{cfg1.Table.OID})
-	cache.cacheRows(cfg3, data, nil, nil) // No dependencies
+	cache.cacheRows(cfg1, data, nil, []string{cfg2.Table.OID}, nil)
+	cache.cacheRows(cfg2, data, nil, []string{cfg1.Table.OID}, nil)
+	cache.cacheRows(cfg3, data, nil, nil, nil) // No dependencies
 
 	// All should be cached
 	_, _, found1 := cache.getCachedData(cfg1)
@@ -643,14 +643,14 @@ func TestTableCacheDisabled(t *testing.T) {
 	}
 
 	// Try to cache data
-	cache.cacheRows(cfg, oidMap, tagValues, nil)
+	cache.cacheRows(cfg, oidMap, tagValues, nil, nil)
 
 	// Should not find anything
 	_, _, found := cache.getCachedData(cfg)
 	assert.False(t, found)
 
 	// Try to cache with dependencies
-	cache.cacheRows(cfg, oidMap, tagValues, []string{"other.table"})
+	cache.cacheRows(cfg, oidMap, tagValues, []string{"other.table"}, nil)
 
 	// Should not find anything
 	_, _, found = cache.getCachedData(cfg)
@@ -683,7 +683,7 @@ func TestTableCacheDeepCopy(t *testing.T) {
 	}
 
 	// Cache the data
-	cache.cacheRows(cfg, oidMap, tagValues, nil)
+	cache.cacheRows(cfg, oidMap, tagValues, nil, nil)
 
 	// Modify original maps
 	oidMap["1"]["col2"] = "should not appear"
@@ -725,8 +725,8 @@ func TestTableCacheDependencyCleanup(t *testing.T) {
 	data := map[string]map[string]string{"1": {"col": "val"}}
 
 	// Cache with circular deps
-	cache.cacheRows(cfg1, data, nil, []string{cfg2.Table.OID})
-	cache.cacheRows(cfg2, data, nil, []string{cfg1.Table.OID})
+	cache.cacheRows(cfg1, data, nil, []string{cfg2.Table.OID}, nil)
+	cache.cacheRows(cfg2, data, nil, []string{cfg1.Table.OID}, nil)
 
 	// Check initial state
 	tables, configs, withDeps, totalDeps := cache.stats()
@@ -780,7 +780,7 @@ func TestTableCacheNonExistentDependency(t *testing.T) {
 	cache.cacheRows(cfgA,
 		map[string]map[string]string{"1": {"col": "val"}},
 		nil,
-		[]string{cfgB.Table.OID})
+		[]string{cfgB.Table.OID}, nil)
 
 	// tableA should be cached
 	_, _, found := cache.getCachedData(cfgA)
@@ -798,7 +798,7 @@ func TestTableCacheNonExistentDependency(t *testing.T) {
 	cache.cacheRows(cfgB,
 		map[string]map[string]string{"1": {"col": "val"}},
 		nil,
-		[]string{cfgA.Table.OID})
+		[]string{cfgA.Table.OID}, nil)
 
 	// Both should be cached
 	assert.True(t, cache.areTablesCached([]string{cfgA.Table.OID, cfgB.Table.OID}))
@@ -850,9 +850,9 @@ func TestTableCacheMultipleConfigsSameTableExpiration(t *testing.T) {
 	}
 
 	// Cache multiple configs for the same table
-	cache.cacheRows(cfg1, map[string]map[string]string{"1": {"col1": "val1"}}, nil, nil)
-	cache.cacheRows(cfg2, map[string]map[string]string{"1": {"col2": "val2"}}, nil, nil)
-	cache.cacheRows(cfg3, map[string]map[string]string{"1": {"col3": "val3"}}, nil, nil)
+	cache.cacheRows(cfg1, map[string]map[string]string{"1": {"col1": "val1"}}, nil, nil, nil)
+	cache.cacheRows(cfg2, map[string]map[string]string{"1": {"col2": "val2"}}, nil, nil, nil)
+	cache.cacheRows(cfg3, map[string]map[string]string{"1": {"col3": "val3"}}, nil, nil, nil)
 
 	// All configs should be cached
 	assert.True(t, cache.isConfigCached(cfg1))
@@ -919,8 +919,8 @@ func TestTableCacheConfigIsolation(t *testing.T) {
 	}
 
 	// Cache configs with different tags
-	cache.cacheRows(cfg1, config1OIDs, config1Tags, nil)
-	cache.cacheRows(cfg2, config2OIDs, config2Tags, nil)
+	cache.cacheRows(cfg1, config1OIDs, config1Tags, nil, nil)
+	cache.cacheRows(cfg2, config2OIDs, config2Tags, nil, nil)
 
 	// Retrieve and verify isolation
 	_, tags1, found1 := cache.getCachedData(cfg1)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_store.go
@@ -490,6 +490,20 @@ type DeviceWriter struct {
 	owner string
 }
 
+// RegistrationID is available only while this accepted runtime owns the job.
+func (w *DeviceWriter) RegistrationID() DeviceRegistrationID {
+	if w == nil {
+		return 0
+	}
+	s := w.store
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.writers[w.owner] != w {
+		return 0
+	}
+	return s.ownerRegistrations[w.owner]
+}
+
 func (w *DeviceWriter) UpdateDevice(info DeviceConnectionInfo) {
 	if w == nil {
 		return

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/metric.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/metric.go
@@ -35,6 +35,7 @@ type Metric struct {
 
 	TopologyKind ddprofiledefinition.TopologyKind
 	IsTable      bool
+	IsVirtual    bool
 }
 
 type MetaTag struct {

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/source_evidence.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/source_evidence.go
@@ -6,14 +6,19 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 )
 
 // SourceOperation is one completed Handler call, including its internal retries.
-// Its one-based position in a context identifies it; wire packets and credentials
-// are deliberately not retained. WALK terminal details hidden by the Handler are unknown.
+// Ordinal identifies it within its acquisition context; ContextID qualifies that
+// identity across normal polls. Wire packets and credentials are not retained.
+// WALK terminal details hidden by the Handler are unknown.
 type SourceOperation struct {
+	ContextID     uint64            `json:"context_id,omitempty"`
+	Ordinal       uint64            `json:"ordinal"`
+	StartedAt     time.Time         `json:"started_at"`
 	Method        string            `json:"method"`
 	RequestedOIDs []string          `json:"requested_oids"`
 	ElapsedNanos  int64             `json:"elapsed_ns"`
@@ -41,6 +46,7 @@ type SourceValue struct {
 // SourceBinding records requested input, not a claim that it was processed.
 // Operation is one-based within the owning collection context.
 type SourceBinding struct {
+	ContextID uint64 `json:"context_id,omitempty"`
 	Operation uint64 `json:"operation"`
 	OID       string `json:"oid"`
 	Role      string `json:"role"`
@@ -57,8 +63,11 @@ type ProcessingEvent struct {
 	Reason   string `json:"reason"`
 }
 
-func ValidateSourceOperations(operations []SourceOperation) error {
+func ValidateSourceOperations(operations []*SourceOperation) error {
 	for i, op := range operations {
+		if op == nil {
+			return fmt.Errorf("operation %d: missing source operation", i+1)
+		}
 		if op.Method != "get" && op.Method != "walk" && op.Method != "bulk_walk" {
 			return fmt.Errorf("operation %d: invalid method", i+1)
 		}
@@ -107,7 +116,7 @@ func ValidateSourceOperations(operations []SourceOperation) error {
 
 // SourceRequestIndex is temporary import-validation state. Building it once per
 // context avoids rescanning a large GET batch for every consumer reference.
-func SourceRequestIndex(operations []SourceOperation) []map[string]struct{} {
+func SourceRequestIndex(operations []*SourceOperation) []map[string]struct{} {
 	index := make([]map[string]struct{}, len(operations))
 	for i, op := range operations {
 		index[i] = make(map[string]struct{}, len(op.RequestedOIDs))
@@ -149,10 +158,10 @@ func ValidateProcessingEvents(events []ProcessingEvent) error {
 
 // SourceOperationsShape describes retained logical content, not heap usage or
 // encoded bytes. Physical operations are counted once, independently of consumers.
-func SourceOperationsShape(operations []SourceOperation) (records, logicalBytes uint64) {
+func SourceOperationsShape(operations []*SourceOperation) (records, logicalBytes uint64) {
 	for _, op := range operations {
 		records += uint64(1 + len(op.RequestedOIDs) + len(op.PDUs))
-		logicalBytes += uint64(64+len(op.Method)) + snmputils.FailureLogicalBytes
+		logicalBytes += uint64(104+len(op.Method)) + snmputils.FailureLogicalBytes
 		for _, oid := range op.RequestedOIDs {
 			logicalBytes += uint64(16 + len(oid))
 		}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/source_evidence.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/source_evidence.go
@@ -139,6 +139,25 @@ func ValidateSourceBindings(bindings []SourceBinding, requests []map[string]stru
 	return nil
 }
 
+// IsFailure distinguishes failed processing from ordinary omitted input/output.
+// Rejection counts describe row acceptance and must not decide failure retention.
+func (e ProcessingEvent) IsFailure() bool {
+	failed, _ := processingReason(e.Reason)
+	return failed
+}
+
+// Validation and classification share the same closed reason vocabulary.
+func processingReason(reason string) (failed, valid bool) {
+	switch reason {
+	case "missing_input", "missing_dependency", "empty_date", "sentinel", "no_signals", "incomplete_identity":
+		return false, true
+	case "conversion", "pattern_mismatch", "extract_mismatch", "index_processing", "dependency_processing":
+		return true, true
+	default:
+		return true, false
+	}
+}
+
 func ValidateProcessingEvents(events []ProcessingEvent) error {
 	for _, event := range events {
 		if event.Stage != "" && event.Stage != "raw_text" {
@@ -147,9 +166,7 @@ func ValidateProcessingEvents(events []ProcessingEvent) error {
 		if event.Field == "" {
 			return fmt.Errorf("processing event has no field")
 		}
-		switch event.Reason {
-		case "missing_input", "missing_dependency", "conversion", "empty_date", "pattern_mismatch", "extract_mismatch", "index_processing", "dependency_processing", "no_signals", "incomplete_identity":
-		default:
+		if _, valid := processingReason(event.Reason); !valid {
 			return fmt.Errorf("invalid processing reason")
 		}
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/source_evidence_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/source_evidence_test.go
@@ -10,10 +10,12 @@ import (
 
 func TestValidateSourceEvidence(t *testing.T) {
 	for name, tc := range map[string]struct {
-		mutate  func(*SourceOperation, *SourceBinding, *ProcessingEvent)
-		invalid bool
+		mutate           func(*SourceOperation, *SourceBinding, *ProcessingEvent)
+		invalid          bool
+		missingOperation bool
 	}{
 		"valid partial response":  {},
+		"missing operation":       {missingOperation: true, invalid: true},
 		"unknown method":          {mutate: func(o *SourceOperation, _ *SourceBinding, _ *ProcessingEvent) { o.Method = "packet" }, invalid: true},
 		"negative elapsed":        {mutate: func(o *SourceOperation, _ *SourceBinding, _ *ProcessingEvent) { o.ElapsedNanos = -1 }, invalid: true},
 		"absent result with PDUs": {mutate: func(o *SourceOperation, _ *SourceBinding, _ *ProcessingEvent) { o.ResultPresent = false }, invalid: true},
@@ -38,7 +40,10 @@ func TestValidateSourceEvidence(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(&operation, &binding, &event)
 			}
-			operations := []SourceOperation{operation}
+			operations := []*SourceOperation{&operation}
+			if tc.missingOperation {
+				operations[0] = nil
+			}
 			err := ValidateSourceOperations(operations)
 			if err == nil {
 				err = ValidateSourceBindings([]SourceBinding{binding}, SourceRequestIndex(operations))

--- a/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/device_lifecycle.go
@@ -111,6 +111,10 @@ func (c *Collector) commitDeviceLifecycle(previousOwner string) {
 	)
 	c.deviceLifecyclePending = nil
 	c.deviceLifecycleCommitted = true
+	c.normalWriter = c.diagnosticPublisher.ReplaceNormal(previousOwner, c.deviceLifecycleOwner, uint64(c.deviceWriter.RegistrationID()))
+	if c.normal.cut != nil {
+		c.normalWriter.Update(c.normal.cut)
+	}
 }
 
 func (c *Collector) deviceLifecycleBoundTo(owner string) bool {

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
@@ -41,7 +41,7 @@ func Write(w io.Writer, document Document) error {
 }
 
 // One serial publisher reuses the compressor's workspace across device files.
-// Per-file construction would allocate megabytes on every ordinary SNMP poll.
+// Per-file construction would allocate megabytes on every device publication.
 type archiveEncoder struct{ encoder *zstd.Encoder }
 
 func newArchiveEncoder() (*archiveEncoder, error) {

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"reflect"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -33,6 +34,9 @@ func DefaultReadLimits() ReadLimits { return ReadLimits{128 << 20, 512 << 20} }
 
 // Write encodes one complete document. The caller owns its immutable snapshot.
 func Write(w io.Writer, document Document) error {
+	if w == nil {
+		return errors.New("write SNMP diagnostic archive: nil writer")
+	}
 	encoder, err := newArchiveEncoder()
 	if err != nil {
 		return err
@@ -129,7 +133,7 @@ func (d Document) ValidateEnvelope() error {
 	}
 	switch d.Kind {
 	case KindNormal:
-		if d.Normal == nil || d.Snapshot.Topology != nil || d.Snapshot.LastAborted != nil || d.TopologyActive || d.Checkpoint != 0 {
+		if d.Normal == nil || !reflect.ValueOf(d.Snapshot).IsZero() || d.TopologyActive || d.Checkpoint != 0 {
 			return errors.New("invalid normal device document envelope")
 		}
 	case KindLifecycle:

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/codec.go
@@ -33,24 +33,41 @@ func DefaultReadLimits() ReadLimits { return ReadLimits{128 << 20, 512 << 20} }
 
 // Write encodes one complete document. The caller owns its immutable snapshot.
 func Write(w io.Writer, document Document) error {
-	if w == nil {
-		return errors.New("write SNMP diagnostic archive: nil writer")
+	encoder, err := newArchiveEncoder()
+	if err != nil {
+		return err
 	}
+	return encoder.write(w, document)
+}
+
+// One serial publisher reuses the compressor's workspace across device files.
+// Per-file construction would allocate megabytes on every ordinary SNMP poll.
+type archiveEncoder struct{ encoder *zstd.Encoder }
+
+func newArchiveEncoder() (*archiveEncoder, error) {
 	encoder, err := zstd.NewWriter(
-		w,
+		nil,
 		zstd.WithEncoderLevel(zstd.SpeedDefault),
 		zstd.WithEncoderConcurrency(1),
 		zstd.WithEncoderCRC(true),
 	)
 	if err != nil {
-		return fmt.Errorf("create diagnostic zstd encoder: %w", err)
+		return nil, fmt.Errorf("create diagnostic zstd encoder: %w", err)
 	}
+	return &archiveEncoder{encoder: encoder}, nil
+}
+
+func (e *archiveEncoder) write(w io.Writer, document Document) error {
+	if w == nil {
+		return errors.New("write SNMP diagnostic archive: nil writer")
+	}
+	e.encoder.Reset(w)
 	encodeErr := jsonv2.MarshalWrite(
-		encoder,
+		e.encoder,
 		document,
 		jsonv2.JoinOptions(jsonv1.DefaultOptionsV1(), jsontext.EscapeForHTML(false)),
 	)
-	closeErr := encoder.Close()
+	closeErr := e.encoder.Close()
 	return errors.Join(encodeErr, closeErr)
 }
 
@@ -111,11 +128,21 @@ func (d Document) ValidateEnvelope() error {
 		return fmt.Errorf("unsupported version %d", d.Version)
 	}
 	switch d.Kind {
+	case KindNormal:
+		if d.Normal == nil || d.Snapshot.Topology != nil || d.Snapshot.LastAborted != nil || d.TopologyActive || d.Checkpoint != 0 {
+			return errors.New("invalid normal device document envelope")
+		}
 	case KindLifecycle:
+		if d.Normal != nil {
+			return errors.New("lifecycle document contains normal evidence")
+		}
 		if d.Snapshot.Topology != nil || d.Snapshot.LastAborted != nil || d.Snapshot.ProducerScopeID != "" || d.Checkpoint != 0 {
 			return errors.New("lifecycle document contains topology checkpoint data")
 		}
 	case KindTopology:
+		if d.Normal != nil {
+			return errors.New("topology document contains normal evidence")
+		}
 		if d.TopologyActive {
 			return errors.New("topology checkpoint contains current lifecycle status")
 		}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/codec_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/codec_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -43,4 +44,53 @@ type failingArchiveWriter struct{}
 
 func (failingArchiveWriter) Write([]byte) (int, error) {
 	return 0, errors.New("synthetic archive write failure")
+}
+
+func TestNormalEnvelopeSnapshot(t *testing.T) {
+	for name, tc := range map[string]struct {
+		snapshot Snapshot
+		invalid  bool
+	}{
+		"empty":               {},
+		"producer scope":      {Snapshot{ProducerScopeID: "scope"}, true},
+		"topology":            {Snapshot{Topology: &Sweep{}}, true},
+		"aborted sweep":       {Snapshot{LastAborted: &Abort{}}, true},
+		"lifecycle state":     {Snapshot{Lifecycle: Lifecycle{State: "available"}}, true},
+		"lifecycle reason":    {Snapshot{Lifecycle: Lifecycle{Reason: "none"}}, true},
+		"lifecycle sequence":  {Snapshot{Lifecycle: Lifecycle{Cut: LifecycleCut{Sequence: 1}}}, true},
+		"lifecycle timestamp": {Snapshot{Lifecycle: Lifecycle{Cut: LifecycleCut{CapturedAt: time.Unix(1, 0).UTC()}}}, true},
+		"lifecycle entries":   {Snapshot{Lifecycle: Lifecycle{Cut: LifecycleCut{Entries: []LifecycleEntry{{RegistrationID: 1}}}}}, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			doc := Document{Format: Format, Version: Version, Kind: KindNormal, Normal: &NormalDevice{}, Snapshot: tc.snapshot}
+			var encoded bytes.Buffer
+			require.NoError(t, Write(&encoded, doc))
+			_, err := Read(&encoded, DefaultReadLimits())
+			if tc.invalid {
+				require.ErrorContains(t, err, "invalid normal device document envelope")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestArchiveWrite(t *testing.T) {
+	for name, tc := range map[string]struct {
+		writer    io.Writer
+		wantError string
+	}{
+		"nil writer":    {wantError: "nil writer"},
+		"failed writer": {writer: failingArchiveWriter{}, wantError: "synthetic archive write failure"},
+		"valid writer":  {writer: io.Discard},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := Write(tc.writer, testDocument(1))
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/codec_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/codec_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveEncoderReuse(t *testing.T) {
+	for name, tc := range map[string]struct {
+		first  io.Writer
+		failed bool
+	}{
+		"completed file": {first: io.Discard},
+		"failed file":    {first: failingArchiveWriter{}, failed: true},
+		"missing writer": {failed: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			encoder, err := newArchiveEncoder()
+			require.NoError(t, err)
+			err = encoder.write(tc.first, testDocument(1))
+			if tc.failed {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			var encoded bytes.Buffer
+			want := testDocument(2)
+			require.NoError(t, encoder.write(&encoded, want))
+			got, err := Read(&encoded, DefaultReadLimits())
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+type failingArchiveWriter struct{}
+
+func (failingArchiveWriter) Write([]byte) (int, error) {
+	return 0, errors.New("synthetic archive write failure")
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/document.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/document.go
@@ -13,14 +13,15 @@ import (
 )
 
 type Document struct {
-	Format         string    `json:"format"`
-	Version        uint64    `json:"version"`
-	Producer       Producer  `json:"producer"`
-	Snapshot       Snapshot  `json:"snapshot"`
-	Kind           string    `json:"kind"`
-	PublishedAt    time.Time `json:"published_at"`
-	Checkpoint     uint64    `json:"checkpoint,omitempty"`
-	TopologyActive bool      `json:"topology_active,omitempty"`
+	Normal         *NormalDevice `json:"normal_device,omitempty"`
+	Format         string        `json:"format"`
+	Version        uint64        `json:"version"`
+	Producer       Producer      `json:"producer"`
+	Snapshot       Snapshot      `json:"snapshot"`
+	Kind           string        `json:"kind"`
+	PublishedAt    time.Time     `json:"published_at"`
+	Checkpoint     uint64        `json:"checkpoint,omitempty"`
+	TopologyActive bool          `json:"topology_active,omitempty"`
 }
 
 type Producer struct {
@@ -168,7 +169,7 @@ type Phase struct {
 }
 
 type ContextEvidence struct {
-	Sources      []ddsnmp.SourceOperation  `json:"source_operations,omitempty"`
+	Sources      []*ddsnmp.SourceOperation `json:"source_operations,omitempty"`
 	Interruption snmputils.Failure         `json:"interruption"`
 	Failures     ddsnmp.CollectionFailures `json:"failures"`
 	Ordinal      uint32                    `json:"ordinal"`

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/normal.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/normal.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+const KindNormal = "normal"
+
+// NormalDevice is a self-contained cut of one accepted runtime. Operation keys
+// are local to this runtime; Producer.RunID and RuntimeID qualify them globally.
+type NormalDevice struct {
+	RegistrationID uint64                    `json:"registration_id"`
+	RuntimeID      uint64                    `json:"runtime_id"`
+	Hostname       string                    `json:"hostname"`
+	CapturedAt     time.Time                 `json:"captured_at"`
+	Initialization []SourceRef               `json:"initialization_sources,omitempty"`
+	Device         DeviceInput               `json:"device"`
+	ProfileContext ddsnmp.ProfileContextData `json:"profile_context"`
+	Latest         *NormalAttempt            `json:"latest_attempt"`
+	LastFailure    *NormalAttempt            `json:"last_failed_attempt,omitempty"`
+	Sources        []*ddsnmp.SourceOperation `json:"source_operations,omitempty"`
+}
+
+type SourceRef struct {
+	ContextID uint64 `json:"context_id"`
+	Operation uint64 `json:"operation"`
+}
+
+type NormalAttempt struct {
+	BGP            NormalBGP                                  `json:"bgp_cache"`
+	Licensing      NormalLicensing                            `json:"licensing_cache"`
+	ID             uint64                                     `json:"id"`
+	Phase          string                                     `json:"phase"`
+	StartedAt      time.Time                                  `json:"started_at"`
+	CompletedAt    time.Time                                  `json:"completed_at"`
+	Failed         bool                                       `json:"failed"`
+	Failure        snmputils.Failure                          `json:"failure"`
+	Failures       ddsnmp.CollectionFailures                  `json:"failures"`
+	Sources        []SourceRef                                `json:"sources,omitempty"`
+	Profiles       []NormalProfile                            `json:"profiles,omitempty"`
+	Caches         []NormalCache                              `json:"cache_inputs,omitempty"`
+	NegativeCauses []ddsnmpcollector.AcquisitionNegativeCause `json:"negative_causes,omitempty"`
+	Metrics        []NormalMetricDecision                     `json:"metric_decisions,omitempty"`
+	Samples        map[string]int64                           `json:"samples,omitempty"`
+}
+
+type NormalProfile struct {
+	Source        string                                   `json:"source"`
+	Acquisition   ddsnmpcollector.AcquisitionProfileReport `json:"acquisition"`
+	Tags          map[string]string                        `json:"tags,omitempty"`
+	Metadata      map[string]ddsnmp.MetaTag                `json:"metadata,omitempty"`
+	Metrics       []NormalMetric                           `json:"metrics,omitempty"`
+	HiddenMetrics []NormalMetric                           `json:"hidden_metrics,omitempty"`
+	BGPRows       []ddsnmp.BGPRow                          `json:"bgp_rows,omitempty"`
+	BGPFailed     bool                                     `json:"bgp_failed"`
+	LicenseRows   []ddsnmp.LicenseRow                      `json:"license_rows,omitempty"`
+}
+
+// Cache content is the exact committed structure/tag generation. Its source
+// references join the shared operation table rather than repeating raw PDUs.
+type NormalCache struct {
+	Kind      string                       `json:"kind"`
+	Profile   string                       `json:"profile"`
+	RootOID   string                       `json:"root_oid,omitempty"`
+	ConfigID  string                       `json:"config_id,omitempty"`
+	CreatedAt time.Time                    `json:"created_at"`
+	ExpiresAt time.Time                    `json:"expires_at"`
+	Marker    bool                         `json:"marker"`
+	OIDs      map[string]map[string]string `json:"oids,omitempty"`
+	TableTags map[string]map[string]string `json:"table_tags,omitempty"`
+	Tags      map[string]string            `json:"tags,omitempty"`
+	Metadata  map[string]ddsnmp.MetaTag    `json:"metadata,omitempty"`
+	Sources   []SourceRef                  `json:"sources,omitempty"`
+}
+
+type NormalMetricDecision struct {
+	Metric    NormalMetric `json:"metric"`
+	Action    string       `json:"action"`
+	SampleIDs []string     `json:"sample_ids,omitempty"`
+}
+
+type NormalBGP struct {
+	Enabled         bool                   `json:"enabled"`
+	LastUpdate      time.Time              `json:"last_update"`
+	LastFailure     time.Time              `json:"last_failure"`
+	StaleAfterNanos int64                  `json:"stale_after_ns"`
+	Entries         []NormalBGPPeer        `json:"entries,omitempty"`
+	Sources         map[string][]SourceRef `json:"sources,omitempty"`
+}
+
+type NormalLicensing struct {
+	Enabled      bool            `json:"enabled"`
+	NormalizedAt time.Time       `json:"normalized_at"`
+	Rows         []NormalLicense `json:"rows,omitempty"`
+	Sources      []SourceRef     `json:"sources,omitempty"`
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/normal_layout.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/normal_layout.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const NormalDirectory = "normal"
+const normalRunsFilename = "runs.json"
+
+// Updating this small index activates a run only after a complete device file
+// exists. Failed/empty startups leave the previous evidence-bearing run intact.
+type NormalRuns struct {
+	Current  string `json:"current"`
+	Previous string `json:"previous,omitempty"`
+}
+
+type NormalFile struct {
+	RunID          string `json:"run_id"`
+	Previous       bool   `json:"previous"`
+	RegistrationID uint64 `json:"registration_id"`
+	Filename       string `json:"filename"`
+}
+
+func normalFilename(registration uint64) string { return fmt.Sprintf("device-%020d.zst", registration) }
+
+func parseNormalFilename(name string) (registration uint64, ok bool) {
+	number := strings.TrimSuffix(strings.TrimPrefix(name, "device-"), ".zst")
+	registration, _ = strconv.ParseUint(number, 10, 64)
+	return registration, registration != 0 && name == normalFilename(registration)
+}
+
+func ReadNormalRuns(directory string) (NormalRuns, error) {
+	file, err := os.Open(filepath.Join(directory, NormalDirectory, normalRunsFilename))
+	if errors.Is(err, os.ErrNotExist) {
+		return NormalRuns{}, nil
+	}
+	if err != nil {
+		return NormalRuns{}, err
+	}
+	defer file.Close()
+	var runs NormalRuns
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&runs); err != nil {
+		return runs, err
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		return runs, errors.New("invalid normal run index trailer")
+	}
+	if !validNormalRun(runs.Current) || (runs.Previous != "" && (!validNormalRun(runs.Previous) || runs.Previous == runs.Current)) {
+		return runs, errors.New("invalid normal run identity")
+	}
+	return runs, nil
+}
+
+func validNormalRun(id string) bool {
+	parsed, err := uuid.Parse(id)
+	return err == nil && parsed.String() == id
+}
+
+// ListNormalFiles reads only the committed run index and filenames. Temporary
+// or unactivated files never become previous-run evidence by accident.
+func ListNormalFiles(directory string) ([]NormalFile, error) {
+	runs, err := ReadNormalRuns(directory)
+	if err != nil {
+		return nil, err
+	}
+	var result []NormalFile
+	for _, run := range []string{runs.Current, runs.Previous} {
+		if run == "" {
+			continue
+		}
+		files, err := os.ReadDir(filepath.Join(directory, NormalDirectory, run))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range files {
+			registration, ok := parseNormalFilename(file.Name())
+			if !file.Type().IsRegular() || !ok {
+				continue
+			}
+			result = append(result, NormalFile{RunID: run, Previous: run == runs.Previous, RegistrationID: registration, Filename: file.Name()})
+		}
+	}
+	return result, nil
+}
+
+func (p *Publisher) activateNormal(ctx context.Context) error {
+	if p.normal.activated {
+		return nil
+	}
+	runs, err := ReadNormalRuns(p.directory)
+	if err != nil {
+		return err
+	}
+	if runs.Current != p.runID {
+		runs = NormalRuns{Current: p.runID, Previous: runs.Current}
+		path := filepath.Join(p.directory, NormalDirectory, normalRunsFilename)
+		err = writeAtomicFile(ctx, path, (*os.File).Close, func(w io.Writer) error { return json.NewEncoder(w).Encode(runs) }, p.rename)
+		if err != nil {
+			return err
+		}
+	}
+	p.normal.activated, p.normal.prunePending = true, true
+	return nil
+}
+
+func (p *Publisher) cleanupNormal(ctx context.Context) error {
+	p.mu.Lock()
+	retired := p.normal.retired
+	p.normal.retired = nil
+	p.mu.Unlock()
+	var retry []normalRetirement
+	var errs []error
+	for _, file := range retired {
+		if ctx.Err() != nil {
+			retry = append(retry, file)
+			continue
+		}
+		if err := p.removeRetiredNormal(file); err != nil {
+			retry = append(retry, file)
+			errs = append(errs, err)
+		}
+	}
+	if len(retry) > 0 {
+		p.mu.Lock()
+		p.normal.retired = append(p.normal.retired, retry...)
+		p.mu.Unlock()
+	}
+	if p.normal.prunePending && ctx.Err() == nil {
+		if err := p.pruneNormalRuns(ctx); err != nil {
+			errs = append(errs, err)
+		} else {
+			p.normal.prunePending = false
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (p *Publisher) pruneNormalRuns(ctx context.Context) error {
+	runs, err := ReadNormalRuns(p.directory)
+	if err != nil {
+		return err
+	}
+	root := filepath.Join(p.directory, NormalDirectory)
+	directories, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, directory := range directories {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !directory.IsDir() || !validNormalRun(directory.Name()) || directory.Name() == runs.Current || directory.Name() == runs.Previous {
+			continue
+		}
+		path := filepath.Join(root, directory.Name())
+		files, err := os.ReadDir(path)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		remaining := false
+		for _, file := range files {
+			_, owned := parseNormalFilename(strings.TrimSuffix(file.Name(), ".tmp"))
+			if !owned || !file.Type().IsRegular() {
+				remaining = true
+				continue
+			}
+			if err := p.remove(filepath.Join(path, file.Name())); err != nil && !errors.Is(err, os.ErrNotExist) {
+				remaining = true
+				errs = append(errs, err)
+			}
+		}
+		if !remaining {
+			if err := p.remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/normal_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/normal_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalSourceValidation(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mutate  func(*NormalDevice)
+		invalid bool
+	}{
+		"current and cached bindings": {},
+		"missing operation":           {func(d *NormalDevice) { d.Sources = nil }, true},
+		"duplicate identity":          {func(d *NormalDevice) { d.Sources = append(d.Sources, d.Sources[0]) }, true},
+		"missing cache source":        {func(d *NormalDevice) { d.Latest.Caches[0].Sources[0].Operation = 99 }, true},
+		"missing consumer source":     {func(d *NormalDevice) { d.Latest.Licensing.Sources = []SourceRef{{99, 1}} }, true},
+		"missing discarded candidate": {func(d *NormalDevice) {
+			d.Latest.Profiles[0].Acquisition.Routes[0].DiscardedSources = []ddsnmp.SourceBinding{{Operation: 99, OID: "1.2.3", Role: "primary"}}
+		}, true},
+		"incorrect requested OID":         {func(d *NormalDevice) { d.Latest.Profiles[0].Acquisition.Routes[0].Sources[0].OID = "1.2.4" }, true},
+		"retained success is not failure": {func(d *NormalDevice) { d.LastFailure = &NormalAttempt{ID: 1} }, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			now := time.Now().UTC()
+			d := &NormalDevice{RegistrationID: 1, RuntimeID: 1, CapturedAt: now,
+				Sources: []*ddsnmp.SourceOperation{{ContextID: 1, Ordinal: 1, StartedAt: now, Method: "get", RequestedOIDs: []string{"1.2.3"}}},
+				Latest: &NormalAttempt{ID: 2, Phase: "collect", StartedAt: now, CompletedAt: now,
+					Caches:   []NormalCache{{Sources: []SourceRef{{1, 1}}}},
+					Profiles: []NormalProfile{{Acquisition: ddsnmpcollector.AcquisitionProfileReport{Routes: []ddsnmpcollector.AcquisitionRouteReport{{Sources: []ddsnmp.SourceBinding{{ContextID: 1, Operation: 1, OID: "1.2.3", Role: "primary"}}}}}}},
+				},
+			}
+			if tc.mutate != nil {
+				tc.mutate(d)
+			}
+			err := d.Validate()
+			if tc.invalid {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/normal_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/normal_test.go
@@ -3,6 +3,7 @@
 package diagnostics
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -47,4 +48,27 @@ func TestNormalSourceValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalNegativeCauseJSON(t *testing.T) {
+	cause := ddsnmpcollector.AcquisitionNegativeCause{
+		ContextID: 1, Operation: 2, ObservedAt: time.Unix(1, 0).UTC(), PDU: ddsnmp.SourcePDU{OID: "1.2.3"},
+	}
+	attempt := NormalAttempt{NegativeCauses: []ddsnmpcollector.AcquisitionNegativeCause{cause}}
+	encoded, err := json.Marshal(attempt)
+	require.NoError(t, err)
+	var decoded struct {
+		NegativeCauses []map[string]json.RawMessage `json:"negative_causes"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.Len(t, decoded.NegativeCauses, 1)
+	require.Len(t, decoded.NegativeCauses[0], 4)
+	for name, tc := range map[string]struct{ key string }{
+		"context": {"context_id"}, "operation": {"operation"}, "timestamp": {"observed_at"}, "pdu": {"pdu"},
+	} {
+		t.Run(name, func(t *testing.T) { require.Contains(t, decoded.NegativeCauses[0], tc.key) })
+	}
+	var restored NormalAttempt
+	require.NoError(t, json.Unmarshal(encoded, &restored))
+	require.Equal(t, attempt, restored)
 }

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/normal_validate.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/normal_validate.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+func (d *NormalDevice) Validate() error {
+	if d == nil || d.RegistrationID == 0 || d.RuntimeID == 0 || d.Latest == nil || d.CapturedAt.IsZero() {
+		return errors.New("normal evidence is missing its device or latest attempt identity")
+	}
+	if err := ddsnmp.ValidateSourceOperations(d.Sources); err != nil {
+		return err
+	}
+	sources := make(map[SourceRef]*ddsnmp.SourceOperation, len(d.Sources))
+	requests := make(map[SourceRef]map[string]bool, len(d.Sources))
+	for _, source := range d.Sources {
+		ref := SourceRef{ContextID: source.ContextID, Operation: source.Ordinal}
+		if ref.ContextID == 0 || ref.Operation == 0 || source.StartedAt.IsZero() || sources[ref] != nil {
+			return fmt.Errorf("invalid or duplicate normal source identity %+v", ref)
+		}
+		sources[ref] = source
+		oids := make(map[string]bool, len(source.RequestedOIDs))
+		for _, oid := range source.RequestedOIDs {
+			oids[strings.TrimPrefix(oid, ".")] = true
+		}
+		requests[ref] = oids
+	}
+	check := func(refs []SourceRef) error {
+		for _, ref := range refs {
+			if sources[ref] == nil {
+				return fmt.Errorf("missing normal source %+v", ref)
+			}
+		}
+		return nil
+	}
+	if err := check(d.Initialization); err != nil {
+		return err
+	}
+	if d.LastFailure != nil && (!d.LastFailure.Failed || d.LastFailure.ID >= d.Latest.ID) {
+		return errors.New("invalid retained failure attempt")
+	}
+	for _, attempt := range []*NormalAttempt{d.Latest, d.LastFailure} {
+		if attempt == nil {
+			continue
+		}
+		if attempt.ID == 0 || attempt.StartedAt.IsZero() || attempt.CompletedAt.IsZero() || (attempt.Phase != "check" && attempt.Phase != "collect") {
+			return errors.New("invalid normal attempt")
+		}
+		if !attempt.Failures.Valid() || !attempt.Failure.Valid() {
+			return errors.New("invalid normal failure evidence")
+		}
+
+		for _, refs := range attempt.BGP.Sources {
+			if err := check(refs); err != nil {
+				return err
+			}
+		}
+		if err := check(attempt.Licensing.Sources); err != nil {
+			return err
+		}
+		if err := check(attempt.Sources); err != nil {
+			return err
+		}
+		for _, cache := range attempt.Caches {
+			if err := check(cache.Sources); err != nil {
+				return err
+			}
+		}
+		for _, profile := range attempt.Profiles {
+			for _, route := range profile.Acquisition.Routes {
+				for _, bindings := range [][]ddsnmp.SourceBinding{route.Sources, route.DiscardedSources} {
+					for _, binding := range bindings {
+						context := binding.ContextID
+						if context == 0 {
+							context = attempt.ID
+						}
+						ref := SourceRef{ContextID: context, Operation: binding.Operation}
+						if !requests[ref][binding.OID] || (binding.Role != "primary" && binding.Role != "dependency") {
+							return fmt.Errorf("invalid normal source binding %+v", ref)
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/normal_validate.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/normal_validate.go
@@ -74,6 +74,9 @@ func (d *NormalDevice) Validate() error {
 		}
 		for _, profile := range attempt.Profiles {
 			for _, route := range profile.Acquisition.Routes {
+				if err := ddsnmp.ValidateProcessingEvents(route.Processing); err != nil {
+					return err
+				}
 				for _, bindings := range [][]ddsnmp.SourceBinding{route.Sources, route.DiscardedSources} {
 					for _, binding := range bindings {
 						context := binding.ContextID

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/normal_values.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/normal_values.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+)
+
+type NormalMetric struct {
+	IsVirtual   bool                                  `json:"is_virtual"`
+	Profile     string                                `json:"profile"`
+	Name        string                                `json:"name"`
+	Description string                                `json:"description"`
+	Family      string                                `json:"family"`
+	Unit        string                                `json:"unit"`
+	ChartType   string                                `json:"chart_type"`
+	MetricType  ddprofiledefinition.ProfileMetricType `json:"metric_type"`
+	StaticTags  map[string]string                     `json:"static_tags"`
+	Tags        map[string]string                     `json:"tags"`
+	Table       string                                `json:"table"`
+	Value       int64                                 `json:"value"`
+	MultiValue  map[string]int64                      `json:"multi_value"`
+	IsTable     bool                                  `json:"is_table"`
+}
+
+type NormalLicense struct {
+	ID                   string  `json:"id"`
+	StructuralID         string  `json:"structural_id"`
+	Source               string  `json:"source"`
+	Table                string  `json:"table"`
+	Name                 string  `json:"name"`
+	Feature              string  `json:"feature"`
+	Component            string  `json:"component"`
+	Type                 string  `json:"type"`
+	Impact               string  `json:"impact"`
+	StateRaw             string  `json:"state_raw"`
+	StateSeverity        int64   `json:"state_severity"`
+	HasState             bool    `json:"has_state"`
+	StateBucket          string  `json:"state_bucket"`
+	ExpiryTS             int64   `json:"expiry_ts"`
+	HasExpiry            bool    `json:"has_expiry"`
+	AuthorizationExpiry  int64   `json:"authorization_expiry"`
+	HasAuthorizationTime bool    `json:"has_authorization_time"`
+	CertificateExpiry    int64   `json:"certificate_expiry"`
+	HasCertificateTime   bool    `json:"has_certificate_time"`
+	GraceExpiry          int64   `json:"grace_expiry"`
+	HasGraceTime         bool    `json:"has_grace_time"`
+	Usage                int64   `json:"usage"`
+	HasUsage             bool    `json:"has_usage"`
+	Capacity             int64   `json:"capacity"`
+	HasCapacity          bool    `json:"has_capacity"`
+	Available            int64   `json:"available"`
+	HasAvailable         bool    `json:"has_available"`
+	UsagePercent         float64 `json:"usage_percent"`
+	HasUsagePct          bool    `json:"has_usage_pct"`
+	IsUnlimited          bool    `json:"is_unlimited"`
+	IsPerpetual          bool    `json:"is_perpetual"`
+	ExpirySource         string  `json:"expiry_source"`
+	AuthSource           string  `json:"auth_source"`
+	CertSource           string  `json:"cert_source"`
+	GraceSource          string  `json:"grace_source"`
+}
+
+type NormalBGPPeer struct {
+	Key                  string            `json:"key"`
+	Scope                string            `json:"scope"`
+	Source               string            `json:"source"`
+	Tags                 map[string]string `json:"tags"`
+	Stale                bool              `json:"stale"`
+	LastUpdate           time.Time         `json:"last_update"`
+	LastFailure          time.Time         `json:"last_failure"`
+	AdminStatus          string            `json:"admin_status"`
+	State                string            `json:"state"`
+	PreviousState        string            `json:"previous_state"`
+	EstablishedUptime    *int64            `json:"established_uptime"`
+	LastReceivedUpdate   *int64            `json:"last_received_update"`
+	EstablishedCount     *int64            `json:"established_count"`
+	DownTransitions      *int64            `json:"down_transitions"`
+	UpTransitions        *int64            `json:"up_transitions"`
+	Flaps                *int64            `json:"flaps"`
+	LastErrorCode        *int64            `json:"last_error_code"`
+	LastErrorSubcode     *int64            `json:"last_error_subcode"`
+	LastErrorText        string            `json:"last_error_text"`
+	LastDownReason       string            `json:"last_down_reason"`
+	LastRecvNotify       string            `json:"last_recv_notify"`
+	LastSentNotify       string            `json:"last_sent_notify"`
+	GracefulRestart      string            `json:"graceful_restart"`
+	UnavailabilityReason string            `json:"unavailability_reason"`
+	UpdateCounts         map[string]int64  `json:"update_counts"`
+	MessageCounts        map[string]int64  `json:"message_counts"`
+	NotificationCounts   map[string]int64  `json:"notification_counts"`
+	RouteRefreshCounts   map[string]int64  `json:"route_refresh_counts"`
+	OpenCounts           map[string]int64  `json:"open_counts"`
+	KeepaliveCounts      map[string]int64  `json:"keepalive_counts"`
+	RouteCounts          map[string]int64  `json:"route_counts"`
+	RouteTotals          map[string]int64  `json:"route_totals"`
+	RouteLimits          map[string]int64  `json:"route_limits"`
+	RouteLimitThresholds map[string]int64  `json:"route_limit_thresholds"`
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -41,6 +42,7 @@ type pendingCheckpoint struct {
 }
 
 type Publisher struct {
+	normal normalPublication
 	*logger.Logger
 	source     Source
 	directory  string
@@ -61,6 +63,7 @@ type Publisher struct {
 	fileSequence           uint64
 	initialized            bool
 	prunePending           bool
+	encoder                *archiveEncoder
 	rename                 func(string, string) error
 	remove                 func(string) error
 	writeFile              func(context.Context, string, Document, func(string, string) error) error
@@ -68,9 +71,22 @@ type Publisher struct {
 
 func NewPublisher(source Source, varLibDir string) *Publisher {
 	// A prior run may have published a complete checkpoint without finishing rotation.
-	return &Publisher{Logger: logger.New(), source: source, directory: DirectoryPath(varLibDir),
+	p := &Publisher{Logger: logger.New(), source: source, directory: DirectoryPath(varLibDir),
 		runID: uuid.NewString(), changed: make(chan struct{}, 1), prunePending: true,
-		rename: os.Rename, remove: os.Remove, writeFile: writeArchiveFile}
+		rename: os.Rename, remove: os.Remove}
+	p.writeFile = p.writeArchiveFile
+	return p
+}
+
+func (p *Publisher) writeArchiveFile(ctx context.Context, path string, document Document, replace func(string, string) error) error {
+	if p.encoder == nil {
+		var err error
+		p.encoder, err = newArchiveEncoder()
+		if err != nil {
+			return err
+		}
+	}
+	return writeArchiveFileWithEncoder(ctx, path, document, (*os.File).Close, replace, p.encoder.write)
 }
 
 // SetTopology admits only an accepted configuration and its already captured cuts.
@@ -172,6 +188,9 @@ func (p *Publisher) flush(ctx context.Context) {
 		p.warn(err)
 	}
 	if err := p.publishTopology(ctx); err != nil {
+		p.warn(err)
+	}
+	if err := p.publishNormal(ctx); err != nil {
 		p.warn(err)
 	}
 	if p.prunePending && ctx.Err() == nil {
@@ -298,9 +317,24 @@ func writeArchiveFileWithClose(
 	closeFile func(*os.File) error,
 	replace func(string, string) error,
 ) error {
+	return writeArchiveFileWithEncoder(ctx, path, document, closeFile, replace, Write)
+}
+
+func writeArchiveFileWithEncoder(
+	ctx context.Context,
+	path string,
+	document Document,
+	closeFile func(*os.File) error,
+	replace func(string, string) error,
+	encode func(io.Writer, Document) error,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	return writeAtomicFile(ctx, path, closeFile, func(w io.Writer) error { return encode(w, document) }, replace)
+}
+
+func writeAtomicFile(ctx context.Context, path string, closeFile func(*os.File) error, encode func(io.Writer) error, replace func(string, string) error) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
@@ -321,7 +355,7 @@ func writeArchiveFileWithClose(
 		_ = closeFile(file)
 		return err
 	}
-	encodeErr := Write(file, document)
+	encodeErr := encode(file)
 	closeErr := closeFile(file)
 	if err := errors.Join(encodeErr, closeErr); err != nil {
 		return err

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
@@ -167,12 +167,22 @@ func (p *Publisher) Run(ctx context.Context) {
 	p.flush(ctx)
 	retry := time.NewTicker(publicationRetryEvery)
 	defer retry.Stop()
+	normal := time.NewTimer(0)
+	defer normal.Stop()
 	for {
+		var normalReady <-chan time.Time
+		if due, ok := p.normalDeadline(); ok {
+			normal.Reset(max(0, time.Until(due)))
+			normalReady = normal.C
+		} else {
+			normal.Stop()
+		}
 		select {
 		case <-ctx.Done():
 			return
 		case <-p.changed:
 		case <-p.source.LifecycleChanges():
+		case <-normalReady:
 		case <-retry.C: // Retry dirty files only; unchanged state does not serialize.
 		}
 		p.flush(ctx)

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication.go
@@ -338,13 +338,13 @@ func writeArchiveFileWithEncoder(
 	replace func(string, string) error,
 	encode func(io.Writer, Document) error,
 ) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	return writeAtomicFile(ctx, path, closeFile, func(w io.Writer) error { return encode(w, document) }, replace)
 }
 
 func writeAtomicFile(ctx context.Context, path string, closeFile func(*os.File) error, encode func(io.Writer) error, replace func(string, string) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal.go
@@ -3,11 +3,13 @@
 package diagnostics
 
 import (
+	"container/heap"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 type NormalCheckpoint interface{ CaptureNormal() (*NormalDevice, error) }
@@ -20,15 +22,18 @@ type NormalWriter struct {
 	registration, runtime uint64
 	version               uint64
 	pending               NormalCheckpoint
-	queued                bool
+	index                 int
+	writing               bool
+	due                   time.Time
 }
 
 type normalPublication struct {
 	onDisk   map[uint64]uint64
 	writers  map[string]*NormalWriter
 	sequence uint64
-	queue    []*NormalWriter
+	queue    normalQueue
 	retired  []normalRetirement
+	closed   bool
 	// Run's serial writer owns activation and disk cleanup.
 	activated    bool
 	prunePending bool
@@ -39,6 +44,10 @@ func (p *Publisher) ReplaceNormal(previous, owner string, registration uint64) *
 		return nil
 	}
 	p.mu.Lock()
+	if p.normal.closed {
+		p.mu.Unlock()
+		return nil
+	}
 	if p.normal.writers == nil {
 		p.normal.writers = make(map[string]*NormalWriter)
 	}
@@ -47,7 +56,7 @@ func (p *Publisher) ReplaceNormal(previous, owner string, registration uint64) *
 	var writer *NormalWriter
 	if registration != 0 {
 		p.normal.sequence++
-		writer = &NormalWriter{publisher: p, owner: owner, registration: registration, runtime: p.normal.sequence}
+		writer = &NormalWriter{publisher: p, owner: owner, registration: registration, runtime: p.normal.sequence, index: -1}
 		p.normal.writers[owner] = writer
 	}
 	p.mu.Unlock()
@@ -60,6 +69,10 @@ func (p *Publisher) RemoveNormal(owner string) {
 		return
 	}
 	p.mu.Lock()
+	if p.normal.closed {
+		p.mu.Unlock()
+		return
+	}
 	p.retireNormalLocked(owner)
 	p.mu.Unlock()
 	p.notify()
@@ -68,6 +81,9 @@ func (p *Publisher) RemoveNormal(owner string) {
 func (p *Publisher) retireNormalLocked(owner string) {
 	if writer := p.normal.writers[owner]; writer != nil {
 		delete(p.normal.writers, owner)
+		if writer.index >= 0 {
+			heap.Remove(&p.normal.queue, writer.index)
+		}
 		writer.pending = nil
 		p.normal.retired = append(p.normal.retired, normalRetirement{registration: writer.registration, runtime: writer.runtime})
 	}
@@ -81,49 +97,54 @@ func (w *NormalWriter) Update(cut NormalCheckpoint) {
 	}
 	p := w.publisher
 	p.mu.Lock()
-	if p.normal.writers[w.owner] == w {
+	notify := false
+	if !p.normal.closed && p.normal.writers[w.owner] == w {
 		w.version++
 		w.pending = cut
+		notify = w.index < 0 && !w.writing
 		p.queueNormalLocked(w)
 	}
 	p.mu.Unlock()
-	p.notify()
-}
-
-func (p *Publisher) queueNormalLocked(w *NormalWriter) {
-	if !w.queued && w.pending != nil {
-		w.queued = true
-		p.normal.queue = append(p.normal.queue, w)
+	if notify {
+		p.notify()
 	}
 }
 
 var errNormalRetired = errors.New("normal runtime retired before publication")
 
 func (p *Publisher) publishNormal(ctx context.Context) error {
+	return p.publishNormalPending(ctx, false)
+}
+
+func (p *Publisher) publishNormalPending(ctx context.Context, final bool) error {
 	p.mu.Lock()
 	through := len(p.normal.queue)
 	p.mu.Unlock()
+	now := time.Now()
 	var errs []error
 	for range through {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		p.mu.Lock()
-		writer := p.normal.queue[0]
-		p.normal.queue[0] = nil
-		p.normal.queue = p.normal.queue[1:]
-		writer.queued = false
+		if len(p.normal.queue) == 0 || (!final && p.normal.queue[0].due.After(now)) {
+			p.mu.Unlock()
+			break
+		}
+		writer := heap.Pop(&p.normal.queue).(*NormalWriter)
+		writer.writing = true
 		cut, version := writer.pending, writer.version
 		p.mu.Unlock()
-		if cut == nil {
-			continue
-		}
 		err := p.publishNormalCut(ctx, writer, cut)
 		p.mu.Lock()
+		writer.writing = false
 		if err == nil && writer.version == version {
 			writer.pending = nil
 		}
-		if p.normal.writers[writer.owner] == writer {
+		if err != nil {
+			writer.due = time.Now().Add(publicationRetryEvery)
+		}
+		if !final && p.normal.writers[writer.owner] == writer {
 			p.queueNormalLocked(writer)
 		}
 		p.mu.Unlock()
@@ -131,6 +152,13 @@ func (p *Publisher) publishNormal(ctx context.Context) error {
 			errs = append(errs, err)
 		}
 		// The next loop holds only one source cut, never a batch of device snapshots.
+	}
+	// A committed device file stays on its own cadence even if the small run
+	// index cannot be activated yet. Retry the index without re-encoding it.
+	if len(p.normal.onDisk) > 0 && ctx.Err() == nil {
+		if err := p.activateNormal(ctx); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if err := p.cleanupNormal(ctx); err != nil {
 		errs = append(errs, err)
@@ -173,12 +201,22 @@ func (p *Publisher) publishNormalCut(ctx context.Context, writer *NormalWriter, 
 			p.normal.onDisk = make(map[uint64]uint64)
 		}
 		p.normal.onDisk[writer.registration] = writer.runtime
+		writer.due = time.Now().Add(normalPublicationEvery)
 		return nil
 	}
 	if err := p.writeFile(ctx, path, document, replace); err != nil {
 		return err
 	}
-	return p.activateNormal(ctx)
+	return nil
+}
+
+// Finalize runs only after Run has joined. Admission is sealed before taking
+// one finite pass; collection finishing later cannot extend process shutdown.
+func (p *Publisher) Finalize(ctx context.Context) error {
+	p.mu.Lock()
+	p.normal.closed = true
+	p.mu.Unlock()
+	return p.publishNormalPending(ctx, true)
 }
 
 type normalRetirement struct{ registration, runtime uint64 }

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type NormalCheckpoint interface{ CaptureNormal() (*NormalDevice, error) }
+
+// NormalWriter is authority for one accepted runtime, even when the framework
+// reuses its configuration and registration IDs for a replacement.
+type NormalWriter struct {
+	publisher             *Publisher
+	owner                 string
+	registration, runtime uint64
+	version               uint64
+	pending               NormalCheckpoint
+	queued                bool
+}
+
+type normalPublication struct {
+	onDisk   map[uint64]uint64
+	writers  map[string]*NormalWriter
+	sequence uint64
+	queue    []*NormalWriter
+	retired  []normalRetirement
+	// Run's serial writer owns activation and disk cleanup.
+	activated    bool
+	prunePending bool
+}
+
+func (p *Publisher) ReplaceNormal(previous, owner string, registration uint64) *NormalWriter {
+	if p == nil || owner == "" {
+		return nil
+	}
+	p.mu.Lock()
+	if p.normal.writers == nil {
+		p.normal.writers = make(map[string]*NormalWriter)
+	}
+	p.retireNormalLocked(previous)
+	p.retireNormalLocked(owner)
+	var writer *NormalWriter
+	if registration != 0 {
+		p.normal.sequence++
+		writer = &NormalWriter{publisher: p, owner: owner, registration: registration, runtime: p.normal.sequence}
+		p.normal.writers[owner] = writer
+	}
+	p.mu.Unlock()
+	p.notify()
+	return writer
+}
+
+func (p *Publisher) RemoveNormal(owner string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.retireNormalLocked(owner)
+	p.mu.Unlock()
+	p.notify()
+}
+
+func (p *Publisher) retireNormalLocked(owner string) {
+	if writer := p.normal.writers[owner]; writer != nil {
+		delete(p.normal.writers, owner)
+		writer.pending = nil
+		p.normal.retired = append(p.normal.retired, normalRetirement{registration: writer.registration, runtime: writer.runtime})
+	}
+}
+
+func (w *NormalWriter) filename() string { return normalFilename(w.registration) }
+
+func (w *NormalWriter) Update(cut NormalCheckpoint) {
+	if w == nil || cut == nil {
+		return
+	}
+	p := w.publisher
+	p.mu.Lock()
+	if p.normal.writers[w.owner] == w {
+		w.version++
+		w.pending = cut
+		p.queueNormalLocked(w)
+	}
+	p.mu.Unlock()
+	p.notify()
+}
+
+func (p *Publisher) queueNormalLocked(w *NormalWriter) {
+	if !w.queued && w.pending != nil {
+		w.queued = true
+		p.normal.queue = append(p.normal.queue, w)
+	}
+}
+
+var errNormalRetired = errors.New("normal runtime retired before publication")
+
+func (p *Publisher) publishNormal(ctx context.Context) error {
+	p.mu.Lock()
+	through := len(p.normal.queue)
+	p.mu.Unlock()
+	var errs []error
+	for range through {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		p.mu.Lock()
+		writer := p.normal.queue[0]
+		p.normal.queue[0] = nil
+		p.normal.queue = p.normal.queue[1:]
+		writer.queued = false
+		cut, version := writer.pending, writer.version
+		p.mu.Unlock()
+		if cut == nil {
+			continue
+		}
+		err := p.publishNormalCut(ctx, writer, cut)
+		p.mu.Lock()
+		if err == nil && writer.version == version {
+			writer.pending = nil
+		}
+		if p.normal.writers[writer.owner] == writer {
+			p.queueNormalLocked(writer)
+		}
+		p.mu.Unlock()
+		if err != nil && !errors.Is(err, errNormalRetired) {
+			errs = append(errs, err)
+		}
+		// The next loop holds only one source cut, never a batch of device snapshots.
+	}
+	if err := p.cleanupNormal(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (p *Publisher) publishNormalCut(ctx context.Context, writer *NormalWriter, cut NormalCheckpoint) (err error) {
+	defer func() {
+		if v := recover(); v != nil {
+			err = fmt.Errorf("normal capture panic: %v", v)
+		}
+	}()
+	device, err := cut.CaptureNormal()
+	if err != nil {
+		return err
+	}
+	if device == nil {
+		return errors.New("normal capture returned no device")
+	}
+	// The provider owns its cut; publication adds identity to a private header.
+	normal := *device
+	normal.RegistrationID, normal.RuntimeID = writer.registration, writer.runtime
+	if err := normal.Validate(); err != nil {
+		return fmt.Errorf("invalid normal capture: %w", err)
+	}
+	document := p.document(KindNormal, Snapshot{})
+	document.Normal = &normal
+	path := filepath.Join(p.directory, NormalDirectory, p.runID, writer.filename())
+	replace := func(from, to string) error {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if p.normal.writers[writer.owner] != writer {
+			return errNormalRetired
+		}
+		if err := p.rename(from, to); err != nil {
+			return err
+		}
+		if p.normal.onDisk == nil {
+			p.normal.onDisk = make(map[uint64]uint64)
+		}
+		p.normal.onDisk[writer.registration] = writer.runtime
+		return nil
+	}
+	if err := p.writeFile(ctx, path, document, replace); err != nil {
+		return err
+	}
+	return p.activateNormal(ctx)
+}
+
+type normalRetirement struct{ registration, runtime uint64 }
+
+func (p *Publisher) removeRetiredNormal(retired normalRetirement) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if current := p.normal.onDisk[retired.registration]; current != 0 && current != retired.runtime {
+		return nil
+	}
+	path := filepath.Join(p.directory, NormalDirectory, p.runID, normalFilename(retired.registration))
+	if err := p.remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	delete(p.normal.onDisk, retired.registration)
+	return nil
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal.go
@@ -85,7 +85,11 @@ func (p *Publisher) retireNormalLocked(owner string) {
 			heap.Remove(&p.normal.queue, writer.index)
 		}
 		writer.pending = nil
-		p.normal.retired = append(p.normal.retired, normalRetirement{registration: writer.registration, runtime: writer.runtime})
+		// Unpublished runtimes own no file; the identity fence rejects any
+		// in-flight rename without creating a cleanup obligation.
+		if p.normal.onDisk[writer.registration] == writer.runtime {
+			p.normal.retired = append(p.normal.retired, normalRetirement{registration: writer.registration, runtime: writer.runtime})
+		}
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal_test.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type normalTestCut struct {
+	attempt uint64
+	capture func()
+}
+
+func (c *normalTestCut) CaptureNormal() (*NormalDevice, error) {
+	if c.capture != nil {
+		c.capture()
+	}
+	now := time.Now().UTC()
+	return &NormalDevice{Hostname: "switch.example", CapturedAt: now,
+		Latest: &NormalAttempt{ID: c.attempt, Phase: "collect", StartedAt: now, CompletedAt: now},
+	}, nil
+}
+
+func TestNormalPublicationOwnershipAndProgress(t *testing.T) {
+	for name, tc := range map[string]struct {
+		coalesce, replace, fail, concurrentUpdate bool
+	}{
+		"pending polls coalesce":                   {coalesce: true},
+		"replacement fences in flight rename":      {replace: true},
+		"failed device does not block another":     {fail: true},
+		"new updates cannot starve the finite cut": {concurrentUpdate: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := NewPublisher(ddsnmp.NewDeviceStore(), t.TempDir())
+			first := p.ReplaceNormal("", "first", 1)
+			second := p.ReplaceNormal("", "second", 2)
+			cut := &normalTestCut{attempt: 1}
+			first.Update(cut)
+			if tc.coalesce {
+				first.Update(&normalTestCut{attempt: 2})
+				first.Update(&normalTestCut{attempt: 3})
+			}
+			second.Update(&normalTestCut{attempt: 1})
+			if tc.concurrentUpdate {
+				cut.capture = func() { first.Update(&normalTestCut{attempt: 4}) }
+			}
+			write := p.writeFile
+			var published []uint64
+			failed := false
+			p.writeFile = func(ctx context.Context, path string, document Document, replace func(string, string) error) error {
+				if document.Normal.RegistrationID == 1 {
+					if tc.replace && document.Normal.RuntimeID == first.runtime {
+						successor := p.ReplaceNormal("first", "first", 1)
+						successor.Update(&normalTestCut{attempt: 5})
+					}
+					if tc.fail && !failed {
+						failed = true
+						return errors.New("disk unavailable for first device")
+					}
+				}
+				if err := write(ctx, path, document, replace); err != nil {
+					return err
+				}
+				published = append(published, document.Normal.RegistrationID)
+				return nil
+			}
+			err := p.publishNormal(t.Context())
+			if tc.fail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tc.replace || tc.fail {
+				assert.Equal(t, []uint64{2}, published)
+			} else {
+				assert.Equal(t, []uint64{1, 2}, published)
+			}
+			if tc.coalesce {
+				d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
+				assert.EqualValues(t, 3, d.Normal.Latest.ID)
+			}
+			require.NoError(t, p.publishNormal(t.Context()))
+			files, err := ListNormalFiles(p.directory)
+			require.NoError(t, err)
+			require.Len(t, files, 2)
+			if tc.replace {
+				d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
+				require.NotEqual(t, first.runtime, d.Normal.RuntimeID)
+				require.EqualValues(t, 5, d.Normal.Latest.ID)
+				first.Update(&normalTestCut{attempt: 99})
+				require.NoError(t, p.publishNormal(t.Context()))
+				assert.Empty(t, p.normal.queue)
+			}
+			if tc.concurrentUpdate {
+				d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
+				assert.EqualValues(t, 4, d.Normal.Latest.ID)
+			}
+		})
+	}
+}
+
+func TestNormalRunRetentionAndRetry(t *testing.T) {
+	for name, tc := range map[string]struct{ failWrite, failActivation, failCleanup bool }{
+		"successful run":                           {},
+		"device write fails before activation":     {failWrite: true},
+		"activation fails after complete file":     {failActivation: true},
+		"old run cleanup is retried independently": {failCleanup: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			publish := func(p *Publisher) {
+				p.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
+				require.NoError(t, p.publishNormal(t.Context()))
+			}
+			old := NewPublisher(ddsnmp.NewDeviceStore(), root)
+			publish(old)
+			empty := NewPublisher(ddsnmp.NewDeviceStore(), root)
+			require.NoError(t, empty.publishNormal(t.Context()))
+			runs, err := ReadNormalRuns(old.directory)
+			require.NoError(t, err)
+			assert.Equal(t, old.runID, runs.Current)
+			current := NewPublisher(ddsnmp.NewDeviceStore(), root)
+			current.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
+			write, rename := current.writeFile, current.rename
+			if tc.failWrite {
+				current.writeFile = func(context.Context, string, Document, func(string, string) error) error {
+					return errors.New("write failure")
+				}
+			}
+			if tc.failActivation {
+				current.rename = func(from, to string) error {
+					if filepath.Base(to) == normalRunsFilename {
+						return errors.New("index failure")
+					}
+					return os.Rename(from, to)
+				}
+			}
+			err = current.publishNormal(t.Context())
+			if tc.failWrite || tc.failActivation {
+				require.Error(t, err)
+				runs, err = ReadNormalRuns(old.directory)
+				require.NoError(t, err)
+				assert.Equal(t, old.runID, runs.Current)
+				current.writeFile, current.rename = write, rename
+				require.NoError(t, current.publishNormal(t.Context()))
+			} else {
+				require.NoError(t, err)
+			}
+			runs, err = ReadNormalRuns(old.directory)
+			require.NoError(t, err)
+			assert.Equal(t, NormalRuns{Current: current.runID, Previous: old.runID}, runs)
+			next := NewPublisher(ddsnmp.NewDeviceStore(), root)
+			if tc.failCleanup {
+				next.remove = func(path string) error {
+					if filepath.Dir(path) == filepath.Join(next.directory, NormalDirectory, old.runID) {
+						return errors.New("cleanup failure")
+					}
+					return os.Remove(path)
+				}
+			}
+			next.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
+			err = next.publishNormal(t.Context())
+			if tc.failCleanup {
+				require.Error(t, err)
+				next.remove = os.Remove
+				require.NoError(t, next.publishNormal(t.Context()))
+			} else {
+				require.NoError(t, err)
+			}
+			runs, err = ReadNormalRuns(old.directory)
+			require.NoError(t, err)
+			assert.Equal(t, NormalRuns{Current: next.runID, Previous: current.runID}, runs)
+			require.NoDirExists(t, filepath.Join(old.directory, NormalDirectory, old.runID))
+			files, err := ListNormalFiles(old.directory)
+			require.NoError(t, err)
+			require.Len(t, files, 2)
+		})
+	}
+}
+
+func TestNormalRegistrationRetirementRetries(t *testing.T) {
+	for name, tc := range map[string]struct{ replacement bool }{"removed": {}, "replaced": {true}} {
+		t.Run(name, func(t *testing.T) {
+			p := NewPublisher(ddsnmp.NewDeviceStore(), t.TempDir())
+			writer := p.ReplaceNormal("", "device", 1)
+			writer.Update(&normalTestCut{attempt: 1})
+			require.NoError(t, p.publishNormal(t.Context()))
+			if tc.replacement {
+				p.ReplaceNormal("device", "device", 1)
+			} else {
+				p.RemoveNormal("device")
+			}
+			writer.Update(&normalTestCut{attempt: 2})
+			p.remove = func(string) error { return errors.New("retirement failure") }
+			require.Error(t, p.publishNormal(t.Context()))
+			p.remove = os.Remove
+			require.NoError(t, p.publishNormal(t.Context()))
+			files, err := ListNormalFiles(p.directory)
+			require.NoError(t, err)
+			assert.Empty(t, files)
+		})
+	}
+}
+
+type normalPublicationBenchmarkCut struct{ device *NormalDevice }
+
+func (c normalPublicationBenchmarkCut) CaptureNormal() (*NormalDevice, error) { return c.device, nil }
+
+// Measures complete per-device validation, serial encoder reuse, atomic file
+// replacement and run-index handling. Timings are workstation trends only.
+func BenchmarkNormalPublication(b *testing.B) {
+	for name, rows := range map[string]int{"small": 32, "many_rows": 4096} {
+		b.Run(name, func(b *testing.B) {
+			p := NewPublisher(ddsnmp.NewDeviceStore(), b.TempDir())
+			now := time.Now().UTC()
+			source := &ddsnmp.SourceOperation{ContextID: 1, Ordinal: 1, StartedAt: now, Method: "bulk_walk", RequestedOIDs: []string{"1.3.6.1.4.1.99999"}, ResultPresent: true}
+			samples := make(map[string]int64, rows)
+			for i := range rows {
+				oid := fmt.Sprintf("1.3.6.1.4.1.99999.1.%d", i+1)
+				source.PDUs = append(source.PDUs, ddsnmp.SourcePDU{OID: oid, Type: 65, Value: ddsnmp.SourceValue{Kind: "unsigned", Text: "7"}})
+				samples[oid] = 7
+			}
+			cut := normalPublicationBenchmarkCut{&NormalDevice{Hostname: "benchmark", CapturedAt: now, Sources: []*ddsnmp.SourceOperation{source},
+				Latest: &NormalAttempt{ID: 1, Phase: "collect", StartedAt: now, CompletedAt: now, Sources: []SourceRef{{1, 1}}, Samples: samples},
+			}}
+			writer := p.ReplaceNormal("", "benchmark", 1)
+			writer.Update(cut)
+			require.NoError(b, p.publishNormal(b.Context()))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				writer.Update(cut)
+				if err := p.publishNormal(b.Context()); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			info, err := os.Stat(filepath.Join(p.directory, NormalDirectory, p.runID, writer.filename()))
+			require.NoError(b, err)
+			b.ReportMetric(float64(info.Size()), "compressed_bytes")
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_normal_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
@@ -41,70 +42,73 @@ func TestNormalPublicationOwnershipAndProgress(t *testing.T) {
 		"new updates cannot starve the finite cut": {concurrentUpdate: true},
 	} {
 		t.Run(name, func(t *testing.T) {
-			p := NewPublisher(ddsnmp.NewDeviceStore(), t.TempDir())
-			first := p.ReplaceNormal("", "first", 1)
-			second := p.ReplaceNormal("", "second", 2)
-			cut := &normalTestCut{attempt: 1}
-			first.Update(cut)
-			if tc.coalesce {
-				first.Update(&normalTestCut{attempt: 2})
-				first.Update(&normalTestCut{attempt: 3})
-			}
-			second.Update(&normalTestCut{attempt: 1})
-			if tc.concurrentUpdate {
-				cut.capture = func() { first.Update(&normalTestCut{attempt: 4}) }
-			}
-			write := p.writeFile
-			var published []uint64
-			failed := false
-			p.writeFile = func(ctx context.Context, path string, document Document, replace func(string, string) error) error {
-				if document.Normal.RegistrationID == 1 {
-					if tc.replace && document.Normal.RuntimeID == first.runtime {
-						successor := p.ReplaceNormal("first", "first", 1)
-						successor.Update(&normalTestCut{attempt: 5})
-					}
-					if tc.fail && !failed {
-						failed = true
-						return errors.New("disk unavailable for first device")
-					}
+			synctest.Test(t, func(t *testing.T) {
+				p := NewPublisher(ddsnmp.NewDeviceStore(), t.TempDir())
+				first := p.ReplaceNormal("", "first", 1)
+				second := p.ReplaceNormal("", "second", 2)
+				cut := &normalTestCut{attempt: 1}
+				first.Update(cut)
+				if tc.coalesce {
+					first.Update(&normalTestCut{attempt: 2})
+					first.Update(&normalTestCut{attempt: 3})
 				}
-				if err := write(ctx, path, document, replace); err != nil {
-					return err
+				second.Update(&normalTestCut{attempt: 1})
+				if tc.concurrentUpdate {
+					cut.capture = func() { first.Update(&normalTestCut{attempt: 4}) }
 				}
-				published = append(published, document.Normal.RegistrationID)
-				return nil
-			}
-			err := p.publishNormal(t.Context())
-			if tc.fail {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			if tc.replace || tc.fail {
-				assert.Equal(t, []uint64{2}, published)
-			} else {
-				assert.Equal(t, []uint64{1, 2}, published)
-			}
-			if tc.coalesce {
-				d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
-				assert.EqualValues(t, 3, d.Normal.Latest.ID)
-			}
-			require.NoError(t, p.publishNormal(t.Context()))
-			files, err := ListNormalFiles(p.directory)
-			require.NoError(t, err)
-			require.Len(t, files, 2)
-			if tc.replace {
-				d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
-				require.NotEqual(t, first.runtime, d.Normal.RuntimeID)
-				require.EqualValues(t, 5, d.Normal.Latest.ID)
-				first.Update(&normalTestCut{attempt: 99})
+				write := p.writeFile
+				var published []uint64
+				failed := false
+				p.writeFile = func(ctx context.Context, path string, document Document, replace func(string, string) error) error {
+					if document.Normal.RegistrationID == 1 {
+						if tc.replace && document.Normal.RuntimeID == first.runtime {
+							successor := p.ReplaceNormal("first", "first", 1)
+							successor.Update(&normalTestCut{attempt: 5})
+						}
+						if tc.fail && !failed {
+							failed = true
+							return errors.New("disk unavailable for first device")
+						}
+					}
+					if err := write(ctx, path, document, replace); err != nil {
+						return err
+					}
+					published = append(published, document.Normal.RegistrationID)
+					return nil
+				}
+				err := p.publishNormal(t.Context())
+				if tc.fail {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				if tc.replace || tc.fail {
+					assert.Equal(t, []uint64{2}, published)
+				} else {
+					assert.Equal(t, []uint64{1, 2}, published)
+				}
+				if tc.coalesce {
+					d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
+					assert.EqualValues(t, 3, d.Normal.Latest.ID)
+				}
+				time.Sleep(normalPublicationEvery)
 				require.NoError(t, p.publishNormal(t.Context()))
-				assert.Empty(t, p.normal.queue)
-			}
-			if tc.concurrentUpdate {
-				d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
-				assert.EqualValues(t, 4, d.Normal.Latest.ID)
-			}
+				files, err := ListNormalFiles(p.directory)
+				require.NoError(t, err)
+				require.Len(t, files, 2)
+				if tc.replace {
+					d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
+					require.NotEqual(t, first.runtime, d.Normal.RuntimeID)
+					require.EqualValues(t, 5, d.Normal.Latest.ID)
+					first.Update(&normalTestCut{attempt: 99})
+					require.NoError(t, p.publishNormal(t.Context()))
+					assert.Empty(t, p.normal.queue)
+				}
+				if tc.concurrentUpdate {
+					d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, first.filename()))
+					assert.EqualValues(t, 4, d.Normal.Latest.ID)
+				}
+			})
 		})
 	}
 }
@@ -117,73 +121,76 @@ func TestNormalRunRetentionAndRetry(t *testing.T) {
 		"old run cleanup is retried independently": {failCleanup: true},
 	} {
 		t.Run(name, func(t *testing.T) {
-			root := t.TempDir()
-			publish := func(p *Publisher) {
-				p.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
-				require.NoError(t, p.publishNormal(t.Context()))
-			}
-			old := NewPublisher(ddsnmp.NewDeviceStore(), root)
-			publish(old)
-			empty := NewPublisher(ddsnmp.NewDeviceStore(), root)
-			require.NoError(t, empty.publishNormal(t.Context()))
-			runs, err := ReadNormalRuns(old.directory)
-			require.NoError(t, err)
-			assert.Equal(t, old.runID, runs.Current)
-			current := NewPublisher(ddsnmp.NewDeviceStore(), root)
-			current.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
-			write, rename := current.writeFile, current.rename
-			if tc.failWrite {
-				current.writeFile = func(context.Context, string, Document, func(string, string) error) error {
-					return errors.New("write failure")
+			synctest.Test(t, func(t *testing.T) {
+				root := t.TempDir()
+				publish := func(p *Publisher) {
+					p.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
+					require.NoError(t, p.publishNormal(t.Context()))
 				}
-			}
-			if tc.failActivation {
-				current.rename = func(from, to string) error {
-					if filepath.Base(to) == normalRunsFilename {
-						return errors.New("index failure")
-					}
-					return os.Rename(from, to)
-				}
-			}
-			err = current.publishNormal(t.Context())
-			if tc.failWrite || tc.failActivation {
-				require.Error(t, err)
-				runs, err = ReadNormalRuns(old.directory)
+				old := NewPublisher(ddsnmp.NewDeviceStore(), root)
+				publish(old)
+				empty := NewPublisher(ddsnmp.NewDeviceStore(), root)
+				require.NoError(t, empty.publishNormal(t.Context()))
+				runs, err := ReadNormalRuns(old.directory)
 				require.NoError(t, err)
 				assert.Equal(t, old.runID, runs.Current)
-				current.writeFile, current.rename = write, rename
-				require.NoError(t, current.publishNormal(t.Context()))
-			} else {
-				require.NoError(t, err)
-			}
-			runs, err = ReadNormalRuns(old.directory)
-			require.NoError(t, err)
-			assert.Equal(t, NormalRuns{Current: current.runID, Previous: old.runID}, runs)
-			next := NewPublisher(ddsnmp.NewDeviceStore(), root)
-			if tc.failCleanup {
-				next.remove = func(path string) error {
-					if filepath.Dir(path) == filepath.Join(next.directory, NormalDirectory, old.runID) {
-						return errors.New("cleanup failure")
+				current := NewPublisher(ddsnmp.NewDeviceStore(), root)
+				current.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
+				write, rename := current.writeFile, current.rename
+				if tc.failWrite {
+					current.writeFile = func(context.Context, string, Document, func(string, string) error) error {
+						return errors.New("write failure")
 					}
-					return os.Remove(path)
 				}
-			}
-			next.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
-			err = next.publishNormal(t.Context())
-			if tc.failCleanup {
-				require.Error(t, err)
-				next.remove = os.Remove
-				require.NoError(t, next.publishNormal(t.Context()))
-			} else {
+				if tc.failActivation {
+					current.rename = func(from, to string) error {
+						if filepath.Base(to) == normalRunsFilename {
+							return errors.New("index failure")
+						}
+						return os.Rename(from, to)
+					}
+				}
+				err = current.publishNormal(t.Context())
+				if tc.failWrite || tc.failActivation {
+					require.Error(t, err)
+					runs, err = ReadNormalRuns(old.directory)
+					require.NoError(t, err)
+					assert.Equal(t, old.runID, runs.Current)
+					current.writeFile, current.rename = write, rename
+					time.Sleep(publicationRetryEvery)
+					require.NoError(t, current.publishNormal(t.Context()))
+				} else {
+					require.NoError(t, err)
+				}
+				runs, err = ReadNormalRuns(old.directory)
 				require.NoError(t, err)
-			}
-			runs, err = ReadNormalRuns(old.directory)
-			require.NoError(t, err)
-			assert.Equal(t, NormalRuns{Current: next.runID, Previous: current.runID}, runs)
-			require.NoDirExists(t, filepath.Join(old.directory, NormalDirectory, old.runID))
-			files, err := ListNormalFiles(old.directory)
-			require.NoError(t, err)
-			require.Len(t, files, 2)
+				assert.Equal(t, NormalRuns{Current: current.runID, Previous: old.runID}, runs)
+				next := NewPublisher(ddsnmp.NewDeviceStore(), root)
+				if tc.failCleanup {
+					next.remove = func(path string) error {
+						if filepath.Dir(path) == filepath.Join(next.directory, NormalDirectory, old.runID) {
+							return errors.New("cleanup failure")
+						}
+						return os.Remove(path)
+					}
+				}
+				next.ReplaceNormal("", "device", 1).Update(&normalTestCut{attempt: 1})
+				err = next.publishNormal(t.Context())
+				if tc.failCleanup {
+					require.Error(t, err)
+					next.remove = os.Remove
+					require.NoError(t, next.publishNormal(t.Context()))
+				} else {
+					require.NoError(t, err)
+				}
+				runs, err = ReadNormalRuns(old.directory)
+				require.NoError(t, err)
+				assert.Equal(t, NormalRuns{Current: next.runID, Previous: current.runID}, runs)
+				require.NoDirExists(t, filepath.Join(old.directory, NormalDirectory, old.runID))
+				files, err := ListNormalFiles(old.directory)
+				require.NoError(t, err)
+				require.Len(t, files, 2)
+			})
 		})
 	}
 }
@@ -191,23 +198,25 @@ func TestNormalRunRetentionAndRetry(t *testing.T) {
 func TestNormalRegistrationRetirementRetries(t *testing.T) {
 	for name, tc := range map[string]struct{ replacement bool }{"removed": {}, "replaced": {true}} {
 		t.Run(name, func(t *testing.T) {
-			p := NewPublisher(ddsnmp.NewDeviceStore(), t.TempDir())
-			writer := p.ReplaceNormal("", "device", 1)
-			writer.Update(&normalTestCut{attempt: 1})
-			require.NoError(t, p.publishNormal(t.Context()))
-			if tc.replacement {
-				p.ReplaceNormal("device", "device", 1)
-			} else {
-				p.RemoveNormal("device")
-			}
-			writer.Update(&normalTestCut{attempt: 2})
-			p.remove = func(string) error { return errors.New("retirement failure") }
-			require.Error(t, p.publishNormal(t.Context()))
-			p.remove = os.Remove
-			require.NoError(t, p.publishNormal(t.Context()))
-			files, err := ListNormalFiles(p.directory)
-			require.NoError(t, err)
-			assert.Empty(t, files)
+			synctest.Test(t, func(t *testing.T) {
+				p := NewPublisher(ddsnmp.NewDeviceStore(), t.TempDir())
+				writer := p.ReplaceNormal("", "device", 1)
+				writer.Update(&normalTestCut{attempt: 1})
+				require.NoError(t, p.publishNormal(t.Context()))
+				if tc.replacement {
+					p.ReplaceNormal("device", "device", 1)
+				} else {
+					p.RemoveNormal("device")
+				}
+				writer.Update(&normalTestCut{attempt: 2})
+				p.remove = func(string) error { return errors.New("retirement failure") }
+				require.Error(t, p.publishNormal(t.Context()))
+				p.remove = os.Remove
+				require.NoError(t, p.publishNormal(t.Context()))
+				files, err := ListNormalFiles(p.directory)
+				require.NoError(t, err)
+				assert.Empty(t, files)
+			})
 		})
 	}
 }
@@ -217,7 +226,8 @@ type normalPublicationBenchmarkCut struct{ device *NormalDevice }
 func (c normalPublicationBenchmarkCut) CaptureNormal() (*NormalDevice, error) { return c.device, nil }
 
 // Measures complete per-device validation, serial encoder reuse, atomic file
-// replacement and run-index handling. Timings are workstation trends only.
+// replacement and run-index handling, bypassing the wait between writes.
+// Timings are workstation trends only.
 func BenchmarkNormalPublication(b *testing.B) {
 	for name, rows := range map[string]int{"small": 32, "many_rows": 4096} {
 		b.Run(name, func(b *testing.B) {
@@ -240,7 +250,7 @@ func BenchmarkNormalPublication(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				writer.Update(cut)
-				if err := p.publishNormal(b.Context()); err != nil {
+				if err := p.publishNormalPending(b.Context(), true); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"container/heap"
+	"time"
+)
+
+// Keep support evidence reasonably fresh without rewriting every ten-second poll.
+const normalPublicationEvery = 5 * time.Minute
+
+// Each current writer has at most one entry. Polls replace its cut without
+// postponing publication or allocating another scheduling entry.
+type normalQueue []*NormalWriter
+
+func (q normalQueue) Len() int           { return len(q) }
+func (q normalQueue) Less(i, j int) bool { return q[i].due.Before(q[j].due) }
+func (q normalQueue) Swap(i, j int) {
+	q[i], q[j] = q[j], q[i]
+	q[i].index, q[j].index = i, j
+}
+func (q *normalQueue) Push(value any) {
+	w := value.(*NormalWriter)
+	w.index = len(*q)
+	*q = append(*q, w)
+}
+func (q *normalQueue) Pop() any {
+	i := len(*q) - 1
+	w := (*q)[i]
+	(*q)[i] = nil
+	*q = (*q)[:i]
+	w.index = -1
+	return w
+}
+
+func (p *Publisher) queueNormalLocked(w *NormalWriter) {
+	if w.index < 0 && !w.writing && w.pending != nil {
+		heap.Push(&p.normal.queue, w)
+	}
+}
+
+func (p *Publisher) normalDeadline() (time.Time, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.normal.queue) == 0 {
+		return time.Time{}, false
+	}
+	return p.normal.queue[0].due, true
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule.go
@@ -36,6 +36,10 @@ func (q *normalQueue) Pop() any {
 
 func (p *Publisher) queueNormalLocked(w *NormalWriter) {
 	if w.index < 0 && !w.writing && w.pending != nil {
+		if w.due.IsZero() {
+			// First evidence is eligible now, behind already overdue work.
+			w.due = time.Now()
+		}
 		heap.Push(&p.normal.queue, w)
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule_benchmark_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+)
+
+// Pending polls must remain O(1), allocation-free, independent of device count.
+// Timings are workstation trends; the benchmark excludes evidence capture.
+func BenchmarkNormalPendingUpdate(b *testing.B) {
+	for name, devices := range map[string]int{"one": 1, "thousand": 1000, "ten_thousand": 10000} {
+		b.Run(name, func(b *testing.B) {
+			p := NewPublisher(ddsnmp.NewDeviceStore(), b.TempDir())
+			cut := &normalTestCut{attempt: 1}
+			writers := make([]*NormalWriter, devices)
+			for i := range writers {
+				writers[i] = p.ReplaceNormal("", fmt.Sprint(i), uint64(i+1))
+				writers[i].Update(cut)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			i := 0
+			for b.Loop() {
+				writers[i].Update(cut)
+				i = (i + 1) % len(writers)
+			}
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package diagnostics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalPublicationSchedule(t *testing.T) {
+	type step struct {
+		after           time.Duration
+		device, attempt uint64
+		remove, replace bool
+		want            []uint64
+	}
+	for name, tc := range map[string]struct {
+		duringWrite bool
+		steps       []step
+	}{
+		"coalescing and quiet deadline": {steps: []step{
+			{after: 10 * time.Second, device: 1, attempt: 2, want: []uint64{1}},
+			{after: 10 * time.Second, device: 1, attempt: 3, want: []uint64{1}},
+			{after: 279 * time.Second, want: []uint64{1}},
+			{after: time.Second, want: []uint64{1, 3}},
+			{after: 5 * time.Minute, want: []uint64{1, 3}},
+		}},
+		"removed pending device stays removed": {steps: []step{
+			{after: time.Second, device: 1, attempt: 2, want: []uint64{1}},
+			{device: 1, remove: true, want: []uint64{1}},
+			{after: 5 * time.Minute, device: 1, attempt: 3, want: []uint64{1}},
+		}},
+		"replacement gets prompt independent evidence": {steps: []step{
+			{after: time.Second, device: 1, attempt: 2, want: []uint64{1}},
+			{device: 1, replace: true, attempt: 9, want: []uint64{1, 9}},
+			{after: 5 * time.Minute, want: []uint64{1, 9}},
+		}},
+		"devices keep separate deadlines": {steps: []step{
+			{after: time.Minute, device: 2, attempt: 20, want: []uint64{1, 20}},
+			{after: 10 * time.Second, device: 1, attempt: 2, want: []uint64{1, 20}},
+			{after: 10 * time.Second, device: 2, attempt: 21, want: []uint64{1, 20}},
+			{after: 220 * time.Second, want: []uint64{1, 20, 2}},
+			{after: time.Minute, want: []uint64{1, 20, 2, 21}},
+		}},
+		"update during write waits for next deadline": {duringWrite: true, steps: []step{
+			{after: 299 * time.Second, want: []uint64{1}},
+			{after: time.Second, want: []uint64{1, 2}},
+		}},
+		"slow poll writes as soon as available": {steps: []step{
+			{after: 6 * time.Minute, device: 1, attempt: 2, want: []uint64{1, 2}},
+			{after: 5 * time.Minute, want: []uint64{1, 2}},
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				p, _ := testPublisher(t)
+				writers := map[uint64]*NormalWriter{1: p.ReplaceNormal("", "1", 1)}
+				writers[1].Update(&normalTestCut{attempt: 1})
+				var published []uint64
+				var writesMu sync.Mutex
+				publishedIDs := func() []uint64 { writesMu.Lock(); defer writesMu.Unlock(); return slices.Clone(published) }
+				write := p.writeFile
+				p.writeFile = func(ctx context.Context, path string, d Document, replace func(string, string) error) error {
+					if d.Normal != nil && tc.duringWrite && d.Normal.Latest.ID == 1 {
+						writers[1].Update(&normalTestCut{attempt: 2})
+					}
+					if err := write(ctx, path, d, replace); err != nil {
+						return err
+					}
+					if d.Normal != nil {
+						writesMu.Lock()
+						published = append(published, d.Normal.Latest.ID)
+						writesMu.Unlock()
+					}
+					return nil
+				}
+				ctx, cancel := context.WithCancel(t.Context())
+				done := make(chan struct{})
+				go func() { defer close(done); p.Run(ctx) }()
+				defer func() { cancel(); <-done }()
+				synctest.Wait()
+				require.Equal(t, []uint64{1}, publishedIDs())
+				for _, s := range tc.steps {
+					time.Sleep(s.after)
+					owner := fmt.Sprint(s.device)
+					if s.remove {
+						p.RemoveNormal(owner)
+					} else if s.device != 0 {
+						if writers[s.device] == nil || s.replace {
+							writers[s.device] = p.ReplaceNormal(owner, owner, s.device)
+						}
+						writers[s.device].Update(&normalTestCut{attempt: s.attempt})
+					}
+					synctest.Wait()
+					require.Equal(t, s.want, publishedIDs())
+					if s.remove {
+						require.Empty(t, p.normal.queue)
+						require.NoFileExists(t, filepath.Join(p.directory, NormalDirectory, p.runID, writers[s.device].filename()))
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestNormalScheduleFailuresAndIndependentStreams(t *testing.T) {
+	for name, tc := range map[string]struct{ index bool }{
+		"device retry": {}, "index retry does not rewrite device": {index: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				p, store := testPublisher(t)
+				first := p.ReplaceNormal("", "first", 1)
+				second := p.ReplaceNormal("", "second", 2)
+				first.Update(&normalTestCut{attempt: 1})
+				second.Update(&normalTestCut{attempt: 1})
+				var fail atomic.Bool
+				fail.Store(true)
+				var writes []uint64
+				var writesMu sync.Mutex
+				writtenIDs := func() []uint64 { writesMu.Lock(); defer writesMu.Unlock(); return slices.Clone(writes) }
+				write := p.writeFile
+				p.writeFile = func(ctx context.Context, path string, d Document, replace func(string, string) error) error {
+					if fail.Load() && !tc.index && d.Normal != nil && d.Normal.RegistrationID == 1 {
+						return errors.New("device write unavailable")
+					}
+					if err := write(ctx, path, d, replace); err != nil {
+						return err
+					}
+					if d.Normal != nil {
+						writesMu.Lock()
+						writes = append(writes, d.Normal.RegistrationID)
+						writesMu.Unlock()
+					}
+					return nil
+				}
+				p.rename = func(from, to string) error {
+					if fail.Load() && tc.index && filepath.Base(to) == normalRunsFilename {
+						return errors.New("index unavailable")
+					}
+					return os.Rename(from, to)
+				}
+				ctx, cancel := context.WithCancel(t.Context())
+				done := make(chan struct{})
+				go func() { defer close(done); p.Run(ctx) }()
+				defer func() { cancel(); <-done }()
+				synctest.Wait()
+				if tc.index {
+					assert.ElementsMatch(t, []uint64{1, 2}, writtenIDs())
+				} else {
+					assert.Equal(t, []uint64{2}, writtenIDs())
+				}
+				// Neither a fresh poll nor unrelated stream events bypass the delay.
+				time.Sleep(10 * time.Second)
+				first.Update(&normalTestCut{attempt: 2})
+				source := &testTopologySource{}
+				source.add(1)
+				p.SetTopology("topology", source)
+				store.RegisterJob("other", ddsnmp.DeviceLifecycleInfo{})
+				synctest.Wait()
+				require.Len(t, topologyDocuments(t, p), 1)
+				require.Len(t, readFile(t, filepath.Join(p.directory, LifecycleFilename)).Snapshot.Lifecycle.Cut.Entries, 1)
+				before := len(writtenIDs())
+				fail.Store(false)
+				time.Sleep(50 * time.Second)
+				synctest.Wait()
+				files, err := ListNormalFiles(p.directory)
+				require.NoError(t, err)
+				require.Len(t, files, 2)
+				if tc.index {
+					assert.Len(t, writtenIDs(), before)
+				} else {
+					assert.Len(t, writtenIDs(), before+1)
+				}
+			})
+		})
+	}
+}
+
+func TestNormalFinalization(t *testing.T) {
+	for name, tc := range map[string]struct{ expired, fail bool }{
+		"flush latest and preserve through retirement": {},
+		"expired shutdown budget":                      {expired: true},
+		"one failed device does not prevent another":   {fail: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				p, _ := testPublisher(t)
+				writers := []*NormalWriter{p.ReplaceNormal("", "first", 1), p.ReplaceNormal("", "second", 2)}
+				for _, w := range writers {
+					w.Update(&normalTestCut{attempt: 1})
+				}
+				ctx, cancel := context.WithCancel(t.Context())
+				done := make(chan struct{})
+				go func() { defer close(done); p.Run(ctx) }()
+				synctest.Wait()
+				for _, w := range writers {
+					w.Update(&normalTestCut{attempt: 2})
+				}
+				synctest.Wait()
+				cancel()
+				<-done
+				shutdown, finish := context.WithCancel(t.Context())
+				defer finish()
+				if tc.expired {
+					finish()
+				}
+				if tc.fail {
+					p.rename = func(from, to string) error {
+						if filepath.Base(to) == writers[0].filename() {
+							return errors.New("first device unavailable")
+						}
+						return os.Rename(from, to)
+					}
+				}
+				err := p.Finalize(shutdown)
+				if tc.expired || tc.fail {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				for i, w := range writers {
+					p.RemoveNormal(w.owner)
+					w.Update(&normalTestCut{attempt: 99})
+					d := readFile(t, filepath.Join(p.directory, NormalDirectory, p.runID, w.filename()))
+					want := uint64(2)
+					if tc.expired || (tc.fail && i == 0) {
+						want = 1
+					}
+					assert.Equal(t, want, d.Normal.Latest.ID)
+				}
+				require.Nil(t, p.ReplaceNormal("first", "new", 1))
+			})
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_schedule_test.go
@@ -28,9 +28,15 @@ func TestNormalPublicationSchedule(t *testing.T) {
 		want            []uint64
 	}
 	for name, tc := range map[string]struct {
-		duringWrite bool
-		steps       []step
+		duringWrite   bool
+		slowNewWriter bool
+		steps         []step
 	}{
+		"later registrations cannot overtake overdue evidence": {slowNewWriter: true, steps: []step{
+			{after: 10 * time.Second, device: 1, attempt: 2, want: []uint64{1}},
+			{after: 50 * time.Second, device: 2, attempt: 20, want: []uint64{1}},
+			{after: 4*time.Minute + time.Second, want: []uint64{1, 20, 2, 30}},
+		}},
 		"coalescing and quiet deadline": {steps: []step{
 			{after: 10 * time.Second, device: 1, attempt: 2, want: []uint64{1}},
 			{after: 10 * time.Second, device: 1, attempt: 3, want: []uint64{1}},
@@ -74,6 +80,9 @@ func TestNormalPublicationSchedule(t *testing.T) {
 				publishedIDs := func() []uint64 { writesMu.Lock(); defer writesMu.Unlock(); return slices.Clone(published) }
 				write := p.writeFile
 				p.writeFile = func(ctx context.Context, path string, d Document, replace func(string, string) error) error {
+					if tc.slowNewWriter && d.Normal != nil && d.Normal.RegistrationID == 2 {
+						time.Sleep(4*time.Minute + time.Second)
+					}
 					if d.Normal != nil && tc.duringWrite && d.Normal.Latest.ID == 1 {
 						writers[1].Update(&normalTestCut{attempt: 2})
 					}
@@ -84,6 +93,9 @@ func TestNormalPublicationSchedule(t *testing.T) {
 						writesMu.Lock()
 						published = append(published, d.Normal.Latest.ID)
 						writesMu.Unlock()
+						if tc.slowNewWriter && d.Normal.RegistrationID == 2 {
+							p.ReplaceNormal("", "late", 3).Update(&normalTestCut{attempt: 30})
+						}
 					}
 					return nil
 				}
@@ -244,6 +256,38 @@ func TestNormalFinalization(t *testing.T) {
 				}
 				require.Nil(t, p.ReplaceNormal("first", "new", 1))
 			})
+		})
+	}
+}
+
+func TestNormalCleanupTracksPublishedOwnership(t *testing.T) {
+	for name, published := range map[string]struct{ first bool }{
+		"no file was ever published":             {},
+		"one published file still needs cleanup": {first: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			p, _ := testPublisher(t)
+			writer := p.ReplaceNormal("", "device", 1)
+			writer.Update(&normalTestCut{attempt: 1})
+			if published.first {
+				require.NoError(t, p.publishNormal(t.Context()))
+			}
+			denied := os.ErrPermission
+			removals := 0
+			p.writeFile = func(context.Context, string, Document, func(string, string) error) error { return denied }
+			p.remove = func(string) error { removals++; return denied }
+			for i := range 20 {
+				writer = p.ReplaceNormal("device", "device", 1)
+				writer.Update(&normalTestCut{attempt: uint64(i + 2)})
+				before := removals
+				require.ErrorIs(t, p.publishNormal(t.Context()), denied)
+				want := 0
+				if published.first {
+					want = 1
+				}
+				assert.Equal(t, want, removals-before, "cleanup must follow actual files, not replacement history")
+				require.Len(t, p.normal.retired, want)
+			}
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/publication_test.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/publication_test.go
@@ -5,6 +5,7 @@ package diagnostics
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -461,4 +462,36 @@ func TestPublisherNewSubmissionsDoNotStarveLifecycle(t *testing.T) {
 	p.flush(t.Context())
 	require.Equal(t, []string{KindLifecycle, KindTopology, KindLifecycle, KindTopology}, writes)
 	require.Equal(t, "failed", readFile(t, filepath.Join(p.directory, LifecycleFilename)).Snapshot.Lifecycle.Cut.Entries[0].LastCompleted.Outcome)
+}
+
+func TestAtomicFileCanceledBeforeWrite(t *testing.T) {
+	for name, tc := range map[string]struct{ existing bool }{
+		"absent directory":        {},
+		"existing temporary file": {existing: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "normal")
+			path := filepath.Join(dir, "runs.json")
+			if tc.existing {
+				require.NoError(t, os.Mkdir(dir, 0700))
+				require.NoError(t, os.WriteFile(path+".tmp", []byte("untouched"), 0600))
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			encoded := false
+			err := writeAtomicFile(ctx, path, (*os.File).Close, func(io.Writer) error {
+				encoded = true
+				return nil
+			}, os.Rename)
+			require.ErrorIs(t, err, context.Canceled)
+			require.False(t, encoded, "canceled writes must not encode")
+			if tc.existing {
+				data, err := os.ReadFile(path + ".tmp")
+				require.NoError(t, err)
+				require.Equal(t, "untouched", string(data))
+			} else {
+				require.NoDirExists(t, dir)
+			}
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp/job_config_lifecycle.go
+++ b/src/go/plugin/go.d/collector/snmp/job_config_lifecycle.go
@@ -5,14 +5,16 @@ package snmp
 import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
 
 type snmpJobConfigLifecycle struct {
-	store *ddsnmp.DeviceStore
+	store     *ddsnmp.DeviceStore
+	publisher *diagnostics.Publisher
 }
 
-func newSNMPJobConfigLifecycle(store *ddsnmp.DeviceStore) collectorapi.JobConfigLifecycle {
-	return &snmpJobConfigLifecycle{store: store}
+func newSNMPJobConfigLifecycle(store *ddsnmp.DeviceStore, publisher *diagnostics.Publisher) collectorapi.JobConfigLifecycle {
+	return &snmpJobConfigLifecycle{store: store, publisher: publisher}
 }
 
 func (*snmpJobConfigLifecycle) Project(
@@ -71,6 +73,7 @@ func (l *snmpJobConfigLifecycle) Reconcile(
 	collector := snmpCollectorFromRuntimeJob(job)
 	if collector == nil || !collector.deviceLifecycleBoundTo(current.identity.String()) {
 		l.store.ReplaceJob(previous.String(), current.identity.String(), current.info, current.status, nil)
+		l.publisher.ReplaceNormal(previous.String(), current.identity.String(), 0)
 		return
 	}
 	collector.commitDeviceLifecycle(previous.String())
@@ -79,6 +82,7 @@ func (l *snmpJobConfigLifecycle) Reconcile(
 func (l *snmpJobConfigLifecycle) Remove(identity collectorapi.JobConfigIdentity) {
 	if l != nil && l.store != nil {
 		l.store.Unregister(identity.String())
+		l.publisher.RemoveNormal(identity.String())
 	}
 }
 

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
@@ -117,7 +117,7 @@ func (c *Collector) finishNormalAttempt(err error, samples map[string]int64) {
 		attempt.document.NegativeCauses = collector.NegativeCauses()
 	}
 	for _, profile := range attempt.document.Profiles {
-		if normalProfileFailed(profile.Acquisition) {
+		if profile.Acquisition.HasFailures() {
 			attempt.document.Failed = true
 		}
 	}
@@ -144,39 +144,6 @@ func normalSourcesFailed(sources []*ddsnmp.SourceOperation) bool {
 	for _, source := range sources {
 		if source.Failure.Reason != "" {
 			return true
-		}
-	}
-	return false
-}
-
-func normalProfileFailed(report ddsnmpcollector.AcquisitionProfileReport) bool {
-	if report.Outcome == ddsnmpcollector.AcquisitionProfileOutcomeFailed {
-		return true
-	}
-	p := report.Stats.Errors.Processing
-	if p.Preparation+p.Scalar+p.Table+p.BGP+p.Licensing > 0 {
-		return true
-	}
-	for _, route := range report.Routes {
-		if route.Source == ddsnmpcollector.AcquisitionRouteSourceCache &&
-			(route.Kind == ddsnmpcollector.AcquisitionRouteKindProfileTagScalar || route.Kind == ddsnmpcollector.AcquisitionRouteKindMetadataScalar) {
-			// Preserve the original failed attempt; reusing its cached omissions
-			// is not new failed work on every later poll.
-			continue
-		}
-		if route.Outcome == ddsnmpcollector.AcquisitionRouteOutcomeFailed || route.Rejected > 0 {
-			return true
-		}
-		for _, event := range route.Processing {
-			switch event.Reason {
-			case "missing_input", "empty_date", "sentinel":
-			case "no_signals":
-				if route.Outcome != ddsnmpcollector.AcquisitionRouteOutcomeMissing {
-					return true
-				}
-			default:
-				return true
-			}
 		}
 	}
 	return false

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
@@ -171,6 +171,7 @@ func (c *Collector) normalDeviceInput() diagnostics.DeviceInput {
 
 func (c *Collector) recordNormalMetric(metric ddsnmp.Metric, action string, ids []string) {
 	if c.normal != nil && c.normal.current != nil {
+		slices.Sort(ids)
 		c.normal.current.document.Metrics = append(c.normal.current.document.Metrics, diagnostics.NormalMetricDecision{Metric: normalMetric(metric), Action: action, SampleIDs: ids})
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
@@ -170,6 +170,10 @@ func normalProfileFailed(report ddsnmpcollector.AcquisitionProfileReport) bool {
 		for _, event := range route.Processing {
 			switch event.Reason {
 			case "missing_input", "empty_date", "sentinel":
+			case "no_signals":
+				if route.Outcome != ddsnmpcollector.AcquisitionRouteOutcomeMissing {
+					return true
+				}
 			default:
 				return true
 			}

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+// Mutable builders belong to the synchronous collector. Only terminal immutable
+// cuts cross into the serial publisher, never a Collector or live cache pointer.
+type normalDiagnostics struct {
+	sequence       uint64
+	current        *normalAttempt
+	recorder       *ddsnmpcollector.SourceRecorder
+	client         gosnmp.Handler
+	initialization []*ddsnmp.SourceOperation
+	latest, failed *normalAttempt
+	bgpSources     map[string][]*ddsnmp.SourceOperation
+	licenseSources []*ddsnmp.SourceOperation
+	cut            *normalCut
+}
+
+type normalAttempt struct {
+	bgpSources     map[string][]*ddsnmp.SourceOperation
+	licenseSources []*ddsnmp.SourceOperation
+	document       diagnostics.NormalAttempt
+	sources        []*ddsnmp.SourceOperation
+	caches         []ddsnmpcollector.AcquisitionCacheInput
+}
+
+type normalCut struct {
+	document       diagnostics.NormalDevice
+	profileContext *ddsnmp.ProfileContext
+	initialization []*ddsnmp.SourceOperation
+	latest, failed *normalAttempt
+}
+
+func (c *Collector) beginNormalAttempt(phase string) {
+	n := c.normal
+	n.sequence++
+	n.current = &normalAttempt{document: diagnostics.NormalAttempt{ID: n.sequence, Phase: phase, StartedAt: time.Now().UTC()}}
+	n.recorder = &ddsnmpcollector.SourceRecorder{ContextID: n.sequence}
+	c.wrapNormalClient()
+}
+
+func (c *Collector) wrapNormalClient() {
+	n := c.normal
+	if n.recorder == nil || c.snmpClient == nil || n.client != nil {
+		return
+	}
+	n.client = c.snmpClient
+	c.snmpClient = n.recorder.Wrap(n.client)
+	if collector, ok := c.ddSnmpColl.(interface{ SetSNMPClient(gosnmp.Handler) }); ok {
+		collector.SetSNMPClient(c.snmpClient)
+	}
+}
+
+func (c *Collector) observeNormalProfile(report ddsnmpcollector.AcquisitionProfileReport, pm *ddsnmp.ProfileMetrics) {
+	if c.normal.current == nil {
+		return
+	}
+	profile := diagnostics.NormalProfile{Acquisition: report}
+	if pm != nil {
+		profile.Source = pm.Source
+		profile.Tags, profile.Metadata = maps.Clone(pm.Tags), maps.Clone(pm.DeviceMetadata)
+		profile.Metrics, profile.HiddenMetrics = normalMetrics(pm.Metrics), normalMetrics(pm.HiddenMetrics)
+		profile.BGPFailed = pm.BGPCollectError != nil
+		profile.BGPRows = slices.Clone(pm.BGPRows)
+		for i := range profile.BGPRows {
+			profile.BGPRows[i].Tags = maps.Clone(profile.BGPRows[i].Tags)
+			profile.BGPRows[i].Device.ByState = maps.Clone(profile.BGPRows[i].Device.ByState)
+		}
+		profile.LicenseRows = slices.Clone(pm.LicenseRows)
+		for i := range profile.LicenseRows {
+			profile.LicenseRows[i].Tags = maps.Clone(profile.LicenseRows[i].Tags)
+		}
+	}
+	c.normal.current.document.Profiles = append(c.normal.current.document.Profiles, profile)
+}
+
+func (c *Collector) finishNormalAttempt(err error, samples map[string]int64) {
+	n := c.normal
+	if n.current == nil {
+		return
+	}
+	attempt := n.current
+	n.current = nil
+	attempt.sources = n.recorder.Finish()
+	n.recorder = nil
+	if n.client != nil {
+		c.snmpClient = n.client
+		if collector, ok := c.ddSnmpColl.(interface{ SetSNMPClient(gosnmp.Handler) }); ok {
+			collector.SetSNMPClient(n.client)
+		}
+		n.client = nil
+	}
+	attempt.document.CompletedAt = time.Now().UTC()
+	attempt.document.Failure = snmputils.ClassifyFailure(err)
+	attempt.document.Failed = err != nil || normalSourcesFailed(attempt.sources)
+	attempt.document.Samples = maps.Clone(samples)
+	c.deviceLifecycleMu.Lock()
+	attempt.document.Failures = c.deviceCollectionFailures
+	c.deviceLifecycleMu.Unlock()
+	if collector, ok := c.ddSnmpColl.(interface {
+		CachedInputs() []ddsnmpcollector.AcquisitionCacheInput
+		NegativeCauses() []ddsnmpcollector.AcquisitionNegativeCause
+	}); ok {
+		attempt.caches = collector.CachedInputs()
+		attempt.document.NegativeCauses = collector.NegativeCauses()
+	}
+	for _, profile := range attempt.document.Profiles {
+		if normalProfileFailed(profile.Acquisition) {
+			attempt.document.Failed = true
+		}
+	}
+	n.latest = attempt
+	if attempt.document.Failed {
+		n.failed = attempt
+	}
+	if attempt.document.Phase == "check" && err == nil {
+		n.initialization = slices.Clone(attempt.sources)
+	}
+	cut := &normalCut{latest: n.latest, failed: n.failed, initialization: slices.Clone(n.initialization)}
+	cut.document = diagnostics.NormalDevice{Hostname: c.Hostname, CapturedAt: attempt.document.CompletedAt, Device: c.normalDeviceInput()}
+	attempt.document.BGP, attempt.bgpSources = c.captureNormalBGP()
+	attempt.document.Licensing, attempt.licenseSources = c.captureNormalLicensing()
+	c.deviceLifecycleMu.Lock()
+	cut.profileContext = c.deviceLifecycleInfo.Profiles
+	n.cut = cut
+	writer := c.normalWriter
+	c.deviceLifecycleMu.Unlock()
+	writer.Update(cut)
+}
+
+func normalSourcesFailed(sources []*ddsnmp.SourceOperation) bool {
+	for _, source := range sources {
+		if source.Failure.Reason != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalProfileFailed(report ddsnmpcollector.AcquisitionProfileReport) bool {
+	if report.Outcome == ddsnmpcollector.AcquisitionProfileOutcomeFailed {
+		return true
+	}
+	p := report.Stats.Errors.Processing
+	if p.Preparation+p.Scalar+p.Table+p.BGP+p.Licensing > 0 {
+		return true
+	}
+	for _, route := range report.Routes {
+		if route.Source == ddsnmpcollector.AcquisitionRouteSourceCache &&
+			(route.Kind == ddsnmpcollector.AcquisitionRouteKindProfileTagScalar || route.Kind == ddsnmpcollector.AcquisitionRouteKindMetadataScalar) {
+			// Preserve the original failed attempt; reusing its cached omissions
+			// is not new failed work on every later poll.
+			continue
+		}
+		if route.Outcome == ddsnmpcollector.AcquisitionRouteOutcomeFailed || route.Rejected > 0 {
+			return true
+		}
+		for _, event := range route.Processing {
+			switch event.Reason {
+			case "missing_input", "empty_date", "sentinel":
+			default:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalMetrics(metrics []ddsnmp.Metric) []diagnostics.NormalMetric {
+	result := make([]diagnostics.NormalMetric, len(metrics))
+	for i, metric := range metrics {
+		result[i] = normalMetric(metric)
+	}
+	return result
+}
+
+func (c *Collector) normalDeviceInput() diagnostics.DeviceInput {
+	result := diagnostics.DeviceInput{Hostname: c.Hostname}
+	if si := c.sysInfo; si != nil {
+		result.SysObjectID, result.SysName, result.SysDescr = si.SysObjectID, si.Name, si.Descr
+		result.SysContact, result.SysLocation, result.Vendor, result.Model = si.Contact, si.Location, si.Vendor, si.Model
+	}
+	if c.vnode != nil {
+		result.VnodeGUID, result.VnodeLabels = c.vnode.GUID, maps.Clone(c.vnode.Labels)
+	}
+	return result
+}
+
+func (c *Collector) recordNormalMetric(metric ddsnmp.Metric, action string, ids []string) {
+	if c.normal != nil && c.normal.current != nil {
+		c.normal.current.document.Metrics = append(c.normal.current.document.Metrics, diagnostics.NormalMetricDecision{Metric: normalMetric(metric), Action: action, SampleIDs: ids})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_benchmark_test.go
@@ -3,7 +3,9 @@
 package snmp
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"testing"
@@ -12,17 +14,22 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 )
 
 type normalBenchmarkHandler struct {
 	gosnmp.Handler
 	rows int
+	fail bool
 }
 
 func (*normalBenchmarkHandler) Version() gosnmp.SnmpVersion { return gosnmp.Version2c }
 func (*normalBenchmarkHandler) MaxOids() int                { return 32 }
-func (*normalBenchmarkHandler) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+func (h *normalBenchmarkHandler) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	if h.fail {
+		return nil, errors.New("benchmark timeout")
+	}
 	packet := &gosnmp.SnmpPacket{Variables: make([]gosnmp.SnmpPDU, len(oids))}
 	for i, oid := range oids {
 		value := 7
@@ -56,24 +63,7 @@ func BenchmarkNormalWarmCollection(b *testing.B) {
 	} {
 		for mode, record := range map[string]bool{"baseline": false, "capture": true} {
 			b.Run(name+"/"+mode, func(b *testing.B) {
-				profile := normalTestProfile()
-				for i := range shape.tables {
-					root := fmt.Sprintf("1.3.6.1.4.1.99999.200.%d", i+1)
-					profile.Definition.Metrics = append(profile.Definition.Metrics, ddprofiledefinition.MetricsConfig{
-						Table:      ddprofiledefinition.SymbolConfig{OID: root, Name: fmt.Sprintf("table%d", i)},
-						Symbols:    []ddprofiledefinition.SymbolConfig{{OID: root + ".1", Name: fmt.Sprintf("metric%d", i)}},
-						MetricTags: []ddprofiledefinition.MetricTagConfig{{Tag: "index", Index: 1}},
-					})
-				}
-				c := New(ddsnmp.NewDeviceStore())
-				c.Config = prepareV2Config()
-				c.sysInfo = &snmputils.SysInfo{Name: "benchmark"}
-				c.snmpClient = &normalBenchmarkHandler{rows: shape.rows}
-				cfg := ddsnmpcollector.Config{SnmpClient: c.snmpClient, Profiles: []*ddsnmp.Profile{profile}, Log: c.Logger}
-				if record {
-					cfg.AcquisitionObserver = ddsnmpcollector.AcquisitionObserverFunc(c.observeNormalProfile)
-				}
-				c.ddSnmpColl = ddsnmpcollector.New(cfg)
+				c := newNormalBenchmarkCollector(shape.tables, shape.rows, record)
 				collect := func() {
 					if record {
 						c.beginNormalAttempt("collect")
@@ -109,6 +99,94 @@ func BenchmarkNormalWarmCollection(b *testing.B) {
 						}
 					}
 					b.ReportMetric(float64(retainedPDUs), "retained_walk_pdus")
+				}
+			})
+		}
+	}
+}
+
+func newNormalBenchmarkCollector(tables, rows int, record bool) *Collector {
+	profile := normalTestProfile()
+	for i := range tables {
+		root := fmt.Sprintf("1.3.6.1.4.1.99999.200.%d", i+1)
+		profile.Definition.Metrics = append(profile.Definition.Metrics, ddprofiledefinition.MetricsConfig{
+			Table:      ddprofiledefinition.SymbolConfig{OID: root, Name: fmt.Sprintf("table%d", i)},
+			Symbols:    []ddprofiledefinition.SymbolConfig{{OID: root + ".1", Name: fmt.Sprintf("metric%d", i)}},
+			MetricTags: []ddprofiledefinition.MetricTagConfig{{Tag: "index", Index: 1}},
+		})
+	}
+	c := New(ddsnmp.NewDeviceStore())
+	c.Config = prepareV2Config()
+	c.sysInfo = &snmputils.SysInfo{Name: "benchmark"}
+	c.snmpClient = &normalBenchmarkHandler{rows: rows}
+	cfg := ddsnmpcollector.Config{SnmpClient: c.snmpClient, Profiles: []*ddsnmp.Profile{profile}, Log: c.Logger}
+	if record {
+		cfg.AcquisitionObserver = ddsnmpcollector.AcquisitionObserverFunc(c.observeNormalProfile)
+	}
+	c.ddSnmpColl = ddsnmpcollector.New(cfg)
+	return c
+}
+
+// Cold costs include constructing a device and its profile fixture in both modes.
+func BenchmarkNormalColdCollection(b *testing.B) {
+	for name, shape := range map[string]struct{ tables, rows int }{"small": {1, 32}, "many_rows": {16, 256}} {
+		for mode, capture := range map[string]bool{"baseline": false, "capture": true} {
+			b.Run(name+"/"+mode, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					c := newNormalBenchmarkCollector(shape.tables, shape.rows, capture)
+					if capture {
+						c.beginNormalAttempt("collect")
+					}
+					mx := make(map[string]int64)
+					err := c.collectSNMP(mx)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if capture {
+						c.finishNormalAttempt(err, mx)
+					}
+				}
+			})
+		}
+	}
+}
+
+// Uses a real populated cut after success, failure and recovery, including
+// normalized rows, decisions, cache structure and shared historical operations.
+// Encoding deliberately includes a fresh encoder, an allocation upper bound for
+// the publisher's reused encoder. The separate publisher benchmark measures IO.
+func BenchmarkNormalCaptureAndEncode(b *testing.B) {
+	for name, shape := range map[string]struct{ tables, rows int }{"small": {1, 32}, "many_rows": {16, 256}} {
+		c := newNormalBenchmarkCollector(shape.tables, shape.rows, true)
+		handler := c.snmpClient.(*normalBenchmarkHandler)
+		for _, failed := range []bool{false, false, true, false} {
+			handler.fail = failed
+			c.beginNormalAttempt("collect")
+			mx := make(map[string]int64)
+			err := c.collectSNMP(mx)
+			if (err != nil) != failed {
+				b.Fatalf("unexpected collection result: %v", err)
+			}
+			c.finishNormalAttempt(err, mx)
+		}
+		for mode, encode := range map[string]bool{"assemble": false, "assemble_and_encode": true} {
+			b.Run(name+"/"+mode, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					device, err := c.normal.cut.CaptureNormal()
+					if err != nil {
+						b.Fatal(err)
+					}
+					device.RegistrationID, device.RuntimeID = 1, 1
+					if err := device.Validate(); err != nil {
+						b.Fatal(err)
+					}
+					if encode {
+						if err := diagnostics.Write(io.Discard, diagnostics.Document{Format: diagnostics.Format, Version: diagnostics.Version, Kind: diagnostics.KindNormal, Normal: device}); err != nil {
+							b.Fatal(err)
+						}
+					}
 				}
 			})
 		}

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_benchmark_test.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_benchmark_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+type normalBenchmarkHandler struct {
+	gosnmp.Handler
+	rows int
+}
+
+func (*normalBenchmarkHandler) Version() gosnmp.SnmpVersion { return gosnmp.Version2c }
+func (*normalBenchmarkHandler) MaxOids() int                { return 32 }
+func (*normalBenchmarkHandler) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	packet := &gosnmp.SnmpPacket{Variables: make([]gosnmp.SnmpPDU, len(oids))}
+	for i, oid := range oids {
+		value := 7
+		if oid == normalTestRoot+".3.0" {
+			value = 0
+		}
+		if oid == normalTestRoot+".4.0" {
+			value = 3600
+		}
+		if oid == normalTestRoot+".5.0" {
+			value = 6
+		}
+		packet.Variables[i] = gosnmp.SnmpPDU{Name: oid, Type: gosnmp.Integer, Value: value}
+	}
+	return packet, nil
+}
+func (h *normalBenchmarkHandler) BulkWalkAll(root string) ([]gosnmp.SnmpPDU, error) {
+	values := make([]gosnmp.SnmpPDU, h.rows)
+	for i := range values {
+		values[i] = gosnmp.SnmpPDU{Name: root + ".1." + strconv.Itoa(i+1), Type: gosnmp.Counter64, Value: uint64(7)}
+	}
+	return values, nil
+}
+
+// Both modes run the real acquisition, normalization, chart/sample and consumer
+// cache pipeline. The baseline omits only passive diagnostic capture.
+func BenchmarkNormalWarmCollection(b *testing.B) {
+	for name, shape := range map[string]struct{ tables, rows int }{
+		"small":     {1, 32},
+		"many_rows": {16, 256},
+	} {
+		for mode, record := range map[string]bool{"baseline": false, "capture": true} {
+			b.Run(name+"/"+mode, func(b *testing.B) {
+				profile := normalTestProfile()
+				for i := range shape.tables {
+					root := fmt.Sprintf("1.3.6.1.4.1.99999.200.%d", i+1)
+					profile.Definition.Metrics = append(profile.Definition.Metrics, ddprofiledefinition.MetricsConfig{
+						Table:      ddprofiledefinition.SymbolConfig{OID: root, Name: fmt.Sprintf("table%d", i)},
+						Symbols:    []ddprofiledefinition.SymbolConfig{{OID: root + ".1", Name: fmt.Sprintf("metric%d", i)}},
+						MetricTags: []ddprofiledefinition.MetricTagConfig{{Tag: "index", Index: 1}},
+					})
+				}
+				c := New(ddsnmp.NewDeviceStore())
+				c.Config = prepareV2Config()
+				c.sysInfo = &snmputils.SysInfo{Name: "benchmark"}
+				c.snmpClient = &normalBenchmarkHandler{rows: shape.rows}
+				cfg := ddsnmpcollector.Config{SnmpClient: c.snmpClient, Profiles: []*ddsnmp.Profile{profile}, Log: c.Logger}
+				if record {
+					cfg.AcquisitionObserver = ddsnmpcollector.AcquisitionObserverFunc(c.observeNormalProfile)
+				}
+				c.ddSnmpColl = ddsnmpcollector.New(cfg)
+				collect := func() {
+					if record {
+						c.beginNormalAttempt("collect")
+					}
+					mx := make(map[string]int64)
+					err := c.collectSNMP(mx)
+					if record {
+						c.finishNormalAttempt(err, mx)
+					}
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(mx) < shape.tables*shape.rows {
+						b.Fatalf("missing table samples: %d", len(mx))
+					}
+				}
+				collect()
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					collect()
+				}
+				b.StopTimer()
+				if record {
+					d, err := c.normal.cut.CaptureNormal()
+					if err != nil {
+						b.Fatal(err)
+					}
+					var retainedPDUs int
+					for _, source := range d.Sources {
+						if strings.Contains(source.Method, "walk") {
+							retainedPDUs += len(source.PDUs)
+						}
+					}
+					b.ReportMetric(float64(retainedPDUs), "retained_walk_pdus")
+				}
+			})
+		}
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_consumers.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_consumers.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+)
+
+// Called after successful consumer commits. Partial source failures retain only
+// the sources actually still owned by the BGP cache; licensing replaces a set.
+func (c *Collector) commitNormalConsumers(pms []*ddsnmp.ProfileMetrics) {
+	n := c.normal
+	if n.current == nil {
+		return
+	}
+	if n.bgpSources == nil {
+		n.bgpSources = make(map[string][]*ddsnmp.SourceOperation)
+	}
+	current := make(map[string]diagnostics.NormalProfile, len(n.current.document.Profiles))
+	for _, profile := range n.current.document.Profiles {
+		current[profile.Source] = profile
+	}
+	n.licenseSources = nil
+	for _, pm := range pms {
+		if pm == nil {
+			continue
+		}
+		profile := current[pm.Source]
+		if pm.BGPCollectError == nil {
+			n.bgpSources[pm.Source] = n.consumerSources(profile.Acquisition, false)
+		}
+		n.licenseSources = append(n.licenseSources, n.consumerSources(profile.Acquisition, true)...)
+	}
+}
+
+func (n *normalDiagnostics) consumerSources(report ddsnmpcollector.AcquisitionProfileReport, licensing bool) []*ddsnmp.SourceOperation {
+	seen := make(map[*ddsnmp.SourceOperation]bool)
+	var result []*ddsnmp.SourceOperation
+	for _, route := range report.Routes {
+		isLicense := route.Kind == ddsnmpcollector.AcquisitionRouteKindLicenseScalar || route.Kind == ddsnmpcollector.AcquisitionRouteKindLicenseTable
+		isBGP := route.Kind == ddsnmpcollector.AcquisitionRouteKindBGPScalar || route.Kind == ddsnmpcollector.AcquisitionRouteKindBGPTable
+		if (!licensing && !isBGP) || (licensing && !isLicense) {
+			continue
+		}
+		for _, binding := range route.Sources {
+			operation := n.recorder.Operation(binding.Operation)
+			if operation != nil && !seen[operation] {
+				seen[operation] = true
+				result = append(result, operation)
+			}
+		}
+	}
+	return result
+}
+
+func (c *Collector) captureNormalBGP() (diagnostics.NormalBGP, map[string][]*ddsnmp.SourceOperation) {
+	result := diagnostics.NormalBGP{Enabled: c.bgp != nil}
+	if c.bgp == nil || c.bgp.peerCache == nil {
+		return result, nil
+	}
+	cache := c.bgp.peerCache
+	cache.mu.RLock()
+	result.LastUpdate, result.LastFailure, result.StaleAfterNanos = cache.lastUpdate, cache.lastFailure, int64(cache.staleAfter)
+	owners := make(map[string]bool)
+	for _, entry := range cache.entries {
+		result.Entries = append(result.Entries, normalBGPPeer(entry))
+		owners[entry.source] = true
+	}
+	cache.mu.RUnlock()
+	slices.SortFunc(result.Entries, func(a, b diagnostics.NormalBGPPeer) int { return strings.Compare(a.Key, b.Key) })
+	for source := range c.normal.bgpSources {
+		if !owners[source] {
+			delete(c.normal.bgpSources, source)
+		}
+	}
+	return result, maps.Clone(c.normal.bgpSources)
+}
+
+func (c *Collector) captureNormalLicensing() (diagnostics.NormalLicensing, []*ddsnmp.SourceOperation) {
+	result := diagnostics.NormalLicensing{Enabled: c.licensing != nil}
+	if c.licensing == nil || c.licensing.cache == nil {
+		return result, nil
+	}
+	cache := c.licensing.cache
+	cache.mu.RLock()
+	result.NormalizedAt = cache.lastUpdate
+	result.Rows = make([]diagnostics.NormalLicense, len(cache.rows))
+	for i, row := range cache.rows {
+		result.Rows[i] = normalLicense(row)
+	}
+	cache.mu.RUnlock()
+	return result, c.normal.licenseSources
+}

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_cut.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_cut.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+)
+
+// CaptureNormal runs on the publisher. It deduplicates direct immutable source
+// objects across attempts, initialization, caches and retained consumer output.
+func (cut *normalCut) CaptureNormal() (*diagnostics.NormalDevice, error) {
+	document := cut.document
+	document.ProfileContext = cut.profileContext.Snapshot()
+	sources := make(map[diagnostics.SourceRef]*ddsnmp.SourceOperation)
+	var collision error
+	add := func(operations []*ddsnmp.SourceOperation) []diagnostics.SourceRef {
+		refs := make([]diagnostics.SourceRef, 0, len(operations))
+		for _, operation := range operations {
+			ref := diagnostics.SourceRef{ContextID: operation.ContextID, Operation: operation.Ordinal}
+			if existing := sources[ref]; existing != nil && existing != operation {
+				collision = fmt.Errorf("conflicting source identity %+v", ref)
+			}
+			sources[ref] = operation
+			refs = append(refs, ref)
+		}
+		return refs
+	}
+	captureAttempt := func(native *normalAttempt) *diagnostics.NormalAttempt {
+		if native == nil {
+			return nil
+		}
+		attempt := native.document
+		attempt.Sources = add(native.sources)
+		attempt.Caches = make([]diagnostics.NormalCache, len(native.caches))
+		for i, cache := range native.caches {
+			attempt.Caches[i] = diagnostics.NormalCache{
+				Kind: cache.Kind, Profile: cache.Profile, RootOID: cache.RootOID, ConfigID: cache.ConfigID,
+				CreatedAt: cache.CreatedAt, ExpiresAt: cache.ExpiresAt, Marker: cache.Marker,
+				OIDs: cache.OIDs, TableTags: cache.TableTags, Tags: cache.Tags, Metadata: cache.Metadata,
+				Sources: add(cache.Sources),
+			}
+		}
+		attempt.BGP.Sources = make(map[string][]diagnostics.SourceRef, len(native.bgpSources))
+		for source, operations := range native.bgpSources {
+			attempt.BGP.Sources[source] = add(operations)
+		}
+		attempt.Licensing.Sources = add(native.licenseSources)
+		return &attempt
+	}
+	document.Initialization = add(cut.initialization)
+	document.Latest = captureAttempt(cut.latest)
+	if cut.failed != cut.latest {
+		document.LastFailure = captureAttempt(cut.failed)
+	}
+
+	if collision != nil {
+		return nil, collision
+	}
+	document.Sources = make([]*ddsnmp.SourceOperation, 0, len(sources))
+	for _, operation := range sources {
+		document.Sources = append(document.Sources, operation)
+	}
+	slices.SortFunc(document.Sources, func(a, b *ddsnmp.SourceOperation) int {
+		return cmp.Or(cmp.Compare(a.ContextID, b.ContextID), cmp.Compare(a.Ordinal, b.Ordinal))
+	})
+	return &document, nil
+}

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
@@ -6,9 +6,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -244,6 +246,42 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 			files, err = diagnostics.ListNormalFiles(directory)
 			require.NoError(t, err)
 			assert.Len(t, files, 1, "shutdown retirement preserves the last published file")
+		})
+	}
+}
+
+func TestNormalMetricSampleOrder(t *testing.T) {
+	for name, tc := range map[string]struct{ table bool }{
+		"scalar": {}, "table": {table: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := New(ddsnmp.NewDeviceStore())
+			c.sysInfo = &snmputils.SysInfo{Name: "switch"}
+			c.beginNormalAttempt("collect")
+			metric := ddsnmp.Metric{
+				Profile: &ddsnmp.ProfileMetrics{Source: "states.yaml"}, Name: "state", IsTable: tc.table, Table: "states", Tags: map[string]string{"index": "1"},
+				MultiValue: make(map[string]int64),
+			}
+			for i := range 16 {
+				metric.MultiValue[fmt.Sprintf("state%02d", i)] = int64(i)
+			}
+			samples := make(map[string]int64)
+			metrics := []ddsnmp.Metric{metric}
+			c.collectProfileScalarMetrics(samples, metrics)
+			c.collectProfileTableMetrics(samples, metrics)
+			require.Len(t, c.normal.current.document.Metrics, 1)
+			decision := c.normal.current.document.Metrics[0]
+			require.Len(t, decision.SampleIDs, len(metric.MultiValue))
+			require.True(t, slices.IsSorted(decision.SampleIDs), "%v", decision.SampleIDs)
+			require.Len(t, samples, len(metric.MultiValue))
+			for key, value := range metric.MultiValue {
+				id := metricIDFromName(metric.Name, key)
+				if tc.table {
+					id = metricIDFromKey(tableMetricKey(metric), key)
+				}
+				require.Contains(t, decision.SampleIDs, id)
+				require.Equal(t, value, samples[id])
+			}
 		})
 	}
 }

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+const normalTestRoot = "1.3.6.1.4.1.99999.100"
+
+func normalTestProfile() *ddsnmp.Profile {
+	return &ddsnmp.Profile{SourceFile: "normal.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
+		Metrics: []ddprofiledefinition.MetricsConfig{
+			{Symbol: ddprofiledefinition.SymbolConfig{OID: normalTestRoot + ".1.0", Name: "visible"}},
+			{Symbol: ddprofiledefinition.SymbolConfig{OID: normalTestRoot + ".2.0", Name: "_hidden"}},
+		},
+		VirtualMetrics: []ddprofiledefinition.VirtualMetricConfig{{Name: "derived", Sources: []ddprofiledefinition.VirtualMetricSourceConfig{{Metric: "_hidden"}}}},
+		Licensing: []ddprofiledefinition.LicensingConfig{{
+			ID: "license", OriginProfileID: "normal.yaml",
+			State:   ddprofiledefinition.LicenseStateConfig{LicenseValueConfig: ddprofiledefinition.LicenseValueConfig{OID: normalTestRoot + ".3.0"}},
+			Signals: ddprofiledefinition.LicenseSignalsConfig{Expiry: ddprofiledefinition.LicenseTimerSignalsConfig{Remaining: ddprofiledefinition.LicenseValueConfig{OID: normalTestRoot + ".4.0"}}},
+		}},
+		BGP: []ddprofiledefinition.BGPConfig{{
+			ID: "peer", OriginProfileID: "normal.yaml", Kind: ddprofiledefinition.BGPRowKindPeer,
+			Identity: ddprofiledefinition.BGPIdentityConfig{Neighbor: ddprofiledefinition.BGPValueConfig{Value: "192.0.2.2"}, RemoteAS: ddprofiledefinition.BGPValueConfig{Value: "65001"}},
+			State: ddprofiledefinition.BGPStateConfig{BGPValueConfig: ddprofiledefinition.BGPValueConfig{Symbol: ddprofiledefinition.SymbolConfig{
+				OID: normalTestRoot + ".5.0", Name: "state", Mapping: ddprofiledefinition.NewExactMapping(map[string]string{"6": "established"}),
+			}}},
+		}},
+	}}
+}
+
+func normalTestDocument(t *testing.T, c *Collector, directory string) *diagnostics.NormalDevice {
+	t.Helper()
+	device, err := c.normal.cut.CaptureNormal()
+	require.NoError(t, err)
+	device.RegistrationID, device.RuntimeID = 1, 1
+	require.NoError(t, device.Validate())
+	var archive bytes.Buffer
+	require.NoError(t, diagnostics.Write(&archive, diagnostics.Document{Format: diagnostics.Format, Version: diagnostics.Version, Kind: diagnostics.KindNormal, Normal: device}))
+	document, err := diagnostics.Read(&archive, diagnostics.DefaultReadLimits())
+	require.NoError(t, err)
+	require.NoError(t, document.Normal.Validate())
+	var published *diagnostics.NormalDevice
+	require.Eventually(t, func() bool {
+		files, err := diagnostics.ListNormalFiles(directory)
+		if err != nil || len(files) != 1 {
+			return false
+		}
+		data, err := os.ReadFile(filepath.Join(directory, diagnostics.NormalDirectory, files[0].RunID, files[0].Filename))
+		if err != nil {
+			return false
+		}
+		archive, err := diagnostics.Read(bytes.NewReader(data), diagnostics.DefaultReadLimits())
+		if err != nil || archive.Normal == nil || archive.Normal.Latest.ID != device.Latest.ID {
+			return false
+		}
+		published = archive.Normal
+		return true
+	}, 5*time.Second, time.Millisecond)
+	require.NoError(t, published.Validate())
+	assert.Equal(t, document.Normal.Latest, published.Latest)
+	return published
+}
+
+func TestNormalEvidenceRealCollection(t *testing.T) {
+	for name, tc := range map[string]struct{ failure string }{
+		"total collection failure":                 {"metrics"},
+		"partial BGP failure":                      {"bgp"},
+		"malformed licensing timer":                {"license"},
+		"ordinary absent timer":                    {"missing"},
+		"cached rejected tag is not a new failure": {"cached"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			handler, cleanup := mockInit(t)
+			defer cleanup()
+			handler.EXPECT().Version().Return(gosnmp.Version2c).AnyTimes()
+			setMockClientInitExpect(handler)
+			handler.EXPECT().BulkWalkAll(snmputils.RootOidMibSystem).Return([]gosnmp.SnmpPDU{{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: "switch"}}, nil).Times(2)
+			handler.EXPECT().MaxOids().Return(20).AnyTimes()
+			poll := 0
+			handler.EXPECT().Get(gomock.Any()).DoAndReturn(func(oids []string) (*gosnmp.SnmpPacket, error) {
+				packet := &gosnmp.SnmpPacket{}
+				for _, oid := range oids {
+					if oid == snmputils.OidSysObject {
+						packet.Variables = append(packet.Variables, gosnmp.SnmpPDU{Name: oid, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.99999"})
+						continue
+					}
+					if poll == 2 && ((tc.failure == "metrics" && oid == normalTestRoot+".1.0") || (tc.failure == "bgp" && oid == normalTestRoot+".5.0")) {
+						return nil, errors.New("synthetic timeout")
+					}
+					value := 7
+					if oid == normalTestRoot+".3.0" {
+						value = 0
+					}
+					if oid == normalTestRoot+".4.0" {
+						value = 3600
+					}
+					if oid == normalTestRoot+".5.0" {
+						value = 6
+					}
+					pdu := gosnmp.SnmpPDU{Name: oid, Type: gosnmp.Integer, Value: value}
+					if tc.failure == "cached" && oid == normalTestRoot+".6.0" {
+						pdu.Type, pdu.Value = gosnmp.OctetString, "invalid"
+					}
+					if poll == 2 && oid == normalTestRoot+".4.0" {
+						if tc.failure == "license" {
+							pdu.Type, pdu.Value = gosnmp.OctetString, "not-a-number"
+						}
+						if tc.failure == "missing" {
+							pdu.Type, pdu.Value = gosnmp.NoSuchInstance, nil
+						}
+					}
+					packet.Variables = append(packet.Variables, pdu)
+				}
+				return packet, nil
+			}).AnyTimes()
+			store := ddsnmp.NewDeviceStore()
+			root := t.TempDir()
+			directory := diagnostics.DirectoryPath(root)
+			publisher := diagnostics.NewPublisher(store, root)
+			ctx, cancel := context.WithCancel(t.Context())
+			done := make(chan struct{})
+			go func() { defer close(done); publisher.Run(ctx) }()
+			t.Cleanup(func() { cancel(); <-done })
+			creator := Creator(store, publisher)
+			c := creator.Create().(*Collector)
+			c.Config = prepareV2Config()
+			c.newSnmpClient = func() gosnmp.Handler { return handler }
+			// Inject profile input only; Init, Check, all acquisition, normalization
+			// and consumer commits run through their production implementations.
+			c.snmpProfiles = []*ddsnmp.Profile{normalTestProfile()}
+			if tc.failure == "cached" {
+				c.snmpProfiles[0].Definition.MetricTags = []ddprofiledefinition.GlobalMetricTagConfig{{MetricTagConfig: ddprofiledefinition.MetricTagConfig{Tag: "site", Symbol: ddprofiledefinition.SymbolConfigCompat{OID: normalTestRoot + ".6.0", Name: "site", ExtractValue: "^([0-9]+)$", ExtractValueCompiled: regexp.MustCompile("^([0-9]+)$")}}}}
+			}
+			require.NoError(t, ddsnmp.CompileTransforms(c.snmpProfiles[0]))
+			job := snmpLifecycleTestRuntimeJob{collector: c}
+			identity := collectorapi.JobConfigIdentity{1}
+			creator.JobConfigLifecycle.Bind(identity, job)
+			require.NoError(t, c.Init(t.Context()))
+			require.NoError(t, c.Check(t.Context()))
+			files, err := diagnostics.ListNormalFiles(directory)
+			require.NoError(t, err)
+			assert.Empty(t, files, "candidate evidence is not published before acceptance")
+			creator.JobConfigLifecycle.Reconcile(collectorapi.JobConfigIdentity{}, creator.JobConfigLifecycle.Capture(identity, job), job)
+			poll = 1
+			firstSamples := c.Collect(t.Context())
+			require.NotEmpty(t, firstSamples)
+			first := normalTestDocument(t, c, directory)
+			require.Equal(t, tc.failure == "cached", first.Latest.Failed)
+			require.Len(t, first.Latest.BGP.Entries, 1)
+			require.Len(t, first.Latest.Licensing.Rows, 1)
+			require.NotEmpty(t, first.Initialization)
+			require.Len(t, first.Latest.Profiles[0].HiddenMetrics, 1)
+			var virtual bool
+			for _, metric := range first.Latest.Profiles[0].Metrics {
+				if metric.Name == "derived" {
+					virtual = metric.IsVirtual
+				}
+			}
+			assert.True(t, virtual)
+			assert.NotContains(t, firstSamples, metricIDFromName("_hidden"))
+			poll = 2
+			secondSamples := c.Collect(t.Context())
+			second := normalTestDocument(t, c, directory)
+			assert.Equal(t, tc.failure != "missing" && tc.failure != "cached", second.Latest.Failed)
+			if tc.failure == "metrics" {
+				assert.Empty(t, secondSamples)
+				assert.Equal(t, first.Latest.Licensing.NormalizedAt, second.Latest.Licensing.NormalizedAt)
+				assert.Equal(t, first.Latest.Licensing.Sources, second.Latest.Licensing.Sources)
+				assert.True(t, c.bgp.peerCache.snapshot(time.Now().Add(c.bgpStaleAfter())).expired)
+			}
+			if tc.failure == "metrics" || tc.failure == "bgp" {
+				assert.Equal(t, first.Latest.BGP.Sources, second.Latest.BGP.Sources)
+				require.Len(t, second.Latest.BGP.Entries, 1)
+				assert.Equal(t, first.Latest.BGP.Entries[0].LastUpdate, second.Latest.BGP.Entries[0].LastUpdate)
+			}
+			poll = 3
+			require.NotEmpty(t, c.Collect(t.Context()))
+			third := normalTestDocument(t, c, directory)
+			assert.False(t, third.Latest.Failed)
+			if tc.failure != "missing" {
+				require.NotNil(t, third.LastFailure)
+				wantFailure := second.Latest.ID
+				if tc.failure == "cached" {
+					wantFailure = first.Latest.ID
+				}
+				assert.Equal(t, wantFailure, third.LastFailure.ID)
+			} else {
+				assert.Nil(t, third.LastFailure)
+			}
+			assert.Equal(t, firstSamples, first.Latest.Samples, "retained first document remains independent")
+			cancel()
+			<-done
+			creator.JobConfigLifecycle.Remove(identity)
+			files, err = diagnostics.ListNormalFiles(directory)
+			require.NoError(t, err)
+			assert.Len(t, files, 1, "shutdown retirement preserves the last published file")
+		})
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
@@ -49,7 +49,7 @@ func normalTestProfile() *ddsnmp.Profile {
 	}}
 }
 
-func normalTestDocument(t *testing.T, c *Collector, directory string) *diagnostics.NormalDevice {
+func normalTestDocument(t *testing.T, c *Collector) *diagnostics.NormalDevice {
 	t.Helper()
 	device, err := c.normal.cut.CaptureNormal()
 	require.NoError(t, err)
@@ -60,26 +60,7 @@ func normalTestDocument(t *testing.T, c *Collector, directory string) *diagnosti
 	document, err := diagnostics.Read(&archive, diagnostics.DefaultReadLimits())
 	require.NoError(t, err)
 	require.NoError(t, document.Normal.Validate())
-	var published *diagnostics.NormalDevice
-	require.Eventually(t, func() bool {
-		files, err := diagnostics.ListNormalFiles(directory)
-		if err != nil || len(files) != 1 {
-			return false
-		}
-		data, err := os.ReadFile(filepath.Join(directory, diagnostics.NormalDirectory, files[0].RunID, files[0].Filename))
-		if err != nil {
-			return false
-		}
-		archive, err := diagnostics.Read(bytes.NewReader(data), diagnostics.DefaultReadLimits())
-		if err != nil || archive.Normal == nil || archive.Normal.Latest.ID != device.Latest.ID {
-			return false
-		}
-		published = archive.Normal
-		return true
-	}, 5*time.Second, time.Millisecond)
-	require.NoError(t, published.Validate())
-	assert.Equal(t, document.Normal.Latest, published.Latest)
-	return published
+	return document.Normal
 }
 
 func TestNormalEvidenceRealCollection(t *testing.T) {
@@ -198,7 +179,7 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 			poll = 1
 			firstSamples := c.Collect(t.Context())
 			require.NotEmpty(t, firstSamples)
-			first := normalTestDocument(t, c, directory)
+			first := normalTestDocument(t, c)
 			require.Equal(t, tc.failure == "cached", first.Latest.Failed)
 			if bgpMissing {
 				require.Empty(t, first.Latest.BGP.Entries)
@@ -218,7 +199,7 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 			assert.NotContains(t, firstSamples, metricIDFromName("_hidden"))
 			poll = 2
 			secondSamples := c.Collect(t.Context())
-			second := normalTestDocument(t, c, directory)
+			second := normalTestDocument(t, c)
 			assert.Equal(t, tc.failure != "missing" && tc.failure != "cached", second.Latest.Failed)
 			if tc.failure == "metrics" {
 				assert.Empty(t, secondSamples)
@@ -233,7 +214,7 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 			}
 			poll = 3
 			require.NotEmpty(t, c.Collect(t.Context()))
-			third := normalTestDocument(t, c, directory)
+			third := normalTestDocument(t, c)
 			assert.False(t, third.Latest.Failed)
 			if tc.failure != "missing" {
 				require.NotNil(t, third.LastFailure)
@@ -248,6 +229,17 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 			assert.Equal(t, firstSamples, first.Latest.Samples, "retained first document remains independent")
 			cancel()
 			<-done
+			require.NoError(t, publisher.Finalize(t.Context()))
+			files, err = diagnostics.ListNormalFiles(directory)
+			require.NoError(t, err)
+			require.Len(t, files, 1)
+			data, err := os.ReadFile(filepath.Join(directory, diagnostics.NormalDirectory, files[0].RunID, files[0].Filename))
+			require.NoError(t, err)
+			published, err := diagnostics.Read(bytes.NewReader(data), diagnostics.DefaultReadLimits())
+			require.NoError(t, err)
+			require.NoError(t, published.Normal.Validate())
+			assert.Equal(t, third.Latest, published.Normal.Latest)
+			assert.Equal(t, third.LastFailure, published.Normal.LastFailure)
 			creator.JobConfigLifecycle.Remove(identity)
 			files, err = diagnostics.ListNormalFiles(directory)
 			require.NoError(t, err)

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
@@ -86,6 +86,7 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 		"total collection failure":                 {"metrics"},
 		"partial BGP failure":                      {"bgp"},
 		"malformed licensing timer":                {"license"},
+		"ordinary absent BGP signals":              {"missing_bgp"},
 		"ordinary absent timer":                    {"missing"},
 		"cached rejected tag is not a new failure": {"cached"},
 	} {
@@ -104,7 +105,7 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 						packet.Variables = append(packet.Variables, gosnmp.SnmpPDU{Name: oid, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.99999"})
 						continue
 					}
-					if poll == 2 && ((tc.failure == "metrics" && oid == normalTestRoot+".1.0") || (tc.failure == "bgp" && oid == normalTestRoot+".5.0")) {
+					if poll == 2 && (((tc.failure == "metrics" || tc.failure == "missing_bgp") && oid == normalTestRoot+".1.0") || (tc.failure == "bgp" && oid == normalTestRoot+".5.0")) {
 						return nil, errors.New("synthetic timeout")
 					}
 					value := 7
@@ -118,6 +119,9 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 						value = 6
 					}
 					pdu := gosnmp.SnmpPDU{Name: oid, Type: gosnmp.Integer, Value: value}
+					if tc.failure == "missing_bgp" && oid == normalTestRoot+".5.0" {
+						pdu.Type, pdu.Value = gosnmp.NoSuchObject, nil
+					}
 					if tc.failure == "cached" && oid == normalTestRoot+".6.0" {
 						pdu.Type, pdu.Value = gosnmp.OctetString, "invalid"
 					}
@@ -166,7 +170,11 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 			require.NotEmpty(t, firstSamples)
 			first := normalTestDocument(t, c, directory)
 			require.Equal(t, tc.failure == "cached", first.Latest.Failed)
-			require.Len(t, first.Latest.BGP.Entries, 1)
+			if tc.failure == "missing_bgp" {
+				require.Empty(t, first.Latest.BGP.Entries)
+			} else {
+				require.Len(t, first.Latest.BGP.Entries, 1)
+			}
 			require.Len(t, first.Latest.Licensing.Rows, 1)
 			require.NotEmpty(t, first.Initialization)
 			require.Len(t, first.Latest.Profiles[0].HiddenMetrics, 1)

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,13 +85,18 @@ func normalTestDocument(t *testing.T, c *Collector, directory string) *diagnosti
 func TestNormalEvidenceRealCollection(t *testing.T) {
 	for name, tc := range map[string]struct{ failure string }{
 		"total collection failure":                 {"metrics"},
+		"malformed BGP value":                      {"bgp_conversion"},
+		"absent BGP table signals":                 {"missing_bgp_table"},
+		"absent BGP identity":                      {"missing_bgp_identity"},
 		"partial BGP failure":                      {"bgp"},
 		"malformed licensing timer":                {"license"},
+		"absent BGP signals with available tags":   {"missing_bgp_tags"},
 		"ordinary absent BGP signals":              {"missing_bgp"},
 		"ordinary absent timer":                    {"missing"},
 		"cached rejected tag is not a new failure": {"cached"},
 	} {
 		t.Run(name, func(t *testing.T) {
+			bgpMissing := strings.HasPrefix(tc.failure, "missing_bgp")
 			handler, cleanup := mockInit(t)
 			defer cleanup()
 			handler.EXPECT().Version().Return(gosnmp.Version2c).AnyTimes()
@@ -105,7 +111,7 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 						packet.Variables = append(packet.Variables, gosnmp.SnmpPDU{Name: oid, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.99999"})
 						continue
 					}
-					if poll == 2 && (((tc.failure == "metrics" || tc.failure == "missing_bgp") && oid == normalTestRoot+".1.0") || (tc.failure == "bgp" && oid == normalTestRoot+".5.0")) {
+					if poll == 2 && (((tc.failure == "metrics" || bgpMissing) && oid == normalTestRoot+".1.0") || (tc.failure == "bgp" && oid == normalTestRoot+".5.0")) {
 						return nil, errors.New("synthetic timeout")
 					}
 					value := 7
@@ -119,7 +125,14 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 						value = 6
 					}
 					pdu := gosnmp.SnmpPDU{Name: oid, Type: gosnmp.Integer, Value: value}
-					if tc.failure == "missing_bgp" && oid == normalTestRoot+".5.0" {
+					if poll == 2 && tc.failure == "bgp_conversion" && oid == normalTestRoot+".7.0" {
+						pdu.Type, pdu.Value = gosnmp.OctetString, "invalid"
+					}
+					missingBGPOID := normalTestRoot + ".5.0"
+					if tc.failure == "missing_bgp_identity" {
+						missingBGPOID = normalTestRoot + ".6.0"
+					}
+					if bgpMissing && oid == missingBGPOID {
 						pdu.Type, pdu.Value = gosnmp.NoSuchObject, nil
 					}
 					if tc.failure == "cached" && oid == normalTestRoot+".6.0" {
@@ -152,6 +165,23 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 			// Inject profile input only; Init, Check, all acquisition, normalization
 			// and consumer commits run through their production implementations.
 			c.snmpProfiles = []*ddsnmp.Profile{normalTestProfile()}
+			if tc.failure == "bgp_conversion" {
+				c.snmpProfiles[0].Definition.BGP[0].Connection.EstablishedUptime = ddprofiledefinition.BGPValueConfig{Symbol: ddprofiledefinition.SymbolConfig{OID: normalTestRoot + ".7.0", Name: "uptime"}}
+			}
+			if tc.failure == "missing_bgp_identity" {
+				c.snmpProfiles[0].Definition.BGP[0].Identity.Neighbor = ddprofiledefinition.BGPValueConfig{Symbol: ddprofiledefinition.SymbolConfig{OID: normalTestRoot + ".6.0", Name: "neighbor"}}
+			}
+			if tc.failure == "missing_bgp_table" {
+				cfg := &c.snmpProfiles[0].Definition.BGP[0]
+				root := normalTestRoot + ".20"
+				cfg.Table = ddprofiledefinition.SymbolConfig{OID: root, Name: "peers"}
+				cfg.State.Symbol.OID = root + ".1"
+				cfg.MetricTags = []ddprofiledefinition.MetricTagConfig{{Tag: "site", Symbol: ddprofiledefinition.SymbolConfigCompat{OID: root + ".2", Name: "site"}}}
+				handler.EXPECT().BulkWalkAll(root).Return([]gosnmp.SnmpPDU{{Name: root + ".2.1", Type: gosnmp.OctetString, Value: "site"}}, nil).AnyTimes()
+			}
+			if tc.failure == "missing_bgp_tags" {
+				c.snmpProfiles[0].Definition.BGP[0].MetricTags = []ddprofiledefinition.MetricTagConfig{{Tag: "site", Symbol: ddprofiledefinition.SymbolConfigCompat{OID: normalTestRoot + ".6.0", Name: "site"}}}
+			}
 			if tc.failure == "cached" {
 				c.snmpProfiles[0].Definition.MetricTags = []ddprofiledefinition.GlobalMetricTagConfig{{MetricTagConfig: ddprofiledefinition.MetricTagConfig{Tag: "site", Symbol: ddprofiledefinition.SymbolConfigCompat{OID: normalTestRoot + ".6.0", Name: "site", ExtractValue: "^([0-9]+)$", ExtractValueCompiled: regexp.MustCompile("^([0-9]+)$")}}}}
 			}
@@ -170,7 +200,7 @@ func TestNormalEvidenceRealCollection(t *testing.T) {
 			require.NotEmpty(t, firstSamples)
 			first := normalTestDocument(t, c, directory)
 			require.Equal(t, tc.failure == "cached", first.Latest.Failed)
-			if tc.failure == "missing_bgp" {
+			if bgpMissing {
 				require.Empty(t, first.Latest.BGP.Entries)
 			} else {
 				require.Len(t, first.Latest.BGP.Entries, 1)

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics_values.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics_values.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"maps"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+)
+
+func normalMetric(value ddsnmp.Metric) diagnostics.NormalMetric {
+	result := diagnostics.NormalMetric{
+		Name:        value.Name,
+		Description: value.Description,
+		Family:      value.Family,
+		Unit:        value.Unit,
+		ChartType:   value.ChartType,
+		MetricType:  value.MetricType,
+		StaticTags:  maps.Clone(value.StaticTags),
+		Tags:        maps.Clone(value.Tags),
+		Table:       value.Table,
+		Value:       value.Value,
+		MultiValue:  maps.Clone(value.MultiValue),
+		IsTable:     value.IsTable,
+		IsVirtual:   value.IsVirtual,
+	}
+	if value.Profile != nil {
+		result.Profile = value.Profile.Source
+	}
+	return result
+}
+
+func normalLicense(value licenseRow) diagnostics.NormalLicense {
+	result := diagnostics.NormalLicense{
+		ID:                   value.ID,
+		StructuralID:         value.StructuralID,
+		Source:               value.Source,
+		Table:                value.Table,
+		Name:                 value.Name,
+		Feature:              value.Feature,
+		Component:            value.Component,
+		Type:                 value.Type,
+		Impact:               value.Impact,
+		StateRaw:             value.StateRaw,
+		StateSeverity:        value.StateSeverity,
+		HasState:             value.HasState,
+		StateBucket:          string(value.StateBucket),
+		ExpiryTS:             value.ExpiryTS,
+		HasExpiry:            value.HasExpiry,
+		AuthorizationExpiry:  value.AuthorizationExpiry,
+		HasAuthorizationTime: value.HasAuthorizationTime,
+		CertificateExpiry:    value.CertificateExpiry,
+		HasCertificateTime:   value.HasCertificateTime,
+		GraceExpiry:          value.GraceExpiry,
+		HasGraceTime:         value.HasGraceTime,
+		Usage:                value.Usage,
+		HasUsage:             value.HasUsage,
+		Capacity:             value.Capacity,
+		HasCapacity:          value.HasCapacity,
+		Available:            value.Available,
+		HasAvailable:         value.HasAvailable,
+		UsagePercent:         value.UsagePercent,
+		HasUsagePct:          value.HasUsagePct,
+		IsUnlimited:          value.IsUnlimited,
+		IsPerpetual:          value.IsPerpetual,
+		ExpirySource:         value.ExpirySource,
+		AuthSource:           value.AuthSource,
+		CertSource:           value.CertSource,
+		GraceSource:          value.GraceSource,
+	}
+	return result
+}
+
+func normalBGPPeer(value *bgpPeerEntry) diagnostics.NormalBGPPeer {
+	result := diagnostics.NormalBGPPeer{
+		Key:                  value.key,
+		Scope:                value.scope,
+		Source:               value.source,
+		Tags:                 maps.Clone(value.tags),
+		Stale:                value.stale,
+		LastUpdate:           value.lastUpdate,
+		LastFailure:          value.lastFailure,
+		AdminStatus:          value.adminStatus,
+		State:                value.state,
+		PreviousState:        value.previousState,
+		EstablishedUptime:    value.establishedUptime,
+		LastReceivedUpdate:   value.lastReceivedUpdate,
+		EstablishedCount:     value.establishedCount,
+		DownTransitions:      value.downTransitions,
+		UpTransitions:        value.upTransitions,
+		Flaps:                value.flaps,
+		LastErrorCode:        value.lastErrorCode,
+		LastErrorSubcode:     value.lastErrorSubcode,
+		LastErrorText:        value.lastErrorText,
+		LastDownReason:       value.lastDownReason,
+		LastRecvNotify:       value.lastRecvNotify,
+		LastSentNotify:       value.lastSentNotify,
+		GracefulRestart:      value.gracefulRestart,
+		UnavailabilityReason: value.unavailabilityReason,
+		UpdateCounts:         maps.Clone(value.updateCounts),
+		MessageCounts:        maps.Clone(value.messageCounts),
+		NotificationCounts:   maps.Clone(value.notificationCounts),
+		RouteRefreshCounts:   maps.Clone(value.routeRefreshCounts),
+		OpenCounts:           maps.Clone(value.openCounts),
+		KeepaliveCounts:      maps.Clone(value.keepaliveCounts),
+		RouteCounts:          maps.Clone(value.routeCounts),
+		RouteTotals:          maps.Clone(value.routeTotals),
+		RouteLimits:          maps.Clone(value.routeLimits),
+		RouteLimitThresholds: maps.Clone(value.routeLimitThresholds),
+	}
+	return result
+}

--- a/src/go/plugin/go.d/collector/snmp_topology/collector.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector.go
@@ -540,12 +540,12 @@ func (c *Collector) refreshDeviceTopology(
 	}
 
 	coll := c.newDdSnmpColl(ddsnmpcollector.Config{
-		SnmpClient:                 snmpClient,
-		Profiles:                   profiles,
-		Log:                        c.Logger,
-		SysObjectID:                dev.SysObjectID,
-		DisableBulkWalk:            dev.DisableBulkWalk,
-		InitialAcquisitionObserver: mainObserver,
+		SnmpClient:          snmpClient,
+		Profiles:            profiles,
+		Log:                 c.Logger,
+		SysObjectID:         dev.SysObjectID,
+		DisableBulkWalk:     dev.DisableBulkWalk,
+		AcquisitionObserver: mainObserver,
 	})
 
 	pms, err := coll.Collect()

--- a/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/collector_refresh_test.go
@@ -507,9 +507,9 @@ func TestCollectorRefreshCapturesBorrowedProfileValuesThroughAcquisitionObserver
 		return []*ddsnmp.Profile{{}}
 	}
 	coll.newDdSnmpColl = func(cfg ddsnmpcollector.Config) ddCollector {
-		require.NotNil(t, cfg.InitialAcquisitionObserver)
+		require.NotNil(t, cfg.AcquisitionObserver)
 		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) {
-			cfg.InitialAcquisitionObserver.ObserveProfile(ddsnmpcollector.AcquisitionProfileReport{
+			cfg.AcquisitionObserver.ObserveProfile(ddsnmpcollector.AcquisitionProfileReport{
 				Identity: ddsnmpcollector.AcquisitionProfileIdentity{Ordinal: 0},
 				Outcome:  ddsnmpcollector.AcquisitionProfileOutcomeSuccess,
 				Routes: []ddsnmpcollector.AcquisitionRouteReport{{
@@ -1071,9 +1071,9 @@ func TestCollectorVLANContextsRecordDistinctSuccessAndFailureEvidence(t *testing
 		return client
 	}
 	coll.newDdSnmpColl = func(cfg ddsnmpcollector.Config) ddCollector {
-		require.NotNil(t, cfg.InitialAcquisitionObserver)
+		require.NotNil(t, cfg.AcquisitionObserver)
 		return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) {
-			cfg.InitialAcquisitionObserver.ObserveProfile(acquisitionReportForMetrics(
+			cfg.AcquisitionObserver.ObserveProfile(acquisitionReportForMetrics(
 				0, ddsnmpcollector.AcquisitionProfileOutcomeSuccess, profileMetrics,
 			), profileMetrics)
 			return []*ddsnmp.ProfileMetrics{profileMetrics}, nil
@@ -2022,7 +2022,7 @@ func BenchmarkCollectorRefreshDueDeviceWithAcquisition(b *testing.B) {
 			)
 			coll.newDdSnmpColl = func(cfg ddsnmpcollector.Config) ddCollector {
 				return ddCollectorFunc(func() ([]*ddsnmp.ProfileMetrics, error) {
-					cfg.InitialAcquisitionObserver.ObserveProfile(report, metrics[0])
+					cfg.AcquisitionObserver.ObserveProfile(report, metrics[0])
 					return metrics, nil
 				})
 			}

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologydiag/api_types.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologydiag/api_types.go
@@ -224,7 +224,7 @@ type diagnosticDeviceCaptureInspection struct {
 }
 
 type diagnosticContextAccounting struct {
-	Sources      []ddsnmp.SourceOperation      `json:"source_operations,omitempty"`
+	Sources      []*ddsnmp.SourceOperation     `json:"source_operations,omitempty"`
 	Interruption snmputils.Failure             `json:"interruption"`
 	Failures     ddsnmp.CollectionFailures     `json:"failures"`
 	Client       diagnosticPhaseStatus         `json:"client"`

--- a/src/go/plugin/go.d/collector/snmp_topology/internal/topologydiag/evidence.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/internal/topologydiag/evidence.go
@@ -79,7 +79,7 @@ type AcquisitionAttemptEvidence struct {
 }
 
 type AcquisitionContextEvidence struct {
-	Sources []ddsnmp.SourceOperation
+	Sources []*ddsnmp.SourceOperation
 
 	Interruption snmputils.Failure
 	Failures     ddsnmp.CollectionFailures

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_acquisition.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_acquisition.go
@@ -268,7 +268,7 @@ func topologyAcquisitionReportShape(routes []ddsnmpcollector.AcquisitionRouteRep
 		logicalBytes += uint64(64 + len(route.RootOID))
 		records += uint64(len(route.Sources) + len(route.Processing))
 		for _, binding := range route.Sources {
-			logicalBytes += uint64(40 + len(binding.OID) + len(binding.Role))
+			logicalBytes += uint64(48 + len(binding.OID) + len(binding.Role))
 		}
 		for _, event := range route.Processing {
 			logicalBytes += uint64(80 + len(event.RowIndex) + len(event.Field) + len(event.OID) + len(event.Reason) + len(event.Stage))

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_execution_test.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_diagnostic_execution_test.go
@@ -70,9 +70,9 @@ func collectSourceTestCapture(tb testing.TB, pdus []gosnmp.SnmpPDU) *topologydia
 	handler := &executionTestHandler{walkPDUs: pdus}
 	observer := recorder.beginContext(0, "", "")
 	collector := ddsnmpcollector.New(ddsnmpcollector.Config{
-		SnmpClient:                 recorder.sourceClient(handler),
-		Log:                        logger.New(),
-		InitialAcquisitionObserver: observer,
+		SnmpClient:          recorder.sourceClient(handler),
+		Log:                 logger.New(),
+		AcquisitionObserver: observer,
 		Profiles: []*ddsnmp.Profile{{SourceFile: "synthetic.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
 			MetricTags: []ddprofiledefinition.GlobalMetricTagConfig{
 				{MetricTagConfig: ddprofiledefinition.MetricTagConfig{

--- a/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context_collect.go
+++ b/src/go/plugin/go.d/collector/snmp_topology/topology_vlan_context_collect.go
@@ -29,7 +29,7 @@ func resolveTopologyVLANProfileView(dev ddsnmp.DeviceConnectionInfo) ddsnmp.Proj
 }
 
 type topologyVLANProgress struct {
-	sources      []ddsnmp.SourceOperation
+	sources      []*ddsnmp.SourceOperation
 	client       topologydiag.AcquisitionPhaseEvidence
 	connect      topologydiag.AcquisitionPhaseEvidence
 	collection   topologydiag.AcquisitionPhaseEvidence
@@ -80,7 +80,7 @@ func collectTopologyVLANContext(
 	sourceRecorder := &ddsnmpcollector.SourceRecorder{}
 	client = sourceRecorder.Wrap(client)
 	collector := c.newDdSnmpColl(ddsnmpcollector.Config{
-		SnmpClient: client, Profiles: profiles, Log: c.Logger, SysObjectID: dev.SysObjectID, DisableBulkWalk: dev.DisableBulkWalk, InitialAcquisitionObserver: observer,
+		SnmpClient: client, Profiles: profiles, Log: c.Logger, SysObjectID: dev.SysObjectID, DisableBulkWalk: dev.DisableBulkWalk, AcquisitionObserver: observer,
 	})
 	pms, err := collector.Collect()
 	progress.sources = sourceRecorder.Finish()

--- a/src/go/tools/snmp-topology-diagnostics/main.go
+++ b/src/go/tools/snmp-topology-diagnostics/main.go
@@ -96,6 +96,10 @@ func runWithOpener(arguments []string, stdout, stderr io.Writer, openArchive arc
 	}
 
 	if operation == "list" {
+		if options.normal || options.previousRun || options.registrationID != 0 {
+			fmt.Fprintln(stderr, "error: list does not support --normal, --previous-run, or --registration-id")
+			return 1
+		}
 		info, err := os.Stat(options.inputPath)
 		if err != nil || !info.IsDir() || options.checkpoint != 0 {
 			fmt.Fprintln(stderr, "error: list requires a directory and does not select a checkpoint")

--- a/src/go/tools/snmp-topology-diagnostics/main.go
+++ b/src/go/tools/snmp-topology-diagnostics/main.go
@@ -38,10 +38,18 @@ type diagnosticArchive interface {
 	InspectLinkAt(snmptopology.DiagnosticQueryOptions, int) (snmptopology.DiagnosticLinkInspection, error)
 }
 
-type archiveOpener func(io.Reader, snmpdiag.ReadLimits) (diagnosticArchive, error)
+type openedArchive struct {
+	topology diagnosticArchive
+	normal   *snmpdiag.NormalDevice
+	producer snmpdiag.Producer
+}
+
+type archiveOpener func(io.Reader, snmpdiag.ReadLimits) (openedArchive, error)
 
 type commandOptions struct {
 	inputPath         string
+	normal            bool
+	previousRun       bool
 	checkpoint        uint64
 	maxCompressedSize string
 	maxDecodedSize    string
@@ -60,7 +68,7 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 	return runWithOpener(arguments, stdout, stderr, func(
 		reader io.Reader,
 		limits snmpdiag.ReadLimits,
-	) (diagnosticArchive, error) {
+	) (openedArchive, error) {
 		return openDiagnosticArchive(reader, limits)
 	})
 }
@@ -98,14 +106,23 @@ func runWithOpener(arguments []string, stdout, stderr io.Writer, openArchive arc
 			fmt.Fprintf(stderr, "error: list checkpoints: %v\n", err)
 			return 1
 		}
-		if err := jsonv2.MarshalWrite(stdout, entries, outputJSONOptions); err != nil {
+		normal, err := snmpdiag.ListNormalFiles(options.inputPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "error: list normal devices: %v\n", err)
+			return 1
+		}
+		listing := struct {
+			Topology []snmpdiag.CheckpointFile `json:"topology_checkpoints"`
+			Normal   []snmpdiag.NormalFile     `json:"normal_devices"`
+		}{entries, normal}
+		if err := jsonv2.MarshalWrite(stdout, listing, outputJSONOptions); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
 		fmt.Fprintln(stdout)
 		return 0
 	}
-	path, err := resolveInput(options.inputPath, options.checkpoint)
+	path, err := resolveCommandInput(options)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: select input: %v\n", err)
 		return 1
@@ -152,6 +169,9 @@ func parseCommandOptions(operation string, arguments []string, stderr io.Writer)
 		flags.PrintDefaults()
 	}
 	flags.StringVar(&options.inputPath, "input", "", "new-format diagnostic file or directory (latest topology checkpoint)")
+	flags.BoolVar(&options.normal, "normal", false, "select normal device evidence from a directory")
+	flags.BoolVar(&options.previousRun, "previous-run", false, "select the previous evidence-bearing normal run")
+	flags.Uint64Var(&options.registrationID, "registration-id", 0, "device registration ID")
 	flags.Uint64Var(&options.checkpoint, "checkpoint", 0, "checkpoint sequence to select from a directory")
 	flags.StringVar(
 		&options.maxCompressedSize,
@@ -169,8 +189,6 @@ func parseCommandOptions(operation string, arguments []string, stderr io.Writer)
 		addQueryFlags(flags, &options.query)
 	}
 	switch operation {
-	case "inspect-device":
-		flags.Uint64Var(&options.registrationID, "registration-id", 0, "device registration ID")
 	case "inspect-link":
 		flags.IntVar(&options.linkIndex, "link-index", -1, "zero-based link index in this archive and query replay")
 		flags.StringVar(&options.link.SourceIdentity, "source-identity", "", "source actor identity key")
@@ -256,7 +274,11 @@ func addQueryFlags(flags *flag.FlagSet, options *snmptopology.DiagnosticQueryOpt
 	flags.StringVar(&options.Depth, "depth", options.Depth, "topology traversal depth or all")
 }
 
-func executeOperation(operation string, archive diagnosticArchive, options commandOptions) (any, error) {
+func executeOperation(operation string, opened openedArchive, options commandOptions) (any, error) {
+	if opened.normal != nil {
+		return executeNormalOperation(operation, opened, options)
+	}
+	archive := opened.topology
 	switch operation {
 	case "validate":
 		return snmptopology.DiagnosticValidation{Valid: true, Archive: archive.Identity()}, nil
@@ -317,12 +339,19 @@ func operationUsage(writer io.Writer, operation string) {
 	fmt.Fprintf(writer, "usage: snmp-topology-diagnostics %s --input PATH [options]\n", operation)
 }
 
-func openDiagnosticArchive(r io.Reader, limits snmpdiag.ReadLimits) (*snmptopology.DiagnosticArchive, error) {
+func openDiagnosticArchive(r io.Reader, limits snmpdiag.ReadLimits) (openedArchive, error) {
 	document, err := snmpdiag.Read(r, limits)
 	if err != nil {
-		return nil, err
+		return openedArchive{}, err
 	}
-	return snmptopology.InspectDiagnosticDocument(document)
+	if document.Kind == snmpdiag.KindNormal {
+		if err := document.Normal.Validate(); err != nil {
+			return openedArchive{}, err
+		}
+		return openedArchive{normal: document.Normal, producer: document.Producer}, nil
+	}
+	archive, err := snmptopology.InspectDiagnosticDocument(document)
+	return openedArchive{topology: archive}, err
 }
 
 func resolveInput(input string, sequence uint64) (string, error) {

--- a/src/go/tools/snmp-topology-diagnostics/main_test.go
+++ b/src/go/tools/snmp-topology-diagnostics/main_test.go
@@ -110,10 +110,10 @@ func TestRunDispatchesReplayAndInspectionOnce(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fake := &fakeDiagnosticArchive{}
 			openCalls := 0
-			opener := func(_ io.Reader, limits snmpdiag.ReadLimits) (diagnosticArchive, error) {
+			opener := func(_ io.Reader, limits snmpdiag.ReadLimits) (openedArchive, error) {
 				openCalls++
 				fake.limits = limits
-				return fake, nil
+				return openedArchive{topology: fake}, nil
 			}
 			var stdout, stderr bytes.Buffer
 			if exitCode := runWithOpener(tc.args, &stdout, &stderr, opener); exitCode != 0 {
@@ -479,7 +479,7 @@ func readReplayableDiagnosticArchive(t testing.TB) *snmptopology.DiagnosticArchi
 	if err != nil {
 		t.Fatal(err)
 	}
-	return archive
+	return archive.topology.(*snmptopology.DiagnosticArchive)
 }
 
 func TestRunDiagnosticDirectory(t *testing.T) {

--- a/src/go/tools/snmp-topology-diagnostics/normal.go
+++ b/src/go/tools/snmp-topology-diagnostics/normal.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+)
+
+func resolveCommandInput(options commandOptions) (string, error) {
+	if !options.normal {
+		if options.previousRun {
+			return "", errors.New("--previous-run requires --normal")
+		}
+		return resolveInput(options.inputPath, options.checkpoint)
+	}
+	if options.registrationID == 0 || options.checkpoint != 0 {
+		return "", errors.New("--normal requires --registration-id and cannot select a topology checkpoint")
+	}
+	files, err := snmpdiag.ListNormalFiles(options.inputPath)
+	if err != nil {
+		return "", err
+	}
+	for _, file := range files {
+		if file.Previous == options.previousRun && file.RegistrationID == options.registrationID {
+			return filepath.Join(options.inputPath, snmpdiag.NormalDirectory, file.RunID, file.Filename), nil
+		}
+	}
+	return "", fmt.Errorf("normal device %d is not retained in the selected run", options.registrationID)
+}
+
+func executeNormalOperation(operation string, archive openedArchive, options commandOptions) (any, error) {
+	device := archive.normal
+	switch operation {
+	case "validate":
+		return struct {
+			Valid    bool              `json:"valid"`
+			Kind     string            `json:"kind"`
+			Producer snmpdiag.Producer `json:"producer"`
+		}{true, snmpdiag.KindNormal, archive.producer}, nil
+	case "summary":
+		return struct {
+			Producer          snmpdiag.Producer `json:"producer"`
+			RegistrationID    uint64            `json:"registration_id"`
+			RuntimeID         uint64            `json:"runtime_id"`
+			Hostname          string            `json:"hostname"`
+			LatestAttempt     uint64            `json:"latest_attempt"`
+			LatestFailed      bool              `json:"latest_failed"`
+			RetainedFailure   bool              `json:"retained_failure"`
+			SourceOperations  int               `json:"source_operations"`
+			Samples           int               `json:"samples"`
+			BGPCachedRows     int               `json:"bgp_cached_rows"`
+			LicenseCachedRows int               `json:"license_cached_rows"`
+		}{archive.producer, device.RegistrationID, device.RuntimeID, device.Hostname, device.Latest.ID, device.Latest.Failed,
+			device.LastFailure != nil || device.Latest.Failed, len(device.Sources), len(device.Latest.Samples), len(device.Latest.BGP.Entries), len(device.Latest.Licensing.Rows)}, nil
+	case "inspect-device":
+		if options.registrationID != device.RegistrationID {
+			return nil, fmt.Errorf("normal archive contains device %d", device.RegistrationID)
+		}
+		return device, nil
+	default:
+		return nil, fmt.Errorf("%s requires topology evidence", operation)
+	}
+}

--- a/src/go/tools/snmp-topology-diagnostics/normal_test.go
+++ b/src/go/tools/snmp-topology-diagnostics/normal_test.go
@@ -44,17 +44,21 @@ func TestNormalCommands(t *testing.T) {
 		want string
 		code int
 	}{
-		"list both runs":        {[]string{"list", "--input", root}, `"previous": true`, 0},
-		"direct summary":        {[]string{"summary", "--input", currentPath}, "current.example", 0},
-		"directory summary":     {[]string{"summary", "--input", root, "--normal", "--registration-id", "7"}, "current.example", 0},
-		"previous run":          {[]string{"summary", "--input", root, "--normal", "--previous-run", "--registration-id", "7"}, "previous.example", 0},
-		"validate":              {[]string{"validate", "--input", currentPath}, `"valid": true`, 0},
-		"inspect":               {[]string{"inspect-device", "--input", currentPath, "--registration-id", "7"}, `"sample": 42`, 0},
-		"wrong device":          {[]string{"inspect-device", "--input", currentPath, "--registration-id", "8"}, "contains device 7", 1},
-		"unretained device":     {[]string{"summary", "--input", root, "--normal", "--registration-id", "8"}, "not retained", 1},
-		"no normal replay":      {[]string{"replay", "--input", currentPath}, "requires topology evidence", 1},
-		"missing selection":     {[]string{"summary", "--input", root, "--normal"}, "requires --registration-id", 1},
-		"conflicting selection": {[]string{"summary", "--input", root, "--normal", "--registration-id", "7", "--checkpoint", "1"}, "cannot select a topology checkpoint", 1},
+		"list rejects normal":             {[]string{"list", "--input", root, "--normal"}, "does not support", 1},
+		"list rejects previous run":       {[]string{"list", "--input", root, "--previous-run"}, "does not support", 1},
+		"list rejects registration":       {[]string{"list", "--input", root, "--registration-id", "7"}, "does not support", 1},
+		"list rejects combined selectors": {[]string{"list", "--input", root, "--normal", "--previous-run", "--registration-id", "7"}, "does not support", 1},
+		"list both runs":                  {[]string{"list", "--input", root}, `"previous": true`, 0},
+		"direct summary":                  {[]string{"summary", "--input", currentPath}, "current.example", 0},
+		"directory summary":               {[]string{"summary", "--input", root, "--normal", "--registration-id", "7"}, "current.example", 0},
+		"previous run":                    {[]string{"summary", "--input", root, "--normal", "--previous-run", "--registration-id", "7"}, "previous.example", 0},
+		"validate":                        {[]string{"validate", "--input", currentPath}, `"valid": true`, 0},
+		"inspect":                         {[]string{"inspect-device", "--input", currentPath, "--registration-id", "7"}, `"sample": 42`, 0},
+		"wrong device":                    {[]string{"inspect-device", "--input", currentPath, "--registration-id", "8"}, "contains device 7", 1},
+		"unretained device":               {[]string{"summary", "--input", root, "--normal", "--registration-id", "8"}, "not retained", 1},
+		"no normal replay":                {[]string{"replay", "--input", currentPath}, "requires topology evidence", 1},
+		"missing selection":               {[]string{"summary", "--input", root, "--normal"}, "requires --registration-id", 1},
+		"conflicting selection":           {[]string{"summary", "--input", root, "--normal", "--registration-id", "7", "--checkpoint", "1"}, "cannot select a topology checkpoint", 1},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var out, errors bytes.Buffer

--- a/src/go/tools/snmp-topology-diagnostics/normal_test.go
+++ b/src/go/tools/snmp-topology-diagnostics/normal_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalCommands(t *testing.T) {
+	root := t.TempDir()
+	current, previous := "11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"
+	now := time.Now().UTC()
+	var currentPath string
+	for _, runID := range []string{current, previous} {
+		directory := filepath.Join(root, snmpdiag.NormalDirectory, runID)
+		require.NoError(t, os.MkdirAll(directory, 0700))
+		path := filepath.Join(directory, "device-00000000000000000007.zst")
+		hostname := "current.example"
+		if runID == previous {
+			hostname = "previous.example"
+		} else {
+			currentPath = path
+		}
+		var data bytes.Buffer
+		require.NoError(t, snmpdiag.Write(&data, snmpdiag.Document{Format: snmpdiag.Format, Version: snmpdiag.Version, Kind: snmpdiag.KindNormal,
+			Producer: snmpdiag.Producer{RunID: runID}, Normal: &snmpdiag.NormalDevice{RegistrationID: 7, RuntimeID: 1, Hostname: hostname, CapturedAt: now,
+				Latest: &snmpdiag.NormalAttempt{ID: 2, Phase: "collect", StartedAt: now, CompletedAt: now, Samples: map[string]int64{"sample": 42}},
+			},
+		}))
+		require.NoError(t, os.WriteFile(path, data.Bytes(), 0600))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, snmpdiag.NormalDirectory, "runs.json"), []byte(fmt.Sprintf(`{"current":%q,"previous":%q}`, current, previous)), 0600))
+	for name, tc := range map[string]struct {
+		args []string
+		want string
+		code int
+	}{
+		"list both runs":        {[]string{"list", "--input", root}, `"previous": true`, 0},
+		"direct summary":        {[]string{"summary", "--input", currentPath}, "current.example", 0},
+		"directory summary":     {[]string{"summary", "--input", root, "--normal", "--registration-id", "7"}, "current.example", 0},
+		"previous run":          {[]string{"summary", "--input", root, "--normal", "--previous-run", "--registration-id", "7"}, "previous.example", 0},
+		"validate":              {[]string{"validate", "--input", currentPath}, `"valid": true`, 0},
+		"inspect":               {[]string{"inspect-device", "--input", currentPath, "--registration-id", "7"}, `"sample": 42`, 0},
+		"wrong device":          {[]string{"inspect-device", "--input", currentPath, "--registration-id", "8"}, "contains device 7", 1},
+		"unretained device":     {[]string{"summary", "--input", root, "--normal", "--registration-id", "8"}, "not retained", 1},
+		"no normal replay":      {[]string{"replay", "--input", currentPath}, "requires topology evidence", 1},
+		"missing selection":     {[]string{"summary", "--input", root, "--normal"}, "requires --registration-id", 1},
+		"conflicting selection": {[]string{"summary", "--input", root, "--normal", "--registration-id", "7", "--checkpoint", "1"}, "cannot select a topology checkpoint", 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var out, errors bytes.Buffer
+			assert.Equal(t, tc.code, run(tc.args, &out, &errors), errors.String())
+			if tc.code == 0 {
+				assert.Contains(t, out.String(), tc.want)
+				assert.Empty(t, errors.String())
+			} else {
+				assert.Contains(t, errors.String(), tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
##### Summary

Extend built-in SNMP diagnostics to cover ongoing metrics, BGP and licensing collection. Preserve recent failures and the evidence behind cached results in independently updated device files.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds recurring per-device SNMP diagnostics; previously diagnostics covered only the initial acquisition and now they cover ongoing metrics, BGP, and licensing collection while preserving recent failures and the evidence behind cached results. Publications are paced to five minutes and fairly scheduled, validation rejects incomplete or inconsistent evidence, and pending diagnostics are flushed before job shutdown.

**New Features**
- `snmp-topology-diagnostics` can inspect the new per-device normal diagnostic files with `--normal --registration-id`, including the previous run.

<sup>Written for commit 4533a1402e564cd6ac87bbf8c6bab3f11f063546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added normal-device SNMP diagnostics covering collection attempts, metric decisions, BGP and licensing details, cached inputs, failures, and source evidence.
  * Normal diagnostic data is published on a schedule with current and previous run retention.
  * Extended the diagnostics tool with normal-device listing, validation, summaries, inspection, and replay options.
  * Added visibility into missing OIDs and filtered metrics.
  * Added safe service finalization during process shutdown.

* **Bug Fixes**
  * Improved diagnostic evidence handling across cached and recurring SNMP collections, including failure and retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->