### PR TITLE
refactor(support-bundle): improve Unix script maintainability and reliability

### DIFF
--- a/.github/workflows/netdata-support-bundle.yml
+++ b/.github/workflows/netdata-support-bundle.yml
@@ -32,36 +32,46 @@ concurrency:
 
 jobs:
   posix:
-    name: POSIX sanitization (${{ matrix.shell }})
+    name: POSIX sanitization (${{ matrix.shell }}, ${{ matrix.awk }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shell:
-          - sh
-          - dash
-          - busybox
+        include:
+          - shell: sh
+            awk: gawk
+          - shell: dash
+            awk: mawk
+          - shell: busybox
+            awk: busybox
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install BusyBox
-        if: matrix.shell == 'busybox'
-        run: sudo apt-get update && sudo apt-get install -y busybox
+      - name: Install Unix validation tools
+        run: sudo apt-get update && sudo apt-get install -y busybox gawk mawk shellcheck
 
-      - name: Parse and run adversarial self-test
+      - name: Parse and run fixture suites
         env:
           TEST_SHELL: ${{ matrix.shell }}
+          TEST_AWK: ${{ matrix.awk }}
+          ND_SUPPORT_BUNDLE_DEMOTED: '1'
         run: |
           set -eu
+          tools_dir="$RUNNER_TEMP/support-bundle-tools"
+          mkdir -p "$tools_dir"
+          ln -s "$(command -v "$TEST_AWK")" "$tools_dir/awk"
+          export PATH="$tools_dir:$PATH"
           if [ "$TEST_SHELL" = busybox ]; then
             busybox sh -n packaging/installer/netdata-support-bundle
             busybox sh packaging/installer/netdata-support-bundle --selftest
-            SUPPORT_BUNDLE_TEST_SHELL="busybox sh" python3 packaging/installer/tests/test_snmp_diagnostics.py -v
+            export SUPPORT_BUNDLE_TEST_SHELL="busybox sh"
           else
             "$TEST_SHELL" -n packaging/installer/netdata-support-bundle
             "$TEST_SHELL" packaging/installer/netdata-support-bundle --selftest
-            SUPPORT_BUNDLE_TEST_SHELL="$TEST_SHELL" python3 packaging/installer/tests/test_snmp_diagnostics.py -v
+            export SUPPORT_BUNDLE_TEST_SHELL="$TEST_SHELL"
           fi
+          python3 -m unittest discover -s packaging/installer/tests -p 'test_*.py' -v
+          shellcheck packaging/installer/netdata-support-bundle
 
   posix-e2e:
     name: POSIX end-to-end bundle
@@ -116,6 +126,8 @@ jobs:
           trap 'kill "$fixture_root_pid" "$fixture_child_pid" 2>/dev/null || true; wait "$fixture_root_pid" 2>/dev/null || true' EXIT
           output=$(mktemp -d)
           extract=$(mktemp -d)
+          printf '{"cause":"UNTRUSTED-TMP-SENTINEL"}\n' > /tmp/status-netdata.json
+          sudo sh -c 'printf "fixture\n" > /var/lib/netdata/private-job-INVENTORY-SENTINEL'
           sh packaging/installer/netdata-support-bundle --timeout 3 --since 1 --include-snmp-diagnostics -o "$output"
           bundle=$(find "$output" -maxdepth 1 \( -name '*.tar.gz' -o -name '*.tar.zst' \) -print -quit)
           test -n "$bundle"
@@ -154,17 +166,37 @@ jobs:
           [ "$(head -c 3 "$sc" | od -An -tx1 | tr -d ' \n')" = efbbbf ] || { echo 'the UTF-8 BOM was not preserved' >&2; exit 1; }
           [ "$(tr -dc '\r' < "$sc" | wc -c)" -ge 4 ] || { echo 'CRLF line endings were not preserved' >&2; exit 1; }
 
+          if grep -R -qE 'UNTRUSTED-TMP-SENTINEL|INVENTORY-SENTINEL' "$root"; then
+            echo 'unsafe crash or state filename evidence included' >&2
+            exit 1
+          fi
+          python3 - "$root" <<'VALIDATE'
+          import json, pathlib, sys
+          root = pathlib.Path(sys.argv[1])
+          manifest = json.loads((root / 'MANIFEST.json').read_text())
+          rows = {row['path']: row for row in manifest['files']}
+          files = {str(p.relative_to(root)) for p in root.rglob('*')
+                   if p.is_file() and p.name != 'MANIFEST.json'}
+          assert len(rows) == len(manifest['files']), 'duplicate manifest rows'
+          assert files == set(rows), (files - set(rows), set(rows) - files)
+          for path, row in rows.items():
+              assert (root / path).stat().st_size == row['bytes'], path
+          assert not any(p.name.endswith(('.raw', '.rc', '.san', '.tmp')) for p in root.rglob('*'))
+          VALIDATE
+
   macos-posix:
     name: macOS POSIX sanitization
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
       - name: Parse and run adversarial self-test
+        env:
+          ND_SUPPORT_BUNDLE_DEMOTED: '1'
         run: |
           set -eu
           sh -n packaging/installer/netdata-support-bundle
           sh packaging/installer/netdata-support-bundle --selftest
-          python3 packaging/installer/tests/test_snmp_diagnostics.py -v
+          python3 -m unittest discover -s packaging/installer/tests -p 'test_*.py' -v
 
   powershell-core:
     name: PowerShell 7 sanitization

--- a/packaging/installer/SUPPORT-BUNDLE.md
+++ b/packaging/installer/SUPPORT-BUNDLE.md
@@ -421,9 +421,10 @@ Two passes, one sweep, applied to **every** collected file:
    - MAC addresses → `[MAC]`; email addresses → `[EMAIL]`;
    - this host's hostname/FQDN → `redacted-host`; the invoking user's name →
      `redacted-user`;
-   - ordinary FQDNs → `private-host-N`; only public Netdata service domains and
-     a small exact allowlist of known Netdata filenames are preserved (a broad
-     suffix exemption would leak names such as `customer.key`);
+   - on Unix, hostnames under private suffixes (`.internal`, `.local`, `.lan`,
+     `.corp`, `.intranet`, `.localdomain`) → `private-host-N`; other names are
+     recognized when preseeded from the API or discovered in stream destinations.
+     Arbitrary public-domain names are not generically classified as private;
    - child/mirrored node hostnames (pre-seeded from the local API before
      collection, so they pseudonymize consistently in every file) and
      `stream.conf` `destination` hosts regardless of TLD → `private-host-N`;
@@ -441,11 +442,20 @@ Two passes, one sweep, applied to **every** collected file:
 
 The private map is written next to the bundle (`*.pseudonym-map.tsv`) so the
 **user** can decode references if support asks "what is private-host-2?" — it
-is never included in the bundle itself. Unix pseudonym mappings are capped at 4096 entries per category (IPv4, IPv6,
-private hostnames and users), including hostnames preseeded from the API and the
-invoking user. Windows uses a shared 4096-entry map. Past the applicable cap,
-values get a non-correlating placeholder. Unix hostname preseeding also observes
-the API response-size cap and rejects failed or truncated responses.
+is never included in the bundle itself. Unix numbered pseudonyms are capped at 4096 per category (IPv4, IPv6,
+private hostnames and users). Further identities use a non-correlating placeholder.
+Every discovered hostname is retained in the private map and matching index,
+including names assigned `redacted-host-overflow`, so overflow names remain
+recognizable in later captures. Windows uses a shared 4096-entry map.
+
+Unix hostname discovery has a request timeout but no response-size cutoff: losing
+a returned name would prevent its later obfuscation. Discovery storage, private
+hostname-map size and index memory therefore scale with the returned names;
+ordinary API artifacts retain their 2 MiB cap. The index is rebuilt per sanitized
+file and costs memory proportional to total distinct hostname-prefix bytes.
+`--no-obfuscate` skips discovery and index construction while retaining secret
+redaction. Failed discovery does not provide reliable child-hostname knowledge;
+generic private-suffix and destination rules still apply.
 
 Redaction here is defense in depth, not a substitute for exclusion: files that
 are pure secrets (see exclusion list) are never read at all. Files containing
@@ -516,7 +526,8 @@ PII obfuscation. Preserve this order and the stream.conf context when editing.
 Mapped hostnames use a prefix index instead of scanning the entire map for every
 record. Matching preserves the existing ASCII word boundaries and chooses the
 longest complete match when names overlap. All hostname/user insertion, including
-preseeding, follows the same bounded mapping helpers.
+preseeding, follows the shared numbering/overflow policy above. Retaining overflow
+hostname identities is necessary for cross-file obfuscation.
 
 Unix fixture tests source the script with `ND_SUPPORT_BUNDLE_SOURCE_ONLY=1`, then
 call initialization and the real collectors with private synthetic paths. This

--- a/packaging/installer/SUPPORT-BUNDLE.md
+++ b/packaging/installer/SUPPORT-BUNDLE.md
@@ -44,10 +44,12 @@ sudo sh "$t"
 powershell -ExecutionPolicy Bypass -File "C:\Program Files\Netdata\usr\libexec\netdata\netdata-support-bundle.ps1"
 ```
 
-Both scripts implement the same bundle contract: same directory layout, same
-`MANIFEST.json` schema (`netdata-support-bundle/v2`), same sanitization rules.
-**If you change one script, mirror the change in the other and update this
-document.**
+Both scripts share the directory layout and `MANIFEST.json` schema
+(`netdata-support-bundle/v2`), including the streaming-key and raw SNMP exceptions.
+Platform-specific implementation details are identified below. When changing a
+shared contract, update both implementations unless the work is explicitly scoped
+to one platform; document any resulting difference. The Unix maintainability
+refactor described below does not change the PowerShell implementation.
 
 SNMP troubleshooting uses an explicit raw-evidence option:
 
@@ -63,7 +65,7 @@ bundle through a restricted support ticket. Default bundles omit these files.
 
 | guarantee | implementation |
 |---|---|
-| Minimize system impact | self-demotion to idle CPU/IO priority (`nice -n 19` + `ionice -c 3` / `PriorityClass = Idle`); per-command timeout (10 s default, via `timeout` or a portable watchdog — the watchdog kills the direct child only, a documented limitation); global deadline checked before collectors (blocking filesystem operations and final packaging are not a hard runtime bound); size caps (5 MiB per log, 1 MiB per file, 2 MiB per command/API output); read-only — writes only its private staging dir and the final artifacts, never restarts or reconfigures anything; artifacts are published with `O_EXCL` so pre-existing files or symlinks in shared tmp dirs are never followed |
+| Minimize system impact | self-demotion to idle CPU/IO priority (`nice -n 19` + `ionice -c 3` / `PriorityClass = Idle`); per-command timeout (10 s default, via `timeout` or a portable watchdog — the watchdog kills the direct child only, a documented limitation); global deadline checked before collectors (filesystem operations, sanitization and final packaging can exceed the admission deadline); size caps (5 MiB per log, 1 MiB per file, 2 MiB per command/API output); read-only — writes only its private staging dir and the final artifacts, never restarts or reconfigures anything; artifacts are published with `O_EXCL` so pre-existing files or symlinks in shared tmp dirs are never followed |
 | Works when the agent is dead | no hard dependency on a running agent; the most valuable crash artifacts (status file, logs, buildinfo via the binary) are collected from disk; a `07-runtime/AGENT-WAS-DOWN.txt` marker is written instead of API captures |
 | Standard captures redact secrets | non-optional single-pass sanitizer; see "Sanitization" below. The streaming API key in `stream.conf` is kept verbatim (see "The streaming API key exception"). Explicitly included SNMP evidence bypasses sanitization entirely (see "Raw SNMP evidence") |
 | Source bytes preserved | collected files keep their byte-order mark, their per-line terminators (CRLF/CR/LF, including on lines the sanitizer rewrote) and a missing final newline, so an encoding fault in the user's file is still visible in the bundle |
@@ -194,8 +196,10 @@ Every item collected maps to a recurring support ask. That mapping is the
 | `netdatacli aclk-state json` | canned Freshdesk ask for cloud issues |
 | netdata self CPU/memory/clients CSVs (10 min, bounded) | replaces the "please send a screenshot of the Netdata memory charts" round trip |
 
-Local API reads target `127.0.0.1:19999` directly and bypass any configured
-proxy, so diagnostic data cannot leave the host through a forced proxy.
+On Unix, all local API reads (including probes and hostname preseeding) use one
+transport targeting `127.0.0.1:19999`. It clears proxy environment variables and
+explicitly disables curl/wget proxy use. Cloud connectivity probes retain the
+normal proxy configuration so they represent the installation's network path.
 
 ### `08-network/` — connectivity
 
@@ -437,9 +441,11 @@ Two passes, one sweep, applied to **every** collected file:
 
 The private map is written next to the bundle (`*.pseudonym-map.tsv`) so the
 **user** can decode references if support asks "what is private-host-2?" — it
-is never included in the bundle itself. Pseudonym mappings are capped at 4096
-entries; past the cap, values get a non-correlating placeholder so hostile
-high-cardinality input cannot grow memory or the private map without bound.
+is never included in the bundle itself. Unix pseudonym mappings are capped at 4096 entries per category (IPv4, IPv6,
+private hostnames and users), including hostnames preseeded from the API and the
+invoking user. Windows uses a shared 4096-entry map. Past the applicable cap,
+values get a non-correlating placeholder. Unix hostname preseeding also observes
+the API response-size cap and rejects failed or truncated responses.
 
 Redaction here is defense in depth, not a substitute for exclusion: files that
 are pure secrets (see exclusion list) are never read at all. Files containing
@@ -464,12 +470,14 @@ by these scripts.
 1. Map the new item to a real support ask (link the ticket/issue class) and
    add it to the right section table above **with its why**.
 2. Use the existing helpers — `collect_cmd` / `collect_file` / `collect_api`
-   (`Save-Cmd` / `Save-File` / `Save-Api` / `Save-CmdRaw` on Windows). They enforce
-   timeouts, size caps, sanitization, and manifest registration. Never write
-   into the bundle directly.
-3. Respect the cost budget: nothing unbounded, nothing that queries metric
-   data without a tight window, nothing that can block longer than the
-   per-command timeout.
+   (`Save-Cmd` / `Save-File` / `Save-Api` / `Save-CmdRaw` on Windows). On Unix,
+   command/API execution is time-limited; regular-file reads and sanitization
+   follow the admission-deadline limitation above. Helpers apply format-specific
+   caps, sanitization and manifest registration. Raw SNMP evidence has its own
+   explicitly unsanitized copy path. Register generated markers in the manifest.
+3. Respect the cost budget: bound command execution and capture sizes; query
+   metric data only with a tight window. Include sanitizer and discovery work in
+   performance checks, since the admission deadline does not interrupt them.
 4. If the item can contain credentials or PII of a NEW shape, extend the sanitizer
    in **both** scripts and add the pattern to the Sanitization section above.
    A COPIED file must go through `collect_file` / `Save-File` so its bytes are
@@ -479,12 +487,55 @@ by these scripts.
    in your PR why it is platform-specific.
 6. Test the redaction: add a vector to the built-in regression suite and run
    `netdata-support-bundle --selftest` (`netdata-support-bundle.ps1 -SelfTest` on Windows) — it must
-   pass on GNU awk, mawk, BusyBox awk, and PowerShell. CI executes both suites.
+   pass on GNU awk, mawk, BusyBox awk, and PowerShell. Unix CI explicitly selects
+   each AWK binary and disables priority re-execution during interpreter tests,
+   so invoking BusyBox sh does not silently test the system sh or system awk.
    For new collection sources also
    plant a sentinel secret in the source, run a collection, and `grep -r` the
    extracted bundle. Zero hits or it does not ship.
 7. Never add anything from the "What is NEVER collected" list, and never make
    the tool write, restart, reconfigure, or otherwise mutate the system.
+
+## Maintaining the Unix implementation
+
+Keep one standalone distributable script. `main()` owns initialization, discovery,
+the nine collection phases, summaries, manifest emission and publication. Helpers
+use function-specific scratch prefixes because POSIX sh has no standard local
+variables. Shared uppercase run state (plus `api_ok` and `have_timeout`) and the
+`CAPTURE_RC` / `CAPTURE_BYTES` helper results are intentional outputs.
+
+`capture_output` preserves producer exit status separately from the POSIX pipeline
+status. `collect_body` shares raw-command/API finalization: a failed capture or
+size overflow becomes a JSON error marker, while successful empty output is
+omitted. Text commands retain their exit/duration trailer. These markers do not
+add a manifest schema or guarantee that a successful producer emitted valid JSON.
+The separate zstd archive pipeline checks both tar and compressor success.
+
+The AWK record action calls ordered secret-redaction stages followed by optional
+PII obfuscation. Preserve this order and the stream.conf context when editing.
+Mapped hostnames use a prefix index instead of scanning the entire map for every
+record. Matching preserves the existing ASCII word boundaries and chooses the
+longest complete match when names overlap. All hostname/user insertion, including
+preseeding, follows the same bounded mapping helpers.
+
+Unix fixture tests source the script with `ND_SUPPORT_BUNDLE_SOURCE_ONLY=1`, then
+call initialization and the real collectors with private synthetic paths. This
+mode defines functions without running discovery, collection or staging setup.
+Do not replace these fixtures with workstation collection or stub past the helper
+whose behavior is being asserted. Keep the built-in `--selftest` available in the
+standalone artifact and exercise full synthetic bundles in Linux CI.
+
+Run the fixture suites on macOS or a disposable Linux environment with:
+
+```sh
+ND_SUPPORT_BUNDLE_DEMOTED=1 sh packaging/installer/netdata-support-bundle --selftest
+python3 -m unittest discover -s packaging/installer/tests -p 'test_*.py' -v
+```
+
+For interpreter validation, select the shell with `SUPPORT_BUNDLE_TEST_SHELL` and
+put the desired AWK executable at `awk` in a private PATH directory. The workflow
+contains the supported combinations. Windows fixture extraction and PowerShell
+behavior are maintained separately.
 
 ## Bundle format contract
 

--- a/packaging/installer/SUPPORT-BUNDLE.md
+++ b/packaging/installer/SUPPORT-BUNDLE.md
@@ -412,8 +412,9 @@ Two passes, one sweep, applied to **every** collected file:
    - `[<UUID>]` section headers, which are API keys or machine GUIDs — **except
      in `stream.conf`**, where they are kept (see "The streaming API key
      exception");
-   - `bearer_tokens/` directory listings show a file COUNT only — the
-     filenames are the tokens.
+   - Unix state inventory reports aggregate file counts and sizes without
+     filenames. In particular, `bearer_tokens/` filenames are live tokens and
+     must not appear in inventory output.
 2. **PII — on by default, `--no-obfuscate` / `-NoObfuscate` to disable:**
    - non-loopback IPv4 addresses → `ip-N` and IPv6 → `ip6-N` (stable per
      bundle; compressed, lettered, and numeric-only uncompressed forms;

--- a/packaging/installer/netdata-support-bundle
+++ b/packaging/installer/netdata-support-bundle
@@ -67,7 +67,7 @@ init_defaults() {
   LOG_CAP=5242880          # 5 MiB per log file
   FILE_CAP=1048576         # 1 MiB per config/state file
   API_CAP=2097152          # 2 MiB per API response
-  MAP_LIMIT=4096           # per pseudonym category, including seeded hostnames
+  MAP_LIMIT=4096           # numbered pseudonyms per category
   NDPORT=19999
   api_ok=0
 }
@@ -254,13 +254,17 @@ sanitize_file() {
     nsec = split("api key,apikey,token,password,passwd,pwd,secret,community,bearer,webhook,license key,auth,credential,cookie,passphrase,proxy user,proxy pass,username,dsn,private key,access key,session,recipient,account sid,priv key", SK, ",");
     for (i = 1; i <= nsec; i++) gsub(/[-_]/, " ", SK[i]);
     nip = 0;
-    while ((getline line < mapfile) > 0) {
+    while (obf == 1 && (getline line < mapfile) > 0) {
       split(line, a, "\t");
       if (a[1] == "ip") { ipmap[a[2]] = a[3]; nip++; }
       else if (a[1] == "host") hostmap[a[2]] = a[3];
       else if (a[1] == "user") { nusers++; usermap[a[2]] = a[3]; if (a[3] ~ /^user-[0-9]+$/) { un = a[3]; sub(/user-/, "", un); if (un + 0 > nusr) nusr = un + 0 } }
       else if (a[1] == "ip6") { ip6map[a[2]] = a[3]; nip6++; }
-      else if (a[1] == "fqdn") { fqmap[a[2]] = a[3]; nfq++; index_hostname(a[2]); }
+      else if (a[1] == "fqdn") {
+        fqmap[a[2]] = a[3];
+        if (a[3] ~ /^private-host-[0-9]+$/) nfq++;
+        index_hostname(a[2]);
+      }
     }
     close(mapfile);
   }
@@ -399,8 +403,11 @@ sanitize_file() {
   }
   function pseudo_fqdn(h) {
     if (!(h in fqmap)) {
-      if (nfq >= map_limit) return "redacted-host-overflow";  # cap: non-correlating
-      nfq++; fqmap[h] = "private-host-" nfq; index_hostname(h);
+      # Keep overflow identities recognizable in later files, even though they
+      # share one non-correlating placeholder after the numbered-map budget.
+      if (nfq >= map_limit) fqmap[h] = "redacted-host-overflow";
+      else { nfq++; fqmap[h] = "private-host-" nfq; }
+      index_hostname(h);
       print "fqdn\t" h "\t" fqmap[h] >> mapfile;
     }
     return fqmap[h];
@@ -1179,9 +1186,12 @@ STREAMVEC
 
 # Discover hostnames before collecting files so pseudonyms correlate throughout.
 seed_hostnames() {
+  [ "$OBFUSCATE" = 1 ] || return 0
   deadline_exceeded && return 0
-  capture_output "$STAGING/node-seed.json" "$((API_CAP + 1))" 0 api_request 5 /api/v2/node_instances
-  [ "$CAPTURE_RC" = 0 ] && [ "$CAPTURE_BYTES" -le "$API_CAP" ] || return 0
+  # Discovery must retain every returned name, including on large parents.
+  # The request is timed; storage and matching memory scale with the response.
+  # API artifacts still use their ordinary size cap through collect_api.
+  api_request 5 /api/v2/node_instances > "$STAGING/node-seed.json" 2>>"$ERRORS" || return 0
   tr ',{' '\n' < "$STAGING/node-seed.json" | awk '
     match($0, /"(nm|hostname)" *: *"/) {
       value = substr($0, RSTART + RLENGTH); sub(/".*/, "", value);

--- a/packaging/installer/netdata-support-bundle
+++ b/packaging/installer/netdata-support-bundle
@@ -21,8 +21,7 @@
 #     --no-obfuscate disables PII pass only. Explicit --include-snmp-diagnostics
 #     adds raw SNMP files with neither secret redaction nor PII obfuscation.
 #   - Collected files keep their original bytes: BOM, line terminators and a
-#     missing final newline survive redaction, and what was observed is recorded
-#     per file in MANIFEST.json, so encoding faults stay diagnosable.
+#     missing final newline survive redaction, so encoding faults stay diagnosable.
 #   - Bundle is legible to humans AND AI agents: triage-ordered directories, pristine
 #     file copies, provenance in MANIFEST.json, human summary.txt, README.md inside.
 #
@@ -37,114 +36,126 @@
 #   -v, --version        print version
 #   -h, --help           this help
 
-set -u
-
-# --- self-demotion FIRST (before arg parsing consumes "$@"): never compete
-# --- with real workloads
-if [ -z "${ND_SUPPORT_BUNDLE_DEMOTED:-}" ]; then
-  ND_SUPPORT_BUNDLE_DEMOTED=1; export ND_SUPPORT_BUNDLE_DEMOTED
-  # ionice may exist but be denied (e.g. no CAP_SYS_NICE): probe idle class
-  # once, and only route through it if it actually works; else just nice
-  if command -v ionice >/dev/null 2>&1 && ionice -c 3 true >/dev/null 2>&1; then
-    exec nice -n 19 ionice -c 3 sh "$0" "$@"
+demote() {
+  # --- self-demotion FIRST (before arg parsing consumes "$@"): never compete
+  # --- with real workloads
+  if [ -z "${ND_SUPPORT_BUNDLE_DEMOTED:-}" ]; then
+    ND_SUPPORT_BUNDLE_DEMOTED=1; export ND_SUPPORT_BUNDLE_DEMOTED
+    # ionice may exist but be denied (e.g. no CAP_SYS_NICE): probe idle class
+    # once, and only route through it if it actually works; else just nice
+    if command -v ionice >/dev/null 2>&1 && ionice -c 3 true >/dev/null 2>&1; then
+      exec nice -n 19 ionice -c 3 sh "$0" "$@"
+    fi
+    exec nice -n 19 sh "$0" "$@"
   fi
-  exec nice -n 19 sh "$0" "$@"
-fi
+}
 
-VERSION="1.3.0"
-OUTDIR="/tmp"
-SINCE_HOURS=24
-CMD_TIMEOUT=10
-OBFUSCATE=1
-KEEP_STAGING=0
-SELFTEST=0
-INCLUDE_SNMP=0
-SNMP_FILES=0
-SNMP_STATUS=not_requested
-# checked before each collector; one in-flight command may overrun by up to
-# CMD_TIMEOUT, so the hard runtime bound is GLOBAL_DEADLINE + CMD_TIMEOUT
-GLOBAL_DEADLINE=240
-LOG_CAP=5242880          # 5 MiB per log file
-FILE_CAP=1048576         # 1 MiB per config/state file
-API_CAP=2097152          # 2 MiB per API response
+init_defaults() {
+  VERSION="1.3.0"
+  OUTDIR="/tmp"
+  SINCE_HOURS=24
+  CMD_TIMEOUT=10
+  OBFUSCATE=1
+  KEEP_STAGING=0
+  SELFTEST=0
+  INCLUDE_SNMP=0
+  SNMP_FILES=0
+  SNMP_STATUS=not_requested
+  # Admission deadline checked before collectors; filesystem operations,
+  # sanitization and final packaging are not a hard wall-clock bound.
+  GLOBAL_DEADLINE=240
+  LOG_CAP=5242880          # 5 MiB per log file
+  FILE_CAP=1048576         # 1 MiB per config/state file
+  API_CAP=2097152          # 2 MiB per API response
+  MAP_LIMIT=4096           # per pseudonym category, including seeded hostnames
+  NDPORT=19999
+  api_ok=0
+}
 
-need_val() { _opt="$1"; [ $# -ge 2 ] || { echo "option $_opt needs a value" >&2; exit 1; }; }
-while [ $# -gt 0 ]; do
-  case "$1" in
-    -o|--output) need_val "$@"; OUTDIR="$2"; shift 2 ;;
-    --since) need_val "$@"; SINCE_HOURS="$2"; shift 2 ;;
-    --timeout) need_val "$@"; CMD_TIMEOUT="$2"; shift 2 ;;
-    --no-obfuscate) OBFUSCATE=0; shift ;;
-    --include-snmp-diagnostics) INCLUDE_SNMP=1; shift ;;
-    --keep-staging) KEEP_STAGING=1; shift ;;
-    --selftest) SELFTEST=1; shift ;;
-    -v|--version) echo "netdata-support-bundle $VERSION"; exit 0 ;;
-    -h|--help) sed -n '/^# netdata-support-bundle - collect/,/^#   -h, --help/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-    *) echo "unknown option: $1" >&2; exit 1 ;;
-  esac
-done
+need_val() { [ $# -ge 2 ] || { echo "option $1 needs a value" >&2; exit 1; }; }
+parse_options() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o|--output) need_val "$@"; OUTDIR="$2"; shift 2 ;;
+      --since) need_val "$@"; SINCE_HOURS="$2"; shift 2 ;;
+      --timeout) need_val "$@"; CMD_TIMEOUT="$2"; shift 2 ;;
+      --no-obfuscate) OBFUSCATE=0; shift ;;
+      --include-snmp-diagnostics) INCLUDE_SNMP=1; shift ;;
+      --keep-staging) KEEP_STAGING=1; shift ;;
+      --selftest) SELFTEST=1; shift ;;
+      -v|--version) echo "netdata-support-bundle $VERSION"; exit 0 ;;
+      -h|--help) sed -n '/^# netdata-support-bundle - collect/,/^#   -h, --help/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+      *) echo "unknown option: $1" >&2; exit 1 ;;
+    esac
+  done
 
-case "$SINCE_HOURS" in *[!0-9]*|''|0) echo "--since must be a positive integer (hours)" >&2; exit 1 ;; *) : ;; esac
-case "$CMD_TIMEOUT" in *[!0-9]*|''|0) echo "--timeout must be a positive integer (seconds)" >&2; exit 1 ;; *) : ;; esac
+  case "$SINCE_HOURS" in *[!0-9]*|''|0) echo "--since must be a positive integer (hours)" >&2; exit 1 ;; *) : ;; esac
+  case "$CMD_TIMEOUT" in *[!0-9]*|''|0) echo "--timeout must be a positive integer (seconds)" >&2; exit 1 ;; *) : ;; esac
+}
 
-umask 077
-START_TS=$(date +%s)
-NOW=$(date -u +%Y%m%d-%H%M%S)
-STAGING=$(mktemp -d "${TMPDIR:-/tmp}/netdata-support-bundle.XXXXXX") || exit 1
-BUNDLE="netdata-support-bundle-${NOW}-$$"
-WORK="$STAGING/$BUNDLE"
-mkdir -p "$WORK"
-MAP_FILE="$STAGING/map.tsv"; : > "$MAP_FILE"
-MANIFEST_ROWS="$STAGING/manifest.rows"; : > "$MANIFEST_ROWS"
-ERRORS="$STAGING/errors.txt"; : > "$ERRORS"
-# what the sanitizer must preserve for the file it is currently processing
-ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0
+init_staging() {
+  umask 077
+  START_TS=$(date +%s)
+  NOW=$(date -u +%Y%m%d-%H%M%S)
+  STAGING=$(mktemp -d "${TMPDIR:-/tmp}/netdata-support-bundle.XXXXXX") || exit 1
+  BUNDLE="netdata-support-bundle-${NOW}-$$"
+  WORK="$STAGING/$BUNDLE"
+  mkdir -p "$WORK"
+  MAP_FILE="$STAGING/map.tsv"; : > "$MAP_FILE"
+  MANIFEST_ROWS="$STAGING/manifest.rows"; : > "$MANIFEST_ROWS"
+  ERRORS="$STAGING/errors.txt"; : > "$ERRORS"
+  # what the sanitizer must preserve for the file it is currently processing
+  ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0
+  trap cleanup EXIT
+  trap 'cleanup; trap - EXIT; exit 130' INT TERM
+}
 
 cleanup() { [ "$KEEP_STAGING" = "1" ] || rm -rf "$STAGING"; }
-trap cleanup EXIT
-trap 'cleanup; trap - EXIT; exit 130' INT TERM
 
 info() { printf ' [*] %s\n' "$*" >&2; }
 now_s() { date +%s; }
 deadline_exceeded() { [ $(( $(now_s) - START_TS )) -ge "$GLOBAL_DEADLINE" ]; }
 
 # timeout capability: GNU/FreeBSD support -k (kill-after); busybox does not; macOS has none
-have_timeout=0
-if command -v timeout >/dev/null 2>&1; then
-  if timeout -k 2 5 true 2>/dev/null; then have_timeout=2
-  elif timeout 5 true 2>/dev/null; then have_timeout=1
+detect_timeout() {
+  have_timeout=0
+  if command -v timeout >/dev/null 2>&1; then
+    if timeout -k 2 5 true 2>/dev/null; then have_timeout=2
+    elif timeout 5 true 2>/dev/null; then have_timeout=1
+    fi
   fi
-fi
+}
+
 run_capped() { # run_capped <seconds> <cmd...>
-  _t="$1"; shift
+  _rc_t="$1"; shift
   case "$have_timeout" in
-    2) timeout -k 2 "$_t" "$@" ;;
-    1) timeout "$_t" "$@" ;;
+    2) timeout -k 2 "$_rc_t" "$@" ;;
+    1) timeout "$_rc_t" "$@" ;;
     *)
       # no timeout binary (macOS): portable watchdog so a stuck collector
       # cannot hang the whole run. KNOWN WEAKER GUARANTEE than GNU/BSD
       # timeout (which kills the whole process group): this best-effort path
       # SIGKILLs the direct child and, where pkill exists, its children;
-      # deeper sh -c grandchildren may briefly orphan. Total runtime is still
-      # bounded by GLOBAL_DEADLINE. Only reached on hosts lacking timeout.
+      # deeper sh -c grandchildren may briefly orphan. Only reached on hosts
+      # lacking timeout; this is not a process-group runtime guarantee.
       "$@" &
-      _cmdpid=$!
+      _rc_cmdpid=$!
       (
-        _i=0
-        while [ "$_i" -lt "$_t" ]; do
+        _rc_i=0
+        while [ "$_rc_i" -lt "$_rc_t" ]; do
           sleep 1
-          kill -0 "$_cmdpid" 2>/dev/null || exit 0
-          _i=$((_i + 1))
+          kill -0 "$_rc_cmdpid" 2>/dev/null || exit 0
+          _rc_i=$((_rc_i + 1))
         done
-        command -v pkill >/dev/null 2>&1 && pkill -9 -P "$_cmdpid" 2>/dev/null
-        kill -9 "$_cmdpid" 2>/dev/null
+        command -v pkill >/dev/null 2>&1 && pkill -9 -P "$_rc_cmdpid" 2>/dev/null
+        kill -9 "$_rc_cmdpid" 2>/dev/null
       ) &
-      _wdpid=$!
-      wait "$_cmdpid"
-      _rc=$?
-      kill "$_wdpid" 2>/dev/null
-      wait "$_wdpid" 2>/dev/null
-      return "$_rc"
+      _rc_wdpid=$!
+      wait "$_rc_cmdpid"
+      _rc_rc=$?
+      kill "$_rc_wdpid" 2>/dev/null
+      wait "$_rc_wdpid" 2>/dev/null
+      return "$_rc_rc"
       ;;
   esac
 }
@@ -166,24 +177,26 @@ run_capped() { # run_capped <seconds> <cmd...>
 #
 # pass 1 (always): credential-key values, URL/DSN creds, JWTs, PEM key blocks
 # pass 2 (default): emails, MACs, IPv4 pseudonyms (stable via map), hostnames
-HOST_SHORT=$(hostname 2>/dev/null || echo "")
-HOST_FQDN=$(hostname -f 2>/dev/null || echo "")
-[ "$HOST_SHORT" = "localhost" ] && HOST_SHORT=""
-[ "$HOST_FQDN" = "localhost" ] && HOST_FQDN=""
-[ ${#HOST_SHORT} -lt 4 ] && HOST_SHORT=""
-# the invoking user's name is PII too (ps USER column, /home/<name> paths)
-RUN_USER=$(id -un 2>/dev/null || echo "")
-case "$RUN_USER" in root|netdata|"") RUN_USER="" ;; *) : ;; esac
-[ ${#RUN_USER} -lt 3 ] && RUN_USER=""
+init_sanitizer_context() {
+  HOST_SHORT=$(hostname 2>/dev/null || echo "")
+  HOST_FQDN=$(hostname -f 2>/dev/null || echo "")
+  [ "$HOST_SHORT" = "localhost" ] && HOST_SHORT=""
+  [ "$HOST_FQDN" = "localhost" ] && HOST_FQDN=""
+  [ ${#HOST_SHORT} -lt 4 ] && HOST_SHORT=""
+  # the invoking user's name is PII too (ps USER column, /home/<name> paths)
+  RUN_USER=$(id -un 2>/dev/null || echo "")
+  case "$RUN_USER" in root|netdata|"") RUN_USER="" ;; *) : ;; esac
+  [ ${#RUN_USER} -lt 3 ] && RUN_USER=""
+}
 
 # encoding_probe <staged-file> - work out what the sanitizer must preserve:
 # where the BOM ends, whether the file ends with a terminator, and whether it
 # uses CR-only line endings. Redaction used to silently normalize all three
 # away (netdata/netdata#23448).
 encoding_probe() {
-  _ef="$1"
+  _ep_ef="$1"
   ENC_BOM_BYTES=0; ENC_FINAL=true; ENC_CRONLY=0
-  case "$(head -c 4 "$_ef" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')" in
+  case "$(head -c 4 "$_ep_ef" 2>/dev/null | od -An -tx1 2>/dev/null | tr -d ' \n')" in
     efbbbf*)  ENC_BOM_BYTES=3 ;;
     fffe0000|0000feff) ENC_BOM_BYTES=4 ;;
     fffe*|feff*) ENC_BOM_BYTES=2 ;;
@@ -191,14 +204,14 @@ encoding_probe() {
   esac
   # CR is a line terminator too, so a CR-terminated file is not missing its
   # final newline - sanitize_file relies on this to not eat that last byte
-  case "$(tail -c 1 "$_ef" 2>/dev/null | od -An -tx1 | tr -d ' \n')" in
+  case "$(tail -c 1 "$_ep_ef" 2>/dev/null | od -An -tx1 | tr -d ' \n')" in
     0a|0d) : ;;
     *) ENC_FINAL=false ;;
   esac
   # CR-only (classic Mac) endings make the whole file ONE awk record, so only
   # its first key would ever be examined - sanitize_file translates for the pass
-  if [ "$(LC_ALL=C tr -dc '\n' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')" = "0" ] &&
-     [ "$(LC_ALL=C tr -dc '\r' < "$_ef" 2>/dev/null | wc -c | tr -d ' ')" != "0" ]; then
+  if [ "$(LC_ALL=C tr -dc '\n' < "$_ep_ef" 2>/dev/null | wc -c | tr -d ' ')" = "0" ] &&
+     [ "$(LC_ALL=C tr -dc '\r' < "$_ep_ef" 2>/dev/null | wc -c | tr -d ' ')" != "0" ]; then
     ENC_CRONLY=1
   fi
   return 0
@@ -209,23 +222,23 @@ encoding_probe() {
 # is kept verbatim (netdata/netdata#23448). Every other file, and every other
 # secret key inside stream.conf, is redacted as before.
 sanitize_file() {
-  _f="$1"; _ctx="${2:-}"
-  [ -f "$_f" ] || return 0
-  encoding_probe "$_f"
+  _san_f="$1"; _san_ctx="${2:-}"
+  [ -f "$_san_f" ] || return 0
+  encoding_probe "$_san_f"
   # binary/UTF-16 input would make line-based redaction byte-unsafe: withhold
-  _b_all=$(wc -c < "$_f")
-  _b_txt=$(LC_ALL=C tr -d '\000' < "$_f" | wc -c)
-  if [ "$_b_all" -ne "$_b_txt" ]; then
-    echo "[content withheld: file contains NUL bytes (binary or UTF-16?)]" > "$_f"
+  _san_b_all=$(wc -c < "$_san_f")
+  _san_b_txt=$(LC_ALL=C tr -d '\000' < "$_san_f" | wc -c)
+  if [ "$_san_b_all" -ne "$_san_b_txt" ]; then
+    echo "[content withheld: file contains NUL bytes (binary or UTF-16?)]" > "$_san_f"
     return 0
   fi
   # A BOM shifts every ^-anchored rule in the sanitizer: a BOM'd "[<API_KEY>]"
   # header did NOT match the section rule and shipped verbatim. Strip the BOM
   # for the redaction pass and restore the exact bytes afterwards.
-  _sanin="$_f"; _bomstripped=0
+  _san_sanin="$_san_f"; _san_bomstripped=0
   if [ "$ENC_BOM_BYTES" -gt 0 ]; then
-    if tail -c "+$((ENC_BOM_BYTES + 1))" "$_f" > "$_f.nobom" 2>>"$ERRORS"; then
-      _sanin="$_f.nobom"; _bomstripped=1
+    if tail -c "+$((ENC_BOM_BYTES + 1))" "$_san_f" > "$_san_f.nobom" 2>>"$ERRORS"; then
+      _san_sanin="$_san_f.nobom"; _san_bomstripped=1
     fi
   fi
   # A CR-only file is a single record to awk, so every rule would see one giant
@@ -233,9 +246,9 @@ sanitize_file() {
   # unredacted. Translate CR to LF for the pass and translate back after, which
   # redacts correctly and still reproduces the original bytes.
   if [ "$ENC_CRONLY" = "1" ]; then
-    if LC_ALL=C tr '\r' '\n' < "$_sanin" > "$_f.lf" 2>>"$ERRORS"; then _sanin="$_f.lf"; fi
+    if LC_ALL=C tr '\r' '\n' < "$_san_sanin" > "$_san_f.lf" 2>>"$ERRORS"; then _san_sanin="$_san_f.lf"; fi
   fi
-  if awk -v ctx="$_ctx" -v obf="$OBFUSCATE" -v mapfile="$MAP_FILE" \
+  if LC_ALL=C awk -v map_limit="$MAP_LIMIT" -v ctx="$_san_ctx" -v obf="$OBFUSCATE" -v mapfile="$MAP_FILE" \
       -v host_short="$HOST_SHORT" -v host_fqdn="$HOST_FQDN" -v run_user="$RUN_USER" '
   BEGIN {
     nsec = split("api key,apikey,token,password,passwd,pwd,secret,community,bearer,webhook,license key,auth,credential,cookie,passphrase,proxy user,proxy pass,username,dsn,private key,access key,session,recipient,account sid,priv key", SK, ",");
@@ -245,11 +258,14 @@ sanitize_file() {
       split(line, a, "\t");
       if (a[1] == "ip") { ipmap[a[2]] = a[3]; nip++; }
       else if (a[1] == "host") hostmap[a[2]] = a[3];
-      else if (a[1] == "user") { usermap[a[2]] = a[3]; if (a[3] ~ /^user-[0-9]+$/) { un = a[3]; sub(/user-/, "", un); if (un + 0 > nusr) nusr = un + 0 } }
+      else if (a[1] == "user") { nusers++; usermap[a[2]] = a[3]; if (a[3] ~ /^user-[0-9]+$/) { un = a[3]; sub(/user-/, "", un); if (un + 0 > nusr) nusr = un + 0 } }
       else if (a[1] == "ip6") { ip6map[a[2]] = a[3]; nip6++; }
-      else if (a[1] == "fqdn") { fqmap[a[2]] = a[3]; nfq++; }
+      else if (a[1] == "fqdn") { fqmap[a[2]] = a[3]; nfq++; index_hostname(a[2]); }
     }
     close(mapfile);
+  }
+  function normalize_key(key) {
+    key = tolower(key); gsub(/[-_]/, " ", key); return key;
   }
   function diagnostic_key(lk) {
     # exemptions are decided by the KEY, never the value (a secret can be any
@@ -282,8 +298,7 @@ sanitize_file() {
       # only plausible config keys: short, no sentence/shell punctuation
       # (prevents prose like "token and ... not collected: X" matching as a key)
       if (length(key) > 64 || key !~ /^[A-Za-z0-9]/ || key ~ /["`;|()\/]/) return line;
-      lk = tolower(key);
-      gsub(/[-_]/, " ", lk);
+      lk = normalize_key(key);
       if (diagnostic_key(lk)) return line;
       if (streaming_api_key(lk)) return line;
       for (i = 1; i <= nsec; i++) {
@@ -299,7 +314,7 @@ sanitize_file() {
     while (match(rest, /"[^"]+"[ \t]*:[ \t]*"([^"\\]|\\.)*"/)) {
       m = substr(rest, RSTART, RLENGTH);
       key = m; sub(/^"/, "", key); sub(/".*/, "", key);
-      lk = tolower(key); gsub(/[-_]/, " ", lk);
+      lk = normalize_key(key);
       if (!diagnostic_key(lk)) {
         for (i = 1; i <= nsec; i++) {
           if (index(lk, SK[i]) > 0) {
@@ -317,7 +332,7 @@ sanitize_file() {
     while (match(rest, /"[^"]+"[ \t]*:[ \t]*[-0-9truefalsnu][0-9truefalsnul.eE+-]*/)) {
       m = substr(rest, RSTART, RLENGTH);
       key = m; sub(/^"/, "", key); sub(/".*/, "", key);
-      lk = tolower(key); gsub(/[-_]/, " ", lk);
+      lk = normalize_key(key);
       hit = 0;
       for (i = 1; i <= nsec; i++) if (index(lk, SK[i]) > 0) hit = 1;
       if (hit && !diagnostic_key(lk)) sub(/:[ \t]*[-0-9truefalsnu][0-9truefalsnul.eE+-]*$/, ": \"[REDACTED]\"", m);
@@ -336,7 +351,7 @@ sanitize_file() {
   function pseudo_ip(ip,   p) {
     if (ip ~ /^127\./ || ip == "0.0.0.0" || ip ~ /^255\./) return ip;
     if (!(ip in ipmap)) {
-      if (nip >= 4096) return "redacted-ip";  # cap: non-correlating past 4096
+      if (nip >= map_limit) return "redacted-ip";  # cap: non-correlating past 4096
       nip++; ipmap[ip] = "ip-" nip;
       print "ip\t" ip "\t" ipmap[ip] >> mapfile;
     }
@@ -358,6 +373,7 @@ sanitize_file() {
     #   - >=3 colons or a "::" compression
     #   - contains a hex letter or a "::" (all-digit uncompressed v6 is skipped)
     # ::1 and :: are kept (loopback/wildcard).
+    if (index(line, ":") == 0) return line;
     out = ""; rest = line;
     while (match(rest, /[0-9A-Fa-f:]+/)) {
       cand = substr(rest, RSTART, RLENGTH);
@@ -372,7 +388,7 @@ sanitize_file() {
         continue;
       }
       if (!(cand in ip6map)) {
-        if (nip6 >= 4096) { out = out substr(rest, 1, RSTART - 1) "redacted-ip6"; rest = substr(rest, RSTART + RLENGTH); continue; }
+        if (nip6 >= map_limit) { out = out substr(rest, 1, RSTART - 1) "redacted-ip6"; rest = substr(rest, RSTART + RLENGTH); continue; }
         nip6++; ip6map[cand] = "ip6-" nip6;
         print "ip6\t" cand "\t" ip6map[cand] >> mapfile;
       }
@@ -383,32 +399,45 @@ sanitize_file() {
   }
   function pseudo_fqdn(h) {
     if (!(h in fqmap)) {
-      if (nfq >= 4096) return "redacted-host-overflow";  # cap: non-correlating
-      nfq++; fqmap[h] = "private-host-" nfq;
+      if (nfq >= map_limit) return "redacted-host-overflow";  # cap: non-correlating
+      nfq++; fqmap[h] = "private-host-" nfq; index_hostname(h);
       print "fqdn\t" h "\t" fqmap[h] >> mapfile;
     }
     return fqmap[h];
   }
-  function replace_mapped_fqdns(line,   h, out, idx, pre, nxt) {
-    # replace every known (pre-seeded or discovered) hostname, with word
-    # boundaries so "host1" never corrupts "host10"
-    for (h in fqmap) {
-      if (length(h) < 4) continue;
-      out = "";
-      while ((idx = index(line, h)) > 0) {
-        pre = (idx > 1) ? substr(line, idx - 1, 1) : "";
-        nxt = substr(line, idx + length(h), 1);
-        if (pre ~ /[A-Za-z0-9.-]/ || nxt ~ /[A-Za-z0-9.-]/) {
-          out = out substr(line, 1, idx + length(h) - 1);
-          line = substr(line, idx + length(h));
-          continue;
-        }
-        out = out substr(line, 1, idx - 1) fqmap[h];
-        line = substr(line, idx + length(h));
-      }
-      line = out line;
+  function index_hostname(h,   node, i, edge) {
+    # A prefix index makes matching independent of the number of mapped hosts.
+    if (length(h) < 4) return;
+    node = 0;
+    for (i = 1; i <= length(h); i++) {
+      edge = node SUBSEP substr(h, i, 1);
+      if (!(edge in hostedge)) hostedge[edge] = ++hostnodes;
+      node = hostedge[edge];
     }
-    return line;
+    hostvalue[node] = fqmap[h];
+  }
+  function replace_mapped_fqdns(line,   out, start, pos, j, node, edge, last, value, len) {
+    # Preserve the existing word boundaries. Overlapping names use the longest
+    # complete match, independent of associative-array iteration order.
+    if (!nfq) return line;
+    out = ""; start = 1; len = length(line);
+    for (pos = 1; pos <= len; pos++) {
+      if (pos > 1 && substr(line, pos - 1, 1) ~ /[A-Za-z0-9.-]/) continue;
+      node = 0; last = 0;
+      for (j = pos; j <= len; j++) {
+        edge = node SUBSEP substr(line, j, 1);
+        if (!(edge in hostedge)) break;
+        node = hostedge[edge];
+        if (node in hostvalue && substr(line, j + 1, 1) !~ /[A-Za-z0-9.-]/) {
+          last = j; value = hostvalue[node];
+        }
+      }
+      if (last) {
+        out = out substr(line, start, pos - start) value;
+        pos = last; start = last + 1;
+      }
+    }
+    return out substr(line, start);
   }
   function redact_destination(line,   pos, head, valpart, n, parts, i, tok, hostp, rest2, cpos, proto) {
     # stream.conf destination/proxy destination values are user infrastructure
@@ -493,28 +522,116 @@ sanitize_file() {
     line = gensub_home_one(line, "/Users/");
     return line;
   }
-  function pseudo_user_name(u,   p) {
+  function pseudo_user_name(u, invoking) {
     if (u == "" || u == "root") return u;
     if (!(u in usermap)) {
-      nusr++; usermap[u] = "user-" nusr;
+      if (nusers >= map_limit) return "redacted-user-overflow";
+      nusers++;
+      if (invoking) usermap[u] = "redacted-user";
+      else { nusr++; usermap[u] = "user-" nusr; }
       print "user\t" u "\t" usermap[u] >> mapfile;
     }
     return usermap[u];
   }
-  function replace_user(line, u,   out, idx) {
+  function replace_user(line, u,   out, idx, pseudonym) {
     if (u == "") return line;
-    if (!(u in usermap)) {
-      usermap[u] = "redacted-user";
-      print "user\t" u "\t" usermap[u] >> mapfile;
-    }
+    pseudonym = pseudo_user_name(u, 1);
     out = "";
     while ((idx = index(line, u)) > 0) {
-      out = out substr(line, 1, idx - 1) usermap[u];
+      out = out substr(line, 1, idx - 1) pseudonym;
       line = substr(line, idx + length(u));
     }
     return out line;
   }
+  function redact_url_credentials(line,   m) {
+    # URL creds: scheme://user:pass@  and Go DSN: user:pass@tcp(
+    while (match(line, /:\/\/[^:\/@ \t]+:[^@ \t]+@/))
+      line = substr(line, 1, RSTART - 1) "://[REDACTED]@" substr(line, RSTART + RLENGTH);
+    while (match(line, /[A-Za-z0-9_]+:[^@ \t]+@(tcp|unix)\(/)) {
+      m = substr(line, RSTART, RLENGTH);
+      line = substr(line, 1, RSTART - 1) "[REDACTED]" substr(m, index(m, "@")) substr(line, RSTART + RLENGTH);
+    }
+    return line;
+  }
+  function redact_authentication(line) {
+    # JWTs (the eyJ prefix is base64 for double-quote-brace)
+    while (match(line, /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/))
+      line = substr(line, 1, RSTART - 1) "[REDACTED-JWT]" substr(line, RSTART + RLENGTH);
+    # HTTP auth header values anywhere in a line (headers in configs, curl -v, logs).
+    # The value must contain a digit: real bearer tokens do, English words after
+    # "bearer" in config prose ("bearer token protection = no") do not.
+    while (match(line, /[Bb]earer[ \t]+[A-Za-z._~+\/=-]*[0-9][A-Za-z0-9._~+\/=-]*/))
+      line = substr(line, 1, RSTART - 1) "Bearer [REDACTED]" substr(line, RSTART + RLENGTH);
+    while (match(line, /[Bb]asic[ \t]+[A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=]+/))
+      line = substr(line, 1, RSTART - 1) "Basic [REDACTED]" substr(line, RSTART + RLENGTH);
+    return line;
+  }
+  function redact_query_parameters(line,   out, rest) {
+    # secrets passed as URL query parameters (access.log request lines etc.)
+    out = ""; rest = line;
+    while (match(rest, /[?&][A-Za-z0-9_.-]*(token|apikey|api_key|access_key|private_key|secret_key|password|passwd|secret|bearer|claim_token|claim_rooms|key|auth)=/)) {
+      out = out substr(rest, 1, RSTART + RLENGTH - 1) "[REDACTED]";
+      rest = substr(rest, RSTART + RLENGTH);
+      sub(/^[^&" \t]+/, "", rest);
+    }
+    line = out rest;
+    return line;
+  }
+  function redact_arguments(line,   out, rest, m, lk) {
+    # argv/env-style secrets mid-line (ps output, command lines: -token=X, CLAIM_TOKEN=X)
+    out = ""; rest = line;
+    while (match(rest, /[A-Za-z0-9_.-]*(token|TOKEN|Token|password|PASSWORD|Password|passwd|PASSWD|secret|SECRET|Secret|apikey|APIKEY|ApiKey|api_key|API_KEY|community|COMMUNITY|bearer|BEARER)[ ]?[=:][ ]?[^&" \t[]+/)) {
+      m = substr(rest, RSTART, RLENGTH);
+      sub(/[ ]?[=:].*/, "", m);
+      lk = normalize_key(m);
+      if (diagnostic_key(lk))
+        out = out substr(rest, 1, RSTART + RLENGTH - 1);
+      else
+        out = out substr(rest, 1, RSTART - 1) m "=[REDACTED]";
+      rest = substr(rest, RSTART + RLENGTH);
+    }
+    line = out rest;
+    # two-word secret keys mid-line ("api key = X" inside a captured command line)
+    out = ""; rest = line;
+    while (match(rest, /([Aa][Pp][Ii]|[Ll][Ii][Cc][Ee][Nn][Ss][Ee]|[Aa][Uu][Tt][Hh]|[Aa][Cc][Cc][Ee][Ss][Ss])[ ][Kk][Ee][Yy][ ]?=[ ]?[^&" \t[]+|[Pp][Rr][Oo][Xx][Yy][ ]([Uu][Ss][Ee][Rr]|[Pp][Aa][Ss][Ss]([Ww][Oo][Rr][Dd])?)[ ]?=[ ]?[^&" \t[]+/)) {
+      m = substr(rest, RSTART, RLENGTH);
+      sub(/[ ]?=.*/, "", m);
+      lk = normalize_key(m);
+      if (diagnostic_key(lk) || streaming_api_key(lk))
+        out = out substr(rest, 1, RSTART + RLENGTH - 1);
+      else
+        out = out substr(rest, 1, RSTART - 1) m " = [REDACTED]";
+      rest = substr(rest, RSTART + RLENGTH);
+    }
+    line = out rest;
+    return line;
+  }
+  function obfuscate_pii(line) {
+    # emails
+    while (match(line, /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z][A-Za-z]+/))
+      line = substr(line, 1, RSTART - 1) "[EMAIL]" substr(line, RSTART + RLENGTH);
+    # MACs
+    while (match(line, /[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]/))
+      line = substr(line, 1, RSTART - 1) "[MAC]" substr(line, RSTART + RLENGTH);
+    if (line ~ /^[ \t#]*(proxy )?destination[ \t]*=/) line = redact_destination(line);
+    line = replace_ips(line);
+    line = replace_ip6(line);
+    line = replace_private_fqdns(line);
+    line = replace_mapped_fqdns(line);
+    if (host_fqdn != "") line = replace_host(line, host_fqdn);
+    if (host_short != "") line = replace_host(line, host_short);
+    if (run_user != "") line = replace_user(line, run_user);
+    # other local users appear in mount tables / paths when run as root
+    line = gensub_home(line);
+    return line;
+  }
+
   {
+    if (ctx == "host-seed") {
+      if (length($0) >= 4 && $0 != "localhost" && $0 != host_short && $0 != host_fqdn)
+        pseudo_fqdn($0);
+      next;
+    }
     # NOTE: no {n,m} regex intervals anywhere in this program - older BSD awks
     # treat them as literal braces, which would silently disable redaction.
     # Split a CRLF terminator off first and re-append it at print time. Two
@@ -552,120 +669,61 @@ sanitize_file() {
     }
     line = redact_kv(line);
     if (line ~ /"[^"]+"[ \t]*:[ \t]*/) line = redact_json(line);
-    # URL creds: scheme://user:pass@  and Go DSN: user:pass@tcp(
-    while (match(line, /:\/\/[^:\/@ \t]+:[^@ \t]+@/))
-      line = substr(line, 1, RSTART - 1) "://[REDACTED]@" substr(line, RSTART + RLENGTH);
-    while (match(line, /[A-Za-z0-9_]+:[^@ \t]+@(tcp|unix)\(/)) {
-      m = substr(line, RSTART, RLENGTH);
-      line = substr(line, 1, RSTART - 1) "[REDACTED]" substr(m, index(m, "@")) substr(line, RSTART + RLENGTH);
-    }
-    # JWTs (the eyJ prefix is base64 for double-quote-brace)
-    while (match(line, /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/))
-      line = substr(line, 1, RSTART - 1) "[REDACTED-JWT]" substr(line, RSTART + RLENGTH);
-    # HTTP auth header values anywhere in a line (headers in configs, curl -v, logs).
-    # The value must contain a digit: real bearer tokens do, English words after
-    # "bearer" in config prose ("bearer token protection = no") do not.
-    while (match(line, /[Bb]earer[ \t]+[A-Za-z._~+\/=-]*[0-9][A-Za-z0-9._~+\/=-]*/))
-      line = substr(line, 1, RSTART - 1) "Bearer [REDACTED]" substr(line, RSTART + RLENGTH);
-    while (match(line, /[Bb]asic[ \t]+[A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=][A-Za-z0-9+\/=]+/))
-      line = substr(line, 1, RSTART - 1) "Basic [REDACTED]" substr(line, RSTART + RLENGTH);
-    # secrets passed as URL query parameters (access.log request lines etc.)
-    out = ""; rest = line;
-    while (match(rest, /[?&][A-Za-z0-9_.-]*(token|apikey|api_key|access_key|private_key|secret_key|password|passwd|secret|bearer|claim_token|claim_rooms|key|auth)=/)) {
-      out = out substr(rest, 1, RSTART + RLENGTH - 1) "[REDACTED]";
-      rest = substr(rest, RSTART + RLENGTH);
-      sub(/^[^&" \t]+/, "", rest);
-    }
-    line = out rest;
-    # argv/env-style secrets mid-line (ps output, command lines: -token=X, CLAIM_TOKEN=X)
-    out = ""; rest = line;
-    while (match(rest, /[A-Za-z0-9_.-]*(token|TOKEN|Token|password|PASSWORD|Password|passwd|PASSWD|secret|SECRET|Secret|apikey|APIKEY|ApiKey|api_key|API_KEY|community|COMMUNITY|bearer|BEARER)[ ]?[=:][ ]?[^&" \t[]+/)) {
-      m = substr(rest, RSTART, RLENGTH);
-      sub(/[ ]?[=:].*/, "", m);
-      lk = tolower(m); gsub(/[-_]/, " ", lk);
-      if (diagnostic_key(lk))
-        out = out substr(rest, 1, RSTART + RLENGTH - 1);
-      else
-        out = out substr(rest, 1, RSTART - 1) m "=[REDACTED]";
-      rest = substr(rest, RSTART + RLENGTH);
-    }
-    line = out rest;
-    # two-word secret keys mid-line ("api key = X" inside a captured command line)
-    out = ""; rest = line;
-    while (match(rest, /([Aa][Pp][Ii]|[Ll][Ii][Cc][Ee][Nn][Ss][Ee]|[Aa][Uu][Tt][Hh]|[Aa][Cc][Cc][Ee][Ss][Ss])[ ][Kk][Ee][Yy][ ]?=[ ]?[^&" \t[]+|[Pp][Rr][Oo][Xx][Yy][ ]([Uu][Ss][Ee][Rr]|[Pp][Aa][Ss][Ss]([Ww][Oo][Rr][Dd])?)[ ]?=[ ]?[^&" \t[]+/)) {
-      m = substr(rest, RSTART, RLENGTH);
-      sub(/[ ]?=.*/, "", m);
-      lk = tolower(m); gsub(/[-_]/, " ", lk);
-      if (diagnostic_key(lk) || streaming_api_key(lk))
-        out = out substr(rest, 1, RSTART + RLENGTH - 1);
-      else
-        out = out substr(rest, 1, RSTART - 1) m " = [REDACTED]";
-      rest = substr(rest, RSTART + RLENGTH);
-    }
-    line = out rest;
-    if (obf == 1) {
-      # emails
-      while (match(line, /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z][A-Za-z]+/))
-        line = substr(line, 1, RSTART - 1) "[EMAIL]" substr(line, RSTART + RLENGTH);
-      # MACs
-      while (match(line, /[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]/))
-        line = substr(line, 1, RSTART - 1) "[MAC]" substr(line, RSTART + RLENGTH);
-      if (line ~ /^[ \t#]*(proxy )?destination[ \t]*=/) line = redact_destination(line);
-      line = replace_ips(line);
-      line = replace_ip6(line);
-      line = replace_private_fqdns(line);
-      line = replace_mapped_fqdns(line);
-      if (host_fqdn != "") line = replace_host(line, host_fqdn);
-      if (host_short != "") line = replace_host(line, host_short);
-      if (run_user != "") line = replace_user(line, run_user);
-      # other local users appear in mount tables / paths when run as root
-      line = gensub_home(line);
-    }
+    line = redact_url_credentials(line);
+    line = redact_authentication(line);
+    line = redact_query_parameters(line);
+    line = redact_arguments(line);
+    if (obf == 1) line = obfuscate_pii(line);
     print line cr;
-  }' "$_sanin" > "$_f.san" 2>>"$ERRORS"; then
+  }' "$_san_sanin" > "$_san_f.san" 2>>"$ERRORS"; then
     if [ "$ENC_CRONLY" = "1" ]; then
-      LC_ALL=C tr '\n' '\r' < "$_f.san" > "$_f.san2" 2>>"$ERRORS" && mv "$_f.san2" "$_f.san"
+      LC_ALL=C tr '\n' '\r' < "$_san_f.san" > "$_san_f.san2" 2>>"$ERRORS" && mv "$_san_f.san2" "$_san_f.san"
     fi
     # restore the exact BOM bytes the source had, so an encoding fault in the
     # user's file is still visible in the bundle
-    if [ "$_bomstripped" = "1" ]; then
-      head -c "$ENC_BOM_BYTES" "$_f" > "$_f.out" 2>>"$ERRORS"
+    if [ "$_san_bomstripped" = "1" ]; then
+      head -c "$ENC_BOM_BYTES" "$_san_f" > "$_san_f.out" 2>>"$ERRORS"
     else
-      : > "$_f.out"
+      : > "$_san_f.out"
     fi
-    cat "$_f.san" >> "$_f.out"
+    cat "$_san_f.san" >> "$_san_f.out"
     # awk always terminates its last line: drop that byte again when the source
     # had no final newline, so a truncated source file still looks truncated
     if [ "$ENC_FINAL" = "false" ]; then
-      _osz=$(wc -c < "$_f.out" | tr -d ' ')
-      _lastout=$(tail -c 1 "$_f.out" 2>/dev/null | od -An -tx1 | tr -d ' \n')
-      if [ "${_osz:-0}" -gt 0 ] && { [ "$_lastout" = "0a" ] || [ "$_lastout" = "0d" ]; }; then
-        head -c "$((_osz - 1))" "$_f.out" > "$_f.out2" 2>>"$ERRORS" && mv "$_f.out2" "$_f.out"
+      _san_osz=$(wc -c < "$_san_f.out" | tr -d ' ')
+      _san_lastout=$(tail -c 1 "$_san_f.out" 2>/dev/null | od -An -tx1 | tr -d ' \n')
+      if [ "${_san_osz:-0}" -gt 0 ] && { [ "$_san_lastout" = "0a" ] || [ "$_san_lastout" = "0d" ]; }; then
+        head -c "$((_san_osz - 1))" "$_san_f.out" > "$_san_f.out2" 2>>"$ERRORS" && mv "$_san_f.out2" "$_san_f.out"
       fi
     fi
-    mv "$_f.out" "$_f"
-    rm -f "$_f.san" "$_f.nobom" "$_f.lf" "$_f.out2"
+    mv "$_san_f.out" "$_san_f"
+    rm -f "$_san_f.san" "$_san_f.nobom" "$_san_f.lf" "$_san_f.out2"
   else
     # fail CLOSED: never ship content the sanitizer could not process
-    rm -f "$_f.san" "$_f.san2" "$_f.nobom" "$_f.lf" "$_f.out" "$_f.out2"
-    echo "[netdata-support-bundle] sanitization failed for this file - content withheld for safety" > "$_f"
+    rm -f "$_san_f.san" "$_san_f.san2" "$_san_f.nobom" "$_san_f.lf" "$_san_f.out" "$_san_f.out2"
+    echo "[netdata-support-bundle] sanitization failed for this file - content withheld for safety" > "$_san_f"
   fi
 }
 
 # --- manifest ----------------------------------------------------------------
 # manifest_add <rel-path> <kind:cmd|file|api> <origin> <title> [raw:0|1]
-json_str() { # collapse newlines/tabs, escape backslashes and quotes
-  _js="$1"
-  printf '%s' "$_js" | tr '\n\t' '  ' | sed 's/\\/\\\\/g; s/"/\\"/g'
+json_str() { # JSON-escape every control byte, including in source filenames.
+  printf '%s' "$1" | LC_ALL=C od -An -v -tu1 | LC_ALL=C awk '
+    { for (i = 1; i <= NF; i++) {
+        n = $i + 0;
+        if (n == 34 || n == 92) printf "\\%c", n;
+        else if (n < 32) printf "\\u%04x", n;
+        else printf "%c", n;
+    } }'
 }
 manifest_add() {
-  _rel="$1"; _kind="$2"; _origin="$3"; _title="$4"; _raw="${5:-0}"
-  _bytes=0; [ -f "$WORK/$_rel" ] && _bytes=$(wc -c < "$WORK/$_rel" | tr -d ' ')
+  _ma_rel="$1"; _ma_kind="$2"; _ma_origin="$3"; _ma_title="$4"; _ma_raw="${5:-0}"
+  _ma_bytes=0; [ -f "$WORK/$_ma_rel" ] && _ma_bytes=$(wc -c < "$WORK/$_ma_rel" | tr -d ' ')
   printf '{"path":"%s","kind":"%s","origin":"%s","title":"%s","bytes":%s,"pii_obfuscated":%s,"sanitized":%s}
 ' \
-    "$(json_str "$_rel")" "$_kind" "$(json_str "$_origin")" "$(json_str "$_title")" "$_bytes" \
-    "$([ "$OBFUSCATE" = "1" ] && [ "$_raw" = "0" ] && echo true || echo false)" \
-    "$([ "$_raw" = "0" ] && echo true || echo false)" >> "$MANIFEST_ROWS"
+    "$(json_str "$_ma_rel")" "$_ma_kind" "$(json_str "$_ma_origin")" "$(json_str "$_ma_title")" "$_ma_bytes" \
+    "$([ "$OBFUSCATE" = "1" ] && [ "$_ma_raw" = "0" ] && echo true || echo false)" \
+    "$([ "$_ma_raw" = "0" ] && echo true || echo false)" >> "$MANIFEST_ROWS"
 }
 
 
@@ -791,122 +849,143 @@ collect_snmp_diagnostics() {
 # --- end SNMP diagnostics ------------------------------------------------------
 
 # --- collectors ---------------------------------------------------------------
-# collect_cmd <rel-path> <title> <cmd...>
+# command_origin <argv...> - keep command provenance on one readable line.
+command_origin() {
+  printf '%s' "$*" | tr '\n\t' '  ' | tr -s ' '
+}
+
+# capture_output <file> <byte-limit> <merge-stderr:0|1> <command...>
+# The caller supplies the timeout wrapper. Results: CAPTURE_RC, CAPTURE_BYTES.
+# Keep the producer status separately: POSIX pipelines only report the consumer.
+capture_output() {
+  _co_out="$1"; _co_limit="$2"; _co_merge="$3"; shift 3
+  {
+    if [ "$_co_merge" = 1 ]; then "$@" 2>&1
+    else "$@" 2>>"$ERRORS"
+    fi
+    printf '%s\n' "$?" > "$_co_out.rc"
+  } | head -c "$_co_limit" > "$_co_out"
+  _co_write_rc=$?
+  CAPTURE_RC=$(cat "$_co_out.rc" 2>/dev/null || echo unknown)
+  rm -f "$_co_out.rc"
+  CAPTURE_BYTES=$(wc -c < "$_co_out" | tr -d ' ')
+  [ "$_co_write_rc" = 0 ] || CAPTURE_RC="$_co_write_rc"
+}
+
+# collect_cmd [--cap BYTES] <rel-path> <title> <command...>
 collect_cmd() {
-  # optional: --cap BYTES overrides the default output cap (journal captures
-  # are documented at 5 MiB while command output defaults to 2 MiB)
-  _ccap="$API_CAP"
-  _first="${1:-}"
-  if [ "$_first" = "--cap" ]; then _ccap="$2"; shift 2; fi
-  _rel="$1"; _title="$2"; shift 2
-  _out="$WORK/$_rel"
-  mkdir -p "$(dirname "$_out")"
+  _cc_cap="$API_CAP"
+  if [ "${1:-}" = "--cap" ]; then _cc_cap="$2"; shift 2; fi
+  _cc_rel="$1"; _cc_title="$2"; shift 2
+  _cc_out="$WORK/$_cc_rel"
+  mkdir -p "$(dirname "$_cc_out")"
   if deadline_exceeded; then
-    echo "SKIPPED: global deadline reached" > "$_out"
-    manifest_add "$_rel" "cmd" "skipped" "$_title (skipped: deadline)"
+    echo "SKIPPED: global deadline reached" > "$_cc_out"
+    manifest_add "$_cc_rel" cmd skipped "$_cc_title (skipped: deadline)"
     return 0
   fi
-  _t0=$(now_s)
-  # header must stay a single line even for multi-line sh -c scripts
-  # shellcheck disable=SC1003  # literal backslash deletion, not a quote escape
-  _cmdline=$(printf '%s' "$*" | tr -d '\\' | tr '\n\t' '  ' | tr -s ' ')
-  { run_capped "$CMD_TIMEOUT" "$@" 2>&1; echo "$?" > "$_out.rc"; } | head -c "$((_ccap * 4))" > "$_out.raw"
-  _rc=$(cat "$_out.rc" 2>/dev/null || echo '?'); rm -f "$_out.rc"
-  _raw_size=$(wc -c < "$_out.raw" | tr -d ' ')
+  _cc_start=$(now_s)
+  _cc_origin=$(command_origin "$@")
+  capture_output "$_cc_out.raw" "$((_cc_cap * 4))" 1 run_capped "$CMD_TIMEOUT" "$@"
   {
-    printf '# netdata-support-bundle v%s | command: %s | captured: %s\n' "$VERSION" "$_cmdline" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    awk -v cap="$_ccap" 'BEGIN { b = 0 } { b += length($0) + 1; if (b > cap) exit; print }' "$_out.raw"
-    [ "$_raw_size" -gt "$_ccap" ] && printf '### TRUNCATED: output was %s bytes, first %s kept (line-aligned) ###\n' "$_raw_size" "$_ccap"
-    printf '# exit: %s | duration: %ss\n' "$_rc" "$(( $(now_s) - _t0 ))"
-  } > "$_out"
-  rm -f "$_out.raw"
-  sanitize_file "$_out"
-  manifest_add "$_rel" "cmd" "$_cmdline" "$_title"
+    printf '# netdata-support-bundle v%s | command: %s | captured: %s\n' "$VERSION" "$_cc_origin" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    LC_ALL=C awk -v cap="$_cc_cap" 'BEGIN { b = 0 } { b += length($0) + 1; if (b > cap) exit; print }' "$_cc_out.raw"
+    [ "$CAPTURE_BYTES" -gt "$_cc_cap" ] && printf '### TRUNCATED: captured %s bytes, first ~%s kept (line-aligned) ###\n' "$CAPTURE_BYTES" "$_cc_cap"
+    printf '# exit: %s | duration: %ss\n' "$CAPTURE_RC" "$(( $(now_s) - _cc_start ))"
+  } > "$_cc_out"
+  rm -f "$_cc_out.raw"
+  sanitize_file "$_cc_out"
+  manifest_add "$_cc_rel" cmd "$_cc_origin" "$_cc_title"
 }
 
 # collect_file <rel-path> <title> <source-file> [cap-bytes]
 collect_file() {
-  _rel="$1"; _title="$2"; _src="$3"; _cap="${4:-$FILE_CAP}"
+  _cf_rel="$1"; _cf_title="$2"; _cf_src="$3"; _cf_cap="${4:-$FILE_CAP}"
   deadline_exceeded && return 0
-  [ -f "$_src" ] && [ -r "$_src" ] || return 0
+  [ -f "$_cf_src" ] && [ -r "$_cf_src" ] || return 0
   # stream.conf is the one file whose streaming API key is kept verbatim; the
   # context is keyed on the SOURCE name, never on the bundle path
-  _fctx=""
-  case "${_src##*/}" in stream.conf) _fctx="stream" ;; *) : ;; esac
+  _cf_fctx=""
+  case "${_cf_src##*/}" in stream.conf) _cf_fctx="stream" ;; *) : ;; esac
   # a symlinked final component is not a real config/log file we chose to
   # collect; refuse it so a swapped link cannot redirect us to another target
   # (symlinked parent DIRECTORIES resolve normally - only the leaf is checked)
-  if [ -h "$_src" ]; then
-    _out="$WORK/$_rel"; mkdir -p "$(dirname "$_out")"
-    echo "[content withheld: source is a symlink]" > "$_out"
-    manifest_add "$_rel" "file" "$_src (symlink, withheld)" "$_title"
+  if [ -h "$_cf_src" ]; then
+    _cf_out="$WORK/$_cf_rel"; mkdir -p "$(dirname "$_cf_out")"
+    echo "[content withheld: source is a symlink]" > "$_cf_out"
+    manifest_add "$_cf_rel" "file" "$_cf_src (symlink, withheld)" "$_cf_title"
     return 0
   fi
-  _out="$WORK/$_rel"; mkdir -p "$(dirname "$_out")"
-  _size=$(wc -c < "$_src" 2>/dev/null | tr -d ' ')
-  if [ "${_size:-0}" -gt "$_cap" ]; then
+  _cf_out="$WORK/$_cf_rel"; mkdir -p "$(dirname "$_cf_out")"
+  _cf_size=$(wc -c < "$_cf_src" 2>/dev/null | tr -d ' ')
+  if [ "${_cf_size:-0}" -gt "$_cf_cap" ]; then
     # cap at a LINE boundary (drop the first, possibly partial, line) so a
     # secret can never straddle the cut and dodge the line-based sanitizer
-    tail -c "$_cap" "$_src" 2>>"$ERRORS" | tail -n +2 > "$_out"
-    if [ ! -s "$_out" ]; then
+    tail -c "$_cf_cap" "$_cf_src" 2>>"$ERRORS" | tail -n +2 > "$_cf_out"
+    if [ ! -s "$_cf_out" ]; then
       # the whole tail was one giant line: withhold rather than risk a
       # mid-token cut hiding a secret from the line-based sanitizer
-      echo "[content withheld: file tail exceeds the cap without a line break]" > "$_out"
+      echo "[content withheld: file tail exceeds the cap without a line break]" > "$_cf_out"
     fi
-    _origin="$_src (last ~$_cap of $_size bytes, line-aligned)"
+    _cf_origin="$_cf_src (last ~$_cf_cap of $_cf_size bytes, line-aligned)"
   else
-    cat "$_src" > "$_out" 2>>"$ERRORS"
-    _origin="$_src"
+    cat "$_cf_src" > "$_cf_out" 2>>"$ERRORS"
+    _cf_origin="$_cf_src"
   fi
-  sanitize_file "$_out" "$_fctx"
-  manifest_add "$_rel" "file" "$_origin" "$_title"
+  sanitize_file "$_cf_out" "$_cf_fctx"
+  manifest_add "$_cf_rel" "file" "$_cf_origin" "$_cf_title"
 }
 
-# collect_cmd_raw <rel-path> <title> <cmd...> - like collect_cmd but with NO
-# provenance header/trailer, for commands whose output must stay parseable
-# (JSON). Provenance lives in MANIFEST.json. Removed if the command yields nothing.
-collect_cmd_raw() {
-  _rel="$1"; _title="$2"; shift 2
-  _out="$WORK/$_rel"
+# collect_body <rel-path> <title> <kind> <origin> <command...>
+# Pristine captures have no text provenance. Failures/overflow replace the whole
+# body with a JSON marker; successful empty output remains omitted.
+collect_body() {
+  _cb_rel="$1"; _cb_title="$2"; _cb_kind="$3"; _cb_origin="$4"; shift 4
   deadline_exceeded && return 0
-  mkdir -p "$(dirname "$_out")"
-  # shellcheck disable=SC1003  # literal backslash deletion, not a quote escape
-  _cmdline=$(printf '%s' "$*" | tr -d '\\' | tr '\n\t' '  ' | tr -s ' ')
-  run_capped "$CMD_TIMEOUT" "$@" 2>>"$ERRORS" | head -c "$((API_CAP + 1))" > "$_out"
-  if [ "$(wc -c < "$_out" | tr -d ' ')" -gt "$API_CAP" ]; then
-    # a truncated JSON document is worse than none: fail closed
-    echo '{"error":"output exceeded the cap and was withheld"}' > "$_out"
+  _cb_out="$WORK/$_cb_rel"
+  mkdir -p "$(dirname "$_cb_out")"
+  capture_output "$_cb_out" "$((API_CAP + 1))" 0 "$@"
+  if [ "$CAPTURE_BYTES" -gt "$API_CAP" ]; then
+    echo '{"error":"output exceeded the cap and was withheld"}' > "$_cb_out"
+  elif [ "$CAPTURE_RC" != 0 ]; then
+    printf '{"error":"capture failed; partial output withheld","exit_code":"%s"}\n' "$CAPTURE_RC" > "$_cb_out"
   fi
-  if [ -s "$_out" ]; then
-    sanitize_file "$_out"
-    manifest_add "$_rel" "cmd" "$_cmdline" "$_title"
+  if [ -s "$_cb_out" ]; then
+    sanitize_file "$_cb_out"
+    manifest_add "$_cb_rel" "$_cb_kind" "$_cb_origin" "$_cb_title"
   else
-    rm -f "$_out"
+    rm -f "$_cb_out"
   fi
 }
+
+# collect_cmd_raw <rel-path> <title> <command...>
+collect_cmd_raw() {
+  _cr_rel="$1"; _cr_title="$2"; shift 2
+  collect_body "$_cr_rel" "$_cr_title" cmd "$(command_origin "$@")" run_capped "$CMD_TIMEOUT" "$@"
+}
+
+# api_request <seconds> <url-path> - all local reads share the same transport.
+# Subshell confines proxy overrides to the request, preserving Cloud probes.
+api_request() (
+  _ar_seconds="$1"; _ar_url="http://127.0.0.1:${NDPORT}$2"
+  unset http_proxy HTTP_PROXY https_proxy HTTPS_PROXY all_proxy ALL_PROXY
+  no_proxy='*'; NO_PROXY='*'; export no_proxy NO_PROXY
+  if command -v curl >/dev/null 2>&1; then
+    run_capped "$_ar_seconds" curl -q -sf --noproxy '*' --max-time "$_ar_seconds" "$_ar_url"
+  elif command -v wget >/dev/null 2>&1; then
+    if wget --help 2>&1 | grep -q -- '--no-proxy'; then
+      run_capped "$_ar_seconds" wget --no-proxy -q -T "$_ar_seconds" -O - "$_ar_url"
+    else
+      run_capped "$_ar_seconds" wget -Y off -q -T "$_ar_seconds" -O - "$_ar_url"
+    fi
+  else
+    return 127
+  fi
+)
 
 # collect_api <rel-path> <title> <url-path>
-NDPORT=19999
-api_ok=0
 collect_api() {
-  _rel="$1"; _title="$2"; _upath="$3"; _url="http://127.0.0.1:${NDPORT}${_upath}"
-  deadline_exceeded && return 0
-  _out="$WORK/$_rel"; mkdir -p "$(dirname "$_out")"
-  if command -v curl >/dev/null 2>&1; then
-    curl -sf --max-time "$CMD_TIMEOUT" "$_url" 2>>"$ERRORS" | head -c "$((API_CAP + 1))" > "$_out"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q -T "$CMD_TIMEOUT" -O - "$_url" 2>>"$ERRORS" | head -c "$((API_CAP + 1))" > "$_out"
-  fi
-  # a JSON body cut at any point is malformed, so overflow is withheld whole
-  if [ "$(wc -c < "$_out" 2>/dev/null | tr -d ' ')" -gt "$API_CAP" ]; then
-    echo '{"error":"response exceeded the cap and was withheld"}' > "$_out"
-  fi
-  if [ -s "$_out" ]; then
-    sanitize_file "$_out"
-    manifest_add "$_rel" "api" "$_upath" "$_title"
-  else
-    rm -f "$_out"
-  fi
+  collect_body "$1" "$2" api "$3" api_request "$CMD_TIMEOUT" "$3"
 }
 
 # --- sanitizer regression vectors (run with --selftest; extend when adding
@@ -1097,621 +1176,622 @@ STREAMVEC
   echo "netdata-support-bundle selftest: $_fails FAILURE(S)" >&2
   exit 1
 }
-[ "$SELFTEST" = "1" ] && run_selftest
 
-# --- environment detection ------------------------------------------------------
-# Prefer the exact daemon command name: pidof can also return Netdata helper
-# processes whose executable names or invocation paths contain "netdata".
-NETDATA_PID=$(ps -eo pid=,comm= 2>/dev/null | awk '$2=="netdata"{print $1; exit}')
-[ -z "${NETDATA_PID:-}" ] && NETDATA_PID=$(pidof netdata 2>/dev/null | awk '{print $1}')
-export NETDATA_PID
+# Discover hostnames before collecting files so pseudonyms correlate throughout.
+seed_hostnames() {
+  deadline_exceeded && return 0
+  capture_output "$STAGING/node-seed.json" "$((API_CAP + 1))" 0 api_request 5 /api/v2/node_instances
+  [ "$CAPTURE_RC" = 0 ] && [ "$CAPTURE_BYTES" -le "$API_CAP" ] || return 0
+  tr ',{' '\n' < "$STAGING/node-seed.json" | awk '
+    match($0, /"(nm|hostname)" *: *"/) {
+      value = substr($0, RSTART + RLENGTH); sub(/".*/, "", value);
+      if (value != "") print value;
+    }' > "$STAGING/host-seed.txt"
+  sanitize_file "$STAGING/host-seed.txt" host-seed
+}
 
-# Include plugin processes by walking the live parent/child relationship. A
-# fixed process-name list misses custom plugin launchers and can match unrelated
-# services; socket ownership stays limited to this Netdata process tree.
-NETDATA_PIDS="${NETDATA_PID:-}"
-if [ -n "${NETDATA_PID:-}" ]; then
-  _proc_tree=$(ps -eo pid=,ppid= 2>/dev/null | awk -v root="$NETDATA_PID" '
-    { pid=$1; parent[pid]=$2 }
-    END {
-      owned[root]=1; changed=1
-      while (changed) {
-        changed=0
-        for (pid in parent) if (!owned[pid] && owned[parent[pid]]) {
-          owned[pid]=1; changed=1
-        }
-      }
-      for (pid in owned) if (owned[pid]) print pid
-    }' | sort -n)
-  [ -n "$_proc_tree" ] && NETDATA_PIDS="$_proc_tree"
-fi
-export NETDATA_PIDS
+discover_environment() {
+  # --- environment detection ------------------------------------------------------
+  # Prefer the exact daemon command name: pidof can also return Netdata helper
+  # processes whose executable names or invocation paths contain "netdata".
+  NETDATA_PID=$(ps -eo pid=,comm= 2>/dev/null | awk '$2=="netdata"{print $1; exit}')
+  [ -z "${NETDATA_PID:-}" ] && NETDATA_PID=$(pidof netdata 2>/dev/null | awk '{print $1}')
+  export NETDATA_PID
 
-# path candidates per install type: FHS packages, static (/opt/netdata),
-# FreeBSD ports (/usr/local + /var/db), Homebrew (incl. Apple Silicon prefix)
-CONFDIR=""
-for d in /etc/netdata /opt/netdata/etc/netdata /usr/local/etc/netdata /opt/homebrew/etc/netdata; do
-  [ -d "$d" ] && { CONFDIR="$d"; break; }
-done
-LOGDIR=""
-for d in /var/log/netdata /opt/netdata/var/log/netdata /usr/local/var/log/netdata /opt/homebrew/var/log/netdata; do
-  [ -d "$d" ] && { LOGDIR="$d"; break; }
-done
-LIBDIR=""
-for d in /var/lib/netdata /opt/netdata/var/lib/netdata /var/db/netdata /usr/local/var/lib/netdata /opt/homebrew/var/lib/netdata; do
-  [ -d "$d" ] && { LIBDIR="$d"; break; }
-done
-CACHEDIR=""
-for d in /var/cache/netdata /opt/netdata/var/cache/netdata /var/db/netdata/cache /usr/local/var/cache/netdata /opt/homebrew/var/cache/netdata; do
-  [ -d "$d" ] && { CACHEDIR="$d"; break; }
-done
-
-NETDATA_BIN=$(command -v netdata 2>/dev/null)
-[ -z "${NETDATA_BIN:-}" ] && [ -n "${NETDATA_PID:-}" ] && [ -r "/proc/$NETDATA_PID/exe" ] && \
-  NETDATA_BIN=$(readlink -f "/proc/$NETDATA_PID/exe" 2>/dev/null)
-[ -z "${NETDATA_BIN:-}" ] && [ -x /opt/netdata/usr/sbin/netdata ] && NETDATA_BIN=/opt/netdata/usr/sbin/netdata
-
-# probe /api/v3/info first: it stays reachable even under bearer protection,
-# where /api/v1/* is locked (so a protected-but-running agent isn't mis-flagged)
-for _probe in /api/v3/info /api/v1/info; do
-  if command -v curl >/dev/null 2>&1 && curl -sf --max-time 3 "http://127.0.0.1:${NDPORT}${_probe}" >/dev/null 2>&1; then
-    api_ok=1; break
-  elif command -v wget >/dev/null 2>&1 && wget -q -T 3 -O /dev/null "http://127.0.0.1:${NDPORT}${_probe}" 2>/dev/null; then
-    api_ok=1; break
-  fi
-done
-
-# pre-seed child/mirrored node hostnames so they pseudonymize consistently in
-# EVERY file (node_instances, stream configs, logs). Their real names stay in
-# the local map for the user to decode.
-if [ "$api_ok" = "1" ]; then
-  _seed_n=0
-  set -f
-  for _h in $( { curl -sf --max-time 5 "http://127.0.0.1:${NDPORT}/api/v2/node_instances" 2>/dev/null || wget -q -T 5 -O - "http://127.0.0.1:${NDPORT}/api/v2/node_instances" 2>/dev/null; }       | tr ',{' '\n' | awk 'match($0, /"(nm|hostname)" *: *"/) { _v = substr($0, RSTART + RLENGTH); sub(/".*/, "", _v); if (_v != "") print _v }' | sort -u); do
-    [ "$_h" = "$HOST_SHORT" ] && continue
-    [ "$_h" = "$HOST_FQDN" ] && continue
-    [ "$_h" = "localhost" ] && continue
-    [ ${#_h} -lt 4 ] && continue
-    _seed_n=$((_seed_n + 1))
-    printf 'fqdn\t%s\tprivate-host-%s\n' "$_h" "$_seed_n" >> "$MAP_FILE"
+  # path candidates per install type: FHS packages, static (/opt/netdata),
+  # FreeBSD ports (/usr/local + /var/db), Homebrew (incl. Apple Silicon prefix)
+  CONFDIR=""
+  for d in /etc/netdata /opt/netdata/etc/netdata /usr/local/etc/netdata /opt/homebrew/etc/netdata; do
+    [ -d "$d" ] && { CONFDIR="$d"; break; }
   done
-  set +f
-fi
+  LOGDIR=""
+  for d in /var/log/netdata /opt/netdata/var/log/netdata /usr/local/var/log/netdata /opt/homebrew/var/log/netdata; do
+    [ -d "$d" ] && { LOGDIR="$d"; break; }
+  done
+  LIBDIR=""
+  for d in /var/lib/netdata /opt/netdata/var/lib/netdata /var/db/netdata /usr/local/var/lib/netdata /opt/homebrew/var/lib/netdata; do
+    [ -d "$d" ] && { LIBDIR="$d"; break; }
+  done
+  CACHEDIR=""
+  for d in /var/cache/netdata /opt/netdata/var/cache/netdata /var/db/netdata/cache /usr/local/var/cache/netdata /opt/homebrew/var/cache/netdata; do
+    [ -d "$d" ] && { CACHEDIR="$d"; break; }
+  done
 
-IS_CONTAINER=0
-[ -f /.dockerenv ] && IS_CONTAINER=1
-grep -qE '(docker|containerd|kubepods|lxc)' /proc/1/cgroup 2>/dev/null && IS_CONTAINER=1
+  NETDATA_BIN=$(command -v netdata 2>/dev/null)
+  [ -z "${NETDATA_BIN:-}" ] && [ -n "${NETDATA_PID:-}" ] && [ -r "/proc/$NETDATA_PID/exe" ] && \
+    NETDATA_BIN=$(readlink -f "/proc/$NETDATA_PID/exe" 2>/dev/null)
+  [ -z "${NETDATA_BIN:-}" ] && [ -x /opt/netdata/usr/sbin/netdata ] && NETDATA_BIN=/opt/netdata/usr/sbin/netdata
 
-info "netdata-support-bundle $VERSION"
-info "agent pid: ${NETDATA_PID:-not running} | api: $([ $api_ok = 1 ] && echo up || echo unreachable) | config: ${CONFDIR:-not found} | container: $IS_CONTAINER"
+  # probe /api/v3/info first: it stays reachable even under bearer protection,
+  # where /api/v1/* is locked (so a protected-but-running agent isn't mis-flagged)
+  for _probe in /api/v3/info /api/v1/info; do
+    if api_request 3 "$_probe" >/dev/null 2>&1; then
+      api_ok=1; break
+    fi
+  done
+
+  [ "$api_ok" = "1" ] && seed_hostnames
+
+  IS_CONTAINER=0
+  [ -f /.dockerenv ] && IS_CONTAINER=1
+  grep -qE '(docker|containerd|kubepods|lxc)' /proc/1/cgroup 2>/dev/null && IS_CONTAINER=1
+
+  info "netdata-support-bundle $VERSION"
+  info "agent pid: ${NETDATA_PID:-not running} | api: $([ $api_ok = 1 ] && echo up || echo unreachable) | config: ${CONFDIR:-not found} | container: $IS_CONTAINER"
+}
 
 # =============================================================================
 # 01-system
 # =============================================================================
-info "collecting: system"
-collect_cmd 01-system/uname.txt            "Kernel and architecture" uname -a
-collect_cmd 01-system/os-release.txt      "OS distribution (first of os-release/lsb-release)" sh -c '
-  for f in /etc/os-release /usr/lib/os-release /etc/lsb-release; do
-    [ -r "$f" ] && { echo "# source: $f"; cat "$f"; break; }
-  done' 
-collect_cmd 01-system/uptime-load.txt      "Uptime and load" uptime
-collect_cmd 01-system/cpu-count.txt        "CPU count" sh -c 'nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null'
-collect_cmd 01-system/memory.txt           "Memory overview" sh -c '
-  if command -v free >/dev/null; then free -m;
-  elif [ -r /proc/meminfo ]; then head -6 /proc/meminfo;
-  else sysctl -n hw.memsize hw.physmem 2>/dev/null; command -v vm_stat >/dev/null && vm_stat; fi 2>/dev/null; true'
-collect_cmd 01-system/disk-usage.txt       "Filesystem usage" df -h
-collect_cmd 01-system/virtualization.txt   "Virtualization/container detection" sh -c 'command -v systemd-detect-virt >/dev/null && systemd-detect-virt || echo "systemd-detect-virt not available"'
-[ -d /sys/fs/cgroup ] && collect_cmd 01-system/cgroups.txt "cgroup version" stat -fc %T /sys/fs/cgroup
-collect_cmd 01-system/clock-timesync.txt   "Clock and time sync (drift breaks streaming/cloud)" sh -c 'date -u; command -v timedatectl >/dev/null && timedatectl status || true'
-collect_cmd 01-system/mountinfo.txt        "Mount table (namespace visibility issues)" sh -c 'cat /proc/self/mountinfo 2>/dev/null || mount'
-collect_cmd 01-system/selinux-apparmor.txt "MAC status" sh -c '
-  o="";
-  command -v getenforce >/dev/null && o="selinux: $(getenforce 2>/dev/null)";
-  [ -d /sys/kernel/security/apparmor ] && o="$o apparmor: present";
-  [ -n "$o" ] && echo "$o" || echo "(no SELinux/AppArmor detected)"'
-collect_cmd 01-system/kernel-messages.txt  "Kernel messages: OOM/segfault/netdata (evidence of kills and crashes)" \
-  sh -c 'out=""; command -v journalctl >/dev/null && out=$(journalctl -k --no-pager --since "-'"$SINCE_HOURS"' hours" 2>/dev/null | grep -iE "oom|out of memory|segfault|netdata" | tail -300);
-  [ -z "$out" ] && out=$(dmesg 2>/dev/null | grep -iE "oom|out of memory|segfault|netdata" | tail -300);
-  if [ -n "$out" ]; then printf "%s\n" "$out"; else echo "(no matching kernel messages, or kernel log not readable in this environment)"; fi; true'
+collect_system() {
+  info "collecting: system"
+  collect_cmd 01-system/uname.txt            "Kernel and architecture" uname -a
+  collect_cmd 01-system/os-release.txt      "OS distribution (first of os-release/lsb-release)" sh -c '
+    for f in /etc/os-release /usr/lib/os-release /etc/lsb-release; do
+      [ -r "$f" ] && { echo "# source: $f"; cat "$f"; break; }
+    done'
+  collect_cmd 01-system/uptime-load.txt      "Uptime and load" uptime
+  collect_cmd 01-system/cpu-count.txt        "CPU count" sh -c 'nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null'
+  collect_cmd 01-system/memory.txt           "Memory overview" sh -c '
+    if command -v free >/dev/null; then free -m;
+    elif [ -r /proc/meminfo ]; then head -6 /proc/meminfo;
+    else sysctl -n hw.memsize hw.physmem 2>/dev/null; command -v vm_stat >/dev/null && vm_stat; fi 2>/dev/null; true'
+  collect_cmd 01-system/disk-usage.txt       "Filesystem usage" df -h
+  collect_cmd 01-system/virtualization.txt   "Virtualization/container detection" sh -c 'command -v systemd-detect-virt >/dev/null && systemd-detect-virt || echo "systemd-detect-virt not available"'
+  [ -d /sys/fs/cgroup ] && collect_cmd 01-system/cgroups.txt "cgroup version" stat -fc %T /sys/fs/cgroup
+  collect_cmd 01-system/clock-timesync.txt   "Clock and time sync (drift breaks streaming/cloud)" sh -c 'date -u; command -v timedatectl >/dev/null && timedatectl status || true'
+  collect_cmd 01-system/mountinfo.txt        "Mount table (namespace visibility issues)" sh -c 'cat /proc/self/mountinfo 2>/dev/null || mount'
+  collect_cmd 01-system/selinux-apparmor.txt "MAC status" sh -c '
+    o="";
+    command -v getenforce >/dev/null && o="selinux: $(getenforce 2>/dev/null)";
+    [ -d /sys/kernel/security/apparmor ] && o="$o apparmor: present";
+    [ -n "$o" ] && echo "$o" || echo "(no SELinux/AppArmor detected)"'
+  collect_cmd 01-system/kernel-messages.txt  "Kernel messages: OOM/segfault/netdata (evidence of kills and crashes)" \
+    sh -c 'out=""; command -v journalctl >/dev/null && out=$(journalctl -k --no-pager --since "-'"$SINCE_HOURS"' hours" 2>/dev/null | grep -iE "oom|out of memory|segfault|netdata" | tail -300);
+    [ -z "$out" ] && out=$(dmesg 2>/dev/null | grep -iE "oom|out of memory|segfault|netdata" | tail -300);
+    if [ -n "$out" ]; then printf "%s\n" "$out"; else echo "(no matching kernel messages, or kernel log not readable in this environment)"; fi; true'
+}
 
 # =============================================================================
 # 02-install
 # =============================================================================
-info "collecting: install"
-for envf in "$CONFDIR/.environment" /etc/netdata/.environment /opt/netdata/etc/netdata/.environment; do
-  [ -f "$envf" ] && { collect_file 02-install/environment-file.txt "Install-time environment (method, flags, channel; contains no secrets)" "$envf"; break; }
-done
-for itf in "$CONFDIR/.install-type" /etc/netdata/.install-type /opt/netdata/etc/netdata/.install-type; do
-  [ -f "$itf" ] && { collect_file 02-install/install-type.file.txt "Install type marker (kickstart-build|kickstart-static|oci|custom|binpkg-*)" "$itf"; break; }
-done
-collect_cmd 02-install/package-info.txt "Netdata packages installed (name/version/status)" sh -c '
-  found=0;
-  if command -v dpkg-query >/dev/null; then
-    out=$(dpkg-query -W -f "\${Package} \${Version} [\${Status}]\n" "*netdata*" 2>/dev/null);
-    printf "%s\n" "$out";
-    printf "%s" "$out" | grep -q "install ok installed" && found=1;
-  fi;
-  if command -v rpm >/dev/null; then
-    out=$(rpm -qa "*netdata*" 2>/dev/null); [ -n "$out" ] && { printf "%s\n" "$out"; found=1; };
-  fi;
-  if command -v apk >/dev/null; then
-    out=$(apk list --installed 2>/dev/null | grep -i netdata); [ -n "$out" ] && { printf "%s\n" "$out"; found=1; };
-  fi;
-  [ "$found" = "0" ] && echo "(no netdata OS package installed via dpkg/rpm/apk - normal for docker, static and from-source installs; a \"not-installed\" stub above just means another package references the name. See install-type.txt for how this agent was installed.)";
-  true'
-collect_cmd 02-install/install-type.txt "Install type inference" sh -c '
-  o=0;
-  [ -d /opt/netdata/etc/netdata ] && { echo "static build (/opt/netdata)"; o=1; };
-  [ -f /.dockerenv ] && { echo "docker container (/.dockerenv present)"; o=1; };
-  [ -f /etc/netdata/.environment ] && { echo "kickstart-managed (/etc/netdata/.environment present)"; o=1; };
-  command -v netdata >/dev/null && { echo "netdata binary: $(command -v netdata)"; o=1; };
-  [ "$o" = "0" ] && echo "(no netdata installation detected on this system)";
-  true'
-if [ "$IS_CONTAINER" = "1" ]; then
-  collect_cmd 02-install/container-context.txt "Container context (pid1, env, cgroup)" sh -c '
-    echo "== /proc/1/comm =="; cat /proc/1/comm 2>/dev/null;
-    echo "== /proc/1/cgroup =="; cat /proc/1/cgroup 2>/dev/null;
-    echo "== container env (NETDATA_*/DOCKER_*) ==";
-    tr "\0" "\n" < /proc/1/environ 2>/dev/null | grep -E "^(NETDATA_|DOCKER_|DO_NOT)" \
-      || env | grep -E "^(NETDATA_|DOCKER_|DO_NOT)" \
-      || echo "(no NETDATA_*/DOCKER_* env vars visible)";
+collect_install() {
+  info "collecting: install"
+  for envf in "$CONFDIR/.environment" /etc/netdata/.environment /opt/netdata/etc/netdata/.environment; do
+    [ -f "$envf" ] && { collect_file 02-install/environment-file.txt "Install-time environment (method, flags, channel; contains no secrets)" "$envf"; break; }
+  done
+  for itf in "$CONFDIR/.install-type" /etc/netdata/.install-type /opt/netdata/etc/netdata/.install-type; do
+    [ -f "$itf" ] && { collect_file 02-install/install-type.file.txt "Install type marker (kickstart-build|kickstart-static|oci|custom|binpkg-*)" "$itf"; break; }
+  done
+  collect_cmd 02-install/package-info.txt "Netdata packages installed (name/version/status)" sh -c '
+    found=0;
+    if command -v dpkg-query >/dev/null; then
+      out=$(dpkg-query -W -f "\${Package} \${Version} [\${Status}]\n" "*netdata*" 2>/dev/null);
+      printf "%s\n" "$out";
+      printf "%s" "$out" | grep -q "install ok installed" && found=1;
+    fi;
+    if command -v rpm >/dev/null; then
+      out=$(rpm -qa "*netdata*" 2>/dev/null); [ -n "$out" ] && { printf "%s\n" "$out"; found=1; };
+    fi;
+    if command -v apk >/dev/null; then
+      out=$(apk list --installed 2>/dev/null | grep -i netdata); [ -n "$out" ] && { printf "%s\n" "$out"; found=1; };
+    fi;
+    [ "$found" = "0" ] && echo "(no netdata OS package installed via dpkg/rpm/apk - normal for docker, static and from-source installs; a \"not-installed\" stub above just means another package references the name. See install-type.txt for how this agent was installed.)";
     true'
-fi
+  collect_cmd 02-install/install-type.txt "Install type inference" sh -c '
+    o=0;
+    [ -d /opt/netdata/etc/netdata ] && { echo "static build (/opt/netdata)"; o=1; };
+    [ -f /.dockerenv ] && { echo "docker container (/.dockerenv present)"; o=1; };
+    [ -f /etc/netdata/.environment ] && { echo "kickstart-managed (/etc/netdata/.environment present)"; o=1; };
+    command -v netdata >/dev/null && { echo "netdata binary: $(command -v netdata)"; o=1; };
+    [ "$o" = "0" ] && echo "(no netdata installation detected on this system)";
+    true'
+  if [ "$IS_CONTAINER" = "1" ]; then
+    collect_cmd 02-install/container-context.txt "Container context (pid1, env, cgroup)" sh -c '
+      echo "== /proc/1/comm =="; cat /proc/1/comm 2>/dev/null;
+      echo "== /proc/1/cgroup =="; cat /proc/1/cgroup 2>/dev/null;
+      echo "== container env (NETDATA_*/DOCKER_*) ==";
+      tr "\0" "\n" < /proc/1/environ 2>/dev/null | grep -E "^(NETDATA_|DOCKER_|DO_NOT)" \
+        || env | grep -E "^(NETDATA_|DOCKER_|DO_NOT)" \
+        || echo "(no NETDATA_*/DOCKER_* env vars visible)";
+      true'
+  fi
+}
 
 # =============================================================================
 # 03-process
 # =============================================================================
-info "collecting: process"
-collect_cmd 03-process/ps-netdata.txt "Netdata process tree with CPU/memory" sh -c 'ps aux 2>/dev/null | head -1; ps aux 2>/dev/null | grep -E "[n]etdata|[g]o.d|[e]bpf|[a]pps.plugin|[c]harts.d|[p]ython.d" | grep -v "netdata-support-bundle" | head -50'
-if [ -n "${NETDATA_PID:-}" ]; then
-  collect_cmd 03-process/threads-cpu.txt "Per-thread CPU of netdata (which thread is hot)" sh -c "
-    if ps -L -o pid,tid,pcpu,pmem,comm -p $NETDATA_PID >/dev/null 2>&1; then
-      ps -L -o pid,tid,pcpu,pmem,comm -p $NETDATA_PID | head -1;
-      ps -L -o pid,tid,pcpu,pmem,comm -p $NETDATA_PID | tail -n +2 | sort -k3 -rn | head -40;
-    else ps -M -p $NETDATA_PID 2>/dev/null | head -40 || ps -H -p $NETDATA_PID 2>/dev/null | head -40; fi; true"
-  if [ -d "/proc/$NETDATA_PID" ]; then
-    collect_cmd 03-process/proc-status.txt "Process status (RSS, threads, ctx switches)" cat "/proc/$NETDATA_PID/status"
-    collect_cmd 03-process/proc-limits.txt "Process limits" cat "/proc/$NETDATA_PID/limits"
-    collect_cmd 03-process/fd-count.txt "Open file descriptors" sh -c "ls /proc/$NETDATA_PID/fd 2>/dev/null | wc -l"
-    collect_cmd 03-process/process-environ.txt "Netdata process environment (proxy/claim vars; values sanitized)" \
-      sh -c "if tr '\0' '\n' < /proc/$NETDATA_PID/environ 2>/dev/null; then :; else
-        echo '(/proc/$NETDATA_PID/environ not readable - containers need CAP_SYS_PTRACE for this)';
-        echo '-- fallback: NETDATA_*/proxy vars visible to this shell (docker exec inherits container env) --';
-        env | grep -iE '^(NETDATA_|https?_proxy|no_proxy|all_proxy)' || echo '(none)';
-        echo '-- on the docker HOST you can also run: docker inspect -f \"{{.Config.Env}}\" <container> --';
-      fi"
+collect_process() {
+  info "collecting: process"
+  collect_cmd 03-process/ps-netdata.txt "Netdata process tree with CPU/memory" sh -c 'ps aux 2>/dev/null | head -1; ps aux 2>/dev/null | grep -E "[n]etdata|[g]o.d|[e]bpf|[a]pps.plugin|[c]harts.d|[p]ython.d" | grep -v "netdata-support-bundle" | head -50'
+  if [ -n "${NETDATA_PID:-}" ]; then
+    collect_cmd 03-process/threads-cpu.txt "Per-thread CPU of netdata (which thread is hot)" sh -c "
+      if ps -L -o pid,tid,pcpu,pmem,comm -p $NETDATA_PID >/dev/null 2>&1; then
+        ps -L -o pid,tid,pcpu,pmem,comm -p $NETDATA_PID | head -1;
+        ps -L -o pid,tid,pcpu,pmem,comm -p $NETDATA_PID | tail -n +2 | sort -k3 -rn | head -40;
+      else ps -M -p $NETDATA_PID 2>/dev/null | head -40 || ps -H -p $NETDATA_PID 2>/dev/null | head -40; fi; true"
+    if [ -d "/proc/$NETDATA_PID" ]; then
+      collect_cmd 03-process/proc-status.txt "Process status (RSS, threads, ctx switches)" cat "/proc/$NETDATA_PID/status"
+      collect_cmd 03-process/proc-limits.txt "Process limits" cat "/proc/$NETDATA_PID/limits"
+      collect_cmd 03-process/fd-count.txt "Open file descriptors" sh -c "ls /proc/$NETDATA_PID/fd 2>/dev/null | wc -l"
+      collect_cmd 03-process/process-environ.txt "Netdata process environment (proxy/claim vars; values sanitized)" \
+        sh -c "if tr '\0' '\n' < /proc/$NETDATA_PID/environ 2>/dev/null; then :; else
+          echo '(/proc/$NETDATA_PID/environ not readable - containers need CAP_SYS_PTRACE for this)';
+          echo '-- fallback: NETDATA_*/proxy vars visible to this shell (docker exec inherits container env) --';
+          env | grep -iE '^(NETDATA_|https?_proxy|no_proxy|all_proxy)' || echo '(none)';
+          echo '-- on the docker HOST you can also run: docker inspect -f \"{{.Config.Env}}\" <container> --';
+        fi"
+    fi
   fi
-fi
-collect_cmd 03-process/zombies.txt "Zombie processes (plugin reaping issues in containers)" \
-  sh -c 'z=$(ps -eo pid=,ppid=,stat=,comm= 2>/dev/null | awk "\$3 ~ /Z/" | head -30); [ -n "$z" ] && printf "%s\n" "$z" || echo "(no zombie processes)"'
+  collect_cmd 03-process/zombies.txt "Zombie processes (plugin reaping issues in containers)" \
+    sh -c 'z=$(ps -eo pid=,ppid=,stat=,comm= 2>/dev/null | awk "\$3 ~ /Z/" | head -30); [ -n "$z" ] && printf "%s\n" "$z" || echo "(no zombie processes)"'
+}
 
 # =============================================================================
 # 04-config
 # =============================================================================
-info "collecting: config"
-if [ "$api_ok" = "1" ]; then
-  collect_api 04-config/effective-netdata.conf "EFFECTIVE running config (merged, annotated) - authoritative over on-disk file" /netdata.conf
-fi
-if [ -n "$CONFDIR" ]; then
-  collect_cmd 04-config/config-tree.txt "User config dir tree (files here = user-customized; ssl/ and key material excluded)" sh -c '
-    ls -laR '"$CONFDIR"' 2>/dev/null | head -2000 | awk "
-      /\/ssl:\$/ { print; skip = 1; print \"  [ssl directory contents withheld]\"; next }
-      skip && /^\$/ { skip = 0; print; next }
-      skip { next }
-      /\.(pem|key)\$/ { next }
-      { print }"'
-  collect_file 04-config/netdata.conf "On-disk main config" "$CONFDIR/netdata.conf"
-  collect_file 04-config/stream.conf "Streaming config (parent/child; the streaming api key is KEPT VERBATIM - see README.md)" "$CONFDIR/stream.conf"
-  collect_file 04-config/exporting.conf "Exporting engine config (credentials redacted)" "$CONFDIR/exporting.conf"
-  collect_file 04-config/go.d.conf "go.d orchestrator config (module enable/disable)" "$CONFDIR/go.d.conf"
-  # every user-customized config, nested dirs included (go.d/sd/, go.d/ss/,
-  # otel.d/, vnodes/, ...), relative paths preserved; ssl and key material
-  # excluded; capped at 200 files
-  find "$CONFDIR" -type f \( -name '*.conf' -o -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | head -200 | while IFS= read -r f; do
-    case "$f" in */ssl/*|*.pem|*.key) continue ;; *) : ;; esac
-    _relc=${f#"$CONFDIR"/}
-    case "$_relc" in netdata.conf|stream.conf|exporting.conf|go.d.conf) continue ;; *) : ;; esac
-    collect_file "04-config/$_relc" "User config (secrets redacted)" "$f" 262144
-  done
-fi
-if [ -n "$LIBDIR" ] && [ -f "$LIBDIR/cloud.d/cloud.conf" ]; then
-  collect_file 04-config/cloud.conf "Cloud connection config (token redacted)" "$LIBDIR/cloud.d/cloud.conf"
-fi
+collect_config() {
+  info "collecting: config"
+  if [ "$api_ok" = "1" ]; then
+    collect_api 04-config/effective-netdata.conf "EFFECTIVE running config (merged, annotated) - authoritative over on-disk file" /netdata.conf
+  fi
+  if [ -n "$CONFDIR" ]; then
+    collect_cmd 04-config/config-tree.txt "User config dir tree (files here = user-customized; ssl/ and key material excluded)" sh -c '
+      ls -laR '"$CONFDIR"' 2>/dev/null | head -2000 | awk "
+        /\/ssl:\$/ { print; skip = 1; print \"  [ssl directory contents withheld]\"; next }
+        skip && /^\$/ { skip = 0; print; next }
+        skip { next }
+        /\.(pem|key)\$/ { next }
+        { print }"'
+    collect_file 04-config/netdata.conf "On-disk main config" "$CONFDIR/netdata.conf"
+    collect_file 04-config/stream.conf "Streaming config (parent/child; the streaming api key is KEPT VERBATIM - see README.md)" "$CONFDIR/stream.conf"
+    collect_file 04-config/exporting.conf "Exporting engine config (credentials redacted)" "$CONFDIR/exporting.conf"
+    collect_file 04-config/go.d.conf "go.d orchestrator config (module enable/disable)" "$CONFDIR/go.d.conf"
+    # every user-customized config, nested dirs included (go.d/sd/, go.d/ss/,
+    # otel.d/, vnodes/, ...), relative paths preserved; ssl and key material
+    # excluded; capped at 200 files
+    find "$CONFDIR" -type f \( -name '*.conf' -o -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | head -200 | while IFS= read -r f; do
+      case "$f" in */ssl/*|*.pem|*.key) continue ;; *) : ;; esac
+      _relc=${f#"$CONFDIR"/}
+      case "$_relc" in netdata.conf|stream.conf|exporting.conf|go.d.conf) continue ;; *) : ;; esac
+      collect_file "04-config/$_relc" "User config (secrets redacted)" "$f" 262144
+    done
+  fi
+  if [ -n "$LIBDIR" ] && [ -f "$LIBDIR/cloud.d/cloud.conf" ]; then
+    collect_file 04-config/cloud.conf "Cloud connection config (token redacted)" "$LIBDIR/cloud.d/cloud.conf"
+  fi
+}
 
 # =============================================================================
 # 05-logs
 # =============================================================================
-info "collecting: logs (last ${SINCE_HOURS}h, capped)"
-if command -v journalctl >/dev/null 2>&1; then
-  collect_cmd --cap "$LOG_CAP" 05-logs/journal-netdata.txt "systemd journal for netdata unit" \
-    sh -c "journalctl -u netdata --no-pager -o short-iso --since '-${SINCE_HOURS} hours' 2>/dev/null | tail -n 20000; true"
-  collect_cmd --cap "$LOG_CAP" 05-logs/journal-namespace-netdata.txt "netdata journal namespace (some installs log here)" \
-    sh -c "journalctl --namespace=netdata --no-pager -o short-iso --since '-${SINCE_HOURS} hours' 2>/dev/null | tail -n 20000; true"
-fi
-if [ -n "$LOGDIR" ]; then
-  for lf in error.log daemon.log collector.log health.log aclk.log debug.log; do
-    collect_file "05-logs/$lf" "Agent log file: $lf" "$LOGDIR/$lf" "$LOG_CAP"
-  done
-  collect_file 05-logs/access.log "API access log (clients pseudonymized)" "$LOGDIR/access.log" 1048576
-  # docker images symlink logs to /dev/stdout|stderr - history only exists in `docker logs`
-  DOCKER_LOGS_NEEDED=0
-  if [ -L "$LOGDIR/daemon.log" ] || [ -L "$LOGDIR/error.log" ]; then
-    _lt=$(readlink "$LOGDIR/daemon.log" 2>/dev/null || readlink "$LOGDIR/error.log" 2>/dev/null)
-    case "$_lt" in
-    /dev/std*)
-      DOCKER_LOGS_NEEDED=1
-      mkdir -p "$WORK/05-logs"
-      cat > "$WORK/05-logs/LOGS-ARE-IN-DOCKER.txt" <<'EOF'
-This agent logs to the container's stdout/stderr. Its log history is NOT
-available from inside the container. To complete this bundle, ALSO run on
-the docker host and attach the output:
-
-    docker logs --since 24h <netdata-container> > netdata-docker.log 2>&1
-EOF
-      manifest_add 05-logs/LOGS-ARE-IN-DOCKER.txt file generated "Instruction: agent logs live in 'docker logs' on the host"
-      ;;
-    *) : ;;
-    esac
+collect_logs() {
+  info "collecting: logs (last ${SINCE_HOURS}h, capped)"
+  if command -v journalctl >/dev/null 2>&1; then
+    collect_cmd --cap "$LOG_CAP" 05-logs/journal-netdata.txt "systemd journal for netdata unit" \
+      sh -c "journalctl -u netdata --no-pager -o short-iso --since '-${SINCE_HOURS} hours' 2>/dev/null | tail -n 20000; true"
+    collect_cmd --cap "$LOG_CAP" 05-logs/journal-namespace-netdata.txt "netdata journal namespace (some installs log here)" \
+      sh -c "journalctl --namespace=netdata --no-pager -o short-iso --since '-${SINCE_HOURS} hours' 2>/dev/null | tail -n 20000; true"
   fi
-fi
-if command -v journalctl >/dev/null 2>&1; then
-  collect_cmd 05-logs/journal-updater.txt "Auto-updater service journal (updater keeps no persistent log file)" \
-    sh -c "journalctl -u netdata-updater.service --no-pager -o short-iso 2>/dev/null | tail -200; true"
-fi
-collect_cmd 05-logs/coredumps.txt "Recent coredump METADATA for netdata (not the dumps)" \
-  sh -c 'if command -v coredumpctl >/dev/null; then coredumpctl list --no-pager 2>/dev/null | awk "NR==1 || tolower(\$0) ~ /netdata/" | tail -21; else echo "coredumpctl not available"; fi; true'
+  if [ -n "$LOGDIR" ]; then
+    for lf in error.log daemon.log collector.log health.log aclk.log debug.log; do
+      collect_file "05-logs/$lf" "Agent log file: $lf" "$LOGDIR/$lf" "$LOG_CAP"
+    done
+    collect_file 05-logs/access.log "API access log (clients pseudonymized)" "$LOGDIR/access.log" 1048576
+    # docker images symlink logs to /dev/stdout|stderr - history only exists in `docker logs`
+    DOCKER_LOGS_NEEDED=0
+    if [ -L "$LOGDIR/daemon.log" ] || [ -L "$LOGDIR/error.log" ]; then
+      _lt=$(readlink "$LOGDIR/daemon.log" 2>/dev/null || readlink "$LOGDIR/error.log" 2>/dev/null)
+      case "$_lt" in
+      /dev/std*)
+        DOCKER_LOGS_NEEDED=1
+        mkdir -p "$WORK/05-logs"
+        {
+          echo "This agent logs to the container stdout/stderr; capture its history on the Docker host."
+          echo "The output is UNSANITIZED. Keep it private until you review and redact credentials and PII."
+          echo
+          echo "    umask 077"
+          printf '    docker logs --since %sh <netdata-container> > netdata-docker.log 2>&1\n' "$SINCE_HOURS"
+          echo
+          echo "Attach only the reviewed, redacted copy through your restricted support ticket."
+        } > "$WORK/05-logs/LOGS-ARE-IN-DOCKER.txt"
+        manifest_add 05-logs/LOGS-ARE-IN-DOCKER.txt file generated "Instruction: agent logs live in 'docker logs' on the host"
+        ;;
+      *) : ;;
+      esac
+    fi
+  fi
+  if command -v journalctl >/dev/null 2>&1; then
+    collect_cmd 05-logs/journal-updater.txt "Auto-updater service journal (updater keeps no persistent log file)" \
+      sh -c "journalctl -u netdata-updater.service --no-pager -o short-iso 2>/dev/null | tail -200; true"
+  fi
+  collect_cmd 05-logs/coredumps.txt "Recent coredump METADATA for netdata (not the dumps)" \
+    sh -c 'if command -v coredumpctl >/dev/null; then coredumpctl list --no-pager 2>/dev/null | awk "NR==1 || tolower(\$0) ~ /netdata/" | tail -21; else echo "coredumpctl not available"; fi; true'
+}
 
 # =============================================================================
 # 06-state
 # =============================================================================
-info "collecting: state"
-collect_snmp_diagnostics
-# status file: agent writes to first writable of these; newest mtime wins (status-file-io.c)
-NEWEST_STATUS=""
-# shellcheck disable=SC3013  # -nt is supported by dash, ash/busybox, bash and FreeBSD sh
-_status_candidates=""
-[ -n "$LIBDIR" ] && _status_candidates="$_status_candidates $LIBDIR/status-netdata.json"
-[ -n "$CACHEDIR" ] && _status_candidates="$_status_candidates $CACHEDIR/status-netdata.json"
-# transient fallback locations only when netdata is actually on this host, so a
-# no-agent run can't package an unrelated /tmp/status-netdata.json as crash state
-if [ -n "$CONFDIR$LIBDIR" ] || [ -n "${NETDATA_PID:-}" ]; then
-  _status_candidates="$_status_candidates /tmp/status-netdata.json /run/status-netdata.json /var/run/status-netdata.json"
-fi
-for sf in $_status_candidates; do
-  [ -f "$sf" ] || continue
-  if [ -z "$NEWEST_STATUS" ] || [ "$sf" -nt "$NEWEST_STATUS" ]; then NEWEST_STATUS="$sf"; fi
-done
-[ -n "$NEWEST_STATUS" ] && collect_file 06-state/status-file.json "Daemon status file: LAST EXIT/CRASH RECORD incl. fatal stack trace (read this first for crashes)" "$NEWEST_STATUS"
-if [ -n "$LIBDIR" ]; then
-  # bearer_tokens/ FILENAMES are live API tokens - withhold them from the listing
-  collect_cmd 06-state/state-tree.txt "State dir listing (bearer token filenames withheld - they are live tokens)" \
-    sh -c 'ls -laR '"$LIBDIR"' 2>/dev/null | head -2000 | awk "
-      /\/bearer_tokens:\$/ { print; skip=1; n=0; next }
-      skip && /^\$/         { print \"  [\" n \" token file(s) - names withheld, they ARE the tokens]\"; print; skip=0; next }
-      skip && /^total/      { next }
-      skip                  { if (\$0 !~ / \.\.?\$/) n++; next }
-                            { print }"'
-  collect_cmd 06-state/cloud-state.txt "Cloud claim state (claimed_id is safe; token/private.pem are never collected)" sh -c '
-    echo "== cloud.d listing =="; ls -la '"$LIBDIR"'/cloud.d/ 2>/dev/null;
-    echo "== claimed_id ==";
-    cat '"$LIBDIR"'/cloud.d/claimed_id 2>/dev/null || echo "(no claimed_id file - agent not claimed)"; echo;
-    echo "(token and private.pem intentionally NOT collected)"; true'
-  collect_file 06-state/health-silencers.json "Persisted alert silencers" "$LIBDIR/health.silencers.json"
-  for gjs in "$LIBDIR"/god-jobs-statuses.json "$LIBDIR"/*jobs-statuses*.json; do
-    [ -f "$gjs" ] && { collect_file 06-state/go.d-job-statuses.json "go.d collector job states (which jobs run/fail)" "$gjs"; break; }
-  done
-  if [ -d "$LIBDIR/config" ]; then
-    for dc in "$LIBDIR/config"/*.dyncfg; do
-      [ -f "$dc" ] || continue
-      collect_file "06-state/dyncfg/$(basename "$dc")" "Dynamic config created via UI/API (secrets redacted)" "$dc" 262144
-    done
+collect_state() {
+  info "collecting: state"
+  collect_snmp_diagnostics
+  # status file: agent writes to first writable of these; newest mtime wins (status-file-io.c)
+  NEWEST_STATUS=""
+  _status_candidates=""
+  [ -n "$LIBDIR" ] && _status_candidates="$_status_candidates $LIBDIR/status-netdata.json"
+  [ -n "$CACHEDIR" ] && _status_candidates="$_status_candidates $CACHEDIR/status-netdata.json"
+  # Shared /tmp is not trusted crash evidence. Restrict transient fallbacks to
+  # service runtime directories and only when an installation is present.
+  if [ -n "$CONFDIR$LIBDIR" ] || [ -n "${NETDATA_PID:-}" ]; then
+    _status_candidates="$_status_candidates /run/status-netdata.json /var/run/status-netdata.json"
   fi
-fi
-if [ -n "$CACHEDIR$LIBDIR" ]; then
-  collect_cmd 06-state/db-disk-usage.txt "Database disk usage per tier + sqlite sizes + corruption sentinels" sh -c '
-    [ -n "'"$CACHEDIR"'" ] && du -sh '"$CACHEDIR"'/* 2>/dev/null | sort -rh | head -30;
-    [ -n "'"$LIBDIR"'" ] && ls -la '"$LIBDIR"'/*.db* 2>/dev/null;
-    echo "== sqlite corruption/recovery sentinels (presence = past corruption) ==";
-    ls -la '"$CACHEDIR"'/*.bad* '"$CACHEDIR"'/.*.recover '"$CACHEDIR"'/*.recover 2>/dev/null || echo "(none found)";
-    true'
-fi
+  for sf in $_status_candidates; do
+    if [ ! -f "$sf" ] || [ ! -r "$sf" ] || [ -h "$sf" ]; then continue; fi
+    # shellcheck disable=SC3013  # supported by dash, BusyBox, bash and FreeBSD sh
+    if [ -z "$NEWEST_STATUS" ] || [ "$sf" -nt "$NEWEST_STATUS" ]; then NEWEST_STATUS="$sf"; fi
+  done
+  [ -n "$NEWEST_STATUS" ] && collect_file 06-state/status-file.json "Daemon status file: LAST EXIT/CRASH RECORD incl. fatal stack trace (read this first for crashes)" "$NEWEST_STATUS"
+  if [ -n "$LIBDIR" ]; then
+    # Aggregate metadata only: a state filename can itself be a credential.
+    collect_cmd 06-state/state-tree.txt "State directory aggregate inventory (filenames withheld)" sh -c '
+      if stat -c %s "$1" >/dev/null 2>&1; then
+        find "$1" -type f -exec stat -c %s {} + 2>/dev/null
+      else
+        find "$1" -type f -exec stat -f %z {} + 2>/dev/null
+      fi | awk "{ n++; bytes += \$1 } END { printf \"files: %d\\nlogical bytes: %.0f\\n\", n, bytes }"
+      ' sh "$LIBDIR"
+    collect_cmd 06-state/cloud-state.txt "Cloud claim state (claimed_id is safe; token/private.pem are never collected)" sh -c '
+      echo "== cloud.d listing =="; ls -la '"$LIBDIR"'/cloud.d/ 2>/dev/null;
+      echo "== claimed_id ==";
+      cat '"$LIBDIR"'/cloud.d/claimed_id 2>/dev/null || echo "(no claimed_id file - agent not claimed)"; echo;
+      echo "(token and private.pem intentionally NOT collected)"; true'
+    collect_file 06-state/health-silencers.json "Persisted alert silencers" "$LIBDIR/health.silencers.json"
+    for gjs in "$LIBDIR"/god-jobs-statuses.json "$LIBDIR"/*jobs-statuses*.json; do
+      [ -f "$gjs" ] && { collect_file 06-state/go.d-job-statuses.json "go.d collector job states (which jobs run/fail)" "$gjs"; break; }
+    done
+    if [ -d "$LIBDIR/config" ]; then
+      for dc in "$LIBDIR/config"/*.dyncfg; do
+        [ -f "$dc" ] || continue
+        collect_file "06-state/dyncfg/$(basename "$dc")" "Dynamic config created via UI/API (secrets redacted)" "$dc" 262144
+      done
+    fi
+  fi
+  if [ -n "$CACHEDIR$LIBDIR" ]; then
+    collect_cmd 06-state/db-disk-usage.txt "Database disk usage per tier + sqlite sizes + corruption sentinels" sh -c '
+      [ -n "'"$CACHEDIR"'" ] && du -sh '"$CACHEDIR"'/* 2>/dev/null | sort -rh | head -30;
+      [ -n "'"$LIBDIR"'" ] && ls -la '"$LIBDIR"'/*.db* 2>/dev/null;
+      echo "== sqlite corruption/recovery sentinels (presence = past corruption) ==";
+      ls -la '"$CACHEDIR"'/*.bad* '"$CACHEDIR"'/.*.recover '"$CACHEDIR"'/*.recover 2>/dev/null || echo "(none found)";
+      true'
+  fi
+}
 
 # =============================================================================
 # 07-runtime (only when the agent responds)
 # =============================================================================
-if [ "$api_ok" = "1" ]; then
-  info "collecting: runtime (agent is up)"
-  collect_api 07-runtime/info-v3.json "BEST SINGLE CALL: buildinfo, features, cloud status, per-tier retention (works even under bearer protection)" /api/v3/info
-  collect_api 07-runtime/info-v1.json "Agent info v1: version, cloud/stream booleans, mirrored hosts" /api/v1/info
-  collect_api 07-runtime/node-instances.json "Node instances: children, streaming state, db_size per tier, metric counts" /api/v2/node_instances
-  collect_api 07-runtime/stream-info.json "Streaming diagnostics" /api/v3/stream_info
-  collect_api 07-runtime/aclk.json "Cloud/ACLK connection state" /api/v1/aclk
-  collect_api 07-runtime/alerts-active.json "Currently raised alerts" "/api/v3/alerts?options=active"
-  collect_api 07-runtime/alerts-all.json "All alert instances (summary)" "/api/v1/alarms?all"
-  collect_api 07-runtime/functions.json "Registered functions (which plugins expose what)" /api/v1/functions
-  collect_api 07-runtime/ml-info.json "Machine learning status" /api/v1/ml_info
-  # netdata's own resource usage, bounded windows (perf triage without screenshots)
-  collect_api 07-runtime/self-cpu.csv "Netdata CPU last 10min (csv)" "/api/v1/data?chart=netdata.server_cpu&after=-600&points=60&format=csv"
-  collect_api 07-runtime/self-memory.csv "Netdata memory last 10min (csv)" "/api/v1/data?chart=netdata.memory&after=-600&points=60&format=csv"
-  collect_api 07-runtime/self-api-clients.csv "Netdata API clients last 10min (csv)" "/api/v1/data?chart=netdata.clients&after=-600&points=60&format=csv"
-else
-  info "agent API unreachable - skipping runtime section"
-  mkdir -p "$WORK/07-runtime"
-  echo "Agent API at 127.0.0.1:$NDPORT was unreachable when this bundle was created. See 05-logs and 06-state/status-file.json for why." > "$WORK/07-runtime/AGENT-WAS-DOWN.txt"
-  manifest_add 07-runtime/AGENT-WAS-DOWN.txt "file" "generated" "Marker: agent API unreachable at collection time"
-fi
-if [ -n "${NETDATA_BIN:-}" ]; then
-  collect_cmd 07-runtime/buildinfo.txt "netdata -W buildinfo (verbatim - paths section matters; works with daemon down)" "$NETDATA_BIN" -W buildinfo
-  collect_cmd_raw 07-runtime/buildinfo.json "netdata -W buildinfojson (machine-readable; no header so it parses as JSON)" "$NETDATA_BIN" -W buildinfojson
-  collect_cmd 07-runtime/cmakecache.txt "netdata -W cmakecache: authoritative build config (compiler flags, enabled plugins, configured paths) - superset of buildinfo" "$NETDATA_BIN" -W cmakecache
-fi
-if command -v netdatacli >/dev/null 2>&1 && [ -n "${NETDATA_PID:-}" ]; then
-  collect_cmd_raw 07-runtime/aclk-state.json "Cloud connectivity state (netdatacli aclk-state json; no header so it parses as JSON)" netdatacli aclk-state json
-fi
+collect_runtime() {
+  if [ "$api_ok" = "1" ]; then
+    info "collecting: runtime (agent is up)"
+    collect_api 07-runtime/info-v3.json "BEST SINGLE CALL: buildinfo, features, cloud status, per-tier retention (works even under bearer protection)" /api/v3/info
+    collect_api 07-runtime/info-v1.json "Agent info v1: version, cloud/stream booleans, mirrored hosts" /api/v1/info
+    collect_api 07-runtime/node-instances.json "Node instances: children, streaming state, db_size per tier, metric counts" /api/v2/node_instances
+    collect_api 07-runtime/stream-info.json "Streaming diagnostics" /api/v3/stream_info
+    collect_api 07-runtime/aclk.json "Cloud/ACLK connection state" /api/v1/aclk
+    collect_api 07-runtime/alerts-active.json "Currently raised alerts" "/api/v3/alerts?options=active"
+    collect_api 07-runtime/alerts-all.json "All alert instances (summary)" "/api/v1/alarms?all"
+    collect_api 07-runtime/functions.json "Registered functions (which plugins expose what)" /api/v1/functions
+    collect_api 07-runtime/ml-info.json "Machine learning status" /api/v1/ml_info
+    # netdata's own resource usage, bounded windows (perf triage without screenshots)
+    collect_api 07-runtime/self-cpu.csv "Netdata CPU last 10min (csv)" "/api/v1/data?chart=netdata.server_cpu&after=-600&points=60&format=csv"
+    collect_api 07-runtime/self-memory.csv "Netdata memory last 10min (csv)" "/api/v1/data?chart=netdata.memory&after=-600&points=60&format=csv"
+    collect_api 07-runtime/self-api-clients.csv "Netdata API clients last 10min (csv)" "/api/v1/data?chart=netdata.clients&after=-600&points=60&format=csv"
+  else
+    info "agent API unreachable - skipping runtime section"
+    mkdir -p "$WORK/07-runtime"
+    echo "Agent API at 127.0.0.1:$NDPORT was unreachable when this bundle was created. See 05-logs and 06-state/status-file.json for why." > "$WORK/07-runtime/AGENT-WAS-DOWN.txt"
+    manifest_add 07-runtime/AGENT-WAS-DOWN.txt "file" "generated" "Marker: agent API unreachable at collection time"
+  fi
+  if [ -n "${NETDATA_BIN:-}" ]; then
+    collect_cmd 07-runtime/buildinfo.txt "netdata -W buildinfo (verbatim - paths section matters; works with daemon down)" "$NETDATA_BIN" -W buildinfo
+    collect_cmd_raw 07-runtime/buildinfo.json "netdata -W buildinfojson (machine-readable; no header so it parses as JSON)" "$NETDATA_BIN" -W buildinfojson
+    collect_cmd 07-runtime/cmakecache.txt "netdata -W cmakecache: authoritative build config (compiler flags, enabled plugins, configured paths) - superset of buildinfo" "$NETDATA_BIN" -W cmakecache
+  fi
+  if command -v netdatacli >/dev/null 2>&1 && [ -n "${NETDATA_PID:-}" ]; then
+    collect_cmd_raw 07-runtime/aclk-state.json "Cloud connectivity state (netdatacli aclk-state json; no header so it parses as JSON)" netdatacli aclk-state json
+  fi
+}
 
 # =============================================================================
 # 08-network
 # =============================================================================
-info "collecting: network"
-collect_cmd 08-network/netdata-sockets.txt "All sockets owned by the Netdata process tree" \
-  sh -c '
-    _live_pids=""
-    if [ -n "${NETDATA_PID:-}" ] && command -v ps >/dev/null 2>&1; then
-      _live_pids=$(ps -eo pid=,ppid=,comm= 2>/dev/null | awk -v root="$NETDATA_PID" "
-        { pid=\$1; parent[pid]=\$2; comm[pid]=\$3 }
-        END {
-          if (root !~ /^[0-9]+$/ || comm[root] != \"netdata\") exit
-          owned[root]=1; changed=1
-          while (changed) {
-            changed=0
-            for (pid in parent) if (!owned[pid] && owned[parent[pid]]) {
-              owned[pid]=1; changed=1
+collect_network() {
+  info "collecting: network"
+  collect_cmd 08-network/netdata-sockets.txt "All sockets owned by the Netdata process tree" \
+    sh -c '
+      _live_pids=""
+      if [ -n "${NETDATA_PID:-}" ] && command -v ps >/dev/null 2>&1; then
+        _live_pids=$(ps -eo pid=,ppid=,comm= 2>/dev/null | awk -v root="$NETDATA_PID" "
+          { pid=\$1; parent[pid]=\$2; comm[pid]=\$3 }
+          END {
+            if (root !~ /^[0-9]+$/ || comm[root] != \"netdata\") exit
+            owned[root]=1; changed=1
+            while (changed) {
+              changed=0
+              for (pid in parent) if (!owned[pid] && owned[parent[pid]]) {
+                owned[pid]=1; changed=1
+              }
             }
-          }
-          for (pid in owned) if (owned[pid]) print pid
-        }" | sort -n)
-    fi
-    if [ -z "$_live_pids" ]; then
-      echo "(unavailable: Netdata process not found)"
-    elif command -v lsof >/dev/null 2>&1; then
-      _valid_pids=$(printf "%s\\n" "$_live_pids" | awk "/^[0-9]+$/")
-      if [ -z "$_valid_pids" ]; then
-        echo "(unavailable: Netdata process tree contains no valid PIDs)"
-      else
-        _pid_list=$(printf "%s\\n" "$_valid_pids" | awk "/^[0-9]+$/ { printf \"%s%s\", sep, \$1; sep=\",\" }")
-        _pid_re=$(printf "%s" "$_pid_list" | tr "," "|")
-        # Keep a second PID check on the text output. Some lsof variants have
-        # different selection semantics; an ignored -p must never publish a
-        # host-wide listing.
-        lsof -nP -a -p "$_pid_list" -i 2>&1 |
-          awk -v re="^(${_pid_re})$" "\$1 ~ /^lsof:/ || \$1 == \"COMMAND\" || \$2 ~ re"
-        lsof -nP -a -p "$_pid_list" -U 2>&1 |
-          awk -v re="^(${_pid_re})$" "\$1 ~ /^lsof:/ || \$1 == \"COMMAND\" || \$2 ~ re"
+            for (pid in owned) if (owned[pid]) print pid
+          }" | sort -n)
       fi
-    elif command -v ss >/dev/null 2>&1; then
-      _pid_re=$(printf "%s\\n" "$_live_pids" | awk "/^[0-9]+$/ { printf \"%s%s\", sep, \$1; sep=\"|\" }")
-      ss -a -tunxp 2>&1 | awk -v re="pid=(${_pid_re})(,|\\))" "NR == 1 || \$0 ~ re"
-    elif command -v sockstat >/dev/null 2>&1; then
-      _pid_re=$(printf "%s\\n" "$_live_pids" | awk "/^[0-9]+$/ { printf \"%s%s\", sep, \$1; sep=\"|\" }")
-      sockstat -s 2>&1 | awk -v re="^(${_pid_re})$" "NR == 1 || \$3 ~ re"
-    elif command -v netstat >/dev/null 2>&1; then
-      echo "(degraded: process ownership unavailable; showing port 19999 listeners only)"
-      netstat -an 2>&1 | awk "NR == 1 || (\$0 ~ /19999/ && \$0 ~ /LISTEN|listen|LISTENING/)"
-    else
-      echo "(unavailable: lsof, ss, sockstat, or netstat is required for socket details)"
-    fi; true'
-if [ "$OBFUSCATE" = "1" ]; then
-  # search/domain values are often corporate-internal names outside private TLDs
-  collect_cmd 08-network/resolv-conf.txt "DNS resolver config (search domains withheld)" \
-    sh -c 'sed -E "s/^((search|domain)[ \t]).*/\1[SEARCH-DOMAINS-WITHHELD]/" /etc/resolv.conf 2>/dev/null; true'
-else
-  collect_file 08-network/resolv-conf.txt "DNS resolver config" /etc/resolv.conf
-fi
-collect_cmd 08-network/proxy-env.txt "Proxy environment (this shell; see 03-process/process-environ.txt for the agent view)" \
-  sh -c 'env | grep -iE "^(https?_proxy|no_proxy|all_proxy)=" || echo "(no proxy variables set)"'
-collect_cmd 08-network/cloud-connectivity.txt "Reachability of Netdata Cloud (DNS + TLS + response code, no data sent)" sh -c '
-  if command -v curl >/dev/null; then
-    curl -sv --max-time 8 -o /dev/null https://app.netdata.cloud/ 2>&1 \
-      | grep -E "^\*|^< HTTP|^> " \
-      | grep -viE "TLS handshake|change.?cipher|certificate|subject:|issuer:|ALPN|offering|CAfile|user-agent|accept:" \
-      | head -40;
-  elif command -v wget >/dev/null; then
-    if wget -q -T 8 -O /dev/null https://app.netdata.cloud/ 2>/dev/null;
-    then echo "wget https://app.netdata.cloud/ : SUCCESS";
-    else echo "wget https://app.netdata.cloud/ : FAILED (exit $?)"; fi;
-  else echo "neither curl nor wget available"; fi; true'
+      if [ -z "$_live_pids" ]; then
+        echo "(unavailable: Netdata process not found)"
+      elif command -v lsof >/dev/null 2>&1; then
+        _valid_pids=$(printf "%s\\n" "$_live_pids" | awk "/^[0-9]+$/")
+        if [ -z "$_valid_pids" ]; then
+          echo "(unavailable: Netdata process tree contains no valid PIDs)"
+        else
+          _pid_list=$(printf "%s\\n" "$_valid_pids" | awk "/^[0-9]+$/ { printf \"%s%s\", sep, \$1; sep=\",\" }")
+          _pid_re=$(printf "%s" "$_pid_list" | tr "," "|")
+          # Keep a second PID check on the text output. Some lsof variants have
+          # different selection semantics; an ignored -p must never publish a
+          # host-wide listing.
+          lsof -nP -a -p "$_pid_list" -i 2>&1 |
+            awk -v re="^(${_pid_re})$" "\$1 ~ /^lsof:/ || \$1 == \"COMMAND\" || \$2 ~ re"
+          lsof -nP -a -p "$_pid_list" -U 2>&1 |
+            awk -v re="^(${_pid_re})$" "\$1 ~ /^lsof:/ || \$1 == \"COMMAND\" || \$2 ~ re"
+        fi
+      elif command -v ss >/dev/null 2>&1; then
+        _pid_re=$(printf "%s\\n" "$_live_pids" | awk "/^[0-9]+$/ { printf \"%s%s\", sep, \$1; sep=\"|\" }")
+        ss -a -tunxp 2>&1 | awk -v re="pid=(${_pid_re})(,|\\))" "NR == 1 || \$0 ~ re"
+      elif command -v sockstat >/dev/null 2>&1; then
+        _pid_re=$(printf "%s\\n" "$_live_pids" | awk "/^[0-9]+$/ { printf \"%s%s\", sep, \$1; sep=\"|\" }")
+        sockstat -s 2>&1 | awk -v re="^(${_pid_re})$" "NR == 1 || \$3 ~ re"
+      elif command -v netstat >/dev/null 2>&1; then
+        echo "(degraded: process ownership unavailable; showing port 19999 listeners only)"
+        netstat -an 2>&1 | awk "NR == 1 || (\$0 ~ /19999/ && \$0 ~ /LISTEN|listen|LISTENING/)"
+      else
+        echo "(unavailable: lsof, ss, sockstat, or netstat is required for socket details)"
+      fi; true'
+  if [ "$OBFUSCATE" = "1" ]; then
+    # search/domain values are often corporate-internal names outside private TLDs
+    collect_cmd 08-network/resolv-conf.txt "DNS resolver config (search domains withheld)" \
+      sh -c 'sed -E "s/^((search|domain)[ \t]).*/\1[SEARCH-DOMAINS-WITHHELD]/" /etc/resolv.conf 2>/dev/null; true'
+  else
+    collect_file 08-network/resolv-conf.txt "DNS resolver config" /etc/resolv.conf
+  fi
+  collect_cmd 08-network/proxy-env.txt "Proxy environment (this shell; see 03-process/process-environ.txt for the agent view)" \
+    sh -c 'env | grep -iE "^(https?_proxy|no_proxy|all_proxy)=" || echo "(no proxy variables set)"'
+  collect_cmd 08-network/cloud-connectivity.txt "Reachability of Netdata Cloud (DNS + TLS + response code, no data sent)" sh -c '
+    if command -v curl >/dev/null; then
+      curl -sv --max-time 8 -o /dev/null https://app.netdata.cloud/ 2>&1 \
+        | grep -E "^\*|^< HTTP|^> " \
+        | grep -viE "TLS handshake|change.?cipher|certificate|subject:|issuer:|ALPN|offering|CAfile|user-agent|accept:" \
+        | head -40;
+    elif command -v wget >/dev/null; then
+      if wget -q -T 8 -O /dev/null https://app.netdata.cloud/ 2>/dev/null;
+      then echo "wget https://app.netdata.cloud/ : SUCCESS";
+      else echo "wget https://app.netdata.cloud/ : FAILED (exit $?)"; fi;
+    else echo "neither curl nor wget available"; fi; true'
+}
 
 # =============================================================================
 # 09-permissions
 # =============================================================================
-info "collecting: permissions"
-# plugins.d discovery: the binary's own prefix, the known install prefixes, and
-# <config>/custom-plugins.d, which the agent also searches by default
-# (plugins_d.c). A [directories] plugins override in netdata.conf is not read:
-# it is rare, and keeping every path here out of user-controlled input means
-# nothing config-derived ever reaches a collector.
-PLUGINSD_DIRS=""
 _add_pluginsd() {
   [ -n "${1:-}" ] || return 0
   [ -d "$1" ] || return 0
   case " $PLUGINSD_DIRS " in *" $1 "*) return 0 ;; *) : ;; esac
   PLUGINSD_DIRS="$PLUGINSD_DIRS $1"
 }
-if [ -n "${NETDATA_BIN:-}" ]; then
-  case "$NETDATA_BIN" in
-    */usr/sbin/netdata|*/usr/bin/netdata) _add_pluginsd "${NETDATA_BIN%/usr/*}/usr/libexec/netdata/plugins.d" ;;
-    *) : ;;
-  esac
-  _add_pluginsd "$(dirname "$(dirname "$NETDATA_BIN")")/libexec/netdata/plugins.d"
-fi
-for d in /usr/libexec/netdata/plugins.d /usr/lib/netdata/plugins.d \
-         /opt/netdata/usr/libexec/netdata/plugins.d \
-         /usr/local/libexec/netdata/plugins.d \
-         /opt/homebrew/libexec/netdata/plugins.d; do
-  _add_pluginsd "$d"
-done
-[ -n "$CONFDIR" ] && _add_pluginsd "$CONFDIR/custom-plugins.d"
-PLUGINSD_DIRS="${PLUGINSD_DIRS# }"
 
-# The directory list reaches the child as positional ARGUMENTS, never as text
-# spliced into the program: one of these paths can come from the [directories]
-# plugins value in netdata.conf, and a path containing a quote would otherwise
-# close the quoted program and run as shell code with the bundle's privileges.
-# shellcheck disable=SC2086  # deliberate word-split of the discovered dir list
-collect_cmd 09-permissions/plugins-d.txt "plugins.d: modes, ownership, setuid/setgid bits and file CAPABILITIES (lost capabilities are a top cause of a plugin collecting nothing)" sh -c '
-  if [ "$#" -eq 0 ]; then echo "(no plugins.d directory found on this host)"; exit 0; fi
-  for d in "$@"; do
-    echo "===== $d ====="
-    ls -ld "$d" 2>/dev/null
-    echo "-- contents --"
-    ls -la "$d" 2>/dev/null | head -200
-    echo "-- setuid/setgid entries --"
-    s=$(find "$d" -maxdepth 1 -type f \( -perm -4000 -o -perm -2000 \) 2>/dev/null | head -50)
-    if [ -n "$s" ]; then printf "%s\n" "$s"; else echo "(none)"; fi
-    echo "-- file capabilities --"
-    if command -v getcap >/dev/null 2>&1; then
-      c=$(getcap -r "$d" 2>/dev/null | head -50)
-      if [ -n "$c" ]; then printf "%s\n" "$c"; else echo "(no file has capabilities set)"; fi
-    else
-      echo "(getcap not available - file capabilities could NOT be checked)"
-    fi
-    # NOTE: a trailing "+" in the listing means "alternate access method", which
-    # on netdata installs is usually the security.capability xattr shown above,
-    # NOT an ACL. ACLs for the directory itself are in netdata-paths.txt.
+collect_permissions() {
+  info "collecting: permissions"
+  # plugins.d discovery: the binary's own prefix, the known install prefixes, and
+  # <config>/custom-plugins.d, which the agent also searches by default
+  # (plugins_d.c). A [directories] plugins override in netdata.conf is not read:
+  # it is rare, and keeping every path here out of user-controlled input means
+  # nothing config-derived ever reaches a collector.
+  PLUGINSD_DIRS=""
+
+  if [ -n "${NETDATA_BIN:-}" ]; then
+    case "$NETDATA_BIN" in
+      */usr/sbin/netdata|*/usr/bin/netdata) _add_pluginsd "${NETDATA_BIN%/usr/*}/usr/libexec/netdata/plugins.d" ;;
+      *) : ;;
+    esac
+    _add_pluginsd "$(dirname "$(dirname "$NETDATA_BIN")")/libexec/netdata/plugins.d"
+  fi
+  for d in /usr/libexec/netdata/plugins.d /usr/lib/netdata/plugins.d \
+           /opt/netdata/usr/libexec/netdata/plugins.d \
+           /usr/local/libexec/netdata/plugins.d \
+           /opt/homebrew/libexec/netdata/plugins.d; do
+    _add_pluginsd "$d"
   done
-  true' sh $PLUGINSD_DIRS
+  [ -n "$CONFDIR" ] && _add_pluginsd "$CONFDIR/custom-plugins.d"
+  PLUGINSD_DIRS="${PLUGINSD_DIRS# }"
 
-# every netdata-owned path worth reporting permissions for; the cache dir stays
-# TOP-LEVEL only (recursing it would enumerate thousands of dbengine files)
-_PERM_PATHS=""
-for _p in "$CONFDIR" "$CONFDIR/netdata.conf" "$CONFDIR/stream.conf" "$CONFDIR/ssl" \
-          "$LOGDIR" "$LIBDIR" "$LIBDIR/cloud.d" "$LIBDIR/registry" "$CACHEDIR" \
-          $PLUGINSD_DIRS "${NETDATA_BIN:-}"; do
-  [ -n "$_p" ] || continue
-  [ -e "$_p" ] || continue
-  case " $_PERM_PATHS " in *" $_p "*) continue ;; *) : ;; esac
-  _PERM_PATHS="$_PERM_PATHS $_p"
-done
-_PERM_PATHS="${_PERM_PATHS# }"
+  # The directory list reaches the child as positional ARGUMENTS, never as text
+  # spliced into the program: a binary-derived installation path containing a quote
+  # would otherwise
+  # close the quoted program and run as shell code with the bundle's privileges.
+  # shellcheck disable=SC2086  # deliberate word-split of the discovered dir list
+  collect_cmd 09-permissions/plugins-d.txt "plugins.d: modes, ownership, setuid/setgid bits and file CAPABILITIES (lost capabilities are a top cause of a plugin collecting nothing)" sh -c '
+    if [ "$#" -eq 0 ]; then echo "(no plugins.d directory found on this host)"; exit 0; fi
+    for d in "$@"; do
+      echo "===== $d ====="
+      ls -ld "$d" 2>/dev/null
+      echo "-- contents --"
+      ls -la "$d" 2>/dev/null | head -200
+      echo "-- setuid/setgid entries --"
+      s=$(find "$d" -maxdepth 1 -type f \( -perm -4000 -o -perm -2000 \) 2>/dev/null | head -50)
+      if [ -n "$s" ]; then printf "%s\n" "$s"; else echo "(none)"; fi
+      echo "-- file capabilities --"
+      if command -v getcap >/dev/null 2>&1; then
+        c=$(getcap -r "$d" 2>/dev/null | head -50)
+        if [ -n "$c" ]; then printf "%s\n" "$c"; else echo "(no file has capabilities set)"; fi
+      else
+        echo "(getcap not available - file capabilities could NOT be checked)"
+      fi
+      # NOTE: a trailing "+" in the listing means "alternate access method", which
+      # on netdata installs is usually the security.capability xattr shown above,
+      # NOT an ACL. ACLs for the directory itself are in netdata-paths.txt.
+    done
+    true' sh $PLUGINSD_DIRS
 
-# paths reach the child as positional ARGUMENTS - see the note above
-# shellcheck disable=SC2086  # deliberate word-split of the discovered path list
-collect_cmd 09-permissions/netdata-paths.txt "Modes, ownership, extended attributes, security contexts (SELinux/AppArmor) and POSIX ACLs for netdata's directories, configs and binary" sh -c '
-  if [ "$#" -eq 0 ]; then echo "(no netdata paths found on this host)"; exit 0; fi
-  has_selinux=0; [ -e /sys/fs/selinux ] && has_selinux=1
-  for p in "$@"; do
-    echo "===== $p ====="
-    ls -ld "$p" 2>/dev/null
-    stat -c "mode=%A(%a) owner=%U(%u) group=%G(%g) type=%F" "$p" 2>/dev/null \
-      || stat -f "mode=%Sp(%Lp) owner=%Su group=%Sg" "$p" 2>/dev/null \
-      || true
-    if [ "$has_selinux" = "1" ]; then
-      ls -ldZ "$p" 2>/dev/null || echo "(ls -Z unsupported)"
-    fi
-    if command -v getfattr >/dev/null 2>&1; then
-      # -m - includes the security.* and trusted.* namespaces, which is where
-      # SELinux labels and file capabilities actually live
-      a=$(getfattr -d -m - --absolute-names "$p" 2>/dev/null | grep -v "^#" | grep -v "^$" | head -20)
-      if [ -n "$a" ]; then echo "xattrs:"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
-    elif command -v xattr >/dev/null 2>&1; then
-      a=$(xattr -l "$p" 2>/dev/null | head -20)
-      if [ -n "$a" ]; then echo "xattrs (macOS):"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
-    elif command -v lsextattr >/dev/null 2>&1; then
-      a=$( { lsextattr -q system "$p" 2>/dev/null; lsextattr -q user "$p" 2>/dev/null; } | head -20)
-      if [ -n "$a" ]; then echo "xattrs (FreeBSD):"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
-    else
-      echo "xattrs: (getfattr/xattr/lsextattr absent - the checkable namespaces are reported below)"
-    fi
-    # Reported unconditionally: getfattr lives in the "attr" package, which is
-    # NOT installed by default on Debian/Ubuntu, and these cover the attributes
-    # that actually break netdata - security.capability (a dropped capability
-    # stops a plugin dead) and the ext2/3/4 immutable/append-only flags (which
-    # silently block the agent from writing its own state).
-    if command -v getcap >/dev/null 2>&1; then
-      c=$(getcap "$p" 2>/dev/null)
-      if [ -n "$c" ]; then echo "capabilities: $c"; else echo "capabilities: (none set)"; fi
-    else
-      echo "capabilities: (getcap not available)"
-    fi
-    if command -v lsattr >/dev/null 2>&1; then
-      # lsattr only works on ext-family filesystems; elsewhere it is silent.
-      # "e" (extent) is the ext4 default, so report only NON-default flags -
-      # an immutable ("i") or append-only ("a") flag is the interesting case.
-      l=$(lsattr -d "$p" 2>/dev/null | grep -vE "^-*e-* ")
-      [ -n "$l" ] && echo "file flags (non-default): $l"
-    fi
-    if command -v getfacl >/dev/null 2>&1; then
-      f=$(getfacl -p "$p" 2>/dev/null | grep -v "^#" | grep -v "^$" | head -20)
-      if [ -n "$f" ]; then echo "acl:"; printf "%s\n" "$f"; else echo "acl: (none)"; fi
-    else
-      echo "acl: (getfacl not available)"
-    fi
+  # every netdata-owned path worth reporting permissions for; the cache dir stays
+  # TOP-LEVEL only (recursing it would enumerate thousands of dbengine files)
+  _PERM_PATHS=""
+  for _p in "$CONFDIR" "$CONFDIR/netdata.conf" "$CONFDIR/stream.conf" "$CONFDIR/ssl" \
+            "$LOGDIR" "$LIBDIR" "$LIBDIR/cloud.d" "$LIBDIR/registry" "$CACHEDIR" \
+            $PLUGINSD_DIRS "${NETDATA_BIN:-}"; do
+    [ -n "$_p" ] || continue
+    [ -e "$_p" ] || continue
+    case " $_PERM_PATHS " in *" $_p "*) continue ;; *) : ;; esac
+    _PERM_PATHS="$_PERM_PATHS $_p"
   done
-  true' sh $_PERM_PATHS
+  _PERM_PATHS="${_PERM_PATHS# }"
+
+  # paths reach the child as positional ARGUMENTS - see the note above
+  # shellcheck disable=SC2086  # deliberate word-split of the discovered path list
+  collect_cmd 09-permissions/netdata-paths.txt "Modes, ownership, extended attributes, security contexts (SELinux/AppArmor) and POSIX ACLs for netdata's directories, configs and binary" sh -c '
+    if [ "$#" -eq 0 ]; then echo "(no netdata paths found on this host)"; exit 0; fi
+    has_selinux=0; [ -e /sys/fs/selinux ] && has_selinux=1
+    for p in "$@"; do
+      echo "===== $p ====="
+      ls -ld "$p" 2>/dev/null
+      stat -c "mode=%A(%a) owner=%U(%u) group=%G(%g) type=%F" "$p" 2>/dev/null \
+        || stat -f "mode=%Sp(%Lp) owner=%Su group=%Sg" "$p" 2>/dev/null \
+        || true
+      if [ "$has_selinux" = "1" ]; then
+        ls -ldZ "$p" 2>/dev/null || echo "(ls -Z unsupported)"
+      fi
+      if command -v getfattr >/dev/null 2>&1; then
+        # -m - includes the security.* and trusted.* namespaces, which is where
+        # SELinux labels and file capabilities actually live
+        a=$(getfattr -d -m - --absolute-names "$p" 2>/dev/null | grep -v "^#" | grep -v "^$" | head -20)
+        if [ -n "$a" ]; then echo "xattrs:"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
+      elif command -v xattr >/dev/null 2>&1; then
+        a=$(xattr -l "$p" 2>/dev/null | head -20)
+        if [ -n "$a" ]; then echo "xattrs (macOS):"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
+      elif command -v lsextattr >/dev/null 2>&1; then
+        a=$( { lsextattr -q system "$p" 2>/dev/null; lsextattr -q user "$p" 2>/dev/null; } | head -20)
+        if [ -n "$a" ]; then echo "xattrs (FreeBSD):"; printf "%s\n" "$a"; else echo "xattrs: (none set)"; fi
+      else
+        echo "xattrs: (getfattr/xattr/lsextattr absent - the checkable namespaces are reported below)"
+      fi
+      # Reported unconditionally: getfattr lives in the "attr" package, which is
+      # NOT installed by default on Debian/Ubuntu, and these cover the attributes
+      # that actually break netdata - security.capability (a dropped capability
+      # stops a plugin dead) and the ext2/3/4 immutable/append-only flags (which
+      # silently block the agent from writing its own state).
+      if command -v getcap >/dev/null 2>&1; then
+        c=$(getcap "$p" 2>/dev/null)
+        if [ -n "$c" ]; then echo "capabilities: $c"; else echo "capabilities: (none set)"; fi
+      else
+        echo "capabilities: (getcap not available)"
+      fi
+      if command -v lsattr >/dev/null 2>&1; then
+        # lsattr only works on ext-family filesystems; elsewhere it is silent.
+        # "e" (extent) is the ext4 default, so report only NON-default flags -
+        # an immutable ("i") or append-only ("a") flag is the interesting case.
+        l=$(lsattr -d "$p" 2>/dev/null | grep -vE "^-*e-* ")
+        [ -n "$l" ] && echo "file flags (non-default): $l"
+      fi
+      if command -v getfacl >/dev/null 2>&1; then
+        f=$(getfacl -p "$p" 2>/dev/null | grep -v "^#" | grep -v "^$" | head -20)
+        if [ -n "$f" ]; then echo "acl:"; printf "%s\n" "$f"; else echo "acl: (none)"; fi
+      else
+        echo "acl: (getfacl not available)"
+      fi
+    done
+    true' sh $_PERM_PATHS
+}
 
 # =============================================================================
 # summary + manifest + README
 # =============================================================================
-info "writing summary and manifest"
-AGENT_VERSION=$(awk -F'"' '/"version"/{print $4; exit}' "$WORK/07-runtime/info-v1.json" 2>/dev/null)
-[ -z "$AGENT_VERSION" ] && [ -n "${NETDATA_BIN:-}" ] && AGENT_VERSION=$("$NETDATA_BIN" -v 2>/dev/null | head -1)
-CLAIMED="unknown"
-for _aclkf in "$WORK/07-runtime/aclk-state.json" "$WORK/07-runtime/aclk.json"; do
-  [ -f "$_aclkf" ] || continue
-  if grep -q '"agent-claimed":true' "$_aclkf" 2>/dev/null; then CLAIMED="yes"; break; fi
-  if grep -q '"agent-claimed":false' "$_aclkf" 2>/dev/null; then CLAIMED="no"; break; fi
-done
-[ "$CLAIMED" = "unknown" ] && [ -f "$WORK/06-state/cloud-state.txt" ] && \
-  grep -qE '^[0-9a-f-]{36}' "$WORK/06-state/cloud-state.txt" && CLAIMED="yes"
-ERRCOUNT=""
-[ -f "$WORK/05-logs/error.log" ] && ERRCOUNT=$(grep -ci error "$WORK/05-logs/error.log" 2>/dev/null)
-CRASH_HINT=""
-[ -f "$WORK/06-state/status-file.json" ] && CRASH_HINT=$(awk -F'"' '/"exit_reason"|"cause"/{print $4}' "$WORK/06-state/status-file.json" 2>/dev/null | head -1)
+write_summary() {
+  info "writing summary and manifest"
+  AGENT_VERSION=$(awk -F'"' '/"version"/{print $4; exit}' "$WORK/07-runtime/info-v1.json" 2>/dev/null)
+  [ -z "$AGENT_VERSION" ] && [ -n "${NETDATA_BIN:-}" ] && AGENT_VERSION=$("$NETDATA_BIN" -v 2>/dev/null | head -1)
+  CLAIMED="unknown"
+  for _aclkf in "$WORK/07-runtime/aclk-state.json" "$WORK/07-runtime/aclk.json"; do
+    [ -f "$_aclkf" ] || continue
+    if grep -q '"agent-claimed":true' "$_aclkf" 2>/dev/null; then CLAIMED="yes"; break; fi
+    if grep -q '"agent-claimed":false' "$_aclkf" 2>/dev/null; then CLAIMED="no"; break; fi
+  done
+  [ "$CLAIMED" = "unknown" ] && [ -f "$WORK/06-state/cloud-state.txt" ] && \
+    grep -qE '^[0-9a-f-]{36}' "$WORK/06-state/cloud-state.txt" && CLAIMED="yes"
+  ERRCOUNT=""
+  [ -f "$WORK/05-logs/error.log" ] && ERRCOUNT=$(grep -ci error "$WORK/05-logs/error.log" 2>/dev/null)
+  CRASH_HINT=""
+  [ -f "$WORK/06-state/status-file.json" ] && CRASH_HINT=$(awk -F'"' '/"exit_reason"|"cause"/{print $4}' "$WORK/06-state/status-file.json" 2>/dev/null | head -1)
 
-{
-  echo "NETDATA SUPPORT BUNDLE SUMMARY"
-  echo "generated:        $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  echo "tool version:     $VERSION"
-  echo "runtime seconds:  $(( $(now_s) - START_TS ))"
-  echo "ran as root:      $([ "$(id -u)" = "0" ] && echo yes || echo no)"
-  echo "pii obfuscation:  $([ "$OBFUSCATE" = "1" ] && echo on || echo OFF)"
-  [ -f "$WORK/04-config/stream.conf" ] && \
-    echo "streaming key:    PRESENT VERBATIM in 04-config/stream.conf (by design - see README.md)"
-  echo
-  echo "agent version:    ${AGENT_VERSION:-unknown}"
-  _agent_note=""
-  if [ -n "${NETDATA_PID:-}" ] && [ "$IS_CONTAINER" = "0" ] && [ -z "$CONFDIR" ] && \
-     grep -qE 'docker|containerd|kubepods|lxc' "/proc/$NETDATA_PID/cgroup" 2>/dev/null; then
-    _agent_note=" (process appears to run INSIDE a container; no local install found on this host)"
-  fi
-  echo "agent running:    $([ -n "${NETDATA_PID:-}" ] && echo "yes (pid $NETDATA_PID)$_agent_note" || echo NO)"
-  if [ -z "${NETDATA_PID:-}" ] && grep -q '"status":"running"' "$WORK/06-state/status-file.json" 2>/dev/null; then
-    echo "WARNING: status file still says 'running' but no netdata process exists -"
-    echo "         unclean termination (SIGKILL / OOM kill / power loss); the agent"
-    echo "         could not update the file at death. Check 01-system/kernel-messages.txt."
-  fi
-  echo "agent api:        $([ "$api_ok" = "1" ] && echo reachable || echo UNREACHABLE)"
-  echo "container:        $([ "$IS_CONTAINER" = "1" ] && echo yes || echo no)"
-  echo "config dir:       ${CONFDIR:-NOT FOUND}"
-  echo "claimed to cloud: $CLAIMED"
-  [ -n "$CRASH_HINT" ] && echo "last exit reason: $CRASH_HINT   <-- check 06-state/status-file.json"
-  [ -n "$ERRCOUNT" ] && echo "error.log 'error' lines: $ERRCOUNT"
-  [ "${DOCKER_LOGS_NEEDED:-0}" = "1" ] && echo "NOTE: agent log HISTORY is not in this bundle - it lives in 'docker logs' on the host (see 05-logs/LOGS-ARE-IN-DOCKER.txt)"
-  echo
-  echo "SNMP diagnostics: $SNMP_STATUS ($SNMP_FILES raw files; UNSANITIZED when included)"
-  echo "READ ORDER FOR TRIAGE:"
-  echo "  SNMP issues         -> 06-state/snmp-diagnostics-status.txt, 06-state/snmp-diagnostics/"
-  echo "  crashes/won't start -> 06-state/status-file.json, 05-logs/, 01-system/kernel-messages.txt"
-  echo "  collector issues    -> 04-config/go.d*, 05-logs/collector.log, 09-permissions/plugins-d.txt"
-  echo "  streaming issues    -> 04-config/stream.conf, 07-runtime/node-instances.json, 01-system/clock-timesync.txt"
-  echo "  cloud/claiming      -> 06-state/cloud-state.txt, 07-runtime/aclk-state.json, 08-network/"
-  echo "  performance         -> 03-process/threads-cpu.txt, 06-state/db-disk-usage.txt, 07-runtime/node-instances.json"
-  echo "  permission denied   -> 09-permissions/ (modes, capabilities, xattrs, SELinux/AppArmor, ACLs)"
-} > "$WORK/summary.txt"
-manifest_add summary.txt file generated "Human summary"
+  {
+    echo "NETDATA SUPPORT BUNDLE SUMMARY"
+    echo "generated:        $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "tool version:     $VERSION"
+    echo "runtime seconds:  $(( $(now_s) - START_TS ))"
+    echo "ran as root:      $([ "$(id -u)" = "0" ] && echo yes || echo no)"
+    echo "pii obfuscation:  $([ "$OBFUSCATE" = "1" ] && echo on || echo OFF)"
+    [ -f "$WORK/04-config/stream.conf" ] && \
+      echo "streaming key:    PRESENT VERBATIM in 04-config/stream.conf (by design - see README.md)"
+    echo
+    echo "agent version:    ${AGENT_VERSION:-unknown}"
+    _agent_note=""
+    if [ -n "${NETDATA_PID:-}" ] && [ "$IS_CONTAINER" = "0" ] && [ -z "$CONFDIR" ] && \
+       grep -qE 'docker|containerd|kubepods|lxc' "/proc/$NETDATA_PID/cgroup" 2>/dev/null; then
+      _agent_note=" (process appears to run INSIDE a container; no local install found on this host)"
+    fi
+    echo "agent running:    $([ -n "${NETDATA_PID:-}" ] && echo "yes (pid $NETDATA_PID)$_agent_note" || echo NO)"
+    if [ -z "${NETDATA_PID:-}" ] && grep -q '"status":"running"' "$WORK/06-state/status-file.json" 2>/dev/null; then
+      echo "WARNING: status file still says 'running' but no netdata process exists -"
+      echo "         unclean termination (SIGKILL / OOM kill / power loss); the agent"
+      echo "         could not update the file at death. Check 01-system/kernel-messages.txt."
+    fi
+    echo "agent api:        $([ "$api_ok" = "1" ] && echo reachable || echo UNREACHABLE)"
+    echo "container:        $([ "$IS_CONTAINER" = "1" ] && echo yes || echo no)"
+    echo "config dir:       ${CONFDIR:-NOT FOUND}"
+    echo "claimed to cloud: $CLAIMED"
+    [ -n "$CRASH_HINT" ] && echo "last exit reason: $CRASH_HINT   <-- check 06-state/status-file.json"
+    [ -n "$ERRCOUNT" ] && echo "error.log 'error' lines: $ERRCOUNT"
+    [ "${DOCKER_LOGS_NEEDED:-0}" = "1" ] && echo "NOTE: agent log HISTORY is not in this bundle - it lives in 'docker logs' on the host (see 05-logs/LOGS-ARE-IN-DOCKER.txt)"
+    echo
+    echo "SNMP diagnostics: $SNMP_STATUS ($SNMP_FILES raw files; UNSANITIZED when included)"
+    echo "READ ORDER FOR TRIAGE:"
+    echo "  SNMP issues         -> 06-state/snmp-diagnostics-status.txt, 06-state/snmp-diagnostics/"
+    echo "  crashes/won't start -> 06-state/status-file.json, 05-logs/, 01-system/kernel-messages.txt"
+    echo "  collector issues    -> 04-config/go.d*, 05-logs/collector.log, 09-permissions/plugins-d.txt"
+    echo "  streaming issues    -> 04-config/stream.conf, 07-runtime/node-instances.json, 01-system/clock-timesync.txt"
+    echo "  cloud/claiming      -> 06-state/cloud-state.txt, 07-runtime/aclk-state.json, 08-network/"
+    echo "  performance         -> 03-process/threads-cpu.txt, 06-state/db-disk-usage.txt, 07-runtime/node-instances.json"
+    echo "  permission denied   -> 09-permissions/ (modes, capabilities, xattrs, SELinux/AppArmor, ACLs)"
+  } > "$WORK/summary.txt"
+  manifest_add summary.txt file generated "Human summary"
+}
 
-cat > "$WORK/README.md" <<'EOF'
+write_readme() {
+  cat > "$WORK/README.md" <<'EOF'
 # Netdata Support Bundle
 
 Generated by `netdata-support-bundle`. Standard captures are SANITIZED:
@@ -1763,92 +1843,134 @@ in a config file is still visible here.
 - `07-runtime/AGENT-WAS-DOWN.txt` exists when the local API probe failed (the
   agent may be down, or its API bound away from 127.0.0.1 / bearer-protected).
 EOF
-manifest_add README.md file generated "Bundle documentation"
+  manifest_add README.md file generated "Bundle documentation"
+}
 
-# emit MANIFEST.json LAST so every file (incl. summary.txt and README.md) is indexed
-{
-  echo '{'
-  echo '  "schema": "netdata-support-bundle/v2",'
-  echo "  \"tool_version\": \"$VERSION\","
-  echo "  \"generated_utc\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
-  echo "  \"runtime_seconds\": $(( $(now_s) - START_TS )),"
-  echo "  \"pii_obfuscated\": $([ "$OBFUSCATE" = "1" ] && [ "$SNMP_FILES" = "0" ] && echo true || echo false),"
-  echo "  \"secrets_redacted\": $([ "$SNMP_FILES" = "0" ] && echo true || echo false),"
-  echo "  \"snmp_diagnostics\": {\"requested\": $([ "$INCLUDE_SNMP" = "1" ] && echo true || echo false), \"status\": \"$SNMP_STATUS\", \"files\": $SNMP_FILES},"
-  # the standard-capture exception to secrets_redacted (netdata/netdata#23448)
-  echo "  \"streaming_api_key_redacted\": false,"
-  echo "  \"agent_running\": $([ -n "${NETDATA_PID:-}" ] && echo true || echo false),"
-  echo "  \"agent_api_reachable\": $([ "$api_ok" = "1" ] && echo true || echo false),"
-  echo "  \"is_container\": $([ "$IS_CONTAINER" = "1" ] && echo true || echo false),"
-  echo '  "files": ['
-  sed '$!s/$/,/' "$MANIFEST_ROWS" | sed 's/^/    /'
-  echo '  ]'
-  echo '}'
-} > "$WORK/MANIFEST.json"
+write_manifest() {
+  # emit MANIFEST.json LAST so every file (incl. summary.txt and README.md) is indexed
+  {
+    echo '{'
+    echo '  "schema": "netdata-support-bundle/v2",'
+    echo "  \"tool_version\": \"$VERSION\","
+    echo "  \"generated_utc\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\","
+    echo "  \"runtime_seconds\": $(( $(now_s) - START_TS )),"
+    echo "  \"pii_obfuscated\": $([ "$OBFUSCATE" = "1" ] && [ "$SNMP_FILES" = "0" ] && echo true || echo false),"
+    echo "  \"secrets_redacted\": $([ "$SNMP_FILES" = "0" ] && echo true || echo false),"
+    echo "  \"snmp_diagnostics\": {\"requested\": $([ "$INCLUDE_SNMP" = "1" ] && echo true || echo false), \"status\": \"$SNMP_STATUS\", \"files\": $SNMP_FILES},"
+    # the standard-capture exception to secrets_redacted (netdata/netdata#23448)
+    echo "  \"streaming_api_key_redacted\": false,"
+    echo "  \"agent_running\": $([ -n "${NETDATA_PID:-}" ] && echo true || echo false),"
+    echo "  \"agent_api_reachable\": $([ "$api_ok" = "1" ] && echo true || echo false),"
+    echo "  \"is_container\": $([ "$IS_CONTAINER" = "1" ] && echo true || echo false),"
+    echo '  "files": ['
+    sed '$!s/$/,/' "$MANIFEST_ROWS" | sed 's/^/    /'
+    echo '  ]'
+    echo '}'
+  } > "$WORK/MANIFEST.json"
+}
 
 # =============================================================================
 # tarball
 # =============================================================================
-mkdir -p "$OUTDIR"
-# zstd compresses faster and smaller than gzip on this kind of text-heavy data;
-# use it when the tar build supports --zstd, else a zstd pipe, else gzip
-if command -v zstd >/dev/null 2>&1 && tar --zstd -cf /dev/null -T /dev/null 2>/dev/null; then
-  _ext="tar.zst"; _mode="tar-zstd"
-elif command -v zstd >/dev/null 2>&1; then
-  _ext="tar.zst"; _mode="zstd-pipe"
-else
-  _ext="tar.gz"; _mode="gzip"
-fi
-TARBALL="$OUTDIR/$BUNDLE.$_ext"
-# build inside the 0700 staging dir, then publish with O_EXCL (set -C) so a
-# pre-existing file OR symlink planted in a shared tmp dir can never be
-# followed or overwritten (no check/open TOCTOU window)
-# anonymize archive owner/group so a non-root user's account isn't in tar headers
-_towner=""
-if tar --owner=0 --group=0 -cf /dev/null -T /dev/null 2>/dev/null; then
-  _towner="--owner=0 --group=0 --numeric-owner"
-fi
-_tarok=0
-# shellcheck disable=SC2086  # $_towner intentionally splits into separate tar flags
-case "$_mode" in
-  tar-zstd)  ( cd "$STAGING" && tar $_towner --zstd -cf "$STAGING/bundle.$_ext" "$BUNDLE" ) && _tarok=1 ;;
-  zstd-pipe) ( cd "$STAGING" && tar $_towner -cf - "$BUNDLE" | zstd -q -o "$STAGING/bundle.$_ext" ) && _tarok=1 ;;
-  gzip)      ( cd "$STAGING" && tar $_towner -czf "$STAGING/bundle.$_ext" "$BUNDLE" ) && _tarok=1 ;;
-  *) : ;;
-esac
-if [ "$_tarok" != "1" ]; then
-  echo "failed to create tarball" >&2; exit 1
-fi
-if ! ( set -C; cat "$STAGING/bundle.$_ext" > "$TARBALL" ) 2>/dev/null; then
-  echo "refusing to write $TARBALL (a file or symlink already exists there)" >&2
-  exit 1
-fi
+publish_bundle() {
+  mkdir -p "$OUTDIR"
+  # zstd compresses faster and smaller than gzip on this kind of text-heavy data;
+  # use it when the tar build supports --zstd, else a zstd pipe, else gzip
+  if command -v zstd >/dev/null 2>&1 && tar --zstd -cf /dev/null -T /dev/null 2>/dev/null; then
+    _ext="tar.zst"; _mode="tar-zstd"
+  elif command -v zstd >/dev/null 2>&1; then
+    _ext="tar.zst"; _mode="zstd-pipe"
+  else
+    _ext="tar.gz"; _mode="gzip"
+  fi
+  TARBALL="$OUTDIR/$BUNDLE.$_ext"
+  # build inside the 0700 staging dir, then publish with O_EXCL (set -C) so a
+  # pre-existing file OR symlink planted in a shared tmp dir can never be
+  # followed or overwritten (no check/open TOCTOU window)
+  # anonymize archive owner/group so a non-root user's account isn't in tar headers
+  _towner=""
+  if tar --owner=0 --group=0 -cf /dev/null -T /dev/null 2>/dev/null; then
+    _towner="--owner=0 --group=0 --numeric-owner"
+  fi
+  _tarok=0
+  # shellcheck disable=SC2086  # $_towner intentionally splits into separate tar flags
+  case "$_mode" in
+    tar-zstd)  ( cd "$STAGING" && tar $_towner --zstd -cf "$STAGING/bundle.$_ext" "$BUNDLE" ) && _tarok=1 ;;
+    zstd-pipe)
+      # POSIX pipelines hide tar failures behind a successful compressor.
+      ( cd "$STAGING" || exit 1
+        { tar $_towner -cf - "$BUNDLE"; echo "$?" > "$STAGING/tar.rc"; } |
+          zstd -q -o "$STAGING/bundle.$_ext"
+      ) && [ "$(cat "$STAGING/tar.rc" 2>/dev/null)" = 0 ] && _tarok=1
+      ;;
+    gzip)      ( cd "$STAGING" && tar $_towner -czf "$STAGING/bundle.$_ext" "$BUNDLE" ) && _tarok=1 ;;
+    *) : ;;
+  esac
+  if [ "$_tarok" != "1" ]; then
+    echo "failed to create tarball" >&2; exit 1
+  fi
+  if ! ( set -C; cat "$STAGING/bundle.$_ext" > "$TARBALL" ) 2>/dev/null; then
+    echo "refusing to write $TARBALL (a file or symlink already exists there)" >&2
+    exit 1
+  fi
 
-if [ "$OBFUSCATE" = "1" ] && [ -s "$MAP_FILE" ]; then
-  MAP_OUT="$OUTDIR/$BUNDLE.pseudonym-map.tsv"
-  if ! ( set -C; cat "$MAP_FILE" > "$MAP_OUT" ) 2>/dev/null; then
-    MAP_OUT="$OUTDIR/$BUNDLE.pseudonym-map.$$.tsv"
+  if [ "$OBFUSCATE" = "1" ] && [ -s "$MAP_FILE" ]; then
+    MAP_OUT="$OUTDIR/$BUNDLE.pseudonym-map.tsv"
     if ! ( set -C; cat "$MAP_FILE" > "$MAP_OUT" ) 2>/dev/null; then
-      info "WARNING: could not write the pseudonym map next to the bundle - it was DISCARDED; rerun with --keep-staging if you need it"
-      MAP_OUT=""
+      MAP_OUT="$OUTDIR/$BUNDLE.pseudonym-map.$$.tsv"
+      if ! ( set -C; cat "$MAP_FILE" > "$MAP_OUT" ) 2>/dev/null; then
+        info "WARNING: could not write the pseudonym map next to the bundle - it was DISCARDED; rerun with --keep-staging if you need it"
+        MAP_OUT=""
+      fi
     fi
   fi
-fi
 
-TOTAL_S=$(( $(now_s) - START_TS ))
-SIZE=$(du -h "$TARBALL" 2>/dev/null | cut -f1)
-echo >&2
-info "done in ${TOTAL_S}s"
-info "bundle:  $TARBALL ($SIZE)"
-[ "$OBFUSCATE" = "1" ] && [ -n "${MAP_OUT:-}" ] && info "pseudonym map (KEEP PRIVATE, do not send): $MAP_OUT"
-if [ "$_ext" = "tar.zst" ]; then
-  info "review it:  tar --zstd -tf $TARBALL   (or: zstd -dc $TARBALL | tar -tf -)"
-else
-  info "review it:  tar -tzf $TARBALL"
+  TOTAL_S=$(( $(now_s) - START_TS ))
+  SIZE=$(du -h "$TARBALL" 2>/dev/null | cut -f1)
+  echo >&2
+  info "done in ${TOTAL_S}s"
+  info "bundle:  $TARBALL ($SIZE)"
+  [ "$OBFUSCATE" = "1" ] && [ -n "${MAP_OUT:-}" ] && info "pseudonym map (KEEP PRIVATE, do not send): $MAP_OUT"
+  if [ "$_ext" = "tar.zst" ]; then
+    info "review it:  tar --zstd -tf $TARBALL   (or: zstd -dc $TARBALL | tar -tf -)"
+  else
+    info "review it:  tar -tzf $TARBALL"
+  fi
+  if [ "${DOCKER_LOGS_NEEDED:-0}" = "1" ]; then
+    info "IMPORTANT: this agent logs to the container's stdout - its log history is NOT in this bundle."
+    info "follow 05-logs/LOGS-ARE-IN-DOCKER.txt to capture, review and redact host logs before sharing."
+  fi
+  info "attach the bundle to your support ticket."
+}
+
+# Collector helper scratch variables are function-prefixed. Uppercase variables,
+# api_ok and have_timeout are shared run state; CAPTURE_* are capture results.
+# Tests source the definitions and call initialization/collectors on private fixtures.
+main() {
+  set -u
+  demote "$@"
+  init_defaults
+  parse_options "$@"
+  init_staging
+  detect_timeout
+  init_sanitizer_context
+  [ "$SELFTEST" = "1" ] && run_selftest
+  discover_environment
+  collect_system
+  collect_install
+  collect_process
+  collect_config
+  collect_logs
+  collect_state
+  collect_runtime
+  collect_network
+  collect_permissions
+  write_summary
+  write_readme
+  write_manifest
+  publish_bundle
+}
+
+if [ "${ND_SUPPORT_BUNDLE_SOURCE_ONLY:-0}" != "1" ]; then
+  main "$@"
 fi
-if [ "${DOCKER_LOGS_NEEDED:-0}" = "1" ]; then
-  info "IMPORTANT: this agent logs to the container's stdout - its log history is NOT in this bundle."
-  info "on the docker HOST also run:  docker logs --since 24h <netdata-container> > netdata-docker.log 2>&1"
-  info "and attach netdata-docker.log to the ticket as well."
-fi
-info "attach the bundle to your support ticket."

--- a/packaging/installer/tests/test_snmp_diagnostics.py
+++ b/packaging/installer/tests/test_snmp_diagnostics.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Exercise the shipped collector helpers and manifest against a private fixture.
 
-The prefix contains the real option parser, staging, sanitizer and collectors.
-Stop before host discovery to avoid collecting workstation data. CI additionally
-runs complete installed-path bundles on POSIX and Windows.
+Unix tests source the real functions and initialize only private fixture state.
+Windows tests retain checked section extraction. CI additionally runs complete
+installed-path bundles on POSIX and Windows.
 """
 import json
 import os
@@ -50,9 +50,9 @@ class SnmpDiagnosticsTests(unittest.TestCase):
         shell = os.environ.get("SUPPORT_BUNDLE_TEST_SHELL", "sh")
         windows = shell in ("powershell", "pwsh")
         script = INSTALLER / ("netdata-support-bundle.ps1" if windows else "netdata-support-bundle")
-        source = script.read_text()
-        prefix, manifest, _ = collection_sections(source, windows)
         if windows:
+            source = script.read_text()
+            prefix, manifest, _ = collection_sections(source, windows)
             body = r'''
 $Work = Join-Path $env:SNMP_FIXTURE 'work'
 New-Item -ItemType Directory -Path $Work -Force | Out-Null
@@ -72,6 +72,13 @@ $RuntimeSecs = 0; $NetdataProc = $null; $ApiOk = $false
                 args.append("-IncludeSnmpDiagnostics")
         else:
             body = r'''
+set -u
+ND_SUPPORT_BUNDLE_SOURCE_ONLY=1 . "$SUPPORT_BUNDLE_SCRIPT"
+init_defaults
+parse_options "$@"
+init_staging
+detect_timeout
+HOST_SHORT=""; HOST_FQDN=""; RUN_USER=""
 WORK="$SNMP_FIXTURE/work"
 mkdir -p "$WORK"
 LIBDIR="$SNMP_FIXTURE/lib"
@@ -82,9 +89,9 @@ collect_file config.txt 'fixture config' "$SNMP_FIXTURE/config.txt"
 NETDATA_PID=""; api_ok=0; IS_CONTAINER=0
 '''
             path = fixture / "run.sh"
-            path.write_text(prefix + body + manifest)
+            path.write_text(body + "\nwrite_manifest\n")
             args = (shell.split() + [str(path)] + (["--include-snmp-diagnostics"] if include else []))
-        env = dict(os.environ, SNMP_FIXTURE=str(fixture), SNMP_EXPIRED=str(int(deadline)), ND_SUPPORT_BUNDLE_DEMOTED="1")
+        env = dict(os.environ, SNMP_FIXTURE=str(fixture), SNMP_EXPIRED=str(int(deadline)), ND_SUPPORT_BUNDLE_DEMOTED="1", SUPPORT_BUNDLE_SCRIPT=str(script))
         env["PATH"] = str(fixture / "bin") + os.pathsep + env["PATH"]
         result = subprocess.run(args, env=env, text=True, capture_output=True, timeout=60)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
@@ -238,7 +245,7 @@ $before = [GC]::GetTotalAllocatedBytes($true)
 
     def test_collection_section_boundaries(self):
         # Mutate source only in memory: malformed extracts must never execute.
-        for windows in (False, True):
+        for windows in (True,):
             source = (INSTALLER / ("netdata-support-bundle.ps1" if windows else "netdata-support-bundle")).read_text()
             environment = next(line for line in source.splitlines(True) if line.startswith("# --- environment detection"))
             manifest = next(line for line in source.splitlines(True) if line.startswith("# emit MANIFEST.json LAST"))

--- a/packaging/installer/tests/test_support_bundle.py
+++ b/packaging/installer/tests/test_support_bundle.py
@@ -129,24 +129,54 @@ cp "$MAP_FILE" "$FIXTURE/map"
         self.assertEqual(sum(line.startswith('user\t') for line in mappings), 4096)
         self.assertIn('/home/redacted-user-overflow/file', (self.root / 'users').read_text())
 
-    def test_seed_hostnames_uses_mapping_limit(self):
+    def test_seed_overflow_keeps_names_for_later_captures(self):
         (self.root / 'nodes.json').write_text(json.dumps([
             {'hostname': f'node-{n}.example.test'} for n in range(4100)]))
+        (self.root / 'evidence.log').write_text('node-4095.example.test node-4096.example.test node-4099.example.test\n')
         self.stub('curl', 'cat "$FIXTURE/nodes.json"\n')
         self.run_fixture('''
 seed_hostnames
+collect_file evidence.log fixture "$FIXTURE/evidence.log"
 cp "$MAP_FILE" "$FIXTURE/map"
 ''')
-        self.assertEqual(len((self.root / 'map').read_text().splitlines()), 4096)
+        mappings = (self.root / 'map').read_text().splitlines()
+        self.assertEqual(len(mappings), 4100)
+        self.assertEqual(sum('\tprivate-host-' in line for line in mappings), 4096)
+        evidence = (self.root / 'work/evidence.log').read_text()
+        self.assertNotIn('.example.test', evidence)
+        self.assertIn('private-host-4096', evidence)
+        self.assertEqual(evidence.count('redacted-host-overflow'), 2)
 
-    def test_seed_hostnames_withholds_overflow_and_failure(self):
-        (self.root / 'nodes.json').write_text(json.dumps({'hostname': 'node.example.test', 'data': 'x' * 100}))
-        self.stub('curl', 'cat "$FIXTURE/nodes.json"; exit "${FIXTURE_EXIT:-0}"\n')
-        for cap, code in ((64, '0'), (1024, '28')):
-            with self.subTest(cap=cap, code=code):
-                self.env['FIXTURE_EXIT'] = code
-                self.run_fixture(f'API_CAP={cap}\nseed_hostnames\ncp "$MAP_FILE" "$FIXTURE/map"\n')
-                self.assertEqual((self.root / 'map').read_text(), '')
+    def test_large_discovery_response_keeps_hostname_knowledge(self):
+        (self.root / 'nodes.json').write_text(json.dumps({
+            'hostname': 'large-parent.example.test', 'data': 'x' * (2 * 1024 * 1024)}))
+        (self.root / 'evidence.log').write_text('large-parent.example.test\n')
+        self.stub('curl', 'cat "$FIXTURE/nodes.json"\n')
+        self.run_fixture('''
+seed_hostnames
+collect_file evidence.log fixture "$FIXTURE/evidence.log"
+collect_api api.json fixture /api/v2/node_instances
+''')
+        self.assertNotIn('large-parent.example.test', (self.root / 'work/evidence.log').read_text())
+        self.assertIn('cap', json.loads((self.root / 'work/api.json').read_text())['error'])
+
+    def test_failed_seed_response_is_not_used(self):
+        self.stub('curl', 'printf \'{"hostname":"incomplete.example.test"}\'; exit 28\n')
+        self.run_fixture('seed_hostnames\ncp "$MAP_FILE" "$FIXTURE/map"\n')
+        self.assertEqual((self.root / 'map').read_text(), '')
+
+    def test_no_obfuscation_skips_discovery_but_redacts_secrets(self):
+        self.stub('curl', 'touch "$FIXTURE/discovery-called"; exit 1\n')
+        (self.root / 'config').write_text('password=SENTINEL\nnode.example.test\n')
+        self.run_fixture('''
+OBFUSCATE=0
+seed_hostnames
+collect_file config fixture "$FIXTURE/config"
+''')
+        self.assertFalse((self.root / 'discovery-called').exists())
+        result = (self.root / 'work/config').read_text()
+        self.assertNotIn('SENTINEL', result)
+        self.assertIn('node.example.test', result)
 
     def test_archive_pipeline_propagates_tar_failure(self):
         self.stub('tar', 'case "$*" in *--zstd*|*--owner*) exit 1;; esac\nprintf partial; exit 9\n')

--- a/packaging/installer/tests/test_support_bundle.py
+++ b/packaging/installer/tests/test_support_bundle.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unix support-bundle contracts against private synthetic fixtures."""
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'netdata-support-bundle'
+
+
+class SupportBundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        (self.root / 'bin').mkdir()
+        self.env = dict(os.environ, SUPPORT_BUNDLE_SCRIPT=str(SCRIPT), FIXTURE=str(self.root),
+                        ND_SUPPORT_BUNDLE_DEMOTED='1', TMPDIR=str(self.root))
+        self.env['PATH'] = str(self.root / 'bin') + os.pathsep + self.env['PATH']
+
+    def run_fixture(self, body, timeout=30, expected=0):
+        setup = '''
+set -u
+ND_SUPPORT_BUNDLE_SOURCE_ONLY=1 . "$SUPPORT_BUNDLE_SCRIPT"
+init_defaults
+init_staging
+detect_timeout
+HOST_SHORT=""; HOST_FQDN=""; RUN_USER=""
+WORK="$FIXTURE/work"
+mkdir -p "$WORK"
+NETDATA_PID=""; api_ok=0; IS_CONTAINER=0
+'''
+        shell = shlex.split(os.environ.get('SUPPORT_BUNDLE_TEST_SHELL', 'sh'))
+        result = subprocess.run(shell + ['-c', setup + body], env=self.env,
+                                text=True, capture_output=True, timeout=timeout)
+        self.assertEqual(result.returncode, expected, result.stdout + result.stderr)
+        return result
+
+    def stub(self, name, body):
+        path = self.root / 'bin' / name
+        path.write_text('#!/bin/sh\n' + body)
+        path.chmod(0o755)
+
+    def test_source_does_not_collect_or_initialize(self):
+        result = subprocess.run(['sh', '-c', 'ND_SUPPORT_BUNDLE_SOURCE_ONLY=1 . "$SUPPORT_BUNDLE_SCRIPT"'],
+                                env=self.env, capture_output=True, text=True, timeout=5)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(list(self.root.iterdir()), [self.root / 'bin'])
+
+    def test_failed_raw_capture_withholds_partial_json(self):
+        self.run_fixture('''
+collect_cmd_raw partial.json fixture sh -c 'printf "{\\"partial\\":"; exit 7'
+write_manifest
+''')
+        body = json.loads((self.root / 'work/partial.json').read_text())
+        self.assertIn('error', body)
+        self.assertNotIn('partial', body)
+        self.assertEqual(body['exit_code'], '7')
+        manifest = json.loads((self.root / 'work/MANIFEST.json').read_text())
+        self.assertEqual(manifest['files'][0]['bytes'], (self.root / 'work/partial.json').stat().st_size)
+
+    def test_raw_timeout_withholds_partial_json(self):
+        self.run_fixture('''
+CMD_TIMEOUT=1
+collect_cmd_raw timeout.json fixture sh -c 'printf "{\\"partial\\":"; sleep 3'
+''', timeout=10)
+        body = json.loads((self.root / 'work/timeout.json').read_text())
+        self.assertIn('error', body)
+        self.assertNotEqual(body['exit_code'], '0')
+
+    def test_raw_overflow_and_empty_output(self):
+        (self.root / 'large.json').write_text(json.dumps({'data': 'x' * 200}))
+        self.run_fixture('''
+API_CAP=64
+collect_cmd_raw large.json fixture cat "$FIXTURE/large.json"
+collect_cmd_raw empty.json fixture true
+''')
+        self.assertIn('cap', json.loads((self.root / 'work/large.json').read_text())['error'])
+        self.assertFalse((self.root / 'work/empty.json').exists())
+
+    def test_manifest_escapes_control_characters(self):
+        value = 'line\rname\x01\b\f\\".conf'
+        self.env['ODD_NAME'] = value
+        self.run_fixture('''
+printf 'fixture\n' > "$WORK/$ODD_NAME"
+manifest_add "$ODD_NAME" file "$ODD_NAME" "$ODD_NAME"
+write_manifest
+''')
+        entry = json.loads((self.root / 'work/MANIFEST.json').read_text())['files'][0]
+        for key in ('path', 'origin', 'title'):
+            self.assertEqual(entry[key], value)
+
+    def test_command_exit_status_and_sanitization(self):
+        self.run_fixture('''
+collect_cmd cmd.txt fixture sh -c 'echo password=SENTINEL; exit 9'
+''')
+        text = (self.root / 'work/cmd.txt').read_text()
+        self.assertIn('# exit: 9', text)
+        self.assertNotIn('SENTINEL', text)
+
+    def test_api_bypasses_proxy_environment(self):
+        self.stub('curl', '''
+printf '%s\\n' "$*" > "$FIXTURE/curl-args"
+printf '%s|%s|%s|%s' "${http_proxy:-}" "${HTTP_PROXY:-}" "${all_proxy:-}" "${ALL_PROXY:-}" > "$FIXTURE/proxy-env"
+printf '{"keep":true}\\n'
+''')
+        for key in ('http_proxy', 'HTTP_PROXY', 'all_proxy', 'ALL_PROXY'):
+            self.env[key] = 'http://proxy.example.test:8080'
+        self.run_fixture('collect_api api.json fixture /api/v3/info\n')
+        self.assertEqual((self.root / 'proxy-env').read_text(), '|||')
+        self.assertIn('--noproxy *', (self.root / 'curl-args').read_text())
+        self.assertTrue(json.loads((self.root / 'work/api.json').read_text())['keep'])
+
+    def test_api_failure_withholds_partial_body(self):
+        self.stub('curl', 'printf "{\\"partial\\":"; exit 28\n')
+        self.run_fixture('collect_api api.json fixture /api/v3/info\n')
+        self.assertIn('error', json.loads((self.root / 'work/api.json').read_text()))
+
+    def test_user_mapping_bound(self):
+        (self.root / 'users').write_text(''.join(f'/home/account-{n}/file\n' for n in range(4100)))
+        self.run_fixture('''
+sanitize_file "$FIXTURE/users"
+cp "$MAP_FILE" "$FIXTURE/map"
+''')
+        mappings = (self.root / 'map').read_text().splitlines()
+        self.assertEqual(sum(line.startswith('user\t') for line in mappings), 4096)
+        self.assertIn('/home/redacted-user-overflow/file', (self.root / 'users').read_text())
+
+    def test_seed_hostnames_uses_mapping_limit(self):
+        (self.root / 'nodes.json').write_text(json.dumps([
+            {'hostname': f'node-{n}.example.test'} for n in range(4100)]))
+        self.stub('curl', 'cat "$FIXTURE/nodes.json"\n')
+        self.run_fixture('''
+seed_hostnames
+cp "$MAP_FILE" "$FIXTURE/map"
+''')
+        self.assertEqual(len((self.root / 'map').read_text().splitlines()), 4096)
+
+    def test_seed_hostnames_withholds_overflow_and_failure(self):
+        (self.root / 'nodes.json').write_text(json.dumps({'hostname': 'node.example.test', 'data': 'x' * 100}))
+        self.stub('curl', 'cat "$FIXTURE/nodes.json"; exit "${FIXTURE_EXIT:-0}"\n')
+        for cap, code in ((64, '0'), (1024, '28')):
+            with self.subTest(cap=cap, code=code):
+                self.env['FIXTURE_EXIT'] = code
+                self.run_fixture(f'API_CAP={cap}\nseed_hostnames\ncp "$MAP_FILE" "$FIXTURE/map"\n')
+                self.assertEqual((self.root / 'map').read_text(), '')
+
+    def test_archive_pipeline_propagates_tar_failure(self):
+        self.stub('tar', 'case "$*" in *--zstd*|*--owner*) exit 1;; esac\nprintf partial; exit 9\n')
+        self.stub('zstd', 'while [ "$#" -gt 0 ]; do if [ "$1" = -o ]; then shift; cat > "$1"; exit 0; fi; shift; done\n')
+        self.run_fixture('OUTDIR="$FIXTURE/output"\npublish_bundle\n', expected=1)
+        self.assertEqual(list((self.root / 'output').iterdir()), [])
+
+    def test_hostname_boundaries_and_cross_file_stability(self):
+        names = ['node.example.test', 'node-2', 'dot.name', 'strange_name.example.test']
+        mapping = ''.join(f'fqdn\t{name}\tprivate-host-{i+1}\n' for i, name in enumerate(names))
+        (self.root / 'seed').write_text(mapping)
+        sample = ('node.example.test:19999 node.example.test.extra xnode.example.test\n'
+                  'node-2 node-20 /dot.name/path strange_name.example.test\n')
+        for name in ('first', 'second'):
+            (self.root / name).write_text(sample)
+        self.run_fixture('''
+cat "$FIXTURE/seed" > "$MAP_FILE"
+sanitize_file "$FIXTURE/first"
+sanitize_file "$FIXTURE/second"
+''')
+        first = (self.root / 'first').read_text()
+        self.assertEqual(first, (self.root / 'second').read_text())
+        self.assertEqual(first, 'private-host-1:19999 node.example.test.extra xnode.example.test\n'
+                               'private-host-2 node-20 /private-host-3/path private-host-4\n')
+
+    def test_docker_log_note_requires_review_and_uses_requested_window(self):
+        log = self.root / 'logs'
+        log.mkdir()
+        (log / 'daemon.log').symlink_to('/dev/stdout')
+        self.stub('journalctl', 'exit 0\n')
+        self.stub('coredumpctl', 'exit 0\n')
+        self.run_fixture('LOGDIR="$FIXTURE/logs"; SINCE_HOURS=7\ncollect_logs\n')
+        note = (self.root / 'work/05-logs/LOGS-ARE-IN-DOCKER.txt').read_text()
+        self.assertIn('--since 7h', note)
+        self.assertIn('UNSANITIZED', note)
+        self.assertIn('review', note)
+
+    def test_state_inventory_does_not_publish_filenames(self):
+        lib = self.root / 'lib'
+        lib.mkdir()
+        (lib / 'private-job-SENTINEL').write_text('secret bytes')
+        self.run_fixture('''
+LIBDIR="$FIXTURE/lib"; CACHEDIR=""; CONFDIR=""
+collect_state
+''')
+        inventory = (self.root / 'work/06-state/state-tree.txt').read_text()
+        self.assertNotIn('SENTINEL', inventory)
+        self.assertIn('files:', inventory)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/packaging/installer/tests/test_support_bundle.py
+++ b/packaging/installer/tests/test_support_bundle.py
@@ -224,7 +224,8 @@ collect_state
 ''')
         inventory = (self.root / 'work/06-state/state-tree.txt').read_text()
         self.assertNotIn('SENTINEL', inventory)
-        self.assertIn('files:', inventory)
+        self.assertIn('files: 1\n', inventory)
+        self.assertIn('logical bytes: 12\n', inventory)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### Summary

Reorganize the Unix support bundle script into named collection phases and shared capture helpers, making execution flow and error handling easier to maintain.

- Consolidate command/API capture and preserve producer failures.
- Fix JSON escaping, local API proxy bypass, and archive failure detection.
- Speed up hostname redaction with indexed matching while retaining all discovered names, including those beyond the numbered pseudonym limit.
- Exclude unsafe crash-record sources and report aggregate state-directory inventory.
- Update documentation, regression tests, and CI coverage across shell/AWK implementations.

The CLI and manifest schema remain unchanged. The Windows PowerShell script is unchanged.

##### Test Plan

- Passed 25 applicable tests, self-tests, and full-bundle checks across macOS and Docker Linux.
- Passed ShellCheck and workflow YAML validation.
- Measured approximately 35× faster sanitization in a hostname-heavy benchmark.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the Unix support bundle script into named collection phases and shared capture helpers, making execution flow and error handling easier to maintain. The CLI and manifest schema are unchanged, and the Windows PowerShell script is unchanged.

**Bug Fixes**
- Failed or size-capped command/API captures now write a JSON error marker instead of partial output.
- Local API reads clear proxy environment variables and pass `--noproxy`, so diagnostic data cannot leave the host through a forced proxy.
- Manifest entries escape control characters, and bundle publication fails when either tar or the zstd compressor fails.

**Refactors**
- Hostname redaction uses a prefix index (roughly 35× faster) and keeps every discovered name, including names past the 4096-entry pseudonym cap.
- State-directory inventory reports aggregate counts and sizes without filenames, keeping bearer token names hidden.
- Unsafe crash-record sources are excluded.
- Added a Unix fixture test suite and expanded CI to cover `sh`/`dash`/`busybox` with `gawk`/`mawk`/busybox awk plus ShellCheck.

<sup>Written for commit 771d15fba43d8d89b9f579880673f09c6af44ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Support-bundle generation now has broader validation across Unix shell and macOS environments.
  * Support bundles receive stronger checks for filename privacy, manifest completeness, file sizes, and archive contents.
  * Local API reads now bypass proxy settings while external connectivity checks retain standard proxy behavior.
  * Sanitization handles additional hostname, token, inventory, and discovery scenarios.

* **Documentation**
  * Updated support-bundle guidance, Unix implementation details, validation requirements, and maintenance procedures.

* **Tests**
  * Added comprehensive coverage for collection, sanitization, privacy, failures, timeouts, proxy handling, and archive generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->