### PR TITLE
feat(go.d/snmp): add Meraki products L2 topology profile

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/profile_test.go
@@ -144,9 +144,25 @@ func Test_FindProfiles(t *testing.T) {
 			sysObjOId:   "1.3.6.1.4.1.1916.2.65",
 			wanProfiles: []string{"extreme-switching", "generic-device"},
 		},
+		"Meraki MS210-24P": {
+			sysObjOId:   "1.3.6.1.4.1.29671.2.346",
+			wanProfiles: []string{"topology-role-meraki-products", "meraki", "generic-device"},
+		},
+		"Meraki MR16": {
+			sysObjOId:   "1.3.6.1.4.1.29671.2.13",
+			wanProfiles: []string{"topology-role-meraki-products", "meraki", "generic-device"},
+		},
+		"Meraki cloud controller": {
+			sysObjOId:   "1.3.6.1.4.1.29671.1",
+			wanProfiles: []string{"meraki-cloud-controller", "meraki", "generic-device"},
+		},
+		"Meraki outside products subtree": {
+			sysObjOId:   "1.3.6.1.4.1.29671.20.346",
+			wanProfiles: []string{"meraki", "generic-device"},
+		},
 		"Meraki MX84": {
 			sysObjOId:   "1.3.6.1.4.1.29671.2.109",
-			wanProfiles: []string{"meraki", "generic-device"},
+			wanProfiles: []string{"topology-role-meraki-products", "meraki", "generic-device"},
 		},
 		"Palo Alto WF-500": {
 			sysObjOId:   "1.3.6.1.4.1.25461.2.3.33",

--- a/src/go/plugin/go.d/config/go.d/snmp.profiles/default/topology-role-meraki-products.yaml
+++ b/src/go/plugin/go.d/config/go.d/snmp.profiles/default/topology-role-meraki-products.yaml
@@ -1,0 +1,18 @@
+# Candidate L2 topology acquisition for the merakiProducts subtree.
+# SNMP support for these tables is unverified; validate collection on a device
+# before wider rollout. Includes switches, access points, and gateways;
+# excludes the separate Meraki cloud-controller subtree.
+# LLDP inheritance also adds six metadata scalar queries to ordinary SNMP collection.
+
+extends:
+  - _std-topology-interface-mib.yaml
+  - _std-topology-lldp-mib.yaml
+  - _std-topology-cdp-mib.yaml
+  - _std-topology-fdb-mib.yaml
+  - _std-topology-q-bridge-mib.yaml
+  - _std-topology-stp-mib.yaml
+
+selector:
+  - sysobjectid:
+      include:
+        - '^1\.3\.6\.1\.4\.1\.29671\.2\..+$'


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new SNMP topology profile for Meraki products so switches, access points, and gateways get L2 topology collection. Previously Meraki devices only had the generic `meraki` profile. The new profile includes LLDP, CDP, FDB, Q-Bridge, STP, and interface MIBs.

- Applies to all Meraki product sysobjectids under `1.3.6.1.4.1.29671.2.*`, excluding the separate cloud-controller subtree.
- Adds `topology-role-meraki-products` to expected profiles for tested Meraki models.
- LLDP inheritance adds six metadata scalar queries to ordinary SNMP collection.
- SNMP support for these tables is unverified; validate on a device before wider rollout.

<sup>Written for commit 852beb1a8bc55f3198a33953807584bb16fbff82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SNMP topology support for Meraki products, including interface, LLDP, CDP, forwarding database, bridge, and spanning-tree data.
  - Meraki devices matching supported product identifiers are now automatically assigned the appropriate topology profile.

- **Bug Fixes**
  - Improved profile detection for Meraki devices, including cloud-controller identities and product OIDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->