### PR TITLE
test(go.d): fix staged secret mutation quarantine test flake

### DIFF
--- a/src/go/plugin/agent/jobmgr/secrets/initial_test.go
+++ b/src/go/plugin/agent/jobmgr/secrets/initial_test.go
@@ -318,17 +318,23 @@ func TestPreparedStoreOperationQuarantinesFailedUntakenMutationRelease(t *testin
 	}
 	stage.mu.Lock()
 	mutation := stage.result.mutation
-	attempt := stage.attempt
 	identity := stage.identity
 	stage.mu.Unlock()
 	require.NotNil(t, mutation)
-	require.NotNil(t, attempt)
+	// The worker can publish readiness before the stage installs its attempt
+	// handle, but the authority registers ownership before starting the worker.
+	released, ok := attempts.ProcessAttemptReleased(identity)
+	require.True(t, ok)
 
 	// Simulate the Store rejecting final mutation release after ownership was
 	// handed to the stage.
 	require.NoError(t, mutation.Abort())
 	stage.Release()
-	<-attempt.Released()
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		require.FailNow(t, "test failed", "Store operation did not release")
+	}
 
 	require.Equal(t, containment.Census{Quarantined: 1}, attempts.Census())
 	_, err = attempts.StartProcessAttempt(context.Background(), jobmgr.ProcessAttemptPlan{


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky test in the staged secret mutation quarantine flow by waiting on the release channel from the attempts manager instead of the stage's attempt handle, which may not be installed yet when the worker publishes readiness.

<sup>Written for commit e2fc299fe58a01e55ba060f87f8e0b35f65101b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for failed mutation handling by verifying that attempt-release signals are received.
  * Added a timeout to prevent the test from blocking indefinitely when release does not occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->