### PR TITLE
Drop Debian 11 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -169,19 +169,6 @@ include:
         - arm64
     test:
       ebpf-core: true
-  - <<: *debian
-    version: "11"
-    base_image: debian:bullseye
-    packages:
-      <<: *debian_packages
-      repo_distro: debian/bullseye
-      arches:
-        - i386
-        - amd64
-        - armhf
-        - arm64
-    test:
-      ebpf-core: false
 
   - &fedora
     distro: fedora
@@ -371,6 +358,11 @@ legacy: # Info for platforms we used to support and still need to handle package
         - el/7Client
       arches:
         - x86_64
+  - <<: *debian
+    version: "11"
+    packages:
+      <<: *debian_packages
+      repo_distro: debian/bullseye
   - <<: *debian
     version: "10"
     packages:

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -72,7 +72,6 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 | Docker                   | 19.03 or newer | x86\_64, ARMv7, AArch64       | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker           |
 | Debian                   | 13.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
 | Debian                   | 12.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
-| Debian                   | 11.x           | x86\_64, i386, ARMv7, AArch64 |                                                                                                                |
 | Fedora                   | 44             | x86\_64, AArch64              |                                                                                                                |
 | Fedora                   | 43             | x86\_64, AArch64              |                                                                                                                |
 | openSUSE                 | Tumbleweed     | x86\_64, AArch64              |                                                                                                                |
@@ -174,6 +173,7 @@ This is a list of platforms that we have supported in the recent past but no lon
 |--------------------------|-----------|----------------------|
 | Amazon Linux             | 2         | EOL as of 2026-06-30 |
 | CentOS                   | 7.x       | EOL as of 2026-06-30 |
+| Debian                   | 11.x      | EOL as of 2026-08-31 |
 | Debian                   | 10.x      | EOL as of 2024-07-01 |
 | Fedora                   | 42        | EOL as of 2026-05-13 |
 | Fedora                   | 41        | EOL as of 2025-12-15 |


### PR DESCRIPTION
##### Summary

It ended LTS upstream 2026-08-31.

##### Test Plan

n/a

##### Additional Information

Closes #23366

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops Debian 11 from CI testing and package builds, since it reached upstream LTS EOL on 2026-08-31. Debian 11 now appears in the legacy platform list in `packaging/PLATFORM_SUPPORT.md`. Closes #23366.

<sup>Written for commit f313fb1a50e06acee3e265b16b1b55b4a5b7931b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Platform Support**
  - Debian 11.x is no longer listed among actively supported platforms.
  - Debian 11.x has been moved to previously supported platforms, with support ending on August 31, 2026.

- **Continuous Integration**
  - Debian 11 has been moved from the active test matrix to the legacy test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->