### PR TITLE
fix(spawn): make SIGPIPE regression tests deterministic

### DIFF
--- a/src/libnetdata/spawn_server/spawn-tester.c
+++ b/src/libnetdata/spawn_server/spawn-tester.c
@@ -595,18 +595,8 @@ static void test_server_destroy(SPAWN_SERVER *server) {
 }
 
 static void test_exec_child_dies_when_stdout_closes(int argc, const char **argv) {
-    // Model the daemon: netdata ignores SIGPIPE before it creates its spawn server, and that is
-    // what the child must not inherit. Without this the test would pass trivially, because the
-    // tester's own SIGPIPE is already default.
-    struct sigaction ignore_pipe, previous_pipe;
-    memset(&ignore_pipe, 0, sizeof(ignore_pipe));
-    ignore_pipe.sa_handler = SIG_IGN;
-    sigemptyset(&ignore_pipe.sa_mask);
-    if(sigaction(SIGPIPE, &ignore_pipe, &previous_pipe) == -1) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot ignore SIGPIPE for the termination contract test");
-        exit(1);
-    }
-
+    // The daemon's ignored SIGPIPE - the thing the child must not inherit - is installed
+    // process-wide by main() (see ignore_sigpipe_like_the_daemon()), so it is already in place here.
     SPAWN_SERVER *server = spawn_server_create(SPAWN_SERVER_OPTION_EXEC, "test-sigpipe", NULL, argc, argv);
     if(!server) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot create spawn server for the termination contract test");
@@ -669,11 +659,6 @@ static void test_exec_child_dies_when_stdout_closes(int argc, const char **argv)
     nd_log(NDLS_COLLECTORS, NDLP_ERR, "child died of SIGPIPE when its stdout closed, as it must");
 
     test_server_destroy(server);
-
-    if(sigaction(SIGPIPE, &previous_pipe, NULL) == -1) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot restore SIGPIPE after the termination contract test");
-        exit(1);
-    }
 }
 #endif
 
@@ -848,6 +833,35 @@ static void test_callback_signal_lifecycle(int argc, const char **argv) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
+#if !defined(OS_WINDOWS)
+// Model the daemon for the whole suite: netdata sets SIGPIPE to SIG_IGN before it creates its spawn
+// server (NETDATA_SIGNAL_IGNORE in src/daemon/signal-handler.c), and SIG_IGN survives execve(), so
+// an ignored SIGPIPE is exactly what a spawned child must NOT inherit.
+//
+// This has to be process-wide, and it has to happen before the FIRST test that asserts anything
+// about a child's SIGPIPE state. Doing it per-test is what made the callback assertion in
+// callback_wait_for_sigterm() depend on the invoking shell: with SIGPIPE left at its default, the
+// callback child sees SIG_DFL no matter what spawn_server_run_callback() does, so the assertion
+// passed even with the reset removed. It only bit on CI, where the runner leaks SIG_IGN into every
+// step's shell (GitHub Actions is Node-based and Node ignores SIGPIPE - the same inheritance the
+// fix is about, which tests/manual/spawn-termination-macos.sh documents). Coverage that depends on
+// the caller's signal state is not coverage.
+//
+// It also makes the tester itself behave like the daemon: a write to a dead child's pipe returns
+// EPIPE and hits our own error path with a diagnostic, instead of killing the tester silently.
+static void ignore_sigpipe_like_the_daemon(void) {
+    struct sigaction ignore_pipe;
+    memset(&ignore_pipe, 0, sizeof(ignore_pipe));
+    ignore_pipe.sa_handler = SIG_IGN;
+    sigemptyset(&ignore_pipe.sa_mask);
+
+    if(sigaction(SIGPIPE, &ignore_pipe, NULL) == -1) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot ignore SIGPIPE to model the daemon");
+        exit(1);
+    }
+}
+#endif
+
 int main(int argc, const char **argv) {
     if(argc > 1 && strcmp(argv[1], "plugin-kill-to-stop") == 0)
         return plugin_kill_to_stop();
@@ -872,6 +886,13 @@ int main(int argc, const char **argv) {
     }
 
     nd_setenv(ENV_VAR_KEY, ENV_VAR_VALUE, 1);
+
+#if !defined(OS_WINDOWS)
+    // Only for the test driver: the plugin-* child modes above returned before this point, so a
+    // child we exec still gets whatever disposition the spawn server gives it - which is what the
+    // termination contract test measures.
+    ignore_sigpipe_like_the_daemon();
+#endif
 
 #if defined(SPAWN_SERVER_VERSION_NOFORK)
     fprintf(stderr, "\n\nTESTING spawn-server listener backlog\n\n");

--- a/src/libnetdata/spawn_server/spawn-tester.c
+++ b/src/libnetdata/spawn_server/spawn-tester.c
@@ -252,7 +252,10 @@ static void test_popen_echo_loop(POPEN_INSTANCE *pi, const char *msg, size_t ite
                    len, rc);
             exit(1);
         }
-        fflush(child_stdin);
+        if(fflush(child_stdin) != 0) {
+            nd_log(NDLS_COLLECTORS, NDLP_ERR, "Cannot flush to plugin: %s", strerror(errno));
+            exit(1);
+        }
 
         char *s = fgets(buffer, (int)buffer_size, child_stdout);
         if (!s || strlen(s) != len) {
@@ -847,12 +850,17 @@ static void test_callback_signal_lifecycle(int argc, const char **argv) {
 // fix is about, which tests/manual/spawn-termination-macos.sh documents). Coverage that depends on
 // the caller's signal state is not coverage.
 //
+// Only the DISPOSITION needs modelling here. The daemon blocks SIGPIPE too, but that half needs no
+// help: spawn_server_event_loop() calls signals_block_all() and unblocks only SIGTERM and SIGCHLD,
+// so the callback child's inherited mask always carries SIGPIPE blocked and the sigdelset() in
+// spawn_server_run_callback() is exercised on every run, whatever our own mask is.
+//
 // It also makes the tester itself behave like the daemon: a write to a dead child's pipe returns
 // EPIPE and hits our own error path with a diagnostic, instead of killing the tester silently.
 static void ignore_sigpipe_like_the_daemon(void) {
-    struct sigaction ignore_pipe;
-    memset(&ignore_pipe, 0, sizeof(ignore_pipe));
-    ignore_pipe.sa_handler = SIG_IGN;
+    struct sigaction ignore_pipe = {
+        .sa_handler = SIG_IGN,
+    };
     sigemptyset(&ignore_pipe.sa_mask);
 
     if(sigaction(SIGPIPE, &ignore_pipe, NULL) == -1) {
@@ -888,9 +896,9 @@ int main(int argc, const char **argv) {
     nd_setenv(ENV_VAR_KEY, ENV_VAR_VALUE, 1);
 
 #if !defined(OS_WINDOWS)
-    // Only for the test driver: the plugin-* child modes above returned before this point, so a
-    // child we exec still gets whatever disposition the spawn server gives it - which is what the
-    // termination contract test measures.
+    // Only for the test driver, and it MUST stay below the plugin-* dispatch above: those early
+    // returns are the exec'd children. If they came through here they would ignore SIGPIPE
+    // themselves, after exec, and test_exec_child_dies_when_stdout_closes() could never fail.
     ignore_sigpipe_like_the_daemon();
 #endif
 

--- a/src/libnetdata/spawn_server/spawn_popen.h
+++ b/src/libnetdata/spawn_server/spawn_popen.h
@@ -20,8 +20,9 @@ int spawn_popen_wait(POPEN_INSTANCE *pi);
 // bounded poll; the wait is always bounded, never infinite.
 // SPAWN_TIMEDWAIT_EXITED: the child exited; *code holds its spawn_popen_wait()-style return code
 //   and pi has been freed.
-// SPAWN_TIMEDWAIT_RUNNING: still running after timeout_ms; pi remains valid - call again, or
-//   spawn_popen_wait()/spawn_popen_kill().
+// SPAWN_TIMEDWAIT_RUNNING: no exit was observed within timeout_ms; pi remains valid - call again, or
+//   spawn_popen_wait()/spawn_popen_kill(). Not proof the child is alive: see the note on
+//   SPAWN_TIMEDWAIT_RUNNING in spawn_server.h before using pi's pid for anything.
 // SPAWN_TIMEDWAIT_ERROR: the wait could not be completed (the child's state is unknown); pi remains
 //   valid and the caller must reclaim it with spawn_popen_kill(). Do NOT loop on ERROR.
 SPAWN_TIMEDWAIT_RESULT spawn_popen_timedwait(POPEN_INSTANCE *pi, int timeout_ms, int *code);

--- a/src/libnetdata/spawn_server/spawn_server.h
+++ b/src/libnetdata/spawn_server/spawn_server.h
@@ -48,7 +48,8 @@ int spawn_server_exec_kill(SPAWN_SERVER *server, SPAWN_INSTANCE *si, int timeout
 int spawn_server_exec_wait(SPAWN_SERVER *server, SPAWN_INSTANCE *si);
 
 typedef enum __attribute__((packed)) {
-    SPAWN_TIMEDWAIT_EXITED = 0,     // the child exited; *status holds its status and si has been freed
+    SPAWN_TIMEDWAIT_EXITED = 0,     // si has been freed and must not be touched again; *status holds
+                                    // the child's status, or -1 if it could not be determined
     SPAWN_TIMEDWAIT_RUNNING = 1,    // the wait observed no exit within the timeout; si remains valid.
                                     // NOT proof the child is alive - see the note below
     SPAWN_TIMEDWAIT_ERROR = 2,      // the wait could not be completed (broken status channel / unusable
@@ -60,6 +61,11 @@ typedef enum __attribute__((packed)) {
 // bounded poll (the nofork backend uses a ~1ms slice because its wait primitive treats 0 as
 // "wait forever"; the others poll once); the wait is always bounded, never infinite.
 // On SPAWN_TIMEDWAIT_EXITED the instance has been freed, exactly like spawn_server_exec_wait().
+// EXITED is a statement about ownership, not about a successful report: a backend that consumes the
+// instance while reading the child's status (nofork does, as soon as the report is readable) must
+// still return EXITED if that report turns out to be truncated or malformed, with *status == -1.
+// Reporting ERROR there would be worse than useless - ERROR obliges the caller to reclaim an
+// instance that no longer exists.
 // On SPAWN_TIMEDWAIT_RUNNING or SPAWN_TIMEDWAIT_ERROR the caller keeps ownership and must eventually
 // call spawn_server_exec_timedwait(), spawn_server_exec_wait() or spawn_server_exec_kill().
 // ERROR is distinct from RUNNING on purpose: the wait could not progress (it is not merely "not yet"),

--- a/src/libnetdata/spawn_server/spawn_server.h
+++ b/src/libnetdata/spawn_server/spawn_server.h
@@ -49,7 +49,8 @@ int spawn_server_exec_wait(SPAWN_SERVER *server, SPAWN_INSTANCE *si);
 
 typedef enum __attribute__((packed)) {
     SPAWN_TIMEDWAIT_EXITED = 0,     // the child exited; *status holds its status and si has been freed
-    SPAWN_TIMEDWAIT_RUNNING = 1,    // the timeout expired; the child is still running and si remains valid
+    SPAWN_TIMEDWAIT_RUNNING = 1,    // the wait observed no exit within the timeout; si remains valid.
+                                    // NOT proof the child is alive - see the note below
     SPAWN_TIMEDWAIT_ERROR = 2,      // the wait could not be completed (broken status channel / unusable
                                     // handle); the child's state is unknown, si remains valid, and the
                                     // caller must reclaim it (e.g. via spawn_server_exec_kill())
@@ -64,6 +65,13 @@ typedef enum __attribute__((packed)) {
 // ERROR is distinct from RUNNING on purpose: the wait could not progress (it is not merely "not yet"),
 // so callers must NOT loop on it (that would spin forever when timeout_ms == 0) - they must reclaim
 // the instance, typically by killing it.
+// RUNNING means "this wait saw no exit", not "the child is alive" - only EXITED is authoritative
+// about the child's fate. Every backend observes the exit indirectly (a report from the spawn server
+// process, a semaphore posted from an exit callback, waitpid(), a waitable handle), and in most of
+// them the observation can lag the reap, so RUNNING is also what you get for a child that is already
+// gone and whose pid the kernel may have released. Callers MUST therefore treat si's pid as
+// last-known-only: reclaim the instance through spawn_server_exec_kill() (which owns whatever
+// pid-safety the backend can offer) instead of signalling that pid themselves.
 // status is optional (may be NULL): on EXITED the wait/cleanup still happens, the status is just not stored.
 SPAWN_TIMEDWAIT_RESULT spawn_server_exec_timedwait(SPAWN_SERVER *server, SPAWN_INSTANCE *si, int timeout_ms, int *status);
 

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -444,11 +444,12 @@ static bool spawn_server_run_callback(SPAWN_SERVER *server __maybe_unused, SPAWN
             _exit(EXIT_FAILURE);
         }
 
-        // The disposition alone is not enough: netdata BLOCKS SIGPIPE as well
-        // (signals_block_all_except_deadly() unblocks only the deadly signals), fork() inherits the
-        // mask, and previous_mask carries that block. A blocked SIGPIPE makes write() return EPIPE
-        // with the signal left pending, so the child would survive a closed pipe exactly as if the
-        // disposition were still SIG_IGN. Restore the inherited mask minus SIGPIPE.
+        // The disposition alone is not enough: SIGPIPE is also BLOCKED here. The block is ours, not
+        // inherited - spawn_server_event_loop() calls signals_block_all() and unblocks only SIGTERM
+        // and SIGCHLD, so previous_mask always carries SIGPIPE blocked, whatever the daemon's mask
+        // was. A blocked SIGPIPE makes write() return EPIPE with the signal left pending, so the
+        // child would survive a closed pipe exactly as if the disposition were still SIG_IGN.
+        // Restore the inherited mask minus SIGPIPE.
         sigset_t child_mask = previous_mask;
         sigdelset(&child_mask, SIGPIPE);
 
@@ -1631,7 +1632,9 @@ SPAWN_TIMEDWAIT_RESULT spawn_server_exec_timedwait(SPAWN_SERVER *server, SPAWN_I
     NETDATA_SSL ssl = { 0 };
     int rc = wait_on_socket_or_cancel_with_timeout(&ssl, instance->sock, timeout_ms, POLLIN, &revents);
     if(rc == -1 /* thread cancelled */ || rc == 1 /* timeout */)
-        // the child is still running; the caller decides whether to keep waiting or kill it
+        // Nothing was observed - the poll expired, or the wait was cancelled before observing
+        // anything at all. Usually the child is still running, but this is not proof of it; see the
+        // RUNNING note on spawn_server_exec_timedwait() in spawn_server.h.
         return SPAWN_TIMEDWAIT_RUNNING;
 
     if(rc == 2 /* error on the socket */) {
@@ -1692,6 +1695,12 @@ int spawn_server_exec_wait(SPAWN_SERVER *server __maybe_unused, SPAWN_INSTANCE *
     return rc;
 }
 
+// NOTE on pid safety: every kill below can in principle hit a recycled pid. Our spawn server reaps
+// the child and only then writes the status report, and it writes none at all if the pid is not in
+// its request list - so "no report yet" (SPAWN_TIMEDWAIT_RUNNING) does not mean the pid is still
+// ours. The pre-kill grace makes this worse by discarding its poll result and signalling regardless.
+// Closing the window needs the signalling to move into the spawn server, keyed by request id, so the
+// process that reaps is the one that signals; until then this is a known, accepted race.
 int spawn_server_exec_kill(SPAWN_SERVER *server, SPAWN_INSTANCE *instance, int timeout_ms) {
     if(instance->write_fd != -1) { close(instance->write_fd); instance->write_fd = -1; }
     if(instance->read_fd != -1) { close(instance->read_fd); instance->read_fd = -1; }
@@ -1702,7 +1711,7 @@ int spawn_server_exec_kill(SPAWN_SERVER *server, SPAWN_INSTANCE *instance, int t
         wait_on_socket_or_cancel_with_timeout(&ssl, instance->sock, timeout_ms, POLLIN, &revents);
     }
 
-    // kill the child, if it is still running
+    // we still have a pid recorded for this child - not a liveness check (see the note above)
     if(instance->child_pid) {
         if(kill(instance->child_pid, SIGTERM) != 0)
             spawn_server_log_kill_failure(instance, SIGTERM);
@@ -1710,17 +1719,8 @@ int spawn_server_exec_kill(SPAWN_SERVER *server, SPAWN_INSTANCE *instance, int t
         // wait a bounded grace for the child to exit after SIGTERM. NOTE: timeout_ms is already
         // consumed above as the pre-kill grace (voluntary exit before SIGTERM); the post-SIGTERM
         // grace uses the fixed default so the caller's grace is not applied twice.
-        //
-        // What the status channel does and does not guarantee: the spawn server reaps the child and
-        // only THEN sends the status report, so an EXITED result is authoritative - the child is
-        // reaped and this pid is done. RUNNING is not the negation of that. It is what
-        // spawn_server_exec_timedwait() returns when its poll expires (or the thread is cancelled),
-        // and a report landing just after that instant yields RUNNING for a child that is already
-        // reaped and whose pid the kernel has released. So RUNNING means "no report readable yet",
-        // NOT "the pid is still held", and neither the kills below nor the pre-kill grace above -
-        // which discards its poll result entirely and signals regardless - are protected against
-        // signalling a recycled pid. Closing that window needs the signalling to move into the
-        // spawn server, keyed by request id, so the same process that reaps also signals.
+        // EXITED here is authoritative (the server reaps before it reports); RUNNING is not - see
+        // the pid-safety note above this function.
         int status;
         if(spawn_server_exec_timedwait(server, instance, SPAWN_KILL_DEFAULT_GRACE_MS, &status) == SPAWN_TIMEDWAIT_EXITED)
             return status;

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1710,9 +1710,17 @@ int spawn_server_exec_kill(SPAWN_SERVER *server, SPAWN_INSTANCE *instance, int t
         // wait a bounded grace for the child to exit after SIGTERM. NOTE: timeout_ms is already
         // consumed above as the pre-kill grace (voluntary exit before SIGTERM); the post-SIGTERM
         // grace uses the fixed default so the caller's grace is not applied twice.
-        // No PID-reuse race on the RUNNING path: the spawn server reaps the child and only then
-        // sends the status report that makes timedwait return EXITED, so a RUNNING result means
-        // the child has not been reaped yet and its PID is still held.
+        //
+        // What the status channel does and does not guarantee: the spawn server reaps the child and
+        // only THEN sends the status report, so an EXITED result is authoritative - the child is
+        // reaped and this pid is done. RUNNING is not the negation of that. It is what
+        // spawn_server_exec_timedwait() returns when its poll expires (or the thread is cancelled),
+        // and a report landing just after that instant yields RUNNING for a child that is already
+        // reaped and whose pid the kernel has released. So RUNNING means "no report readable yet",
+        // NOT "the pid is still held", and neither the kills below nor the pre-kill grace above -
+        // which discards its poll result entirely and signals regardless - are protected against
+        // signalling a recycled pid. Closing that window needs the signalling to move into the
+        // spawn server, keyed by request id, so the same process that reaps also signals.
         int status;
         if(spawn_server_exec_timedwait(server, instance, SPAWN_KILL_DEFAULT_GRACE_MS, &status) == SPAWN_TIMEDWAIT_EXITED)
             return status;


### PR DESCRIPTION
##### Summary
- Ignore SIGPIPE throughout the test driver to match daemon behavior and reliably detect missing child signal resets regardless of the invoking shell
- correct the nofork termination comment to document the existing PID-reuse race.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and handling of output-flush failures during process communication tests.
  - Updated signal-handling coverage to more accurately reflect daemon behavior across process execution scenarios.

- **Documentation**
  - Clarified that a timed-out process wait does not confirm the process is still running.
  - Added guidance for interpreting process status results and safely reclaiming process instances.
  - Documented signal-handling behavior and process identifier reuse considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->