### PR TITLE
feat(go.d): add independent SNMP-backed virtual nodes

### DIFF
--- a/.agents/skills/collectors-go-design/SKILL.md
+++ b/.agents/skills/collectors-go-design/SKILL.md
@@ -66,6 +66,11 @@ loads `mutating-collectors.md`.
 
 ## Architecture Gate
 
+For configured vnode acquisition and named attachment, use
+`src/go/plugin/framework/vnodes/README.md#ownership` and
+`src/go/plugin/framework/vnodes/README.md#collector-attachment` as the existing ownership contract before proposing
+collector-owned identity polling or shared connection settings.
+
 **When:** a proposal makes one job depend on another job's state (scanning its journals, waiting for its cleanup,
 sharing an operational lock, consulting a registry for permission to run), introduces durable state for otherwise
 independent reads, adds a scheduler or queue, lets cleanup freeze measurement, or builds a generic engine around one

--- a/.agents/skills/collectors-go-design/config-schema.md
+++ b/.agents/skills/collectors-go-design/config-schema.md
@@ -125,7 +125,9 @@ Use a discriminator plus `dependencies` for mutually exclusive configurations (m
 ```
 
 - The discriminator is a radio; its `ui:help` compares the modes (when to choose which).
-- Branch section keys are `<discriminator>_<value>`; each branch carries its own `required`.
+- Branch section keys SHOULD be `<discriminator>_<value>`. When multiple discriminator values share one shape,
+  semantic keys MAY be used (for example `version` with `credentials` and `credentials3`). Each branch MUST carry
+  its own `required`; the renderer constraints below still apply.
 - A branch key MUST NOT also be a plain sibling property (it would render for every mode).
 - With tabs, branch keys MUST be listed on a tab (they render only while their mode is selected); an unlisted branch
   key is dropped like any other property.

--- a/docs/learn/node-identities.md
+++ b/docs/learn/node-identities.md
@@ -525,33 +525,35 @@ For virtual nodes, see [Does renaming a virtual node change its identity?](#does
 <details>
 <summary>Does renaming a virtual node change its identity?</summary>
 
-A virtual node's identity is determined by its **`guid`** field — not its `hostname` or `name`. The fields behave as follows:
+A virtual node's identity is determined by its **UUID**. This is either explicitly configured as `guid` or, for an SNMP vnode without an override, derived from its exact configured address. The fields behave as follows:
 
 - **`guid`** — This is the vnode's identity. Changing it creates an entirely new node in Netdata Cloud. The old vnode's historical data remains under the old GUID but is no longer associated with the new one.
 - **`hostname`** — The display name, and the reference key for static YAML definitions. Changing it without changing the UUID renames the display. Update job references too when renaming a static YAML definition.
 - **`name`** — Required as the stable reference key for SNMP YAML definitions. Static YAML definitions ignore this field and use `hostname`; GUI definitions use their resource name.
 
-**To preserve data continuity when renaming a vnode**, change only the `hostname` field in its YAML file in the `vnodes/` directory of your [Netdata config directory](/docs/netdata-agent/configuration/README.md) and keep the `guid` unchanged. For SNMP vnodes, hostname overrides keep the stable reference name. Mode/address/context/UUID changes require a replacement vnode. Historical data belongs to the old UUID.
+**To preserve data continuity when renaming a vnode**, edit `hostname` in the configuration source you used: its YAML file in the `vnodes/` directory of your [Netdata config directory](/docs/netdata-agent/configuration/README.md), or its [Vnodes GUI configuration](#creating-virtual-nodes-via-the-gui-dynamic-configuration). Keep any explicit `guid` unchanged. For an SNMP vnode with a derived UUID, keep the exact address unchanged too.
+
+SNMP hostname overrides preserve the stable reference name. Changing an existing SNMP vnode's mode, address, context, or UUID requires a replacement vnode. Historical data belongs to the old UUID.
 
 </details>
 
 <details>
 <summary>How do I find the UUID of my existing vnode?</summary>
 
-An explicitly configured GUID is stored in its YAML configuration file in the `vnodes/` directory of your [Netdata config directory](/docs/netdata-agent/configuration/README.md). To look it up:
+If the vnode has an explicit `guid`, that value is its UUID. Look it up in the configuration source:
+
+- **YAML-defined vnode:** read its `guid` in the `vnodes/` directory of your [Netdata config directory](/docs/netdata-agent/configuration/README.md).
+- **GUI-created vnode:** open the node's dynamic configuration view, select **go.d → Vnodes**, and inspect the vnode's `guid`. GUI-created definitions are managed through dynamic configuration; they do not require a YAML file in `vnodes/`.
+
+To inspect YAML definitions:
 
 ```bash
 # Default path — adjust if your Netdata config directory differs.
 cat /etc/netdata/vnodes/*
 ```
 
-Static definitions contain a `guid` field that uniquely identifies the vnode. SNMP definitions may omit it; the UUID is then derived from the exact address and becomes visible when an attached job publishes the node:
+Static vnodes require an explicit `guid`. SNMP vnodes can omit it in either YAML or the GUI; their UUID is then derived from the exact `mode_snmp.address` string. The derived UUID is not written back into the authored configuration. It becomes visible with the vnode when an attached collector job publishes that node.
 
-```yaml
-- hostname: remote-server.example.com
-  guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-```
-
-For an explicitly configured GUID, the `guid` value is the vnode's UUID and the YAML configuration file is its authoritative source. SNMP definitions that omit `guid` derive the UUID from the exact address, so it is not stored in the YAML file. See [Virtual Nodes](#virtual-nodes-vnodes) for the full configuration reference.
+See [Virtual Nodes](#virtual-nodes-vnodes) for the full configuration reference.
 
 </details>

--- a/docs/learn/node-identities.md
+++ b/docs/learn/node-identities.md
@@ -164,10 +164,13 @@ For SNMPv3, replace `credentials` with `credentials3` and set `version: "3"`:
 
 The version choices are `"1"`, `2c` (default), and `"3"`. SNMPv3 supports `noAuthNoPriv`, `authNoPriv`, and
 `authPriv` (default). Authentication defaults to `sha512`; privacy defaults to `aes192c`. Passwords must contain at
-least eight bytes. Omit authentication fields for `noAuthNoPriv`, privacy fields for `authNoPriv`, and the entire
-inactive credential block. Optional `credentials3.context_name` selects an SNMP context. These new field names
+least eight bytes. Inactive credentials are discarded before validation and retention by go.d: authentication and privacy fields
+for `noAuthNoPriv`, privacy fields for `authNoPriv`, and the credential block for the unselected version. This applies
+to both files and forms; switching back requires entering the discarded credentials again. Active credentials remain
+strictly validated. Optional `credentials3.context_name` selects an SNMP context. These new field names
 apply to vnode acquisition; existing collector and discovery credential names are unchanged. Use literal credentials;
-secret references are not supported in vnode acquisition yet.
+secret references are not supported in vnode acquisition yet. This does not rewrite source files or scrub the Agent's
+saved copy of the originally submitted DynCfg payload.
 
 A usable `sysObjectID`, `sysName`, or `sysDescr` lets attached jobs start. Failed profile enrichment retries while
 keeping usable system identity. Acquisition retries every 10 seconds after failure and refreshes complete metadata

--- a/docs/learn/node-identities.md
+++ b/docs/learn/node-identities.md
@@ -552,6 +552,6 @@ Static definitions contain a `guid` field that uniquely identifies the vnode. SN
   guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
-The `guid` value is the vnode's UUID. You do **not** need to query any internal database — the YAML configuration file is the authoritative source for the vnode GUID. See [Virtual Nodes](#virtual-nodes-vnodes) for the full configuration reference.
+For an explicitly configured GUID, the `guid` value is the vnode's UUID and the YAML configuration file is its authoritative source. SNMP definitions that omit `guid` derive the UUID from the exact address, so it is not stored in the YAML file. See [Virtual Nodes](#virtual-nodes-vnodes) for the full configuration reference.
 
 </details>

--- a/docs/learn/node-identities.md
+++ b/docs/learn/node-identities.md
@@ -92,11 +92,11 @@ See [VM Templates](/docs/learn/vm-templates.md) for how to avoid this when cloni
 |---------------|-------------------------------------------------------------------------------------------|
 | **Directory** | `vnodes/` in your [Netdata config directory](/docs/netdata-agent/configuration/README.md) |
 | **Format**    | YAML files (`.yaml`, `.yml`, `.conf`)                                                     |
-| **Identity**  | User-defined GUID in config file                                                          |
+| **Identity**  | Configured UUID, or a UUID derived from the SNMP address                                                          |
 
 ### Configuration
 
-Each virtual node is defined in a YAML file:
+Static virtual nodes use the existing YAML format (`mode: static` is optional):
 
 ```yaml
 - hostname: remote-server.example.com
@@ -122,9 +122,68 @@ Each virtual node GUID must be unique across your entire infrastructure. Using t
 
 :::
 
+### Acquiring Virtual Node Identity Through SNMP
+
+With go.d, a vnode can acquire its hostname and host labels independently of any metrics job:
+
+```yaml
+- name: router
+  mode: snmp
+  mode_snmp:
+    address: 192.0.2.1
+    version: 2c
+    credentials:
+      community: example-community
+  labels:
+    site: example-site
+```
+
+- `name` is required and stays the job reference even if the device's hostname changes.
+- `hostname` is an optional override. Otherwise, the vnode uses a usable SNMP `sysName`, then `name`.
+- `guid` is an optional UUID override. Otherwise, the exact `address` string determines the UUID. Different spellings
+  for the same device produce different UUIDs; port and SNMP context do not distinguish UUIDs. Supply unique UUIDs
+  explicitly when multiple virtual nodes use the same address.
+- `labels` override acquired host labels. Removing an override restores the last acquired value.
+- `mode_snmp.port` defaults to `161`, `timeout` to `5s`, and `retries` to `1`; set `retries: 0` to disable request retries.
+  Automatic profile matching enriches system identity; metric profile coverage is not required.
+
+For SNMPv3, replace `credentials` with `credentials3` and set `version: "3"`:
+
+```yaml
+  mode_snmp:
+    address: 192.0.2.1
+    version: "3"
+    credentials3:
+      username: example-user
+      security_level: authPriv
+      auth_protocol: sha512
+      auth_password: example-auth-password
+      priv_protocol: aes192c
+      priv_password: example-priv-password
+```
+
+The version choices are `"1"`, `2c` (default), and `"3"`. SNMPv3 supports `noAuthNoPriv`, `authNoPriv`, and
+`authPriv` (default). Authentication defaults to `sha512`; privacy defaults to `aes192c`. Passwords must contain at
+least eight bytes. Omit authentication fields for `noAuthNoPriv`, privacy fields for `authNoPriv`, and the entire
+inactive credential block. Optional `credentials3.context_name` selects an SNMP context. These new field names
+apply to vnode acquisition; existing collector and discovery credential names are unchanged. Use literal credentials;
+secret references are not supported in vnode acquisition yet.
+
+A usable `sysObjectID`, `sysName`, or `sysDescr` lets attached jobs start. Failed profile enrichment retries while
+keeping usable system identity. Acquisition retries every 10 seconds after failure and refreshes complete metadata
+hourly. These intervals are internal defaults. Failed refreshes retain the last usable metadata; a successful refresh
+replaces acquired labels. Acquisition continues without metrics jobs, but the node is announced only by ordinary
+job output.
+
+Acquired metadata is held in memory. After a plugin restart, jobs wait for fresh identity acquisition. Label and hostname
+override edits need no network request. Credential edits reacquire metadata while retaining the last usable identity.
+Changing the mode, address, context, or UUID of an existing SNMP vnode is rejected: create a replacement vnode and move
+job references to it. Static vnode updates retain their existing behavior. The scripts.d and ibm.d plugins ignore
+SNMP-mode file definitions and expose only static vnode configuration.
+
 ### Creating Virtual Nodes via the GUI (Dynamic Configuration)
 
-In addition to the YAML file method, you can create, edit, test, and remove virtual nodes directly from the Netdata UI using [dynamic configuration (dyncfg)](/docs/netdata-agent/configuration/dynamic-configuration.md). Both methods produce a working vnode that collectors can attach metrics to, though field requirements differ — see the table below. The Vnodes GUI path is available under the go.d plugin's dynamic configuration view.
+In addition to the YAML file method, you can create, edit, test, and remove virtual nodes directly from the Netdata UI using [dynamic configuration (dyncfg)](/docs/netdata-agent/configuration/dynamic-configuration.md). Both methods configure a vnode that collectors can attach metrics to; SNMP mode first acquires a usable device identity. The Vnodes GUI path is available under the go.d plugin's dynamic configuration view.
 
 :::note
 
@@ -134,7 +193,7 @@ In the Netdata UI, open the node's dynamic configuration view and look for the *
 
 :::
 
-The GUI form exposes `hostname`, `guid`, `labels`, and `stale_after` — the same fields as YAML, minus `name` which the Agent ignores:
+The go.d GUI form selects `static` or `snmp` mode. The resource name entered when creating a vnode is its stable reference name. Static mode uses these fields:
 
 | Field      | Required in the GUI | Description                                                                                                                         |
 |------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------|
@@ -179,19 +238,39 @@ jobs:
     url: http://203.0.113.10:9182/metrics
 ```
 
-The `vnode` value must exactly match the vnode reference name. For YAML definitions, the reference name is always `hostname` and any explicit `name` is ignored; for GUI definitions, use the name assigned when creating the vnode. If that name is not registered, the job fails to start.
+The `vnode` value must exactly match the vnode reference name. For static YAML definitions, use `hostname`; for SNMP YAML definitions, use the required `name`. For GUI definitions, use the resource name assigned when creating the vnode. An unknown name or an SNMP vnode awaiting its first usable identity prevents the job from starting; configured detection retries can start it once the identity is available.
 
 Several jobs can reference the same vnode. Its configured hostname and host labels govern output to its GUID within that plugin process, including collector-generated scopes using the same GUID. Job labels remain chart labels. Removing an unreferenced configured vnode lets generated contributors resume using their own host metadata.
 
 :::note
 
-**SNMP** collectors behave differently: their `create_vnode: true` option auto-creates the vnode from the job configuration, so no separate vnode definition step is needed.
+**SNMP** jobs can use the same `vnode: router` string reference. This takes precedence over `create_vnode`, including its default of `true`. Without a named reference, `create_vnode: true` retains the existing automatic vnode behavior and `local_vnode` configures the job-owned identity. Legacy inline `vnode` objects remain accepted. A named reference supplies identity only: keep the SNMP job's own `hostname`, credentials, and metric profiles configured.
 
 :::
 
+For a vnode created within an SNMP job, configure `local_vnode` instead of a named reference:
+
+```yaml
+jobs:
+  - name: router_metrics
+    hostname: 192.0.2.1
+    community: example-collector-community
+    create_vnode: true
+    local_vnode:
+      hostname: office-router
+      labels:
+        site: office
+```
+
+Existing SNMP configurations using `vnode: { hostname: ..., guid: ..., labels: ... }` keep working.
+Dynamic configuration returns these settings under `local_vnode`, so the form can edit them without changing
+which host receives metrics. Files are not rewritten. Do not specify both the legacy object and `local_vnode`.
+A string `vnode` reference takes precedence over `create_vnode` and `local_vnode`; configure the central vnode to
+change its host labels.
+
 ### How Virtual Nodes Work
 
-1. Define a vnode (YAML file or GUI) with a unique `hostname` and `guid`
+1. Define a static vnode with a unique hostname and UUID, or an SNMP vnode with a stable name and acquisition connection
 2. Configure the collector job with `vnode: <name>` to attach it
 3. Metrics are tagged with the vnode's GUID instead of the Agent's Machine GUID
 4. Cloud sees the vnode as a separate node in your Space
@@ -446,24 +525,24 @@ For virtual nodes, see [Does renaming a virtual node change its identity?](#does
 A virtual node's identity is determined by its **`guid`** field — not its `hostname` or `name`. The fields behave as follows:
 
 - **`guid`** — This is the vnode's identity. Changing it creates an entirely new node in Netdata Cloud. The old vnode's historical data remains under the old GUID but is no longer associated with the new one.
-- **`hostname`** — This is used as the internal lookup key in the Agent and as the display name in dashboards. Changing `hostname` while keeping the same `guid` renames the display without creating a new node identity.
-- **`name`** — The Agent ignores this field. When set to a value different from `hostname`, the Agent logs a warning and overrides it with `hostname`.
+- **`hostname`** — The display name, and the reference key for static YAML definitions. Changing it without changing the UUID renames the display. Update job references too when renaming a static YAML definition.
+- **`name`** — Required as the stable reference key for SNMP YAML definitions. Static YAML definitions ignore this field and use `hostname`; GUI definitions use their resource name.
 
-**To preserve data continuity when renaming a vnode**, change only the `hostname` field in its YAML file in the `vnodes/` directory of your [Netdata config directory](/docs/netdata-agent/configuration/README.md) and keep the `guid` unchanged. If a true identity change is needed, accept that historical data belongs to the old identity.
+**To preserve data continuity when renaming a vnode**, change only the `hostname` field in its YAML file in the `vnodes/` directory of your [Netdata config directory](/docs/netdata-agent/configuration/README.md) and keep the `guid` unchanged. For SNMP vnodes, hostname overrides keep the stable reference name. Mode/address/context/UUID changes require a replacement vnode. Historical data belongs to the old UUID.
 
 </details>
 
 <details>
 <summary>How do I find the UUID of my existing vnode?</summary>
 
-The GUID for each virtual node is stored in its YAML configuration file in the `vnodes/` directory of your [Netdata config directory](/docs/netdata-agent/configuration/README.md). To look it up:
+An explicitly configured GUID is stored in its YAML configuration file in the `vnodes/` directory of your [Netdata config directory](/docs/netdata-agent/configuration/README.md). To look it up:
 
 ```bash
 # Default path — adjust if your Netdata config directory differs.
 cat /etc/netdata/vnodes/*
 ```
 
-Each file contains a `guid` field that uniquely identifies the vnode:
+Static definitions contain a `guid` field that uniquely identifies the vnode. SNMP definitions may omit it; the UUID is then derived from the exact address and becomes visible when an attached job publishes the node:
 
 ```yaml
 - hostname: remote-server.example.com

--- a/src/go/cmd/godplugin/main.go
+++ b/src/go/cmd/godplugin/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/discovery/sdext"
+	govnode "github.com/netdata/netdata/go/plugins/plugin/go.d/vnode"
 	"go.uber.org/automaxprocs/maxprocs"
 	"golang.org/x/net/http/httpproxy"
 )
@@ -69,6 +70,7 @@ func main() {
 	runModePolicy := policy.Agent(isTerminal)
 
 	a := agent.New(agent.Config{
+		SNMPVnodeAcquirer:         govnode.SNMP{},
 		Name:                      executable.Name,
 		PluginConfigDir:           pluginconfig.ConfigDir(),
 		CollectorsConfigDir:       pluginconfig.CollectorsDir(),

--- a/src/go/pkg/snmpauth/config.go
+++ b/src/go/pkg/snmpauth/config.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmpauth
+
+import (
+	"fmt"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// Config is the authentication contract for new SNMP consumers. Legacy public
+// collector and discovery formats retain their own compatibility rules.
+type Config struct {
+	Version      string     `yaml:"version,omitempty" json:"version,omitempty"`
+	Credentials  *Community `yaml:"credentials,omitempty" json:"credentials,omitempty"`
+	Credentials3 *USM       `yaml:"credentials3,omitempty" json:"credentials3,omitempty"`
+}
+type Community struct {
+	Community string `yaml:"community" json:"community"`
+}
+type USM struct {
+	Username      string `yaml:"username" json:"username"`
+	SecurityLevel string `yaml:"security_level,omitempty" json:"security_level,omitempty"`
+	AuthProtocol  string `yaml:"auth_protocol,omitempty" json:"auth_protocol,omitempty"`
+	AuthPassword  string `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
+	PrivProtocol  string `yaml:"priv_protocol,omitempty" json:"priv_protocol,omitempty"`
+	PrivPassword  string `yaml:"priv_password,omitempty" json:"priv_password,omitempty"`
+	ContextName   string `yaml:"context_name,omitempty" json:"context_name,omitempty"`
+}
+
+func (c Config) Copy() Config {
+	if c.Credentials != nil {
+		v := *c.Credentials
+		c.Credentials = &v
+	}
+	if c.Credentials3 != nil {
+		v := *c.Credentials3
+		c.Credentials3 = &v
+	}
+	return c
+}
+func (c Config) ContextName() string {
+	if c.Version == "3" && c.Credentials3 != nil {
+		return c.Credentials3.ContextName
+	}
+	return ""
+}
+func (c Config) Validate() error { return c.Apply(&gosnmp.GoSNMP{}) }
+
+// Apply validates before installing credentials. Errors name fields, never values.
+func (c Config) Apply(client *gosnmp.GoSNMP) error {
+	switch c.Version {
+	case "", "2c", "1":
+		if c.Credentials3 != nil {
+			return fmt.Errorf("credentials3 requires version 3")
+		}
+		if c.Credentials == nil || c.Credentials.Community == "" {
+			return fmt.Errorf("credentials.community is required")
+		}
+		client.Version = gosnmp.Version2c
+		if c.Version == "1" {
+			client.Version = gosnmp.Version1
+		}
+		client.Community = c.Credentials.Community
+		return nil
+	case "3":
+	default:
+		return fmt.Errorf("version must be 1, 2c or 3")
+	}
+	if c.Credentials != nil {
+		return fmt.Errorf("credentials cannot be used with version 3")
+	}
+	if c.Credentials3 == nil || c.Credentials3.Username == "" {
+		return fmt.Errorf("credentials3.username is required")
+	}
+	u := *c.Credentials3
+	if u.SecurityLevel == "" {
+		u.SecurityLevel = "authPriv"
+	}
+	flags, ok := map[string]gosnmp.SnmpV3MsgFlags{"noAuthNoPriv": gosnmp.NoAuthNoPriv, "authNoPriv": gosnmp.AuthNoPriv, "authPriv": gosnmp.AuthPriv}[u.SecurityLevel]
+	if !ok {
+		return fmt.Errorf("invalid credentials3.security_level")
+	}
+	auth, priv := gosnmp.NoAuth, gosnmp.NoPriv
+	if flags != gosnmp.NoAuthNoPriv {
+		if u.AuthProtocol == "" {
+			u.AuthProtocol = "sha512"
+		}
+		auth, ok = map[string]gosnmp.SnmpV3AuthProtocol{"md5": gosnmp.MD5, "sha": gosnmp.SHA, "sha224": gosnmp.SHA224, "sha256": gosnmp.SHA256, "sha384": gosnmp.SHA384, "sha512": gosnmp.SHA512}[u.AuthProtocol]
+		if !ok {
+			return fmt.Errorf("invalid credentials3.auth_protocol")
+		}
+		if len(u.AuthPassword) < 8 {
+			return fmt.Errorf("credentials3.auth_password must contain at least 8 bytes")
+		}
+	} else if u.AuthProtocol != "" || u.AuthPassword != "" {
+		return fmt.Errorf("authentication fields require an authenticated security_level")
+	}
+	if flags == gosnmp.AuthPriv {
+		if u.PrivProtocol == "" {
+			u.PrivProtocol = "aes192c"
+		}
+		priv, ok = map[string]gosnmp.SnmpV3PrivProtocol{"des": gosnmp.DES, "aes": gosnmp.AES, "aes192": gosnmp.AES192, "aes256": gosnmp.AES256, "aes192c": gosnmp.AES192C, "aes256c": gosnmp.AES256C}[u.PrivProtocol]
+		if !ok {
+			return fmt.Errorf("invalid credentials3.priv_protocol")
+		}
+		if len(u.PrivPassword) < 8 {
+			return fmt.Errorf("credentials3.priv_password must contain at least 8 bytes")
+		}
+	} else if u.PrivProtocol != "" || u.PrivPassword != "" {
+		return fmt.Errorf("privacy fields require authPriv security_level")
+	}
+	client.Version = gosnmp.Version3
+	client.MsgFlags = flags
+	client.SecurityModel = gosnmp.UserSecurityModel
+	client.ContextName = u.ContextName
+	client.SecurityParameters = &gosnmp.UsmSecurityParameters{UserName: u.Username, AuthenticationProtocol: auth, AuthenticationPassphrase: u.AuthPassword, PrivacyProtocol: priv, PrivacyPassphrase: u.PrivPassword}
+	return nil
+}

--- a/src/go/pkg/snmpauth/config.go
+++ b/src/go/pkg/snmpauth/config.go
@@ -39,6 +39,28 @@ func (c Config) Copy() Config {
 	}
 	return c
 }
+
+// Normalized returns owned credentials for the selected version and security level.
+// Forms can retain hidden fields when an operator switches a nested section.
+func (c Config) Normalized() Config {
+	c = c.Copy()
+	switch c.Version {
+	case "", "1", "2c":
+		c.Credentials3 = nil
+	case "3":
+		c.Credentials = nil
+		if u := c.Credentials3; u != nil {
+			switch u.SecurityLevel {
+			case "noAuthNoPriv":
+				u.AuthProtocol, u.AuthPassword = "", ""
+				u.PrivProtocol, u.PrivPassword = "", ""
+			case "authNoPriv":
+				u.PrivProtocol, u.PrivPassword = "", ""
+			}
+		}
+	}
+	return c
+}
 func (c Config) ContextName() string {
 	if c.Version == "3" && c.Credentials3 != nil {
 		return c.Credentials3.ContextName
@@ -49,11 +71,9 @@ func (c Config) Validate() error { return c.Apply(&gosnmp.GoSNMP{}) }
 
 // Apply validates before installing credentials. Errors name fields, never values.
 func (c Config) Apply(client *gosnmp.GoSNMP) error {
+	c = c.Normalized()
 	switch c.Version {
 	case "", "2c", "1":
-		if c.Credentials3 != nil {
-			return fmt.Errorf("credentials3 requires version 3")
-		}
 		if c.Credentials == nil || c.Credentials.Community == "" {
 			return fmt.Errorf("credentials.community is required")
 		}
@@ -66,9 +86,6 @@ func (c Config) Apply(client *gosnmp.GoSNMP) error {
 	case "3":
 	default:
 		return fmt.Errorf("version must be 1, 2c or 3")
-	}
-	if c.Credentials != nil {
-		return fmt.Errorf("credentials cannot be used with version 3")
 	}
 	if c.Credentials3 == nil || c.Credentials3.Username == "" {
 		return fmt.Errorf("credentials3.username is required")
@@ -93,8 +110,6 @@ func (c Config) Apply(client *gosnmp.GoSNMP) error {
 		if len(u.AuthPassword) < 8 {
 			return fmt.Errorf("credentials3.auth_password must contain at least 8 bytes")
 		}
-	} else if u.AuthProtocol != "" || u.AuthPassword != "" {
-		return fmt.Errorf("authentication fields require an authenticated security_level")
 	}
 	if flags == gosnmp.AuthPriv {
 		if u.PrivProtocol == "" {
@@ -107,8 +122,6 @@ func (c Config) Apply(client *gosnmp.GoSNMP) error {
 		if len(u.PrivPassword) < 8 {
 			return fmt.Errorf("credentials3.priv_password must contain at least 8 bytes")
 		}
-	} else if u.PrivProtocol != "" || u.PrivPassword != "" {
-		return fmt.Errorf("privacy fields require authPriv security_level")
 	}
 	client.Version = gosnmp.Version3
 	client.MsgFlags = flags

--- a/src/go/pkg/snmpauth/config_test.go
+++ b/src/go/pkg/snmpauth/config_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmpauth
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	for _, version := range []string{"", "1", "2c"} {
+		c := Config{Version: version, Credentials: &Community{Community: "test-secret"}}
+		client := &gosnmp.GoSNMP{}
+		require.NoError(t, c.Apply(client))
+		require.Equal(t, "test-secret", client.Community)
+		if version == "1" {
+			require.Equal(t, gosnmp.Version1, client.Version)
+		} else {
+			require.Equal(t, gosnmp.Version2c, client.Version)
+		}
+	}
+	for _, level := range []string{"noAuthNoPriv", "authNoPriv", "authPriv", ""} {
+		t.Run(level, func(t *testing.T) {
+			u := &USM{Username: "test-user", SecurityLevel: level}
+			if level != "noAuthNoPriv" {
+				u.AuthPassword = "test-auth"
+			}
+			if level == "authPriv" || level == "" {
+				u.PrivPassword = "test-priv"
+			}
+			c := Config{Version: "3", Credentials3: u}
+			client := &gosnmp.GoSNMP{}
+			require.NoError(t, c.Apply(client))
+			require.Equal(t, gosnmp.Version3, client.Version)
+			if level == "" {
+				require.Equal(t, gosnmp.AuthPriv, client.MsgFlags)
+				require.Equal(t, gosnmp.SHA512, client.SecurityParameters.(*gosnmp.UsmSecurityParameters).AuthenticationProtocol)
+			}
+		})
+	}
+}
+func TestInvalidAuthIsNotSilentlyDowngraded(t *testing.T) {
+	cases := []Config{
+		{Version: "invalid-secret"}, {},
+		{Credentials: &Community{Community: "secret"}, Credentials3: &USM{}},
+		{Version: "3", Credentials: &Community{Community: "secret"}, Credentials3: &USM{Username: "user"}},
+		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "invalid-secret"}},
+		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "authNoPriv", AuthProtocol: "invalid-secret", AuthPassword: "test-secret"}},
+		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "authPriv", AuthPassword: "short", PrivPassword: "test-secret"}},
+		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "noAuthNoPriv", AuthPassword: "test-secret"}},
+		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "authNoPriv", AuthPassword: "test-secret", PrivPassword: "test-secret"}},
+	}
+	for _, c := range cases {
+		err := c.Validate()
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secret")
+	}
+}
+func TestCopyOwnsCredentials(t *testing.T) {
+	c := Config{Credentials: &Community{Community: "original"}, Credentials3: &USM{AuthPassword: "original"}}
+	copy := c.Copy()
+	copy.Credentials.Community = "new"
+	copy.Credentials3.AuthPassword = "new"
+	require.Equal(t, "original", c.Credentials.Community)
+	require.Equal(t, "original", c.Credentials3.AuthPassword)
+}

--- a/src/go/pkg/snmpauth/config_test.go
+++ b/src/go/pkg/snmpauth/config_test.go
@@ -44,18 +44,52 @@ func TestApply(t *testing.T) {
 func TestInvalidAuthIsNotSilentlyDowngraded(t *testing.T) {
 	cases := []Config{
 		{Version: "invalid-secret"}, {},
-		{Credentials: &Community{Community: "secret"}, Credentials3: &USM{}},
-		{Version: "3", Credentials: &Community{Community: "secret"}, Credentials3: &USM{Username: "user"}},
+		{Credentials3: &USM{Username: "inactive"}},
 		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "invalid-secret"}},
 		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "authNoPriv", AuthProtocol: "invalid-secret", AuthPassword: "test-secret"}},
 		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "authPriv", AuthPassword: "short", PrivPassword: "test-secret"}},
-		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "noAuthNoPriv", AuthPassword: "test-secret"}},
-		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "authNoPriv", AuthPassword: "test-secret", PrivPassword: "test-secret"}},
+		{Version: "3", Credentials3: &USM{Username: "user", SecurityLevel: "authPriv", AuthPassword: "test-secret", PrivPassword: "short"}},
 	}
 	for _, c := range cases {
 		err := c.Validate()
 		require.Error(t, err)
 		require.NotContains(t, err.Error(), "secret")
+	}
+}
+
+func TestNormalizeInactiveCredentials(t *testing.T) {
+	for _, version := range []string{"", "1", "2c", "3", "invalid"} {
+		for _, level := range []string{"", "authPriv", "authNoPriv", "noAuthNoPriv", "invalid"} {
+			t.Run(version+"/"+level, func(t *testing.T) {
+				input := Config{Version: version, Credentials: &Community{Community: "fixture"}, Credentials3: &USM{Username: "fixture", SecurityLevel: level, AuthPassword: "test-auth", PrivPassword: "test-priv", ContextName: "context"}}
+				original := input.Copy()
+				got := input.Normalized()
+				require.Equal(t, original, input, "normalizing must not mutate caller-owned credentials")
+				require.Equal(t, got, got.Normalized())
+				if version == "invalid" || version == "3" && level == "invalid" {
+					require.Error(t, got.Validate())
+					return
+				}
+				client := &gosnmp.GoSNMP{}
+				require.NoError(t, input.Apply(client))
+				if version != "3" {
+					require.Nil(t, got.Credentials3)
+					require.Equal(t, "fixture", client.Community)
+					return
+				}
+				require.Nil(t, got.Credentials)
+				require.Equal(t, "context", got.ContextName())
+				usm := client.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+				if level == "noAuthNoPriv" {
+					require.Empty(t, got.Credentials3.AuthPassword)
+					require.Empty(t, usm.AuthenticationPassphrase)
+				}
+				if level == "authNoPriv" || level == "noAuthNoPriv" {
+					require.Empty(t, got.Credentials3.PrivPassword)
+					require.Empty(t, usm.PrivacyPassphrase)
+				}
+			})
+		}
 	}
 }
 func TestCopyOwnsCredentials(t *testing.T) {

--- a/src/go/plugin/agent/agent.go
+++ b/src/go/plugin/agent/agent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/policy"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/runtimechartemit"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 )
 
 var (
@@ -29,8 +30,9 @@ var (
 
 // Config is an Agent configuration.
 type Config struct {
-	Name            string
-	PluginConfigDir []string
+	SNMPVnodeAcquirer vnodes.SNMPAcquirer
+	Name              string
+	PluginConfigDir   []string
 
 	CollectorsConfigDir       []string
 	CollectorsConfigWatchPath []string
@@ -55,6 +57,7 @@ type Config struct {
 
 // Agent represents orchestrator.
 type Agent struct {
+	SNMPVnodeAcquirer vnodes.SNMPAcquirer
 	*logger.Logger
 
 	Name string
@@ -93,6 +96,7 @@ type Agent struct {
 // New creates a new Agent.
 func New(cfg Config) *Agent {
 	a := &Agent{
+		SNMPVnodeAcquirer: cfg.SNMPVnodeAcquirer,
 		Logger: logger.New().With(
 			slog.String("component", "agent"),
 		),
@@ -189,6 +193,7 @@ func (a *Agent) run(ctx context.Context) error {
 		AutoEnable:            a.runModePolicy.AutoEnableDiscovered,
 		InitialSecrets:        a.setupSecretStoreConfigs(),
 		InitialVnodes:         a.setupVnodeRegistry(),
+		SNMPVnodeAcquirer:     a.SNMPVnodeAcquirer,
 		Runtime:               a.setupRuntimeService(),
 		Services:              a.Services,
 		KeepAlive:             !a.runModePolicy.IsTerminal,

--- a/src/go/plugin/agent/jobmgr/composition/process_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/process_test.go
@@ -627,13 +627,13 @@ func TestProcessCoreVnodeDynCfgOrdersAddCreateAndGet(t *testing.T) {
 	reader, writer := io.Pipe()
 	output := newProcessSynchronizedBuffer()
 	jobs := testRunJobServices(t)
-	jobs.InitialVnodes = map[string]*vnodes.VirtualNode{
-		"initial": {
+	jobs.InitialVnodes = map[string]*vnodes.Config{
+		"initial": {VirtualNode: vnodes.VirtualNode{
 			Name: "initial", Hostname: "initial",
 			GUID:       "11111111-1111-1111-1111-111111111111",
 			Source:     "file=test",
 			SourceType: confgroup.TypeUser,
-		},
+		}},
 	}
 	process, err := newProcessCore(processCoreConfig{
 		Input:           reader,
@@ -1241,15 +1241,15 @@ func TestProcessCorePublishesConfiguredMetadataForGeneratedJob(t *testing.T) {
 	jobs.Defaults = confgroup.Registry{
 		"module": {UpdateEvery: 1},
 	}
-	jobs.InitialVnodes = map[string]*vnodes.VirtualNode{
-		"router": {
+	jobs.InitialVnodes = map[string]*vnodes.Config{
+		"router": {VirtualNode: vnodes.VirtualNode{
 			Name:       "router",
 			Hostname:   "configured",
 			GUID:       guid,
 			Source:     "file=test",
 			SourceType: confgroup.TypeUser,
 			Labels:     map[string]string{"site": "athens"},
-		},
+		}},
 	}
 	config := confgroup.Config{
 		"module":       "module",

--- a/src/go/plugin/agent/jobmgr/composition/public.go
+++ b/src/go/plugin/agent/jobmgr/composition/public.go
@@ -61,8 +61,9 @@ type RuntimeService interface {
 // the mutable registries and constructs the provider, secret-creator, resolver,
 // vnode-metadata, UID, and frame authorities exactly once.
 type Config struct {
-	Input  io.Reader // plugin stdin
-	Output io.Writer // plugin stdout
+	SNMPVnodeAcquirer vnodes.SNMPAcquirer
+	Input             io.Reader // plugin stdin
+	Output            io.Writer // plugin stdout
 
 	PluginName string                // plugin name (go.d / ibm.d / scripts.d)
 	Modules    collectorapi.Registry // enabled collector module registry
@@ -73,8 +74,8 @@ type Config struct {
 	RunJob                []string                         // allow-list filter of job names (empty = allow all)
 	AutoEnable            bool                             // publish discovered jobs as Running vs Accepted
 
-	InitialSecrets []secretstore.Config           // initial secret store configs
-	InitialVnodes  map[string]*vnodes.VirtualNode // file-configured vnodes
+	InitialSecrets []secretstore.Config      // initial secret store configs
+	InitialVnodes  map[string]*vnodes.Config // file-configured vnodes
 
 	Services []ProcessService // optional process-owned background services
 
@@ -125,10 +126,13 @@ func NewProcess(config Config) (*Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	initialVnodes := make(map[string]*vnodes.VirtualNode, len(config.InitialVnodes))
+	initialVnodes := make(map[string]*vnodes.Config, len(config.InitialVnodes))
 	for id, vnode := range config.InitialVnodes {
 		if vnode == nil {
 			return nil, fmt.Errorf("jobmgr composition: initial vnode %q is nil", id)
+		}
+		if vnode.IsSNMP() && config.SNMPVnodeAcquirer == nil {
+			return nil, fmt.Errorf("SNMP vnode mode is unavailable in this plugin")
 		}
 		initialVnodes[id] = vnode.Copy()
 	}
@@ -164,12 +168,13 @@ func NewProcess(config Config) (*Process, error) {
 		KeepAlive:       config.KeepAlive,
 		Modules:         modules,
 		Jobs: runJobServices{
-			PluginName:    config.PluginName,
-			Defaults:      defaults,
-			Resolver:      resolver,
-			StoreCreators: creatorCatalog,
-			Runtime:       config.Runtime,
-			InitialVnodes: initialVnodes,
+			PluginName:        config.PluginName,
+			Defaults:          defaults,
+			Resolver:          resolver,
+			StoreCreators:     creatorCatalog,
+			Runtime:           config.Runtime,
+			InitialVnodes:     initialVnodes,
+			SNMPVnodeAcquirer: config.SNMPVnodeAcquirer,
 		},
 		Secrets: runSecretServices{
 			Initial: initialSecrets,

--- a/src/go/plugin/agent/jobmgr/composition/public_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/public_test.go
@@ -127,7 +127,7 @@ func TestProductionProcessAcceptsIndividuallyValidatedVNodeLoad(t *testing.T) {
   guid: 22222222-2222-2222-2222-222222222222
 `), 0o644))
 
-	initial := vnodes.Load(dir)
+	initial := vnodes.Load(dir, false)
 	require.Len(t, initial, 1)
 	config := testProductionProcessConfig(strings.NewReader(""), io.Discard)
 	config.InitialVnodes = initial

--- a/src/go/plugin/agent/jobmgr/composition/public_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/public_test.go
@@ -21,88 +21,88 @@ import (
 
 func TestProductionProcessRejectsInvalidInitialVnodes(t *testing.T) {
 	tests := map[string]struct {
-		vnodes map[string]*vnodes.VirtualNode
+		vnodes map[string]*vnodes.Config
 	}{
-		"nil vnode": {vnodes: map[string]*vnodes.VirtualNode{"missing": nil}},
+		"nil vnode": {vnodes: map[string]*vnodes.Config{"missing": nil}},
 		"source type with separator": {
-			vnodes: map[string]*vnodes.VirtualNode{
-				"node": {
+			vnodes: map[string]*vnodes.Config{
+				"node": {VirtualNode: vnodes.VirtualNode{
 					Name:       "node",
 					Hostname:   "node",
 					GUID:       "11111111-1111-1111-1111-111111111111",
 					SourceType: "user type",
 					Source:     "file=/etc/netdata/vnodes.conf",
-				},
+				}},
 			},
 		},
 		"hostname unsafe for host emission": {
-			vnodes: map[string]*vnodes.VirtualNode{
-				"node": {
+			vnodes: map[string]*vnodes.Config{
+				"node": {VirtualNode: vnodes.VirtualNode{
 					Name:       "node",
 					Hostname:   "operator's-node",
 					GUID:       "11111111-1111-1111-1111-111111111111",
 					SourceType: confgroup.TypeUser,
 					Source:     "file=/etc/netdata/vnodes.conf",
-				},
+				}},
 			},
 		},
 		"unsupported GUID spelling": {
-			vnodes: map[string]*vnodes.VirtualNode{
-				"node": {
+			vnodes: map[string]*vnodes.Config{
+				"node": {VirtualNode: vnodes.VirtualNode{
 					Name:       "node",
 					Hostname:   "node",
 					GUID:       "urn:uuid:11111111-1111-1111-1111-111111111111",
 					SourceType: confgroup.TypeUser,
 					Source:     "file=/etc/netdata/vnodes.conf",
-				},
+				}},
 			},
 		},
 		"semantically duplicate GUID": {
-			vnodes: map[string]*vnodes.VirtualNode{
-				"first": {
+			vnodes: map[string]*vnodes.Config{
+				"first": {VirtualNode: vnodes.VirtualNode{
 					Name:       "first",
 					Hostname:   "first",
 					GUID:       "11111111-1111-1111-1111-111111111111",
 					SourceType: confgroup.TypeUser,
 					Source:     "file=/etc/netdata/vnodes.conf",
-				},
-				"second": {
+				}},
+				"second": {VirtualNode: vnodes.VirtualNode{
 					Name:       "second",
 					Hostname:   "second",
 					GUID:       "11111111111111111111111111111111",
 					SourceType: confgroup.TypeUser,
 					Source:     "file=/etc/netdata/vnodes.conf",
-				},
+				}},
 			},
 		},
 		"host label with trailing escape": {
-			vnodes: map[string]*vnodes.VirtualNode{
-				"node": {
+			vnodes: map[string]*vnodes.Config{
+				"node": {VirtualNode: vnodes.VirtualNode{
 					Name:       "node",
 					Hostname:   "node",
 					GUID:       "11111111-1111-1111-1111-111111111111",
 					Labels:     map[string]string{"site": `value\`},
 					SourceType: confgroup.TypeUser,
 					Source:     "file=/etc/netdata/vnodes.conf",
-				},
+				}},
 			},
 		},
 		"hostnames collide after host emission preparation": {
-			vnodes: map[string]*vnodes.VirtualNode{
-				"first": {
+			vnodes: map[string]*vnodes.Config{
+				"first": {VirtualNode: vnodes.VirtualNode{
 					Name:       "first",
 					Hostname:   "host",
 					GUID:       "11111111-1111-1111-1111-111111111111",
 					SourceType: confgroup.TypeUser,
 					Source:     "file=/etc/netdata/vnodes.conf",
-				},
-				"second": {
+				}},
+				"second": {VirtualNode: vnodes.VirtualNode{
 					Name:       "second",
 					Hostname:   " host ",
 					GUID:       "22222222-2222-2222-2222-222222222222",
 					SourceType: confgroup.TypeUser,
 					Source:     "file=/etc/netdata/vnodes.conf",
-				},
+				}},
 			},
 		},
 	}
@@ -138,14 +138,14 @@ func TestProductionProcessAcceptsIndividuallyValidatedVNodeLoad(t *testing.T) {
 
 func TestProductionProcessAcceptsCompactInitialVNodeGUID(t *testing.T) {
 	config := testProductionProcessConfig(strings.NewReader(""), io.Discard)
-	config.InitialVnodes = map[string]*vnodes.VirtualNode{
-		"node": {
+	config.InitialVnodes = map[string]*vnodes.Config{
+		"node": {VirtualNode: vnodes.VirtualNode{
 			Name:       "node",
 			Hostname:   "node",
 			GUID:       "11111111111111111111111111111111",
 			SourceType: confgroup.TypeUser,
 			Source:     "file=/etc/netdata/vnodes.conf",
-		},
+		}},
 	}
 
 	_, err := NewProcess(config)
@@ -154,14 +154,14 @@ func TestProductionProcessAcceptsCompactInitialVNodeGUID(t *testing.T) {
 
 func TestProductionProcessAcceptsWindowsInitialVNodeSource(t *testing.T) {
 	config := testProductionProcessConfig(strings.NewReader(""), io.Discard)
-	config.InitialVnodes = map[string]*vnodes.VirtualNode{
-		"node": {
+	config.InitialVnodes = map[string]*vnodes.Config{
+		"node": {VirtualNode: vnodes.VirtualNode{
 			Name:       "node",
 			Hostname:   "node",
 			GUID:       "11111111-1111-1111-1111-111111111111",
 			SourceType: confgroup.TypeUser,
 			Source:     `file=C:\Program Files\Netdata\vnodes.conf`,
-		},
+		}},
 	}
 
 	_, err := NewProcess(config)

--- a/src/go/plugin/agent/jobmgr/composition/run.go
+++ b/src/go/plugin/agent/jobmgr/composition/run.go
@@ -26,12 +26,13 @@ import (
 )
 
 type runJobServices struct {
-	PluginName    string                         // owning plugin name
-	Defaults      confgroup.Registry             // per-module config defaults
-	Resolver      *secretresolver.AtomicResolver // atomic secret resolver (process-fixed)
-	StoreCreators *secretstore.CreatorCatalog    // frozen secret store creator catalog
-	Runtime       runtimecomp.Service            // runtime service dependency
-	InitialVnodes map[string]*vnodes.VirtualNode // file-configured vnodes
+	SNMPVnodeAcquirer vnodes.SNMPAcquirer
+	PluginName        string                         // owning plugin name
+	Defaults          confgroup.Registry             // per-module config defaults
+	Resolver          *secretresolver.AtomicResolver // atomic secret resolver (process-fixed)
+	StoreCreators     *secretstore.CreatorCatalog    // frozen secret store creator catalog
+	Runtime           runtimecomp.Service            // runtime service dependency
+	InitialVnodes     map[string]*vnodes.Config      // file-configured vnodes
 }
 
 type runSecretServices struct {
@@ -155,6 +156,7 @@ func newRunGeneration(
 	if err != nil {
 		return nil, err
 	}
+	vnodeBinding.acquirer = config.Jobs.SNMPVnodeAcquirer
 	vnodeRoute, err := newVNodeInitialRoute(config.Generation, vnodeBinding)
 	if err != nil {
 		return nil, err
@@ -396,6 +398,7 @@ func (rg *runGeneration) startWithRunContext(
 	if err := rg.vnodes.publishInitial(startupCtx, rg.kernel); err != nil {
 		return rg.stopAfterStartFailure(startupCtx, err)
 	}
+	rg.vnodes.startAcquisition(runCtx, rg.kernel)
 	if err := rg.secrets.PublishInitial(startupCtx, rg.kernel); err != nil {
 		return rg.stopAfterStartFailure(startupCtx, err)
 	}
@@ -440,6 +443,7 @@ func (rg *runGeneration) abortConstruction() error {
 
 func (rg *runGeneration) Stop() {
 	if rg != nil && rg.kernel != nil {
+		rg.vnodes.stopAcquisition()
 		rg.scheduler.StopBackgroundWorkers()
 		rg.kernel.Stop()
 	}
@@ -452,10 +456,11 @@ func (rg *runGeneration) Wait(ctx context.Context) error {
 	waitErr := rg.kernel.Wait(ctx)
 	select {
 	case <-rg.kernel.Done():
+		rg.vnodes.stopAcquisition()
 		rg.scheduler.StopBackgroundWorkers()
 	default:
 	}
-	return errors.Join(waitErr, rg.scheduler.WaitBackgroundWorkers(ctx))
+	return errors.Join(waitErr, rg.scheduler.WaitBackgroundWorkers(ctx), rg.vnodes.waitAcquisition(ctx))
 }
 
 type runMetricsRegistration struct {

--- a/src/go/plugin/agent/jobmgr/composition/snmp_vnode_integration_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/snmp_vnode_integration_test.go
@@ -99,6 +99,18 @@ func newVNodeSNMPPeer(t *testing.T, community, hostname string, metrics bool) *v
 	return peer
 }
 
+func loadVNodeSNMPMetricProfile(t *testing.T) string {
+	t.Helper()
+	const name = "apc-ups"
+	// Cold catalog loading is fixture setup, not part of the vnode readiness deadline.
+	profiles := ddsnmp.DefaultCatalog().Resolve(ddsnmp.ResolveRequest{
+		ManualProfiles: []string{name},
+	}).Project(ddsnmp.ConsumerMetrics).Profiles()
+	require.Len(t, profiles, 1)
+	require.NotEmpty(t, profiles[0].Definition.Metrics)
+	return name
+}
+
 func TestSNMPVnodeFileAcquisitionAndNamedJobs(t *testing.T) {
 	for _, withSNMPJob := range []bool{false, true} {
 		t.Run(fmt.Sprint(withSNMPJob), func(t *testing.T) {
@@ -136,6 +148,7 @@ func TestSNMPVnodeFileAcquisitionAndNamedJobs(t *testing.T) {
   autodetection_retry: 1
 `, server.URL+"?auto")
 			if withSNMPJob {
+				profile := loadVNodeSNMPMetricProfile(t)
 				jobYAML += fmt.Sprintf(`
 - module: snmp
   name: metrics
@@ -144,10 +157,12 @@ func TestSNMPVnodeFileAcquisitionAndNamedJobs(t *testing.T) {
   options:
     port: %d
   vnode: router
-  manual_profiles: [apc-ups]
+  manual_profiles: [%s]
   update_every: 1
   autodetection_retry: 1
-`, collector.port)
+  ping:
+    enabled: false
+`, collector.port, profile)
 			}
 			require.NoError(t, yaml.Unmarshal([]byte(jobYAML), &jobs))
 			for _, job := range jobs {
@@ -237,6 +252,7 @@ func TestSNMPVnodeFileAcquisitionAndNamedJobs(t *testing.T) {
 }
 
 func TestSNMPLegacyLocalVnodeDynCfgRoundTrip(t *testing.T) {
+	profile := loadVNodeSNMPMetricProfile(t)
 	peer := newVNodeSNMPPeer(t, "fixture-local", "device-name", true)
 	var jobs []confgroup.Config
 	require.NoError(t, yaml.Unmarshal([]byte(fmt.Sprintf(`
@@ -251,11 +267,11 @@ func TestSNMPLegacyLocalVnodeDynCfgRoundTrip(t *testing.T) {
     hostname: local-router
     labels:
       site: before
-  manual_profiles: [apc-ups]
+  manual_profiles: [%s]
   update_every: 1
   ping:
     enabled: false
-`, peer.port)), &jobs))
+`, peer.port, profile)), &jobs))
 	jobs[0].SetSourceType(confgroup.TypeUser)
 	jobs[0].SetSource("file=legacy-fixture")
 	jobs[0].SetProvider("test")

--- a/src/go/plugin/agent/jobmgr/composition/snmp_vnode_integration_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/snmp_vnode_integration_test.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composition
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gosnmp/gosnmp"
+	agentdiscovery "github.com/netdata/netdata/go/plugins/plugin/agent/discovery"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/apache"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	govnode "github.com/netdata/netdata/go/plugins/plugin/go.d/vnode"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+// This peer accepts only its own community. The provider intentionally has no
+// sysObjectID or metric data; the collector peer uses a stock metric profile.
+type vnodeSNMPPeer struct {
+	port     int
+	enabled  atomic.Bool
+	requests atomic.Int32
+	metrics  atomic.Int32
+}
+
+func newVNodeSNMPPeer(t *testing.T, community, hostname string, metrics bool) *vnodeSNMPPeer {
+	t.Helper()
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(conn.LocalAddr().String())
+	require.NoError(t, err)
+	portNum, err := strconv.Atoi(port)
+	require.NoError(t, err)
+	peer := &vnodeSNMPPeer{port: portNum}
+	peer.enabled.Store(true)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 65535)
+		for {
+			n, addr, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			p, err := (&gosnmp.GoSNMP{}).SnmpDecodePacket(buf[:n])
+			if err != nil || p.Community != community {
+				continue
+			}
+			peer.requests.Add(1)
+			if !peer.enabled.Load() {
+				continue
+			}
+			r := &gosnmp.SnmpPacket{Version: p.Version, Community: p.Community, PDUType: gosnmp.GetResponse, RequestID: p.RequestID}
+			for _, request := range p.Variables {
+				v := gosnmp.SnmpPDU{Name: request.Name, Type: gosnmp.NoSuchObject}
+				switch request.Name {
+				case ".1.3.6.1.2.1.1.5.0":
+					v.Type, v.Value = gosnmp.OctetString, hostname
+				case ".1.3.6.1.2.1.1.1.0":
+					v.Type, v.Value = gosnmp.OctetString, "synthetic device"
+				default:
+					if !strings.HasPrefix(request.Name, ".1.3.6.1.2.1.1.") {
+						peer.metrics.Add(1)
+						if metrics {
+							v.Type, v.Value = gosnmp.Counter32, uint32(42)
+						}
+					}
+				}
+				if p.PDUType != gosnmp.GetRequest {
+					v.Type, v.Value = gosnmp.EndOfMibView, nil
+				}
+				r.Variables = append(r.Variables, v)
+			}
+			raw, err := r.MarshalMsg()
+			if err == nil {
+				_, _ = conn.WriteTo(raw, addr)
+			}
+		}
+	}()
+	t.Cleanup(func() { _ = conn.Close(); <-done })
+	return peer
+}
+
+func TestSNMPVnodeFileAcquisitionAndNamedJobs(t *testing.T) {
+	for _, withSNMPJob := range []bool{false, true} {
+		t.Run(fmt.Sprint(withSNMPJob), func(t *testing.T) {
+			provider := newVNodeSNMPPeer(t, "fixture-provider", "canonical-router", false)
+			collector := newVNodeSNMPPeer(t, "fixture-collector", "collector-local-name", true)
+			var apiRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				apiRequests.Add(1)
+				_, _ = io.WriteString(w, "BusyWorkers: 1\nIdleWorkers: 4\nScoreboard: _W___\n")
+			}))
+			t.Cleanup(server.Close)
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "vnodes.conf"), []byte(fmt.Sprintf(`
+- name: router
+  mode: snmp
+  mode_snmp:
+    address: 127.0.0.1
+    port: %d
+    timeout: 1m
+    retries: 0
+    credentials:
+      community: fixture-provider
+  labels:
+    site: test
+`, provider.port)), 0600))
+			initial := vnodes.Load(dir, true)
+			require.Len(t, initial, 1)
+			var jobs []confgroup.Config
+			jobYAML := fmt.Sprintf(`
+- module: apache
+  name: api
+  url: %s
+  vnode: router
+  update_every: 1
+  autodetection_retry: 1
+`, server.URL+"?auto")
+			if withSNMPJob {
+				jobYAML += fmt.Sprintf(`
+- module: snmp
+  name: metrics
+  hostname: 127.0.0.1
+  community: fixture-collector
+  options:
+    port: %d
+  vnode: router
+  manual_profiles: [apc-ups]
+  update_every: 1
+  autodetection_retry: 1
+`, collector.port)
+			}
+			require.NoError(t, yaml.Unmarshal([]byte(jobYAML), &jobs))
+			for _, job := range jobs {
+				job.SetSourceType(confgroup.TypeUser)
+				job.SetSource("file=fixture")
+				job.SetProvider("test")
+			}
+			store := ddsnmp.NewDeviceStore()
+			reader, writer := io.Pipe()
+			t.Cleanup(func() { _ = reader.Close(); _ = writer.Close() })
+			output := newProcessSynchronizedBuffer()
+			config := testProductionProcessConfig(reader, output)
+			config.InitialVnodes, config.SNMPVnodeAcquirer = initial, govnode.SNMP{}
+			config.AutoEnable = true
+			config.Modules = collectorapi.Registry{"apache": {Create: func() collectorapi.CollectorV1 { return apache.New() }, Config: func() any { return &apache.Config{} }}, "snmp": snmp.Creator(store, nil)}
+			config.Defaults = confgroup.Registry{"apache": {}, "snmp": {}}
+			config.DiscoveryProviders = []agentdiscovery.ProviderFactory{agentdiscovery.NewProviderFactory("test", func(agentdiscovery.BuildContext) (agentdiscovery.Discoverer, bool, error) {
+				return runTestDiscoverer{configs: jobs}, true, nil
+			})}
+			process, err := NewProcess(config)
+			require.NoError(t, err)
+			ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+			t.Cleanup(cancel)
+			done := make(chan error, 1)
+			go func() { done <- process.Run(ctx) }()
+			t.Cleanup(func() {
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(3 * time.Second):
+					t.Error("process did not join")
+				}
+			})
+			guid := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("127.0.0.1")).String()
+			require.Eventually(t, func() bool {
+				return strings.Contains(output.String(), "HOST_DEFINE '"+guid+"' 'canonical-router'") && apiRequests.Load() > 0
+			}, 8*time.Second, 10*time.Millisecond)
+			require.NotContains(t, output.String(), "fixture-provider")
+			require.Zero(t, provider.metrics.Load(), "acquisition must not read metric OIDs")
+			if withSNMPJob {
+				require.Eventually(t, func() bool { return len(store.Entries()) == 1 && collector.metrics.Load() > 0 }, 5*time.Second, 10*time.Millisecond)
+				info := store.Entries()[0].Info
+				require.Equal(t, "fixture-collector", info.Community)
+				require.Equal(t, collector.port, info.Port)
+				require.Equal(t, guid, info.VnodeGUID)
+				require.Equal(t, "canonical-router", info.VnodeHostname)
+				require.Equal(t, "test", info.VnodeLabels["site"])
+			} else {
+				require.Empty(t, store.Entries(), "provider must not register connections")
+			}
+			require.NotRegexp(t, `HOST_DEFINE '[^']*' 'collector-local-name'`, output.String(), "job-local names may appear in chart labels, never in host definitions")
+			requestsBeforeEdit := provider.requests.Load()
+			edited := initial["router"].Copy()
+			edited.Hostname = "operator-router"
+			edited.Labels["site"] = "updated"
+			payload, err := json.Marshal(edited)
+			require.NoError(t, err)
+			_, err = fmt.Fprintf(writer, "FUNCTION_PAYLOAD vnode-edit 30 \"config go.d:vnode:router update\" 0xFFFF \"user=test\" application/json\n%s\nFUNCTION_PAYLOAD_END\n", payload)
+			require.NoError(t, err)
+			output.waitContains(t, "FUNCTION_RESULT_BEGIN vnode-edit 202 application/json")
+			require.Eventually(t, func() bool {
+				return strings.Contains(output.String(), "HOST_DEFINE '"+guid+"' 'operator-router'")
+			}, 3*time.Second, 10*time.Millisecond)
+			if withSNMPJob {
+				require.Eventually(t, func() bool {
+					entries := store.Entries()
+					return len(entries) == 1 && entries[0].Info.VnodeHostname == "operator-router" && entries[0].Info.VnodeLabels["site"] == "updated"
+				}, 3*time.Second, 10*time.Millisecond)
+			}
+			require.Equal(t, requestsBeforeEdit, provider.requests.Load(), "override-only edits must not acquire again")
+
+			// Every run starts without acquired metadata. A long blocked UDP read
+			// must be canceled and joined on both restart and termination.
+			provider.enabled.Store(false)
+			for range 2 {
+				before := provider.requests.Load()
+				restartCtx, restartCancel := context.WithTimeout(ctx, 3*time.Second)
+				require.NoError(t, process.Restart(restartCtx))
+				restartCancel()
+				require.Eventually(t, func() bool { return provider.requests.Load() > before }, time.Second, time.Millisecond)
+				afterRestart := len(output.String())
+				require.Never(t, func() bool { return strings.Contains(output.String()[afterRestart:], "HOST_DEFINE") }, 100*time.Millisecond, 10*time.Millisecond)
+			}
+			require.NoError(t, process.Terminate(ctx))
+		})
+	}
+}
+
+func TestSNMPLegacyLocalVnodeDynCfgRoundTrip(t *testing.T) {
+	peer := newVNodeSNMPPeer(t, "fixture-local", "device-name", true)
+	var jobs []confgroup.Config
+	require.NoError(t, yaml.Unmarshal([]byte(fmt.Sprintf(`
+- module: snmp
+  name: local
+  hostname: 127.0.0.1
+  community: fixture-local
+  options:
+    port: %d
+  vnode:
+    guid: 6e17cd2c-0518-4e94-965b-d25673decb21
+    hostname: local-router
+    labels:
+      site: before
+  manual_profiles: [apc-ups]
+  update_every: 1
+  ping:
+    enabled: false
+`, peer.port)), &jobs))
+	jobs[0].SetSourceType(confgroup.TypeUser)
+	jobs[0].SetSource("file=legacy-fixture")
+	jobs[0].SetProvider("test")
+	store := ddsnmp.NewDeviceStore()
+	reader, writer := io.Pipe()
+	t.Cleanup(func() { _ = reader.Close(); _ = writer.Close() })
+	output := newProcessSynchronizedBuffer()
+	config := testProductionProcessConfig(reader, output)
+	config.AutoEnable = true
+	config.Modules = collectorapi.Registry{"snmp": snmp.Creator(store, nil)}
+	config.Defaults = confgroup.Registry{"snmp": {}}
+	config.DiscoveryProviders = []agentdiscovery.ProviderFactory{agentdiscovery.NewProviderFactory("test", func(agentdiscovery.BuildContext) (agentdiscovery.Discoverer, bool, error) {
+		return runTestDiscoverer{configs: jobs}, true, nil
+	})}
+	process, err := NewProcess(config)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- process.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Error("process did not join")
+		}
+	})
+	require.Eventually(t, func() bool {
+		return strings.Contains(output.String(), "HOST_DEFINE '6e17cd2c-0518-4e94-965b-d25673decb21' 'local-router'")
+	}, 5*time.Second, 10*time.Millisecond)
+	_, err = io.WriteString(writer, "FUNCTION legacy-get 30 \"config go.d:collector:snmp:local get\" 0xFFFF \"user=test\"\n")
+	require.NoError(t, err)
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN legacy-get 200 application/json")
+	wire := output.String()
+	start := strings.Index(wire, "FUNCTION_RESULT_BEGIN legacy-get ")
+	result := wire[start:]
+	_, result, _ = strings.Cut(result, "\n")
+	result, _, _ = strings.Cut(result, "\nFUNCTION_RESULT_END")
+	var editable map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result), &editable))
+	require.Equal(t, "", editable["vnode"])
+	local := editable["local_vnode"].(map[string]any)
+	require.Equal(t, "local-router", local["hostname"])
+	require.Equal(t, "6e17cd2c-0518-4e94-965b-d25673decb21", local["guid"])
+	require.Equal(t, "before", local["labels"].(map[string]any)["site"])
+	local["labels"].(map[string]any)["site"] = "after"
+	payload, err := json.Marshal(editable)
+	require.NoError(t, err)
+	_, err = fmt.Fprintf(writer, "FUNCTION_PAYLOAD local-save 30 \"config go.d:collector:snmp:local update\" 0xFFFF \"user=test\" application/json\n%s\nFUNCTION_PAYLOAD_END\n", payload)
+	require.NoError(t, err)
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN local-save 200 application/json")
+	require.Eventually(t, func() bool {
+		entries := store.Entries()
+		return len(entries) == 1 && entries[0].Info.VnodeHostname == "local-router" && entries[0].Info.VnodeGUID == "6e17cd2c-0518-4e94-965b-d25673decb21" && entries[0].Info.VnodeLabels["site"] == "after"
+	}, 5*time.Second, 10*time.Millisecond)
+	require.NoError(t, process.Terminate(ctx))
+}

--- a/src/go/plugin/agent/jobmgr/composition/vnode_acquisition.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnode_acquisition.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composition
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	agentdiscovery "github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/discovery"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/joboutput"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+)
+
+const vnodeRetryInterval = 10 * time.Second
+const vnodeRefreshInterval = time.Hour
+
+type vnodeWorker struct {
+	token  *agentdiscovery.AcquisitionToken
+	cancel context.CancelFunc
+}
+
+// Acquisition belongs to the run, independently of attached metric jobs. Only
+// short result commits use the vnode transaction lane; network I/O never does.
+type vnodeAcquisition struct {
+	mu       sync.Mutex
+	ctx      context.Context
+	cancel   context.CancelFunc
+	commands jobmgr.PreparedCommandPort
+	workers  map[string]vnodeWorker
+	wg       sync.WaitGroup
+	done     chan struct{}
+	stopped  bool
+}
+
+func (vb *vnodeBinding) startAcquisition(ctx context.Context, commands jobmgr.PreparedCommandPort) {
+	if vb.acquirer == nil {
+		return
+	}
+	a := &vb.acquisition
+	a.mu.Lock()
+	a.ctx, a.cancel = context.WithCancel(ctx)
+	a.commands = commands
+	a.workers = make(map[string]vnodeWorker)
+	a.done = make(chan struct{})
+	a.mu.Unlock()
+	for _, entry := range vb.config.Entries() {
+		vb.syncAcquisition(entry.ID)
+	}
+}
+func (vb *vnodeBinding) syncAcquisition(name string) {
+	a := &vb.acquisition
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.ctx == nil || a.stopped {
+		return
+	}
+	token, config := vb.config.Acquisition(name)
+	old, exists := a.workers[name]
+	if exists && old.token == token {
+		return
+	}
+	if exists {
+		old.cancel()
+		delete(a.workers, name)
+	}
+	if token == nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(a.ctx)
+	a.workers[name] = vnodeWorker{token: token, cancel: cancel}
+	a.wg.Add(1)
+	go func() { defer a.wg.Done(); vb.acquireLoop(ctx, a.commands, name, token, config) }()
+}
+func (vb *vnodeBinding) stopAcquisition() {
+	a := &vb.acquisition
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.ctx == nil || a.stopped {
+		return
+	}
+	a.stopped = true
+	a.cancel()
+	go func() { a.wg.Wait(); close(a.done) }()
+}
+func (vb *vnodeBinding) waitAcquisition(ctx context.Context) error {
+	a := &vb.acquisition
+	a.mu.Lock()
+	done := a.done
+	a.mu.Unlock()
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+func (vb *vnodeBinding) acquireLoop(ctx context.Context, commands jobmgr.PreparedCommandPort, name string, token *agentdiscovery.AcquisitionToken, config vnodes.SNMPConfig) {
+	for ctx.Err() == nil {
+		metadata, err := vb.acquirer.Acquire(ctx, config.Copy())
+		if ctx.Err() != nil {
+			return
+		}
+		if metadata == nil && err == nil {
+			err = errors.New("acquisition returned no identity")
+		}
+		publishErr := vb.publishAcquisition(ctx, commands, name, token, metadata, err != nil)
+		interval := vnodeRefreshInterval
+		current, exists := vb.config.Authored(name)
+		if err != nil || publishErr != nil || exists && current.Failed {
+			interval = vnodeRetryInterval
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+func (vb *vnodeBinding) publishAcquisition(ctx context.Context, commands jobmgr.PreparedCommandPort, name string, token *agentdiscovery.AcquisitionToken, metadata *vnodes.Metadata, failed bool) error {
+	result := mustDynCfgMessage(204, "")
+	plan := jobmgr.WorkPlan{Claims: []string{joboutput.DynCfgJobGraphClaim}, NoResponse: true, Transaction: &jobmgr.ResourceTransactionPlan{
+		ID: "vnode:" + name,
+		Prepare: func(_ context.Context, current lifecycle.ReadyResource, scope lifecycle.ResourceTransactionScope, permit lifecycle.LongLivedPermit) (lifecycle.PreparedResourceTransaction, error) {
+			if current != nil || scope.Current.Valid() || scope.Successor.Valid() || permit.Valid() {
+				return nil, errors.New("invalid vnode acquisition transaction scope")
+			}
+			prepared, err := vb.config.PrepareMetadata(token, metadata, failed)
+			if errors.Is(err, agentdiscovery.ErrVNodeRevision) {
+				return vb.noop(scope, result, nil)
+			}
+			if err != nil {
+				return nil, err
+			}
+			entry, ok := vb.config.Authored(name)
+			if !ok {
+				return nil, agentdiscovery.ErrVNodeRevision
+			}
+			return newPreparedVNodeTransaction(scope, prepared, result, vb.configCreateCleanup(entry.Config))
+		},
+	}}
+	return commands.SubmitPreparedAndWait(ctx, jobmgr.Request{UID: "jobmgr-vnode-acquire-" + uuid.NewString(), LaneKey: "vnode:" + name, Source: lifecycle.SourceJobManager, Route: "internal/vnodes/acquire"}, plan)
+}

--- a/src/go/plugin/agent/jobmgr/composition/vnode_acquisition.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnode_acquisition.go
@@ -146,7 +146,16 @@ func (vb *vnodeBinding) publishAcquisition(ctx context.Context, commands jobmgr.
 			if !ok {
 				return nil, agentdiscovery.ErrVNodeRevision
 			}
-			return newPreparedVNodeTransaction(scope, prepared, result, vb.configCreateCleanup(entry.Config))
+			cleanup := vb.configCreateCleanup(entry.Config)
+			return newPreparedVNodeTransaction(scope, prepared, result, func() error {
+				if err := prepared.MetadataError(); err != nil {
+					jobmgr.ObserveDiagnostic(vb.diagnostics, jobmgr.DiagnosticEvent{
+						Level: jobmgr.DiagnosticWarning, Name: "vnode acquired metadata rejected",
+						Resource: "vnode:" + name, Generation: vb.epoch, Err: err,
+					})
+				}
+				return cleanup()
+			})
 		},
 	}}
 	return commands.SubmitPreparedAndWait(ctx, jobmgr.Request{UID: "jobmgr-vnode-acquire-" + uuid.NewString(), LaneKey: "vnode:" + name, Source: lifecycle.SourceJobManager, Route: "internal/vnodes/acquire"}, plan)

--- a/src/go/plugin/agent/jobmgr/composition/vnode_acquisition_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnode_acquisition_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composition
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"github.com/stretchr/testify/require"
+)
+
+type acquisitionAttempt struct {
+	config   vnodes.SNMPConfig
+	reply    chan acquisitionReply
+	canceled chan struct{}
+}
+type acquisitionReply struct {
+	metadata *vnodes.Metadata
+	err      error
+}
+type controlledAcquirer struct{ attempts chan acquisitionAttempt }
+
+func (a controlledAcquirer) Acquire(ctx context.Context, c vnodes.SNMPConfig) (*vnodes.Metadata, error) {
+	attempt := acquisitionAttempt{config: c, reply: make(chan acquisitionReply, 1), canceled: make(chan struct{})}
+	select {
+	case a.attempts <- attempt:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case r := <-attempt.reply:
+		return r.metadata, r.err
+	case <-ctx.Done():
+		close(attempt.canceled)
+		return nil, ctx.Err()
+	}
+}
+func nextAcquisition(t *testing.T, a controlledAcquirer) acquisitionAttempt {
+	t.Helper()
+	select {
+	case attempt := <-a.attempts:
+		return attempt
+	case <-time.After(12 * time.Second):
+		t.Fatal("acquisition did not start")
+		return acquisitionAttempt{}
+	}
+}
+func TestRunOwnsIndependentAcquisitionAndModeAwareUpdates(t *testing.T) {
+	var initial vnodes.Config
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"router","mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"first"}},"labels":{"site":"before"}}`), &initial))
+	initial.SourceType = "dyncfg"
+	initial.Source = "user=test"
+	jobs := testRunJobServices(t)
+	jobs.InitialVnodes = map[string]*vnodes.Config{"router": &initial}
+	acquirer := controlledAcquirer{attempts: make(chan acquisitionAttempt, 8)}
+	jobs.SNMPVnodeAcquirer = acquirer
+	output := newProcessSynchronizedBuffer()
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	generation, err := newTestRunGeneration(t, runGenerationConfig{Generation: 1, ShutdownTimeout: time.Second, UIDs: lifecycle.NewUIDLedger(), Frames: frames, Modules: collectorapi.Registry{}, Jobs: jobs, Discovery: testRunDiscoveryServices(t)})
+	require.NoError(t, err)
+	require.NoError(t, generation.start(context.Background()))
+	t.Cleanup(func() {
+		generation.Stop()
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		require.NoError(t, generation.Wait(ctx))
+	})
+	first := nextAcquisition(t, acquirer)
+	pending, ok := generation.vnodeConfig.Lookup("router")
+	require.True(t, ok)
+	require.Nil(t, pending.Vnode)
+	require.NotContains(t, output.String(), "HOST_DEFINE")
+	update := func(uid, payload string) {
+		require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: uid, Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "update"}, HasPayload: true, Payload: []byte(payload), ContentType: "application/json", CallerSource: "user=test"}))
+		output.waitContains(t, "FUNCTION_RESULT_BEGIN "+uid+" 202 application/json")
+	}
+	require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "validate-only", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode", "test", "probe"}, HasPayload: true, Payload: []byte(`{"mode":"snmp","mode_snmp":{"address":"other-device","credentials":{"community":"test-only"}}}`), ContentType: "application/json", CallerSource: "user=test"}))
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN validate-only 202 application/json")
+	require.Empty(t, acquirer.attempts, "test must not acquire metadata")
+	update("labels", `{"mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"first"}},"labels":{"site":"after"}}`)
+	select {
+	case <-acquirer.attempts:
+		t.Fatal("label-only edit restarted acquisition")
+	default:
+	}
+	first.reply <- acquisitionReply{metadata: &vnodes.Metadata{Hostname: "device-name", Labels: map[string]string{"serial": "good"}}, err: errors.New("enrichment incomplete")}
+	require.Eventually(t, func() bool { s, _ := generation.vnodeConfig.Lookup("router"); return s.Vnode != nil }, time.Second, time.Millisecond)
+	ready, _ := generation.vnodeConfig.Lookup("router")
+	require.Equal(t, "device-name", ready.Vnode.Hostname)
+	output.waitContains(t, "CONFIG go.d:vnode:router create failed job")
+	require.Equal(t, "after", ready.Vnode.Labels["site"])
+	require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "authored-get", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "get"}}))
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN authored-get 200 application/json")
+	require.NotContains(t, output.String(), "device-name", "get must return authored configuration rather than acquired metadata")
+	require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "change-target", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "update"}, HasPayload: true, Payload: []byte(`{"mode":"snmp","mode_snmp":{"address":"replacement","credentials":{"community":"first"}}}`), ContentType: "application/json", CallerSource: "user=test"}))
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN change-target 400 application/json")
+	retry := nextAcquisition(t, acquirer)
+	require.Equal(t, "first", retry.config.Credentials.Community)
+	update("rotate", `{"mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"rotated"}},"labels":{"site":"after"}}`)
+	select {
+	case <-retry.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("credential rotation did not cancel old acquisition")
+	}
+	rotated := nextAcquisition(t, acquirer)
+	require.Equal(t, "rotated", rotated.config.Credentials.Community)
+	kept, _ := generation.vnodeConfig.Lookup("router")
+	require.Equal(t, "good", kept.Vnode.Labels["serial"])
+	require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "remove", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "remove"}}))
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN remove 200 application/json")
+	select {
+	case <-rotated.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("removal did not cancel acquisition")
+	}
+	require.NotContains(t, output.String(), "HOST_DEFINE")
+
+}

--- a/src/go/plugin/agent/jobmgr/composition/vnode_acquisition_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnode_acquisition_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 	"github.com/stretchr/testify/require"
 )
@@ -111,6 +112,7 @@ func TestRunOwnsIndependentAcquisitionAndModeAwareUpdates(t *testing.T) {
 		t.Fatal("credential rotation did not cancel old acquisition")
 	}
 	rotated := nextAcquisition(t, acquirer)
+	require.Equal(t, dyncfg.StatusAccepted, generation.vnodes.configStatus("router"), "new credentials are pending even while last-good identity remains usable")
 	require.Equal(t, "rotated", rotated.config.Credentials.Community)
 	kept, _ := generation.vnodeConfig.Lookup("router")
 	require.Equal(t, "good", kept.Vnode.Labels["serial"])

--- a/src/go/plugin/agent/jobmgr/composition/vnode_acquisition_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnode_acquisition_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
@@ -108,75 +109,134 @@ func nextAcquisition(t *testing.T, a controlledAcquirer) acquisitionAttempt {
 	}
 }
 func TestRunOwnsIndependentAcquisitionAndModeAwareUpdates(t *testing.T) {
-	var initial vnodes.Config
-	require.NoError(t, json.Unmarshal([]byte(`{"name":"router","mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"first"}},"labels":{"site":"before"}}`), &initial))
-	initial.SourceType = "dyncfg"
-	initial.Source = "user=test"
-	jobs := testRunJobServices(t)
-	jobs.InitialVnodes = map[string]*vnodes.Config{"router": &initial}
-	acquirer := controlledAcquirer{attempts: make(chan acquisitionAttempt, 8)}
-	jobs.SNMPVnodeAcquirer = acquirer
-	output := newProcessSynchronizedBuffer()
-	frames, err := lifecycle.NewFrameOwner(output)
-	require.NoError(t, err)
-	generation, err := newTestRunGeneration(t, runGenerationConfig{Generation: 1, ShutdownTimeout: time.Second, UIDs: lifecycle.NewUIDLedger(), Frames: frames, Modules: collectorapi.Registry{}, Jobs: jobs, Discovery: testRunDiscoveryServices(t)})
-	require.NoError(t, err)
-	require.NoError(t, generation.start(context.Background()))
-	t.Cleanup(func() {
-		generation.Stop()
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		defer cancel()
-		require.NoError(t, generation.Wait(ctx))
-	})
-	first := nextAcquisition(t, acquirer)
-	pending, ok := generation.vnodeConfig.Lookup("router")
-	require.True(t, ok)
-	require.Nil(t, pending.Vnode)
-	require.NotContains(t, output.String(), "HOST_DEFINE")
-	update := func(uid, payload string) {
-		require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: uid, Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "update"}, HasPayload: true, Payload: []byte(payload), ContentType: "application/json", CallerSource: "user=test"}))
-		output.waitContains(t, "FUNCTION_RESULT_BEGIN "+uid+" 202 application/json")
-	}
-	require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "validate-only", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode", "test", "probe"}, HasPayload: true, Payload: []byte(`{"mode":"snmp","mode_snmp":{"address":"other-device","credentials":{"community":"test-only"}}}`), ContentType: "application/json", CallerSource: "user=test"}))
-	output.waitContains(t, "FUNCTION_RESULT_BEGIN validate-only 202 application/json")
-	require.Empty(t, acquirer.attempts, "test must not acquire metadata")
-	update("labels", `{"mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"first"}},"labels":{"site":"after"}}`)
-	select {
-	case <-acquirer.attempts:
-		t.Fatal("label-only edit restarted acquisition")
-	default:
-	}
-	first.reply <- acquisitionReply{metadata: &vnodes.Metadata{Hostname: "device-name", Labels: map[string]string{"serial": "good"}}, err: errors.New("enrichment incomplete")}
-	require.Eventually(t, func() bool { s, _ := generation.vnodeConfig.Lookup("router"); return s.Vnode != nil }, time.Second, time.Millisecond)
-	ready, _ := generation.vnodeConfig.Lookup("router")
-	require.Equal(t, "device-name", ready.Vnode.Hostname)
-	output.waitContains(t, "CONFIG go.d:vnode:router create failed job")
-	require.Equal(t, "after", ready.Vnode.Labels["site"])
-	require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "authored-get", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "get"}}))
-	output.waitContains(t, "FUNCTION_RESULT_BEGIN authored-get 200 application/json")
-	require.NotContains(t, output.String(), "device-name", "get must return authored configuration rather than acquired metadata")
-	require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "change-target", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "update"}, HasPayload: true, Payload: []byte(`{"mode":"snmp","mode_snmp":{"address":"replacement","credentials":{"community":"first"}}}`), ContentType: "application/json", CallerSource: "user=test"}))
-	output.waitContains(t, "FUNCTION_RESULT_BEGIN change-target 400 application/json")
-	retry := nextAcquisition(t, acquirer)
-	require.Equal(t, "first", retry.config.Credentials.Community)
-	update("rotate", `{"mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"rotated"}},"labels":{"site":"after"}}`)
-	select {
-	case <-retry.canceled:
-	case <-time.After(time.Second):
-		t.Fatal("credential rotation did not cancel old acquisition")
-	}
-	rotated := nextAcquisition(t, acquirer)
-	require.Equal(t, dyncfg.StatusAccepted, generation.vnodes.configStatus("router"), "new credentials are pending even while last-good identity remains usable")
-	require.Equal(t, "rotated", rotated.config.Credentials.Community)
-	kept, _ := generation.vnodeConfig.Lookup("router")
-	require.Equal(t, "good", kept.Vnode.Labels["serial"])
-	require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "remove", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "remove"}}))
-	output.waitContains(t, "FUNCTION_RESULT_BEGIN remove 200 application/json")
-	select {
-	case <-rotated.canceled:
-	case <-time.After(time.Second):
-		t.Fatal("removal did not cancel acquisition")
-	}
-	require.NotContains(t, output.String(), "HOST_DEFINE")
+	synctest.Test(t, func(t *testing.T) {
+		var initial vnodes.Config
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"router","mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"first"}},"labels":{"site":"before"}}`), &initial))
+		initial.SourceType = "dyncfg"
+		initial.Source = "user=test"
+		jobs := testRunJobServices(t)
+		jobs.InitialVnodes = map[string]*vnodes.Config{"router": &initial}
+		acquirer := controlledAcquirer{attempts: make(chan acquisitionAttempt, 8)}
+		jobs.SNMPVnodeAcquirer = acquirer
+		output := newProcessSynchronizedBuffer()
+		frames, err := lifecycle.NewFrameOwner(output)
+		require.NoError(t, err)
+		generation, err := newTestRunGeneration(t, runGenerationConfig{Generation: 1, ShutdownTimeout: time.Second, UIDs: lifecycle.NewUIDLedger(), Frames: frames, Modules: collectorapi.Registry{}, Jobs: jobs, Discovery: testRunDiscoveryServices(t)})
+		require.NoError(t, err)
+		require.NoError(t, generation.start(context.Background()))
+		t.Cleanup(func() {
+			generation.Stop()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			require.NoError(t, generation.Wait(ctx))
+			require.NoError(t, generation.run.FinishShutdown())
+		})
+		first := nextAcquisition(t, acquirer)
+		pending, ok := generation.vnodeConfig.Lookup("router")
+		require.True(t, ok)
+		require.Nil(t, pending.Vnode)
+		require.NotContains(t, output.String(), "HOST_DEFINE")
+		update := func(uid, payload string) {
+			require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: uid, Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "update"}, HasPayload: true, Payload: []byte(payload), ContentType: "application/json", CallerSource: "user=test"}))
+			output.waitContains(t, "FUNCTION_RESULT_BEGIN "+uid+" 202 application/json")
+		}
+		require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "validate-only", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode", "test", "probe"}, HasPayload: true, Payload: []byte(`{"mode":"snmp","mode_snmp":{"address":"other-device","credentials":{"community":"test-only"}}}`), ContentType: "application/json", CallerSource: "user=test"}))
+		output.waitContains(t, "FUNCTION_RESULT_BEGIN validate-only 202 application/json")
+		require.Empty(t, acquirer.attempts, "test must not acquire metadata")
+		update("labels", `{"mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"first"}},"labels":{"site":"after"}}`)
+		select {
+		case <-acquirer.attempts:
+			t.Fatal("label-only edit restarted acquisition")
+		default:
+		}
+		first.reply <- acquisitionReply{metadata: &vnodes.Metadata{Hostname: "device-name", Labels: map[string]string{"serial": "good"}}, err: errors.New("enrichment incomplete")}
+		require.Eventually(t, func() bool { s, _ := generation.vnodeConfig.Lookup("router"); return s.Vnode != nil }, time.Second, time.Millisecond)
+		ready, _ := generation.vnodeConfig.Lookup("router")
+		require.Equal(t, "device-name", ready.Vnode.Hostname)
+		output.waitContains(t, "CONFIG go.d:vnode:router create failed job")
+		require.Equal(t, "after", ready.Vnode.Labels["site"])
+		require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "authored-get", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "get"}}))
+		output.waitContains(t, "FUNCTION_RESULT_BEGIN authored-get 200 application/json")
+		require.NotContains(t, output.String(), "device-name", "get must return authored configuration rather than acquired metadata")
+		require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "change-target", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "update"}, HasPayload: true, Payload: []byte(`{"mode":"snmp","mode_snmp":{"address":"replacement","credentials":{"community":"first"}}}`), ContentType: "application/json", CallerSource: "user=test"}))
+		output.waitContains(t, "FUNCTION_RESULT_BEGIN change-target 400 application/json")
+		retry := nextAcquisition(t, acquirer)
+		require.Equal(t, "first", retry.config.Credentials.Community)
+		update("rotate", `{"mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"rotated"}},"labels":{"site":"after"}}`)
+		select {
+		case <-retry.canceled:
+		case <-time.After(time.Second):
+			t.Fatal("credential rotation did not cancel old acquisition")
+		}
+		rotated := nextAcquisition(t, acquirer)
+		require.Equal(t, dyncfg.StatusAccepted, generation.vnodes.configStatus("router"), "new credentials are pending even while last-good identity remains usable")
+		require.Equal(t, "rotated", rotated.config.Credentials.Community)
+		kept, _ := generation.vnodeConfig.Lookup("router")
+		require.Equal(t, "good", kept.Vnode.Labels["serial"])
+		require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: "remove", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "remove"}}))
+		output.waitContains(t, "FUNCTION_RESULT_BEGIN remove 200 application/json")
+		select {
+		case <-rotated.canceled:
+		case <-time.After(time.Second):
+			t.Fatal("removal did not cancel acquisition")
+		}
+		require.NotContains(t, output.String(), "HOST_DEFINE")
 
+	})
+}
+
+func TestAcquiredHostnameCollisionIsDiagnosedAfterCommit(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		jobs := testRunJobServices(t)
+		var router, other vnodes.Config
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"router","mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"fixture-secret"}}}`), &router))
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"other","hostname":"taken","guid":"6e17cd2c-0518-4e94-965b-d25673decb21"}`), &other))
+		router.SourceType, other.SourceType = "dyncfg", "dyncfg"
+		jobs.InitialVnodes = map[string]*vnodes.Config{"router": &router, "other": &other}
+		acquirer := controlledAcquirer{attempts: make(chan acquisitionAttempt, 8)}
+		jobs.SNMPVnodeAcquirer = acquirer
+		diagnostics := &recordingCompositionDiagnosticObserver{}
+		output := newProcessSynchronizedBuffer()
+		frames, err := lifecycle.NewFrameOwner(output)
+		require.NoError(t, err)
+		generation, err := newTestRunGeneration(t, runGenerationConfig{Generation: 1, ShutdownTimeout: time.Second, UIDs: lifecycle.NewUIDLedger(), Frames: frames, Modules: collectorapi.Registry{}, Jobs: jobs, Discovery: testRunDiscoveryServices(t), Diagnostics: diagnostics})
+		require.NoError(t, err)
+		require.NoError(t, generation.start(context.Background()))
+		t.Cleanup(func() {
+			generation.Stop()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			require.NoError(t, generation.Wait(ctx))
+			require.NoError(t, generation.run.FinishShutdown())
+		})
+		first := nextAcquisition(t, acquirer)
+		first.reply <- acquisitionReply{metadata: &vnodes.Metadata{Hostname: "original", Labels: map[string]string{"serial": "good"}}}
+		synctest.Wait()
+		ready, _ := generation.vnodeConfig.Lookup("router")
+		require.NotNil(t, ready.Vnode)
+		time.Sleep(vnodeRefreshInterval)
+		refresh := nextAcquisition(t, acquirer)
+		refresh.reply <- acquisitionReply{metadata: &vnodes.Metadata{Hostname: "taken", Labels: map[string]string{"serial": "replacement"}}}
+		synctest.Wait()
+		retained, _ := generation.vnodeConfig.Authored("router")
+		require.True(t, retained.Failed)
+		require.Equal(t, ready.Vnode, retained.Snapshot.Vnode)
+		var collisions []jobmgr.DiagnosticEvent
+		for _, event := range diagnostics.snapshot() {
+			if event.Name == "vnode acquired metadata rejected" {
+				collisions = append(collisions, event)
+			}
+		}
+		require.Len(t, collisions, 1)
+		require.Equal(t, "vnode:router", collisions[0].Resource)
+		require.Equal(t, jobmgr.DiagnosticWarning, collisions[0].Level)
+		require.ErrorContains(t, collisions[0].Err, "duplicate configured vnode hostname")
+		require.NotContains(t, fmt.Sprint(collisions), "fixture-secret")
+		retry := nextAcquisition(t, acquirer)
+		retry.reply <- acquisitionReply{metadata: &vnodes.Metadata{Hostname: "recovered"}}
+		synctest.Wait()
+		recovered, _ := generation.vnodeConfig.Authored("router")
+		require.False(t, recovered.Failed)
+		require.Equal(t, "recovered", recovered.Snapshot.Vnode.Hostname)
+	})
 }

--- a/src/go/plugin/agent/jobmgr/composition/vnode_acquisition_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnode_acquisition_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +24,58 @@ type acquisitionAttempt struct {
 	reply    chan acquisitionReply
 	canceled chan struct{}
 }
+
+func TestCredentialFormTransitionsDiscardInactiveFields(t *testing.T) {
+	jobs := testRunJobServices(t)
+	acquirer := controlledAcquirer{attempts: make(chan acquisitionAttempt, 8)}
+	jobs.SNMPVnodeAcquirer = acquirer
+	output := newProcessSynchronizedBuffer()
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	generation, err := newTestRunGeneration(t, runGenerationConfig{Generation: 1, ShutdownTimeout: time.Second, UIDs: lifecycle.NewUIDLedger(), Frames: frames, Modules: collectorapi.Registry{}, Jobs: jobs, Discovery: testRunDiscoveryServices(t)})
+	require.NoError(t, err)
+	require.NoError(t, generation.start(context.Background()))
+	t.Cleanup(func() {
+		generation.Stop()
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		require.NoError(t, generation.Wait(ctx))
+	})
+	var current acquisitionAttempt
+	for i, tc := range []struct{ auth, absent string }{
+		{`"version":"2c","credentials":{"community":"fixture"},"credentials3":{"username":"hidden"}`, "credentials3"},
+		{`"version":"3","credentials":{"community":"hidden"},"credentials3":{"username":"fixture","security_level":"authPriv","auth_password":"test-auth","priv_password":"test-priv"}`, "community"},
+		{`"version":"3","credentials3":{"username":"fixture","security_level":"authNoPriv","auth_password":"test-auth","priv_password":"hidden-priv","priv_protocol":"aes"}`, "priv_password"},
+		{`"version":"3","credentials3":{"username":"fixture","security_level":"noAuthNoPriv","auth_password":"hidden-auth","auth_protocol":"sha","priv_password":"hidden-priv"}`, "auth_password"},
+	} {
+		uid := fmt.Sprintf("transition-%d", i)
+		args := []string{"go.d:vnode:router", "update"}
+		if i == 0 {
+			args = []string{"go.d:vnode", "add", "router"}
+		}
+		payload := `{"mode":"snmp","mode_snmp":{"address":"device",` + tc.auth + `}}`
+		require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: uid, Route: "config", Source: lifecycle.SourceFunction, Args: args, HasPayload: true, Payload: []byte(payload), ContentType: "application/json", CallerSource: "user=test"}))
+		output.waitContains(t, "FUNCTION_RESULT_BEGIN "+uid+" ")
+		require.Contains(t, output.String(), "FUNCTION_RESULT_BEGIN "+uid+" 202 application/json")
+		if i > 0 {
+			select {
+			case <-current.canceled:
+			case <-time.After(time.Second):
+				t.Fatal("active credential edit did not cancel previous acquisition")
+			}
+		}
+		current = nextAcquisition(t, acquirer)
+		raw, err := json.Marshal(current.config)
+		require.NoError(t, err)
+		require.NotContains(t, string(raw), tc.absent)
+		require.NoError(t, generation.kernel.Submit(context.Background(), jobmgr.Request{UID: uid + "-get", Route: "config", Source: lifecycle.SourceFunction, Args: []string{"go.d:vnode:router", "get"}}))
+		output.waitContains(t, "FUNCTION_RESULT_BEGIN "+uid+"-get 200 application/json")
+		_, body, ok := strings.Cut(output.String(), "FUNCTION_RESULT_BEGIN "+uid+"-get 200 application/json")
+		require.True(t, ok)
+		require.NotContains(t, body, tc.absent, "get must omit inactive credentials from stored configuration")
+	}
+}
+
 type acquisitionReply struct {
 	metadata *vnodes.Metadata
 	err      error

--- a/src/go/plugin/agent/jobmgr/composition/vnodes.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnodes.go
@@ -486,7 +486,7 @@ func (vb *vnodeBinding) configCreateCleanup(vnode *vnodes.Config) lifecycle.Task
 }
 func (vb *vnodeBinding) configStatus(name string) dyncfg.Status {
 	entry, ok := vb.config.Authored(name)
-	if !ok || entry.Snapshot.Vnode == nil && !entry.Failed {
+	if !ok || entry.Pending || entry.Snapshot.Vnode == nil && !entry.Failed {
 		return dyncfg.StatusAccepted
 	}
 	if entry.Failed {

--- a/src/go/plugin/agent/jobmgr/composition/vnodes.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnodes.go
@@ -701,6 +701,7 @@ func vnodeJobName(value string) string {
 }
 
 func normalizeVNode(vnode *vnodes.Config, name string, source string) {
+	vnode.NormalizeCredentials()
 	vnode.Name = name
 	if !vnode.IsSNMP() && vnode.Hostname == "" {
 		vnode.Hostname = name

--- a/src/go/plugin/agent/jobmgr/composition/vnodes.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnodes.go
@@ -20,7 +20,6 @@ import (
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/dyncfg"
 	frameworkfunctions "github.com/netdata/netdata/go/plugins/plugin/framework/functions"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/jobruntime"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
 	"gopkg.in/yaml.v2"
 )
@@ -36,6 +35,8 @@ type vnodeBinding struct {
 	config      *agentdiscovery.VNodeConfiguration // configured-vnode authority it mutates
 	graph       *dyncfg.Graph                      // dyncfg graph for vnode config entries
 	diagnostics jobmgr.DiagnosticObserver          // operational log sink
+	acquirer    vnodes.SNMPAcquirer
+	acquisition vnodeAcquisition
 }
 
 func newVNodeBinding(
@@ -179,10 +180,10 @@ func (vb *vnodeBinding) prepareAdd(
 	if failure != nil {
 		return vb.noop(scope, *failure, nil)
 	}
-	current, exists := vb.config.Lookup(name)
+	current, exists := vb.config.Authored(name)
 	expected := uint64(0)
 	if exists {
-		expected = current.Revision
+		expected = current.Snapshot.Revision
 	}
 	prepared, err := vb.config.PrepareUpsert(name, expected, next)
 	if errors.Is(err, agentdiscovery.ErrVNodeNoChange) {
@@ -200,13 +201,13 @@ func (vb *vnodeBinding) prepareAdd(
 func (vb *vnodeBinding) resolveConfiguredVNode(
 	input functionadapter.HandlerInput,
 	scope lifecycle.ResourceTransactionScope,
-) (name string, current jobruntime.VnodeSnapshot, done bool, result lifecycle.PreparedResourceTransaction, err error) {
+) (name string, current agentdiscovery.ConfiguredVNode, done bool, result lifecycle.PreparedResourceTransaction, err error) {
 	name, ok := vb.configName(input)
 	if !ok {
 		result, err = vb.noop(scope, mustDynCfgMessage(400, "invalid config ID format."), nil)
 		return name, current, true, result, err
 	}
-	current, exists := vb.config.Lookup(name)
+	current, exists := vb.config.Authored(name)
 	if !exists {
 		result, err = vb.noop(
 			scope,
@@ -230,7 +231,7 @@ func (vb *vnodeBinding) prepareUpdate(
 	if failure != nil {
 		return vb.noop(scope, *failure, nil)
 	}
-	prepared, err := vb.config.PrepareUpsert(name, current.Revision, next)
+	prepared, err := vb.config.PrepareUpsert(name, current.Snapshot.Revision, next)
 	if errors.Is(err, agentdiscovery.ErrVNodeNoChange) {
 		return vb.noop(scope, mustDynCfgMessage(202, ""), nil)
 	}
@@ -248,14 +249,14 @@ func (vb *vnodeBinding) prepareRemove(
 	if done {
 		return result, err
 	}
-	if current.Vnode.SourceType != confgroup.TypeDyncfg {
+	if current.Config.SourceType != confgroup.TypeDyncfg {
 		return vb.noop(
 			scope,
 			mustDynCfgMessage(
 				405,
 				fmt.Sprintf(
 					"Removing vnode of type '%s' is not supported. Only 'dyncfg' vnodes can be removed.",
-					current.Vnode.SourceType,
+					current.Config.SourceType,
 				),
 			),
 			nil,
@@ -275,7 +276,7 @@ func (vb *vnodeBinding) prepareRemove(
 			nil,
 		)
 	}
-	prepared, err := vb.config.PrepareRemove(name, current.Revision)
+	prepared, err := vb.config.PrepareRemove(name, current.Snapshot.Revision)
 	if err != nil {
 		return nil, err
 	}
@@ -287,11 +288,11 @@ func (vb *vnodeBinding) get(input functionadapter.HandlerInput) (lifecycle.Seale
 	if !ok {
 		return dynCfgMessage(400, "invalid config ID format.")
 	}
-	snapshot, exists := vb.config.Lookup(name)
+	snapshot, exists := vb.config.Authored(name)
 	if !exists {
 		return dynCfgMessage(404, fmt.Sprintf("The specified vnode '%s' is not registered.", name))
 	}
-	payload, err := json.Marshal(snapshot.Vnode)
+	payload, err := json.Marshal(snapshot.Config)
 	if err != nil {
 		return lifecycle.SealedResult{}, err
 	}
@@ -299,11 +300,11 @@ func (vb *vnodeBinding) get(input functionadapter.HandlerInput) (lifecycle.Seale
 }
 
 func (vb *vnodeBinding) userConfig(input functionadapter.HandlerInput) (lifecycle.SealedResult, error) {
-	var config vnodes.VirtualNode
+	var config vnodes.Config
 	if err := unmarshalVNodePayload(input, &config); err != nil {
 		return dynCfgMessage(
 			400,
-			fmt.Sprintf("Invalid configuration format. Failed to create configuration from payload: %v.", err),
+			"Invalid configuration format.",
 		)
 	}
 	name := "test"
@@ -339,21 +340,25 @@ func (vb *vnodeBinding) test(input functionadapter.HandlerInput) (lifecycle.Seal
 func (vb *vnodeBinding) parseVNode(
 	input functionadapter.HandlerInput,
 	name string,
-) (*vnodes.VirtualNode, *lifecycle.SealedResult) {
+) (*vnodes.Config, *lifecycle.SealedResult) {
 	if !input.HasPayload || len(input.Payload) == 0 {
 		result := mustDynCfgMessage(400, "Missing configuration payload.")
 		return nil, &result
 	}
-	var config vnodes.VirtualNode
+	var config vnodes.Config
 	if err := unmarshalVNodePayload(input, &config); err != nil {
 		result := mustDynCfgMessage(
 			400,
-			fmt.Sprintf("Failed to create configuration from payload. Invalid configuration format: %v.", err),
+			"Invalid configuration format.",
 		)
 		return nil, &result
 	}
 	normalizeVNode(&config, name, input.CallerSource)
-	if err := vnodes.ValidateConfigured(&config); err != nil {
+	if config.IsSNMP() && vb.acquirer == nil {
+		result := mustDynCfgMessage(400, "SNMP vnode mode is unavailable in this plugin.")
+		return nil, &result
+	}
+	if err := config.Validate(); err != nil {
 		result := mustDynCfgMessage(
 			400,
 			fmt.Sprintf("Failed to create configuration from payload. Invalid vnode configuration: %v.", err),
@@ -375,20 +380,27 @@ func (vb *vnodeBinding) configName(input functionadapter.HandlerInput) (string, 
 	return name, ok && name != ""
 }
 
-func (vb *vnodeBinding) validateUnique(next *vnodes.VirtualNode) error {
-	nextGUID, err := vnodes.ConfiguredGUIDKey(next.GUID)
+func (vb *vnodeBinding) validateUnique(next *vnodes.Config) error {
+	nextGUID, err := vnodes.ConfiguredGUIDKey(next.IdentityGUID())
 	if err != nil {
 		return err
 	}
 	for _, entry := range vb.config.Entries() {
-		current := entry.Snapshot.Vnode
+		current := entry.Config
 		if entry.ID == next.Name {
+			if err := current.ValidateUpdate(next); err != nil {
+				return err
+			}
 			continue
 		}
-		if current.Hostname == next.Hostname {
+		hostname := current.Hostname
+		if entry.Snapshot.Vnode != nil {
+			hostname = entry.Snapshot.Vnode.Hostname
+		}
+		if next.Hostname != "" && hostname == next.Hostname {
 			return fmt.Errorf("duplicate virtual node hostname detected (job '%s')", entry.ID)
 		}
-		currentGUID, err := vnodes.ConfiguredGUIDKey(current.GUID)
+		currentGUID, err := vnodes.ConfiguredGUIDKey(current.IdentityGUID())
 		if err != nil {
 			return fmt.Errorf("invalid existing virtual node guid (job '%s'): %w", entry.ID, err)
 		}
@@ -400,15 +412,15 @@ func (vb *vnodeBinding) validateUnique(next *vnodes.VirtualNode) error {
 }
 
 func (vb *vnodeBinding) validateInitial() error {
-	initial := make(map[string]*vnodes.VirtualNode)
+	initial := make(map[string]*vnodes.Config)
 	for _, entry := range vb.config.Entries() {
-		initial[entry.ID] = entry.Snapshot.Vnode
+		initial[entry.ID] = entry.Config
 	}
 	return validateInitialVNodeSet(initial)
 }
 
-func validateInitialVNodeSet(initial map[string]*vnodes.VirtualNode) error {
-	if err := vnodes.ValidateConfiguredSet(initial); err != nil {
+func validateInitialVNodeSet(initial map[string]*vnodes.Config) error {
+	if err := vnodes.ValidateConfigSet(initial); err != nil {
 		return fmt.Errorf("jobmgr composition: invalid initial vnode configuration: %w", err)
 	}
 	return nil
@@ -443,7 +455,7 @@ func (vb *vnodeBinding) noop(
 
 // configCreateVNodeJob emits the CONFIG CREATE that declares one vnode as a
 // dyncfg job entry, with the removable command added for dyncfg-sourced vnodes.
-func (vb *vnodeBinding) configCreateVNodeJob(api *netdataapi.API, vnode *vnodes.VirtualNode) error {
+func (vb *vnodeBinding) configCreateVNodeJob(api *netdataapi.API, vnode *vnodes.Config) error {
 	commands := dyncfg.JoinCommands(
 		dyncfg.CommandUserconfig,
 		dyncfg.CommandSchema,
@@ -456,7 +468,7 @@ func (vb *vnodeBinding) configCreateVNodeJob(api *netdataapi.API, vnode *vnodes.
 	}
 	return api.TryCONFIGCREATE(netdataapi.ConfigOpts{
 		ID:                vb.prefix() + ":" + vnode.Name,
-		Status:            dyncfg.StatusRunning.String(),
+		Status:            vb.configStatus(vnode.Name).String(),
 		ConfigType:        dyncfg.ConfigTypeJob.String(),
 		Path:              vb.path(),
 		SourceType:        vnode.SourceType,
@@ -465,16 +477,29 @@ func (vb *vnodeBinding) configCreateVNodeJob(api *netdataapi.API, vnode *vnodes.
 	})
 }
 
-func (vb *vnodeBinding) configCreateCleanup(vnode *vnodes.VirtualNode) lifecycle.TaskCleanup {
-	return vb.protocolCleanup(func(api *netdataapi.API) error {
-		return vb.configCreateVNodeJob(api, vnode)
-	})
+func (vb *vnodeBinding) configCreateCleanup(vnode *vnodes.Config) lifecycle.TaskCleanup {
+	return func() error {
+		err := vb.protocolCleanup(func(api *netdataapi.API) error { return vb.configCreateVNodeJob(api, vnode) })()
+		vb.syncAcquisition(vnode.Name)
+		return err
+	}
+}
+func (vb *vnodeBinding) configStatus(name string) dyncfg.Status {
+	entry, ok := vb.config.Authored(name)
+	if !ok || entry.Snapshot.Vnode == nil && !entry.Failed {
+		return dyncfg.StatusAccepted
+	}
+	if entry.Failed {
+		return dyncfg.StatusFailed
+	}
+	return dyncfg.StatusRunning
 }
 
 func (vb *vnodeBinding) configDeleteCleanup(name string) lifecycle.TaskCleanup {
-	return vb.protocolCleanup(func(api *netdataapi.API) error {
-		return api.TryCONFIGDELETE(vb.prefix() + ":" + name)
-	})
+	return func() error {
+		vb.syncAcquisition(name)
+		return vb.protocolCleanup(func(api *netdataapi.API) error { return api.TryCONFIGDELETE(vb.prefix() + ":" + name) })()
+	}
 }
 
 func (vb *vnodeBinding) initialCleanup() lifecycle.TaskCleanup {
@@ -496,7 +521,7 @@ func (vb *vnodeBinding) initialCleanup() lifecycle.TaskCleanup {
 			return err
 		}
 		for _, entry := range vb.config.Entries() {
-			if err := vb.configCreateVNodeJob(api, entry.Snapshot.Vnode); err != nil {
+			if err := vb.configCreateVNodeJob(api, entry.Config); err != nil {
 				return err
 			}
 		}
@@ -675,16 +700,16 @@ func vnodeJobName(value string) string {
 	return dyncfg.NormalizeJobName(value)
 }
 
-func normalizeVNode(vnode *vnodes.VirtualNode, name string, source string) {
+func normalizeVNode(vnode *vnodes.Config, name string, source string) {
 	vnode.Name = name
-	if vnode.Hostname == "" {
+	if !vnode.IsSNMP() && vnode.Hostname == "" {
 		vnode.Hostname = name
 	}
 	vnode.Source = source
 	vnode.SourceType = confgroup.TypeDyncfg
 }
 
-func unmarshalVNodePayload(input functionadapter.HandlerInput, target *vnodes.VirtualNode) error {
+func unmarshalVNodePayload(input functionadapter.HandlerInput, target *vnodes.Config) error {
 	if input.ContentType == "application/json" {
 		return json.Unmarshal(input.Payload, target)
 	}

--- a/src/go/plugin/agent/jobmgr/composition/vnodes.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnodes.go
@@ -79,7 +79,7 @@ func (vb *vnodeBinding) handle(
 	command := vnodeCommand(input)
 	switch command {
 	case dyncfg.CommandSchema:
-		return lifecycle.NewSealedResult(200, "application/json", []byte(vnodes.ConfigSchema))
+		return lifecycle.NewSealedResult(200, "application/json", []byte(vnodes.ConfigSchemaFor(vb.acquirer != nil)))
 	case dyncfg.CommandUserconfig:
 		return vb.userConfig(input)
 	case dyncfg.CommandGet:

--- a/src/go/plugin/agent/jobmgr/composition/vnodes_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/vnodes_test.go
@@ -317,8 +317,8 @@ func newTestVNodeBindingWithDiagnostics(
 		source = "file=test"
 	}
 	configured, err := agentdiscovery.NewVNodeConfigurationWithInitial(
-		map[string]*vnodes.VirtualNode{
-			"db": {Name: "db", Hostname: "db", GUID: testVNodeGUID, Source: source, SourceType: sourceType},
+		map[string]*vnodes.Config{
+			"db": {VirtualNode: vnodes.VirtualNode{Name: "db", Hostname: "db", GUID: testVNodeGUID, Source: source, SourceType: sourceType}},
 		},
 	)
 	require.NoError(t, err)

--- a/src/go/plugin/agent/jobmgr/discovery/vnode.go
+++ b/src/go/plugin/agent/jobmgr/discovery/vnode.go
@@ -53,14 +53,15 @@ type ConfiguredVNode struct {
 	Pending  bool
 }
 type preparedVNodeState struct {
-	mu         sync.Mutex
-	consumed   bool
-	owner      *VNodeConfiguration
-	id         string
-	expected   *vnodeRecord
-	next       *vnodeRecord
-	remove     bool
-	definition *hostoutput.Definition
+	mu          sync.Mutex
+	consumed    bool
+	owner       *VNodeConfiguration
+	id          string
+	expected    *vnodeRecord
+	next        *vnodeRecord
+	remove      bool
+	definition  *hostoutput.Definition
+	metadataErr error
 }
 
 func NewVNodeConfigurationWithInitial(initial map[string]*vnodes.Config) (*VNodeConfiguration, error) {
@@ -131,6 +132,7 @@ func (vc *VNodeConfiguration) PrepareMetadata(token *AcquisitionToken, metadata 
 		return PreparedVNode{}, ErrVNodeRevision
 	}
 	next := *current
+	var metadataErr error
 	next.failed = failed
 	next.pending = false
 	if metadata != nil && (!failed || current.metadata == nil) {
@@ -138,6 +140,7 @@ func (vc *VNodeConfiguration) PrepareMetadata(token *AcquisitionToken, metadata 
 	}
 	if resolved := next.config.Resolve(next.metadata); resolved != nil {
 		if err := vnodes.ValidateConfigured(resolved); err != nil {
+			metadataErr = err
 			next.metadata = current.metadata
 			next.failed = true
 		}
@@ -145,11 +148,24 @@ func (vc *VNodeConfiguration) PrepareMetadata(token *AcquisitionToken, metadata 
 	prepared, err := vc.prepareLocked(token.name, current, &next, false)
 	if err != nil {
 		// Conflicting acquired hostnames cannot replace valid last-known metadata.
+		metadataErr = err
 		next.metadata = current.metadata
 		next.failed = true
-		return vc.prepareLocked(token.name, current, &next, false)
+		prepared, err = vc.prepareLocked(token.name, current, &next, false)
 	}
-	return prepared, nil
+	if err == nil {
+		prepared.state.metadataErr = metadataErr
+	}
+	return prepared, err
+}
+
+// MetadataError explains a rejected acquisition whose last-good fallback was
+// prepared successfully. Callers report it only after committing that fallback.
+func (pv PreparedVNode) MetadataError() error {
+	if pv.state == nil {
+		return nil
+	}
+	return pv.state.metadataErr
 }
 func (vc *VNodeConfiguration) PrepareRemove(id string, expected uint64) (PreparedVNode, error) {
 	if vc == nil || id == "" || id != strings.TrimSpace(id) || expected == 0 || expected == ^uint64(0) {

--- a/src/go/plugin/agent/jobmgr/discovery/vnode.go
+++ b/src/go/plugin/agent/jobmgr/discovery/vnode.go
@@ -32,6 +32,7 @@ type vnodeRecord struct {
 	token    *AcquisitionToken
 	snapshot jobruntime.VnodeSnapshot
 	failed   bool
+	pending  bool
 }
 
 // VNodeConfiguration separates authored secrets, acquired metadata and public snapshots.
@@ -49,6 +50,7 @@ type ConfiguredVNode struct {
 	Config   *vnodes.Config
 	Snapshot jobruntime.VnodeSnapshot
 	Failed   bool
+	Pending  bool
 }
 type preparedVNodeState struct {
 	mu         sync.Mutex
@@ -105,10 +107,12 @@ func (vc *VNodeConfiguration) PrepareUpsert(id string, expected uint64, config *
 		next.metadata = current.metadata
 		next.token = current.token
 		next.failed = current.failed
+		next.pending = current.pending
 	}
 	if next.config.IsSNMP() && (current == nil || !current.config.SameAcquisition(next.config)) {
 		next.token = &AcquisitionToken{name: id}
 		next.failed = false
+		next.pending = true
 	}
 	return vc.prepareLocked(id, current, next, false)
 }
@@ -127,6 +131,7 @@ func (vc *VNodeConfiguration) PrepareMetadata(token *AcquisitionToken, metadata 
 	}
 	next := *current
 	next.failed = failed
+	next.pending = false
 	if metadata != nil && (!failed || current.metadata == nil) {
 		next.metadata = metadata.Copy()
 	}
@@ -294,7 +299,7 @@ func (vc *VNodeConfiguration) Authored(id string) (ConfiguredVNode, bool) {
 	return configuredVNode(id, r), true
 }
 func configuredVNode(id string, r *vnodeRecord) ConfiguredVNode {
-	return ConfiguredVNode{ID: id, Config: r.config.Copy(), Snapshot: r.snapshot.Copy(), Failed: r.failed}
+	return ConfiguredVNode{ID: id, Config: r.config.Copy(), Snapshot: r.snapshot.Copy(), Failed: r.failed, Pending: r.pending}
 }
 func (vc *VNodeConfiguration) Acquisition(id string) (*AcquisitionToken, vnodes.SNMPConfig) {
 	vc.mu.Lock()

--- a/src/go/plugin/agent/jobmgr/discovery/vnode.go
+++ b/src/go/plugin/agent/jobmgr/discovery/vnode.go
@@ -97,6 +97,7 @@ func (vc *VNodeConfiguration) PrepareUpsert(id string, expected uint64, config *
 		return PreparedVNode{}, ErrVNodeRevision
 	}
 	next := &vnodeRecord{config: config.Copy()}
+	next.config.NormalizeCredentials()
 	if current != nil {
 		if reflect.DeepEqual(current.config, next.config) {
 			return PreparedVNode{}, ErrVNodeNoChange

--- a/src/go/plugin/agent/jobmgr/discovery/vnode.go
+++ b/src/go/plugin/agent/jobmgr/discovery/vnode.go
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	"errors"
 	"maps"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -22,235 +23,306 @@ var (
 	ErrVNodeNoChange         = errors.New("vnode configuration: no change")
 )
 
-// VNodeConfiguration owns immutable configured-vnode values and their atomic
-// revision changes.
+// AcquisitionToken identifies one configuration incarnation and acquisition
+// setting generation. Label-only edits preserve it; remove/re-add never does.
+type AcquisitionToken struct{ name string }
+type vnodeRecord struct {
+	config   *vnodes.Config
+	metadata *vnodes.Metadata
+	token    *AcquisitionToken
+	snapshot jobruntime.VnodeSnapshot
+	failed   bool
+}
+
+// VNodeConfiguration separates authored secrets, acquired metadata and public snapshots.
+// Records are immutable after commit; pointer comparison also fences remove/re-add ABA.
 type VNodeConfiguration struct {
-	mu sync.Mutex // guards records
-
-	records     map[string]jobruntime.VnodeSnapshot // committed vnode snapshots by name
+	mu          sync.Mutex
+	records     map[string]*vnodeRecord
 	definitions map[string]*hostoutput.Definition
+	guids       map[string]string
+	hostnames   map[string]string
 }
-
-type PreparedVNode struct {
-	state *preparedVNodeState
-}
-
+type PreparedVNode struct{ state *preparedVNodeState }
 type ConfiguredVNode struct {
-	ID       string                   // vnode name
-	Snapshot jobruntime.VnodeSnapshot // the vnode snapshot (hostname, GUID, labels)
+	ID       string
+	Config   *vnodes.Config
+	Snapshot jobruntime.VnodeSnapshot
+	Failed   bool
 }
-
 type preparedVNodeState struct {
-	mu         sync.Mutex               // guards consumed
-	consumed   bool                     // the prepared edit has been committed or aborted
-	owner      *VNodeConfiguration      // the vnode configuration this edit belongs to
-	id         string                   // vnode name
-	expected   uint64                   // revision the edit was prepared against (optimistic check)
-	next       jobruntime.VnodeSnapshot // the snapshot to commit
-	remove     bool                     // the edit removes the vnode
+	mu         sync.Mutex
+	consumed   bool
+	owner      *VNodeConfiguration
+	id         string
+	expected   *vnodeRecord
+	next       *vnodeRecord
+	remove     bool
 	definition *hostoutput.Definition
 }
 
-func NewVNodeConfigurationWithInitial(initial map[string]*vnodes.VirtualNode) (*VNodeConfiguration, error) {
-	configuration := &VNodeConfiguration{
-		records:     make(map[string]jobruntime.VnodeSnapshot),
-		definitions: make(map[string]*hostoutput.Definition),
-	}
-	ids := slices.Sorted(maps.Keys(initial))
-	for _, id := range ids {
-		vnode := initial[id]
-		if vnode == nil {
+func NewVNodeConfigurationWithInitial(initial map[string]*vnodes.Config) (*VNodeConfiguration, error) {
+	vc := &VNodeConfiguration{records: make(map[string]*vnodeRecord), definitions: make(map[string]*hostoutput.Definition), guids: make(map[string]string), hostnames: make(map[string]string)}
+	for _, id := range slices.Sorted(maps.Keys(initial)) {
+		c := initial[id].Copy()
+		if c == nil {
 			continue
 		}
-		vnode = vnode.Copy()
-		if vnode.Name == "" {
-			vnode.Name = id
+		if c.Name == "" {
+			c.Name = id
 		}
-		if vnode.Name != id {
+		if c.Name != id {
 			return nil, errors.New("vnode configuration: initial identity differs from map key")
 		}
-		prepared, err := configuration.PrepareUpsert(id, 0, vnode)
+		prepared, err := vc.PrepareUpsert(id, 0, c)
 		if err != nil {
 			return nil, err
 		}
-		if _, err := prepared.Commit(); err != nil {
+		if _, err = prepared.Commit(); err != nil {
 			return nil, err
 		}
 	}
-	return configuration, nil
+	return vc, nil
 }
-
-func (vc *VNodeConfiguration) PrepareUpsert(
-	id string,
-	expected uint64,
-	vnode *vnodes.VirtualNode,
-) (PreparedVNode, error) {
-	if vc == nil || id == "" || id != strings.TrimSpace(id) || expected == ^uint64(0) || vnode == nil {
+func (vc *VNodeConfiguration) PrepareUpsert(id string, expected uint64, config *vnodes.Config) (PreparedVNode, error) {
+	if vc == nil || id == "" || id != strings.TrimSpace(id) || expected == ^uint64(0) || config == nil || config.Name != id {
 		return PreparedVNode{}, errors.New("vnode configuration: invalid preparation")
-	}
-	nextVNode := vnode.Copy()
-	definition, err := hostoutput.NewDefinition(
-		netdataapi.HostInfo{
-			GUID:     nextVNode.GUID,
-			Hostname: nextVNode.Hostname,
-			Labels:   nextVNode.HostLabels(),
-		},
-	)
-	if err != nil {
-		return PreparedVNode{}, err
 	}
 	vc.mu.Lock()
 	defer vc.mu.Unlock()
 	current := vc.records[id]
-	if current.Revision != expected {
+	if recordRevision(current) != expected {
 		return PreparedVNode{}, ErrVNodeRevision
 	}
-	if current.Vnode != nil && vnodeConfigurationEqual(current.Vnode, nextVNode) {
-		return PreparedVNode{}, ErrVNodeNoChange
-	}
-	if previous := vc.definitions[hostoutput.GUIDKey(nextVNode.GUID)]; previous.Equal(definition) {
-		definition = previous
-	}
-	metadataRevision := uint64(1)
-	if current.Vnode != nil {
-		metadataRevision = current.MetadataRevision
-		if !vnodeMetadataEqual(current.Vnode, nextVNode) {
-			if metadataRevision == ^uint64(0) {
-				return PreparedVNode{}, errors.New("vnode configuration: metadata revision wrapped")
-			}
-			metadataRevision++
+	next := &vnodeRecord{config: config.Copy()}
+	if current != nil {
+		if reflect.DeepEqual(current.config, next.config) {
+			return PreparedVNode{}, ErrVNodeNoChange
 		}
+		if err := current.config.ValidateUpdate(next.config); err != nil {
+			return PreparedVNode{}, err
+		}
+		next.metadata = current.metadata
+		next.token = current.token
+		next.failed = current.failed
 	}
-	state := &preparedVNodeState{
-		definition: definition,
-		owner:      vc,
-		id:         strings.Clone(id),
-		expected:   expected,
-		next: jobruntime.VnodeSnapshot{
-			Vnode:            nextVNode,
-			Revision:         expected + 1,
-			MetadataRevision: metadataRevision,
-		},
+	if next.config.IsSNMP() && (current == nil || !current.config.SameAcquisition(next.config)) {
+		next.token = &AcquisitionToken{name: id}
+		next.failed = false
 	}
-	return PreparedVNode{
-		state: state,
-	}, nil
+	return vc.prepareLocked(id, current, next, false)
 }
 
+// PrepareMetadata applies the current authored overrides, even when they changed
+// while this request was in flight. Errors retain the last usable acquisition.
+func (vc *VNodeConfiguration) PrepareMetadata(token *AcquisitionToken, metadata *vnodes.Metadata, failed bool) (PreparedVNode, error) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	if token == nil {
+		return PreparedVNode{}, ErrVNodeRevision
+	}
+	current := vc.records[token.name]
+	if current == nil || current.token != token {
+		return PreparedVNode{}, ErrVNodeRevision
+	}
+	next := *current
+	next.failed = failed
+	if metadata != nil && (!failed || current.metadata == nil) {
+		next.metadata = metadata.Copy()
+	}
+	if resolved := next.config.Resolve(next.metadata); resolved != nil {
+		if err := vnodes.ValidateConfigured(resolved); err != nil {
+			next.metadata = current.metadata
+			next.failed = true
+		}
+	}
+	prepared, err := vc.prepareLocked(token.name, current, &next, false)
+	if err != nil {
+		// Conflicting acquired hostnames cannot replace valid last-known metadata.
+		next.metadata = current.metadata
+		next.failed = true
+		return vc.prepareLocked(token.name, current, &next, false)
+	}
+	return prepared, nil
+}
 func (vc *VNodeConfiguration) PrepareRemove(id string, expected uint64) (PreparedVNode, error) {
 	if vc == nil || id == "" || id != strings.TrimSpace(id) || expected == 0 || expected == ^uint64(0) {
 		return PreparedVNode{}, errors.New("vnode configuration: invalid removal")
 	}
 	vc.mu.Lock()
 	defer vc.mu.Unlock()
-	current, ok := vc.records[id]
-	if !ok || current.Revision != expected {
+	current := vc.records[id]
+	if current == nil || recordRevision(current) != expected {
 		return PreparedVNode{}, ErrVNodeRevision
 	}
-	state := &preparedVNodeState{
-		owner:    vc,
-		id:       strings.Clone(id),
-		expected: expected,
-		next: jobruntime.VnodeSnapshot{
-			Revision:         expected + 1,
-			MetadataRevision: current.MetadataRevision,
-		},
-		remove: true,
+	return vc.prepareLocked(id, current, &vnodeRecord{}, true)
+}
+func recordRevision(r *vnodeRecord) uint64 {
+	if r == nil {
+		return 0
 	}
-	return PreparedVNode{
-		state: state,
-	}, nil
+	return r.snapshot.Revision
+}
+func (vc *VNodeConfiguration) prepareLocked(id string, current, next *vnodeRecord, remove bool) (PreparedVNode, error) {
+	revision := recordRevision(current)
+	if revision == ^uint64(0) {
+		return PreparedVNode{}, ErrVNodeRevision
+	}
+	next.snapshot = jobruntime.VnodeSnapshot{Revision: revision + 1}
+	if current != nil {
+		next.snapshot.MetadataRevision = current.snapshot.MetadataRevision
+	}
+	var definition *hostoutput.Definition
+	if !remove {
+		resolved := next.config.Resolve(next.metadata)
+		if resolved != nil {
+			var err error
+			definition, err = hostoutput.NewDefinition(netdataapi.HostInfo{GUID: resolved.GUID, Hostname: resolved.Hostname, Labels: resolved.HostLabels()})
+			if err != nil {
+				return PreparedVNode{}, err
+			}
+			if previous := vc.definitions[hostoutput.GUIDKey(resolved.GUID)]; previous.Equal(definition) {
+				definition = previous
+			}
+			if current == nil || current.snapshot.Vnode == nil || !vnodeMetadataEqual(current.snapshot.Vnode, resolved) {
+				if next.snapshot.MetadataRevision == ^uint64(0) {
+					return PreparedVNode{}, ErrVNodeRevision
+				}
+				next.snapshot.MetadataRevision++
+			}
+		}
+		next.snapshot.Vnode = resolved
+		if err := vc.validateUniqueLocked(id, next.config, resolved); err != nil {
+			return PreparedVNode{}, err
+		}
+	}
+	return PreparedVNode{state: &preparedVNodeState{owner: vc, id: id, expected: current, next: next, remove: remove, definition: definition}}, nil
+}
+func recordHostname(config *vnodes.Config, resolved *vnodes.VirtualNode) string {
+	if resolved != nil {
+		return resolved.Hostname
+	}
+	return config.Hostname
+}
+func (vc *VNodeConfiguration) validateUniqueLocked(id string, config *vnodes.Config, resolved *vnodes.VirtualNode) error {
+	if other, ok := vc.guids[hostoutput.GUIDKey(config.IdentityGUID())]; ok && other != id {
+		return errors.New("duplicate configured vnode GUID")
+	}
+	if hostname := recordHostname(config, resolved); hostname != "" {
+		if other, ok := vc.hostnames[hostname]; ok && other != id {
+			return errors.New("duplicate configured vnode hostname")
+		}
+	}
+	return nil
 }
 
 func (pv PreparedVNode) Commit() (jobruntime.VnodeSnapshot, error) {
 	if pv.state == nil {
 		return jobruntime.VnodeSnapshot{}, ErrVNodePreparedConsumed
 	}
-	state := pv.state
-	state.mu.Lock()
-	defer state.mu.Unlock()
-	if state.consumed {
+	s := pv.state
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.consumed {
 		return jobruntime.VnodeSnapshot{}, ErrVNodePreparedConsumed
 	}
-	configuration := state.owner
-	configuration.mu.Lock()
-	defer configuration.mu.Unlock()
-	current := configuration.records[state.id]
-	if current.Revision != state.expected {
+	vc := s.owner
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	if vc.records[s.id] != s.expected {
 		return jobruntime.VnodeSnapshot{}, ErrVNodeRevision
 	}
-	state.consumed = true
-	if current.Vnode != nil {
-		delete(configuration.definitions, hostoutput.GUIDKey(current.Vnode.GUID))
+	if !s.remove {
+		if err := vc.validateUniqueLocked(s.id, s.next.config, s.next.snapshot.Vnode); err != nil {
+			return jobruntime.VnodeSnapshot{}, err
+		}
 	}
-	if state.remove {
-		delete(configuration.records, state.id)
-		return state.next.Copy(), nil
+	s.consumed = true
+	if s.expected != nil {
+		delete(vc.guids, hostoutput.GUIDKey(s.expected.config.IdentityGUID()))
+		delete(vc.hostnames, recordHostname(s.expected.config, s.expected.snapshot.Vnode))
 	}
-	configuration.records[state.id] = state.next.Copy()
-	key := hostoutput.GUIDKey(state.next.Vnode.GUID)
-	configuration.definitions[key] = state.definition
-	return state.next.Copy(), nil
+	if s.expected != nil && s.expected.snapshot.Vnode != nil {
+		delete(vc.definitions, hostoutput.GUIDKey(s.expected.snapshot.Vnode.GUID))
+	}
+	if s.remove {
+		delete(vc.records, s.id)
+	} else {
+		vc.records[s.id] = s.next
+		vc.guids[hostoutput.GUIDKey(s.next.config.IdentityGUID())] = s.id
+		if hostname := recordHostname(s.next.config, s.next.snapshot.Vnode); hostname != "" {
+			vc.hostnames[hostname] = s.id
+		}
+		if s.next.snapshot.Vnode != nil {
+			vc.definitions[hostoutput.GUIDKey(s.next.snapshot.Vnode.GUID)] = s.definition
+		}
+	}
+	return s.next.snapshot.Copy(), nil
 }
-
 func (pv PreparedVNode) Abort() error {
 	if pv.state == nil {
 		return ErrVNodePreparedConsumed
 	}
-	state := pv.state
-	state.mu.Lock()
-	defer state.mu.Unlock()
-	if state.consumed {
+	s := pv.state
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.consumed {
 		return ErrVNodePreparedConsumed
 	}
-	state.consumed = true
+	s.consumed = true
 	return nil
 }
-
 func (vc *VNodeConfiguration) Lookup(id string) (jobruntime.VnodeSnapshot, bool) {
 	if vc == nil {
 		return jobruntime.VnodeSnapshot{}, false
 	}
 	vc.mu.Lock()
 	defer vc.mu.Unlock()
-	snapshot, ok := vc.records[id]
-	return snapshot.Copy(), ok
+	r, ok := vc.records[id]
+	if !ok {
+		return jobruntime.VnodeSnapshot{}, false
+	}
+	return r.snapshot.Copy(), true
 }
-
-// Definition returns immutable metadata for authority selection inside frame admission.
+func (vc *VNodeConfiguration) Authored(id string) (ConfiguredVNode, bool) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	r, ok := vc.records[id]
+	if !ok {
+		return ConfiguredVNode{}, false
+	}
+	return configuredVNode(id, r), true
+}
+func configuredVNode(id string, r *vnodeRecord) ConfiguredVNode {
+	return ConfiguredVNode{ID: id, Config: r.config.Copy(), Snapshot: r.snapshot.Copy(), Failed: r.failed}
+}
+func (vc *VNodeConfiguration) Acquisition(id string) (*AcquisitionToken, vnodes.SNMPConfig) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	r := vc.records[id]
+	if r == nil || r.token == nil {
+		return nil, vnodes.SNMPConfig{}
+	}
+	return r.token, r.config.ModeSNMP.Copy()
+}
 func (vc *VNodeConfiguration) Definition(guid string) *hostoutput.Definition {
 	vc.mu.Lock()
 	defer vc.mu.Unlock()
 	return vc.definitions[hostoutput.GUIDKey(guid)]
 }
-
 func (vc *VNodeConfiguration) Entries() []ConfiguredVNode {
 	if vc == nil {
 		return nil
 	}
 	vc.mu.Lock()
 	entries := make([]ConfiguredVNode, 0, len(vc.records))
-	for id, snapshot := range vc.records {
-		entries = append(entries, ConfiguredVNode{
-			ID:       id,
-			Snapshot: snapshot.Copy(),
-		})
+	for id, r := range vc.records {
+		entries = append(entries, configuredVNode(id, r))
 	}
 	vc.mu.Unlock()
-	slices.SortFunc(entries, func(a, b ConfiguredVNode) int {
-		return cmp.Compare(a.ID, b.ID)
-	})
+	slices.SortFunc(entries, func(a, b ConfiguredVNode) int { return cmp.Compare(a.ID, b.ID) })
 	return entries
 }
-
-func vnodeConfigurationEqual(left, right *vnodes.VirtualNode) bool {
-	return left.Equal(right) &&
-		left.Source == right.Source &&
-		left.SourceType == right.SourceType &&
-		vnodeMetadataEqual(left, right)
-}
-
 func vnodeMetadataEqual(left, right *vnodes.VirtualNode) bool {
-	return left.Hostname == right.Hostname && left.GUID == right.GUID &&
-		maps.Equal(left.HostLabels(), right.HostLabels())
+	return left.Hostname == right.Hostname && left.GUID == right.GUID && maps.Equal(left.HostLabels(), right.HostLabels())
 }

--- a/src/go/plugin/agent/jobmgr/discovery/vnode_acquisition_test.go
+++ b/src/go/plugin/agent/jobmgr/discovery/vnode_acquisition_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package discovery
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"github.com/stretchr/testify/require"
+)
+
+func snmpConfig(t *testing.T, name, address string) *vnodes.Config {
+	t.Helper()
+	var c vnodes.Config
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"`+name+`","mode":"snmp","mode_snmp":{"address":"`+address+`","credentials":{"community":"fixture"}},"labels":{"site":"override"}}`), &c))
+	c.SourceType = "dyncfg"
+	c.Source = "user=test"
+	require.NoError(t, c.Validate())
+	return &c
+}
+func commitConfig(t *testing.T, vc *VNodeConfiguration, c *vnodes.Config) {
+	t.Helper()
+	current, _ := vc.Lookup(c.Name)
+	p, err := vc.PrepareUpsert(c.Name, current.Revision, c)
+	require.NoError(t, err)
+	_, err = p.Commit()
+	require.NoError(t, err)
+}
+func publishMetadata(t *testing.T, vc *VNodeConfiguration, token *AcquisitionToken, m *vnodes.Metadata, failed bool) {
+	t.Helper()
+	p, err := vc.PrepareMetadata(token, m, failed)
+	require.NoError(t, err)
+	_, err = p.Commit()
+	require.NoError(t, err)
+}
+func TestSNMPAcquisitionUsesCurrentOverridesAndRetainsLastGood(t *testing.T) {
+	vc := newTestVNodeConfiguration(t)
+	c := snmpConfig(t, "router", "device")
+	commitConfig(t, vc, c)
+	pending, ok := vc.Lookup("router")
+	require.True(t, ok)
+	require.Nil(t, pending.Vnode)
+	token, _ := vc.Acquisition("router")
+	c.Labels["site"] = "new override"
+	commitConfig(t, vc, c)
+	unchanged, _ := vc.Acquisition("router")
+	require.Same(t, token, unchanged)
+	raw := &vnodes.Metadata{Hostname: "device-name", Labels: map[string]string{"site": "acquired", "serial": "first"}}
+	publishMetadata(t, vc, token, raw, true)
+	first, _ := vc.Lookup("router")
+	require.Equal(t, "new override", first.Vnode.Labels["site"])
+	require.Equal(t, "device-name", first.Vnode.Hostname)
+	raw.Labels["serial"] = "mutated"
+	again, _ := vc.Lookup("router")
+	require.Equal(t, "first", again.Vnode.Labels["serial"])
+	publishMetadata(t, vc, token, &vnodes.Metadata{Hostname: "degraded", Labels: map[string]string{}}, true)
+	retained, _ := vc.Lookup("router")
+	require.Equal(t, first.Vnode, retained.Vnode)
+	delete(c.Labels, "site")
+	commitConfig(t, vc, c)
+	withoutOverride, _ := vc.Lookup("router")
+	require.Equal(t, "acquired", withoutOverride.Vnode.Labels["site"])
+	c.ModeSNMP.Credentials.Community = "rotated"
+	commitConfig(t, vc, c)
+	rotated, _ := vc.Acquisition("router")
+	require.NotSame(t, token, rotated)
+	_, err := vc.PrepareMetadata(token, raw, false)
+	require.ErrorIs(t, err, ErrVNodeRevision)
+	publishMetadata(t, vc, rotated, nil, true)
+	kept, _ := vc.Lookup("router")
+	require.Equal(t, "first", kept.Vnode.Labels["serial"])
+	publishMetadata(t, vc, rotated, &vnodes.Metadata{Hostname: "new-name", Labels: map[string]string{"serial": "second"}}, false)
+	updated, _ := vc.Lookup("router")
+	require.Equal(t, "new-name", updated.Vnode.Hostname)
+	require.NotContains(t, updated.Vnode.Labels, "site")
+	authored, _ := vc.Authored("router")
+	require.Empty(t, authored.Config.Hostname)
+	require.False(t, authored.Failed)
+}
+func TestSNMPRemoveReaddFencesPreparedAndAcquiredResults(t *testing.T) {
+	vc := newTestVNodeConfiguration(t)
+	c := snmpConfig(t, "router", "device")
+	commitConfig(t, vc, c)
+	token, _ := vc.Acquisition("router")
+	late, err := vc.PrepareMetadata(token, &vnodes.Metadata{Hostname: "old"}, false)
+	require.NoError(t, err)
+	old, _ := vc.Lookup("router")
+	removal, err := vc.PrepareRemove("router", old.Revision)
+	require.NoError(t, err)
+	_, err = removal.Commit()
+	require.NoError(t, err)
+	commitConfig(t, vc, c)
+	_, err = late.Commit()
+	require.ErrorIs(t, err, ErrVNodeRevision)
+	_, err = vc.PrepareMetadata(token, &vnodes.Metadata{Hostname: "old"}, false)
+	require.ErrorIs(t, err, ErrVNodeRevision)
+	current, _ := vc.Lookup("router")
+	require.Nil(t, current.Vnode)
+}
+func TestSNMPReservesIdentityBeforeReadinessAndRejectsHostnameCollision(t *testing.T) {
+	vc := newTestVNodeConfiguration(t)
+	a := snmpConfig(t, "a", "device-a")
+	b := snmpConfig(t, "b", "device-b")
+	commitConfig(t, vc, a)
+	same := snmpConfig(t, "same", "device-a")
+	_, err := vc.PrepareUpsert("same", 0, same)
+	require.ErrorContains(t, err, "duplicate")
+	commitConfig(t, vc, b)
+	ta, _ := vc.Acquisition("a")
+	tb, _ := vc.Acquisition("b")
+	publishMetadata(t, vc, ta, &vnodes.Metadata{Hostname: "shared-name"}, false)
+	publishMetadata(t, vc, tb, &vnodes.Metadata{Hostname: "shared-name"}, false)
+	pending, _ := vc.Authored("b")
+	require.Nil(t, pending.Snapshot.Vnode)
+	require.True(t, pending.Failed)
+	publishMetadata(t, vc, tb, &vnodes.Metadata{Hostname: "unique-name"}, false)
+	ready, _ := vc.Authored("b")
+	require.NotNil(t, ready.Snapshot.Vnode)
+	require.False(t, ready.Failed)
+}

--- a/src/go/plugin/agent/jobmgr/discovery/vnode_test.go
+++ b/src/go/plugin/agent/jobmgr/discovery/vnode_test.go
@@ -21,7 +21,7 @@ func TestVNodeConfigAtomicRevisions(t *testing.T) {
 		"abort preserves current": {
 			run: func(t *testing.T, configuration *VNodeConfiguration) {
 				first := commitVNode(t, configuration, "node", 0, testVNode("host", "source"))
-				aborted, err := configuration.PrepareUpsert("node", first.Revision, testVNode("changed", "source"))
+				aborted, err := configuration.PrepareUpsert("node", first.Revision, &vnodes.Config{VirtualNode: *testVNode("changed", "source")})
 				require.NoError(t, err)
 
 				require.NoError(t, aborted.Abort())
@@ -64,16 +64,16 @@ func TestVNodeConfigAtomicRevisions(t *testing.T) {
 			run: func(t *testing.T, configuration *VNodeConfiguration) {
 				commitVNode(t, configuration, "node", 0, testVNode("host", "source"))
 
-				_, err := configuration.PrepareUpsert("node", 0, testVNode("stale", "source"))
+				_, err := configuration.PrepareUpsert("node", 0, &vnodes.Config{VirtualNode: *testVNode("stale", "source")})
 				require.ErrorIs(t, err, ErrVNodeRevision)
 			},
 		},
 		"commit selects one preparation from the same revision": {
 			run: func(t *testing.T, configuration *VNodeConfiguration) {
 				first := commitVNode(t, configuration, "node", 0, testVNode("host", "source"))
-				winner, err := configuration.PrepareUpsert("node", first.Revision, testVNode("winner", "source"))
+				winner, err := configuration.PrepareUpsert("node", first.Revision, &vnodes.Config{VirtualNode: *testVNode("winner", "source")})
 				require.NoError(t, err)
-				stale, err := configuration.PrepareUpsert("node", first.Revision, testVNode("stale", "source"))
+				stale, err := configuration.PrepareUpsert("node", first.Revision, &vnodes.Config{VirtualNode: *testVNode("stale", "source")})
 				require.NoError(t, err)
 
 				_, err = winner.Commit()
@@ -105,9 +105,9 @@ func TestVNodeConfigCopiesMutableValues(t *testing.T) {
 }
 
 func TestVNodeConfigInitialSnapshotIsDeterministicAndIndependent(t *testing.T) {
-	initial := map[string]*vnodes.VirtualNode{
-		"z": {Name: "z", Hostname: "z-host", GUID: "z-guid", Labels: map[string]string{"site": "z"}},
-		"a": {Name: "a", Hostname: "a-host", GUID: "a-guid", Labels: map[string]string{"site": "a"}},
+	initial := map[string]*vnodes.Config{
+		"z": {VirtualNode: vnodes.VirtualNode{Name: "z", Hostname: "z-host", GUID: "z-guid", Labels: map[string]string{"site": "z"}}},
+		"a": {VirtualNode: vnodes.VirtualNode{Name: "a", Hostname: "a-host", GUID: "a-guid", Labels: map[string]string{"site": "a"}}},
 	}
 	configuration, err := NewVNodeConfigurationWithInitial(initial)
 	require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestVNodeConfigInitialSnapshotIsDeterministicAndIndependent(t *testing.T) {
 }
 
 func TestVNodeConfigInitialIdentityMustMatchMapKey(t *testing.T) {
-	_, err := NewVNodeConfigurationWithInitial(map[string]*vnodes.VirtualNode{"map-name": {Name: "vnode-name"}})
+	_, err := NewVNodeConfigurationWithInitial(map[string]*vnodes.Config{"map-name": {VirtualNode: vnodes.VirtualNode{Name: "vnode-name"}}})
 	require.Error(t, err)
 }
 
@@ -156,7 +156,7 @@ func commitVNode(
 	vnode *vnodes.VirtualNode,
 ) jobruntime.VnodeSnapshot {
 	t.Helper()
-	prepared, err := configuration.PrepareUpsert(id, expected, vnode)
+	prepared, err := configuration.PrepareUpsert(id, expected, &vnodes.Config{VirtualNode: *vnode})
 	require.NoError(t, err)
 	snapshot, err := prepared.Commit()
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestVNodeDefinitionIndex(t *testing.T) {
 				zero := confopt.Duration(0)
 				next.StaleAfter = &zero
 			}
-			prepared, err := c.PrepareUpsert("node", first.Revision, next)
+			prepared, err := c.PrepareUpsert("node", first.Revision, &vnodes.Config{VirtualNode: *next})
 			require.NoError(t, err)
 			assert.Same(t, old, c.Definition(initial.GUID))
 			if tc.abort {
@@ -218,7 +218,7 @@ func TestVNodeDefinitionIndex(t *testing.T) {
 				_, err = removal.Commit()
 				require.NoError(t, err)
 				assert.Nil(t, c.Definition(initial.GUID))
-				prepared, err = c.PrepareUpsert("node", 0, next)
+				prepared, err = c.PrepareUpsert("node", 0, &vnodes.Config{VirtualNode: *next})
 				require.NoError(t, err)
 			}
 			snapshot, err := prepared.Commit()

--- a/src/go/plugin/agent/jobmgr/joboutput/factory.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/factory.go
@@ -640,7 +640,10 @@ func (f *Factory) lookupVNode(config confgroup.Config) (jobruntime.VnodeSnapshot
 		)
 	}
 	vnode, ok := f.config.Vnode(config.Vnode())
-	if !ok || vnode.Vnode == nil {
+	if ok && vnode.Vnode == nil {
+		return jobruntime.VnodeSnapshot{}, transientJobConstruction(withJobConfigFailure(fmt.Errorf("job output: vnode %q is awaiting identity acquisition", config.Vnode()), "vnode", "pending_vnode"))
+	}
+	if !ok {
 		return jobruntime.VnodeSnapshot{}, transientJobConstruction(
 			withJobConfigFailure(
 				fmt.Errorf("job output: vnode %q is not registered", config.Vnode()),

--- a/src/go/plugin/agent/jobmgr/joboutput/host_publication_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/host_publication_test.go
@@ -201,21 +201,21 @@ func BenchmarkConfiguredHostPublication(b *testing.B) {
 			p := hostoutput.New()
 			d := testHostDefinition(b, "node")
 			guid := d.Info().GUID
-			definitions := make(map[string]*vnodes.VirtualNode, count)
+			definitions := make(map[string]*vnodes.Config, count)
 			for i := 0; i < count; i++ {
 				key := fmt.Sprint(i)
-				definitions[key] = &vnodes.VirtualNode{
+				definitions[key] = &vnodes.Config{VirtualNode: vnodes.VirtualNode{
 					Name:     key,
 					GUID:     key,
 					Hostname: key,
-				}
+				}}
 			}
-			definitions[guid] = &vnodes.VirtualNode{
+			definitions[guid] = &vnodes.Config{VirtualNode: vnodes.VirtualNode{
 				Name:     guid,
 				GUID:     guid,
 				Hostname: d.Info().Hostname,
 				Labels:   d.Info().Labels,
-			}
+			}}
 			configuration, err := discovery.NewVNodeConfigurationWithInitial(definitions)
 			require.NoError(b, err)
 			p.Bind(configuration.Definition)
@@ -401,7 +401,7 @@ func TestV1FencedCollectionPreservesCommittedState(t *testing.T) {
 				Hostname: "device",
 				GUID:     guid,
 			}
-			cfgs, err := discovery.NewVNodeConfigurationWithInitial(map[string]*vnodes.VirtualNode{"device": &vnode})
+			cfgs, err := discovery.NewVNodeConfigurationWithInitial(map[string]*vnodes.Config{"device": &vnodes.Config{VirtualNode: vnode}})
 			require.NoError(t, err)
 			publisher := hostoutput.New()
 			cfg := jobruntime.JobConfig{
@@ -447,7 +447,7 @@ func TestV1FencedCollectionPreservesCommittedState(t *testing.T) {
 				if tc.hostSwitch {
 					next := vnode
 					next.GUID = "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee"
-					edit, err := cfgs.PrepareUpsert("device", 1, &next)
+					edit, err := cfgs.PrepareUpsert("device", 1, &vnodes.Config{VirtualNode: next})
 					require.NoError(t, err)
 					_, err = edit.Commit()
 					require.NoError(t, err)

--- a/src/go/plugin/agent/setup.go
+++ b/src/go/plugin/agent/setup.go
@@ -168,7 +168,7 @@ func (a *Agent) buildDiscoveryConf(enabled collectorapi.Registry) discoverySetup
 	return cfg
 }
 
-func (a *Agent) setupVnodeRegistry() map[string]*vnodes.VirtualNode {
+func (a *Agent) setupVnodeRegistry() map[string]*vnodes.Config {
 	a.Debugf("looking for 'vnodes/' in %v", a.ConfigDir)
 	if len(a.ConfigDir) == 0 {
 		return nil

--- a/src/go/plugin/agent/setup.go
+++ b/src/go/plugin/agent/setup.go
@@ -179,7 +179,7 @@ func (a *Agent) setupVnodeRegistry() map[string]*vnodes.Config {
 		return nil
 	}
 
-	reg := vnodes.Load(dirPath)
+	reg := vnodes.Load(dirPath, a.SNMPVnodeAcquirer != nil)
 	a.Infof("found '%s' (%d vhosts)", dirPath, len(reg))
 
 	return reg

--- a/src/go/plugin/agent/vnode_modes_test.go
+++ b/src/go/plugin/agent/vnode_modes_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"github.com/stretchr/testify/require"
+)
+
+type unusedVnodeAcquirer struct{}
+
+func (unusedVnodeAcquirer) Acquire(context.Context, vnodes.SNMPConfig) (*vnodes.Metadata, error) {
+	panic("loading must not acquire")
+}
+func TestSharedVnodeFilesDoNotBreakPluginsWithoutSNMPAcquisition(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "vnodes")
+	require.NoError(t, os.Mkdir(dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "devices.yaml"), []byte(`
+- hostname: static-node
+  guid: 11111111-2222-3333-4444-555555555555
+- name: snmp-device
+  mode: snmp
+  mode_snmp:
+    address: device
+    credentials:
+      community: fixture
+`), 0600))
+	for _, name := range []string{"scripts.d", "ibm.d", "go.d"} {
+		t.Run(name, func(t *testing.T) {
+			config := Config{Name: name, PluginConfigDir: []string{root}}
+			if name == "go.d" {
+				config.SNMPVnodeAcquirer = unusedVnodeAcquirer{}
+			}
+			a := New(config)
+			loaded := a.setupVnodeRegistry()
+			require.Contains(t, loaded, "static-node")
+			if name == "go.d" {
+				require.Contains(t, loaded, "snmp-device")
+			} else {
+				require.NotContains(t, loaded, "snmp-device", "shared SNMP entries must not reach unsupported plugin startup")
+			}
+		})
+	}
+}

--- a/src/go/plugin/framework/collectorapi/collector.go
+++ b/src/go/plugin/framework/collectorapi/collector.go
@@ -67,7 +67,7 @@ type CollectorV2Runner interface {
 	Run(context.Context) error
 }
 
-// ConfiguredVnodeConsumer is an optional CollectorV2 capability. It receives an
+// ConfiguredVnodeConsumer is an optional CollectorV1 or CollectorV2 capability. It receives an
 // owned snapshot before Init/Check and,
 // when configuration changes, synchronously before Collect on the job goroutine.
 // Consumers must not treat this as a source of generated host identity.

--- a/src/go/plugin/framework/hostoutput/README.md
+++ b/src/go/plugin/framework/hostoutput/README.md
@@ -45,10 +45,11 @@ end-to-end host staleness until that parser ordering is corrected.
 
 ## Collector roles
 
-`VirtualNode()` supplies a collector-generated default host. V2 collectors implementing
+`VirtualNode()` supplies a collector-generated default host. V1 and V2 collectors implementing
 `collectorapi.ConfiguredVnodeConsumer` receive an
 owned configured snapshot initially before Init/Check, and on changed revisions synchronously before Collect.
-Nagios uses this consumer for host macros. Configuration commits never mutate collector state asynchronously.
+Nagios uses this consumer for host macros; SNMP uses it for canonical DeviceStore identity on named attachment.
+Configuration commits never mutate collector state asynchronously.
 A collection already in progress retains its original target; the next collection receives the updated snapshot.
 
 ## V1 output settlement

--- a/src/go/plugin/framework/jobruntime/configured_vnode_v1_test.go
+++ b/src/go/plugin/framework/jobruntime/configured_vnode_v1_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobruntime
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"github.com/stretchr/testify/require"
+)
+
+type configuredV1Consumer struct {
+	collectorapi.MockCollectorV1
+	vnode    vnodes.VirtualNode
+	supplies int
+}
+
+func (c *configuredV1Consumer) SetConfiguredVnode(v vnodes.VirtualNode) {
+	c.vnode = v
+	c.supplies++
+}
+
+func TestV1ConfiguredConsumerReceivesOwnedSnapshotsAtLifecycleBoundaries(t *testing.T) {
+	v := vnodes.VirtualNode{Name: "router", GUID: "node-guid", Hostname: "router-one", Labels: map[string]string{"site": "before"}}
+	holder := newSnapshotHolder(VnodeSnapshot{Vnode: &v, Revision: 1, MetadataRevision: 1})
+	c := &configuredV1Consumer{}
+	c.InitFunc = func(context.Context) error {
+		require.Equal(t, "router-one", c.vnode.Hostname)
+		c.vnode.Labels["consumer-only"] = "owned"
+		return nil
+	}
+	c.ChartsFunc = func() *collectorapi.Charts { return &collectorapi.Charts{} }
+	c.CollectFunc = func(context.Context) map[string]int64 {
+		require.Equal(t, "router-two", c.vnode.Hostname)
+		return nil
+	}
+	j := NewJob(JobConfig{PluginName: "go.d", Name: "test", ModuleName: "test", FullName: "test_test", Module: c, Out: io.Discard, Vnode: *v.Copy(), VnodeName: v.Name, VnodeRevision: 1, VnodeMetadataRevision: 1, VnodeLookup: holder.lookup})
+	require.NoError(t, j.AutoDetectionManaged(context.Background()))
+	require.NotContains(t, j.vnode.Labels, "consumer-only")
+	next := v.Copy()
+	next.Hostname = "router-two"
+	holder.set(VnodeSnapshot{Vnode: next, Revision: 2, MetadataRevision: 2})
+	j.runOnce()
+	require.Equal(t, 2, c.supplies)
+	j.runOnce()
+	require.Equal(t, 2, c.supplies, "unchanged cycles must not resupply snapshots")
+}

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -141,7 +141,7 @@ func NewJob(cfg JobConfig) *Job {
 		j.module.GetBase().Logger = moduleLog
 	}
 
-	j.supplyConfiguredVnode()
+	supplyConfiguredVnode(j.module, &j.vnode)
 	return j
 }
 
@@ -342,15 +342,7 @@ func (j *Job) applyVnodeSnapshot(snapshot VnodeSnapshot) {
 		j.vnodeMetadataRevision = snapshot.MetadataRevision
 	}
 	j.vnodeMu.Unlock()
-	j.supplyConfiguredVnode()
-}
-
-func (j *Job) supplyConfiguredVnode() {
-	if consumer, ok := j.module.(collectorapi.ConfiguredVnodeConsumer); ok {
-		snapshot := j.vnode.Copy()
-		snapshot.Labels = snapshot.HostLabels()
-		consumer.SetConfiguredVnode(*snapshot)
-	}
+	supplyConfiguredVnode(j.module, &j.vnode)
 }
 
 // Tick Tick.

--- a/src/go/plugin/framework/jobruntime/job_v1.go
+++ b/src/go/plugin/framework/jobruntime/job_v1.go
@@ -141,6 +141,7 @@ func NewJob(cfg JobConfig) *Job {
 		j.module.GetBase().Logger = moduleLog
 	}
 
+	j.supplyConfiguredVnode()
 	return j
 }
 
@@ -327,9 +328,9 @@ func (j *Job) applyVnodeSnapshot(snapshot VnodeSnapshot) {
 	next := snapshot.Vnode.Copy()
 
 	j.vnodeMu.Lock()
-	defer j.vnodeMu.Unlock()
 
 	if snapshot.Revision != 0 && snapshot.Revision <= j.vnodeRevision {
+		j.vnodeMu.Unlock()
 		return
 	}
 
@@ -339,6 +340,16 @@ func (j *Job) applyVnodeSnapshot(snapshot VnodeSnapshot) {
 	}
 	if snapshot.MetadataRevision != 0 {
 		j.vnodeMetadataRevision = snapshot.MetadataRevision
+	}
+	j.vnodeMu.Unlock()
+	j.supplyConfiguredVnode()
+}
+
+func (j *Job) supplyConfiguredVnode() {
+	if consumer, ok := j.module.(collectorapi.ConfiguredVnodeConsumer); ok {
+		snapshot := j.vnode.Copy()
+		snapshot.Labels = snapshot.HostLabels()
+		consumer.SetConfiguredVnode(*snapshot)
 	}
 }
 

--- a/src/go/plugin/framework/jobruntime/job_v2.go
+++ b/src/go/plugin/framework/jobruntime/job_v2.go
@@ -103,7 +103,7 @@ func NewJobV2(cfg JobV2Config) *JobV2 {
 			moduleLog = moduleLog.WithMessageSanitizer(sanitize)
 		}
 		j.module.GetBase().Logger = moduleLog
-		j.supplyConfiguredVnode()
+		supplyConfiguredVnode(j.module, &j.vnode)
 	}
 	return j
 }
@@ -254,7 +254,7 @@ func (j *JobV2) applyVnodeSnapshot(snapshot VnodeSnapshot) {
 		j.vnodeMetadataRevision = snapshot.MetadataRevision
 	}
 	j.vnodeMu.Unlock()
-	j.supplyConfiguredVnode()
+	supplyConfiguredVnode(j.module, &j.vnode)
 }
 
 func (j *JobV2) Cleanup() {
@@ -869,14 +869,6 @@ func (j *JobV2) prepareVnodeEmission(
 	decision.owner = owner
 	decision.definition = definition
 	return nil
-}
-
-func (j *JobV2) supplyConfiguredVnode() {
-	if consumer, ok := j.module.(collectorapi.ConfiguredVnodeConsumer); ok {
-		snapshot := j.vnode.Copy()
-		snapshot.Labels = snapshot.HostLabels()
-		consumer.SetConfiguredVnode(*snapshot)
-	}
 }
 
 func (j *JobV2) disableAutoDetection() {

--- a/src/go/plugin/framework/jobruntime/vnode_snapshot.go
+++ b/src/go/plugin/framework/jobruntime/vnode_snapshot.go
@@ -2,7 +2,10 @@
 
 package jobruntime
 
-import "github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+import (
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+)
 
 type VnodeLookup func(name string) (VnodeSnapshot, bool)
 
@@ -25,5 +28,13 @@ func (s VnodeSnapshot) Copy() VnodeSnapshot {
 		Vnode:            vnode,
 		Revision:         s.Revision,
 		MetadataRevision: s.MetadataRevision,
+	}
+}
+
+func supplyConfiguredVnode(module any, vnode *vnodes.VirtualNode) {
+	if consumer, ok := module.(collectorapi.ConfiguredVnodeConsumer); ok {
+		snapshot := vnode.Copy()
+		snapshot.Labels = snapshot.HostLabels()
+		consumer.SetConfiguredVnode(*snapshot)
 	}
 }

--- a/src/go/plugin/framework/jobruntime/vnode_snapshot.go
+++ b/src/go/plugin/framework/jobruntime/vnode_snapshot.go
@@ -31,6 +31,8 @@ func (s VnodeSnapshot) Copy() VnodeSnapshot {
 	}
 }
 
+// Called during construction or synchronously by the owning job's collection loop.
+// Configuration updates never write job state directly, so this copy has no competing writer.
 func supplyConfiguredVnode(module any, vnode *vnodes.VirtualNode) {
 	if consumer, ok := module.(collectorapi.ConfiguredVnodeConsumer); ok {
 		snapshot := vnode.Copy()

--- a/src/go/plugin/framework/vnodes/README.md
+++ b/src/go/plugin/framework/vnodes/README.md
@@ -33,6 +33,10 @@ existing framework boundary for vnode design work. This maintainer document is n
 - Credential changes mark status accepted while pending, even when last-good metadata remains available. Completion
   reports running or failed. DynCfg test validates authored configuration without network access; get returns authored
   configuration. The result path never substitutes acquired metadata into authored credentials/configuration.
+- File and DynCfg input discard inactive authentication fields before validation and storage in Go. The selected version
+  and security level determine active credentials; those remain strictly validated. Acquisition comparison uses the
+  same normalization, so changes to inactive fields cannot restart acquisition. Source files and the C DynCfg layer's
+  saved original request are unchanged; replay is normalized again at the Go boundary.
 - Removal cancels the vnode's worker; run shutdown cancels and joins all workers. Late results cannot publish into a
   retired run or incarnation.
 - Acquisition updates the configured host authority but MUST NOT announce a host by itself. Ordinary job output

--- a/src/go/plugin/framework/vnodes/README.md
+++ b/src/go/plugin/framework/vnodes/README.md
@@ -1,0 +1,60 @@
+# Configured virtual nodes
+
+This document is the maintainer contract for configured vnode acquisition and attachment.
+Operator configuration is documented in [node identities](../../../../../docs/learn/node-identities.md).
+
+Place in the documentation set: the collectors-go-design skill cites Ownership and Collector attachment as the
+existing framework boundary for vnode design work. This maintainer document is not a Learn page.
+
+## Ownership
+
+- `Config` is authored configuration, including acquisition credentials. `VirtualNode` is public host metadata.
+  Credentials MUST NOT enter public snapshots, host definitions, acquisition diagnostics or whole-record logs.
+- `VNodeConfiguration` owns authored records, raw acquired metadata, resolved snapshots and GUID/hostname indexes.
+  Configured overrides are applied to raw metadata on every update, so removing an override needs no acquisition.
+- Each run owns independent acquisition workers. The go.d entrypoint injects the concrete SNMP adapter; generic
+  composition MUST NOT import collectors. Plugins without the adapter omit the mode from their form and filter
+  unsupported file definitions before set-wide uniqueness checks.
+- Acquisition does not register a connection in SNMP's `DeviceStore`. Only a metrics job owns that connection.
+  A named SNMP job combines its own connection, profiles and system observations with the configured vnode identity.
+
+## Acquisition and publication
+
+- The one-shot adapter returns raw metadata plus an optional enrichment error. Nil metadata means no usable identity.
+  System identity requires a nonempty usable sysObjectID, sysName or sysDescr. Profile enrichment uses automatic
+  matching and scalar metadata reads only; metric profile coverage is not a readiness condition.
+- First usable metadata makes attachment possible, including partial system identity with failed enrichment.
+  A failed refresh retains the entire last usable snapshot. Complete success replaces acquired metadata.
+- Workers perform network I/O outside graph, configuration and output locks. Results commit through existing vnode
+  transaction lanes. A record-pointer comparison fences prepared mutations; an acquisition token fences old requests
+  after credential changes or remove/re-add. Label/hostname overrides preserve the acquisition token.
+- Retry and refresh intervals are internal fixed values (10 seconds and one hour). Each attempt has fresh transport
+  and metadata-reader state. There is no persistent acquired cache; a new run must acquire identity again.
+- Credential changes mark status accepted while pending, even when last-good metadata remains available. Completion
+  reports running or failed. DynCfg test validates authored configuration without network access; get returns authored
+  configuration. The result path never substitutes acquired metadata into authored credentials/configuration.
+- Removal and run shutdown cancel and join workers. Late results cannot publish into a retired run or incarnation.
+- Acquisition updates the configured host authority but MUST NOT announce a host by itself. Ordinary job output
+  publishes it under the existing [host ownership contract](../hostoutput/README.md#metadata-ownership).
+
+## Collector attachment
+
+V1 and V2 runtimes supply `collectorapi.ConfiguredVnodeConsumer` with an owned public snapshot before Init/Check and
+synchronously before the next Collect when its revision changes. The callback MUST be cheap and MUST NOT perform
+network I/O. It is separate from the collector's `VirtualNode()` generated-identity capability.
+
+SNMP uses `vnode` for a string reference and `local_vnode` for job-owned generation settings. Legacy inline `vnode`
+objects decode to `local_vnode`; configuration output uses this canonical shape for stable form editing. Supplying
+both local object spellings is rejected as ambiguous. A string suppresses collector-generated vnodes even
+when `create_vnode` is true. The collector publishes canonical identity into its job-owned DeviceStore registration;
+the provider's credentials are never substituted. The configured vnode owns host labels; job labels remain chart labels.
+
+## Validation
+
+- `config_test.go`, discovery vnode tests and composition acquisition tests cover authored/resolved separation,
+  current override precedence, partial readiness, retention, mode-aware edits, uniqueness and generation fencing.
+- `plugin/go.d/vnode/snmp_test.go` covers real UDP, missing v1 OIDs, enrichment failure and blocked-read cancellation.
+- Composition's `snmp_vnode_integration_test.go` loads vnode YAML, constructs actual Apache and SNMP jobs, and checks
+  shared identity, independent credentials, acquisition without metrics jobs and cold restarts with unavailable SNMP.
+- V1 configured-consumer tests cover owned snapshots and revision updates; existing V1/V2 host publication suites
+  remain the authority for output ordering, scope routing and configured-host precedence.

--- a/src/go/plugin/framework/vnodes/README.md
+++ b/src/go/plugin/framework/vnodes/README.md
@@ -33,7 +33,8 @@ existing framework boundary for vnode design work. This maintainer document is n
 - Credential changes mark status accepted while pending, even when last-good metadata remains available. Completion
   reports running or failed. DynCfg test validates authored configuration without network access; get returns authored
   configuration. The result path never substitutes acquired metadata into authored credentials/configuration.
-- Removal and run shutdown cancel and join workers. Late results cannot publish into a retired run or incarnation.
+- Removal cancels the vnode's worker; run shutdown cancels and joins all workers. Late results cannot publish into a
+  retired run or incarnation.
 - Acquisition updates the configured host authority but MUST NOT announce a host by itself. Ordinary job output
   publishes it under the existing [host ownership contract](../hostoutput/README.md#metadata-ownership).
 

--- a/src/go/plugin/framework/vnodes/README.md
+++ b/src/go/plugin/framework/vnodes/README.md
@@ -25,6 +25,7 @@ existing framework boundary for vnode design work. This maintainer document is n
   matching and scalar metadata reads only; metric profile coverage is not a readiness condition.
 - First usable metadata makes attachment possible, including partial system identity with failed enrichment.
   A failed refresh retains the entire last usable snapshot. Complete success replaces acquired metadata.
+  Rejected metadata, including hostname collisions, produces a safe diagnostic after the fallback state commits.
 - Workers perform network I/O outside graph, configuration and output locks. Results commit through existing vnode
   transaction lanes. A record-pointer comparison fences prepared mutations; an acquisition token fences old requests
   after credential changes or remove/re-add. Label/hostname overrides preserve the acquisition token.

--- a/src/go/plugin/framework/vnodes/config.go
+++ b/src/go/plugin/framework/vnodes/config.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package vnodes
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/pkg/snmpauth"
+)
+
+// Config is authored input. Credentials must never enter VirtualNode snapshots.
+type Config struct {
+	VirtualNode `yaml:",inline"`
+	Mode        string      `yaml:"mode,omitempty" json:"mode,omitempty"`
+	ModeSNMP    *SNMPConfig `yaml:"mode_snmp,omitempty" json:"mode_snmp,omitempty"`
+}
+type SNMPConfig struct {
+	snmpauth.Config `yaml:",inline"`
+	Address         string           `yaml:"address" json:"address"`
+	Port            int              `yaml:"port,omitempty" json:"port,omitempty"`
+	Timeout         confopt.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	Retries         *int             `yaml:"retries,omitempty" json:"retries,omitempty"`
+}
+
+// Metadata contains acquired values only; authored overrides are applied on publication.
+type Metadata struct {
+	Hostname string
+	Labels   map[string]string
+}
+
+func (m *Metadata) Copy() *Metadata {
+	if m == nil {
+		return nil
+	}
+	return &Metadata{Hostname: m.Hostname, Labels: maps.Clone(m.Labels)}
+}
+
+// SNMPAcquirer may return usable metadata with an enrichment error. A nil result
+// means no usable identity was acquired. Implementations must honor cancellation.
+type SNMPAcquirer interface {
+	Acquire(context.Context, SNMPConfig) (*Metadata, error)
+}
+
+func (c *Config) Copy() *Config {
+	if c == nil {
+		return nil
+	}
+	v := *c
+	v.VirtualNode = *c.VirtualNode.Copy()
+	if c.ModeSNMP != nil {
+		s := c.ModeSNMP.Copy()
+		v.ModeSNMP = &s
+	}
+	return &v
+}
+func (c SNMPConfig) Copy() SNMPConfig {
+	c.Config = c.Config.Copy()
+	if c.Retries != nil {
+		v := *c.Retries
+		c.Retries = &v
+	}
+	return c
+}
+func (c SNMPConfig) Defaults() SNMPConfig {
+	c = c.Copy()
+	if c.Version == "" {
+		c.Version = "2c"
+	}
+	if c.Port == 0 {
+		c.Port = 161
+	}
+	if c.Timeout == 0 {
+		c.Timeout = confopt.Duration(5 * time.Second)
+	}
+	if c.Retries == nil {
+		v := 1
+		c.Retries = &v
+	}
+	return c
+}
+func (c *Config) IsSNMP() bool { return c != nil && c.Mode == "snmp" }
+func (c *Config) IdentityGUID() string {
+	if c.GUID != "" || !c.IsSNMP() || c.ModeSNMP == nil {
+		return c.GUID
+	}
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(c.ModeSNMP.Address)).String()
+}
+func (c *Config) Validate() error {
+	if c == nil {
+		return fmt.Errorf("configured vnode is nil")
+	}
+	switch c.Mode {
+	case "", "static":
+		if c.ModeSNMP != nil {
+			return fmt.Errorf("mode_snmp requires mode snmp")
+		}
+		return ValidateConfigured(&c.VirtualNode)
+	case "snmp":
+		if c.ModeSNMP == nil {
+			return fmt.Errorf("mode_snmp is required")
+		}
+	default:
+		return fmt.Errorf("mode must be static or snmp")
+	}
+	s := c.ModeSNMP.Defaults()
+	if strings.TrimSpace(s.Address) == "" {
+		return fmt.Errorf("mode_snmp.address is required")
+	}
+	if s.Port < 1 || s.Port > 65535 {
+		return fmt.Errorf("mode_snmp.port must be between 1 and 65535")
+	}
+	if s.Timeout <= 0 {
+		return fmt.Errorf("mode_snmp.timeout must be positive")
+	}
+	if *s.Retries < 0 {
+		return fmt.Errorf("mode_snmp.retries cannot be negative")
+	}
+	if err := s.Config.Validate(); err != nil {
+		return fmt.Errorf("mode_snmp: %w", err)
+	}
+	v := c.VirtualNode.Copy()
+	v.GUID = c.IdentityGUID()
+	if v.Hostname == "" {
+		v.Hostname = c.Name
+	}
+	return ValidateConfigured(v)
+}
+func (c *Config) Resolve(m *Metadata) *VirtualNode {
+	if c == nil || c.IsSNMP() && m == nil {
+		return nil
+	}
+	v := c.VirtualNode.Copy()
+	v.GUID = c.IdentityGUID()
+	if c.IsSNMP() {
+		if v.Hostname == "" {
+			v.Hostname = m.Hostname
+		}
+		if v.Hostname == "" {
+			v.Hostname = c.Name
+		}
+		v.Labels = maps.Clone(m.Labels)
+		if v.Labels == nil {
+			v.Labels = make(map[string]string)
+		}
+		maps.Copy(v.Labels, c.Labels)
+	}
+	return v
+}
+
+// ValidateUpdate preserves legacy static edits; SNMP identity replacement is explicit.
+func (c *Config) ValidateUpdate(next *Config) error {
+	if !c.IsSNMP() && !next.IsSNMP() {
+		return nil
+	}
+	if c.IsSNMP() != next.IsSNMP() || c.ModeSNMP.Address != next.ModeSNMP.Address || c.ModeSNMP.ContextName() != next.ModeSNMP.ContextName() {
+		return fmt.Errorf("changing vnode mode or SNMP target requires a replacement vnode")
+	}
+	a, _ := ConfiguredGUIDKey(c.IdentityGUID())
+	b, _ := ConfiguredGUIDKey(next.IdentityGUID())
+	if a != b {
+		return fmt.Errorf("changing SNMP vnode GUID requires a replacement vnode")
+	}
+	return nil
+}
+func (c *Config) SameAcquisition(next *Config) bool {
+	if !c.IsSNMP() || !next.IsSNMP() {
+		return !c.IsSNMP() && !next.IsSNMP()
+	}
+	return reflect.DeepEqual(c.ModeSNMP.Defaults(), next.ModeSNMP.Defaults())
+}

--- a/src/go/plugin/framework/vnodes/config.go
+++ b/src/go/plugin/framework/vnodes/config.go
@@ -141,33 +141,27 @@ func (c *Config) Resolve(m *Metadata) *VirtualNode {
 	}
 	v := c.VirtualNode.Copy()
 	v.GUID = c.IdentityGUID()
+
 	if c.IsSNMP() {
 		if v.Hostname == "" {
-			v.Hostname = m.Hostname
+			v.Hostname = strings.TrimSpace(m.Hostname)
 		}
 		if v.Hostname == "" {
 			v.Hostname = c.Name
 		}
-		// Acquired fields use normal host emission normalization; authored overrides
-		// have already passed strict validation and remain exact.
-		acquiredHost := m.Hostname
-		if acquiredHost == "" {
-			acquiredHost = c.Name
-		}
-		acquiredLabels := m.Labels
-		if prepared, err := chartemit.PrepareHostInfo(netdataapi.HostInfo{GUID: v.GUID, Hostname: acquiredHost, Labels: m.Labels}); err == nil {
-			acquiredHost = prepared.Hostname
-			acquiredLabels = prepared.Labels
-		}
-		if c.Hostname == "" {
-			v.Hostname = acquiredHost
-		}
-		v.Labels = maps.Clone(acquiredLabels)
+		v.Labels = maps.Clone(m.Labels)
 		if v.Labels == nil {
 			v.Labels = make(map[string]string)
 		}
 		maps.Copy(v.Labels, c.Labels)
+		// Normalize acquired fields with the effective hostname. Authored overrides
+		// already passed strict validation, so preparation preserves their spelling.
+		if prepared, err := chartemit.PrepareHostInfo(netdataapi.HostInfo{GUID: v.GUID, Hostname: v.Hostname, Labels: v.Labels}); err == nil {
+			v.Hostname = prepared.Hostname
+			v.Labels = prepared.Labels
+		}
 	}
+
 	return v
 }
 

--- a/src/go/plugin/framework/vnodes/config.go
+++ b/src/go/plugin/framework/vnodes/config.go
@@ -7,12 +7,15 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/pkg/netdataapi"
 	"github.com/netdata/netdata/go/plugins/pkg/snmpauth"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/chartemit"
 )
 
 // Config is authored input. Credentials must never enter VirtualNode snapshots.
@@ -145,7 +148,21 @@ func (c *Config) Resolve(m *Metadata) *VirtualNode {
 		if v.Hostname == "" {
 			v.Hostname = c.Name
 		}
-		v.Labels = maps.Clone(m.Labels)
+		// Acquired fields use normal host emission normalization; authored overrides
+		// have already passed strict validation and remain exact.
+		acquiredHost := m.Hostname
+		if acquiredHost == "" {
+			acquiredHost = c.Name
+		}
+		acquiredLabels := m.Labels
+		if prepared, err := chartemit.PrepareHostInfo(netdataapi.HostInfo{GUID: v.GUID, Hostname: acquiredHost, Labels: m.Labels}); err == nil {
+			acquiredHost = prepared.Hostname
+			acquiredLabels = prepared.Labels
+		}
+		if c.Hostname == "" {
+			v.Hostname = acquiredHost
+		}
+		v.Labels = maps.Clone(acquiredLabels)
 		if v.Labels == nil {
 			v.Labels = make(map[string]string)
 		}
@@ -174,4 +191,34 @@ func (c *Config) SameAcquisition(next *Config) bool {
 		return !c.IsSNMP() && !next.IsSNMP()
 	}
 	return reflect.DeepEqual(c.ModeSNMP.Defaults(), next.ModeSNMP.Defaults())
+}
+
+// ValidateConfigSet validates authored identities, including unresolved GUID reservations.
+func ValidateConfigSet(initial map[string]*Config) error {
+	guids := make(map[string]string)
+	hostnames := make(map[string]string)
+	for _, id := range slices.Sorted(maps.Keys(initial)) {
+		c := initial[id]
+		if c == nil {
+			return fmt.Errorf("configured vnode %q is nil", id)
+		}
+		if c.Name != id {
+			return fmt.Errorf("configured vnode %q identity differs from its map key", id)
+		}
+		if err := c.Validate(); err != nil {
+			return fmt.Errorf("configured vnode %q: %w", id, err)
+		}
+		guid, _ := ConfiguredGUIDKey(c.IdentityGUID())
+		if other, ok := guids[guid]; ok {
+			return fmt.Errorf("duplicate configured vnode GUID (%s and %s)", other, id)
+		}
+		guids[guid] = id
+		if c.Hostname != "" {
+			if other, ok := hostnames[c.Hostname]; ok {
+				return fmt.Errorf("duplicate configured vnode hostname (%s and %s)", other, id)
+			}
+			hostnames[c.Hostname] = id
+		}
+	}
+	return nil
 }

--- a/src/go/plugin/framework/vnodes/config.go
+++ b/src/go/plugin/framework/vnodes/config.go
@@ -73,6 +73,7 @@ func (c SNMPConfig) Copy() SNMPConfig {
 }
 func (c SNMPConfig) Defaults() SNMPConfig {
 	c = c.Copy()
+	c.Config = c.Config.Normalized()
 	if c.Version == "" {
 		c.Version = "2c"
 	}
@@ -89,6 +90,13 @@ func (c SNMPConfig) Defaults() SNMPConfig {
 	return c
 }
 func (c *Config) IsSNMP() bool { return c != nil && c.Mode == "snmp" }
+
+// NormalizeCredentials removes inactive secrets before authored input is retained.
+func (c *Config) NormalizeCredentials() {
+	if c.IsSNMP() && c.ModeSNMP != nil {
+		c.ModeSNMP.Config = c.ModeSNMP.Config.Normalized()
+	}
+}
 func (c *Config) IdentityGUID() string {
 	if c.GUID != "" || !c.IsSNMP() || c.ModeSNMP == nil {
 		return c.GUID

--- a/src/go/plugin/framework/vnodes/config_schema.json
+++ b/src/go/plugin/framework/vnodes/config_schema.json
@@ -212,8 +212,7 @@
                                       "auth_password": {
                                         "title": "Authentication password",
                                         "description": "SNMPv3 authentication passphrase; at least eight bytes.",
-                                        "type": "string",
-                                        "minLength": 8
+                                        "type": "string"
                                       }
                                     },
                                     "required": [
@@ -242,8 +241,7 @@
                                       "auth_password": {
                                         "title": "Authentication password",
                                         "description": "SNMPv3 authentication passphrase; at least eight bytes.",
-                                        "type": "string",
-                                        "minLength": 8
+                                        "type": "string"
                                       },
                                       "priv_protocol": {
                                         "title": "Privacy protocol",
@@ -262,8 +260,7 @@
                                       "priv_password": {
                                         "title": "Privacy password",
                                         "description": "SNMPv3 encryption passphrase; at least eight bytes.",
-                                        "type": "string",
-                                        "minLength": 8
+                                        "type": "string"
                                       }
                                     },
                                     "required": [

--- a/src/go/plugin/framework/vnodes/config_schema.json
+++ b/src/go/plugin/framework/vnodes/config_schema.json
@@ -96,9 +96,10 @@
                   },
                   "timeout": {
                     "title": "Timeout",
-                    "description": "Timeout for each SNMP request, as a duration.",
-                    "type": "string",
-                    "default": "5s"
+                    "description": "Timeout for each SNMP request, in seconds.",
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "default": 5
                   },
                   "retries": {
                     "title": "Retries",
@@ -354,7 +355,7 @@
         }
       },
       "timeout": {
-        "ui:placeholder": "5s"
+        "ui:placeholder": "5"
       },
       "credentials": {
         "community": {

--- a/src/go/plugin/framework/vnodes/config_schema.json
+++ b/src/go/plugin/framework/vnodes/config_schema.json
@@ -16,12 +16,12 @@
       },
       "hostname": {
         "title": "Hostname",
-        "description": "The hostname that identifies this virtual node in the Netdata UI and API. Must be unique within your monitoring environment. Leave empty to use the job name.",
+        "description": "Display hostname override. Static mode defaults to the resource name; SNMP mode uses sysName, then the resource name.",
         "type": "string"
       },
       "guid": {
         "title": "GUID",
-        "description": "Uniquely identifies the node. Must be in [UUID format](https://www.guidgen.com/). Changing this value will result in creating a **new Virtual Node** - the existing Virtual Node and its history will not be modified.",
+        "description": "Unique node UUID. Required in static mode; SNMP mode derives it from the exact address when omitted. An existing SNMP vnode cannot change its identity in place.",
         "type": "string"
       },
       "labels": {
@@ -34,10 +34,278 @@
         "additionalProperties": {
           "type": "string"
         }
+      },
+      "mode": {
+        "title": "Mode",
+        "description": "Use static values or acquire host identity and labels independently through SNMP.",
+        "type": "string",
+        "enum": [
+          "static",
+          "snmp"
+        ],
+        "default": "static"
       }
     },
-    "required": [
-      "guid"
+    "dependencies": {
+      "mode": {
+        "oneOf": [
+          {
+            "properties": {
+              "mode": {
+                "const": "static"
+              }
+            },
+            "required": [
+              "guid"
+            ]
+          },
+          {
+            "properties": {
+              "mode": {
+                "const": "snmp"
+              },
+              "mode_snmp": {
+                "title": "SNMP connection",
+                "description": "Connection used only to acquire virtual node identity and labels. Collector jobs keep their own connection settings.",
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "title": "Address",
+                    "description": "Hostname or IP address of the SNMP device. Its exact spelling determines the default node UUID.",
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "port": {
+                    "title": "Port",
+                    "description": "UDP port for SNMP requests.",
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "default": 161
+                  },
+                  "version": {
+                    "title": "SNMP version",
+                    "description": "SNMP protocol version used for identity acquisition.",
+                    "type": "string",
+                    "enum": [
+                      "1",
+                      "2c",
+                      "3"
+                    ],
+                    "default": "2c"
+                  },
+                  "timeout": {
+                    "title": "Timeout",
+                    "description": "Timeout for each SNMP request, as a duration.",
+                    "type": "string",
+                    "default": "5s"
+                  },
+                  "retries": {
+                    "title": "Retries",
+                    "description": "Number of retries for each SNMP request.",
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 1
+                  }
+                },
+                "required": [
+                  "address"
+                ],
+                "dependencies": {
+                  "version": {
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "version": {
+                            "enum": [
+                              "1",
+                              "2c"
+                            ]
+                          },
+                          "credentials": {
+                            "title": "Community credentials",
+                            "description": "Credentials for SNMPv1 or SNMPv2c. Use a literal value; secret references are not supported.",
+                            "type": "object",
+                            "properties": {
+                              "community": {
+                                "title": "Community",
+                                "description": "SNMP community string.",
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "required": [
+                              "community"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "credentials"
+                        ]
+                      },
+                      {
+                        "properties": {
+                          "version": {
+                            "const": "3"
+                          },
+                          "credentials3": {
+                            "title": "SNMPv3 credentials",
+                            "description": "User-based SNMPv3 credentials. Use literal passwords; secret references are not supported.",
+                            "type": "object",
+                            "properties": {
+                              "username": {
+                                "title": "Username",
+                                "description": "SNMPv3 username.",
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "context_name": {
+                                "title": "Context name",
+                                "description": "SNMPv3 context. Omit to use the default context.",
+                                "type": "string"
+                              },
+                              "security_level": {
+                                "title": "Security level",
+                                "description": "Whether to authenticate and encrypt SNMPv3 messages.",
+                                "type": "string",
+                                "enum": [
+                                  "noAuthNoPriv",
+                                  "authNoPriv",
+                                  "authPriv"
+                                ],
+                                "default": "authPriv"
+                              }
+                            },
+                            "required": [
+                              "username"
+                            ],
+                            "dependencies": {
+                              "security_level": {
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "security_level": {
+                                        "const": "noAuthNoPriv"
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "security_level": {
+                                        "const": "authNoPriv"
+                                      },
+                                      "auth_protocol": {
+                                        "title": "Authentication protocol",
+                                        "description": "Algorithm used to authenticate SNMPv3 messages.",
+                                        "type": "string",
+                                        "enum": [
+                                          "md5",
+                                          "sha",
+                                          "sha224",
+                                          "sha256",
+                                          "sha384",
+                                          "sha512"
+                                        ],
+                                        "default": "sha512"
+                                      },
+                                      "auth_password": {
+                                        "title": "Authentication password",
+                                        "description": "SNMPv3 authentication passphrase; at least eight bytes.",
+                                        "type": "string",
+                                        "minLength": 8
+                                      }
+                                    },
+                                    "required": [
+                                      "auth_password"
+                                    ]
+                                  },
+                                  {
+                                    "properties": {
+                                      "security_level": {
+                                        "const": "authPriv"
+                                      },
+                                      "auth_protocol": {
+                                        "title": "Authentication protocol",
+                                        "description": "Algorithm used to authenticate SNMPv3 messages.",
+                                        "type": "string",
+                                        "enum": [
+                                          "md5",
+                                          "sha",
+                                          "sha224",
+                                          "sha256",
+                                          "sha384",
+                                          "sha512"
+                                        ],
+                                        "default": "sha512"
+                                      },
+                                      "auth_password": {
+                                        "title": "Authentication password",
+                                        "description": "SNMPv3 authentication passphrase; at least eight bytes.",
+                                        "type": "string",
+                                        "minLength": 8
+                                      },
+                                      "priv_protocol": {
+                                        "title": "Privacy protocol",
+                                        "description": "Algorithm used to encrypt SNMPv3 messages.",
+                                        "type": "string",
+                                        "enum": [
+                                          "des",
+                                          "aes",
+                                          "aes192",
+                                          "aes256",
+                                          "aes192c",
+                                          "aes256c"
+                                        ],
+                                        "default": "aes192c"
+                                      },
+                                      "priv_password": {
+                                        "title": "Privacy password",
+                                        "description": "SNMPv3 encryption passphrase; at least eight bytes.",
+                                        "type": "string",
+                                        "minLength": 8
+                                      }
+                                    },
+                                    "required": [
+                                      "auth_password",
+                                      "priv_password"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "required": [
+                          "credentials3"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "required": [
+              "mode_snmp"
+            ]
+          }
+        ]
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "not": {
+            "required": [
+              "mode"
+            ]
+          }
+        },
+        "then": {
+          "required": [
+            "guid"
+          ]
+        }
+      }
     ]
   },
   "uiSchema": {
@@ -53,6 +321,70 @@
     "stale_after": {
       "ui:placeholder": "300",
       "ui:help": "In YAML, durations such as `5m` are also accepted. An explicit value overrides `_node_stale_after_seconds` in the host labels."
+    },
+    "ui:order": [
+      "mode",
+      "hostname",
+      "guid",
+      "labels",
+      "stale_after",
+      "mode_snmp"
+    ],
+    "mode": {
+      "ui:widget": "radio",
+      "ui:options": {
+        "inline": true
+      },
+      "ui:help": "Static mode uses values you supply. SNMP mode waits for a usable device identity before starting attached jobs."
+    },
+    "mode_snmp": {
+      "ui:order": [
+        "address",
+        "port",
+        "version",
+        "credentials",
+        "credentials3",
+        "timeout",
+        "retries"
+      ],
+      "version": {
+        "ui:widget": "radio",
+        "ui:options": {
+          "inline": true
+        }
+      },
+      "timeout": {
+        "ui:placeholder": "5s"
+      },
+      "credentials": {
+        "community": {
+          "ui:widget": "password"
+        }
+      },
+      "credentials3": {
+        "ui:order": [
+          "username",
+          "context_name",
+          "security_level",
+          "auth_protocol",
+          "auth_password",
+          "priv_protocol",
+          "priv_password"
+        ],
+        "security_level": {
+          "ui:widget": "radio",
+          "ui:options": {
+            "inline": true
+          }
+        },
+        "auth_password": {
+          "ui:widget": "password"
+        },
+        "priv_password": {
+          "ui:widget": "password"
+        }
+      },
+      "ui:help": "When changing protocol or security level, remove credentials that no longer apply. Inactive credential fields are rejected."
     }
   }
 }

--- a/src/go/plugin/framework/vnodes/config_schema.json
+++ b/src/go/plugin/framework/vnodes/config_schema.json
@@ -385,7 +385,7 @@
           "ui:widget": "password"
         }
       },
-      "ui:help": "When changing protocol or security level, remove credentials that no longer apply. Inactive credential fields are rejected."
+      "ui:help": "Changing protocol or security level discards credentials that no longer apply. Switching back requires entering those credentials again."
     }
   }
 }

--- a/src/go/plugin/framework/vnodes/config_test.go
+++ b/src/go/plugin/framework/vnodes/config_test.go
@@ -4,10 +4,13 @@ package vnodes
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/netdata/netdata/go/plugins/pkg/snmpauth"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -76,6 +79,8 @@ func TestModeAwareUpdate(t *testing.T) {
 	next.Labels = map[string]string{"site": "new"}
 	require.NoError(t, c.ValidateUpdate(next))
 	require.True(t, c.SameAcquisition(next))
+	next.ModeSNMP.Credentials3 = &snmpauth.USM{Username: "inactive"}
+	require.True(t, c.SameAcquisition(next), "inactive credentials must not restart acquisition")
 	next.ModeSNMP.Credentials.Community = "new"
 	require.NoError(t, c.ValidateUpdate(next))
 	require.False(t, c.SameAcquisition(next))
@@ -87,6 +92,29 @@ func TestModeAwareUpdate(t *testing.T) {
 	next = &Config{VirtualNode: VirtualNode{Name: "router", Hostname: "router", GUID: uuid.NewString()}}
 	require.Error(t, c.ValidateUpdate(next))
 	require.Error(t, next.ValidateUpdate(&c))
+}
+
+func TestFileLoadDiscardsInactiveCredentials(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "vnodes.yaml"), []byte(`- name: router
+  mode: snmp
+  mode_snmp:
+    address: device
+    version: "3"
+    credentials:
+      community: inactive-community
+    credentials3:
+      username: fixture
+      security_level: noAuthNoPriv
+      auth_password: inactive-auth
+      priv_password: inactive-priv
+`), 0600))
+	loaded := Load(dir, true)
+	require.Contains(t, loaded, "router")
+	raw, err := json.Marshal(loaded["router"])
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "inactive")
+	require.NoError(t, loaded["router"].Validate())
 }
 func TestSNMPNameRequired(t *testing.T) {
 	var c Config

--- a/src/go/plugin/framework/vnodes/config_test.go
+++ b/src/go/plugin/framework/vnodes/config_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package vnodes
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestAuthoredConfigRoundtripAndResolution(t *testing.T) {
+	var c Config
+	require.NoError(t, yaml.Unmarshal([]byte(`name: router
+mode: snmp
+labels:
+  site: configured
+mode_snmp:
+  address: router.example
+  credentials:
+    community: test-secret
+  retries: 0
+`), &c))
+	c.SourceType = "stock"
+	require.NoError(t, c.Validate())
+	require.Nil(t, c.Resolve(nil))
+	defaults := c.ModeSNMP.Defaults()
+	require.Equal(t, 161, defaults.Port)
+	require.Equal(t, 5*time.Second, defaults.Timeout.Duration())
+	require.Equal(t, 0, *defaults.Retries)
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			var raw []byte
+			var err error
+			var decoded Config
+			if format == "json" {
+				raw, err = json.Marshal(c)
+				require.NoError(t, err)
+				err = json.Unmarshal(raw, &decoded)
+			} else {
+				raw, err = yaml.Marshal(c)
+				require.NoError(t, err)
+				err = yaml.Unmarshal(raw, &decoded)
+			}
+			require.NoError(t, err)
+			decoded.SourceType = c.SourceType
+			require.Equal(t, c, decoded)
+		})
+	}
+	meta := &Metadata{Hostname: "device-name", Labels: map[string]string{"site": "acquired", "model": "router"}}
+	resolved := c.Resolve(meta)
+	require.Equal(t, "device-name", resolved.Hostname)
+	require.Equal(t, "configured", resolved.Labels["site"])
+	require.Equal(t, uuid.NewSHA1(uuid.NameSpaceDNS, []byte("router.example")).String(), resolved.GUID)
+	raw, err := json.Marshal(resolved)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "secret")
+	require.NotContains(t, string(raw), "mode_snmp")
+	copy := c.Copy()
+	delete(copy.Labels, "site")
+	require.Equal(t, "acquired", copy.Resolve(meta).Labels["site"])
+	copy.Hostname = "override"
+	require.Equal(t, "override", copy.Resolve(meta).Hostname)
+	require.Equal(t, "router", c.Resolve(&Metadata{}).Hostname)
+	require.Equal(t, "acquired", meta.Labels["site"])
+}
+func TestModeAwareUpdate(t *testing.T) {
+	var c Config
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"router","mode":"snmp","mode_snmp":{"address":"router","credentials":{"community":"old"}}}`), &c))
+	c.SourceType = "stock"
+	require.NoError(t, c.Validate())
+	next := c.Copy()
+	next.Labels = map[string]string{"site": "new"}
+	require.NoError(t, c.ValidateUpdate(next))
+	require.True(t, c.SameAcquisition(next))
+	next.ModeSNMP.Credentials.Community = "new"
+	require.NoError(t, c.ValidateUpdate(next))
+	require.False(t, c.SameAcquisition(next))
+	next.ModeSNMP.Address = "replacement"
+	require.Error(t, c.ValidateUpdate(next))
+	next = c.Copy()
+	next.GUID = uuid.NewString()
+	require.Error(t, c.ValidateUpdate(next))
+	next = &Config{VirtualNode: VirtualNode{Name: "router", Hostname: "router", GUID: uuid.NewString()}}
+	require.Error(t, c.ValidateUpdate(next))
+	require.Error(t, next.ValidateUpdate(&c))
+}
+func TestSNMPNameRequired(t *testing.T) {
+	var c Config
+	require.NoError(t, yaml.Unmarshal([]byte("mode: snmp\nmode_snmp:\n  address: router\n  credentials:\n    community: secret\n"), &c))
+	require.ErrorContains(t, c.Validate(), "name is required")
+}

--- a/src/go/plugin/framework/vnodes/config_test.go
+++ b/src/go/plugin/framework/vnodes/config_test.go
@@ -93,3 +93,21 @@ func TestSNMPNameRequired(t *testing.T) {
 	require.NoError(t, yaml.Unmarshal([]byte("mode: snmp\nmode_snmp:\n  address: router\n  credentials:\n    community: secret\n"), &c))
 	require.ErrorContains(t, c.Validate(), "name is required")
 }
+
+func TestResolveUsesEffectiveHostnameForFallbackAndLabel(t *testing.T) {
+	var c Config
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"stable-name","mode":"snmp","mode_snmp":{"address":"device","credentials":{"community":"fixture"}}}`), &c))
+	c.SourceType = "user"
+	require.NoError(t, c.Validate())
+	t.Run("fallback", func(t *testing.T) {
+		fallback := c.Resolve(&Metadata{Hostname: "   ", Labels: map[string]string{"description": "usable"}})
+		require.Equal(t, "stable-name", fallback.Hostname)
+		require.NoError(t, ValidateConfigured(fallback))
+	})
+	t.Run("override", func(t *testing.T) {
+		c.Hostname = "override"
+		effective := c.Resolve(&Metadata{Hostname: "device-name"})
+		require.Equal(t, "override", effective.Hostname)
+		require.Equal(t, "override", effective.Labels["_hostname"])
+	})
+}

--- a/src/go/plugin/framework/vnodes/configured.go
+++ b/src/go/plugin/framework/vnodes/configured.go
@@ -4,8 +4,6 @@ package vnodes
 
 import (
 	"fmt"
-	"maps"
-	"slices"
 	"strings"
 	"time"
 
@@ -108,33 +106,4 @@ func ConfiguredGUIDKey(value string) (string, error) {
 		}
 	}
 	return canonical, nil
-}
-
-// ValidateConfiguredSet validates configured vnodes and their set-wide
-// hostname and GUID uniqueness deterministically.
-func ValidateConfiguredSet(initial map[string]*VirtualNode) error {
-	seenHostnames := make(map[string]string)
-	seenGUIDs := make(map[string]string)
-	for _, id := range slices.Sorted(maps.Keys(initial)) {
-		vnode := initial[id]
-		if vnode == nil {
-			return fmt.Errorf("configured vnode %q is nil", id)
-		}
-		if vnode.Name != id {
-			return fmt.Errorf("configured vnode %q identity differs from its map key", id)
-		}
-		guidKey, err := validateConfigured(vnode)
-		if err != nil {
-			return fmt.Errorf("configured vnode %q: %w", id, err)
-		}
-		if other, ok := seenHostnames[vnode.Hostname]; ok {
-			return fmt.Errorf("duplicate configured vnode hostname %q (%s and %s)", vnode.Hostname, other, id)
-		}
-		if other, ok := seenGUIDs[guidKey]; ok {
-			return fmt.Errorf("duplicate configured vnode GUID (%s and %s)", other, id)
-		}
-		seenHostnames[vnode.Hostname] = id
-		seenGUIDs[guidKey] = id
-	}
-	return nil
 }

--- a/src/go/plugin/framework/vnodes/schema.go
+++ b/src/go/plugin/framework/vnodes/schema.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package vnodes
+
+import "encoding/json"
+
+// ConfigSchemaFor omits acquisition controls from plugins without an adapter.
+func ConfigSchemaFor(snmpSupported bool) string {
+	if snmpSupported {
+		return ConfigSchema
+	}
+	return staticConfigSchema
+}
+
+var staticConfigSchema = func() string {
+	var doc map[string]map[string]any
+	if err := json.Unmarshal([]byte(ConfigSchema), &doc); err != nil {
+		panic(err)
+	}
+	schema, ui := doc["jsonSchema"], doc["uiSchema"]
+	delete(schema["properties"].(map[string]any), "mode")
+	delete(schema, "dependencies")
+	delete(schema, "allOf")
+	schema["required"] = []string{"guid"}
+	delete(ui, "mode")
+	delete(ui, "mode_snmp")
+	ui["ui:order"] = []string{"hostname", "guid", "labels", "stale_after"}
+	properties := schema["properties"].(map[string]any)
+	properties["hostname"].(map[string]any)["description"] = "Display hostname. Omit to use the resource name."
+	properties["guid"].(map[string]any)["description"] = "Unique node UUID. Changing this value creates a new node; existing history stays with the old UUID."
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}()

--- a/src/go/plugin/framework/vnodes/schema_test.go
+++ b/src/go/plugin/framework/vnodes/schema_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package vnodes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVnodeSchemaModesAndCredentials(t *testing.T) {
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal([]byte(ConfigSchemaFor(true)), &doc))
+	compiler := jsonschema.NewCompiler()
+	require.NoError(t, compiler.AddResource("vnode.json", doc["jsonSchema"]))
+	schema, err := compiler.Compile("vnode.json")
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		config string
+		valid  bool
+	}{
+		{`{"guid":"6e17cd2c-0518-4e94-965b-d25673decb21"}`, true},
+		{`{}`, false},
+		{`{"mode":"static"}`, false},
+		{`{"mode":"snmp","mode_snmp":{"address":"device","version":"2c","credentials":{"community":"fixture"}}}`, true},
+		{`{"mode":"snmp","mode_snmp":{"address":"device","version":"3","credentials3":{"username":"fixture","security_level":"noAuthNoPriv"}}}`, true},
+		{`{"mode":"snmp","mode_snmp":{"address":"device","version":"3","credentials3":{"username":"fixture","security_level":"authPriv"}}}`, false},
+		{`{"mode":"snmp","mode_snmp":{"address":"device","version":"2c"}}`, false},
+		{`{"mode":"snmp"}`, false},
+	} {
+		var config any
+		require.NoError(t, json.Unmarshal([]byte(tc.config), &config))
+		if tc.valid {
+			require.NoError(t, schema.Validate(config), tc.config)
+		} else {
+			require.Error(t, schema.Validate(config), tc.config)
+		}
+	}
+	static := ConfigSchemaFor(false)
+	require.NotContains(t, static, "mode_snmp")
+	require.NotContains(t, static, "credentials")
+	require.NotContains(t, static, "SNMP")
+}

--- a/src/go/plugin/framework/vnodes/schema_test.go
+++ b/src/go/plugin/framework/vnodes/schema_test.go
@@ -5,7 +5,10 @@ package vnodes
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/pkg/snmpauth"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +20,17 @@ func TestVnodeSchemaModesAndCredentials(t *testing.T) {
 	require.NoError(t, compiler.AddResource("vnode.json", doc["jsonSchema"]))
 	schema, err := compiler.Compile("vnode.json")
 	require.NoError(t, err)
+	t.Run("authored get roundtrip", func(t *testing.T) {
+		config := Config{VirtualNode: VirtualNode{Name: "router"}, Mode: "snmp", ModeSNMP: &SNMPConfig{
+			Address: "device", Timeout: confopt.Duration(5 * time.Second),
+			Config: snmpauth.Config{Version: "2c", Credentials: &snmpauth.Community{Community: "fixture"}},
+		}}
+		raw, err := json.Marshal(config)
+		require.NoError(t, err)
+		var form any
+		require.NoError(t, json.Unmarshal(raw, &form))
+		require.NoError(t, schema.Validate(form), "authored get must be editable in its schema")
+	})
 	for _, tc := range []struct {
 		config string
 		valid  bool

--- a/src/go/plugin/framework/vnodes/schema_test.go
+++ b/src/go/plugin/framework/vnodes/schema_test.go
@@ -31,6 +31,21 @@ func TestVnodeSchemaModesAndCredentials(t *testing.T) {
 		require.NoError(t, json.Unmarshal(raw, &form))
 		require.NoError(t, schema.Validate(form), "authored get must be editable in its schema")
 	})
+	for _, level := range []string{"authNoPriv", "authPriv"} {
+		t.Run("multibyte password/"+level, func(t *testing.T) {
+			c := Config{VirtualNode: VirtualNode{Name: "router", SourceType: "user"}, Mode: "snmp", ModeSNMP: &SNMPConfig{
+				Address: "device",
+				Config:  snmpauth.Config{Version: "3", Credentials3: &snmpauth.USM{Username: "fixture", SecurityLevel: level, AuthPassword: "éééé", PrivPassword: "éééé"}},
+			}}
+			c.NormalizeCredentials()
+			require.NoError(t, c.Validate())
+			raw, err := json.Marshal(c)
+			require.NoError(t, err)
+			var form any
+			require.NoError(t, json.Unmarshal(raw, &form))
+			require.NoError(t, schema.Validate(form), "valid byte-length passwords must remain editable")
+		})
+	}
 	for _, tc := range []struct {
 		config string
 		valid  bool

--- a/src/go/plugin/framework/vnodes/vnodes.go
+++ b/src/go/plugin/framework/vnodes/vnodes.go
@@ -28,8 +28,8 @@ var log = logger.New().With(
 	slog.String("component", "vnodes"),
 )
 
-func Load(dir string) map[string]*Config {
-	return readConfDir(dir)
+func Load(dir string, snmpSupported bool) map[string]*Config {
+	return readConfDir(dir, snmpSupported)
 }
 
 type VirtualNode struct {
@@ -96,7 +96,7 @@ func (v *VirtualNode) HostLabels() map[string]string {
 	return labels
 }
 
-func readConfDir(dir string) map[string]*Config {
+func readConfDir(dir string, snmpSupported bool) map[string]*Config {
 	vnodes := make(map[string]*Config)
 	guids := make(map[string]string)
 	hostnames := make(map[string]string)
@@ -146,6 +146,10 @@ func readConfDir(dir string) map[string]*Config {
 		}
 
 		for _, v := range cfg {
+			if v.IsSNMP() && !snmpSupported {
+				log.Debugf("skipping virtual node %q: SNMP acquisition is unavailable in this plugin", v.Name)
+				continue
+			}
 
 			if !v.IsSNMP() && v.Name != "" && v.Name != v.Hostname {
 				log.Warningf(

--- a/src/go/plugin/framework/vnodes/vnodes.go
+++ b/src/go/plugin/framework/vnodes/vnodes.go
@@ -28,7 +28,7 @@ var log = logger.New().With(
 	slog.String("component", "vnodes"),
 )
 
-func Load(dir string) map[string]*VirtualNode {
+func Load(dir string) map[string]*Config {
 	return readConfDir(dir)
 }
 
@@ -96,9 +96,10 @@ func (v *VirtualNode) HostLabels() map[string]string {
 	return labels
 }
 
-func readConfDir(dir string) map[string]*VirtualNode {
-	vnodes := make(map[string]*VirtualNode)
+func readConfDir(dir string) map[string]*Config {
+	vnodes := make(map[string]*Config)
 	guids := make(map[string]string)
+	hostnames := make(map[string]string)
 
 	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -137,48 +138,61 @@ func readConfDir(dir string) map[string]*VirtualNode {
 			return nil
 		}
 
-		var cfg []VirtualNode
+		var cfg []Config
 
 		if err := loadConfigFile(&cfg, path); err != nil {
-			log.Warning(err)
+			log.Warningf("invalid vnode configuration file %q", path)
 			return nil
 		}
 
 		for _, v := range cfg {
 
-			if v.Name != "" && v.Name != v.Hostname {
+			if !v.IsSNMP() && v.Name != "" && v.Name != v.Hostname {
 				log.Warningf(
 					"ignoring virtual node name '%s' for hostname '%s'; file-based vnode identity uses hostname",
 					v.Name, v.Hostname,
 				)
 			}
-			v.Name = v.Hostname
+			if !v.IsSNMP() {
+				v.Name = v.Hostname
+			}
 			v.Source = fmt.Sprintf("file=%s", path)
 			if isStockConfig(path) {
 				v.SourceType = "stock"
 			} else {
 				v.SourceType = "user"
 			}
-			guidKey, err := validateConfigured(&v)
+			err := v.Validate()
+			guidKey := v.IdentityGUID()
+			if err == nil {
+				guidKey, err = ConfiguredGUIDKey(guidKey)
+			}
 			if err != nil {
-				log.Warningf("skipping virtual node '%+v': %v (%s)", v, err, path)
+				log.Warningf("skipping virtual node %q: %v (%s)", v.Name, err, path)
 				continue
 			}
-			if _, ok := vnodes[v.Hostname]; ok {
-				log.Warningf("skipping virtual node '%+v': duplicate hostname (%s)", v, path)
+			if _, ok := vnodes[v.Name]; ok {
+				log.Warningf("skipping virtual node %q: duplicate name (%s)", v.Name, path)
 				continue
 			}
 			if other, ok := guids[guidKey]; ok {
 				log.Warningf(
-					"skipping virtual node '%+v': duplicate GUID already used by '%s' (%s)",
-					v, other, path,
+					"skipping virtual node %q: duplicate GUID already used by %q (%s)",
+					v.Name, other, path,
 				)
 				continue
 			}
 
-			log.Debugf("adding virtual node'%+v' (%s)", v, path)
-			vnodes[v.Hostname] = &v
-			guids[guidKey] = v.Hostname
+			if v.Hostname != "" {
+				if _, exists := hostnames[v.Hostname]; exists {
+					log.Warningf("skipping virtual node %q: duplicate hostname (%s)", v.Name, path)
+					continue
+				}
+				hostnames[v.Hostname] = v.Name
+			}
+			log.Debugf("adding virtual node %q (%s)", v.Name, path)
+			vnodes[v.Name] = &v
+			guids[guidKey] = v.Name
 		}
 
 		return nil

--- a/src/go/plugin/framework/vnodes/vnodes.go
+++ b/src/go/plugin/framework/vnodes/vnodes.go
@@ -166,6 +166,7 @@ func readConfDir(dir string, snmpSupported bool) map[string]*Config {
 			} else {
 				v.SourceType = "user"
 			}
+			v.NormalizeCredentials()
 			err := v.Validate()
 			guidKey := v.IdentityGUID()
 			if err == nil {

--- a/src/go/plugin/framework/vnodes/vnodes_test.go
+++ b/src/go/plugin/framework/vnodes/vnodes_test.go
@@ -132,3 +132,33 @@ func TestValidateConfiguredRejectsLabelNormalization(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadSNMPKeepsStableNameAndAuthoredHostname(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "snmp.yaml"), []byte(`
+- name: router
+  mode: snmp
+  mode_snmp:
+    address: device
+    credentials:
+      community: fixture-secret
+- name: duplicate-guid
+  mode: snmp
+  mode_snmp:
+    address: device
+    credentials:
+      community: fixture-secret
+- mode: snmp
+  mode_snmp:
+    address: missing-name
+    credentials:
+      community: fixture-secret
+`), 0600))
+	loaded := Load(dir)
+	require.Len(t, loaded, 1)
+	require.Contains(t, loaded, "router")
+	require.Empty(t, loaded["router"].Hostname)
+	require.Empty(t, loaded["router"].GUID)
+	require.Equal(t, "fixture-secret", loaded["router"].ModeSNMP.Credentials.Community)
+	require.Nil(t, loaded["router"].Resolve(nil))
+}

--- a/src/go/plugin/framework/vnodes/vnodes_test.go
+++ b/src/go/plugin/framework/vnodes/vnodes_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestLoad(t *testing.T) {
-	nodes := Load("testdata")
+	nodes := Load("testdata", false)
 	assert.NotNil(t, nodes)
 	require.Contains(t, nodes, "first")
 	require.Contains(t, nodes, "second")
 	assert.Equal(t, "first", nodes["first"].Name)
 	assert.Equal(t, "second", nodes["second"].Name)
-	assert.NotNil(t, Load("not_exist"))
+	assert.NotNil(t, Load("not_exist", false))
 }
 
 func TestIsStockConfig(t *testing.T) {
@@ -36,7 +36,7 @@ func TestLoad_IgnoresCustomNameInFileAndUsesHostnameIdentity(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o644))
 
-	nodes := Load(dir)
+	nodes := Load(dir, true)
 	require.Len(t, nodes, 1)
 	require.Contains(t, nodes, "host-a")
 	assert.Equal(t, "host-a", nodes["host-a"].Name)
@@ -64,7 +64,7 @@ func TestLoad_SkipsInvalidConfiguredVnodesIndividually(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o644))
 
-	nodes := Load(dir)
+	nodes := Load(dir, true)
 
 	require.Len(t, nodes, 2)
 	require.Contains(t, nodes, "first")
@@ -83,7 +83,7 @@ func TestLoad_SkipsVNodeWhoseSourceCannotBePublished(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o644))
 
-	require.Empty(t, Load(dir))
+	require.Empty(t, Load(dir, true))
 }
 
 func TestValidateConfiguredRejectsLabelNormalization(t *testing.T) {
@@ -154,7 +154,7 @@ func TestLoadSNMPKeepsStableNameAndAuthoredHostname(t *testing.T) {
     credentials:
       community: fixture-secret
 `), 0600))
-	loaded := Load(dir)
+	loaded := Load(dir, true)
 	require.Len(t, loaded, 1)
 	require.Contains(t, loaded, "router")
 	require.Empty(t, loaded["router"].Hostname)

--- a/src/go/plugin/go.d/collector/snmp/collect.go
+++ b/src/go/plugin/go.d/collector/snmp/collect.go
@@ -120,7 +120,7 @@ func (c *Collector) ensureInitialized() error {
 		})
 	}
 
-	if c.CreateVnode {
+	if c.CreateVnode && c.Vnode == "" {
 		var baseLabels map[string]string
 		if c.UpdateEvery >= 1 && c.VnodeDeviceDownThreshold >= 1 {
 			// Allow for collection and transmission delays.
@@ -130,10 +130,10 @@ func (c *Collector) ensureInitialized() error {
 		}
 		identity, err := ddsnmp.AcquireDeviceIdentity(si, c.ddSnmpColl, ddsnmp.DeviceIdentityOptions{
 			Address:    c.Hostname,
-			GUID:       c.Vnode.GUID,
-			Hostname:   c.Vnode.Hostname,
+			GUID:       c.LocalVnode.GUID,
+			Hostname:   c.LocalVnode.Hostname,
 			BaseLabels: baseLabels,
-			Labels:     c.Vnode.Labels,
+			Labels:     c.LocalVnode.Labels,
 		})
 		if c.ddSnmpColl != nil {
 			c.captureCollectionFailures()
@@ -141,8 +141,8 @@ func (c *Collector) ensureInitialized() error {
 		if err != nil {
 			return err
 		}
-		c.Vnode.GUID = identity.GUID
-		c.Vnode.Hostname = identity.Hostname
+		c.LocalVnode.GUID = identity.GUID
+		c.LocalVnode.Hostname = identity.Hostname
 		c.vnode = &vnodes.VirtualNode{
 			GUID:     identity.GUID,
 			Hostname: identity.Hostname,

--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -112,7 +112,8 @@ type (
 		normalWriter        *diagnostics.NormalWriter
 		Config              `yaml:",inline" json:""`
 
-		vnode *vnodes.VirtualNode
+		vnode           *vnodes.VirtualNode
+		configuredVnode *vnodes.VirtualNode
 
 		charts                   *collectorapi.Charts
 		seenScalarMetrics        map[string]bool

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -613,7 +613,7 @@ func TestCollector_InitializationPublishesResolvedDeviceIdentity(t *testing.T) {
 	collr.Config = prepareV2Config()
 	collr.CreateVnode = true
 	collr.VnodeDeviceDownThreshold = 3
-	collr.Vnode.Labels = map[string]string{"model": "operator-model"}
+	collr.LocalVnode.Labels = map[string]string{"model": "operator-model"}
 	collr.snmpClient = handler
 	collr.snmpProfiles = []*ddsnmp.Profile{
 		{SourceFile: "identity.yaml", Definition: &ddprofiledefinition.ProfileDefinition{
@@ -668,7 +668,7 @@ func TestCollector_InitializationPublishesResolvedDeviceIdentity(t *testing.T) {
 		Hostname: "unifi-ap",
 		Labels:   map[string]string{"model": "operator-model"},
 	}
-	assert.Equal(t, wantConfigVnode, collr.Vnode)
+	assert.Equal(t, wantConfigVnode, collr.LocalVnode)
 
 	collr.Collect(context.Background())
 	assert.Equal(t, 2, metadataCalls, "subsequent collections reuse preparation caches")

--- a/src/go/plugin/go.d/collector/snmp/collector_test.go
+++ b/src/go/plugin/go.d/collector/snmp/collector_test.go
@@ -1769,6 +1769,7 @@ func setMockClientSetterExpectWithoutMaxOids(m *snmpmock.MockHandler) {
 	m.EXPECT().Target().AnyTimes()
 	m.EXPECT().Port().AnyTimes()
 	m.EXPECT().Version().AnyTimes()
+	m.EXPECT().ContextName().AnyTimes()
 	m.EXPECT().Community().AnyTimes()
 	m.EXPECT().SetTarget(gomock.Any()).AnyTimes()
 	m.EXPECT().SetPort(gomock.Any()).AnyTimes()

--- a/src/go/plugin/go.d/collector/snmp/config.go
+++ b/src/go/plugin/go.d/collector/snmp/config.go
@@ -18,7 +18,8 @@ type (
 
 		CreateVnode              bool               `yaml:"create_vnode,omitempty" json:"create_vnode"`
 		VnodeDeviceDownThreshold int                `yaml:"vnode_device_down_threshold,omitempty" json:"vnode_device_down_threshold"`
-		Vnode                    vnodes.VirtualNode `yaml:"vnode,omitempty" json:"vnode"`
+		Vnode                    string             `yaml:"vnode,omitempty" json:"vnode"`
+		LocalVnode               vnodes.VirtualNode `yaml:"local_vnode,omitempty" json:"local_vnode"`
 
 		ManualProfiles []string `yaml:"manual_profiles,omitempty" json:"manual_profiles"`
 

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -24,47 +24,21 @@
       },
       "create_vnode": {
         "title": "Create",
-        "description": "If set, the collector will create a [Virtual Node](https://learn.netdata.cloud/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts#virtual-nodes) for this SNMP device, which will appear as a separate Node in Netdata.",
+        "description": "Create a Virtual Node for this SNMP device when no named vnode reference is set. A named reference takes precedence, including when this option is true.",
         "type": "boolean",
         "default": true
       },
       "vnode_device_down_threshold": {
         "title": "Device Down Threshold",
-        "description": "Number of consecutive failed data collections before marking the device as down.",
+        "description": "Number of consecutive failed data collections before marking a collector-generated vnode as down. Named vnodes use their own stale_after setting.",
         "type": "integer",
         "minimum": 1,
         "default": 3
       },
       "vnode": {
         "title": "Virtual node",
-        "description": "Identity of the Virtual Node created for this device when `create_vnode` is enabled.",
-        "type": [
-          "object",
-          "null"
-        ],
-        "properties": {
-          "guid": {
-            "title": "GUID",
-            "description": "A unique identifier for the Virtual Node. If not set, a GUID will be automatically generated from the device's IP address.",
-            "type": "string"
-          },
-          "hostname": {
-            "title": "Hostname",
-            "description": "The hostname that will be used for the Virtual Node. If not set, the device's hostname will be used.",
-            "type": "string"
-          },
-          "labels": {
-            "title": "Labels",
-            "description": "Additional key-value pairs to associate with the Virtual Node.",
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
+        "description": "Name of a centrally configured Virtual Node to attach this job to. Takes precedence over local vnode creation.",
+        "type": "string"
       },
       "options": {
         "title": "Options",
@@ -273,6 +247,37 @@
             "default": 0.1
           }
         }
+      },
+      "local_vnode": {
+        "title": "Local virtual node",
+        "description": "Configuration for the Virtual Node created by this job when create_vnode is enabled and no named vnode reference is set.",
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "guid": {
+            "title": "GUID",
+            "description": "A unique identifier for the Virtual Node. If not set, a GUID will be automatically generated from the device's IP address.",
+            "type": "string"
+          },
+          "hostname": {
+            "title": "Hostname",
+            "description": "The hostname that will be used for the Virtual Node. If not set, the device's hostname will be used.",
+            "type": "string"
+          },
+          "labels": {
+            "title": "Labels",
+            "description": "Additional key-value pairs to associate with the Virtual Node. These are merged with the labels SNMP detects automatically from the device (for example, `vendor` and `sys_object_id`). If a key here matches an auto-detected label, your value takes precedence.",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
     "required": [
@@ -360,11 +365,12 @@
           ]
         },
         {
-          "title": "Vnode",
+          "title": "Virtual node",
           "fields": [
+            "vnode",
             "create_vnode",
-            "vnode_device_down_threshold",
-            "vnode"
+            "local_vnode",
+            "vnode_device_down_threshold"
           ]
         },
         {
@@ -380,6 +386,13 @@
           ]
         }
       ]
+    },
+    "vnode": {
+      "ui:placeholder": "office-router",
+      "ui:help": "Define the vnode in the Vnodes configuration first. This reference supplies host identity and labels; the job keeps its own SNMP connection settings."
+    },
+    "local_vnode": {
+      "ui:help": "Use these fields for a vnode created by this job. Legacy vnode objects remain accepted and appear here when opened in the form."
     }
   }
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 )
 
 // AcquisitionNegativeCause explains a permanent missing-OID entry without
@@ -27,7 +28,7 @@ type negativeEvidence struct {
 
 // Only production suppression reads establish eligibility. Dynamic instance
 // GETs bypass this map, so their churn cannot grow retained diagnostic history.
-func isMissingOID(client any, missing map[string]bool, oid string) bool {
+func isMissingOID(client snmputils.ScalarClient, missing map[string]bool, oid string) bool {
 	if observer, ok := client.(*diagnosticClient); ok && observer.negative != nil && observer.SourceRecorder() != nil {
 		if observer.negative.eligible == nil {
 			observer.negative.eligible = make(map[string]bool)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_negative.go
@@ -27,7 +27,7 @@ type negativeEvidence struct {
 
 // Only production suppression reads establish eligibility. Dynamic instance
 // GETs bypass this map, so their churn cannot grow retained diagnostic history.
-func isMissingOID(client gosnmp.Handler, missing map[string]bool, oid string) bool {
+func isMissingOID(client any, missing map[string]bool, oid string) bool {
 	if observer, ok := client.(*diagnosticClient); ok && observer.negative != nil && observer.SourceRecorder() != nil {
 		if observer.negative.eligible == nil {
 			observer.negative.eligible = make(map[string]bool)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_source.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/acquisition_source.go
@@ -37,7 +37,7 @@ func (r *SourceRecorder) Wrap(client gosnmp.Handler) gosnmp.Handler {
 
 func (c *sourceClient) SourceRecorder() *SourceRecorder { return c.recorder }
 
-func sourceRecorder(client gosnmp.Handler) *SourceRecorder {
+func sourceRecorder(client any) *SourceRecorder {
 	if c, ok := client.(interface{ SourceRecorder() *SourceRecorder }); ok {
 		return c.SourceRecorder()
 	}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
@@ -17,13 +17,14 @@ import (
 
 // deviceMetadataCollector handles collection of device metadata
 type deviceMetadataCollector struct {
-	snmpClient  gosnmp.Handler
+	snmpClient  snmputils.ScalarClient
 	missingOIDs map[string]bool
 	log         *logger.Logger
 	sysobjectid string
+	strict      bool
 }
 
-func newDeviceMetadataCollector(snmpClient gosnmp.Handler, missingOIDs map[string]bool, log *logger.Logger, sysobjectid string) *deviceMetadataCollector {
+func newDeviceMetadataCollector(snmpClient snmputils.ScalarClient, missingOIDs map[string]bool, log *logger.Logger, sysobjectid string) *deviceMetadataCollector {
 	return &deviceMetadataCollector{
 		snmpClient:  snmpClient,
 		missingOIDs: missingOIDs,
@@ -61,6 +62,9 @@ func (dc *deviceMetadataCollector) collectObserved(
 					acquisition.metadataObserver(entry.Metadata),
 				)
 				if err != nil {
+					if dc.strict {
+						return nil, err
+					}
 					dc.log.Warningf("sysobjectid_metadata[%d]: failed to process metadata fields for sysobjectid '%s': %v",
 						i, entry.SysobjectID, err)
 				}
@@ -207,7 +211,7 @@ func (dc *deviceMetadataCollector) processDynamicFieldsObserved(
 		}
 	}
 
-	if len(errs) > 0 && len(metadata) == 0 {
+	if len(errs) > 0 && (dc.strict || len(metadata) == 0) {
 		return snmputils.WithFailure(fmt.Errorf("failed to process any metadata fields: %w", errors.Join(errs...)), "metadata", "processing")
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_device_meta.go
@@ -192,6 +192,7 @@ func (dc *deviceMetadataCollector) processDynamicFieldsObserved(
 			}
 		case len(field.Symbols) > 0:
 			// Multiple symbols - try each until one succeeds
+			fieldErrStart := len(errs)
 			for i, sym := range field.Symbols {
 				v, err := dc.processSymbolValueObserved(name, sym, pdus, i == len(field.Symbols)-1, observer.processing(name))
 				if err != nil {
@@ -202,6 +203,8 @@ func (dc *deviceMetadataCollector) processDynamicFieldsObserved(
 					continue
 				}
 				if v != "" {
+					// A usable fallback resolves only this field's earlier failures.
+					errs = errs[:fieldErrStart]
 					ddsnmp.MergeMetaTag(metadata, name, ddsnmp.MetaTag{Value: v, IsExactMatch: isExactMatch})
 					observer.value(name)
 					break // Use first successful value

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp.go
@@ -3,7 +3,10 @@
 package ddsnmpcollector
 
 import (
+	"fmt"
 	"slices"
+
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -12,7 +15,7 @@ import (
 
 // Count attempted batches here so callers cannot lose or duplicate failed work.
 func getSNMPValues(
-	client gosnmp.Handler,
+	client snmputils.ScalarClient,
 	oids []string,
 	missingOIDs map[string]bool,
 	stats *ddsnmp.CollectionStats,
@@ -22,6 +25,12 @@ func getSNMPValues(
 		stats.SNMP.GetRequests++
 		stats.SNMP.GetOIDs += int64(len(chunk))
 		result, err := client.Get(chunk)
+		if err == nil && result == nil {
+			err = fmt.Errorf("SNMP GET returned nil response")
+		}
+		if err == nil && result.Error != gosnmp.NoError {
+			err = snmputils.WithPacketFailure(fmt.Errorf("SNMP GET response error %s", result.Error), "get", result)
+		}
 		if err != nil {
 			stats.Errors.SNMP++
 			return nil, err

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp.go
@@ -22,30 +22,45 @@ func getSNMPValues(
 ) (map[string]gosnmp.SnmpPDU, error) {
 	pdus := make(map[string]gosnmp.SnmpPDU)
 	for chunk := range slices.Chunk(oids, client.MaxOids()) {
-		stats.SNMP.GetRequests++
-		stats.SNMP.GetOIDs += int64(len(chunk))
-		result, err := client.Get(chunk)
-		if err == nil && result == nil {
-			err = fmt.Errorf("SNMP GET returned nil response")
-		}
-		if err == nil && result.Error != gosnmp.NoError {
-			err = snmputils.WithPacketFailure(fmt.Errorf("SNMP GET response error %s", result.Error), "get", result)
-		}
-		if err != nil {
-			stats.Errors.SNMP++
-			return nil, err
-		}
-		for _, pdu := range result.Variables {
-			if !isPduWithData(pdu) {
-				stats.Errors.MissingOIDs++
-				missingOIDs[trimOID(pdu.Name)] = true
-				if observer, ok := client.(interface{ recordMissing(gosnmp.SnmpPDU) }); ok {
-					observer.recordMissing(pdu)
-				}
+		for len(chunk) > 0 {
+			stats.SNMP.GetRequests++
+			stats.SNMP.GetOIDs += int64(len(chunk))
+			result, err := client.Get(chunk)
+			if err == nil && result == nil {
+				err = fmt.Errorf("SNMP GET returned nil response")
+			}
+			if err == nil && result.Error == gosnmp.NoSuchName && client.Version() == gosnmp.Version1 && result.ErrorIndex > 0 && int(result.ErrorIndex) <= len(chunk) {
+				// V1 fails the whole request for one absent OID. Record that operation's
+				// missing value before retrying the remaining OIDs on an owned slice.
+				i := int(result.ErrorIndex) - 1
+				recordMissingOID(client, gosnmp.SnmpPDU{Name: chunk[i], Type: gosnmp.NoSuchObject}, missingOIDs, stats)
+				chunk = slices.Delete(slices.Clone(chunk), i, i+1)
 				continue
 			}
-			pdus[trimOID(pdu.Name)] = pdu
+			if err == nil && result.Error != gosnmp.NoError {
+				err = snmputils.WithPacketFailure(fmt.Errorf("SNMP GET response error %s", result.Error), "get", result)
+			}
+			if err != nil {
+				stats.Errors.SNMP++
+				return nil, err
+			}
+			for _, pdu := range result.Variables {
+				if !isPduWithData(pdu) {
+					recordMissingOID(client, pdu, missingOIDs, stats)
+					continue
+				}
+				pdus[trimOID(pdu.Name)] = pdu
+			}
+			break
 		}
 	}
 	return pdus, nil
+}
+
+func recordMissingOID(client snmputils.ScalarClient, pdu gosnmp.SnmpPDU, missingOIDs map[string]bool, stats *ddsnmp.CollectionStats) {
+	stats.Errors.MissingOIDs++
+	missingOIDs[trimOID(pdu.Name)] = true
+	if observer, ok := client.(interface{ recordMissing(gosnmp.SnmpPDU) }); ok {
+		observer.recordMissing(pdu)
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp.go
@@ -32,6 +32,7 @@ func getSNMPValues(
 			if err == nil && result.Error == gosnmp.NoSuchName && client.Version() == gosnmp.Version1 && result.ErrorIndex > 0 && int(result.ErrorIndex) <= len(chunk) {
 				// V1 fails the whole request for one absent OID. Record that operation's
 				// missing value before retrying the remaining OIDs on an owned slice.
+				// Request diagnostics retain NoSuchName evidence even if this recovery succeeds.
 				i := int(result.ErrorIndex) - 1
 				recordMissingOID(client, gosnmp.SnmpPDU{Name: chunk[i], Type: gosnmp.NoSuchObject}, missingOIDs, stats)
 				chunk = slices.Delete(slices.Clone(chunk), i, i+1)

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp_response_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp_response_test.go
@@ -3,6 +3,7 @@
 package ddsnmpcollector
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/gosnmp/gosnmp"
@@ -12,12 +13,93 @@ import (
 
 type responseClient struct {
 	gosnmp.Handler
-	packet *gosnmp.SnmpPacket
+	packet  *gosnmp.SnmpPacket
+	version gosnmp.SnmpVersion
 }
 
 func (c responseClient) Get([]string) (*gosnmp.SnmpPacket, error) { return c.packet, nil }
 func (c responseClient) MaxOids() int                             { return 10 }
+func (c responseClient) Version() gosnmp.SnmpVersion              { return c.version }
+
+type indexedMissingClient struct {
+	gosnmp.Handler
+	requests [][]string
+}
+
+func (c *indexedMissingClient) MaxOids() int                { return 10 }
+func (c *indexedMissingClient) Version() gosnmp.SnmpVersion { return gosnmp.Version1 }
+func (c *indexedMissingClient) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	c.requests = append(c.requests, slices.Clone(oids))
+	packet := &gosnmp.SnmpPacket{}
+	for i, oid := range oids {
+		packet.Variables = append(packet.Variables, gosnmp.SnmpPDU{Name: oid, Type: gosnmp.Null})
+		if oid != "1.2.4" && packet.Error == gosnmp.NoError {
+			packet.Error, packet.ErrorIndex = gosnmp.NoSuchName, uint8(i+1)
+		}
+	}
+	if packet.Error == gosnmp.NoError {
+		packet.Variables = []gosnmp.SnmpPDU{{Name: "1.2.4", Type: gosnmp.OctetString, Value: []byte("serial")}}
+	}
+	return packet, nil
+}
+
+func TestMetadataGETRecoversIndexedV1MissingOIDs(t *testing.T) {
+	client := &indexedMissingClient{}
+	oids := []string{"1.2.3", "1.2.4", "1.2.5"}
+	missing := map[string]bool{}
+	stats := &ddsnmp.CollectionStats{}
+	recorder := &SourceRecorder{ContextID: 7}
+	evidence := &negativeEvidence{}
+	observed := &diagnosticClient{Handler: recorder.Wrap(client), negative: evidence, failures: &ddsnmp.CollectionFailures{}}
+	for _, oid := range oids {
+		require.False(t, isMissingOID(observed, missing, oid))
+	}
+	pdus, err := getSNMPValues(observed, oids, missing, stats)
+	require.NoError(t, err)
+	require.Equal(t, []string{"1.2.3", "1.2.4", "1.2.5"}, oids, "do not mutate callers' OID lists")
+	require.Equal(t, [][]string{{"1.2.3", "1.2.4", "1.2.5"}, {"1.2.4", "1.2.5"}, {"1.2.4"}}, client.requests)
+	require.Equal(t, map[string]bool{"1.2.3": true, "1.2.5": true}, missing)
+	require.Equal(t, []byte("serial"), pdus["1.2.4"].Value)
+	require.EqualValues(t, 3, stats.SNMP.GetRequests)
+	require.EqualValues(t, 6, stats.SNMP.GetOIDs)
+	require.EqualValues(t, 2, stats.Errors.MissingOIDs)
+	require.Zero(t, stats.Errors.SNMP)
+	require.EqualValues(t, 1, evidence.causes["1.2.3"].Operation)
+	require.EqualValues(t, 2, evidence.causes["1.2.5"].Operation)
+	require.EqualValues(t, 7, evidence.causes["1.2.5"].ContextID)
+}
 func TestMetadataGETRejectsPacketError(t *testing.T) {
 	_, err := getSNMPValues(responseClient{packet: &gosnmp.SnmpPacket{Error: gosnmp.GenErr}}, []string{"1.2.3"}, map[string]bool{}, &ddsnmp.CollectionStats{})
 	require.Error(t, err)
+}
+
+func TestMetadataGETV1AllMissing(t *testing.T) {
+	client := &indexedMissingClient{}
+	missing := map[string]bool{}
+	stats := &ddsnmp.CollectionStats{}
+	pdus, err := getSNMPValues(client, []string{"1.2.3", "1.2.5"}, missing, stats)
+	require.NoError(t, err)
+	require.Empty(t, pdus)
+	require.Len(t, missing, 2)
+	require.EqualValues(t, 2, stats.SNMP.GetRequests)
+	require.Zero(t, stats.Errors.SNMP)
+}
+
+func TestMetadataGETRejectsUnrecoverableMissingResponse(t *testing.T) {
+	for name, client := range map[string]responseClient{
+		"v1 zero index":      {version: gosnmp.Version1, packet: &gosnmp.SnmpPacket{Error: gosnmp.NoSuchName}},
+		"v1 outside batch":   {version: gosnmp.Version1, packet: &gosnmp.SnmpPacket{Error: gosnmp.NoSuchName, ErrorIndex: 2}},
+		"v2c missing status": {version: gosnmp.Version2c, packet: &gosnmp.SnmpPacket{Error: gosnmp.NoSuchName, ErrorIndex: 1}},
+		"nil packet":         {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			missing := map[string]bool{}
+			stats := &ddsnmp.CollectionStats{}
+			_, err := getSNMPValues(client, []string{"1.2.3"}, missing, stats)
+			require.Error(t, err)
+			require.Empty(t, missing)
+			require.EqualValues(t, 1, stats.SNMP.GetRequests)
+			require.EqualValues(t, 1, stats.Errors.SNMP)
+		})
+	}
 }

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp_response_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/collector_snmp_response_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/stretchr/testify/require"
+)
+
+type responseClient struct {
+	gosnmp.Handler
+	packet *gosnmp.SnmpPacket
+}
+
+func (c responseClient) Get([]string) (*gosnmp.SnmpPacket, error) { return c.packet, nil }
+func (c responseClient) MaxOids() int                             { return 10 }
+func TestMetadataGETRejectsPacketError(t *testing.T) {
+	_, err := getSNMPValues(responseClient{packet: &gosnmp.SnmpPacket{Error: gosnmp.GenErr}}, []string{"1.2.3"}, map[string]bool{}, &ddsnmp.CollectionStats{})
+	require.Error(t, err)
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/device_metadata.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/device_metadata.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+// CollectDeviceMetadata acquires only device metadata, without creating metric,
+// table, topology, or diagnostic state. Missing-OID suppression lasts one attempt.
+func CollectDeviceMetadata(client snmputils.ScalarClient, profiles []*ddsnmp.Profile, sysObjectID string, log *logger.Logger) (map[string]ddsnmp.MetaTag, error) {
+	collector := newDeviceMetadataCollector(client, make(map[string]bool), log, sysObjectID)
+	collector.strict = true
+	result := make(map[string]ddsnmp.MetaTag)
+	for _, profile := range profiles {
+		meta, err := collector.collect(profile)
+		if err != nil {
+			return nil, err
+		}
+		for key, value := range meta {
+			ddsnmp.MergeMetaTag(result, key, value)
+		}
+	}
+	return result, nil
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/device_metadata_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/device_metadata_test.go
@@ -30,3 +30,23 @@ func TestMetadataOnlySourceReportsEnrichmentFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "73657269616c", meta["serial_number"].Value, "missing OIDs are retried by the next attempt")
 }
+
+func TestMetadataOnlyFallbackClearsOnlyResolvedFieldErrors(t *testing.T) {
+	for _, unrelatedFailure := range []bool{false, true} {
+		fields := map[string]ddprofiledefinition.MetadataField{
+			"serial_number": {Symbols: []ddprofiledefinition.SymbolConfig{{OID: "1.2.3", Format: "hex"}, {OID: "1.2.4"}}},
+		}
+		if unrelatedFailure {
+			fields["model"] = ddprofiledefinition.MetadataField{Symbol: ddprofiledefinition.SymbolConfig{OID: "1.2.3", Format: "hex"}}
+		}
+		profile := &ddsnmp.Profile{Definition: &ddprofiledefinition.ProfileDefinition{Metadata: ddprofiledefinition.MetadataConfig{"device": {Fields: fields}}}}
+		packet := &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{{Name: "1.2.3", Type: gosnmp.Integer, Value: 42}, {Name: "1.2.4", Type: gosnmp.OctetString, Value: []byte("fallback")}}}
+		meta, err := CollectDeviceMetadata(responseClient{packet: packet}, []*ddsnmp.Profile{profile}, "", logger.NewWithWriter(io.Discard))
+		if unrelatedFailure {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, "fallback", meta["serial_number"].Value)
+		}
+	}
+}

--- a/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/device_metadata_test.go
+++ b/src/go/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector/device_metadata_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package ddsnmpcollector
+
+import (
+	"io"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddprofiledefinition"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataOnlySourceReportsEnrichmentFailure(t *testing.T) {
+	profile := &ddsnmp.Profile{Definition: &ddprofiledefinition.ProfileDefinition{Metadata: ddprofiledefinition.MetadataConfig{"device": {Fields: map[string]ddprofiledefinition.MetadataField{
+		"vendor": {Value: "fixture"}, "serial_number": {Symbol: ddprofiledefinition.SymbolConfig{OID: "1.2.3", Format: "hex"}},
+	}}}}}
+	for _, packet := range []*gosnmp.SnmpPacket{nil, {Error: gosnmp.GenErr}, {Variables: []gosnmp.SnmpPDU{{Name: "1.2.3", Type: gosnmp.Opaque, Value: struct{}{}}}}} {
+		_, err := CollectDeviceMetadata(responseClient{packet: packet}, []*ddsnmp.Profile{profile}, "", logger.NewWithWriter(io.Discard))
+		require.Error(t, err, "a static field must not hide failed dynamic enrichment")
+	}
+	packet := &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{{Name: "1.2.3", Type: gosnmp.NoSuchObject}}}
+	meta, err := CollectDeviceMetadata(responseClient{packet: packet}, []*ddsnmp.Profile{profile}, "", logger.NewWithWriter(io.Discard))
+	require.NoError(t, err)
+	require.Equal(t, "fixture", meta["vendor"].Value)
+	packet.Variables = []gosnmp.SnmpPDU{{Name: "1.2.3", Type: gosnmp.OctetString, Value: []byte("serial")}}
+	meta, err = CollectDeviceMetadata(responseClient{packet: packet}, []*ddsnmp.Profile{profile}, "", logger.NewWithWriter(io.Discard))
+	require.NoError(t, err)
+	require.Equal(t, "73657269616c", meta["serial_number"].Value, "missing OIDs are retried by the next attempt")
+}

--- a/src/go/plugin/go.d/collector/snmp/device_state.go
+++ b/src/go/plugin/go.d/collector/snmp/device_state.go
@@ -21,22 +21,22 @@ func firstVendor(values ...string) string {
 }
 
 func (c *Collector) vnodeGUID() string {
-	if c.vnode != nil {
-		return c.vnode.GUID
+	if v := c.deviceVnode(); v != nil {
+		return v.GUID
 	}
 	return ""
 }
 
 func (c *Collector) vnodeHostname() string {
-	if c.vnode != nil {
-		return c.vnode.Hostname
+	if v := c.deviceVnode(); v != nil {
+		return v.Hostname
 	}
 	return ""
 }
 
 func (c *Collector) vnodeLabels() map[string]string {
-	if c.vnode != nil && len(c.vnode.Labels) > 0 {
-		return c.vnode.Labels
+	if v := c.deviceVnode(); v != nil {
+		return v.Labels
 	}
 	return nil
 }
@@ -130,7 +130,7 @@ func (c *Collector) publishDeviceState(info ddsnmp.DeviceConnectionInfo) {
 }
 
 func (c *Collector) syncDeviceMetadata(pms []*ddsnmp.ProfileMetrics) {
-	if c.deviceMetadataSynced || c.vnode != nil || c.sysInfo == nil {
+	if c.deviceMetadataSynced || c.deviceVnode() != nil || c.sysInfo == nil {
 		return
 	}
 

--- a/src/go/plugin/go.d/collector/snmp/init.go
+++ b/src/go/plugin/go.d/collector/snmp/init.go
@@ -18,8 +18,8 @@ func (c *Collector) validateConfig() error {
 	if c.Hostname == "" {
 		return snmputils.WithFailure(errors.New("SNMP hostname is required"), "configuration", "missing_hostname")
 	}
-	if c.Vnode.GUID != "" {
-		if err := uuid.Validate(c.Vnode.GUID); err != nil {
+	if c.LocalVnode.GUID != "" {
+		if err := uuid.Validate(c.LocalVnode.GUID); err != nil {
 			return snmputils.WithFailure(fmt.Errorf("invalid Vnode GUID: %v", err), "configuration", "invalid_vnode_id")
 		}
 	}
@@ -32,7 +32,7 @@ func (c *Collector) initSNMPClient() (gosnmp.Handler, error) {
 		return nil, err
 	}
 
-	c.Info(snmputils.SnmpClientConnInfo(client))
+	c.Infof("SNMP client target=%q port=%d version=%s", client.Target(), client.Port(), client.Version())
 
 	return client, nil
 }

--- a/src/go/plugin/go.d/collector/snmp/init.go
+++ b/src/go/plugin/go.d/collector/snmp/init.go
@@ -18,7 +18,7 @@ func (c *Collector) validateConfig() error {
 	if c.Hostname == "" {
 		return snmputils.WithFailure(errors.New("SNMP hostname is required"), "configuration", "missing_hostname")
 	}
-	if c.LocalVnode.GUID != "" {
+	if c.Vnode == "" && c.LocalVnode.GUID != "" {
 		if err := uuid.Validate(c.LocalVnode.GUID); err != nil {
 			return snmputils.WithFailure(fmt.Errorf("invalid Vnode GUID: %v", err), "configuration", "invalid_vnode_id")
 		}
@@ -32,7 +32,7 @@ func (c *Collector) initSNMPClient() (gosnmp.Handler, error) {
 		return nil, err
 	}
 
-	c.Infof("SNMP client target=%q port=%d version=%s", client.Target(), client.Port(), client.Version())
+	c.Infof("SNMP client target=%q port=%d version=%s context=%q", client.Target(), client.Port(), client.Version(), client.ContextName())
 
 	return client, nil
 }

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -456,25 +456,48 @@ modules:
 
             - name: create_vnode
               group: Virtual node
-              description: If set, the collector will create a Netdata Virtual Node for this SNMP device, which will appear as a separate Node in Netdata.
+              description: Create a Virtual Node for this SNMP device when no named vnode reference is set. A named reference takes precedence, including when this option is true.
               default_value: "true"
               required: false
             - name: vnode_device_down_threshold
               group: Virtual node
-              description: Number of consecutive failed data collections before marking the device as down.
+              description: Number of consecutive failed data collections before marking a collector-generated vnode as down. Named vnodes use their own stale_after setting.
               default_value: 3
               required: false
-            - name: vnode.guid
+            - name: vnode
+              group: Virtual node
+              description: Name of a centrally configured Virtual Node to attach this job to. Takes precedence over local vnode creation.
+              default_value: ""
+              required: false
+              detailed_description: |
+                A string such as `vnode: router` attaches this job to a vnode defined in `vnodes/*.conf` or dynamic
+                configuration. Static YAML vnodes use their hostname as the reference; SNMP-mode vnodes use their
+                required stable name. SNMP-mode identity is acquired independently, so this job waits for its first
+                usable identity before starting. The reference supplies host identity and labels only: configure this
+                job's own address, credentials, and metric profiles. It takes precedence over `create_vnode`.
+
+                Use `local_vnode` to configure a vnode created by this job. Legacy inline `vnode` objects remain
+                accepted; opening them through dynamic configuration returns the same settings under `local_vnode`.
+            - name: local_vnode
+              group: Virtual node
+              description: Configuration for the Virtual Node created by this job when create_vnode is enabled and no named vnode reference is set.
+              default_value: ""
+              required: false
+              detailed_description: |
+                Optional hostname, GUID, and host-label settings for the vnode owned by this job. Without these
+                settings, the collector uses its existing device-derived identity. A named `vnode` reference takes
+                precedence. Do not combine a legacy inline `vnode` object with `local_vnode`; use one object.
+            - name: local_vnode.guid
               group: Virtual node
               description: A unique identifier for the Virtual Node. If not set, a GUID will be automatically generated from the device's IP address.
               default_value: ""
               required: false
-            - name: vnode.hostname
+            - name: local_vnode.hostname
               group: Virtual node
               description: The hostname that will be used for the Virtual Node. If not set, the device's hostname will be used.
               default_value: ""
               required: false
-            - name: vnode.labels
+            - name: local_vnode.labels
               group: Virtual node
               description: Additional key-value pairs to associate with the Virtual Node. These are merged with the labels SNMP detects automatically from the device (for example, `vendor` and `sys_object_id`). If a key here matches an auto-detected label, your value takes precedence.
               default_value: ""
@@ -484,6 +507,18 @@ modules:
             title: Config
             enabled: true
           list:
+            - name: Attach to an independently configured vnode
+              description: |
+                First define the vnode named `router` in `vnodes/*.conf` or the Vnodes dynamic configuration view.
+                This job uses its own SNMP connection and metric profiles; the vnode owns host identity and labels.
+              config: |
+                jobs:
+                  - name: router_metrics
+                    vnode: router
+                    hostname: 192.0.2.1
+                    community: example-collector-community
+                    options:
+                      version: 2c
             - name: SNMPv1/2
               description: |
                 In this example:
@@ -570,8 +605,8 @@ modules:
                       version: 2
             - name: Additional node labels
               description: |
-                Because `create_vnode` defaults to true, each SNMP job automatically creates a Virtual Node for its device — no separate vnode definition file is needed.
-                Use `vnode.labels` to attach your own labels, for example to group devices by site or rack. These are merged with the labels SNMP detects automatically from the device (such as `vendor` and `sys_object_id`). If a key you set matches an auto-detected label, your value takes precedence.
+                Without a named vnode reference, `create_vnode: true` (the default) creates a Virtual Node from this job — no separate vnode definition is needed.
+                Use `local_vnode.labels` to attach your own labels, for example to group devices by site or rack. These are merged with the labels SNMP detects automatically from the device (such as `vendor` and `sys_object_id`). If a key you set matches an auto-detected label, your value takes precedence.
               config: |
                 jobs:
                   - name: core-switch
@@ -580,7 +615,7 @@ modules:
                     community: public
                     options:
                       version: 2
-                    vnode:
+                    local_vnode:
                       labels:
                         site: dc1
                         rack: a12

--- a/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
+++ b/src/go/plugin/go.d/collector/snmp/normal_diagnostics.go
@@ -163,8 +163,8 @@ func (c *Collector) normalDeviceInput() diagnostics.DeviceInput {
 		result.SysObjectID, result.SysName, result.SysDescr = si.SysObjectID, si.Name, si.Descr
 		result.SysContact, result.SysLocation, result.Vendor, result.Model = si.Contact, si.Location, si.Vendor, si.Model
 	}
-	if c.vnode != nil {
-		result.VnodeGUID, result.VnodeLabels = c.vnode.GUID, maps.Clone(c.vnode.Labels)
+	if vnode := c.deviceVnode(); vnode != nil {
+		result.VnodeGUID, result.VnodeLabels = vnode.GUID, maps.Clone(vnode.Labels)
 	}
 	return result
 }

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.json
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.json
@@ -3,14 +3,7 @@
   "hostname": "ok",
   "create_vnode": true,
   "vnode_device_down_threshold": 123,
-  "vnode": {
-    "name": "ok",
-    "guid": "ok",
-    "hostname": "ok",
-    "labels": {
-      "ok": "ok"
-    }
-  },
+  "vnode": "ok",
   "community": "ok",
   "user": {
     "name": "ok",
@@ -40,5 +33,13 @@
     "interface": "eth0",
     "packets": 5,
     "interval": 123.123
+  },
+  "local_vnode": {
+    "name": "ok",
+    "guid": "ok",
+    "hostname": "ok",
+    "labels": {
+      "ok": "ok"
+    }
   }
 }

--- a/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
+++ b/src/go/plugin/go.d/collector/snmp/testdata/config.yaml
@@ -5,7 +5,8 @@ vnode_device_down_threshold: 123
 manual_profiles:
   - "ok"
 
-vnode:
+vnode: "ok"
+local_vnode:
   name: "ok"
   guid: "ok"
   hostname: "ok"

--- a/src/go/plugin/go.d/collector/snmp/vnode_config.go
+++ b/src/go/plugin/go.d/collector/snmp/vnode_config.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"gopkg.in/yaml.v2"
+)
+
+// Decode legacy inline vnode objects into the canonical local_vnode field.
+// Configuration output then gives the form one stable type for each field.
+type plainConfig Config
+
+func (c *Config) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	vnode := bytes.TrimSpace(fields["vnode"])
+	if len(vnode) > 0 && vnode[0] == '{' {
+		if local := bytes.TrimSpace(fields["local_vnode"]); len(local) > 0 && !bytes.Equal(local, []byte("null")) {
+			return errors.New("legacy vnode object cannot be combined with local_vnode")
+		}
+		fields["local_vnode"] = vnode
+		fields["vnode"] = json.RawMessage(`""`)
+		normalized, err := json.Marshal(fields)
+		if err != nil {
+			return err
+		}
+		data = normalized
+	}
+	return json.Unmarshal(data, (*plainConfig)(c))
+}
+
+func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
+	var fields map[string]any
+	if err := unmarshal(&fields); err != nil {
+		return err
+	}
+	switch fields["vnode"].(type) {
+	case map[any]any, map[string]any:
+		if fields["local_vnode"] != nil {
+			return errors.New("legacy vnode object cannot be combined with local_vnode")
+		}
+		fields["local_vnode"] = fields["vnode"]
+		fields["vnode"] = ""
+		normalized, err := yaml.Marshal(fields)
+		if err != nil {
+			return err
+		}
+		return yaml.Unmarshal(normalized, (*plainConfig)(c))
+	case nil, string:
+		return unmarshal((*plainConfig)(c))
+	default:
+		return errors.New("vnode must be a name or a legacy inline object")
+	}
+}
+
+func (c *Collector) SetConfiguredVnode(v vnodes.VirtualNode) {
+	if c.Vnode == "" {
+		return
+	}
+	// Runtime transfers ownership and calls this only at lifecycle boundaries.
+	c.configuredVnode = &v
+	if c.initialized && c.sysInfo != nil {
+		c.registerDeviceState(c.sysInfo, nil)
+	}
+}
+
+func (c *Collector) deviceVnode() *vnodes.VirtualNode {
+	if c.Vnode != "" {
+		return c.configuredVnode
+	}
+	return c.vnode
+}

--- a/src/go/plugin/go.d/collector/snmp/vnode_config_test.go
+++ b/src/go/plugin/go.d/collector/snmp/vnode_config_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package snmp
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestNamedVnodeClientInitializationDoesNotLogCredentials(t *testing.T) {
+	c := New(ddsnmp.NewDeviceStore())
+	c.Hostname = "192.0.2.1"
+	c.Community = "fixture-collector-secret"
+	c.Vnode = "router"
+	var logs bytes.Buffer
+	c.Logger = logger.NewWithWriter(&logs)
+	_, err := c.initSNMPClient()
+	require.NoError(t, err)
+	require.NotContains(t, logs.String(), c.Community)
+}
+
+func TestVnodeConfigurationRoundTrip(t *testing.T) {
+	for _, input := range []string{
+		`{"hostname":"device","vnode":"router"}`,
+		`{"hostname":"device","local_vnode":{"hostname":"local","labels":{"site":"test"}}}`,
+		`{"hostname":"device","vnode":{"hostname":"inline","guid":"6e17cd2c-0518-4e94-965b-d25673decb21","labels":{"site":"test"}}}`,
+		`{"hostname":"device","vnode":null}`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			var original Config
+			require.NoError(t, json.Unmarshal([]byte(input), &original))
+			for _, codec := range []struct {
+				marshal   func(any) ([]byte, error)
+				unmarshal func([]byte, any) error
+			}{{json.Marshal, json.Unmarshal}, {yaml.Marshal, yaml.Unmarshal}} {
+				data, err := codec.marshal(original)
+				require.NoError(t, err)
+				var got Config
+				require.NoError(t, codec.unmarshal(data, &got))
+				require.Equal(t, original, got)
+			}
+		})
+	}
+	for _, input := range []string{`{"vnode":1}`, `{"vnode":true}`, `{"vnode":[]}`} {
+		var config Config
+		require.Error(t, json.Unmarshal([]byte(input), &config))
+		require.Error(t, yaml.Unmarshal([]byte(input), &config))
+	}
+}
+
+func TestLegacyVnodeInputUsesCanonicalLocalConfiguration(t *testing.T) {
+	for _, unmarshal := range []func([]byte, any) error{json.Unmarshal, yaml.Unmarshal} {
+		c := New(ddsnmp.NewDeviceStore())
+		require.NoError(t, unmarshal([]byte(`{"hostname":"device","vnode":{"hostname":"local","guid":"6e17cd2c-0518-4e94-965b-d25673decb21","labels":{"site":"test"}}}`), c))
+		require.Empty(t, c.Vnode)
+		require.True(t, c.CreateVnode, "legacy input preserves constructor defaults")
+		require.Equal(t, defaultConfig().Options, c.Options)
+		require.Equal(t, "local", c.LocalVnode.Hostname)
+		require.Equal(t, "test", c.LocalVnode.Labels["site"])
+		raw, err := json.Marshal(c.Configuration())
+		require.NoError(t, err)
+		var canonical map[string]any
+		require.NoError(t, json.Unmarshal(raw, &canonical))
+		require.Equal(t, "", canonical["vnode"])
+		require.Equal(t, "local", canonical["local_vnode"].(map[string]any)["hostname"])
+		var next Config
+		require.NoError(t, json.Unmarshal(raw, &next))
+		require.Equal(t, c.Config, next)
+		for _, conflict := range []string{
+			`{"vnode":{"hostname":"old"},"local_vnode":{"hostname":"new"}}`,
+			`{"vnode":{},"local_vnode":{}}`,
+		} {
+			require.ErrorContains(t, unmarshal([]byte(conflict), &next), "cannot be combined")
+		}
+	}
+}
+
+func TestNamedVnodeDiagnosticsUseCanonicalIdentity(t *testing.T) {
+	c := New(ddsnmp.NewDeviceStore())
+	require.NoError(t, json.Unmarshal([]byte(`{"hostname":"192.0.2.1","vnode":"router"}`), c))
+	c.SetConfiguredVnode(vnodes.VirtualNode{GUID: "6e17cd2c-0518-4e94-965b-d25673decb21", Hostname: "canonical", Labels: map[string]string{"site": "test"}})
+	input := c.normalDeviceInput()
+	require.Equal(t, "6e17cd2c-0518-4e94-965b-d25673decb21", input.VnodeGUID)
+	require.Equal(t, "test", input.VnodeLabels["site"])
+	input.VnodeLabels["site"] = "mutated"
+	require.Equal(t, "test", c.normalDeviceInput().VnodeLabels["site"])
+	require.Nil(t, c.VirtualNode(), "configured snapshots must not become collector-generated identities")
+}

--- a/src/go/plugin/go.d/collector/snmp/vnode_config_test.go
+++ b/src/go/plugin/go.d/collector/snmp/vnode_config_test.go
@@ -4,6 +4,7 @@ package snmp
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -24,6 +25,29 @@ func TestNamedVnodeClientInitializationDoesNotLogCredentials(t *testing.T) {
 	_, err := c.initSNMPClient()
 	require.NoError(t, err)
 	require.NotContains(t, logs.String(), c.Community)
+	c.Options.Version = "3"
+	c.User.Name = "fixture-user"
+	c.User.ContextName = "routing-context"
+	c.User.AuthKey = "fixture-auth-secret"
+	c.User.PrivKey = "fixture-priv-secret"
+	logs.Reset()
+	_, err = c.initSNMPClient()
+	require.NoError(t, err)
+	require.Contains(t, logs.String(), `context=\"routing-context\"`)
+	require.NotContains(t, logs.String(), c.Community)
+	require.NotContains(t, logs.String(), c.User.AuthKey)
+	require.NotContains(t, logs.String(), c.User.PrivKey)
+}
+
+func TestNamedVnodeIgnoresUnusedLocalGUID(t *testing.T) {
+	c := New(ddsnmp.NewDeviceStore())
+	c.Hostname = "192.0.2.1"
+	c.Vnode = "central"
+	c.LocalVnode.GUID = "invalid-unused-guid"
+	require.NoError(t, c.Init(context.Background()))
+	c.Cleanup(context.Background())
+	c.Vnode = ""
+	require.ErrorContains(t, c.Init(context.Background()), "invalid Vnode GUID")
 }
 
 func TestVnodeConfigurationRoundTrip(t *testing.T) {

--- a/src/go/plugin/go.d/config/go.d/snmp.conf
+++ b/src/go/plugin/go.d/config/go.d/snmp.conf
@@ -8,3 +8,24 @@
 #    community: public
 #    options:
 #      version: 2
+
+## Attach to an existing vnode defined in vnodes/*.conf:
+## This string reference takes precedence over create_vnode. Keep this job's own
+## connection and metric profiles; vnode acquisition credentials are independent.
+#  - name: router_metrics
+#    vnode: router
+#    hostname: 192.0.2.1
+#    community: example-collector-community
+#    options:
+#      version: 2c
+
+## For a vnode created by this job, use local_vnode without a named vnode reference.
+## Legacy inline vnode objects are still accepted; use only one object spelling.
+#  - name: local_router_metrics
+#    hostname: 192.0.2.1
+#    community: example-collector-community
+#    create_vnode: true
+#    local_vnode:
+#      hostname: office-router
+#      labels:
+#        site: office

--- a/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
+++ b/src/go/plugin/go.d/pkg/snmputils/sysinfo.go
@@ -55,7 +55,14 @@ type SysInfoProbe struct {
 	SeenSysLocation bool
 }
 
-func GetSysInfo(client gosnmp.Handler) (*SysInfo, error) {
+// ScalarClient is sufficient for system and device metadata acquisition.
+type ScalarClient interface {
+	Get([]string) (*gosnmp.SnmpPacket, error)
+	MaxOids() int
+	Version() gosnmp.SnmpVersion
+}
+
+func GetSysInfo(client ScalarClient) (*SysInfo, error) {
 	pdus, err := getSysInfoPDUs(client)
 	if err != nil {
 		return nil, err
@@ -123,7 +130,7 @@ func sysInfoOIDs() []string {
 	}
 }
 
-func getSysInfoPDUs(client gosnmp.Handler) ([]gosnmp.SnmpPDU, error) {
+func getSysInfoPDUs(client ScalarClient) ([]gosnmp.SnmpPDU, error) {
 	maxOids := client.MaxOids()
 	if maxOids < 1 {
 		return nil, WithFailure(
@@ -146,7 +153,7 @@ func getSysInfoPDUs(client gosnmp.Handler) ([]gosnmp.SnmpPDU, error) {
 	return pdus, nil
 }
 
-func getSysInfoChunkPDUs(client gosnmp.Handler, version gosnmp.SnmpVersion, oids []string) ([]gosnmp.SnmpPDU, error) {
+func getSysInfoChunkPDUs(client ScalarClient, version gosnmp.SnmpVersion, oids []string) ([]gosnmp.SnmpPDU, error) {
 	for len(oids) > 0 {
 		packet, err := client.Get(oids)
 		if err != nil {

--- a/src/go/plugin/go.d/vnode/snmp.go
+++ b/src/go/plugin/go.d/vnode/snmp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/netdata/netdata/go/plugins/logger"
@@ -66,7 +67,8 @@ func acquire(client snmputils.ScalarClient, address string) (*vnodes.Metadata, e
 	if err != nil {
 		return nil, errors.New("SNMP system identity acquisition failed")
 	}
-	if !(si.Probe.SeenSysObjectID && si.SysObjectID != "" || si.Probe.SeenSysName && si.Name != "" || si.Probe.SeenSysDescr && si.Descr != "") {
+	si.Name = strings.TrimSpace(si.Name)
+	if !(si.Probe.SeenSysObjectID && si.SysObjectID != "" || si.Probe.SeenSysName && si.Name != "" || si.Probe.SeenSysDescr && strings.TrimSpace(si.Descr) != "") {
 		return nil, errors.New("SNMP response contains no usable system identity")
 	}
 	if !si.Probe.SeenSysName {

--- a/src/go/plugin/go.d/vnode/snmp.go
+++ b/src/go/plugin/go.d/vnode/snmp.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package vnode supplies go.d acquisition adapters for configured virtual nodes.
+package vnode
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/ddsnmp/ddsnmpcollector"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+)
+
+// SNMP acquires identity independently of any metrics job.
+type SNMP struct{}
+
+func (SNMP) Acquire(ctx context.Context, config vnodes.SNMPConfig) (*vnodes.Metadata, error) {
+	config = config.Defaults()
+	client := &gosnmp.GoSNMP{Target: config.Address, Port: uint16(config.Port), Timeout: config.Timeout.Duration(), Retries: *config.Retries, MaxOids: 60, Context: ctx}
+	if err := config.Config.Apply(client); err != nil {
+		return nil, err
+	}
+	if err := client.Connect(); err != nil {
+		return nil, errors.New("SNMP connection failed")
+	}
+	conn := client.Conn
+	stop := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer func() { stop(); _ = conn.Close() }()
+	return acquire(scalarClient{client}, config.Address)
+}
+
+type scalarClient struct{ *gosnmp.GoSNMP }
+
+func (c scalarClient) MaxOids() int                { return c.GoSNMP.MaxOids }
+func (c scalarClient) Version() gosnmp.SnmpVersion { return c.GoSNMP.Version }
+
+// Handle absent v1 OIDs as ordinary missing values, as with v2c exceptions.
+func (c scalarClient) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	var missing []gosnmp.SnmpPDU
+	for len(oids) > 0 {
+		p, err := c.GoSNMP.Get(oids)
+		if err != nil || p == nil {
+			return p, err
+		}
+		if p.Error == gosnmp.NoError {
+			p.Variables = append(p.Variables, missing...)
+			return p, nil
+		}
+		if c.Version() != gosnmp.Version1 || p.Error != gosnmp.NoSuchName || p.ErrorIndex < 1 || int(p.ErrorIndex) > len(oids) {
+			return p, nil
+		}
+		i := int(p.ErrorIndex) - 1
+		missing = append(missing, gosnmp.SnmpPDU{Name: oids[i], Type: gosnmp.NoSuchObject})
+		next := append([]string(nil), oids[:i]...)
+		oids = append(next, oids[i+1:]...)
+	}
+	return &gosnmp.SnmpPacket{Variables: missing}, nil
+}
+func acquire(client snmputils.ScalarClient, address string) (*vnodes.Metadata, error) {
+	si, err := snmputils.GetSysInfo(client)
+	if err != nil {
+		return nil, errors.New("SNMP system identity acquisition failed")
+	}
+	if !(si.Probe.SeenSysObjectID && si.SysObjectID != "" || si.Probe.SeenSysName && si.Name != "" || si.Probe.SeenSysDescr && si.Descr != "") {
+		return nil, errors.New("SNMP response contains no usable system identity")
+	}
+	if !si.Probe.SeenSysName {
+		si.Name = ""
+	}
+	base, _ := ddsnmp.AcquireDeviceIdentity(si, nil, ddsnmp.DeviceIdentityOptions{Address: address})
+	result := &vnodes.Metadata{Hostname: si.Name, Labels: base.Labels}
+	if si.SysObjectID == "" {
+		return result, nil
+	}
+	profiles := ddsnmp.DefaultCatalog().Resolve(ddsnmp.ResolveRequest{SysObjectID: si.SysObjectID, SysDescr: si.Descr}).Profiles()
+	// Acquisition reports safe phase errors; raw returned values stay out of logs.
+	meta, err := ddsnmpcollector.CollectDeviceMetadata(client, profiles, si.SysObjectID, logger.NewWithWriter(io.Discard))
+	if err != nil {
+		return result, errors.New("SNMP profile metadata acquisition failed")
+	}
+	result.Labels = ddsnmp.ResolveDeviceMetadata(base.Labels, meta, nil)
+	return result, nil
+}

--- a/src/go/plugin/go.d/vnode/snmp.go
+++ b/src/go/plugin/go.d/vnode/snmp.go
@@ -40,28 +40,6 @@ type scalarClient struct{ *gosnmp.GoSNMP }
 func (c scalarClient) MaxOids() int                { return c.GoSNMP.MaxOids }
 func (c scalarClient) Version() gosnmp.SnmpVersion { return c.GoSNMP.Version }
 
-// Handle absent v1 OIDs as ordinary missing values, as with v2c exceptions.
-func (c scalarClient) Get(oids []string) (*gosnmp.SnmpPacket, error) {
-	var missing []gosnmp.SnmpPDU
-	for len(oids) > 0 {
-		p, err := c.GoSNMP.Get(oids)
-		if err != nil || p == nil {
-			return p, err
-		}
-		if p.Error == gosnmp.NoError {
-			p.Variables = append(p.Variables, missing...)
-			return p, nil
-		}
-		if c.Version() != gosnmp.Version1 || p.Error != gosnmp.NoSuchName || p.ErrorIndex < 1 || int(p.ErrorIndex) > len(oids) {
-			return p, nil
-		}
-		i := int(p.ErrorIndex) - 1
-		missing = append(missing, gosnmp.SnmpPDU{Name: oids[i], Type: gosnmp.NoSuchObject})
-		next := append([]string(nil), oids[:i]...)
-		oids = append(next, oids[i+1:]...)
-	}
-	return &gosnmp.SnmpPacket{Variables: missing}, nil
-}
 func acquire(client snmputils.ScalarClient, address string) (*vnodes.Metadata, error) {
 	si, err := snmputils.GetSysInfo(client)
 	if err != nil {

--- a/src/go/plugin/go.d/vnode/snmp_test.go
+++ b/src/go/plugin/go.d/vnode/snmp_test.go
@@ -4,6 +4,7 @@ package vnode
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strconv"
 	"strings"
@@ -31,11 +32,15 @@ func serve(t *testing.T, reply func(*gosnmp.SnmpPacket) *gosnmp.SnmpPacket) (vno
 		for {
 			n, addr, err := conn.ReadFrom(buf)
 			if err != nil {
+				if !errors.Is(err, net.ErrClosed) {
+					t.Errorf("SNMP fixture read: %v", err)
+				}
 				return
 			}
 			decoder := &gosnmp.GoSNMP{}
 			p, err := decoder.SnmpDecodePacket(buf[:n])
 			if err != nil {
+				t.Errorf("SNMP fixture decode request: %v", err)
 				return
 			}
 			select {
@@ -49,9 +54,15 @@ func serve(t *testing.T, reply func(*gosnmp.SnmpPacket) *gosnmp.SnmpPacket) (vno
 				response.RequestID = p.RequestID
 				raw, err := response.MarshalMsg()
 				if err != nil {
+					t.Errorf("SNMP fixture encode response: %v", err)
 					return
 				}
-				_, _ = conn.WriteTo(raw, addr)
+				if _, err := conn.WriteTo(raw, addr); err != nil {
+					if !errors.Is(err, net.ErrClosed) {
+						t.Errorf("SNMP fixture write response: %v", err)
+					}
+					return
+				}
 			}
 		}
 	}()

--- a/src/go/plugin/go.d/vnode/snmp_test.go
+++ b/src/go/plugin/go.d/vnode/snmp_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package vnode
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/netdata/netdata/go/plugins/pkg/confopt"
+	"github.com/netdata/netdata/go/plugins/pkg/snmpauth"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/vnodes"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/snmputils"
+	"github.com/stretchr/testify/require"
+)
+
+func serve(t *testing.T, reply func(*gosnmp.SnmpPacket) *gosnmp.SnmpPacket) (vnodes.SNMPConfig, <-chan struct{}) {
+	t.Helper()
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	done := make(chan struct{})
+	seen := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		buf := make([]byte, 65535)
+		for {
+			n, addr, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			decoder := &gosnmp.GoSNMP{}
+			p, err := decoder.SnmpDecodePacket(buf[:n])
+			if err != nil {
+				return
+			}
+			select {
+			case seen <- struct{}{}:
+			default:
+			}
+			if response := reply(p); response != nil {
+				response.Version = p.Version
+				response.Community = p.Community
+				response.PDUType = gosnmp.GetResponse
+				response.RequestID = p.RequestID
+				raw, err := response.MarshalMsg()
+				if err != nil {
+					return
+				}
+				_, _ = conn.WriteTo(raw, addr)
+			}
+		}
+	}()
+	t.Cleanup(func() { _ = conn.Close(); <-done })
+	_, port, _ := net.SplitHostPort(conn.LocalAddr().String())
+	portNum, _ := strconv.Atoi(port)
+	retries := 0
+	return vnodes.SNMPConfig{Config: snmpauth.Config{Credentials: &snmpauth.Community{Community: "fixture-secret"}}, Address: "127.0.0.1", Port: portNum, Retries: &retries, Timeout: confopt.Duration(time.Second)}, seen
+}
+func TestAcquireRealUDP(t *testing.T) {
+	c, _ := serve(t, func(p *gosnmp.SnmpPacket) *gosnmp.SnmpPacket {
+		result := &gosnmp.SnmpPacket{}
+		for _, request := range p.Variables {
+			v := gosnmp.SnmpPDU{Name: request.Name, Type: gosnmp.NoSuchObject}
+			if request.Name == "."+snmputils.OidSysDescr {
+				v.Type = gosnmp.OctetString
+				v.Value = []byte("fixture device")
+			}
+			result.Variables = append(result.Variables, v)
+		}
+		return result
+	})
+	m, err := (SNMP{}).Acquire(context.Background(), c)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Empty(t, m.Hostname, "missing sysName must not become the legacy unknown placeholder")
+	require.Equal(t, "fixture device", m.Labels["description"])
+}
+func TestAcquireRejectsEmptyAndErrorResponses(t *testing.T) {
+	for _, status := range []gosnmp.SNMPError{gosnmp.NoError, gosnmp.GenErr} {
+		t.Run(status.String(), func(t *testing.T) {
+			c, _ := serve(t, func(*gosnmp.SnmpPacket) *gosnmp.SnmpPacket { return &gosnmp.SnmpPacket{Error: status} })
+			m, err := (SNMP{}).Acquire(context.Background(), c)
+			require.Nil(t, m)
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), "fixture-secret")
+		})
+	}
+}
+func TestCancellationClosesBlockedUDPRead(t *testing.T) {
+	c, seen := serve(t, func(*gosnmp.SnmpPacket) *gosnmp.SnmpPacket { return nil })
+	c.Timeout = confopt.Duration(time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { defer close(done); _, _ = (SNMP{}).Acquire(ctx, c) }()
+	select {
+	case <-seen:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no SNMP request")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not interrupt network read")
+	}
+}

--- a/src/go/plugin/go.d/vnode/snmp_test.go
+++ b/src/go/plugin/go.d/vnode/snmp_test.go
@@ -108,3 +108,25 @@ func TestCancellationClosesBlockedUDPRead(t *testing.T) {
 		t.Fatal("cancellation did not interrupt network read")
 	}
 }
+
+func TestAcquireWhitespaceSystemName(t *testing.T) {
+	for _, description := range []string{"", "usable description"} {
+		t.Run(description, func(t *testing.T) {
+			c, _ := serve(t, func(p *gosnmp.SnmpPacket) *gosnmp.SnmpPacket {
+				result := &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{{Name: "." + snmputils.OidSysName, Type: gosnmp.OctetString, Value: []byte("   ")}}}
+				if description != "" {
+					result.Variables = append(result.Variables, gosnmp.SnmpPDU{Name: "." + snmputils.OidSysDescr, Type: gosnmp.OctetString, Value: []byte(description)})
+				}
+				return result
+			})
+			m, err := (SNMP{}).Acquire(context.Background(), c)
+			if description == "" {
+				require.Error(t, err)
+				require.Nil(t, m)
+			} else {
+				require.NoError(t, err)
+				require.Empty(t, m.Hostname)
+			}
+		})
+	}
+}

--- a/src/go/plugin/go.d/vnode/snmp_test.go
+++ b/src/go/plugin/go.d/vnode/snmp_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"net"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -77,6 +79,50 @@ func TestAcquireRealUDP(t *testing.T) {
 	require.NotNil(t, m)
 	require.Empty(t, m.Hostname, "missing sysName must not become the legacy unknown placeholder")
 	require.Equal(t, "fixture device", m.Labels["description"])
+}
+
+func TestAcquireV1RecoversFromIndexedMissingSystemOIDs(t *testing.T) {
+	c, _ := serve(t, func(p *gosnmp.SnmpPacket) *gosnmp.SnmpPacket {
+		for i, v := range p.Variables {
+			if v.Name != "."+snmputils.OidSysName {
+				return &gosnmp.SnmpPacket{Error: gosnmp.NoSuchName, ErrorIndex: uint8(i + 1), Variables: p.Variables}
+			}
+		}
+		return &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{{Name: "." + snmputils.OidSysName, Type: gosnmp.OctetString, Value: "v1-router"}}}
+	})
+	c.Version = "1"
+	m, err := (SNMP{}).Acquire(t.Context(), c)
+	require.NoError(t, err)
+	require.Equal(t, "v1-router", m.Hostname)
+}
+
+func TestAcquireRealUDPProfileFailureRetainsSystemIdentity(t *testing.T) {
+	var enrichmentRequests atomic.Int32
+	c, _ := serve(t, func(p *gosnmp.SnmpPacket) *gosnmp.SnmpPacket {
+		for _, request := range p.Variables {
+			if !strings.HasPrefix(request.Name, ".1.3.6.1.2.1.1.") {
+				enrichmentRequests.Add(1)
+				return &gosnmp.SnmpPacket{Error: gosnmp.GenErr, Variables: p.Variables}
+			}
+		}
+		r := &gosnmp.SnmpPacket{}
+		for _, request := range p.Variables {
+			v := gosnmp.SnmpPDU{Name: request.Name, Type: gosnmp.NoSuchObject}
+			switch request.Name {
+			case "." + snmputils.OidSysObject:
+				v.Type, v.Value = gosnmp.ObjectIdentifier, ".1.3.6.1.4.1.6574.1"
+			case "." + snmputils.OidSysName:
+				v.Type, v.Value = gosnmp.OctetString, "storage"
+			}
+			r.Variables = append(r.Variables, v)
+		}
+		return r
+	})
+	m, err := (SNMP{}).Acquire(t.Context(), c)
+	require.ErrorContains(t, err, "profile metadata acquisition failed")
+	require.Equal(t, "storage", m.Hostname)
+	require.NotEmpty(t, m.Labels["sys_object_id"])
+	require.Positive(t, enrichmentRequests.Load())
 }
 func TestAcquireRejectsEmptyAndErrorResponses(t *testing.T) {
 	for _, status := range []gosnmp.SNMPError{gosnmp.NoError, gosnmp.GenErr} {

--- a/src/go/plugin/scripts.d/collector/nagios/vnode_snapshot_test.go
+++ b/src/go/plugin/scripts.d/collector/nagios/vnode_snapshot_test.go
@@ -28,7 +28,7 @@ func TestNamedVnodeSnapshotMatchesRunningCheck(t *testing.T) {
 		GUID:     "11111111-1111-1111-1111-111111111111",
 		Labels:   map[string]string{"_address": "192.0.2.1", "_alias": "old-alias", "site": "old", "removed": "value"},
 	}
-	configuration, err := discovery.NewVNodeConfigurationWithInitial(map[string]*vnodes.VirtualNode{"router": initial})
+	configuration, err := discovery.NewVNodeConfigurationWithInitial(map[string]*vnodes.Config{"router": &vnodes.Config{VirtualNode: *initial}})
 	require.NoError(t, err)
 	publisher := hostoutput.New()
 	publisher.Bind(configuration.Definition)
@@ -81,7 +81,7 @@ func TestNamedVnodeSnapshotMatchesRunningCheck(t *testing.T) {
 	updated.GUID = "22222222-2222-2222-2222-222222222222"
 	updated.Hostname = "new"
 	updated.Labels = map[string]string{"_address": "192.0.2.2", "_alias": "new-alias", "site": "new", "added": "value"}
-	prepared, err := configuration.PrepareUpsert("router", 1, updated)
+	prepared, err := configuration.PrepareUpsert("router", 1, &vnodes.Config{VirtualNode: *updated})
 	require.NoError(t, err)
 	_, err = prepared.Commit()
 	require.NoError(t, err)

--- a/system/vnodes/vnodes.conf
+++ b/system/vnodes/vnodes.conf
@@ -3,9 +3,9 @@
 ## It contains a list of virtual nodes. Virtual node, defined with the following parameters:
 ##
 ##  1. hostname
-##     The hostname of the virtual node. String. Required.
+##     The hostname of a static virtual node. String. Required in static mode.
 ##  2. guid
-##     Uniquely identifies the node. String. Required.
+##     Uniquely identifies the node. UUID string. Required in static mode.
 ##  3. labels
 ##     The virtual node host labels. Dictionary in the form key: value. Optional.
 ##     Special labels that are used to set virtual host system information:
@@ -28,3 +28,20 @@
 #
 #- hostname: HOSTNAME2
 #  guid: GUID2
+
+## Independent SNMP identity acquisition (go.d only).
+## Jobs attach with vnode: router; their endpoints and credentials stay job-owned.
+## Name is required. Hostname defaults to sysName, then name; GUID defaults to
+## a UUID derived from the exact address string. Optional overrides: hostname, guid, labels.
+## No metric profile is required. After restart, jobs wait for fresh identity.
+## Port defaults to 161, timeout to 5s, retries to 1. Credentials are literal values.
+## Existing SNMP vnodes cannot change mode/address/context/GUID in place.
+#- name: router
+#  mode: snmp
+#  mode_snmp:
+#    address: 192.0.2.1
+#    version: 2c
+#    credentials:
+#      community: example-community
+#  labels:
+#    site: example-site


### PR DESCRIPTION
##### Summary

Acquire vnode identity and host labels through SNMP independently of metrics jobs, allowing SNMP and other collectors to share one device identity.

Adds named vnode references to SNMP jobs and local_vnode for job-owned settings, preserving legacy inline configuration. Includes mode-aware updates, retry/refresh handling, tests, and documentation.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds independently acquired SNMP-backed virtual nodes to go.d. Previously, each SNMP job created its own vnode; jobs can now attach to a shared named vnode, while job-owned identities use `local_vnode` and legacy inline objects remain supported.

**New Features**

- `vnodes/*.conf` supports `mode: snmp` with address, port, timeout, and SNMP v1/v2c/v3 credentials.
- Acquisition resolves `sysName`, host labels, and device metadata without requiring a metrics job.
- GUIDs default to a UUID derived from the exact address; `hostname`, `guid`, and `labels` overrides remain available.
- Pending jobs wait for acquisition, which retries failures and refreshes metadata hourly.
- Credentials stay out of snapshots, diagnostics, and logs; plugins without SNMP acquisition skip SNMP-mode entries.

**Migration**

- A named `vnode` takes precedence over `create_vnode`; attached jobs keep their own endpoint, credentials, and metric profiles.
- Use `local_vnode` for job-created identity settings; legacy inline vnode objects are normalized to this form.
- Changing an SNMP vnode address creates a new node because the address determines its default identity.

<sup>Written for commit 0f311f23128886ae3d892172d3b9cfcef90fac6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SNMP-based virtual node identity acquisition with v1/v2c/v3 credentials, retries, refresh, and cancellation.
  * Added static and SNMP virtual node modes with mode-aware configuration and validation.
  * Added named virtual node references and `local_vnode` configuration for SNMP jobs, while retaining legacy inline compatibility.
  * SNMP identity and metadata now update through discovery and collector lifecycles.

* **Bug Fixes**
  * Improved SNMPv1 handling for missing OIDs and protected credential information in diagnostics and logs.
  * Added clearer handling for pending or conflicting virtual node identities.

* **Documentation**
  * Expanded virtual node and SNMP configuration guidance with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->