### PR TITLE
docs(netdata-ai): add Infrastructure Knowledge page

### DIFF
--- a/docs/.map/map.yaml
+++ b/docs/.map/map.yaml
@@ -994,6 +994,15 @@ sidebar:
             - real-time
             - live exhibits
       - meta:
+          label: Infrastructure Knowledge
+          edit_url: https://github.com/netdata/netdata/edit/master/docs/netdata-ai/infrastructure-knowledge.md
+          description: Teach Netdata AI about your infrastructure, in a shared document or in conversation
+          keywords:
+            - infrastructure knowledge
+            - context
+            - memory
+            - infra.md
+      - meta:
           label: Insights
           edit_url: https://github.com/netdata/netdata/edit/master/docs/ml-ai/ai-insights.md
         items:

--- a/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md
+++ b/docs/category-overview-pages/machine-learning-and-assisted-troubleshooting.md
@@ -52,6 +52,10 @@ Local, unsupervised ML runs on every agent, learning normal behavior and scoring
 
 Connect AI clients to Netdata’s MCP server to bring live observability into natural‑language workflows and optional automation. Options include [MCP](/docs/netdata-ai/mcp/README.md), [Chat with Netdata](/docs/netdata-ai/mcp/ai-chat-netdata.md), and [Supported AI Clients](/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md) like Claude Desktop, Cursor, VS Code, JetBrains IDEs, Claude Code, Gemini CLI, and the Netdata Web Client. Netdata Cloud can also act as an MCP client that connects to your own tools — see [MCP Connections](/docs/netdata-ai/mcp/mcp-connections.md).
 
+### 8) Infrastructure Knowledge
+
+[Infrastructure Knowledge](/docs/netdata-ai/infrastructure-knowledge.md) is what Netdata AI knows about *your* infrastructure that telemetry cannot show: service tiers, ownership, known behaviours, SLOs. Write it down in a shared document, or simply tell Netdata AI in a conversation and let it remember — every conversation, investigation, and report uses it.
+
 ## Usage and credits
 
 - Eligible Spaces receive 10 free AI credits; each Insights report, investigation, or alert troubleshooting run consumes 1 AI credit.

--- a/docs/netdata-ai/conversations.md
+++ b/docs/netdata-ai/conversations.md
@@ -54,6 +54,10 @@ Use the right tool for the right job:
 
 Click the **"Conversations"** button above the space selectors in Netdata Cloud. Your conversation history is saved, allowing you to pick up an investigation where you left off.
 
+## Teaching Netdata AI about your infrastructure
+
+Conversations are also where Netdata AI learns. Tell it what only your team knows — *"remember that this alert is expected on the batch nodes"*, *"db-3 is the replica, not the primary"* — and it keeps that for every future conversation, investigation, and report in your Space. See [Infrastructure Knowledge](/docs/netdata-ai/infrastructure-knowledge.md).
+
 ## AI credits consumption
 
 Usage is based on AI credits (10 monthly complimentary credits on Business plans, plus the ability to top up as needed).
@@ -71,3 +75,4 @@ Real-Time Conversations are available for all users on a Business plan or free t
 - [Investigations](/docs/netdata-ai/investigations/index.md) – comprehensive async analysis
 - [Insights](/docs/ml-ai/ai-insights.md) – on-demand professional reports
 - [Troubleshooting](/docs/netdata-ai/troubleshooting/index.md) – alert analysis and anomaly exploration
+- [Infrastructure Knowledge](/docs/netdata-ai/infrastructure-knowledge.md) – what Netdata AI knows about your infrastructure, and how to teach it more

--- a/docs/netdata-ai/infrastructure-knowledge.md
+++ b/docs/netdata-ai/infrastructure-knowledge.md
@@ -1,0 +1,63 @@
+# Infrastructure Knowledge
+
+Netdata AI sees everything your infrastructure *does* — every metric, every anomaly, every alert. What it cannot see is what your infrastructure *is*: which services matter, which host is the one that is supposed to run hot, who owns what, and what your team considers normal. Without that, "CPU at 91%" is a finding. With it, it may be a machine doing exactly its job.
+
+**Infrastructure Knowledge** is where that context lives. Think of it as onboarding a new SRE to your team: the more you tell Netdata AI about your infrastructure, the more accurate its conversations, investigations, and reports become — and the more its answers sound like they come from someone who already knows your environment.
+
+There are two ways to teach it, and they work together:
+
+- **Write it down.** Your Space has a shared document that describes your infrastructure. Your team edits it directly.
+- **Tell it in a conversation.** As you work with Netdata AI, you can ask it to remember things, and it can pick up what you tell it along the way. It gets to know your infrastructure progressively, the way a new colleague would.
+
+Everything you teach Netdata AI is visible under **Manage Space → Infrastructure Knowledge**, in two tabs: **Your Context** and **AI Memory**.
+
+## Your Context
+
+**Your Context** is a single Markdown document your team maintains. It is read at the start of every conversation, investigation, and report about your infrastructure.
+
+Describe the things that only your team knows. The editor offers section templates to get you started:
+
+- **Infrastructure Overview** — what you run and where, in a few paragraphs.
+- **Service Tiers** — which services are critical, which are best-effort, what is worth waking someone up for.
+- **Known Behaviours** — patterns that look like problems and are not: the nightly batch job, the ML node that always runs hot, the idle half of a blue-green deployment.
+- **SLOs & Business Context** — your targets and what a breach means to the business.
+- **Team Preferences** — how you want findings presented, who to mention for what.
+- **Upcoming Events** — maintenance windows, migrations, expected load changes.
+- **Architecture Notes** — naming conventions, dependencies, anything that would trip up a newcomer.
+
+You do not need to fill in everything. A few honest lines about what matters and what is expected already change how Netdata AI reads your data. Skip anything Netdata can already see for itself — node lists, current values, running processes — and never put credentials or personal data in it.
+
+Every save keeps a version, so you can review what changed and go back to an earlier version at any time.
+
+You can also ask Netdata AI to update the document for you in a conversation — for example, *"Add the new Kafka cluster to my infrastructure context"* — and it tells you what it changed.
+
+## AI Memory
+
+**AI Memory** is what Netdata AI has learned from talking to your team. Each memory is a single fact about your infrastructure, shared with everyone in the Space and used in every future conversation, investigation, and report.
+
+You build it up simply by talking:
+
+- *"Remember that the 02:00 disk spike on backup-01 is expected."*
+- *"That alert is a false positive — the temp files get cleaned hourly."*
+- *"db-3 is the replica, not the primary."*
+- *"Keep investigation summaries short."*
+
+Netdata AI tells you when it records something, so you can correct it while you still have the context. Say *"don't remember that"* and it forgets. It may also offer to remember a correction you make during troubleshooting.
+
+The **AI Memory** tab lists everything it has learned. You can read each memory, delete the ones that no longer apply, or clear them all.
+
+## How Netdata AI uses it
+
+Netdata AI reads your context and memories before it interprets anything, not after. Your context tells it what things *mean*; telemetry tells it what is *happening*. It uses your knowledge to interpret the data, never to override it — if your document says a node was decommissioned and the node is still reporting, it tells you the two disagree rather than picking a side.
+
+When your context changes a conclusion — a node it did not flag because you marked it as a staging tier, a spike it called expected because you said so — it says where that came from. When it needed context you have not given it, it says that too, so you know what to add next.
+
+## Availability
+
+Infrastructure Knowledge is available on paid Netdata Cloud plans. Space admins, managers, and troubleshooters can edit it; observers can view it.
+
+## See also
+
+- [Conversations](/docs/netdata-ai/conversations.md) — where you teach Netdata AI as you work.
+- [Investigations](/docs/netdata-ai/investigations/index.md) and [AI Insights](/docs/ml-ai/ai-insights.md) — reports that use your context.
+- [MCP Connections](/docs/netdata-ai/mcp/mcp-connections.md) — bring in context from the tools your team already runs.

--- a/docs/netdata-ai/mcp/mcp-connections.md
+++ b/docs/netdata-ai/mcp/mcp-connections.md
@@ -6,6 +6,8 @@ An alert tells you *what* changed. It rarely tells you *why*. That answer usuall
 
 This is the reverse of connecting an AI client *to* Netdata. Here, **Netdata reaches out to your MCP servers**. To instead connect an AI assistant (Claude, Cursor, a CLI) to Netdata's own MCP server, see [Supported AI Clients](/docs/netdata-ai/mcp/mcp-clients/ai-devops-copilot.md).
 
+MCP Connections bring in context from other systems. For the context only your team can provide — service tiers, known behaviours, ownership — see [Infrastructure Knowledge](/docs/netdata-ai/infrastructure-knowledge.md).
+
 ![MCP Connections settings](https://raw.githubusercontent.com/netdata/docs-images/refs/heads/master/netdata-cloud/netdata-ai/mcp-connections-settings.png)
 
 ## Prerequisites


### PR DESCRIPTION
Adds a user-facing documentation page for **Infrastructure Knowledge** in Netdata Cloud (Manage Space → Infrastructure Knowledge): the shared context document a team writes for Netdata AI, and the AI Memory it builds from conversations.

Part of [Infrastructure Knowledge](https://github.com/netdata/product/issues/3306).

**Changes**
- New page `docs/netdata-ai/infrastructure-knowledge.md` — what it is, the two ways to teach Netdata AI (write it down, or tell it in a conversation), what to write, how memories are reviewed and forgotten, how the AI uses it.
- `docs/.map/map.yaml` — sidebar entry under Netdata AI, after Conversations.
- Netdata AI overview — new capability entry.
- Conversations and MCP Connections — short cross-links.

High-level by design: no limits, role tables, or internals. No screenshots yet; they can follow via docs-images.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the user-facing documentation page for Infrastructure Knowledge, the Netdata Cloud feature that lets teams teach Netdata AI about their infrastructure in a shared document or through conversations. The feature has been live without docs; this page explains the two ways to teach the AI, what to write, how to review and forget memories, who can use it, and how the AI weighs that context against live telemetry.

Also registers the page in the sidebar under Netdata AI, lists it as a capability on the Netdata AI overview, and cross-links it from the Conversations and MCP Connections pages. Deliberately leaves out internals like size limits and role tables; screenshots can follow via docs-images. Part of [Infrastructure Knowledge](https://github.com/netdata/product/issues/3306).

<sup>Written for commit 04bca32f83b190d04bb1d4e2c8147ec409cc4512. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added documentation for Infrastructure Knowledge in Netdata AI.
  - Explained how teams can provide infrastructure context through a shared Markdown document or conversations.
  - Documented how this context is retained and applied across future conversations, investigations, reports, and telemetry interpretation.
  - Added details about editing, versioning, availability, and permissions.
  - Added navigation links, sidebar access, and cross-references throughout Netdata AI documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->