### PR TITLE
perf(go.d/chartengine): cache autogen routes and optimize expiry

### DIFF
--- a/src/go/plugin/framework/chartengine/README.md
+++ b/src/go/plugin/framework/chartengine/README.md
@@ -226,7 +226,12 @@ defaults preserve the same three states through inheritance.
 - A live metric identity must keep the same kind while its dimension is materialized. Kind changes are resolved for route
   planning, but an existing Netdata dimension keeps its creation-time wire algorithm until it expires and is recreated.
 
-Route-cache entries are immutable discovery results. Algorithm resolution happens after cache lookup, so a cached route
+Route-cache entries are immutable discovery results. Authored and successful autogen routes share the
+series-identity/revision cache. Autogen hits additionally validate current metric metadata (including its presence),
+exposed kind, source kind, and flatten role before reuse. A changed descriptor rebuilds the route; template reload
+clears the cache, and diagnostic planning bypasses it. Cached autogen discovery follows the same snapshot-membership
+retention as authored routes and trades additional retained route/guard memory for less per-cycle construction.
+Algorithm resolution happens after cache lookup, so a cached route
 cannot retain the effective algorithm from an earlier series kind. Only concrete algorithms reach accumulated dimension
 state and dimension actions; chart-level metadata retains the configured policy.
 
@@ -313,6 +318,19 @@ Notes:
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | Program            | Immutable compiled IR per revision                                                                                                          |
 | Engine state       | Serialized under `Engine.mu` for load/build transitions                                                                                     |
-| Route cache        | Series identity + revision keyed cache; retained by successful sequence, pruned on each build                                               |
+| Route cache        | Series identity + revision keyed authored/autogen discovery; autogen validates current metadata and kinds; retained by successful sequence, pruned on each build                                               |
 | Materialized state | Tracks existing chart/dimension instances for incremental create/update/remove decisions; persists across cycles, resets on template reload |
 | Determinism        | Sorted chart IDs and inferred dimensions provide stable action ordering                                                                     |
+
+## Performance Validation
+
+Steady collector-mode benchmarks must advance the successful collection sequence. Replanning a previously committed
+sequence intentionally deduplicates its updates, so a repeated-snapshot benchmark must instead use runtime planner mode.
+Benchmarks should verify emitted chart/dimension counts and values after warmup.
+
+`BenchmarkAutogenMixedChurn` measures a bounded population with stable, partially replaced, or fully replaced
+identities; `BenchmarkCollectExpiryRemovals` covers stable, partial, and mass expiry across chart/dimension shapes.
+Metric collection and fixture setup are outside those planner/expiry timers. Expiry scans retained charts and enabled
+dimensions but sorts only actual removals. Steady expiry allocates no removal memory; staging and output still scale
+with retained/output cardinality. Unit allocation envelopes guard these properties; elapsed benchmark timings are
+development-machine trends, not CI limits.

--- a/src/go/plugin/framework/chartengine/autogen.go
+++ b/src/go/plugin/framework/chartengine/autogen.go
@@ -16,6 +16,25 @@ const (
 	autogenTemplatePrefix = "__autogen__:"
 )
 
+// Autogen output also depends on current reader metadata and flattened kinds;
+// series identity and template revision alone do not validate these routes.
+type autogenRouteGuard struct {
+	source      autogenSource
+	metadata    metrix.MetricMeta
+	hasMetadata bool
+	kind        metrix.MetricKind
+	sourceKind  metrix.MetricKind
+	role        metrix.FlattenRole
+}
+
+func (g *autogenRouteGuard) valid(reader metrix.Reader, meta metrix.SeriesMeta) bool {
+	if g == nil || g.kind != meta.Kind || g.sourceKind != meta.SourceKind || g.role != meta.FlattenRole {
+		return false
+	}
+	mm, ok := autogenMetricMeta(reader, g.source)
+	return ok == g.hasMetadata && mm == g.metadata
+}
+
 type autogenRoute struct {
 	chartID           string
 	chartName         string
@@ -102,7 +121,8 @@ func (e *Engine) resolveAutogenRouteWithReason(
 	if !ok {
 		return nil, false, PlanRouteReasonAutogenBuildRejected, -1, nil
 	}
-	if metricMeta, ok := autogenMetricMeta(reader, source); ok {
+	metricMeta, hasMetadata := autogenMetricMeta(reader, source)
+	if hasMetadata {
 		route = applyAutogenMetricMeta(route, metricMeta, meta)
 	}
 	route.priority = effectiveChartPriority(route.priority)
@@ -112,6 +132,14 @@ func (e *Engine) resolveAutogenRouteWithReason(
 	}
 	return []routeBinding{
 		{
+			autogenGuard: &autogenRouteGuard{
+				source:      source,
+				metadata:    metricMeta,
+				hasMetadata: hasMetadata,
+				kind:        meta.Kind,
+				sourceKind:  meta.SourceKind,
+				role:        meta.FlattenRole,
+			},
 			ChartTemplateID:   autogenTemplatePrefix + route.chartID,
 			ChartID:           route.chartID,
 			DimensionIndex:    0,

--- a/src/go/plugin/framework/chartengine/autogen_cache_bench_test.go
+++ b/src/go/plugin/framework/chartengine/autogen_cache_bench_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+)
+
+// A rotating subset is replaced every cycle. Eight generations and three-cycle
+// retention keep cardinality bounded while ensuring replaced identities expire
+// before reuse. Writes/commit/indexing are excluded from the planner timer.
+func BenchmarkAutogenMixedChurn(b *testing.B) {
+	const population = 1000
+	for _, percent := range []int{0, 10, 50, 100} {
+		b.Run(fmt.Sprintf("replace_%d_percent", percent), func(b *testing.B) {
+			store := metrix.NewCollectorStore(metrix.WithExpireAfterSuccessCycles(3))
+			managed, _ := metrix.AsCycleManagedStore(store)
+			cc := managed.CycleController()
+			meter := store.Write().SnapshotMeter("")
+			gauge := meter.Gauge("work")
+			var labels [8][]metrix.LabelSet
+			for generation := range labels {
+				for i := range population {
+					suffix := 0
+					if i < population*percent/100 {
+						suffix = generation
+					}
+					labels[generation] = append(labels[generation], meter.LabelSet(metrix.Label{
+						Key:   "id",
+						Value: fmt.Sprintf("%d_%d", i, suffix),
+					}))
+				}
+			}
+			engine := newAutogenCacheTestEngine(b, WithEnginePolicy(EnginePolicy{
+				Autogen: &AutogenPolicy{
+					Enabled:                  true,
+					ExpireAfterSuccessCycles: 3,
+				},
+			}))
+			cycle := func(i int) metrix.Reader {
+				cc.BeginCycle()
+				for n, l := range labels[i%len(labels)] {
+					gauge.Observe(float64(n), l)
+				}
+				if err := cc.CommitCycleSuccess(); err != nil {
+					b.Fatal(err)
+				}
+				reader := store.Read(metrix.ReadRaw(), metrix.ReadFlatten())
+				reader.ForEachSeriesIdentity(
+					func(metrix.SeriesIdentity, metrix.SeriesMeta, string, metrix.LabelView, metrix.SampleValue) {},
+				)
+				return reader
+			}
+			for i := range 16 {
+				if _, err := buildPlan(engine, cycle(i)); err != nil {
+					b.Fatal(err)
+				}
+			}
+			var last Plan
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := range b.N {
+				b.StopTimer()
+				reader := cycle(i + 16)
+				b.StartTimer()
+				var err error
+				last, err = buildPlan(engine, reader)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			updates, creates, removes := 0, 0, 0
+			for _, a := range last.Actions {
+				switch a.(type) {
+				case UpdateChartAction:
+					updates++
+				case CreateChartAction:
+					creates++
+				case RemoveChartAction:
+					removes++
+				}
+			}
+			if updates != population || creates != population*percent/100 || removes != creates {
+				b.Fatalf("updates/create/remove=%d/%d/%d", updates, creates, removes)
+			}
+			if retained := len(engine.state.materialized.charts); retained > population*3 {
+				b.Fatalf("retained charts=%d exceed retention envelope", retained)
+			}
+		})
+	}
+}
+
+// Construct lifecycle state through real collection and planning, then isolate
+// expiry cost. Each destructive sample gets an untimed clone of that state.
+func BenchmarkCollectExpiryRemovals(b *testing.B) {
+	for _, shape := range []struct{ charts, dims int }{{1, 10000}, {100, 100}, {1000, 10}} {
+		for _, mode := range []string{"none", "half_dimensions", "all_dimensions", "all_charts"} {
+			b.Run(fmt.Sprintf("%s/charts_%d_dims_%d", mode, shape.charts, shape.dims), func(b *testing.B) {
+				engine, err := New(WithRuntimeStore(nil))
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err = engine.LoadYAML([]byte(`version: v1
+groups:
+ - family: Expiry
+   metrics: [work]
+   charts:
+    - id: work
+      title: Work
+      context: work
+      units: units
+      instances:
+       by_labels: [chart]
+      lifecycle:
+       expire_after_cycles: 3
+       dimensions:
+        expire_after_cycles: 2
+      dimensions:
+       - selector: work
+         name_from_label: dim
+`), 1); err != nil {
+					b.Fatal(err)
+				}
+				store := metrix.NewCollectorStore()
+				managed, _ := metrix.AsCycleManagedStore(store)
+				cc := managed.CycleController()
+				m := store.Write().SnapshotMeter("")
+				g := m.Gauge("work")
+				write := func(half bool) {
+					cc.BeginCycle()
+					for c := range shape.charts {
+						for d := range shape.dims {
+							if half && d%2 != 0 {
+								continue
+							}
+							g.Observe(float64(d), m.LabelSet(metrix.Label{
+								Key:   "chart",
+								Value: fmt.Sprint(c),
+							}, metrix.Label{
+								Key:   "dim",
+								Value: fmt.Sprint(d),
+							}))
+						}
+					}
+					if err := cc.CommitCycleSuccess(); err != nil {
+						b.Fatal(err)
+					}
+					if _, err := buildPlan(engine, store.Read(metrix.ReadRaw(), metrix.ReadFlatten())); err != nil {
+						b.Fatal(err)
+					}
+				}
+				write(false)
+				current := uint64(1)
+				wantDims, wantCharts := 0, 0
+				switch mode {
+				case "half_dimensions":
+					write(true)
+					current = 3
+					wantDims = shape.charts * (shape.dims / 2)
+				case "all_dimensions":
+					current = 3
+					wantDims = shape.charts * shape.dims
+				case "all_charts":
+					current = 4
+					wantCharts = shape.charts
+				}
+				fixture := engine.state.materialized
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					b.StopTimer()
+					state := fixture.clone()
+					b.StartTimer()
+					dims, charts := collectExpiryRemovals(current, &state)
+					if len(dims) != wantDims || len(charts) != wantCharts {
+						b.Fatalf("removed dims/charts=%d/%d, want %d/%d", len(dims), len(charts), wantDims, wantCharts)
+					}
+				}
+			})
+		}
+	}
+}

--- a/src/go/plugin/framework/chartengine/autogen_cache_test.go
+++ b/src/go/plugin/framework/chartengine/autogen_cache_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package chartengine
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Separate real stores permit a descriptor to change while preserving the
+// flattened identity. Aborting the first plan retains discovery, not lifecycle.
+func TestAutogenCacheReaderTransitions(t *testing.T) {
+	tests := map[string]struct {
+		first, next func(metrix.SnapshotMeter)
+		sharedName  string
+	}{
+		"metadata changes": {sharedName: "work", first: func(m metrix.SnapshotMeter) {
+			m.Gauge("work", metrix.WithDescription("Before"), metrix.WithUnit("bytes")).Observe(7)
+		}, next: func(m metrix.SnapshotMeter) {
+			m.Gauge("work", metrix.WithDescription("After"), metrix.WithUnit("seconds"), metrix.WithFloat(true)).
+				Observe(7)
+		}},
+		"metadata disappears": {sharedName: "work", first: func(m metrix.SnapshotMeter) {
+			m.Gauge("work", metrix.WithDescription("Before"), metrix.WithUnit("bytes"), metrix.WithFloat(true)).
+				Observe(7)
+		}, next: func(m metrix.SnapshotMeter) { m.Gauge("work").Observe(7) }},
+		"gauge becomes counter": {
+			sharedName: "work",
+			first:      func(m metrix.SnapshotMeter) { m.Gauge("work").Observe(7) },
+			next:       func(m metrix.SnapshotMeter) { m.Counter("work").ObserveTotal(7) },
+		},
+		"counter becomes gauge": {
+			sharedName: "work",
+			first:      func(m metrix.SnapshotMeter) { m.Counter("work").ObserveTotal(7) },
+			next:       func(m metrix.SnapshotMeter) { m.Gauge("work").Observe(7) },
+		},
+		"scalar becomes histogram bucket": {sharedName: "latency_bucket", first: func(m metrix.SnapshotMeter) {
+			m.Counter("latency_bucket").ObserveTotal(7, m.LabelSet(metrix.Label{
+				Key:   "le",
+				Value: "1",
+			}))
+		}, next: observeAutogenCacheHistogram},
+		"histogram count becomes summary count": {
+			sharedName: "latency_count",
+			first:      observeAutogenCacheHistogram,
+			next: func(m metrix.SnapshotMeter) {
+				m.Summary("latency").ObservePoint(metrix.SummaryPoint{
+					Count: 8,
+					Sum:   10,
+				})
+			},
+		},
+		"scalar becomes summary quantile": {sharedName: "latency", first: func(m metrix.SnapshotMeter) {
+			m.Gauge("latency").Observe(7, m.LabelSet(metrix.Label{
+				Key:   "quantile",
+				Value: "0.5",
+			}))
+		}, next: func(m metrix.SnapshotMeter) {
+			m.Summary("latency", metrix.WithSummaryQuantiles(0.5)).ObservePoint(metrix.SummaryPoint{
+				Count:     8,
+				Sum:       10,
+				Quantiles: []metrix.QuantilePoint{{Quantile: 0.5, Value: 7}},
+			})
+		}},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := newAutogenCacheTestEngine(t)
+			before := autogenCacheTestReader(t, tc.first)
+			after := autogenCacheTestReader(t, tc.next)
+			identities := func(reader metrix.Reader) map[string]metrix.SeriesIdentity {
+				out := make(map[string]metrix.SeriesIdentity)
+				reader.ForEachSeriesIdentity(
+					func(id metrix.SeriesIdentity, _ metrix.SeriesMeta, name string, _ metrix.LabelView, _ metrix.SampleValue) {
+						out[name] = id
+					},
+				)
+				return out
+			}
+			require.Contains(t, identities(before), tc.sharedName)
+			require.Contains(t, identities(after), tc.sharedName)
+			require.Equal(
+				t,
+				identities(before)[tc.sharedName],
+				identities(after)[tc.sharedName],
+				"transition must reach the same cache identity",
+			)
+			a, err := e.PreparePlan(before)
+			require.NoError(t, err)
+			a.Abort()
+			actual, err := e.PreparePlan(after)
+			require.NoError(t, err)
+			defer actual.Abort()
+			fresh := newAutogenCacheTestEngine(t, WithPlanRouteDiagnosticObserver(func(PlanRouteDiagnostic) {}))
+			expected, err := fresh.PreparePlan(after)
+			require.NoError(t, err)
+			defer expected.Abort()
+			require.NotEmpty(t, expected.Plan().Actions)
+			assert.Equal(t, expected.Plan(), actual.Plan(), "cached discovery must preserve current reader semantics")
+		})
+	}
+}
+
+func TestAutogenCacheReuseAndReload(t *testing.T) {
+	e := newAutogenCacheTestEngine(t)
+	store := metrix.NewCollectorStore(metrix.WithExpireAfterSuccessCycles(1))
+	cc := mustCycleController(t, store)
+	meter := store.Write().SnapshotMeter("")
+	g := meter.Gauge("work")
+	cycle := func(observe bool) metrix.Reader {
+		cc.BeginCycle()
+		if observe {
+			g.Observe(7)
+		}
+		require.NoError(t, cc.CommitCycleSuccess())
+		return store.Read(metrix.ReadRaw(), metrix.ReadFlatten())
+	}
+	first := cycle(true)
+	_, err := buildPlan(e, first)
+	require.NoError(t, err)
+	var identity metrix.SeriesIdentity
+	first.ForEachSeriesIdentity(
+		func(id metrix.SeriesIdentity, _ metrix.SeriesMeta, _ string, _ metrix.LabelView, _ metrix.SampleValue) {
+			identity = id
+		},
+	)
+	routes, ok := e.state.routeCache.Lookup(identity, 1, 1)
+	require.True(t, ok)
+	require.Len(t, routes, 1)
+	original := &routes[0]
+	next := cycle(true)
+	_, err = buildPlan(e, next)
+	require.NoError(t, err)
+	routes, ok = e.state.routeCache.Lookup(identity, 1, 2)
+	require.True(t, ok)
+	require.Len(t, routes, 1)
+	require.Same(t, original, &routes[0], "unchanged routes should reuse their immutable cached binding")
+	// Source eviction must prune the cached autogen route too.
+	_, err = buildPlan(e, cycle(false))
+	require.NoError(t, err)
+	_, ok = e.state.routeCache.Lookup(identity, 1, 3)
+	require.False(t, ok)
+	_, err = buildPlan(e, cycle(true))
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(`version: v1
+context_namespace: changed
+groups:
+ - family: Authored
+   metrics: [work]
+   charts:
+    - id: authored
+      title: Authored
+      context: work
+      units: requests
+      dimensions:
+       - selector: work
+         name: requests
+`), 2))
+	_, ok = e.state.routeCache.Lookup(identity, 1, 4)
+	require.False(t, ok)
+	plan, err := buildPlan(e, cycle(true))
+	require.NoError(t, err)
+	var created []CreateChartAction
+	for _, a := range plan.Actions {
+		if c, ok := a.(CreateChartAction); ok {
+			created = append(created, c)
+		}
+	}
+	require.Len(t, created, 1)
+	assert.Equal(t, "Authored", created[0].Meta.Title)
+	assert.Equal(t, "changed.work", created[0].Meta.Context)
+}
+
+func TestAutogenWarmPlanAllocationEnvelope(t *testing.T) {
+	for _, n := range []int{128, 512} {
+		t.Run(fmt.Sprint(n), func(t *testing.T) {
+			e := newAutogenCacheTestEngine(t, WithRuntimePlannerMode())
+			reader := autogenCacheTestReader(t, func(m metrix.SnapshotMeter) {
+				g := m.Gauge("work")
+				for i := range n {
+					g.Observe(float64(i), m.LabelSet(metrix.Label{
+						Key:   "id",
+						Value: fmt.Sprint(i),
+					}))
+				}
+			})
+			_, err := buildPlan(e, reader)
+			require.NoError(t, err)
+			allocs := testing.AllocsPerRun(
+				10,
+				func() { plan, err := buildPlan(e, reader); require.NoError(t, err); require.Len(t, plan.Actions, n) },
+			)
+			// Plans still allocate O(output charts/dimensions) staged state. This generous
+			// ceiling excludes rebuilding O(series) autogen strings/routes on every hit.
+			assert.LessOrEqual(t, allocs, float64(15*n+128))
+		})
+	}
+}
+
+func newAutogenCacheTestEngine(t testing.TB, opts ...Option) *Engine {
+	t.Helper()
+	opts = append([]Option{WithRuntimeStore(nil), WithEnginePolicy(EnginePolicy{
+		Autogen: &AutogenPolicy{
+			Enabled: true,
+		},
+	})}, opts...)
+	e, err := New(opts...)
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(benchAutogenTemplateYAML), 1))
+	return e
+}
+func autogenCacheTestReader(t testing.TB, observe func(metrix.SnapshotMeter)) metrix.Reader {
+	t.Helper()
+	s := metrix.NewCollectorStore()
+	managed, ok := metrix.AsCycleManagedStore(s)
+	require.True(t, ok)
+	cc := managed.CycleController()
+	cc.BeginCycle()
+	observe(s.Write().SnapshotMeter(""))
+	require.NoError(t, cc.CommitCycleSuccess())
+	return s.Read(metrix.ReadRaw(), metrix.ReadFlatten())
+}
+func observeAutogenCacheHistogram(m metrix.SnapshotMeter) {
+	m.Histogram("latency", metrix.WithHistogramBounds(1)).ObservePoint(metrix.HistogramPoint{
+		Count: 8,
+		Sum:   10,
+		Buckets: []metrix.BucketPoint{
+			{UpperBound: 1, CumulativeCount: 7},
+			{UpperBound: math.Inf(1), CumulativeCount: 8},
+		},
+	})
+}
+
+// Reader permits missing family metadata even when scalar samples are visible.
+// Only that optional input is hidden; real metrix identity/value iteration is used.
+type autogenMetadataAbsentReader struct{ metrix.Reader }
+
+func (autogenMetadataAbsentReader) MetricMeta(string) (metrix.MetricMeta, bool) {
+	return metrix.MetricMeta{}, false
+}
+
+func TestAutogenCacheMetadataPresence(t *testing.T) {
+	reader := autogenCacheTestReader(t, func(m metrix.SnapshotMeter) {
+		m.Gauge("work", metrix.WithUnit("bytes"), metrix.WithFloat(true)).Observe(1.5)
+	})
+	e := newAutogenCacheTestEngine(t)
+	for _, current := range []metrix.Reader{reader, autogenMetadataAbsentReader{
+		Reader: reader,
+	}, reader} {
+		actual, err := e.PreparePlan(current)
+		require.NoError(t, err)
+		oracle := newAutogenCacheTestEngine(t, WithPlanRouteDiagnosticObserver(func(PlanRouteDiagnostic) {}))
+		expected, err := oracle.PreparePlan(current)
+		require.NoError(t, err)
+		assert.Equal(t, expected.Plan(), actual.Plan())
+		actual.Abort()
+		expected.Abort()
+	}
+}
+
+func TestCollectExpiryNoRemovalAllocationEnvelope(t *testing.T) {
+	for _, n := range []int{128, 512} {
+		t.Run(fmt.Sprint(n), func(t *testing.T) {
+			e := newAutogenCacheTestEngine(t, WithEnginePolicy(EnginePolicy{
+				Autogen: &AutogenPolicy{
+					Enabled:                  true,
+					ExpireAfterSuccessCycles: 3,
+				},
+			}))
+			reader := autogenCacheTestReader(t, func(m metrix.SnapshotMeter) {
+				g := m.Gauge("work")
+				for i := range n {
+					g.Observe(1, m.LabelSet(metrix.Label{
+						Key:   "id",
+						Value: fmt.Sprint(i),
+					}))
+				}
+			})
+			_, err := buildPlan(e, reader)
+			require.NoError(t, err)
+			// Stable expiry still scans retained state, but allocates only for removals.
+			removed := 0
+			allocs := testing.AllocsPerRun(10, func() {
+				dims, charts := collectExpiryRemovals(1, &e.state.materialized)
+				removed += len(dims) + len(charts)
+			})
+			require.Zero(t, removed)
+			assert.Zero(t, allocs)
+		})
+	}
+}

--- a/src/go/plugin/framework/chartengine/autogen_cache_test.go
+++ b/src/go/plugin/framework/chartengine/autogen_cache_test.go
@@ -294,3 +294,50 @@ func TestCollectExpiryNoRemovalAllocationEnvelope(t *testing.T) {
 		})
 	}
 }
+
+// A kind transition can change the family selected by autogen rules without
+// changing flattened identity. Rejection must release the previous discovery.
+func TestAutogenCacheRejectionClearsBindingAndRecovers(t *testing.T) {
+	e, err := New(WithRuntimeStore(nil))
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML(benchmarkAutogenRulesTemplate([]string{"latency"}), 1))
+	before := autogenCacheTestReader(t, func(m metrix.SnapshotMeter) { m.Counter("latency_count").ObserveTotal(8) })
+	after := autogenCacheTestReader(t, observeAutogenCacheHistogram)
+	var oldID, newID metrix.SeriesIdentity
+	before.ForEachSeriesIdentity(func(id metrix.SeriesIdentity, _ metrix.SeriesMeta, name string, _ metrix.LabelView, _ metrix.SampleValue) {
+		if name == "latency_count" {
+			oldID = id
+		}
+	})
+	after.ForEachSeriesIdentity(func(id metrix.SeriesIdentity, _ metrix.SeriesMeta, name string, _ metrix.LabelView, _ metrix.SampleValue) {
+		if name == "latency_count" {
+			newID = id
+		}
+	})
+	require.NotEmpty(t, oldID.ID)
+	require.Equal(t, oldID, newID)
+	initial, err := e.PreparePlan(before)
+	require.NoError(t, err)
+	require.NotEmpty(t, initial.Plan().Actions)
+	initialPlan := initial.Plan()
+	initial.Abort()
+	original, hit := e.state.routeCache.Lookup(oldID, 1, 1)
+	require.True(t, hit)
+	require.Len(t, original, 1)
+	for range 3 {
+		rejected, err := e.PreparePlan(after)
+		require.NoError(t, err)
+		require.Empty(t, rejected.Plan().Actions, "histogram family is denied")
+		rejected.Abort()
+		cached, hit := e.state.routeCache.Lookup(oldID, 1, 1)
+		require.True(t, hit)
+		require.Empty(t, cached, "obsolete scalar binding must be cleared after histogram family rejection")
+	}
+	recovered, err := e.PreparePlan(before)
+	require.NoError(t, err)
+	defer recovered.Abort()
+	require.Equal(t, initialPlan, recovered.Plan(), "empty discovery must allow an eligible source to recover")
+	cached, hit := e.state.routeCache.Lookup(oldID, 1, 1)
+	require.True(t, hit)
+	require.Len(t, cached, 1)
+}

--- a/src/go/plugin/framework/chartengine/matcher.go
+++ b/src/go/plugin/framework/chartengine/matcher.go
@@ -13,15 +13,16 @@ import (
 )
 
 type routeBinding struct {
+	autogenGuard      *autogenRouteGuard
 	ChartTemplateID   string
 	ChartID           string
 	DimensionIndex    int
 	DimensionName     string
 	DimensionKeyLabel string
 	Algorithm         program.Algorithm
-	Hidden            bool
 	Multiplier        int
 	Divisor           int
+	Hidden            bool
 	Float             bool
 	Static            bool
 	Inferred          bool

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -532,6 +532,10 @@ func (e *Engine) forEachPlanSeriesRoute(ctx *planBuildContext, replayLabels bool
 		}
 		if len(routes) > 0 && routes[0].Autogen && !routes[0].autogenGuard.valid(ctx.reader, meta) {
 			routes = nil
+			// Release obsolete discovery even if autogen rebuilding is rejected.
+			if ctx.routeCacheEnabled {
+				ctx.cache.Store(identity, ctx.prog.Revision(), buildSeq, nil)
+			}
 		}
 		if len(routes) == 0 {
 			autoRoutes, ok, reason, ruleIndex, err := e.resolveAutogenRouteWithReason(ctx.reader, name, labels, meta)

--- a/src/go/plugin/framework/chartengine/planner.go
+++ b/src/go/plugin/framework/chartengine/planner.go
@@ -225,7 +225,9 @@ func (e *Engine) preparePlan(reader metrix.Reader) (Plan, materializedState, uin
 	if e.state.outstanding != 0 {
 		return Plan{}, materializedState{}, 0, 0, 0, false, ErrOutstandingPlanAttempt
 	}
-	sample := PlanRuntimeSample{startedAt: time.Now()}
+	sample := PlanRuntimeSample{
+		startedAt: time.Now(),
+	}
 	defer func() { e.observeBuildSample(sample) }()
 	// Failed attempt must not trigger lifecycle transitions.
 	if collectMeta.LastAttemptStatus != metrix.CollectStatusSuccess {
@@ -528,6 +530,9 @@ func (e *Engine) forEachPlanSeriesRoute(ctx *planBuildContext, replayLabels bool
 				ctx.routeCacheMisses++
 			}
 		}
+		if len(routes) > 0 && routes[0].Autogen && !routes[0].autogenGuard.valid(ctx.reader, meta) {
+			routes = nil
+		}
 		if len(routes) == 0 {
 			autoRoutes, ok, reason, ruleIndex, err := e.resolveAutogenRouteWithReason(ctx.reader, name, labels, meta)
 			if err != nil {
@@ -536,6 +541,9 @@ func (e *Engine) forEachPlanSeriesRoute(ctx *planBuildContext, replayLabels bool
 			}
 			if ok {
 				routes = autoRoutes
+				if ctx.routeCacheEnabled {
+					ctx.cache.Store(identity, ctx.prog.Revision(), buildSeq, routes)
+				}
 				if trackStats {
 					ctx.seriesAutogenMatched++
 					ctx.seriesMatched++
@@ -562,6 +570,9 @@ func (e *Engine) forEachPlanSeriesRoute(ctx *planBuildContext, replayLabels bool
 				return
 			}
 		} else if trackStats {
+			if routes[0].Autogen {
+				ctx.seriesAutogenMatched++
+			}
 			ctx.seriesMatched++
 		}
 
@@ -876,7 +887,10 @@ func (e *Engine) materializePlanCharts(ctx *planBuildContext) error {
 				if math.IsNaN(entry.value) || math.IsInf(entry.value, 0) {
 					// A non-finite value (e.g. a summary quantile with no observations this
 					// cycle) must render as a gap, not 0: emit SETEMPTY rather than carry NaN.
-					values = append(values, UpdateDimensionValue{Name: name, IsEmpty: true})
+					values = append(values, UpdateDimensionValue{
+						Name:    name,
+						IsEmpty: true,
+					})
 					continue
 				}
 				values = append(values, UpdateDimensionValue{
@@ -999,7 +1013,10 @@ func sortInferredDimensions(in []InferredDimension) {
 		if lhs.DimensionIndex != rhs.DimensionIndex {
 			return lhs.DimensionIndex < rhs.DimensionIndex
 		}
-		if histogramGroups[inferredDimensionGroup{chartTemplateID: lhs.ChartTemplateID, dimensionIndex: lhs.DimensionIndex}] {
+		if histogramGroups[inferredDimensionGroup{
+			chartTemplateID: lhs.ChartTemplateID,
+			dimensionIndex:  lhs.DimensionIndex,
+		}] {
 			lhsBound, lhsOK := parseHistogramBucketUpperBound(lhs.Name)
 			rhsBound, rhsOK := parseHistogramBucketUpperBound(rhs.Name)
 			if lhsOK && rhsOK && lhsBound != rhsBound {

--- a/src/go/plugin/framework/chartengine/planner_bench_test.go
+++ b/src/go/plugin/framework/chartengine/planner_bench_test.go
@@ -75,13 +75,7 @@ func BenchmarkBuildPlanBySeriesCardinality(b *testing.B) {
 				b.Fatalf("load template: %v", err)
 			}
 
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				if _, err := buildPlan(engine, reader); err != nil {
-					b.Fatalf("build plan: %v", err)
-				}
-			}
+			benchmarkSteadySeriesPlan(b, engine, reader, 1, seriesCount)
 		})
 	}
 }
@@ -111,17 +105,7 @@ func BenchmarkBuildPlanRouteDiagnostics(b *testing.B) {
 			if err := engine.LoadYAML([]byte(benchTemplateYAML), 1); err != nil {
 				b.Fatalf("load template: %v", err)
 			}
-			if _, err := buildPlan(engine, reader); err != nil {
-				b.Fatalf("warm build plan: %v", err)
-			}
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				if _, err := buildPlan(engine, reader); err != nil {
-					b.Fatalf("build plan: %v", err)
-				}
-			}
+			benchmarkSteadySeriesPlan(b, engine, reader, 1, seriesCount)
 			if diagnostics && facts == 0 {
 				b.Fatal("diagnostic observer received no facts")
 			}
@@ -141,7 +125,9 @@ func BenchmarkBuildPlanAutogenUnmatchedBaseline(b *testing.B) {
 			reader := benchmarkCollectorReader(b, seriesCount)
 
 			engine, err := New(WithEnginePolicy(EnginePolicy{
-				Autogen: &AutogenPolicy{Enabled: true},
+				Autogen: &AutogenPolicy{
+					Enabled: true,
+				},
 			}))
 			if err != nil {
 				b.Fatalf("new engine: %v", err)
@@ -150,13 +136,7 @@ func BenchmarkBuildPlanAutogenUnmatchedBaseline(b *testing.B) {
 				b.Fatalf("load template: %v", err)
 			}
 
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				if _, err := buildPlan(engine, reader); err != nil {
-					b.Fatalf("build plan: %v", err)
-				}
-			}
+			benchmarkSteadySeriesPlan(b, engine, reader, seriesCount, seriesCount)
 		})
 	}
 }
@@ -202,7 +182,11 @@ func BenchmarkBuildPlanAggregationFanIn(b *testing.B) {
 						if aggregation.value != "" {
 							aggregationLine = "aggregation: " + aggregation.value
 						}
-						tmpl := strings.ReplaceAll(benchAggregationTemplateYAML, "aggregation: AGGREGATION", aggregationLine)
+						tmpl := strings.ReplaceAll(
+							benchAggregationTemplateYAML,
+							"aggregation: AGGREGATION",
+							aggregationLine,
+						)
 
 						b.ReportAllocs()
 						if mode.warm {
@@ -248,7 +232,7 @@ func benchmarkAggregationEngine(b *testing.B, tmpl string) *Engine {
 	return engine
 }
 
-func benchmarkCollectorReader(b *testing.B, seriesCount int) metrix.Reader {
+func benchmarkCollectorReader(b *testing.B, seriesCount int) *benchmarkSequenceReader {
 	b.Helper()
 
 	store := metrix.NewCollectorStore()
@@ -264,11 +248,21 @@ func benchmarkCollectorReader(b *testing.B, seriesCount int) metrix.Reader {
 	cc.BeginCycle()
 	for i := range seriesCount {
 		g.Observe(metrix.SampleValue(i), meter.LabelSet(
-			metrix.Label{Key: "id", Value: strconv.Itoa(i)},
+			metrix.Label{
+				Key:   "id",
+				Value: strconv.Itoa(i),
+			},
 		))
 	}
-	cc.CommitCycleSuccess()
-	return store.Read(metrix.ReadRaw())
+	if err := cc.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit benchmark cycle: %v", err)
+	}
+	reader := store.Read(metrix.ReadRaw())
+	return &benchmarkSequenceReader{
+		Reader: reader,
+		raw:    reader.(metrix.SeriesIdentityRawIterator),
+		seq:    1,
+	}
 }
 
 func benchmarkAggregationReader(b *testing.B, seriesCount, chartCount int) metrix.Reader {
@@ -287,10 +281,67 @@ func benchmarkAggregationReader(b *testing.B, seriesCount, chartCount int) metri
 	cc.BeginCycle()
 	for i := range seriesCount {
 		g.Observe(metrix.SampleValue(i), meter.LabelSet(
-			metrix.Label{Key: "team", Value: strconv.Itoa(i % chartCount)},
-			metrix.Label{Key: "api_key", Value: strconv.Itoa(i)},
+			metrix.Label{
+				Key:   "team",
+				Value: strconv.Itoa(i % chartCount),
+			},
+			metrix.Label{
+				Key:   "api_key",
+				Value: strconv.Itoa(i),
+			},
 		))
 	}
-	cc.CommitCycleSuccess()
+	if err := cc.CommitCycleSuccess(); err != nil {
+		b.Fatalf("commit benchmark cycle: %v", err)
+	}
 	return store.Read(metrix.ReadRaw())
+}
+
+// Each iteration represents a new successful collection. Repeating a committed
+// sequence intentionally deduplicates updates and does not measure steady planning.
+func benchmarkSteadySeriesPlan(b *testing.B, engine *Engine, reader *benchmarkSequenceReader, charts, series int) {
+	b.Helper()
+	reader.seq = 1
+	if _, err := buildPlan(engine, reader); err != nil {
+		b.Fatalf("warm plan: %v", err)
+	}
+	var plan Plan
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		reader.seq = uint64(i) + 2
+		var err error
+		plan, err = buildPlan(engine, reader)
+		if err != nil {
+			b.Fatalf("build plan: %v", err)
+		}
+	}
+	b.StopTimer()
+	updates, values := 0, 0
+	var total int64
+	for _, action := range plan.Actions {
+		update, ok := action.(UpdateChartAction)
+		if !ok {
+			b.Fatalf("unexpected warmed action %T", action)
+		}
+		updates++
+		for _, value := range update.Values {
+			if value.IsEmpty {
+				b.Fatal("unexpected empty value")
+			}
+			values++
+			total += value.Int64
+		}
+	}
+	if updates != charts || values != series || total != int64(series*(series-1)/2) {
+		b.Fatalf(
+			"updates=%d values=%d total=%d; want %d/%d/%d",
+			updates,
+			values,
+			total,
+			charts,
+			series,
+			series*(series-1)/2,
+		)
+	}
 }

--- a/src/go/plugin/framework/chartengine/planner_lifecycle.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle.go
@@ -338,52 +338,70 @@ func enforceDimensionCapsWithObserver(
 	return removeDims
 }
 
-func collectExpiryRemovals(
-	currentSuccessSeq uint64,
-	state *materializedState,
-) ([]RemoveDimensionAction, []RemoveChartAction) {
+func collectExpiryRemovals(currentSuccessSeq uint64, state *materializedState) ([]RemoveDimensionAction, []RemoveChartAction) {
 	if state == nil || len(state.charts) == 0 {
 		return nil, nil
 	}
-
-	chartIDs := make([]string, 0, len(state.charts))
-	for chartID := range state.charts {
-		chartIDs = append(chartIDs, chartID)
+	type expiryCandidate struct {
+		chartID     string
+		chart       *materializedChartState
+		dimensions  []string
+		removeChart bool
 	}
-	sort.Strings(chartIDs)
-
-	toRemoveChart := make(map[string]struct{})
-	for _, chartID := range chartIDs {
-		matChart := state.charts[chartID]
-		if shouldExpire(matChart.lastSeenSuccessSeq, currentSuccessSeq, matChart.lifecycle.ExpireAfterCycles) {
-			toRemoveChart[chartID] = struct{}{}
-		}
-	}
-
-	removeDims := make([]RemoveDimensionAction, 0)
-	for _, chartID := range chartIDs {
-		if _, removed := toRemoveChart[chartID]; removed {
+	var candidates []expiryCandidate
+	dimensionCount, chartCount := 0, 0
+	for chartID, chart := range state.charts {
+		if shouldExpire(chart.lastSeenSuccessSeq, currentSuccessSeq, chart.lifecycle.ExpireAfterCycles) {
+			candidates = append(candidates, expiryCandidate{
+				chartID:     chartID,
+				chart:       chart,
+				removeChart: true,
+			})
+			chartCount++
 			continue
 		}
-		matChart := state.charts[chartID]
-		expireAfter := matChart.lifecycle.Dimensions.ExpireAfterCycles
-		if expireAfter <= 0 || len(matChart.dimensions) == 0 {
+		expireAfter := chart.lifecycle.Dimensions.ExpireAfterCycles
+		if expireAfter <= 0 {
 			continue
 		}
-
-		dimNames := make([]string, 0, len(matChart.dimensions))
-		for name := range matChart.dimensions {
-			dimNames = append(dimNames, name)
-		}
-		sort.Strings(dimNames)
-		for _, name := range dimNames {
-			dim := matChart.dimensions[name]
-			if !shouldExpire(dim.lastSeenSuccessSeq, currentSuccessSeq, expireAfter) {
-				continue
+		var names []string
+		for name, dim := range chart.dimensions {
+			if shouldExpire(dim.lastSeenSuccessSeq, currentSuccessSeq, expireAfter) {
+				names = append(names, name)
 			}
+		}
+		if len(names) > 0 {
+			candidates = append(candidates, expiryCandidate{
+				chartID:    chartID,
+				chart:      chart,
+				dimensions: names,
+			})
+			dimensionCount += len(names)
+		}
+	}
+	// Order only expired identities, before constructing the larger wire actions.
+	// Exact output sizing also avoids repeated copies during mass expiry.
+	if len(candidates) > 1 {
+		sort.Slice(candidates, func(i, j int) bool { return candidates[i].chartID < candidates[j].chartID })
+	}
+	removeDims := make([]RemoveDimensionAction, 0, dimensionCount)
+	removeCharts := make([]RemoveChartAction, 0, chartCount)
+	for _, candidate := range candidates {
+		chartID, chart := candidate.chartID, candidate.chart
+		if candidate.removeChart {
+			removeCharts = append(removeCharts, RemoveChartAction{
+				ChartID: chartID,
+				Meta:    chart.meta,
+			})
+			delete(state.charts, chartID)
+			continue
+		}
+		sort.Strings(candidate.dimensions)
+		for _, name := range candidate.dimensions {
+			dim := chart.dimensions[name]
 			removeDims = append(removeDims, RemoveDimensionAction{
 				ChartID:    chartID,
-				ChartMeta:  matChart.meta,
+				ChartMeta:  chart.meta,
 				Name:       name,
 				Hidden:     dim.hidden,
 				Float:      dim.float,
@@ -391,24 +409,8 @@ func collectExpiryRemovals(
 				Multiplier: dim.multiplier,
 				Divisor:    dim.divisor,
 			})
-			matChart.removeDimension(name)
+			chart.removeDimension(name)
 		}
-	}
-
-	removeCharts := make([]RemoveChartAction, 0, len(toRemoveChart))
-	for _, chartID := range chartIDs {
-		if _, removed := toRemoveChart[chartID]; !removed {
-			continue
-		}
-		matChart := state.charts[chartID]
-		if matChart == nil {
-			continue
-		}
-		removeCharts = append(removeCharts, RemoveChartAction{
-			ChartID: chartID,
-			Meta:    matChart.meta,
-		})
-		delete(state.charts, chartID)
 	}
 	return removeDims, removeCharts
 }

--- a/src/go/plugin/framework/chartengine/planner_lifecycle_test.go
+++ b/src/go/plugin/framework/chartengine/planner_lifecycle_test.go
@@ -4,6 +4,7 @@ package chartengine
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/pkg/metrix"
@@ -46,9 +47,15 @@ func runTestEnforceLifecycleCapsDimensionCapEvictsLRU(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			meta := program.ChartMeta{Title: "Requests", Context: "requests", Units: "requests/s"}
+			meta := program.ChartMeta{
+				Title:   "Requests",
+				Context: "requests",
+				Units:   "requests/s",
+			}
 			lifecycle := program.LifecyclePolicy{
-				Dimensions: program.DimensionLifecyclePolicy{MaxDims: 2},
+				Dimensions: program.DimensionLifecyclePolicy{
+					MaxDims: 2,
+				},
 			}
 
 			state := newMaterializedState()
@@ -111,7 +118,11 @@ func runTestEnforceLifecycleCapsDimensionCapEvictsLRU(t *testing.T) {
 func runTestEnforceLifecycleCapsMixedPolicies(t *testing.T) {
 	const currentSeq = uint64(10)
 
-	meta := program.ChartMeta{Title: "Requests", Context: "requests", Units: "requests/s"}
+	meta := program.ChartMeta{
+		Title:   "Requests",
+		Context: "requests",
+		Units:   "requests/s",
+	}
 	state := newMaterializedState()
 
 	disabledLifecycle := program.LifecyclePolicy{}
@@ -145,13 +156,17 @@ func runTestEnforceLifecycleCapsMixedPolicies(t *testing.T) {
 		"enabled_old",
 		"tpl.enabled",
 		meta,
-		program.LifecyclePolicy{MaxInstances: 1},
+		program.LifecyclePolicy{
+			MaxInstances: 1,
+		},
 	)
 	require.True(t, created)
 	enabledOld.lastSeenSuccessSeq = 1
 
 	dimsLifecycle := program.LifecyclePolicy{
-		Dimensions: program.DimensionLifecyclePolicy{MaxDims: 1},
+		Dimensions: program.DimensionLifecyclePolicy{
+			MaxDims: 1,
+		},
 	}
 	dimsActive, created := state.ensureChart("dims_active", "tpl.dims", meta, dimsLifecycle)
 	require.True(t, created)
@@ -177,10 +192,12 @@ func runTestEnforceLifecycleCapsMixedPolicies(t *testing.T) {
 			},
 		},
 		"enabled_new": {
-			templateID:      "tpl.enabled",
-			chartID:         "enabled_new",
-			meta:            meta,
-			lifecycle:       program.LifecyclePolicy{MaxInstances: 1},
+			templateID: "tpl.enabled",
+			chartID:    "enabled_new",
+			meta:       meta,
+			lifecycle: program.LifecyclePolicy{
+				MaxInstances: 1,
+			},
 			currentBuildSeq: currentSeq,
 			observedCount:   1,
 			entries: map[string]*dimBuildEntry{
@@ -224,8 +241,14 @@ func runTestDimensionCapRemovalRetriesAfterAbort(t *testing.T) {
 	cc := mustCycleController(t, store)
 	sm := store.Write().SnapshotMeter("")
 	gauge := sm.Gauge("svc_mode")
-	modeA := sm.LabelSet(metrix.Label{Key: "mode", Value: "a"})
-	modeB := sm.LabelSet(metrix.Label{Key: "mode", Value: "b"})
+	modeA := sm.LabelSet(metrix.Label{
+		Key:   "mode",
+		Value: "a",
+	})
+	modeB := sm.LabelSet(metrix.Label{
+		Key:   "mode",
+		Value: "b",
+	})
 
 	cc.BeginCycle()
 	gauge.Observe(1, modeA)
@@ -320,16 +343,24 @@ func runTestCollectExpiryRemovalsDimensionAndChartExpiry(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			state := newMaterializedState()
 
-			expiredMeta := program.ChartMeta{Title: "Expired", Context: "expired"}
+			expiredMeta := program.ChartMeta{
+				Title:   "Expired",
+				Context: "expired",
+			}
 			expiredChart, created := state.ensureChart("chart_expired", "tpl.expired", expiredMeta, program.LifecyclePolicy{
 				ExpireAfterCycles: 2,
 			})
 			require.True(t, created)
 			expiredChart.lastSeenSuccessSeq = 3
 
-			liveMeta := program.ChartMeta{Title: "Live", Context: "live"}
+			liveMeta := program.ChartMeta{
+				Title:   "Live",
+				Context: "live",
+			}
 			liveChart, created := state.ensureChart("chart_live", "tpl.live", liveMeta, program.LifecyclePolicy{
-				Dimensions: program.DimensionLifecyclePolicy{ExpireAfterCycles: 2},
+				Dimensions: program.DimensionLifecyclePolicy{
+					ExpireAfterCycles: 2,
+				},
 			})
 			require.True(t, created)
 			liveChart.lastSeenSuccessSeq = tc.currentSeq
@@ -363,5 +394,101 @@ func runTestCollectExpiryRemovalsDimensionAndChartExpiry(t *testing.T) {
 			assert.NotContains(t, liveChart.dimensions, "stale_dim")
 			assert.Contains(t, liveChart.dimensions, "fresh_dim")
 		})
+	}
+}
+
+// Expiry must preserve creation-time wire metadata and deterministic ordering
+// across several charts, even when observations arrive in reverse order.
+func TestExpiryRemovalOrderingAndMetadata(t *testing.T) {
+	e, err := New(WithRuntimeStore(nil))
+	require.NoError(t, err)
+	require.NoError(t, e.LoadYAML([]byte(`version: v1
+groups:
+ - family: Expiry
+   metrics: [work]
+   charts:
+    - id: work
+      title: Work
+      context: work
+      units: units
+      instances:
+       by_labels: [chart]
+      lifecycle:
+       expire_after_cycles: 3
+       dimensions:
+        expire_after_cycles: 2
+      dimensions:
+       - selector: work
+         name_from_label: dim
+         options:
+          hidden: true
+          float: true
+`), 1))
+	store := metrix.NewCollectorStore(metrix.WithExpireAfterSuccessCycles(1))
+	cc := mustCycleController(t, store)
+	m := store.Write().SnapshotMeter("")
+	g := m.Gauge("work")
+	cc.BeginCycle()
+	for _, chart := range []string{"z", "a", "m"} {
+		for _, dim := range []string{"z", "a"} {
+			g.Observe(1.5, m.LabelSet(metrix.Label{
+				Key:   "chart",
+				Value: chart,
+			}, metrix.Label{
+				Key:   "dim",
+				Value: dim,
+			}))
+		}
+	}
+	require.NoError(t, cc.CommitCycleSuccess())
+	first, err := buildPlan(e, store.Read(metrix.ReadRaw()))
+	require.NoError(t, err)
+	var wantDims []RemoveDimensionAction
+	var wantCharts []RemoveChartAction
+	for _, a := range first.Actions {
+		switch a := a.(type) {
+		case CreateChartAction:
+			wantCharts = append(wantCharts, RemoveChartAction{
+				ChartID: a.ChartID,
+				Meta:    a.Meta,
+			})
+		case CreateDimensionAction:
+			wantDims = append(wantDims, RemoveDimensionAction(a))
+		}
+	}
+	require.Len(t, wantCharts, 3)
+	require.Len(t, wantDims, 6)
+	sort.Slice(wantCharts, func(i, j int) bool { return wantCharts[i].ChartID < wantCharts[j].ChartID })
+	sort.Slice(wantDims, func(i, j int) bool {
+		if wantDims[i].ChartID != wantDims[j].ChartID {
+			return wantDims[i].ChartID < wantDims[j].ChartID
+		}
+		return wantDims[i].Name < wantDims[j].Name
+	})
+	for seq := 2; seq <= 4; seq++ {
+		cc.BeginCycle()
+		require.NoError(t, cc.CommitCycleSuccess())
+		plan, err := buildPlan(e, store.Read(metrix.ReadRaw()))
+		require.NoError(t, err)
+		var dims []RemoveDimensionAction
+		var charts []RemoveChartAction
+		for _, a := range plan.Actions {
+			switch a := a.(type) {
+			case RemoveDimensionAction:
+				dims = append(dims, a)
+			case RemoveChartAction:
+				charts = append(charts, a)
+			}
+		}
+		if seq == 3 {
+			assert.Equal(t, wantDims, dims)
+		} else {
+			assert.Empty(t, dims)
+		}
+		if seq == 4 {
+			assert.Equal(t, wantCharts, charts)
+		} else {
+			assert.Empty(t, charts)
+		}
 	}
 }


### PR DESCRIPTION
##### Summary

Reuse autogen routes with metadata and kind validation, and sort only expired chart and dimension identities.

Benchmarks show 25–33% faster warm autogen planning and 38–43% faster mass dimension expiry, with modest additional retained cache memory.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, autogen planning rebuilt routes on every lookup and expiry cleanup sorted all retained identities; it now reuses validated successful routes and sorts only actual removals. This improves warm planning by 25–33% and mass dimension expiry by 38–43%, with modest additional retained cache memory.

- Validates cached routes against metric metadata, metric kinds, and flatten roles; clears invalid or rejected bindings so eligible sources can recover.
- Clears route data on template reload, while diagnostic planning bypasses the cache.
- Preserves deterministic removal ordering and creation-time wire metadata for expired charts and dimensions.
- Adds transition, allocation, churn, and expiry tests and benchmarks for cache reuse and lifecycle behavior.

<sup>Written for commit 3a50cddc28edddc6d723a37f3f8387762873b7b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved autogenerated chart route reuse by validating current metric metadata and types before applying cached routes.
  - Changed metric descriptors now trigger route rebuilding instead of reusing outdated mappings.
  - Configuration reloads clear cached route data, while diagnostic planning bypasses the cache.
  - Expired charts and dimensions are removed deterministically while preserving chart metadata.

- **Tests**
  - Added coverage for metadata changes, route reuse, cache eviction, expiry ordering, and allocation limits.
  - Added performance benchmarks for mixed route churn and expiry removal handling.

- **Documentation**
  - Updated chart engine documentation with cache behavior and performance validation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->