### PR TITLE
refactor(go.d/snmp): extract reusable device identity acquisition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -697,6 +697,11 @@ copy; inspect before use and do not assume they are tracked project interfaces.
 - Prefer table-driven tests using `map[string]struct{}` keyed by case name when cases share setup and assertion
   shape. Map keys beat a `name` field in `[]struct{}`: names stay prominent and order-independent.
 - Use separate test functions only when setup or assertions differ materially.
+- Tests SHOULD compare a complete expected struct or map with the actual result instead of asserting individual
+  fields, so missing and unexpected values are checked.
+- Keep separate assertions for distinct behavior, such as errors, call counts, and input ownership.
+- Focused comparisons MAY be used when unrelated or nondeterministic fields make whole-value comparison
+  inappropriate.
 
 ### C Code
 

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -129,8 +129,11 @@ func (c *Collector) ensureInitialized() error {
 			}
 		}
 		identity, err := ddsnmp.AcquireDeviceIdentity(si, c.ddSnmpColl, ddsnmp.DeviceIdentityOptions{
-			Address: c.Hostname, GUID: c.Vnode.GUID, Hostname: c.Vnode.Hostname,
-			BaseLabels: baseLabels, Labels: c.Vnode.Labels,
+			Address:    c.Hostname,
+			GUID:       c.Vnode.GUID,
+			Hostname:   c.Vnode.Hostname,
+			BaseLabels: baseLabels,
+			Labels:     c.Vnode.Labels,
 		})
 		if c.ddSnmpColl != nil {
 			c.captureCollectionFailures()
@@ -141,7 +144,9 @@ func (c *Collector) ensureInitialized() error {
 		c.Vnode.GUID = identity.GUID
 		c.Vnode.Hostname = identity.Hostname
 		c.vnode = &vnodes.VirtualNode{
-			GUID: identity.GUID, Hostname: identity.Hostname, Labels: identity.Labels,
+			GUID:     identity.GUID,
+			Hostname: identity.Hostname,
+			Labels:   identity.Labels,
 		}
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -7,11 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"slices"
 	"strconv"
 	"syscall"
 
-	"github.com/google/uuid"
 	"github.com/gosnmp/gosnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 	"golang.org/x/sync/errgroup"
@@ -123,15 +121,27 @@ func (c *Collector) ensureInitialized() error {
 	}
 
 	if c.CreateVnode {
-		if c.ddSnmpColl == nil {
-			c.vnode = c.setupVnode(si, nil)
-		} else {
-			deviceMeta, err := c.ddSnmpColl.CollectDeviceMetadata()
-			c.captureCollectionFailures()
-			if err != nil {
-				return err
+		var baseLabels map[string]string
+		if c.UpdateEvery >= 1 && c.VnodeDeviceDownThreshold >= 1 {
+			// Allow for collection and transmission delays.
+			baseLabels = map[string]string{
+				"_node_stale_after_seconds": strconv.Itoa(c.VnodeDeviceDownThreshold*c.UpdateEvery + 2),
 			}
-			c.vnode = c.setupVnode(si, deviceMeta)
+		}
+		identity, err := ddsnmp.AcquireDeviceIdentity(si, c.ddSnmpColl, ddsnmp.DeviceIdentityOptions{
+			Address: c.Hostname, GUID: c.Vnode.GUID, Hostname: c.Vnode.Hostname,
+			BaseLabels: baseLabels, Labels: c.Vnode.Labels,
+		})
+		if c.ddSnmpColl != nil {
+			c.captureCollectionFailures()
+		}
+		if err != nil {
+			return err
+		}
+		c.Vnode.GUID = identity.GUID
+		c.Vnode.Hostname = identity.Hostname
+		c.vnode = &vnodes.VirtualNode{
+			GUID: identity.GUID, Hostname: identity.Hostname, Labels: identity.Labels,
 		}
 	}
 
@@ -145,56 +155,6 @@ func (c *Collector) ensureInitialized() error {
 	return nil
 }
 
-func (c *Collector) setupVnode(si *snmputils.SysInfo, deviceMeta map[string]ddsnmp.MetaTag) *vnodes.VirtualNode {
-	if c.Vnode.GUID == "" {
-		c.Vnode.GUID = uuid.NewSHA1(uuid.NameSpaceDNS, []byte(c.Hostname)).String()
-	}
-
-	hostnames := []string{
-		c.Vnode.Hostname,
-		si.Name,
-		"snmp-device",
-	}
-	i := slices.IndexFunc(hostnames, func(s string) bool { return s != "" })
-	c.Vnode.Hostname = hostnames[i]
-
-	labels := map[string]string{
-		"_vnode_type":           "snmp",
-		"_net_default_iface_ip": c.Hostname,
-		"address":               c.Hostname,
-	}
-
-	if c.UpdateEvery >= 1 && c.VnodeDeviceDownThreshold >= 1 {
-		// Add 2 seconds buffer to account for collection/transmission delays
-		v := c.VnodeDeviceDownThreshold*c.UpdateEvery + 2
-		labels["_node_stale_after_seconds"] = strconv.Itoa(v)
-	}
-
-	labels["sys_object_id"] = si.SysObjectID
-	labels["name"] = si.Name
-	labels["description"] = si.Descr
-	labels["contact"] = si.Contact
-	labels["location"] = si.Location
-	if si.Vendor != "" {
-		labels["vendor"] = si.Vendor
-	} else if si.Organization != "" {
-		labels["vendor"] = si.Organization
-	}
-	if si.Category != "" {
-		labels["type"] = si.Category
-	}
-	if si.Model != "" {
-		labels["model"] = si.Model
-	}
-
-	labels = ddsnmp.ResolveDeviceMetadata(labels, deviceMeta, c.Vnode.Labels)
-
-	return &vnodes.VirtualNode{
-		GUID:     c.Vnode.GUID,
-		Hostname: c.Vnode.Hostname,
-		Labels:   labels,
-	}
-}
 func (c *Collector) initAndConnectSNMPClient() (gosnmp.Handler, error) {
 	snmpClient, err := c.initSNMPClient()
 	if err != nil {

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -555,34 +555,58 @@ func TestCollector_CollectSynchronizesDeviceMetadataOnceWithoutVnode(t *testing.
 	assert.Zero(t, mockCollector.metadataCalls)
 }
 
-func TestCollector_SetupVnodeAndRegisterDeviceStateShareResolvedMetadata(t *testing.T) {
+func TestCollector_InitializationPublishesResolvedDeviceIdentity(t *testing.T) {
+	const sysObjectID = "1.3.6.1.4.1.41112"
+	const metadataOID = "1.3.6.1.4.1.41112.999.0"
+	handler := snmpmock.NewMockHandler(gomock.NewController(t))
+	handler.EXPECT().MaxOids().Return(20).AnyTimes()
+	handler.EXPECT().Version().Return(gosnmp.Version2c).AnyTimes()
+	handler.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+		{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: sysObjectID},
+		{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("unifi-ap")},
+	}}, nil).Times(1)
+	metadataCalls := 0
+	handler.EXPECT().Get([]string{metadataOID}).DoAndReturn(func([]string) (*gosnmp.SnmpPacket, error) {
+		metadataCalls++
+		return &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+			{Name: metadataOID, Type: gosnmp.OctetString, Value: []byte("profile-vendor")},
+		}}, nil
+	}).Times(2)
+
 	deviceStore := ddsnmp.NewDeviceStore()
 	collr := New(deviceStore)
 	collr.Config = prepareV2Config()
-	collr.Vnode.Labels = map[string]string{
-		"model": "operator-model",
-	}
+	collr.CreateVnode = true
+	collr.VnodeDeviceDownThreshold = 3
+	collr.Vnode.Labels = map[string]string{"model": "operator-model"}
+	collr.snmpClient = handler
+	collr.snmpProfiles = []*ddsnmp.Profile{{SourceFile: "identity.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
+		Selector: ddprofiledefinition.SelectorSpec{{SysObjectID: ddprofiledefinition.SelectorIncludeExclude{Include: []string{sysObjectID}}}},
+		Metadata: ddprofiledefinition.MetadataConfig{"device": {Fields: map[string]ddprofiledefinition.MetadataField{
+			"vendor": {Symbol: ddprofiledefinition.SymbolConfig{OID: metadataOID, Name: "vendor"}},
+			"model":  {Value: "profile-model"},
+		}}},
+	}}}
 
-	si := &snmputils.SysInfo{
-		SysObjectID: "1.3.6.1.4.1.41112",
-		Name:        "unifi-ap",
-		Vendor:      "static-vendor",
-		Model:       "static-model",
-	}
-	profileMetadata := map[string]ddsnmp.MetaTag{
-		"vendor": {Value: "profile-vendor", IsExactMatch: true},
-		"model":  {Value: "profile-model", IsExactMatch: true},
-	}
-
-	collr.vnode = collr.setupVnode(si, profileMetadata)
-	collr.registerDeviceState(si, nil)
-
+	require.NoError(t, collr.Check(context.Background()))
+	assert.Zero(t, metadataCalls, "Check only probes system identity and selects profiles")
+	assert.Nil(t, collr.vnode)
+	collr.Collect(context.Background())
+	require.True(t, collr.initialized)
+	assert.Equal(t, 2, metadataCalls, "initial vnode acquisition must not seed metric preparation caches")
 	entries := deviceStore.Entries()
 	require.Len(t, entries, 1)
 	assert.Equal(t, "profile-vendor", entries[0].Info.VnodeLabels["vendor"])
 	assert.Equal(t, "operator-model", entries[0].Info.VnodeLabels["model"])
+	assert.Equal(t, "5", entries[0].Info.VnodeLabels["_node_stale_after_seconds"])
 	assert.Equal(t, "profile-vendor", entries[0].Info.Vendor)
 	assert.Equal(t, "operator-model", entries[0].Info.Model)
+	assert.Equal(t, "unifi-ap", collr.Vnode.Hostname)
+	assert.NotEmpty(t, collr.Vnode.GUID)
+	assert.Equal(t, map[string]string{"model": "operator-model"}, collr.Vnode.Labels)
+
+	collr.Collect(context.Background())
+	assert.Equal(t, 2, metadataCalls, "subsequent collections reuse preparation caches")
 }
 
 func TestCollector_Check(t *testing.T) {

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
@@ -596,14 +597,23 @@ func TestCollector_InitializationPublishesResolvedDeviceIdentity(t *testing.T) {
 	assert.Equal(t, 2, metadataCalls, "initial vnode acquisition must not seed metric preparation caches")
 	entries := deviceStore.Entries()
 	require.Len(t, entries, 1)
-	assert.Equal(t, "profile-vendor", entries[0].Info.VnodeLabels["vendor"])
-	assert.Equal(t, "operator-model", entries[0].Info.VnodeLabels["model"])
-	assert.Equal(t, "5", entries[0].Info.VnodeLabels["_node_stale_after_seconds"])
-	assert.Equal(t, "profile-vendor", entries[0].Info.Vendor)
-	assert.Equal(t, "operator-model", entries[0].Info.Model)
-	assert.Equal(t, "unifi-ap", collr.Vnode.Hostname)
-	assert.NotEmpty(t, collr.Vnode.GUID)
-	assert.Equal(t, map[string]string{"model": "operator-model"}, collr.Vnode.Labels)
+	wantInfo := ddsnmp.DeviceConnectionInfo{
+		Hostname: "192.0.2.1", Port: 161, SNMPVersion: "2c", Community: "public",
+		MaxOIDs: 20, Timeout: 5, Retries: 1,
+		SysObjectID: sysObjectID, SysName: "unifi-ap", Vendor: "profile-vendor", Model: "operator-model",
+		VnodeGUID: "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121", VnodeHostname: "unifi-ap",
+		VnodeLabels: map[string]string{
+			"_vnode_type": "snmp", "_net_default_iface_ip": "192.0.2.1", "address": "192.0.2.1",
+			"sys_object_id": sysObjectID, "name": "unifi-ap", "description": "", "contact": "", "location": "",
+			"vendor": "profile-vendor", "model": "operator-model", "type": "Access Point", "_node_stale_after_seconds": "5",
+		},
+	}
+	assert.Equal(t, wantInfo, entries[0].Info)
+	wantConfigVnode := vnodes.VirtualNode{
+		GUID: "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121", Hostname: "unifi-ap",
+		Labels: map[string]string{"model": "operator-model"},
+	}
+	assert.Equal(t, wantConfigVnode, collr.Vnode)
 
 	collr.Collect(context.Background())
 	assert.Equal(t, 2, metadataCalls, "subsequent collections reuse preparation caches")

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -225,7 +225,13 @@ func TestCollector_CollectRegistersAndCleanupUnregistersDevice(t *testing.T) {
 	assert.Equal(t, "mock sysDescr", entries[0].Info.SysDescr)
 	assert.Equal(t, "mock sysContact", entries[0].Info.SysContact)
 	assert.Equal(t, "mock sysLocation", entries[0].Info.SysLocation)
-	assertDeviceLifecycle(t, deviceStore, ddsnmp.DeviceLifecyclePhaseCollect, ddsnmp.DeviceLifecycleOutcomeSuccess, true)
+	assertDeviceLifecycle(
+		t,
+		deviceStore,
+		ddsnmp.DeviceLifecyclePhaseCollect,
+		ddsnmp.DeviceLifecycleOutcomeSuccess,
+		true,
+	)
 
 	collr.Cleanup(context.Background())
 	require.Empty(t, deviceStore.Entries())
@@ -267,7 +273,9 @@ func TestCollectorManagedLifecycleSurvivesRejectedCleanupUntilReconcile(t *testi
 	store := ddsnmp.NewDeviceStore()
 	collr := New(store)
 	collr.Hostname = ""
-	job := snmpLifecycleTestRuntimeJob{collector: collr}
+	job := snmpLifecycleTestRuntimeJob{
+		collector: collr,
+	}
 	hook := Creator(store, nil).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
@@ -321,9 +329,13 @@ func TestSNMPJobConfigLifecycleProjectsCredentialFreeBaseline(t *testing.T) {
 func TestCollectorRejectedManagedCandidateDoesNotRemoveIncumbentConnection(t *testing.T) {
 	store := ddsnmp.NewDeviceStore()
 	identity := collectorapi.JobConfigIdentity{1}
-	store.Register(identity.String(), ddsnmp.DeviceConnectionInfo{Hostname: "incumbent.example"})
+	store.Register(identity.String(), ddsnmp.DeviceConnectionInfo{
+		Hostname: "incumbent.example",
+	})
 	collr := New(store)
-	job := snmpLifecycleTestRuntimeJob{collector: collr}
+	job := snmpLifecycleTestRuntimeJob{
+		collector: collr,
+	}
 	hook := Creator(store, nil).JobConfigLifecycle
 
 	hook.Bind(identity, job)
@@ -337,7 +349,9 @@ func TestCollectorManagedLifecycleSnapshotIsDetachedAtCapture(t *testing.T) {
 	store := ddsnmp.NewDeviceStore()
 	collr := New(store)
 	collr.Config = prepareV2Config()
-	job := snmpLifecycleTestRuntimeJob{collector: collr}
+	job := snmpLifecycleTestRuntimeJob{
+		collector: collr,
+	}
 	hook := Creator(store, nil).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
@@ -405,7 +419,9 @@ func TestCollectorManagedConnectionCollectedBeforeReconcileIsPublishedAtReconcil
 	collr := New(store)
 	collr.Config = prepareV2Config()
 	collr.ManualProfiles = []string{"profile-a"}
-	job := snmpLifecycleTestRuntimeJob{collector: collr}
+	job := snmpLifecycleTestRuntimeJob{
+		collector: collr,
+	}
 	hook := Creator(store, nil).JobConfigLifecycle
 	identity := collectorapi.JobConfigIdentity{1}
 
@@ -461,7 +477,13 @@ func TestCollector_CheckFailureUpdatesLifecycleWithoutTopologyRegistration(t *te
 	require.Empty(t, deviceStore.Entries())
 
 	require.Nil(t, collr.Collect(context.Background()))
-	assertDeviceLifecycle(t, deviceStore, ddsnmp.DeviceLifecyclePhaseCollect, ddsnmp.DeviceLifecycleOutcomeFailed, false)
+	assertDeviceLifecycle(
+		t,
+		deviceStore,
+		ddsnmp.DeviceLifecyclePhaseCollect,
+		ddsnmp.DeviceLifecycleOutcomeFailed,
+		false,
+	)
 	require.Empty(t, deviceStore.Entries())
 }
 
@@ -523,7 +545,9 @@ func TestCollector_CollectSynchronizesDeviceMetadataOnceWithoutVnode(t *testing.
 			"model":  {Value: "profile-model", IsExactMatch: true},
 		},
 	}
-	mockCollector := &mockDdSnmpCollector{pms: []*ddsnmp.ProfileMetrics{profileMetrics}}
+	mockCollector := &mockDdSnmpCollector{
+		pms: []*ddsnmp.ProfileMetrics{profileMetrics},
+	}
 
 	deviceStore := ddsnmp.NewDeviceStore()
 	collr := New(deviceStore)
@@ -544,8 +568,14 @@ func TestCollector_CollectSynchronizesDeviceMetadataOnceWithoutVnode(t *testing.
 	assert.Equal(t, "profile-model", entries[0].Info.Model)
 	assert.Zero(t, mockCollector.metadataCalls, "normal collection metadata must be reused without a separate request")
 
-	profileMetrics.DeviceMetadata["vendor"] = ddsnmp.MetaTag{Value: "later-vendor", IsExactMatch: true}
-	profileMetrics.DeviceMetadata["model"] = ddsnmp.MetaTag{Value: "later-model", IsExactMatch: true}
+	profileMetrics.DeviceMetadata["vendor"] = ddsnmp.MetaTag{
+		Value:        "later-vendor",
+		IsExactMatch: true,
+	}
+	profileMetrics.DeviceMetadata["model"] = ddsnmp.MetaTag{
+		Value:        "later-model",
+		IsExactMatch: true,
+	}
 	require.NotNil(t, collr.Collect(context.Background()))
 
 	entries = deviceStore.Entries()
@@ -562,16 +592,20 @@ func TestCollector_InitializationPublishesResolvedDeviceIdentity(t *testing.T) {
 	handler := snmpmock.NewMockHandler(gomock.NewController(t))
 	handler.EXPECT().MaxOids().Return(20).AnyTimes()
 	handler.EXPECT().Version().Return(gosnmp.Version2c).AnyTimes()
-	handler.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-		{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: sysObjectID},
-		{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("unifi-ap")},
-	}}, nil).Times(1)
+	handler.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: sysObjectID},
+			{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("unifi-ap")},
+		},
+	}, nil).Times(1)
 	metadataCalls := 0
 	handler.EXPECT().Get([]string{metadataOID}).DoAndReturn(func([]string) (*gosnmp.SnmpPacket, error) {
 		metadataCalls++
-		return &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-			{Name: metadataOID, Type: gosnmp.OctetString, Value: []byte("profile-vendor")},
-		}}, nil
+		return &gosnmp.SnmpPacket{
+			Variables: []gosnmp.SnmpPDU{
+				{Name: metadataOID, Type: gosnmp.OctetString, Value: []byte("profile-vendor")},
+			},
+		}, nil
 	}).Times(2)
 
 	deviceStore := ddsnmp.NewDeviceStore()
@@ -581,13 +615,24 @@ func TestCollector_InitializationPublishesResolvedDeviceIdentity(t *testing.T) {
 	collr.VnodeDeviceDownThreshold = 3
 	collr.Vnode.Labels = map[string]string{"model": "operator-model"}
 	collr.snmpClient = handler
-	collr.snmpProfiles = []*ddsnmp.Profile{{SourceFile: "identity.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
-		Selector: ddprofiledefinition.SelectorSpec{{SysObjectID: ddprofiledefinition.SelectorIncludeExclude{Include: []string{sysObjectID}}}},
-		Metadata: ddprofiledefinition.MetadataConfig{"device": {Fields: map[string]ddprofiledefinition.MetadataField{
-			"vendor": {Symbol: ddprofiledefinition.SymbolConfig{OID: metadataOID, Name: "vendor"}},
-			"model":  {Value: "profile-model"},
-		}}},
-	}}}
+	collr.snmpProfiles = []*ddsnmp.Profile{
+		{SourceFile: "identity.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
+			Selector: ddprofiledefinition.SelectorSpec{
+				{SysObjectID: ddprofiledefinition.SelectorIncludeExclude{
+					Include: []string{sysObjectID},
+				}},
+			},
+			Metadata: ddprofiledefinition.MetadataConfig{
+				"device": {Fields: map[string]ddprofiledefinition.MetadataField{
+					"vendor": {Symbol: ddprofiledefinition.SymbolConfig{
+						OID:  metadataOID,
+						Name: "vendor",
+					}},
+					"model": {Value: "profile-model"},
+				}},
+			},
+		}},
+	}
 
 	require.NoError(t, collr.Check(context.Background()))
 	assert.Zero(t, metadataCalls, "Check only probes system identity and selects profiles")
@@ -598,10 +643,19 @@ func TestCollector_InitializationPublishesResolvedDeviceIdentity(t *testing.T) {
 	entries := deviceStore.Entries()
 	require.Len(t, entries, 1)
 	wantInfo := ddsnmp.DeviceConnectionInfo{
-		Hostname: "192.0.2.1", Port: 161, SNMPVersion: "2c", Community: "public",
-		MaxOIDs: 20, Timeout: 5, Retries: 1,
-		SysObjectID: sysObjectID, SysName: "unifi-ap", Vendor: "profile-vendor", Model: "operator-model",
-		VnodeGUID: "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121", VnodeHostname: "unifi-ap",
+		Hostname:      "192.0.2.1",
+		Port:          161,
+		SNMPVersion:   "2c",
+		Community:     "public",
+		MaxOIDs:       20,
+		Timeout:       5,
+		Retries:       1,
+		SysObjectID:   sysObjectID,
+		SysName:       "unifi-ap",
+		Vendor:        "profile-vendor",
+		Model:         "operator-model",
+		VnodeGUID:     "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121",
+		VnodeHostname: "unifi-ap",
 		VnodeLabels: map[string]string{
 			"_vnode_type": "snmp", "_net_default_iface_ip": "192.0.2.1", "address": "192.0.2.1",
 			"sys_object_id": sysObjectID, "name": "unifi-ap", "description": "", "contact": "", "location": "",
@@ -610,8 +664,9 @@ func TestCollector_InitializationPublishesResolvedDeviceIdentity(t *testing.T) {
 	}
 	assert.Equal(t, wantInfo, entries[0].Info)
 	wantConfigVnode := vnodes.VirtualNode{
-		GUID: "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121", Hostname: "unifi-ap",
-		Labels: map[string]string{"model": "operator-model"},
+		GUID:     "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121",
+		Hostname: "unifi-ap",
+		Labels:   map[string]string{"model": "operator-model"},
 	}
 	assert.Equal(t, wantConfigVnode, collr.Vnode)
 
@@ -646,23 +701,37 @@ func TestCollector_Check(t *testing.T) {
 				gomock.InOrder(
 					m.EXPECT().MaxOids().Return(2),
 					m.EXPECT().Get([]string{snmputils.OidSysDescr, snmputils.OidSysObject}).Return(
-						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-							{Name: snmputils.OidSysDescr, Value: []byte("mock sysDescr"), Type: gosnmp.OctetString},
-							{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
-						}},
+						&gosnmp.SnmpPacket{
+							Variables: []gosnmp.SnmpPDU{
+								{Name: snmputils.OidSysDescr, Value: []byte("mock sysDescr"), Type: gosnmp.OctetString},
+								{
+									Name:  snmputils.OidSysObject,
+									Value: ".1.3.6.1.4.1.14988.1",
+									Type:  gosnmp.ObjectIdentifier,
+								},
+							},
+						},
 						nil,
 					),
 					m.EXPECT().Get([]string{snmputils.OidSysContact, snmputils.OidSysName}).Return(
-						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-							{Name: snmputils.OidSysContact, Value: []byte("mock sysContact"), Type: gosnmp.OctetString},
-							{Name: snmputils.OidSysName, Value: []byte("mock sysName"), Type: gosnmp.OctetString},
-						}},
+						&gosnmp.SnmpPacket{
+							Variables: []gosnmp.SnmpPDU{
+								{Name: snmputils.OidSysContact, Value: []byte("mock sysContact"), Type: gosnmp.OctetString},
+								{Name: snmputils.OidSysName, Value: []byte("mock sysName"), Type: gosnmp.OctetString},
+							},
+						},
 						nil,
 					),
 					m.EXPECT().Get([]string{snmputils.OidSysLocation}).Return(
-						&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-							{Name: snmputils.OidSysLocation, Value: []byte("mock sysLocation"), Type: gosnmp.OctetString},
-						}},
+						&gosnmp.SnmpPacket{
+							Variables: []gosnmp.SnmpPDU{
+								{
+									Name:  snmputils.OidSysLocation,
+									Value: []byte("mock sysLocation"),
+									Type:  gosnmp.OctetString,
+								},
+							},
+						},
 						nil,
 					),
 				)
@@ -722,7 +791,9 @@ func TestCollector_Check(t *testing.T) {
 				c.CreateVnode = false
 				c.newSnmpClient = func() gosnmp.Handler { return m }
 				c.newPinger = func(cfg pinger.Config, log *logger.Logger) (pinger.Client, error) {
-					return &mockPingClient{sample: pingSuccessSample(c.Hostname)}, nil
+					return &mockPingClient{
+						sample: pingSuccessSample(c.Hostname),
+					}, nil
 				}
 				return c
 			},
@@ -740,7 +811,9 @@ func TestCollector_Check(t *testing.T) {
 				c.CreateVnode = false
 				c.newSnmpClient = func() gosnmp.Handler { return m }
 				c.newPinger = func(cfg pinger.Config, log *logger.Logger) (pinger.Client, error) {
-					return &mockPingClient{probeErr: errors.New("host unreachable")}, nil
+					return &mockPingClient{
+						probeErr: errors.New("host unreachable"),
+					}, nil
 				}
 				return c
 			},
@@ -759,7 +832,11 @@ func TestCollector_Check(t *testing.T) {
 				c.newSnmpClient = func() gosnmp.Handler { return m }
 				c.newPinger = func(cfg pinger.Config, log *logger.Logger) (pinger.Client, error) {
 					return &mockPingClient{
-						probeErr: &pinger.ProbeError{Host: c.Hostname, Stage: "run", Err: syscall.EPERM},
+						probeErr: &pinger.ProbeError{
+							Host:  c.Hostname,
+							Stage: "run",
+							Err:   syscall.EPERM,
+						},
 					}, nil
 				}
 				return c
@@ -847,7 +924,9 @@ func TestCollector_CheckRejectsNoProjectedProfiles(t *testing.T) {
 			client := snmpmock.NewMockHandler(ctrl)
 			client.EXPECT().MaxOids().Return(20)
 			client.EXPECT().Version().Return(gosnmp.Version2c)
-			client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: tc.pdus}, nil)
+			client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{
+				Variables: tc.pdus,
+			}, nil)
 
 			collr := newTestSNMPCollector()
 			collr.Config = prepareV2Config()
@@ -887,9 +966,11 @@ func TestCollector_CheckRetainsIdentityForInitialization(t *testing.T) {
 	client := snmpmock.NewMockHandler(ctrl)
 	client.EXPECT().MaxOids().Return(20)
 	client.EXPECT().Version().Return(gosnmp.Version2c)
-	client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-		{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.14988.1"},
-	}}, nil).Times(1)
+	client.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.14988.1"},
+		},
+	}, nil).Times(1)
 
 	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
@@ -941,7 +1022,9 @@ func TestCollector_CheckPingOnlyUsesReadOnlyProbing(t *testing.T) {
 	setMockClientInitExpect(mockSNMP)
 	setMockClientSysInfoExpect(mockSNMP)
 
-	pingClient := &mockPingClient{sample: pingSuccessSample("192.0.2.1")}
+	pingClient := &mockPingClient{
+		sample: pingSuccessSample("192.0.2.1"),
+	}
 
 	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
@@ -980,21 +1063,25 @@ func TestCollector_Collect(t *testing.T) {
 				collr.snmpProfiles = []*ddsnmp.Profile{{}} // non-empty to enable collectSNMP()
 				collr.newSnmpClient = func() gosnmp.Handler { return m }
 				collr.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
-					return &mockDdSnmpCollector{pms: []*ddsnmp.ProfileMetrics{
-						{
-							Source: "test",
-							Metrics: []ddsnmp.Metric{
-								{
-									Name:    "uptime",
-									IsTable: false,
-									Value:   123,
-									Unit:    "s",
-									Tags:    map[string]string{},
-									Profile: &ddsnmp.ProfileMetrics{Tags: map[string]string{}},
+					return &mockDdSnmpCollector{
+						pms: []*ddsnmp.ProfileMetrics{
+							{
+								Source: "test",
+								Metrics: []ddsnmp.Metric{
+									{
+										Name:    "uptime",
+										IsTable: false,
+										Value:   123,
+										Unit:    "s",
+										Tags:    map[string]string{},
+										Profile: &ddsnmp.ProfileMetrics{
+											Tags: map[string]string{},
+										},
+									},
 								},
 							},
 						},
-					}}
+					}
 				}
 				return collr
 			},
@@ -1042,24 +1129,28 @@ func TestCollector_Collect(t *testing.T) {
 				collr.snmpProfiles = []*ddsnmp.Profile{{}}
 				collr.newSnmpClient = func() gosnmp.Handler { return m }
 				collr.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
-					return &mockDdSnmpCollector{pms: []*ddsnmp.ProfileMetrics{
-						{
-							Source: "test",
-							Metrics: []ddsnmp.Metric{
-								{
-									Name:    "if_octets",
-									IsTable: true,
-									Unit:    "bit/s",
-									Tags:    map[string]string{"ifName": "eth0"},
-									Profile: &ddsnmp.ProfileMetrics{Tags: map[string]string{}},
-									MultiValue: map[string]int64{
-										"in":  1,
-										"out": 2,
+					return &mockDdSnmpCollector{
+						pms: []*ddsnmp.ProfileMetrics{
+							{
+								Source: "test",
+								Metrics: []ddsnmp.Metric{
+									{
+										Name:    "if_octets",
+										IsTable: true,
+										Unit:    "bit/s",
+										Tags:    map[string]string{"ifName": "eth0"},
+										Profile: &ddsnmp.ProfileMetrics{
+											Tags: map[string]string{},
+										},
+										MultiValue: map[string]int64{
+											"in":  1,
+											"out": 2,
+										},
 									},
 								},
 							},
 						},
-					}}
+					}
 				}
 				return collr
 			},
@@ -1112,7 +1203,9 @@ func TestCollector_Collect(t *testing.T) {
 			collr.CreateVnode = false
 			collr.newSnmpClient = func() gosnmp.Handler { return m }
 			collr.newPinger = func(cfg pinger.Config, log *logger.Logger) (pinger.Client, error) {
-				return &mockPingClient{sample: pingSuccessSample(collr.Hostname)}, nil
+				return &mockPingClient{
+					sample: pingSuccessSample(collr.Hostname),
+				}, nil
 			}
 
 			return collr
@@ -1138,7 +1231,9 @@ func TestCollector_Collect(t *testing.T) {
 			collr.CreateVnode = false
 			collr.newSnmpClient = func() gosnmp.Handler { return m }
 			collr.newPinger = func(cfg pinger.Config, log *logger.Logger) (pinger.Client, error) {
-				return &mockPingClient{sample: pingNoReplySample(collr.Hostname)}, nil
+				return &mockPingClient{
+					sample: pingNoReplySample(collr.Hostname),
+				}, nil
 			}
 
 			return collr
@@ -1172,7 +1267,9 @@ func TestCollector_CollectPingOnlyUsesTrackingProbing(t *testing.T) {
 	setMockClientInitExpect(mockSNMP)
 	setMockClientSysInfoExpect(mockSNMP)
 
-	pingClient := &mockPingClient{sample: pingSuccessSample("192.0.2.1")}
+	pingClient := &mockPingClient{
+		sample: pingSuccessSample("192.0.2.1"),
+	}
 
 	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
@@ -1214,7 +1311,9 @@ func TestCollector_CollectMixedModeCollectsSNMPAndPingMetrics(t *testing.T) {
 	setMockClientInitExpect(mockSNMP)
 	setMockClientSysInfoExpect(mockSNMP)
 
-	pingClient := &mockPingClient{sample: pingSuccessSample("192.0.2.1")}
+	pingClient := &mockPingClient{
+		sample: pingSuccessSample("192.0.2.1"),
+	}
 
 	collr := newTestSNMPCollector()
 	collr.Config = prepareV2Config()
@@ -1226,21 +1325,25 @@ func TestCollector_CollectMixedModeCollectsSNMPAndPingMetrics(t *testing.T) {
 		return pingClient, nil
 	}
 	collr.newDdSnmpColl = func(ddsnmpcollector.Config) ddCollector {
-		return &mockDdSnmpCollector{pms: []*ddsnmp.ProfileMetrics{
-			{
-				Source: "test",
-				Metrics: []ddsnmp.Metric{
-					{
-						Name:    "uptime",
-						IsTable: false,
-						Value:   123,
-						Unit:    "s",
-						Tags:    map[string]string{},
-						Profile: &ddsnmp.ProfileMetrics{Tags: map[string]string{}},
+		return &mockDdSnmpCollector{
+			pms: []*ddsnmp.ProfileMetrics{
+				{
+					Source: "test",
+					Metrics: []ddsnmp.Metric{
+						{
+							Name:    "uptime",
+							IsTable: false,
+							Value:   123,
+							Unit:    "s",
+							Tags:    map[string]string{},
+							Profile: &ddsnmp.ProfileMetrics{
+								Tags: map[string]string{},
+							},
+						},
 					},
 				},
 			},
-		}}
+		}
 	}
 
 	require.NoError(t, collr.Init(context.Background()))
@@ -1309,7 +1412,11 @@ func (m *mockPingClient) recordedProbe(ctx context.Context, host, method string)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.calls = append(m.calls, probeCall{host: host, method: method, ctx: ctx})
+	m.calls = append(m.calls, probeCall{
+		host:   host,
+		method: method,
+		ctx:    ctx,
+	})
 	if m.probeErr != nil {
 		return pinger.Sample{}, m.probeErr
 	}
@@ -1417,9 +1524,17 @@ func TestCollector_Collect_LicensingAggregation(t *testing.T) {
 				assert.EqualValues(t, 0, got[metricIDLicenseStateDegraded])
 				assert.EqualValues(t, 1, got[metricIDLicenseStateBroken])
 				assert.EqualValues(t, 0, got[metricIDLicenseStateIgnored])
-				assert.GreaterOrEqual(t, got[metricIDLicenseAuthorizationRemainingTime], int64((48*time.Hour/time.Second)-5))
+				assert.GreaterOrEqual(
+					t,
+					got[metricIDLicenseAuthorizationRemainingTime],
+					int64((48*time.Hour/time.Second)-5),
+				)
 				assert.LessOrEqual(t, got[metricIDLicenseAuthorizationRemainingTime], int64(48*time.Hour/time.Second))
-				assert.GreaterOrEqual(t, got[metricIDLicenseCertificateRemainingTime], int64((72*time.Hour/time.Second)-5))
+				assert.GreaterOrEqual(
+					t,
+					got[metricIDLicenseCertificateRemainingTime],
+					int64((72*time.Hour/time.Second)-5),
+				)
 				assert.LessOrEqual(t, got[metricIDLicenseCertificateRemainingTime], int64(72*time.Hour/time.Second))
 				assert.NotContains(t, got, metricIDLicenseRemainingTime)
 				assert.NotContains(t, got, metricIDLicenseGraceRemainingTime)
@@ -1515,9 +1630,17 @@ func TestCollector_Collect_LicensingAggregation(t *testing.T) {
 				assert.EqualValues(t, 90, got[metricIDLicenseUsagePercent])
 				assert.GreaterOrEqual(t, got[metricIDLicenseRemainingTime], int64((6*time.Hour/time.Second)-5))
 				assert.LessOrEqual(t, got[metricIDLicenseRemainingTime], int64(6*time.Hour/time.Second))
-				assert.GreaterOrEqual(t, got[metricIDLicenseAuthorizationRemainingTime], int64((30*time.Hour/time.Second)-5))
+				assert.GreaterOrEqual(
+					t,
+					got[metricIDLicenseAuthorizationRemainingTime],
+					int64((30*time.Hour/time.Second)-5),
+				)
 				assert.LessOrEqual(t, got[metricIDLicenseAuthorizationRemainingTime], int64(30*time.Hour/time.Second))
-				assert.GreaterOrEqual(t, got[metricIDLicenseCertificateRemainingTime], int64((20*time.Hour/time.Second)-5))
+				assert.GreaterOrEqual(
+					t,
+					got[metricIDLicenseCertificateRemainingTime],
+					int64((20*time.Hour/time.Second)-5),
+				)
 				assert.LessOrEqual(t, got[metricIDLicenseCertificateRemainingTime], int64(20*time.Hour/time.Second))
 				assert.GreaterOrEqual(t, got[metricIDLicenseGraceRemainingTime], int64((10*time.Hour/time.Second)-5))
 				assert.LessOrEqual(t, got[metricIDLicenseGraceRemainingTime], int64(10*time.Hour/time.Second))
@@ -1546,7 +1669,9 @@ func TestCollector_Collect_LicensingAggregation(t *testing.T) {
 					Source:      tc.source,
 					LicenseRows: tc.rows(now),
 				}
-				return &mockDdSnmpCollector{pms: []*ddsnmp.ProfileMetrics{pm}}
+				return &mockDdSnmpCollector{
+					pms: []*ddsnmp.ProfileMetrics{pm},
+				}
 			}
 
 			require.NoError(t, collr.Init(context.Background()))
@@ -1662,13 +1787,15 @@ func setMockClientSetterExpectWithoutMaxOids(m *snmpmock.MockHandler) {
 
 func setMockClientSysInfoExpect(m *snmpmock.MockHandler) {
 	m.EXPECT().MaxOids().Return(20).MinTimes(1)
-	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-		{Name: snmputils.OidSysDescr, Value: []uint8("mock sysDescr"), Type: gosnmp.OctetString},
-		{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
-		{Name: snmputils.OidSysContact, Value: []uint8("mock sysContact"), Type: gosnmp.OctetString},
-		{Name: snmputils.OidSysName, Value: []uint8("mock sysName"), Type: gosnmp.OctetString},
-		{Name: snmputils.OidSysLocation, Value: []uint8("mock sysLocation"), Type: gosnmp.OctetString},
-	}}, nil).MinTimes(1)
+	m.EXPECT().Get(sysInfoOIDsForTest()).Return(&gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: snmputils.OidSysDescr, Value: []uint8("mock sysDescr"), Type: gosnmp.OctetString},
+			{Name: snmputils.OidSysObject, Value: ".1.3.6.1.4.1.14988.1", Type: gosnmp.ObjectIdentifier},
+			{Name: snmputils.OidSysContact, Value: []uint8("mock sysContact"), Type: gosnmp.OctetString},
+			{Name: snmputils.OidSysName, Value: []uint8("mock sysName"), Type: gosnmp.OctetString},
+			{Name: snmputils.OidSysLocation, Value: []uint8("mock sysLocation"), Type: gosnmp.OctetString},
+		},
+	}, nil).MinTimes(1)
 }
 
 func sysInfoOIDsForTest() []string {
@@ -1723,7 +1850,9 @@ func TestCollectorInitializationMetadataFailureIsPublished(t *testing.T) {
 			var packet *gosnmp.SnmpPacket
 			if tc.getErr == nil {
 				packet = &gosnmp.SnmpPacket{
-					Variables: []gosnmp.SnmpPDU{{Name: metadataOID, Type: gosnmp.OctetString, Value: []byte("SECRET invalid number")}},
+					Variables: []gosnmp.SnmpPDU{
+						{Name: metadataOID, Type: gosnmp.OctetString, Value: []byte("SECRET invalid number")},
+					},
 				}
 			}
 			handler.EXPECT().Get([]string{metadataOID}).Return(packet, tc.getErr).Times(2)
@@ -1733,14 +1862,26 @@ func TestCollectorInitializationMetadataFailureIsPublished(t *testing.T) {
 			collector.CreateVnode = true
 			collector.snmpClient = handler
 			fields := map[string]ddprofiledefinition.MetadataField{
-				"serial_number": {Symbol: ddprofiledefinition.SymbolConfig{OID: metadataOID, Name: "serial", Format: "uint32"}},
+				"serial_number": {
+					Symbol: ddprofiledefinition.SymbolConfig{
+						OID:    metadataOID,
+						Name:   "serial",
+						Format: "uint32",
+					},
+				},
 			}
 			if tc.staticVendor {
-				fields["vendor"] = ddprofiledefinition.MetadataField{Value: "synthetic"}
+				fields["vendor"] = ddprofiledefinition.MetadataField{
+					Value: "synthetic",
+				}
 			}
-			collector.snmpProfiles = []*ddsnmp.Profile{{SourceFile: "metadata.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
-				Metadata: ddprofiledefinition.MetadataConfig{"device": {Fields: fields}},
-			}}}
+			collector.snmpProfiles = []*ddsnmp.Profile{
+				{SourceFile: "metadata.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
+					Metadata: ddprofiledefinition.MetadataConfig{
+						"device": {Fields: fields},
+					},
+				}},
+			}
 			for range tc.attempts {
 				metrics := collector.Collect(context.Background())
 				status := collector.deviceLifecycleStatus

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity.go
@@ -37,7 +37,11 @@ type DeviceIdentity struct {
 // AcquireDeviceIdentity acquires metadata once and combines it with system identity.
 // A nil source uses system identity alone. The caller owns transport, profile
 // selection, retries, and publication. Inputs are borrowed and are not modified.
-func AcquireDeviceIdentity(si *snmputils.SysInfo, source DeviceMetadataSource, opts DeviceIdentityOptions) (*DeviceIdentity, error) {
+func AcquireDeviceIdentity(
+	si *snmputils.SysInfo,
+	source DeviceMetadataSource,
+	opts DeviceIdentityOptions,
+) (*DeviceIdentity, error) {
 	if si == nil {
 		return nil, errors.New("SNMP system identity is required")
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmp
+
+import (
+	"errors"
+	"maps"
+
+	"github.com/google/uuid"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+// DeviceMetadataSource acquires profile metadata using caller-owned SNMP state.
+type DeviceMetadataSource interface {
+	CollectDeviceMetadata() (map[string]MetaTag, error)
+}
+
+// DeviceIdentityOptions supplies the address, identity overrides, and label policy.
+type DeviceIdentityOptions struct {
+	Address  string
+	GUID     string
+	Hostname string
+	// BaseLabels supplies policy defaults before system and profile metadata.
+	BaseLabels map[string]string
+	// Labels supplies final overrides, including explicitly empty values.
+	Labels map[string]string
+}
+
+// DeviceIdentity is an acquired device identity independent of vnode publication.
+type DeviceIdentity struct {
+	GUID     string
+	Hostname string
+	Labels   map[string]string
+}
+
+// AcquireDeviceIdentity acquires metadata once and combines it with system identity.
+// A nil source uses system identity alone. The caller owns transport, profile
+// selection, retries, and publication. Inputs are borrowed and are not modified.
+func AcquireDeviceIdentity(si *snmputils.SysInfo, source DeviceMetadataSource, opts DeviceIdentityOptions) (*DeviceIdentity, error) {
+	if si == nil {
+		return nil, errors.New("SNMP system identity is required")
+	}
+	var metadata map[string]MetaTag
+	if source != nil {
+		var err error
+		metadata, err = source.CollectDeviceMetadata()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	guid := opts.GUID
+	if guid == "" {
+		guid = uuid.NewSHA1(uuid.NameSpaceDNS, []byte(opts.Address)).String()
+	}
+	hostname := opts.Hostname
+	if hostname == "" {
+		hostname = si.Name
+	}
+	if hostname == "" {
+		hostname = "snmp-device"
+	}
+
+	labels := make(map[string]string, len(opts.BaseLabels)+11)
+	maps.Copy(labels, opts.BaseLabels)
+	labels["_vnode_type"] = "snmp"
+	labels["_net_default_iface_ip"] = opts.Address
+	labels["address"] = opts.Address
+	labels["sys_object_id"] = si.SysObjectID
+	labels["name"] = si.Name
+	labels["description"] = si.Descr
+	labels["contact"] = si.Contact
+	labels["location"] = si.Location
+	if si.Vendor != "" {
+		labels["vendor"] = si.Vendor
+	} else if si.Organization != "" {
+		labels["vendor"] = si.Organization
+	}
+	if si.Category != "" {
+		labels["type"] = si.Category
+	}
+	if si.Model != "" {
+		labels["model"] = si.Model
+	}
+
+	return &DeviceIdentity{
+		GUID:     guid,
+		Hostname: hostname,
+		Labels:   ResolveDeviceMetadata(labels, metadata, opts.Labels),
+	}, nil
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/uuid"
 	"github.com/gosnmp/gosnmp"
 	snmpmock "github.com/gosnmp/gosnmp/mocks"
 	"github.com/stretchr/testify/assert"
@@ -27,83 +26,119 @@ func (f metadataSourceFunc) CollectDeviceMetadata() (map[string]ddsnmp.MetaTag, 
 	return f()
 }
 
-func TestAcquireDeviceIdentityPrecedenceAndOwnership(t *testing.T) {
-	si := snmputils.SysInfo{
-		SysObjectID: "1.3.6.1.4.1.9", Name: "router", Descr: "description", Contact: "contact", Location: "location",
-		Vendor: "system-vendor", Organization: "organization", Category: "Router", Model: "system-model",
+func TestAcquireDeviceIdentity(t *testing.T) {
+	tests := map[string]struct {
+		sysInfo  snmputils.SysInfo
+		metadata map[string]ddsnmp.MetaTag
+		opts     ddsnmp.DeviceIdentityOptions
+		want     *ddsnmp.DeviceIdentity
+	}{
+		"configured identity and label precedence": {
+			sysInfo: snmputils.SysInfo{
+				SysObjectID: "1.3.6.1.4.1.9", Name: "router", Descr: "description", Contact: "contact", Location: "location",
+				Vendor: "system-vendor", Organization: "organization", Category: "Router", Model: "system-model",
+			},
+			metadata: map[string]ddsnmp.MetaTag{
+				"vendor": {Value: "profile-vendor", IsExactMatch: true},
+				"model":  {Value: "generic-model"}, "serial_number": {Value: "serial"},
+				"_node_stale_after_seconds": {Value: "90", IsExactMatch: true},
+			},
+			opts: ddsnmp.DeviceIdentityOptions{
+				Address: "192.0.2.1", GUID: "configured-guid", Hostname: "configured-host",
+				BaseLabels: map[string]string{"_node_stale_after_seconds": "30", "site": "athens"},
+				Labels:     map[string]string{"site": "london", "contact": "", "_vnode_type": "configured-type"},
+			},
+			want: &ddsnmp.DeviceIdentity{
+				GUID: "configured-guid", Hostname: "configured-host",
+				Labels: map[string]string{
+					"_vnode_type": "configured-type", "_net_default_iface_ip": "192.0.2.1", "address": "192.0.2.1",
+					"sys_object_id": "1.3.6.1.4.1.9", "name": "router", "description": "description", "contact": "", "location": "location",
+					"vendor": "profile-vendor", "model": "system-model", "type": "Router", "serial_number": "serial",
+					"site": "london", "_node_stale_after_seconds": "90",
+				},
+			},
+		},
+		"system name and organization fallbacks without metadata source": {
+			sysInfo: snmputils.SysInfo{Name: "router", Organization: "organization"},
+			opts:    ddsnmp.DeviceIdentityOptions{Address: "Router.Example."},
+			want: &ddsnmp.DeviceIdentity{
+				GUID: "a2a0c16c-1b12-5ba4-8814-d81a16f862c6", Hostname: "router",
+				Labels: map[string]string{
+					"_vnode_type": "snmp", "_net_default_iface_ip": "Router.Example.", "address": "Router.Example.",
+					"sys_object_id": "", "name": "router", "description": "", "contact": "", "location": "", "vendor": "organization",
+				},
+			},
+		},
+		"empty system fallback without metadata source": {
+			opts: ddsnmp.DeviceIdentityOptions{Address: "Router.Example."},
+			want: &ddsnmp.DeviceIdentity{
+				GUID: "a2a0c16c-1b12-5ba4-8814-d81a16f862c6", Hostname: "snmp-device",
+				Labels: map[string]string{
+					"_vnode_type": "snmp", "_net_default_iface_ip": "Router.Example.", "address": "Router.Example.",
+					"sys_object_id": "", "name": "", "description": "", "contact": "", "location": "",
+				},
+			},
+		},
 	}
-	metadata := map[string]ddsnmp.MetaTag{
-		"vendor": {Value: "profile-vendor", IsExactMatch: true},
-		"model":  {Value: "generic-model"}, "serial_number": {Value: "serial"},
-		"_node_stale_after_seconds": {Value: "90", IsExactMatch: true},
-	}
-	opts := ddsnmp.DeviceIdentityOptions{
-		Address: "192.0.2.1", GUID: "configured-guid", Hostname: "configured-host",
-		BaseLabels: map[string]string{"_node_stale_after_seconds": "30", "site": "athens"},
-		Labels:     map[string]string{"site": "london", "contact": "", "_vnode_type": "configured-type"},
-	}
-	siBefore, metaBefore := si, maps.Clone(metadata)
-	baseBefore, labelsBefore := maps.Clone(opts.BaseLabels), maps.Clone(opts.Labels)
-	calls := 0
-	identity, err := ddsnmp.AcquireDeviceIdentity(&si, metadataSourceFunc(func() (map[string]ddsnmp.MetaTag, error) {
-		calls++
-		return metadata, nil
-	}), opts)
-	require.NoError(t, err)
-	assert.Equal(t, 1, calls)
-	assert.Equal(t, "configured-guid", identity.GUID)
-	assert.Equal(t, "configured-host", identity.Hostname)
-	assert.Equal(t, map[string]string{
-		"_vnode_type": "configured-type", "_net_default_iface_ip": "192.0.2.1", "address": "192.0.2.1",
-		"sys_object_id": si.SysObjectID, "name": "router", "description": "description", "contact": "", "location": "location",
-		"vendor": "profile-vendor", "model": "system-model", "type": "Router", "serial_number": "serial",
-		"site": "london", "_node_stale_after_seconds": "90",
-	}, identity.Labels)
-	identity.Labels["site"] = "changed"
-	identity.Labels["serial_number"] = "changed"
-	identity.Labels["_node_stale_after_seconds"] = "changed"
-	assert.Equal(t, siBefore, si)
-	assert.Equal(t, metaBefore, metadata)
-	assert.Equal(t, baseBefore, opts.BaseLabels)
-	assert.Equal(t, labelsBefore, opts.Labels)
-}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			siBefore, metaBefore := tc.sysInfo, maps.Clone(tc.metadata)
+			optsBefore := tc.opts
+			optsBefore.BaseLabels = maps.Clone(tc.opts.BaseLabels)
+			optsBefore.Labels = maps.Clone(tc.opts.Labels)
+			calls, wantCalls := 0, 0
+			var source ddsnmp.DeviceMetadataSource
+			if tc.metadata != nil {
+				wantCalls = 1
+				source = metadataSourceFunc(func() (map[string]ddsnmp.MetaTag, error) {
+					calls++
+					return tc.metadata, nil
+				})
+			}
 
-func TestAcquireDeviceIdentityFallbacks(t *testing.T) {
-	for _, tc := range []struct{ name, systemName, organization, hostname string }{
-		{"system name", "router", "organization", "router"},
-		{"empty system", "", "", "snmp-device"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			identity, err := ddsnmp.AcquireDeviceIdentity(&snmputils.SysInfo{Name: tc.systemName, Organization: tc.organization}, nil,
-				ddsnmp.DeviceIdentityOptions{Address: "Router.Example."})
+			identity, err := ddsnmp.AcquireDeviceIdentity(&tc.sysInfo, source, tc.opts)
 			require.NoError(t, err)
-			assert.Equal(t, uuid.NewSHA1(uuid.NameSpaceDNS, []byte("Router.Example.")).String(), identity.GUID)
-			assert.Equal(t, tc.hostname, identity.Hostname)
-			assert.Equal(t, "Router.Example.", identity.Labels["address"])
-			assert.Equal(t, "snmp", identity.Labels["_vnode_type"])
-			assert.Equal(t, tc.organization, identity.Labels["vendor"])
-			assert.NotContains(t, identity.Labels, "_node_stale_after_seconds")
-			assert.NotContains(t, identity.Labels, "model")
-			assert.NotContains(t, identity.Labels, "type")
+			require.Equal(t, tc.want, identity)
+			assert.Equal(t, wantCalls, calls)
+
+			for key := range identity.Labels {
+				identity.Labels[key] = "changed"
+			}
+			assert.Equal(t, siBefore, tc.sysInfo)
+			assert.Equal(t, metaBefore, tc.metadata)
+			assert.Equal(t, optsBefore, tc.opts)
 		})
 	}
 }
 
 func TestAcquireDeviceIdentityFailure(t *testing.T) {
-	wantErr := errors.New("metadata acquisition failed")
-	calls := 0
-	source := metadataSourceFunc(func() (map[string]ddsnmp.MetaTag, error) {
-		calls++
-		return map[string]ddsnmp.MetaTag{"vendor": {Value: "partial"}}, wantErr
-	})
-	identity, err := ddsnmp.AcquireDeviceIdentity(nil, source, ddsnmp.DeviceIdentityOptions{})
-	require.Error(t, err)
-	assert.Nil(t, identity)
-	assert.Zero(t, calls)
-	identity, err = ddsnmp.AcquireDeviceIdentity(&snmputils.SysInfo{}, source, ddsnmp.DeviceIdentityOptions{})
-	assert.Same(t, wantErr, err)
-	assert.Nil(t, identity)
-	assert.Equal(t, 1, calls)
+	metadataErr := errors.New("metadata acquisition failed")
+	tests := map[string]struct {
+		sysInfo   *snmputils.SysInfo
+		wantErr   error
+		wantCalls int
+	}{
+		"missing system identity skips metadata acquisition": {},
+		"metadata failure returns no partial identity": {
+			sysInfo: &snmputils.SysInfo{}, wantErr: metadataErr, wantCalls: 1,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			calls := 0
+			source := metadataSourceFunc(func() (map[string]ddsnmp.MetaTag, error) {
+				calls++
+				return map[string]ddsnmp.MetaTag{"vendor": {Value: "partial"}}, metadataErr
+			})
+			identity, err := ddsnmp.AcquireDeviceIdentity(tc.sysInfo, source, ddsnmp.DeviceIdentityOptions{})
+			require.Error(t, err)
+			if tc.wantErr != nil {
+				assert.Same(t, tc.wantErr, err)
+			}
+			assert.Nil(t, identity)
+			assert.Equal(t, tc.wantCalls, calls)
+		})
+	}
 }
 
 func TestAcquireDeviceIdentityWithoutMetricsJob(t *testing.T) {
@@ -133,7 +168,13 @@ func TestAcquireDeviceIdentityWithoutMetricsJob(t *testing.T) {
 	})
 	identity, err := ddsnmp.AcquireDeviceIdentity(si, source, ddsnmp.DeviceIdentityOptions{Address: "192.0.2.1"})
 	require.NoError(t, err)
-	assert.Equal(t, "router", identity.Hostname)
-	assert.Equal(t, "serial-123", identity.Labels["serial_number"])
-	assert.Equal(t, si.SysObjectID, identity.Labels["sys_object_id"])
+	want := &ddsnmp.DeviceIdentity{
+		GUID: "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121", Hostname: "router",
+		Labels: map[string]string{
+			"_vnode_type": "snmp", "_net_default_iface_ip": "192.0.2.1", "address": "192.0.2.1",
+			"sys_object_id": "1.3.6.1.4.1.9", "name": "router", "description": "", "contact": "", "location": "",
+			"vendor": "Cisco", "serial_number": "serial-123",
+		},
+	}
+	assert.Equal(t, want, identity)
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity_test.go
@@ -35,8 +35,15 @@ func TestAcquireDeviceIdentity(t *testing.T) {
 	}{
 		"configured identity and label precedence": {
 			sysInfo: snmputils.SysInfo{
-				SysObjectID: "1.3.6.1.4.1.9", Name: "router", Descr: "description", Contact: "contact", Location: "location",
-				Vendor: "system-vendor", Organization: "organization", Category: "Router", Model: "system-model",
+				SysObjectID:  "1.3.6.1.4.1.9",
+				Name:         "router",
+				Descr:        "description",
+				Contact:      "contact",
+				Location:     "location",
+				Vendor:       "system-vendor",
+				Organization: "organization",
+				Category:     "Router",
+				Model:        "system-model",
 			},
 			metadata: map[string]ddsnmp.MetaTag{
 				"vendor": {Value: "profile-vendor", IsExactMatch: true},
@@ -44,12 +51,15 @@ func TestAcquireDeviceIdentity(t *testing.T) {
 				"_node_stale_after_seconds": {Value: "90", IsExactMatch: true},
 			},
 			opts: ddsnmp.DeviceIdentityOptions{
-				Address: "192.0.2.1", GUID: "configured-guid", Hostname: "configured-host",
+				Address:    "192.0.2.1",
+				GUID:       "configured-guid",
+				Hostname:   "configured-host",
 				BaseLabels: map[string]string{"_node_stale_after_seconds": "30", "site": "athens"},
 				Labels:     map[string]string{"site": "london", "contact": "", "_vnode_type": "configured-type"},
 			},
 			want: &ddsnmp.DeviceIdentity{
-				GUID: "configured-guid", Hostname: "configured-host",
+				GUID:     "configured-guid",
+				Hostname: "configured-host",
 				Labels: map[string]string{
 					"_vnode_type": "configured-type", "_net_default_iface_ip": "192.0.2.1", "address": "192.0.2.1",
 					"sys_object_id": "1.3.6.1.4.1.9", "name": "router", "description": "description", "contact": "", "location": "location",
@@ -59,10 +69,16 @@ func TestAcquireDeviceIdentity(t *testing.T) {
 			},
 		},
 		"system name and organization fallbacks without metadata source": {
-			sysInfo: snmputils.SysInfo{Name: "router", Organization: "organization"},
-			opts:    ddsnmp.DeviceIdentityOptions{Address: "Router.Example."},
+			sysInfo: snmputils.SysInfo{
+				Name:         "router",
+				Organization: "organization",
+			},
+			opts: ddsnmp.DeviceIdentityOptions{
+				Address: "Router.Example.",
+			},
 			want: &ddsnmp.DeviceIdentity{
-				GUID: "a2a0c16c-1b12-5ba4-8814-d81a16f862c6", Hostname: "router",
+				GUID:     "a2a0c16c-1b12-5ba4-8814-d81a16f862c6",
+				Hostname: "router",
 				Labels: map[string]string{
 					"_vnode_type": "snmp", "_net_default_iface_ip": "Router.Example.", "address": "Router.Example.",
 					"sys_object_id": "", "name": "router", "description": "", "contact": "", "location": "", "vendor": "organization",
@@ -70,9 +86,12 @@ func TestAcquireDeviceIdentity(t *testing.T) {
 			},
 		},
 		"empty system fallback without metadata source": {
-			opts: ddsnmp.DeviceIdentityOptions{Address: "Router.Example."},
+			opts: ddsnmp.DeviceIdentityOptions{
+				Address: "Router.Example.",
+			},
 			want: &ddsnmp.DeviceIdentity{
-				GUID: "a2a0c16c-1b12-5ba4-8814-d81a16f862c6", Hostname: "snmp-device",
+				GUID:     "a2a0c16c-1b12-5ba4-8814-d81a16f862c6",
+				Hostname: "snmp-device",
 				Labels: map[string]string{
 					"_vnode_type": "snmp", "_net_default_iface_ip": "Router.Example.", "address": "Router.Example.",
 					"sys_object_id": "", "name": "", "description": "", "contact": "", "location": "",
@@ -147,29 +166,45 @@ func TestAcquireDeviceIdentityWithoutMetricsJob(t *testing.T) {
 	client.EXPECT().MaxOids().Return(20).AnyTimes()
 	client.EXPECT().Version().Return(gosnmp.Version2c).AnyTimes()
 	gomock.InOrder(
-		client.EXPECT().Get([]string{snmputils.OidSysDescr, snmputils.OidSysObject, snmputils.OidSysContact, snmputils.OidSysName, snmputils.OidSysLocation}).Return(
-			&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-				{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.9"},
-				{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
-			}}, nil),
-		client.EXPECT().Get([]string{metadataOID}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
-			{Name: metadataOID, Type: gosnmp.OctetString, Value: []byte("serial-123")},
-		}}, nil),
+		client.EXPECT().
+			Get([]string{snmputils.OidSysDescr, snmputils.OidSysObject, snmputils.OidSysContact, snmputils.OidSysName, snmputils.OidSysLocation}).
+			Return(
+				&gosnmp.SnmpPacket{
+					Variables: []gosnmp.SnmpPDU{
+						{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.9"},
+						{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
+					},
+				}, nil),
+		client.EXPECT().Get([]string{metadataOID}).Return(&gosnmp.SnmpPacket{
+			Variables: []gosnmp.SnmpPDU{
+				{Name: metadataOID, Type: gosnmp.OctetString, Value: []byte("serial-123")},
+			},
+		}, nil),
 	)
 	si, err := snmputils.GetSysInfo(client)
 	require.NoError(t, err)
 	source := ddsnmpcollector.New(ddsnmpcollector.Config{
-		SnmpClient: client, Log: logger.New(), SysObjectID: si.SysObjectID,
+		SnmpClient:  client,
+		Log:         logger.New(),
+		SysObjectID: si.SysObjectID,
 		Profiles: []*ddsnmp.Profile{{SourceFile: "identity.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
-			Metadata: ddprofiledefinition.MetadataConfig{"device": {Fields: map[string]ddprofiledefinition.MetadataField{
-				"serial_number": {Symbol: ddprofiledefinition.SymbolConfig{OID: metadataOID, Name: "serial"}},
-			}}},
+			Metadata: ddprofiledefinition.MetadataConfig{
+				"device": {Fields: map[string]ddprofiledefinition.MetadataField{
+					"serial_number": {Symbol: ddprofiledefinition.SymbolConfig{
+						OID:  metadataOID,
+						Name: "serial",
+					}},
+				}},
+			},
 		}}},
 	})
-	identity, err := ddsnmp.AcquireDeviceIdentity(si, source, ddsnmp.DeviceIdentityOptions{Address: "192.0.2.1"})
+	identity, err := ddsnmp.AcquireDeviceIdentity(si, source, ddsnmp.DeviceIdentityOptions{
+		Address: "192.0.2.1",
+	})
 	require.NoError(t, err)
 	want := &ddsnmp.DeviceIdentity{
-		GUID: "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121", Hostname: "router",
+		GUID:     "8ec4cad3-78e2-5ea1-ba26-cd6fdc51f121",
+		Hostname: "router",
 		Labels: map[string]string{
 			"_vnode_type": "snmp", "_net_default_iface_ip": "192.0.2.1", "address": "192.0.2.1",
 			"sys_object_id": "1.3.6.1.4.1.9", "name": "router", "description": "", "contact": "", "location": "",

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/device_identity_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmp_test
+
+import (
+	"errors"
+	"maps"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/gosnmp/gosnmp"
+	snmpmock "github.com/gosnmp/gosnmp/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+type metadataSourceFunc func() (map[string]ddsnmp.MetaTag, error)
+
+func (f metadataSourceFunc) CollectDeviceMetadata() (map[string]ddsnmp.MetaTag, error) {
+	return f()
+}
+
+func TestAcquireDeviceIdentityPrecedenceAndOwnership(t *testing.T) {
+	si := snmputils.SysInfo{
+		SysObjectID: "1.3.6.1.4.1.9", Name: "router", Descr: "description", Contact: "contact", Location: "location",
+		Vendor: "system-vendor", Organization: "organization", Category: "Router", Model: "system-model",
+	}
+	metadata := map[string]ddsnmp.MetaTag{
+		"vendor": {Value: "profile-vendor", IsExactMatch: true},
+		"model":  {Value: "generic-model"}, "serial_number": {Value: "serial"},
+		"_node_stale_after_seconds": {Value: "90", IsExactMatch: true},
+	}
+	opts := ddsnmp.DeviceIdentityOptions{
+		Address: "192.0.2.1", GUID: "configured-guid", Hostname: "configured-host",
+		BaseLabels: map[string]string{"_node_stale_after_seconds": "30", "site": "athens"},
+		Labels:     map[string]string{"site": "london", "contact": "", "_vnode_type": "configured-type"},
+	}
+	siBefore, metaBefore := si, maps.Clone(metadata)
+	baseBefore, labelsBefore := maps.Clone(opts.BaseLabels), maps.Clone(opts.Labels)
+	calls := 0
+	identity, err := ddsnmp.AcquireDeviceIdentity(&si, metadataSourceFunc(func() (map[string]ddsnmp.MetaTag, error) {
+		calls++
+		return metadata, nil
+	}), opts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "configured-guid", identity.GUID)
+	assert.Equal(t, "configured-host", identity.Hostname)
+	assert.Equal(t, map[string]string{
+		"_vnode_type": "configured-type", "_net_default_iface_ip": "192.0.2.1", "address": "192.0.2.1",
+		"sys_object_id": si.SysObjectID, "name": "router", "description": "description", "contact": "", "location": "location",
+		"vendor": "profile-vendor", "model": "system-model", "type": "Router", "serial_number": "serial",
+		"site": "london", "_node_stale_after_seconds": "90",
+	}, identity.Labels)
+	identity.Labels["site"] = "changed"
+	identity.Labels["serial_number"] = "changed"
+	identity.Labels["_node_stale_after_seconds"] = "changed"
+	assert.Equal(t, siBefore, si)
+	assert.Equal(t, metaBefore, metadata)
+	assert.Equal(t, baseBefore, opts.BaseLabels)
+	assert.Equal(t, labelsBefore, opts.Labels)
+}
+
+func TestAcquireDeviceIdentityFallbacks(t *testing.T) {
+	for _, tc := range []struct{ name, systemName, organization, hostname string }{
+		{"system name", "router", "organization", "router"},
+		{"empty system", "", "", "snmp-device"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			identity, err := ddsnmp.AcquireDeviceIdentity(&snmputils.SysInfo{Name: tc.systemName, Organization: tc.organization}, nil,
+				ddsnmp.DeviceIdentityOptions{Address: "Router.Example."})
+			require.NoError(t, err)
+			assert.Equal(t, uuid.NewSHA1(uuid.NameSpaceDNS, []byte("Router.Example.")).String(), identity.GUID)
+			assert.Equal(t, tc.hostname, identity.Hostname)
+			assert.Equal(t, "Router.Example.", identity.Labels["address"])
+			assert.Equal(t, "snmp", identity.Labels["_vnode_type"])
+			assert.Equal(t, tc.organization, identity.Labels["vendor"])
+			assert.NotContains(t, identity.Labels, "_node_stale_after_seconds")
+			assert.NotContains(t, identity.Labels, "model")
+			assert.NotContains(t, identity.Labels, "type")
+		})
+	}
+}
+
+func TestAcquireDeviceIdentityFailure(t *testing.T) {
+	wantErr := errors.New("metadata acquisition failed")
+	calls := 0
+	source := metadataSourceFunc(func() (map[string]ddsnmp.MetaTag, error) {
+		calls++
+		return map[string]ddsnmp.MetaTag{"vendor": {Value: "partial"}}, wantErr
+	})
+	identity, err := ddsnmp.AcquireDeviceIdentity(nil, source, ddsnmp.DeviceIdentityOptions{})
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.Zero(t, calls)
+	identity, err = ddsnmp.AcquireDeviceIdentity(&snmputils.SysInfo{}, source, ddsnmp.DeviceIdentityOptions{})
+	assert.Same(t, wantErr, err)
+	assert.Nil(t, identity)
+	assert.Equal(t, 1, calls)
+}
+
+func TestAcquireDeviceIdentityWithoutMetricsJob(t *testing.T) {
+	const metadataOID = "1.3.6.1.4.1.9.999.0"
+	client := snmpmock.NewMockHandler(gomock.NewController(t))
+	client.EXPECT().MaxOids().Return(20).AnyTimes()
+	client.EXPECT().Version().Return(gosnmp.Version2c).AnyTimes()
+	gomock.InOrder(
+		client.EXPECT().Get([]string{snmputils.OidSysDescr, snmputils.OidSysObject, snmputils.OidSysContact, snmputils.OidSysName, snmputils.OidSysLocation}).Return(
+			&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+				{Name: snmputils.OidSysObject, Type: gosnmp.ObjectIdentifier, Value: "1.3.6.1.4.1.9"},
+				{Name: snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("router")},
+			}}, nil),
+		client.EXPECT().Get([]string{metadataOID}).Return(&gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+			{Name: metadataOID, Type: gosnmp.OctetString, Value: []byte("serial-123")},
+		}}, nil),
+	)
+	si, err := snmputils.GetSysInfo(client)
+	require.NoError(t, err)
+	source := ddsnmpcollector.New(ddsnmpcollector.Config{
+		SnmpClient: client, Log: logger.New(), SysObjectID: si.SysObjectID,
+		Profiles: []*ddsnmp.Profile{{SourceFile: "identity.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
+			Metadata: ddprofiledefinition.MetadataConfig{"device": {Fields: map[string]ddprofiledefinition.MetadataField{
+				"serial_number": {Symbol: ddprofiledefinition.SymbolConfig{OID: metadataOID, Name: "serial"}},
+			}}},
+		}}},
+	})
+	identity, err := ddsnmp.AcquireDeviceIdentity(si, source, ddsnmp.DeviceIdentityOptions{Address: "192.0.2.1"})
+	require.NoError(t, err)
+	assert.Equal(t, "router", identity.Hostname)
+	assert.Equal(t, "serial-123", identity.Labels["serial_number"])
+	assert.Equal(t, si.SysObjectID, identity.Labels["sys_object_id"])
+}

--- a/src/go/plugin/go.d/docs/helper-packages.md
+++ b/src/go/plugin/go.d/docs/helper-packages.md
@@ -38,6 +38,7 @@ already owns the behavior.
 | Profile-catalog loading (YAML profiles, stock/user dirs) | `src/go/plugin/go.d/pkg/profilecatalog` |
 | Ping probing | `src/go/plugin/go.d/pkg/pinger` |
 | SNMP utilities | `src/go/plugin/go.d/pkg/snmputils` |
+| SNMP device identity and profile metadata | `src/go/plugin/go.d/collector/snmp/ddsnmp` |
 | Kubernetes client helpers | `src/go/plugin/go.d/pkg/k8sclient` |
 | Docker host helpers | `src/go/plugin/go.d/pkg/dockerhost` |
 | Test helpers for collectors | `src/go/plugin/go.d/pkg/collecttest` |
@@ -342,6 +343,41 @@ Create the resolver at the composition root and inject the same pointer into its
 MUST NOT close, sweep, or replace it during per-job lifecycle. Keep collector-specific address eligibility, candidate
 selection, display precedence, and audit mapping in collector-owned adapters rather than adding those policies to the
 generic package.
+
+## SNMP Device Identity
+
+Use `ddsnmp.AcquireDeviceIdentity` in `src/go/plugin/go.d/collector/snmp/ddsnmp` to obtain a device's GUID,
+hostname, and labels independently of an SNMP metrics job. The result does not publish a vnode or register a device.
+
+The caller composes the existing acquisition steps:
+
+1. Obtain system information with `snmputils.GetSysInfo` using a connected `gosnmp.Handler`.
+2. Resolve profiles with `ddsnmp.Catalog.Resolve`. Choose the appropriate profile projection and no-profile policy
+   for the consumer; those decisions do not belong to identity assembly.
+3. Construct `ddsnmpcollector.New` with the selected profiles, system object ID, client, and logger, or reuse the
+   caller's existing engine. Pass it to `AcquireDeviceIdentity` together with the system information and options.
+   A nil metadata source obtains identity from system information alone.
+
+`ddsnmpcollector` is a library engine. Construction creates its metric and metadata helpers, but does not start a
+metrics job or background work. Identity acquisition calls only `CollectDeviceMetadata`, once per invocation. It
+returns acquisition errors unchanged and does not return a partial identity on error. The caller owns connection
+lifetime, timeout/retry settings, attempt diagnostics, and any subsequent refresh or publication. Engine state is
+mutable; the caller must serialize its use.
+
+Identity defaults preserve the SNMP collector's existing behavior:
+
+- GUID is the SHA1 UUID in the DNS namespace derived from the raw configured address, unless overridden. Address
+  normalization, DNS resolution, port, credentials, and descriptive metadata do not participate in that calculation.
+- Hostname uses the configured override, then system name, then `snmp-device`.
+- System labels include the SNMP vnode marker, address, and system information. Policy defaults supplied through
+  `BaseLabels` precede system labels. Profile metadata fills empty labels or replaces them on an exact match;
+  configured `Labels` override all previous values, including with empty values.
+- Input maps and system information remain unchanged; the returned labels belong to the caller.
+
+The SNMP metrics collector keeps its availability timeout calculation and device publication locally. It passes its
+existing engine so acquisition retains missing-OID and diagnostic state. Initial identity acquisition does not seed
+the engine's metric preparation cache: the first metrics collection still reads metadata again. Keep that behavior
+when extracting or changing callers unless a separate change explicitly revises the request/cache contract.
 
 ## Legacy V1 Helpers
 


### PR DESCRIPTION
##### Summary

Extract SNMP device identity acquisition into a shared helper that can be used without a metrics collection job. Update the SNMP collector to use it while preserving existing identity, label precedence, request/cache behavior, and diagnostics.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts SNMP device identity acquisition into `ddsnmp.AcquireDeviceIdentity` so callers can get a device's GUID, hostname, and labels without a metrics collection job. The SNMP collector now uses the helper; identity, label precedence, request/cache behavior, and diagnostics are unchanged.

- The helper accepts system info, an optional metadata source, and options, and does not publish a vnode or register a device.
- Metadata acquisition errors are returned unchanged; no partial identity is produced on failure.
- `helper-packages.md` documents the identity acquisition contract and caller-owned responsibilities.
- `AGENTS.md` adds testing guidance favoring whole-value comparisons.

<sup>Written for commit 1cf44ebedd04e48476d1f7aa0bde531390f60e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SNMP device identity is now consistently resolved from system information, profile metadata, and configured overrides.
  - Added reliable defaults for device GUIDs, hostnames, and labels when configuration or metadata is unavailable.
  - SNMP collector initialization now reuses device identity and preserves device lifecycle information.

- **Documentation**
  - Added guidance for SNMP device identity resolution and test assertion practices.

- **Tests**
  - Expanded coverage for identity creation, metadata merging, fallback behavior, error handling, and cache reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->