### PR TITLE
fix(mcp): advertise minItems on required array parameters

### DIFF
--- a/src/web/mcp/mcp-params.c
+++ b/src/web/mcp/mcp-params.c
@@ -78,7 +78,9 @@ BUFFER *mcp_params_parse_array_to_pattern(
     if (!json_object_object_get_ex(params, param_name, &array_obj) || !array_obj) {
         if (required && error) {
             buffer_flush(error);
-            buffer_sprintf(error, "Missing required parameter '%s'", param_name);
+            buffer_sprintf(error, "Missing required parameter '%s'.", param_name);
+            if (list_tool)
+                buffer_sprintf(error, " Use the '%s' tool to discover available values.", list_tool);
         }
         return NULL;  // Parameter not provided
     }
@@ -96,7 +98,9 @@ BUFFER *mcp_params_parse_array_to_pattern(
     if (required && json_object_array_length(array_obj) == 0) {
         if (error) {
             buffer_flush(error);
-            buffer_sprintf(error, "The '%s' parameter cannot be an empty array", param_name);
+            buffer_sprintf(error, "The '%s' parameter cannot be an empty array.", param_name);
+            if (list_tool)
+                buffer_sprintf(error, " Use the '%s' tool to discover available values.", list_tool);
         }
         return NULL;
     }
@@ -232,13 +236,16 @@ void mcp_schema_add_array_param(
     BUFFER *buffer,
     const char *param_name,
     const char *title,
-    const char *description
+    const char *description,
+    bool required
 ) {
     buffer_json_member_add_object(buffer, param_name);
     {
         buffer_json_member_add_string(buffer, "type", "array");
         buffer_json_member_add_string(buffer, "title", title);
         buffer_json_member_add_string(buffer, "description", description);
+        if(required)
+            buffer_json_member_add_uint64(buffer, "minItems", 1);
         buffer_json_member_add_object(buffer, "items");
         buffer_json_member_add_string(buffer, "type", "string");
         buffer_json_object_close(buffer); // items

--- a/src/web/mcp/mcp-params.c
+++ b/src/web/mcp/mcp-params.c
@@ -88,7 +88,7 @@ BUFFER *mcp_params_parse_array_to_pattern(
     if (!json_object_is_type(array_obj, json_type_array)) {
         if (error) {
             buffer_flush(error);
-            buffer_sprintf(error, "%s must be an array of strings, not %s", 
+            buffer_sprintf(error, "The '%s' parameter must be an array of strings, not %s.",
                     param_name, json_type_to_name(json_object_get_type(array_obj)));
         }
         return NULL;
@@ -113,17 +113,13 @@ BUFFER *mcp_params_parse_array_to_pattern(
         if (error) {
             buffer_flush(error);
             if (allow_wildcards) {
-                buffer_strcat(error, "invalid array format");
+                buffer_sprintf(error, "The '%s' parameter has an invalid array format.", param_name);
             } else {
-                if (list_tool) {
-                    buffer_sprintf(error,
-                            "must contain exact values, not patterns. "
-                            "Wildcards are not supported. "
-                            "Use the '%s' tool to discover exact values.", list_tool);
-                } else {
-                    buffer_strcat(error,
-                            "must contain exact values, not patterns. Wildcards are not supported.");
-                }
+                buffer_sprintf(error,
+                        "The '%s' parameter must contain exact values, not patterns. "
+                        "Wildcards are not supported.", param_name);
+                if (list_tool)
+                    buffer_sprintf(error, " Use the '%s' tool to discover exact values.", list_tool);
             }
         }
         return NULL;
@@ -131,7 +127,7 @@ BUFFER *mcp_params_parse_array_to_pattern(
         buffer_free(wb);
         if (error) {
             buffer_flush(error);
-            buffer_sprintf(error, "%s must be an array of strings", param_name);
+            buffer_sprintf(error, "The '%s' parameter must be an array of strings.", param_name);
         }
         return NULL;
     }

--- a/src/web/mcp/mcp-params.c
+++ b/src/web/mcp/mcp-params.c
@@ -112,15 +112,11 @@ BUFFER *mcp_params_parse_array_to_pattern(
         buffer_free(wb);
         if (error) {
             buffer_flush(error);
-            if (allow_wildcards) {
-                buffer_sprintf(error, "The '%s' parameter has an invalid array format.", param_name);
-            } else {
-                buffer_sprintf(error,
-                        "The '%s' parameter must contain exact values, not patterns. "
-                        "Wildcards are not supported.", param_name);
-                if (list_tool)
-                    buffer_sprintf(error, " Use the '%s' tool to discover exact values.", list_tool);
-            }
+            buffer_sprintf(error,
+                    "The '%s' parameter must contain exact values, not patterns. "
+                    "Wildcards are not supported.", param_name);
+            if (list_tool)
+                buffer_sprintf(error, " Use the '%s' tool to discover exact values.", list_tool);
         }
         return NULL;
     } else if (result != 0) {
@@ -240,7 +236,7 @@ void mcp_schema_add_array_param(
         buffer_json_member_add_string(buffer, "type", "array");
         buffer_json_member_add_string(buffer, "title", title);
         buffer_json_member_add_string(buffer, "description", description);
-        if(required)
+        if (required)
             buffer_json_member_add_uint64(buffer, "minItems", 1);
         buffer_json_member_add_object(buffer, "items");
         buffer_json_member_add_string(buffer, "type", "string");

--- a/src/web/mcp/mcp-params.h
+++ b/src/web/mcp/mcp-params.h
@@ -33,11 +33,13 @@ BUFFER *mcp_params_parse_labels_object(
 );
 
 // Add array parameter schema (for nodes, instances, dimensions)
+// required: the runtime rejects an empty array, so the schema advertises minItems: 1
 void mcp_schema_add_array_param(
     BUFFER *buffer,
     const char *param_name,
     const char *title,
-    const char *description
+    const char *description,
+    bool required
 );
 
 // Add labels object parameter schema

--- a/src/web/mcp/mcp-params.h
+++ b/src/web/mcp/mcp-params.h
@@ -13,6 +13,8 @@
 // Writes error message to error buffer on failure
 // required: if true, validates parameter exists, is array type, and is non-empty
 // list_tool: tool name to recommend for discovering exact values (e.g., MCP_TOOL_LIST_NODES)
+// Every error message it writes is a complete, period-terminated sentence, so callers may append
+// their own guidance separated by a single space.
 BUFFER *mcp_params_parse_array_to_pattern(
     struct json_object *params,
     const char *param_name,

--- a/src/web/mcp/mcp-tools-alert-transitions.c
+++ b/src/web/mcp/mcp-tools-alert-transitions.c
@@ -33,7 +33,7 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
     mcp_schema_add_array_param(
         buffer, "nodes", "Filter nodes",
         "Show only alerts transitions for these nodes.\n"
-        "Use 'list_nodes' to discover available nodes.\n"
+        "Use '" MCP_TOOL_LIST_NODES "' to discover available nodes.\n"
         "If not specified, alerts transitions from all nodes are included. "
         "Examples: [\"node1\", \"node2\"], [\"web-server-01\", \"db-server-01\"]",
         false);

--- a/src/web/mcp/mcp-tools-alert-transitions.c
+++ b/src/web/mcp/mcp-tools-alert-transitions.c
@@ -26,7 +26,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
         "Each alert name must be an exact match - no wildcards or patterns allowed. "
         "Use '" MCP_TOOL_LIST_ALL_ALERTS "' to discover available alert names. "
         "If not specified, all alerts are included. "
-        "Examples: [\"disk_space_usage\", \"cpu_iowait\", \"ram_in_use\"]");
+        "Examples: [\"disk_space_usage\", \"cpu_iowait\", \"ram_in_use\"]",
+        false);
 
     // Nodes filter
     mcp_schema_add_array_param(
@@ -34,7 +35,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
         "Show only alerts transitions for these nodes.\n"
         "Use 'list_nodes' to discover available nodes.\n"
         "If not specified, alerts transitions from all nodes are included. "
-        "Examples: [\"node1\", \"node2\"], [\"web-server-01\", \"db-server-01\"]");
+        "Examples: [\"node1\", \"node2\"], [\"web-server-01\", \"db-server-01\"]",
+        false);
     
     mcp_schema_add_array_param(
         buffer, "metrics",
@@ -43,7 +45,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
         "Each metric must be an exact match - no wildcards or patterns allowed. "
         "Use '" MCP_TOOL_LIST_METRICS "' to discover available metrics. "
         "If not specified, all metrics are included. "
-        "Examples: [\"system.cpu\", \"system.load\"], [\"disk.io\", \"disk.space\"]");
+        "Examples: [\"system.cpu\", \"system.load\"], [\"disk.io\", \"disk.space\"]",
+        false);
 
     mcp_schema_add_array_param(
         buffer, "instances",
@@ -53,7 +56,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
         "If no instances are specified, all instances of the metric are queried.\n"
         "Example: [\"instance1\", \"instance2\", \"instance3\"]\n."
         "IMPORTANT: when you have a choice, prefer to filter by labels instead of instances, because many monitored "
-        "components may change instance names over time.");
+        "components may change instance names over time.",
+        false);
 
     // Status filter (required multi-select enum)
     buffer_json_member_add_object(buffer, "status");
@@ -70,7 +74,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
             " - UNINITIALIZED: the alert has not been initialized for the first time yet, no data available.\n"
             " - REMOVED: the alert was removed (happens during netdata shutdown, child disconnect, health reload).\n"
             "Multiple statuses can be selected. Example: [\"CRITICAL\", \"WARNING\"]");
-        
+        buffer_json_member_add_uint64(buffer, "minItems", 1);
+
         // Define items schema with enum values
         buffer_json_member_add_object(buffer, "items");
         {
@@ -95,7 +100,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
         "Each classification must be an exact match - no wildcards or patterns allowed. "
         "Use '" MCP_TOOL_LIST_ALL_ALERTS "' to discover available classifications. "
         "If not specified, all classifications are included. "
-        "Examples: [\"Errors\", \"Latency\", \"Utilization\"]");
+        "Examples: [\"Errors\", \"Latency\", \"Utilization\"]",
+        false);
     
     mcp_schema_add_array_param(
         buffer, "types",
@@ -104,7 +110,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
         "Each type must be an exact match - no wildcards or patterns allowed. "
         "Use '" MCP_TOOL_LIST_ALL_ALERTS "' to discover available types. "
         "If not specified, all types are included. "
-        "Examples: [\"System\", \"Web Server\", \"Database\"]");
+        "Examples: [\"System\", \"Web Server\", \"Database\"]",
+        false);
     
     mcp_schema_add_array_param(
         buffer, "components",
@@ -113,7 +120,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
         "Each component must be an exact match - no wildcards or patterns allowed. "
         "Use '" MCP_TOOL_LIST_ALL_ALERTS "' to discover available components. "
         "If not specified, all components are included. "
-        "Examples: [\"Network\", \"Disk\", \"Memory\"]");
+        "Examples: [\"Network\", \"Disk\", \"Memory\"]",
+        false);
     
     mcp_schema_add_array_param(
         buffer, "roles",
@@ -122,7 +130,8 @@ void mcp_tool_list_alert_transitions_schema(BUFFER *buffer) {
         "Each role must be an exact match - no wildcards or patterns allowed. "
         "Use '" MCP_TOOL_LIST_ALL_ALERTS "' to discover available roles. "
         "If not specified, all roles are included. "
-        "Examples: [\"sysadmin\", \"webmaster\", \"dba\"]");
+        "Examples: [\"sysadmin\", \"webmaster\", \"dba\"]",
+        false);
     
     // Cardinality limit
     mcp_schema_add_cardinality_limit(
@@ -204,7 +213,7 @@ MCP_RETURN_CODE mcp_tool_list_alert_transitions_execute(MCP_CLIENT *mcpc, struct
     
     status_buffer = mcp_params_parse_array_to_pattern(params, "status", true, false, NULL, mcpc->error);
     if (buffer_strlen(mcpc->error) > 0) {
-        buffer_strcat(mcpc->error, ". You must select at least one alert status to filter by.");
+        buffer_strcat(mcpc->error, " You must select at least one alert status to filter by.");
         return MCP_RC_BAD_REQUEST;
     }
     if (status_buffer)

--- a/src/web/mcp/mcp-tools-list-metadata.c
+++ b/src/web/mcp/mcp-tools-list-metadata.c
@@ -199,7 +199,8 @@ void mcp_unified_list_tool_schema(BUFFER *buffer, const MCP_LIST_TOOL_CONFIG *co
                             "Each context must be an exact match - no wildcards or patterns allowed. "
                             "Use '" MCP_TOOL_LIST_METRICS "' to discover available contexts. "
                             "If not specified, alerts from all contexts are included. "
-                            "Examples: [\"system.cpu\", \"disk.space\"], [\"mysql.queries\", \"redis.memory\"]");
+                            "Examples: [\"system.cpu\", \"disk.space\"], [\"mysql.queries\", \"redis.memory\"]",
+                        config->params.metrics_required);
                 } else {
                     // For nodes/functions, metrics is a filter
                     mcp_schema_add_array_param(buffer, "metrics",
@@ -213,7 +214,8 @@ void mcp_unified_list_tool_schema(BUFFER *buffer, const MCP_LIST_TOOL_CONFIG *co
                             "Each metric must be an exact match - no wildcards or patterns allowed. "
                             "Use '" MCP_TOOL_LIST_METRICS "' to discover available metrics. "
                             "If not specified, all metrics are included. "
-                            "Examples: [\"system.cpu\", \"system.load\"], [\"disk.io\", \"disk.space\"]");
+                            "Examples: [\"system.cpu\", \"system.load\"], [\"disk.io\", \"disk.space\"]",
+                        config->params.metrics_required);
                 }
             } else {
                 // This is a metrics query
@@ -226,7 +228,8 @@ void mcp_unified_list_tool_schema(BUFFER *buffer, const MCP_LIST_TOOL_CONFIG *co
                         "Array of specific metric names to filter. "
                         "Each metric must be an exact match - no wildcards or patterns allowed. "
                         "If not specified, all metrics are included. "
-                        "Examples: [\"system.cpu\", \"system.load\", \"system.ram\"]");
+                        "Examples: [\"system.cpu\", \"system.load\", \"system.ram\"]",
+                    config->params.metrics_required);
             }
         } else {
             // Use string pattern for metrics
@@ -295,7 +298,8 @@ void mcp_unified_list_tool_schema(BUFFER *buffer, const MCP_LIST_TOOL_CONFIG *co
                     "Each node must be an exact match - no wildcards or patterns allowed. "
                     "Use '" MCP_TOOL_LIST_NODES "' to discover available nodes. "
                     "If not specified, all nodes are included. "
-                    "Examples: [\"node1\", \"node2\"], [\"web-server-01\", \"db-server-01\"]");
+                    "Examples: [\"node1\", \"node2\"], [\"web-server-01\", \"db-server-01\"]",
+                config->params.nodes_required);
         } else {
             // Use string pattern for nodes
             buffer_json_member_add_object(buffer, "nodes");
@@ -402,7 +406,8 @@ MCP_RETURN_CODE mcp_unified_list_tool_execute(MCP_CLIENT *mcpc, const MCP_LIST_T
     if (config->params.has_metrics) {
         if (config->params.metrics_as_array) {
             // Parse metrics as an array
-            metrics_buffer = mcp_params_parse_array_to_pattern(params, "metrics", false, false, MCP_TOOL_LIST_METRICS, mcpc->error);
+            metrics_buffer = mcp_params_parse_array_to_pattern(
+                params, "metrics", config->params.metrics_required, false, MCP_TOOL_LIST_METRICS, mcpc->error);
             if (buffer_strlen(mcpc->error) > 0) {
                 return MCP_RC_BAD_REQUEST;
             }
@@ -423,7 +428,8 @@ MCP_RETURN_CODE mcp_unified_list_tool_execute(MCP_CLIENT *mcpc, const MCP_LIST_T
     if (config->params.has_nodes) {
         if (config->params.nodes_as_array) {
             // Parse nodes as array
-            nodes_buffer = mcp_params_parse_array_to_pattern(params, "nodes", false, false, MCP_TOOL_LIST_NODES, mcpc->error);
+            nodes_buffer = mcp_params_parse_array_to_pattern(
+                params, "nodes", config->params.nodes_required, false, MCP_TOOL_LIST_NODES, mcpc->error);
             if (buffer_strlen(mcpc->error) > 0) {
                 return MCP_RC_BAD_REQUEST;
             }
@@ -440,12 +446,12 @@ MCP_RETURN_CODE mcp_unified_list_tool_execute(MCP_CLIENT *mcpc, const MCP_LIST_T
     // Check required parameters
     if (config->params.metrics_required && !metrics_pattern) {
         buffer_sprintf(mcpc->error, "Missing required parameter 'metrics'. Use '" MCP_TOOL_LIST_METRICS "' to discover available metrics.");
-        return MCP_RC_ERROR;
+        return MCP_RC_BAD_REQUEST;
     }
     
     if (config->params.nodes_required && !nodes_pattern) {
         buffer_sprintf(mcpc->error, "Missing required parameter 'nodes'. Use '" MCP_TOOL_LIST_NODES "' to discover available nodes.");
-        return MCP_RC_ERROR;
+        return MCP_RC_BAD_REQUEST;
     }
 
     // Extract time parameters (only if the tool supports them)

--- a/src/web/mcp/mcp-tools-query-metrics.c
+++ b/src/web/mcp/mcp-tools-query-metrics.c
@@ -58,7 +58,8 @@ void mcp_tool_query_metrics_schema(BUFFER *buffer) {
         "Dimensions Filter",
         "Array of dimensions to include in the query.\n"
         "Examples: [\"read\", \"write\"] or [\"in\", \"out\"] or [\"used\", \"free\", \"cached\"]\n"
-        "Use the '" MCP_TOOL_GET_METRICS_DETAILS "' tool to discover the available dimensions for a metric.");
+        "Use the '" MCP_TOOL_GET_METRICS_DETAILS "' tool to discover the available dimensions for a metric.",
+        true);
 
     mcp_schema_add_labels_object(
         buffer, "Labels Filter",
@@ -75,7 +76,8 @@ void mcp_tool_query_metrics_schema(BUFFER *buffer) {
         "If no instances are specified, all instances of the metric are queried.\n"
         "Example: [\"instance1\", \"instance2\", \"instance3\"]\n."
         "IMPORTANT: when you have a choice, prefer to filter by labels instead of instances, because many monitored "
-        "components may change instance names over time.");
+        "components may change instance names over time.",
+        false);
 
     mcp_schema_add_array_param(
         buffer, "nodes",
@@ -83,7 +85,8 @@ void mcp_tool_query_metrics_schema(BUFFER *buffer) {
         "Array of nodes to include in the query.\n"
         "If no nodes are specified, all nodes having data for the given metrics in the specified time-frame will be queried.\n"
         "Examples: [\"node1\", \"node2\", \"node3\"]\n"
-        "Use the '" MCP_TOOL_LIST_NODES "' tool to discover the available nodes.");
+        "Use the '" MCP_TOOL_LIST_NODES "' tool to discover the available nodes.",
+        false);
 
     // Add cardinality limit
     mcp_schema_add_cardinality_limit(buffer,
@@ -197,6 +200,7 @@ void mcp_tool_query_metrics_schema(BUFFER *buffer) {
             "- 'node': Groups by node. Example: for disks, it provides one metric per node, aggregating reads and writes across all its disks.\n"
             "- 'label': Groups by the given label key (use the parameter 'group_by_label' to set the key). Example: for disks, aggregate over key 'disk_type' to get an group all 'physical', 'virtual' and 'partition' separately.\n"
             "Multiple groupings can be combined. Example: '[\"dimension\", \"label\"]'.");
+        buffer_json_member_add_uint64(buffer, "minItems", 1);
         buffer_json_member_add_array(buffer, "default");
         buffer_json_add_array_item_string(buffer, "dimension");
         buffer_json_array_close(buffer);
@@ -318,7 +322,7 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     struct json_object *group_by_obj = NULL, *aggregation_obj = NULL, *dimensions_obj = NULL;
     
     if (!json_object_object_get_ex(params, "dimensions", &dimensions_obj) || !dimensions_obj) {
-        buffer_sprintf(mcpc->error, "Missing required parameter 'dimensions'. Use the '" MCP_TOOL_LIST_METRICS "' to get the list of dimensions for this metric/context.");
+        buffer_sprintf(mcpc->error, "Missing required parameter 'dimensions'. Use the '" MCP_TOOL_GET_METRICS_DETAILS "' tool to get the list of dimensions for this metric/context.");
         return MCP_RC_BAD_REQUEST;
     }
     
@@ -401,8 +405,7 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     
     dimensions_buffer = mcp_params_parse_array_to_pattern(params, "dimensions", true, false, MCP_TOOL_GET_METRICS_DETAILS, mcpc->error);
     if (buffer_strlen(mcpc->error) > 0) {
-        buffer_strcat(mcpc->error, ". You must explicitly list every dimension you want to query. "
-                                   "Use the '" MCP_TOOL_GET_METRICS_DETAILS "' tool to discover available dimensions for the context.");
+        buffer_strcat(mcpc->error, " You must explicitly list every dimension you want to query.");
         return MCP_RC_BAD_REQUEST;
     }
     // Handle labels - expects a structured object only
@@ -493,8 +496,9 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     CLEAN_BUFFER *group_by_buffer = NULL;
     const char *group_by_str = NULL;
     
-    group_by_buffer = mcp_params_parse_array_to_pattern(params, "group_by", true, false, MCP_TOOL_GET_METRICS_DETAILS, mcpc->error);
+    group_by_buffer = mcp_params_parse_array_to_pattern(params, "group_by", true, false, NULL, mcpc->error);
     if (buffer_strlen(mcpc->error) > 0) {
+        buffer_strcat(mcpc->error, " Valid values are: 'dimension', 'instance', 'node', 'label'.");
         return MCP_RC_BAD_REQUEST;
     }
     

--- a/src/web/mcp/mcp-tools-query-metrics.c
+++ b/src/web/mcp/mcp-tools-query-metrics.c
@@ -319,11 +319,7 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     
     // Check if all required parameters are provided
     struct json_object *after_obj = NULL, *before_obj = NULL, *points_obj = NULL, *time_group_obj = NULL;
-    struct json_object *aggregation_obj = NULL, *dimensions_obj = NULL;
-
-    // 'dimensions' and 'group_by' are validated where they are parsed, so a missing parameter and an empty
-    // array give the same guidance
-    json_object_object_get_ex(params, "dimensions", &dimensions_obj);
+    struct json_object *aggregation_obj = NULL;
 
     if (!json_object_object_get_ex(params, "after", &after_obj) || !after_obj) {
         buffer_sprintf(mcpc->error, "Missing required parameter 'after'. This parameter defines the start time for your query (Unix epoch timestamp in seconds, or negative value relative to 'before', or RFC3339 datetime string).");
@@ -397,12 +393,17 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     // Handle dimensions array parameter
     CLEAN_BUFFER *dimensions_buffer = NULL;
     
+    // 'dimensions' and 'group_by' are validated here, where they are parsed, so that a missing parameter
+    // and an empty array give the same guidance
+    struct json_object *dimensions_obj = NULL;
     dimensions_buffer = mcp_params_parse_array_to_pattern(params, "dimensions", true, false, NULL, mcpc->error);
     if (buffer_strlen(mcpc->error) > 0) {
         buffer_strcat(mcpc->error, " You must explicitly list every dimension you want to query. "
                                    "Use the '" MCP_TOOL_GET_METRICS_DETAILS "' tool to discover available dimensions for the context.");
         return MCP_RC_BAD_REQUEST;
     }
+    // the parse above proves 'dimensions' is a non-empty array of strings
+    json_object_object_get_ex(params, "dimensions", &dimensions_obj);
     // Handle labels - expects a structured object only
     CLEAN_BUFFER *labels_buffer = NULL;
     
@@ -494,7 +495,8 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     group_by_buffer = mcp_params_parse_array_to_pattern(params, "group_by", true, false, NULL, mcpc->error);
     if (buffer_strlen(mcpc->error) > 0) {
         buffer_strcat(mcpc->error, " This parameter defines how to group metrics. "
-                                   "Valid values are: 'dimension', 'instance', 'node', 'label'.");
+                                   "Valid values are: 'dimension', 'instance', 'node', 'label', "
+                                   "and they can be combined, e.g. [\"dimension\", \"node\"].");
         return MCP_RC_BAD_REQUEST;
     }
     

--- a/src/web/mcp/mcp-tools-query-metrics.c
+++ b/src/web/mcp/mcp-tools-query-metrics.c
@@ -319,13 +319,12 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     
     // Check if all required parameters are provided
     struct json_object *after_obj = NULL, *before_obj = NULL, *points_obj = NULL, *time_group_obj = NULL;
-    struct json_object *group_by_obj = NULL, *aggregation_obj = NULL, *dimensions_obj = NULL;
-    
-    if (!json_object_object_get_ex(params, "dimensions", &dimensions_obj) || !dimensions_obj) {
-        buffer_sprintf(mcpc->error, "Missing required parameter 'dimensions'. Use the '" MCP_TOOL_GET_METRICS_DETAILS "' tool to get the list of dimensions for this metric/context.");
-        return MCP_RC_BAD_REQUEST;
-    }
-    
+    struct json_object *aggregation_obj = NULL, *dimensions_obj = NULL;
+
+    // 'dimensions' and 'group_by' are validated where they are parsed, so a missing parameter and an empty
+    // array give the same guidance
+    json_object_object_get_ex(params, "dimensions", &dimensions_obj);
+
     if (!json_object_object_get_ex(params, "after", &after_obj) || !after_obj) {
         buffer_sprintf(mcpc->error, "Missing required parameter 'after'. This parameter defines the start time for your query (Unix epoch timestamp in seconds, or negative value relative to 'before', or RFC3339 datetime string).");
         return MCP_RC_BAD_REQUEST;
@@ -343,11 +342,6 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     
     if (!json_object_object_get_ex(params, "time_group", &time_group_obj) || !time_group_obj) {
         buffer_sprintf(mcpc->error, "Missing required parameter 'time_group'. This parameter defines how to aggregate data points over time (e.g., 'average', 'min', 'max', 'sum').");
-        return MCP_RC_BAD_REQUEST;
-    }
-    
-    if (!json_object_object_get_ex(params, "group_by", &group_by_obj) || !group_by_obj) {
-        buffer_sprintf(mcpc->error, "Missing required parameter 'group_by'. This parameter defines how to group metrics (e.g., 'dimension', 'instance', 'node', or combinations like 'dimension,node').");
         return MCP_RC_BAD_REQUEST;
     }
     
@@ -499,7 +493,8 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     
     group_by_buffer = mcp_params_parse_array_to_pattern(params, "group_by", true, false, NULL, mcpc->error);
     if (buffer_strlen(mcpc->error) > 0) {
-        buffer_strcat(mcpc->error, " Valid values are: 'dimension', 'instance', 'node', 'label'.");
+        buffer_strcat(mcpc->error, " This parameter defines how to group metrics. "
+                                   "Valid values are: 'dimension', 'instance', 'node', 'label'.");
         return MCP_RC_BAD_REQUEST;
     }
     

--- a/src/web/mcp/mcp-tools-query-metrics.c
+++ b/src/web/mcp/mcp-tools-query-metrics.c
@@ -403,9 +403,10 @@ MCP_RETURN_CODE mcp_tool_query_metrics_execute(MCP_CLIENT *mcpc, struct json_obj
     // Handle dimensions array parameter
     CLEAN_BUFFER *dimensions_buffer = NULL;
     
-    dimensions_buffer = mcp_params_parse_array_to_pattern(params, "dimensions", true, false, MCP_TOOL_GET_METRICS_DETAILS, mcpc->error);
+    dimensions_buffer = mcp_params_parse_array_to_pattern(params, "dimensions", true, false, NULL, mcpc->error);
     if (buffer_strlen(mcpc->error) > 0) {
-        buffer_strcat(mcpc->error, " You must explicitly list every dimension you want to query.");
+        buffer_strcat(mcpc->error, " You must explicitly list every dimension you want to query. "
+                                   "Use the '" MCP_TOOL_GET_METRICS_DETAILS "' tool to discover available dimensions for the context.");
         return MCP_RC_BAD_REQUEST;
     }
     // Handle labels - expects a structured object only

--- a/src/web/mcp/mcp-tools-weights.c
+++ b/src/web/mcp/mcp-tools-weights.c
@@ -228,21 +228,25 @@ static void add_weights_filter_parameters(BUFFER *buffer) {
     mcp_schema_add_array_param(
         buffer, "metrics",
         "Filter by metrics",
-        "Array of metrics (contexts) to filter (e.g., ['system.cpu', 'disk.io', 'mysql.queries']). Use '" MCP_TOOL_LIST_METRICS "' to discover available metrics.");
+        "Array of metrics (contexts) to filter (e.g., ['system.cpu', 'disk.io', 'mysql.queries']). Use '" MCP_TOOL_LIST_METRICS "' to discover available metrics.",
+        false);
     
     mcp_schema_add_array_param(
         buffer, "nodes",
         "Filter by nodes",
-        "Array of nodes to filter (e.g., ['web-server-1', 'database-primary']). Use '" MCP_TOOL_LIST_NODES "' to discover available nodes.");
+        "Array of nodes to filter (e.g., ['web-server-1', 'database-primary']). Use '" MCP_TOOL_LIST_NODES "' to discover available nodes.",
+        false);
     
     mcp_schema_add_array_param(
         buffer, "instances",
         "Filter by instances",
-        "Array of metric instances to filter (e.g., ['eth0', 'sda', 'production_db']). Use '" MCP_TOOL_GET_METRICS_DETAILS "' to discover instances for a metric.");
+        "Array of metric instances to filter (e.g., ['eth0', 'sda', 'production_db']). Use '" MCP_TOOL_GET_METRICS_DETAILS "' to discover instances for a metric.",
+        false);
     
     mcp_schema_add_array_param(buffer, "dimensions",
         "Filter by dimensions",
-        "Array of dimension names to filter (e.g., ['user', 'writes', 'slow_queries']). Use '" MCP_TOOL_GET_METRICS_DETAILS "' to discover dimensions for a metric.");
+        "Array of dimension names to filter (e.g., ['user', 'writes', 'slow_queries']). Use '" MCP_TOOL_GET_METRICS_DETAILS "' to discover dimensions for a metric.",
+        false);
     
     mcp_schema_add_labels_object(buffer,
         "Filter by labels",


### PR DESCRIPTION
##### Summary
- MCP tool schemas listed some array parameters as `required` but never advertised a minimum length, so a client could send `[]`, pass client-side validation, and get a runtime `BAD_REQUEST`.
- `mcp_schema_add_array_param()` now takes a `required` flag and emits `"minItems": 1`; every call site passes the flag its runtime check already enforces, so schema and runtime cannot drift.
- Six parameters were affected, not just the reported one: `query_metrics.dimensions`, `query_metrics.group_by`, `list_alert_transitions.status`, `get_metrics_details.metrics`,  `list_functions.nodes`, `get_nodes_details.nodes`.
- Optional array filters are unchanged — `[]` still means "no filter".
- `get_metrics_details` / `list_functions` / `get_nodes_details` now return `BAD_REQUEST` instead of an internal error for a missing or empty required array, with the accurate "cannot be an empty array" message.
- Error messages for missing/empty required arrays now carry the "use `<tool>` to discover values" hint from one place instead of each caller, and the missing-`dimensions` message points at `get_metrics_details` rather than `list_metrics`.

Verified with a before/after A/B on a test host: `tools/list` goes from 0 to exactly 6 parameters with `minItems: 1` out of 38 array parameters; the empty-array calls are still refused server-side, and all optional-empty and real-value calls behave identically.

Fixes #23802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for required array parameters, including clearer parameter-specific errors and appropriate bad-request responses.
  - Schemas now accurately identify required and optional array parameters and reject empty values where necessary.
  - Corrected parameter validation and error reporting for alert transitions, metadata listings, and metric queries.

- **Usability**
  - Error messages now provide clearer guidance for discovering valid parameter values through available listing tools.
  - Added optional guidance when wildcard-containing arrays are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->