### PR TITLE
otel-plugin: bind the gRPC endpoint before declaring Functions

### DIFF
--- a/src/crates/otel-ingestor/src/lib.rs
+++ b/src/crates/otel-ingestor/src/lib.rs
@@ -13,6 +13,7 @@ use opentelemetry_proto::tonic::collector::logs::v1::logs_service_server::LogsSe
 use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::MetricsServiceServer;
 use opentelemetry_proto::tonic::collector::trace::v1::trace_service_server::TraceServiceServer;
 use tokio::sync::RwLock;
+use tonic::transport::server::TcpIncoming;
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 
 mod aggregation;
@@ -40,8 +41,13 @@ const WAL_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3
 
 /// Ingestor worker entry point.
 ///
-/// Connects to the supervisor's IPC socket, performs the Configure → Ready
-/// handshake, then runs the gRPC metrics server and chart emission loop.
+/// Connects to the supervisor's IPC socket, receives Configure, then runs the
+/// gRPC server and chart emission loop. `Ready` is sent from inside
+/// `run_ingestor`, only after the endpoint is bound and every startup step has
+/// succeeded: the supervisor forwards the ledger's Function declarations to the
+/// agent only once it sees this worker's Ready, so a startup failure here (a
+/// port already in use, an unreadable TLS key) leaves the plugin un-advertised
+/// and exits it once, instead of advertising Functions it cannot back.
 pub async fn run_worker(socket_path: &str) -> Result<()> {
     tracing::info!(socket = %socket_path, "connecting to supervisor");
 
@@ -62,13 +68,6 @@ pub async fn run_worker(socket_path: &str) -> Result<()> {
         }
     };
 
-    // Signal ready — ingestor has no function declarations (metrics only)
-    conn.send(IngestorResponse::Ready {
-        declarations: vec![],
-    })
-    .await?;
-    tracing::info!("signaled ready to supervisor");
-
     // Best-effort: log immediately on return, before the supervisor (which
     // SIGKILLs workers the moment the connection closes) can react to the
     // dropped connection. `conn` is owned by `run_ingestor`, so unlike the
@@ -82,6 +81,23 @@ async fn run_ingestor(
     config: PluginConfig,
     mut conn: Connection<IngestorResponse, IngestorRequest>,
 ) -> Result<()> {
+    // Bind the gRPC endpoint FIRST, before this worker's disk setup: a port
+    // conflict is the most likely startup failure (another listener, or another
+    // agent in a shared network namespace), and detecting it here fails fast
+    // before the ingestor touches its WAL directories or the seq high-water
+    // file (the ledger has already done its own disk startup by now). tonic's
+    // `serve(addr)` would bind lazily, only when the server future is polled.
+    let addr: std::net::SocketAddr =
+        config.endpoint.path.parse().with_context(|| {
+            format!("failed to parse endpoint address: {}", config.endpoint.path)
+        })?;
+    // `serve_with_incoming` discards the builder's TCP options, so restore the
+    // TCP_NODELAY default that `serve(addr)` used to apply to accepted sockets.
+    let incoming = TcpIncoming::bind(addr)
+        .with_context(|| format!("failed to bind gRPC endpoint {}", config.endpoint.path))?
+        .with_nodelay(Some(true));
+    tracing::info!(endpoint = %config.endpoint.path, "gRPC endpoint bound");
+
     // Set up metrics pipeline
     let mut ccm = ChartConfigManager::with_default_configs();
     ccm.set_defaults(
@@ -222,12 +238,6 @@ async fn run_ingestor(
         s.sweep_expired_rotations()
     });
 
-    // Parse gRPC endpoint address
-    let addr =
-        config.endpoint.path.parse().with_context(|| {
-            format!("failed to parse endpoint address: {}", config.endpoint.path)
-        })?;
-
     // Build gRPC server (with TLS if configured)
     let mut server_builder = Server::builder();
 
@@ -273,7 +283,16 @@ async fn run_ingestor(
         .add_service(metrics_svc)
         .add_service(logs_svc)
         .add_service(traces_svc)
-        .serve(addr);
+        .serve_with_incoming(incoming);
+
+    // Every fallible startup step is behind us and the listener is bound, so
+    // this is the point at which the supervisor may advertise the plugin. The
+    // ingestor declares no Functions of its own; its Ready gates the ledger's.
+    conn.send(IngestorResponse::Ready {
+        declarations: vec![],
+    })
+    .await?;
+    tracing::info!("signaled ready to supervisor");
 
     // Main loop: forward chart data to supervisor, handle incoming requests, run gRPC
     tokio::select! {

--- a/src/crates/otel-ledger/src/ledger/mod.rs
+++ b/src/crates/otel-ledger/src/ledger/mod.rs
@@ -155,9 +155,13 @@ impl Ledger {
     /// construction (which sets up the handlers) and the ingestor accept: the
     /// supervisor configures workers sequentially, so the ingestor (which the
     /// ledger then waits for on `writer_socket_path`) can't start until the
-    /// supervisor has seen Ready — moving Ready any later deadlocks. A failure
-    /// before Ready leaves the worker un-advertised; a failure during
-    /// `accept_writer` after Ready surfaces as a dropped supervisor connection.
+    /// supervisor has seen Ready — moving Ready any later deadlocks. Ready here
+    /// is a report to the supervisor, not yet an advertisement: the supervisor
+    /// forwards these declarations to the agent only after the ingestor has
+    /// bound its gRPC endpoint (bind before declare), so a failure before Ready
+    /// or an ingestor bind failure both leave the plugin un-advertised. A
+    /// failure during `accept_writer` after Ready surfaces as a dropped
+    /// supervisor connection.
     pub async fn new(
         mut supervisor: Connection<LedgerResponse, LedgerRequest>,
         writer_socket_path: &str,
@@ -320,7 +324,8 @@ impl Ledger {
 
         // Signal Ready between pipeline construction and the ingestor accept;
         // see the method docstring for the full ordering rationale. Both
-        // Functions are advertised: `otel-logs` and `otel-traces`.
+        // Functions are reported: `otel-logs` and `otel-traces`. The supervisor
+        // advertises them once the ingestor is bound.
         let declarations = vec![
             pipelines.logs.declaration().clone(),
             pipelines.traces.declaration().clone(),

--- a/src/crates/otel-plugin/metadata.yaml
+++ b/src/crates/otel-plugin/metadata.yaml
@@ -236,6 +236,27 @@ modules:
                   "redis.cpu.time":
                     - dimension_attribute_key: state
     troubleshooting:
+      errors:
+        list:
+          - error: "`failed to bind gRPC endpoint 127.0.0.1:4317: Address already in use (os error 98)`"
+            when: |
+              Logged in the Agent journal at startup by the `otel-plugin/ingestor` worker, followed by `exited with error code 1 and haven't collected any data. Disabling it.` from the Agent.
+            cause: |
+              Another process already listens on the configured endpoint. Typical sources are a standalone OpenTelemetry Collector on the same host, or several Netdata Agents running in containers that share the host network namespace (`--network host`), where only one of them can own `127.0.0.1:4317`. The plugin binds the endpoint before it advertises anything, so on a conflict it exits once and the Agent disables it until the next Agent restart.
+            fix: |
+              Find the owner with `ss -ltnp 'sport = :4317'`. Then either stop that listener, or give this Agent its own endpoint in `otel.yaml` and point every OTLP sender at the new port (avoid `4318`, the conventional OTLP/HTTP port, which this plugin does not serve):
+
+              ```yaml
+              endpoint:
+                path: 127.0.0.1:14317
+              ```
+
+              When several Agents share one network namespace and only one needs to receive OTLP, disable the plugin on the others in `netdata.conf`:
+
+              ```ini
+              [plugins]
+                otel = no
+              ```
       problems:
         list:
           - name: The plugin does not start

--- a/src/crates/otel-plugin/src/supervisor.rs
+++ b/src/crates/otel-plugin/src/supervisor.rs
@@ -151,8 +151,13 @@ struct Supervisor {
 
 impl Supervisor {
     /// Record a worker's function declarations in the routing table and forward
-    /// each one to the agent. Shared by the three `configure_*` handshakes,
-    /// which differ only in their request/response/config types.
+    /// each one to the agent. The ledger's and ingestor's declarations are held
+    /// by `run()` until BOTH handshakes succeeded, because the ingestor's Ready
+    /// means "the gRPC endpoint is bound and startup completed": a Function the
+    /// agent has seen outlives the plugin as a restartable collector, so a plugin
+    /// that declared and then died on a bind error would be restarted by the
+    /// agent forever. Legacy-logs registers as soon as it is ready; it is
+    /// configured after the ingestor and is best-effort anyway.
     async fn register_declarations(
         &mut self,
         worker: Worker,
@@ -180,38 +185,41 @@ impl Supervisor {
         Ok(())
     }
 
-    /// Send Configure to the ingestor and register the functions it reports.
-    async fn configure_ingestor(&mut self, config: PluginConfig) -> anyhow::Result<()> {
+    /// Send Configure to the ingestor and return the functions it reports. The
+    /// ingestor sends Ready only once its gRPC endpoint is bound and every
+    /// startup step succeeded, so a failure here (typically the port already in
+    /// use) surfaces before anything has been declared to the agent.
+    async fn configure_ingestor(
+        &mut self,
+        config: PluginConfig,
+    ) -> anyhow::Result<Vec<FunctionDeclaration>> {
         self.ingestor
             .send(IngestorRequest::Configure(Box::new(config)))
             .await
             .context("failed to send Configure to ingestor")?;
 
         match self.ingestor.recv().await.context("ingestor handshake")? {
-            IngestorResponse::Ready { declarations } => {
-                self.register_declarations(Worker::Ingestor, declarations)
-                    .await?;
-            }
+            IngestorResponse::Ready { declarations } => Ok(declarations),
             other => bail!("expected Ready from ingestor, got: {other:?}"),
         }
-        Ok(())
     }
 
-    /// Send Configure to the ledger and register the functions it reports.
-    async fn configure_ledger(&mut self, config: PluginConfig) -> anyhow::Result<()> {
+    /// Send Configure to the ledger and return the functions it reports. The
+    /// caller registers them only after the ingestor handshake also succeeded
+    /// (see `register_declarations`).
+    async fn configure_ledger(
+        &mut self,
+        config: PluginConfig,
+    ) -> anyhow::Result<Vec<FunctionDeclaration>> {
         self.ledger
             .send(LedgerRequest::Configure(Box::new(config)))
             .await
             .context("failed to send Configure to ledger")?;
 
         match self.ledger.recv().await.context("ledger handshake")? {
-            LedgerResponse::Ready { declarations } => {
-                self.register_declarations(Worker::Ledger, declarations)
-                    .await?;
-            }
+            LedgerResponse::Ready { declarations } => Ok(declarations),
             other => bail!("expected Ready from ledger, got: {other:?}"),
         }
-        Ok(())
     }
 
     /// Send Configure to the legacy-logs worker and register the functions it reports.
@@ -755,15 +763,29 @@ pub async fn run() -> anyhow::Result<()> {
         .await
         .context("failed to write TRUST_DURATIONS to agent")?;
 
-    supervisor
+    // The ledger is configured first (it must be listening on the writer socket
+    // before the ingestor connects to it), but its Functions are not forwarded to
+    // the agent until the ingestor has bound its endpoint: bind before declare.
+    // A handshake failure here returns straight out and ChildGuard SIGKILLs the
+    // remaining workers: the ledger does not read its supervisor connection
+    // while it waits in `accept_writer`, so a graceful Shutdown would not reach
+    // it anyway, and legacy-logs treats a pre-Configure Shutdown as an error.
+    let ledger_declarations = supervisor
         .configure_ledger(plugin_config.clone())
         .await
         .context("ledger configuration failed")?;
 
-    supervisor
+    let ingestor_declarations = supervisor
         .configure_ingestor(plugin_config)
         .await
         .context("ingestor configuration failed")?;
+
+    supervisor
+        .register_declarations(Worker::Ledger, ledger_declarations)
+        .await?;
+    supervisor
+        .register_declarations(Worker::Ingestor, ingestor_declarations)
+        .await?;
 
     // The legacy-logs viewer is best-effort and decoupled from the new pipeline:
     // a configure failure disables it but MUST NOT take down the new pipeline.


### PR DESCRIPTION
##### Summary

When the OTLP endpoint (default `127.0.0.1:4317`) is already taken, the otel plugin used to declare the `otel-logs` / `otel-traces` Functions to the agent first and die on the bind afterwards. The agent counts FUNCTION lines as successful collections, so it restarted the plugin every ~10s forever, churning Functions on the child, streaming metadata to the parent, and cloud manifests on both. Seen in a lab where several agents share one host network namespace.

Now the ingestor binds first and reports Ready only after every startup step succeeded, and the supervisor forwards the Function declarations only after that. On a port conflict the plugin exits once with no FUNCTION lines and the agent disables it.

- ingestor: eager `TcpIncoming::bind` before disk setup; Ready right before serving; `serve_with_incoming` with `TCP_NODELAY` kept
- supervisor: ledger and ingestor declarations are registered only after both handshakes succeed
- metadata.yaml: known-error entry for the bind failure

##### Test Plan

- Two plugin instances on the same endpoint: the first serves and declares both Functions; the second exits 1 with zero FUNCTION lines and the first is unaffected.
- Port free: bind, Ready, then both FUNCTION lines; clean shutdown on SIGTERM.
- `cargo test -p otel-ingestor -p otel-plugin -p otel-ledger`, `python3 -m unittest integrations.tests.test_collector_metadata`.

##### Additional Information

No agent-side change and no degraded mode: the agent's existing "exited with error and collected nothing, disabling" path handles the failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OTLP plugin so a gRPC port conflict exits it cleanly instead of looping forever.

Previously the plugin declared its `otel-logs`/`otel-traces` Functions before binding the endpoint; when the port was taken, the agent counted those declarations as successful collections and restarted the plugin every ~10s. Now the ingestor binds first, sends Ready only after every startup step succeeds, and the supervisor forwards declarations only after both handshakes succeed, so a port conflict produces one clean exit with zero FUNCTION lines and the agent disables the plugin.

**Bug Fixes**
- Binds the gRPC endpoint before disk setup and reports Ready only once the listener is serving.
- Holds ledger and ingestor Function declarations until both handshakes succeed.
- Adds a known-error entry to `metadata.yaml` for the bind failure.

<sup>Written for commit 7db37adfd1d7bd92bfd79aa44cb70a04b5ee32ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup reliability by confirming the network endpoint is available before reporting the service as ready.
  - Startup and endpoint binding failures are now surfaced more clearly.
  - Function availability is advertised only after all required startup steps complete successfully.

- **Documentation**
  - Added troubleshooting guidance for endpoint binding failures caused by port conflicts, including configuration and resolution steps.
  - Clarified service startup, readiness, and function advertisement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->