### PR TITLE
feat(go.d/snmp): inspect diagnostics directly from support bundles

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/diagnostics/layout.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/layout.go
@@ -5,6 +5,7 @@ package diagnostics
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -37,7 +38,12 @@ func checkpointFilename(sequence uint64) string { return fmt.Sprintf("checkpoint
 // ListCheckpoints reads filenames only. Evidence is decoded when selected, not
 // during rotation; temporary files and unrelated entries never enter retention.
 func ListCheckpoints(directory string) ([]CheckpointFile, error) {
-	files, err := os.ReadDir(filepath.Join(directory, TopologyDirectory))
+	return ListCheckpointsFS(os.DirFS(directory))
+}
+
+// ListCheckpointsFS lists completed checkpoint filenames in a diagnostic filesystem.
+func ListCheckpointsFS(root fs.FS) ([]CheckpointFile, error) {
+	files, err := fs.ReadDir(root, TopologyDirectory)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}

--- a/src/go/plugin/go.d/collector/snmp/diagnostics/normal_layout.go
+++ b/src/go/plugin/go.d/collector/snmp/diagnostics/normal_layout.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -42,7 +44,12 @@ func parseNormalFilename(name string) (registration uint64, ok bool) {
 }
 
 func ReadNormalRuns(directory string) (NormalRuns, error) {
-	file, err := os.Open(filepath.Join(directory, NormalDirectory, normalRunsFilename))
+	return ReadNormalRunsFS(os.DirFS(directory))
+}
+
+// ReadNormalRunsFS reads the committed run identities from a diagnostic filesystem.
+func ReadNormalRunsFS(root fs.FS) (NormalRuns, error) {
+	file, err := root.Open(path.Join(NormalDirectory, normalRunsFilename))
 	if errors.Is(err, os.ErrNotExist) {
 		return NormalRuns{}, nil
 	}
@@ -72,7 +79,12 @@ func validNormalRun(id string) bool {
 // ListNormalFiles reads only the committed run index and filenames. Temporary
 // or unactivated files never become previous-run evidence by accident.
 func ListNormalFiles(directory string) ([]NormalFile, error) {
-	runs, err := ReadNormalRuns(directory)
+	return ListNormalFilesFS(os.DirFS(directory))
+}
+
+// ListNormalFilesFS lists completed device files from committed runs only.
+func ListNormalFilesFS(root fs.FS) ([]NormalFile, error) {
+	runs, err := ReadNormalRunsFS(root)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +93,7 @@ func ListNormalFiles(directory string) ([]NormalFile, error) {
 		if run == "" {
 			continue
 		}
-		files, err := os.ReadDir(filepath.Join(directory, NormalDirectory, run))
+		files, err := fs.ReadDir(root, path.Join(NormalDirectory, run))
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}

--- a/src/go/tools/snmp-diagnostics/README.md
+++ b/src/go/tools/snmp-diagnostics/README.md
@@ -23,20 +23,36 @@ go run ./tools/snmp-diagnostics inspect-link --input /path/to/archive.zst \
   --direction bidirectional
 ```
 
-The input can be a single `.zst` file or the `snmp/diagnostics` directory (including the copy under
-`06-state/snmp-diagnostics` in a support bundle). Directory input selects the latest topology checkpoint by default;
-`--checkpoint N` selects a retained sequence. Select `lifecycle.zst` explicitly to inspect lifecycle state.
-Only the current diagnostic layout is supported.
+The input can be a single diagnostic `.zst` file, the `snmp/diagnostics` directory, an extracted support-bundle
+root, or a support `.tar.zst`, `.tar.gz`, or `.zip` archive. Bundle inputs automatically use `06-state/snmp-diagnostics`.
+Archives may contain that layout directly or under one wrapper directory; ambiguous roots, duplicate relevant members,
+unsafe paths, and linked evidence are rejected. The tool does not extract files.
+
+Directory and bundle input selects the latest topology checkpoint by default. `--checkpoint N` selects a retained
+sequence; `--lifecycle` selects lifecycle state; `--normal --registration-id N` selects a normal device. These evidence
+selectors cannot be combined or used with an individual file. `--previous-run` requires `--normal`. Explicit lifecycle-file
+input remains supported. Only the current diagnostic layout is supported.
 
 ```text
-go run ./tools/snmp-diagnostics list --input /path/to/snmp/diagnostics
-go run ./tools/snmp-diagnostics summary --input /path/to/snmp/diagnostics --checkpoint 3
-go run ./tools/snmp-diagnostics summary --input /path/to/snmp/diagnostics/lifecycle.zst
-go run ./tools/snmp-diagnostics inspect-device --input /path/to/snmp/diagnostics --normal --registration-id 7
-go run ./tools/snmp-diagnostics inspect-device --input /path/to/snmp/diagnostics --normal --previous-run --registration-id 7
+go run ./tools/snmp-diagnostics list --input /path/to/support-bundle.tar.zst
+go run ./tools/snmp-diagnostics summary --input /path/to/support-bundle.tar.zst --checkpoint 3
+go run ./tools/snmp-diagnostics summary --input /path/to/support-bundle.tar.zst --lifecycle
+go run ./tools/snmp-diagnostics inspect-device --input /path/to/support-bundle.tar.zst --normal --registration-id 7
+go run ./tools/snmp-diagnostics inspect-device --input /path/to/support-bundle.tar.zst --normal --previous-run --registration-id 7
+go run ./tools/snmp-diagnostics replay --input /path/to/support-bundle.tar.zst
 ```
 
-`list` reports topology checkpoints and normal device files without decoding them. It takes a directory without selectors.
+`list` takes a directory or bundle without selectors and reports lifecycle availability, topology checkpoints, and indexed
+normal device files without decoding evidence documents. Bundle listings also include `bundle.collection_status`: the
+producer's original collection notes, including why evidence was not requested, unavailable, or partially copied. A
+reported `complete` means the producer copied its selected files; it does not validate their contents or establish that
+all files describe one simultaneous sample. Missing/unreadable status is `null`, with an explanation in `errors`.
+
+Listing errors for one component appear in `errors` alongside the remaining inventory, with exit code zero. For example,
+an invalid normal-run index does not hide topology or lifecycle evidence. Normal selection uses only the committed run
+index; it never guesses current/previous from directory names. A missing index yields no indexed normal devices.
+A selected missing or invalid document fails; the tool does not silently substitute another checkpoint or evidence kind.
+
 Normal files support `validate`, `summary`, and `inspect-device`; replay and link inspection require topology evidence.
 Normal `inspect-device` reports the latest attempt, retained last failure, metric samples, BGP/licensing cache state,
 profile context, and linked source operations. Cached values may originate in an earlier attempt. Compare their source
@@ -71,14 +87,25 @@ Replay and inspection accept the production scalar query options:
 --depth all|0..10
 ```
 
-Decode operations accept human-readable reader limits (128 MiB compressed and 512 MiB decoded by default). Their generous defaults are intended for normal Agent-produced
-archives and can be overridden for a particular invocation:
+Decode operations accept human-readable limits for the **selected diagnostic document** (128 MiB compressed and
+512 MiB decoded JSON by default). They can be overridden for a particular invocation:
 
 ```text
 --max-compressed-size 256MiB --max-decoded-size 1GiB
 ```
 
-Exit codes are `0` for success, `1` for archive or operation failure, and `2` for invalid command-line usage.
+These limits do not cap the size or traversal cost of the enclosing support bundle. Compressed tar input requires one
+complete streaming inventory pass, then at most one additional pass to reach the selected document. Even unrelated tar
+payloads must pass through decompression; repeated CLI invocations repeat this work. ZIP input reads central-directory
+metadata and opens relevant members directly. For repeated analysis of a large tar bundle, supplying an already extracted
+bundle root avoids those scans.
+
+The tool retains member metadata and collection-status/run-index contents, not diagnostic payloads. Only the selected
+inner document is decoded. Tar inventory checks the outer compression stream; ZIP checks the members it reads. Neither
+listing nor validating one selected document is a validation of every file in the support bundle.
+
+Exit codes are `0` for success (including a partial listing with component errors), `1` for input or operation failure,
+and `2` for invalid command-line usage.
 
 ## Collection cost
 

--- a/src/go/tools/snmp-diagnostics/README.md
+++ b/src/go/tools/snmp-diagnostics/README.md
@@ -26,7 +26,8 @@ go run ./tools/snmp-diagnostics inspect-link --input /path/to/archive.zst \
 The input can be a single diagnostic `.zst` file, the `snmp/diagnostics` directory, an extracted support-bundle
 root, or a support `.tar.zst`, `.tar.gz`, or `.zip` archive. Bundle inputs automatically use `06-state/snmp-diagnostics`.
 Archives may contain that layout directly or under one wrapper directory; ambiguous roots, duplicate relevant members,
-unsafe paths, and linked evidence are rejected. The tool does not extract files.
+unsafe paths, and linked evidence are rejected. The tool does not extract files. Directory inputs confine reads to the
+supplied directory tree; relative symlinks that stay within that tree are allowed.
 
 Directory and bundle input selects the latest topology checkpoint by default. `--checkpoint N` selects a retained
 sequence; `--lifecycle` selects lifecycle state; `--normal --registration-id N` selects a normal device. These evidence
@@ -104,8 +105,9 @@ The tool retains member metadata and collection-status/run-index contents, not d
 inner document is decoded. Tar inventory checks the outer compression stream; ZIP checks the members it reads. Neither
 listing nor validating one selected document is a validation of every file in the support bundle.
 
-Exit codes are `0` for success (including a partial listing with component errors), `1` for input or operation failure,
-and `2` for invalid command-line usage.
+Exit codes are `0` for success (including a partial listing with component errors), `1` for evidence-selection, input, or
+operation errors, and `2` for command/flag parsing and argument-validation errors. Evidence-selector conflicts such as
+`--lifecycle --normal`, or `--previous-run` without `--normal`, return `1`.
 
 ## Collection cost
 

--- a/src/go/tools/snmp-diagnostics/bundle.go
+++ b/src/go/tools/snmp-diagnostics/bundle.go
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+const bundleDiagnosticPath = "06-state/snmp-diagnostics"
+const bundleStatusPath = "06-state/snmp-diagnostics-status.txt"
+
+// bundleFS indexes names, not diagnostic payloads. Tar metadata is read during
+// inventory so normal-run selection does not need a separate scan per file.
+type bundleFS struct {
+	file    *os.File
+	size    int64
+	format  string
+	root    string
+	entries map[string]bundleEntry
+}
+
+type bundleEntry struct {
+	info     fs.FileInfo
+	zip      *zip.File
+	metadata []byte
+}
+
+func openBundle(filename, format string) (*bundleFS, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	b := &bundleFS{file: file, size: info.Size(), format: format, entries: make(map[string]bundleEntry)}
+	if err := b.index(); err != nil {
+		file.Close()
+		return nil, err
+	}
+	return b, nil
+}
+
+func (b *bundleFS) Close() error { return b.file.Close() }
+
+func (b *bundleFS) index() error {
+	roots := make(map[string]bool)
+	add := func(name string, info fs.FileInfo, member *zip.File, reader func() (io.ReadCloser, error)) error {
+		name = strings.TrimPrefix(name, "./")
+		name = strings.TrimSuffix(name, "/")
+		if name == "." || name == "" {
+			return nil
+		}
+		if !fs.ValidPath(name) || strings.Contains(name, "\\") {
+			return fmt.Errorf("unsafe bundle member %q", name)
+		}
+		root, relative, relevant := bundleMember(name)
+		if !relevant {
+			return nil
+		}
+		roots[root] = true
+		if len(roots) > 1 {
+			return errors.New("multiple SNMP support-bundle roots")
+		}
+		if _, exists := b.entries[name]; exists {
+			return fmt.Errorf("duplicate bundle member %q", name)
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			return fmt.Errorf("bundle evidence is not a regular file: %q", name)
+		}
+		entry := bundleEntry{info: info, zip: member}
+		if info.Mode().IsRegular() && (relative == bundleStatusPath || relative == bundleDiagnosticPath+"/normal/runs.json") {
+			r, err := reader()
+			if err != nil {
+				return fmt.Errorf("open bundle metadata %q: %w", name, err)
+			}
+			entry.metadata, err = io.ReadAll(r)
+			closeErr := r.Close()
+			if err != nil {
+				return fmt.Errorf("read bundle metadata %q: %w", name, err)
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+		}
+		b.entries[name] = entry
+		return nil
+	}
+	if b.format == ".zip" {
+		archive, err := zip.NewReader(b.file, b.size)
+		if err != nil {
+			return err
+		}
+		for _, member := range archive.File {
+			if err := add(member.Name, member.FileInfo(), member, member.Open); err != nil {
+				return err
+			}
+		}
+	} else {
+		stream, err := b.tarStream()
+		if err != nil {
+			return err
+		}
+		defer stream.Close()
+		archive := tar.NewReader(stream)
+		for {
+			header, err := archive.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return fmt.Errorf("read bundle tar: %w", err)
+			}
+			_, _, relevant := bundleMember(strings.TrimSuffix(strings.TrimPrefix(header.Name, "./"), "/"))
+			if relevant && header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA && header.Typeflag != tar.TypeDir {
+				return fmt.Errorf("bundle evidence is not a regular file: %q", header.Name)
+			}
+			if err := add(header.Name, header.FileInfo(), nil, func() (io.ReadCloser, error) { return io.NopCloser(archive), nil }); err != nil {
+				return err
+			}
+		}
+		// tar EOF precedes the compression trailer. Validate the outer checksum too.
+		if _, err := io.Copy(io.Discard, stream); err != nil {
+			return fmt.Errorf("read bundle compression trailer: %w", err)
+		}
+	}
+	if len(roots) == 0 {
+		return errors.New("no SNMP support-bundle root found")
+	}
+	for root := range roots {
+		b.root = root
+	}
+	// ZIP and tar need not contain directory entries. Synthesize them once and
+	// reject file/directory collisions rather than depend on archive ordering.
+	names := make([]string, 0, len(b.entries))
+	for name := range b.entries {
+		names = append(names, name)
+	}
+	for _, name := range names {
+		for dir := path.Dir(name); ; dir = path.Dir(dir) {
+			if entry, ok := b.entries[dir]; ok {
+				if !entry.info.IsDir() {
+					return fmt.Errorf("bundle file is also a directory: %q", dir)
+				}
+			} else {
+				b.entries[dir] = bundleEntry{info: bundleDirectory(path.Base(dir))}
+			}
+			if dir == "." {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// Producers use one wrapper directory. Also accept a bundle rooted directly at
+// MANIFEST.json/06-state, but never recursively search arbitrary descendants.
+func bundleMember(name string) (root, relative string, relevant bool) {
+	matches := func(s string) bool {
+		return s == "MANIFEST.json" || s == bundleStatusPath || s == bundleDiagnosticPath || strings.HasPrefix(s, bundleDiagnosticPath+"/")
+	}
+	if matches(name) {
+		return ".", name, true
+	}
+	wrapper, rest, ok := strings.Cut(name, "/")
+	if ok && matches(rest) {
+		return wrapper, rest, true
+	}
+	return "", "", false
+}
+
+func (b *bundleFS) tarStream() (io.ReadCloser, error) {
+	reader := io.NewSectionReader(b.file, 0, b.size)
+	if b.format == ".tar.gz" {
+		return gzip.NewReader(reader)
+	}
+	decoder, err := zstd.NewReader(reader, zstd.WithDecoderConcurrency(1))
+	if err != nil {
+		return nil, err
+	}
+	return decoder.IOReadCloser(), nil
+}
+
+func (b *bundleFS) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	entry, ok := b.entries[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	if entry.info.IsDir() {
+		return nil, fmt.Errorf("cannot open bundle directory %q as evidence", name)
+	}
+	var reader io.ReadCloser
+	var err error
+	_, relative, _ := bundleMember(name)
+	if relative == bundleStatusPath || relative == bundleDiagnosticPath+"/normal/runs.json" {
+		reader = io.NopCloser(bytes.NewReader(entry.metadata))
+	} else if entry.zip != nil {
+		reader, err = entry.zip.Open()
+	} else {
+		reader, err = b.openTarMember(name)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &bundleFile{ReadCloser: reader, info: entry.info}, nil
+}
+
+func (b *bundleFS) openTarMember(name string) (io.ReadCloser, error) {
+	stream, err := b.tarStream()
+	if err != nil {
+		return nil, err
+	}
+	archive := tar.NewReader(stream)
+	for {
+		header, err := archive.Next()
+		if err != nil {
+			stream.Close()
+			return nil, fmt.Errorf("open bundle member %q: %w", name, err)
+		}
+		if strings.TrimPrefix(header.Name, "./") == name {
+			return &memberReadCloser{Reader: archive, Closer: stream}, nil
+		}
+	}
+}
+
+func (b *bundleFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+	entry, ok := b.entries[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+	}
+	if !entry.info.IsDir() {
+		return nil, fmt.Errorf("bundle member %q is not a directory", name)
+	}
+	var entries []fs.DirEntry
+	for filename, entry := range b.entries {
+		if filename != name && path.Dir(filename) == name {
+			entries = append(entries, fs.FileInfoToDirEntry(entry.info))
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	return entries, nil
+}
+
+func (b *bundleFS) Stat(name string) (fs.FileInfo, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+	entry, ok := b.entries[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+	}
+	return entry.info, nil
+}
+
+type memberReadCloser struct {
+	io.Reader
+	io.Closer
+}
+type bundleFile struct {
+	io.ReadCloser
+	info fs.FileInfo
+}
+
+func (f *bundleFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+
+type bundleDirectory string
+
+func (d bundleDirectory) Name() string       { return string(d) }
+func (d bundleDirectory) Size() int64        { return 0 }
+func (d bundleDirectory) Mode() fs.FileMode  { return fs.ModeDir | 0700 }
+func (d bundleDirectory) ModTime() time.Time { return time.Time{} }
+func (d bundleDirectory) IsDir() bool        { return true }
+func (d bundleDirectory) Sys() any           { return nil }

--- a/src/go/tools/snmp-diagnostics/bundle.go
+++ b/src/go/tools/snmp-diagnostics/bundle.go
@@ -61,7 +61,7 @@ func (b *bundleFS) Close() error { return b.file.Close() }
 
 func (b *bundleFS) index() error {
 	roots := make(map[string]bool)
-	add := func(name string, info fs.FileInfo, member *zip.File, reader func() (io.ReadCloser, error)) error {
+	add := func(name string, info fs.FileInfo, member *zip.File, reader io.Reader) error {
 		name = strings.TrimPrefix(name, "./")
 		name = strings.TrimSuffix(name, "/")
 		if name == "." || name == "" {
@@ -85,18 +85,11 @@ func (b *bundleFS) index() error {
 			return fmt.Errorf("bundle evidence is not a regular file: %q", name)
 		}
 		entry := bundleEntry{info: info, zip: member}
-		if info.Mode().IsRegular() && (relative == bundleStatusPath || relative == bundleDiagnosticPath+"/normal/runs.json") {
-			r, err := reader()
-			if err != nil {
-				return fmt.Errorf("open bundle metadata %q: %w", name, err)
-			}
-			entry.metadata, err = io.ReadAll(r)
-			closeErr := r.Close()
+		if member == nil && info.Mode().IsRegular() && (relative == bundleStatusPath || relative == bundleDiagnosticPath+"/normal/runs.json") {
+			var err error
+			entry.metadata, err = io.ReadAll(reader)
 			if err != nil {
 				return fmt.Errorf("read bundle metadata %q: %w", name, err)
-			}
-			if closeErr != nil {
-				return closeErr
 			}
 		}
 		b.entries[name] = entry
@@ -108,7 +101,7 @@ func (b *bundleFS) index() error {
 			return err
 		}
 		for _, member := range archive.File {
-			if err := add(member.Name, member.FileInfo(), member, member.Open); err != nil {
+			if err := add(member.Name, member.FileInfo(), member, nil); err != nil {
 				return err
 			}
 		}
@@ -131,7 +124,7 @@ func (b *bundleFS) index() error {
 			if relevant && header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA && header.Typeflag != tar.TypeDir {
 				return fmt.Errorf("bundle evidence is not a regular file: %q", header.Name)
 			}
-			if err := add(header.Name, header.FileInfo(), nil, func() (io.ReadCloser, error) { return io.NopCloser(archive), nil }); err != nil {
+			if err := add(header.Name, header.FileInfo(), nil, archive); err != nil {
 				return err
 			}
 		}
@@ -211,10 +204,12 @@ func (b *bundleFS) Open(name string) (fs.File, error) {
 	var reader io.ReadCloser
 	var err error
 	_, relative, _ := bundleMember(name)
-	if relative == bundleStatusPath || relative == bundleDiagnosticPath+"/normal/runs.json" {
-		reader = io.NopCloser(bytes.NewReader(entry.metadata))
-	} else if entry.zip != nil {
+	if entry.zip != nil {
+		// ZIP can isolate a damaged metadata member without preventing access
+		// to intact topology/lifecycle documents elsewhere in the container.
 		reader, err = entry.zip.Open()
+	} else if relative == bundleStatusPath || relative == bundleDiagnosticPath+"/normal/runs.json" {
+		reader = io.NopCloser(bytes.NewReader(entry.metadata))
 	} else {
 		reader, err = b.openTarMember(name)
 	}

--- a/src/go/tools/snmp-diagnostics/bundle_test.go
+++ b/src/go/tools/snmp-diagnostics/bundle_test.go
@@ -363,3 +363,74 @@ func TestTarBundleHardLinks(t *testing.T) {
 		})
 	}
 }
+
+func TestZIPMetadataReadFailureIsolation(t *testing.T) {
+	for name, tc := range map[string]struct {
+		member    string
+		component string
+	}{
+		"status checksum":    {bundleStatusPath, "collection_status"},
+		"run index checksum": {bundleDiagnosticPath + "/normal/runs.json", "normal"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			filename := writeBundle(t, ".zip", testBundleRoot+"/", bundleFixture(t))
+			data, err := os.ReadFile(filename)
+			require.NoError(t, err)
+			original, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+			require.NoError(t, err)
+			var corrupt bytes.Buffer
+			writer := zip.NewWriter(&corrupt)
+			for _, member := range original.File {
+				header := member.FileHeader
+				if header.Name == testBundleRoot+"/"+tc.member {
+					header.CRC32 ^= 1
+				}
+				destination, err := writer.CreateRaw(&header)
+				require.NoError(t, err)
+				source, err := member.OpenRaw()
+				require.NoError(t, err)
+				_, err = io.Copy(destination, source)
+				require.NoError(t, err)
+			}
+			require.NoError(t, writer.Close())
+			require.NoError(t, os.WriteFile(filename, corrupt.Bytes(), 0600))
+			code, out, message := runBundleCommand(t, filename, "list")
+			require.Zero(t, code, message)
+			var listing diagnosticListing
+			require.NoError(t, json.Unmarshal([]byte(out), &listing))
+			assert.NotEmpty(t, listing.Errors[tc.component])
+			assert.True(t, listing.Lifecycle)
+			assert.Len(t, listing.Topology, 2)
+			for _, args := range [][]string{{"validate"}, {"validate", "--lifecycle"}} {
+				code, _, message := runBundleCommand(t, filename, args...)
+				require.Zero(t, code, message)
+			}
+			if tc.component == "normal" {
+				code, _, message := runBundleCommand(t, filename, "summary", "--normal", "--registration-id", "7")
+				require.Equal(t, 1, code)
+				assert.Contains(t, message, "normal evidence index")
+			}
+		})
+	}
+}
+
+func TestInvalidSelectionDoesNotOpenInput(t *testing.T) {
+	for name, tc := range map[string]struct {
+		args []string
+		want string
+	}{
+		"list selector":           {[]string{"list", "--normal"}, "list does not support"},
+		"lifecycle normal":        {[]string{"summary", "--lifecycle", "--normal"}, "--lifecycle cannot"},
+		"normal missing id":       {[]string{"summary", "--normal"}, "--normal requires"},
+		"normal checkpoint":       {[]string{"summary", "--normal", "--registration-id", "7", "--checkpoint", "8"}, "cannot select a topology"},
+		"previous without normal": {[]string{"summary", "--previous-run"}, "--previous-run requires"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "missing.tar.zst")
+			code, _, message := runBundleCommand(t, filename, tc.args...)
+			require.Equal(t, 1, code)
+			assert.Contains(t, message, tc.want)
+			assert.NotContains(t, message, "open input")
+		})
+	}
+}

--- a/src/go/tools/snmp-diagnostics/bundle_test.go
+++ b/src/go/tools/snmp-diagnostics/bundle_test.go
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const currentRun = "11111111-1111-4111-8111-111111111111"
+const previousRun = "22222222-2222-4222-8222-222222222222"
+const testBundleRoot = "netdata-support-bundle-fixture"
+
+type testBundleMember struct {
+	name string
+	data []byte
+	kind byte
+}
+
+func bundleFixture(t *testing.T) []testBundleMember {
+	t.Helper()
+	raw, err := os.ReadFile(replayableDiagnosticArchivePath())
+	require.NoError(t, err)
+	document, err := snmpdiag.Read(bytes.NewReader(raw), snmpdiag.DefaultReadLimits())
+	require.NoError(t, err)
+	members := []testBundleMember{
+		{name: "MANIFEST.json", data: []byte(`{"schema":"netdata-support-bundle/v2"}`)},
+		{name: bundleStatusPath, data: []byte("Result: complete; complete files copied: 6.\n")},
+		{name: bundleDiagnosticPath + "/normal/runs.json", data: []byte(fmt.Sprintf(`{"current":%q,"previous":%q}`, currentRun, previousRun))},
+	}
+	for _, sequence := range []uint64{8, 10} {
+		document.Checkpoint = sequence
+		members = append(members, testBundleMember{name: fmt.Sprintf("%s/topology/checkpoint-%020d.zst", bundleDiagnosticPath, sequence), data: encodeDocument(t, document)})
+	}
+	document.Kind, document.Checkpoint = snmpdiag.KindLifecycle, 0
+	document.Snapshot = snmpdiag.Snapshot{Lifecycle: document.Snapshot.Lifecycle}
+	members = append(members, testBundleMember{name: bundleDiagnosticPath + "/lifecycle.zst", data: encodeDocument(t, document)})
+	for _, run := range []string{currentRun, previousRun, "33333333-3333-4333-8333-333333333333"} {
+		now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+		document := snmpdiag.Document{
+			Format: snmpdiag.Format, Version: snmpdiag.Version, Kind: snmpdiag.KindNormal,
+			Producer: snmpdiag.Producer{RunID: run},
+			Normal: &snmpdiag.NormalDevice{RegistrationID: 7, RuntimeID: 1, Hostname: run + ".example", CapturedAt: now,
+				Latest: &snmpdiag.NormalAttempt{ID: 2, Phase: "collect", StartedAt: now, CompletedAt: now, Samples: map[string]int64{"sample": 42}},
+			},
+		}
+		members = append(members, testBundleMember{name: bundleDiagnosticPath + "/normal/" + run + "/device-00000000000000000007.zst", data: encodeDocument(t, document)})
+	}
+	return members
+}
+
+func encodeDocument(t *testing.T, document snmpdiag.Document) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	require.NoError(t, snmpdiag.Write(&out, document))
+	return out.Bytes()
+}
+
+// Use real container writers and deliberately omit directory records. Ordering
+// differs from producers so selection cannot rely on tar order or index position.
+func writeBundle(t *testing.T, format, prefix string, members []testBundleMember) string {
+	t.Helper()
+	root := t.TempDir()
+	if format == "directory" {
+		for _, member := range members {
+			filename := filepath.Join(root, member.name)
+			require.NoError(t, os.MkdirAll(filepath.Dir(filename), 0700))
+			require.NoError(t, os.WriteFile(filename, member.data, 0600))
+		}
+		return root
+	}
+	filename := filepath.Join(root, "support"+format)
+	file, err := os.Create(filename)
+	require.NoError(t, err)
+	if format == ".zip" {
+		writer := zip.NewWriter(file)
+		for _, member := range members {
+			header := &zip.FileHeader{Name: prefix + member.name, Method: zip.Deflate}
+			if member.kind == tar.TypeSymlink {
+				header.SetMode(os.ModeSymlink | 0600)
+			}
+			entry, err := writer.CreateHeader(header)
+			require.NoError(t, err)
+			_, err = entry.Write(member.data)
+			require.NoError(t, err)
+		}
+		require.NoError(t, writer.Close())
+	} else {
+		var compressed io.WriteCloser
+		if format == ".tar.gz" {
+			compressed = gzip.NewWriter(file)
+		} else {
+			compressed, err = zstd.NewWriter(file, zstd.WithEncoderConcurrency(1))
+			require.NoError(t, err)
+		}
+		writer := tar.NewWriter(compressed)
+		for _, member := range members {
+			kind := member.kind
+			if kind == 0 {
+				kind = tar.TypeReg
+			}
+			header := &tar.Header{Name: prefix + member.name, Mode: 0600, Size: int64(len(member.data)), Typeflag: kind}
+			if kind == tar.TypeSymlink || kind == tar.TypeLink {
+				header.Linkname = "outside"
+				header.Size = 0
+			}
+			require.NoError(t, writer.WriteHeader(header))
+			if header.Size > 0 {
+				_, err := writer.Write(member.data)
+				require.NoError(t, err)
+			}
+		}
+		require.NoError(t, writer.Close())
+		require.NoError(t, compressed.Close())
+	}
+	require.NoError(t, file.Close())
+	return filename
+}
+
+func runBundleCommand(t *testing.T, filename string, args ...string) (int, string, string) {
+	t.Helper()
+	arguments := append([]string{args[0], "--input", filename}, args[1:]...)
+	var out, err bytes.Buffer
+	code := run(arguments, &out, &err)
+	return code, out.String(), err.String()
+}
+
+func TestSupportBundleCommands(t *testing.T) {
+	for name, format := range map[string]struct{ suffix string }{
+		"zstd tar": {".tar.zst"}, "gzip tar": {".tar.gz"}, "windows zip": {".zip"}, "extracted root": {"directory"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			members := bundleFixture(t)
+			sort.Slice(members, func(i, j int) bool { return members[i].name > members[j].name })
+			filename := writeBundle(t, format.suffix, testBundleRoot+"/", members)
+			for name, tc := range map[string]struct {
+				args []string
+				want string
+				code int
+			}{
+				"inventory":                        {[]string{"list"}, `"sequence": 10`, 0},
+				"latest":                           {[]string{"validate"}, `"checkpoint": 10`, 0},
+				"older":                            {[]string{"validate", "--checkpoint", "8"}, `"checkpoint": 8`, 0},
+				"lifecycle":                        {[]string{"summary", "--lifecycle"}, `"kind": "lifecycle"`, 0},
+				"replay":                           {[]string{"replay"}, `"schema_version": "netdata.topology.v1"`, 0},
+				"topology device":                  {[]string{"inspect-device", "--registration-id", "7"}, `"registration_id": 7`, 0},
+				"current device":                   {[]string{"summary", "--normal", "--registration-id", "7"}, currentRun + ".example", 0},
+				"previous device":                  {[]string{"summary", "--normal", "--previous-run", "--registration-id", "7"}, previousRun + ".example", 0},
+				"normal inspect":                   {[]string{"inspect-device", "--normal", "--registration-id", "7"}, `"sample": 42`, 0},
+				"unretained":                       {[]string{"summary", "--normal", "--registration-id", "8"}, "not retained", 1},
+				"normal needs id":                  {[]string{"summary", "--normal"}, "requires --registration-id", 1},
+				"missing checkpoint":               {[]string{"summary", "--checkpoint", "9"}, "not retained", 1},
+				"conflicting lifecycle normal":     {[]string{"summary", "--lifecycle", "--normal", "--registration-id", "7"}, "cannot be combined", 1},
+				"conflicting lifecycle checkpoint": {[]string{"summary", "--lifecycle", "--checkpoint", "8"}, "cannot be combined", 1},
+				"previous without normal":          {[]string{"summary", "--lifecycle", "--previous-run"}, "requires --normal", 1},
+				"list lifecycle rejected":          {[]string{"list", "--lifecycle"}, "does not support", 1},
+				"compressed limit":                 {[]string{"validate", "--max-compressed-size", "1B"}, "compressed", 1},
+				"decoded limit":                    {[]string{"validate", "--max-decoded-size", "1B"}, "decoded", 1},
+			} {
+				t.Run(name, func(t *testing.T) {
+					code, out, err := runBundleCommand(t, filename, tc.args...)
+					require.Equal(t, tc.code, code, err)
+					if code == 0 {
+						assert.Contains(t, out, tc.want)
+						assert.Empty(t, err)
+					} else {
+						assert.Contains(t, err, tc.want)
+						assert.Empty(t, out)
+					}
+				})
+			}
+			code, out, err := runBundleCommand(t, filename, "list")
+			require.Zero(t, code, err)
+			var listing diagnosticListing
+			require.NoError(t, json.Unmarshal([]byte(out), &listing))
+			require.NotNil(t, listing.Bundle)
+			require.NotNil(t, listing.Bundle.CollectionStatus)
+			assert.Contains(t, *listing.Bundle.CollectionStatus, "Result: complete")
+			assert.True(t, listing.Lifecycle)
+			assert.Len(t, listing.Normal, 2)
+			assert.Equal(t, currentRun, listing.Normal[0].RunID)
+			assert.Equal(t, previousRun, listing.Normal[1].RunID)
+			assert.Empty(t, listing.Errors)
+		})
+	}
+}
+
+func TestSupportBundlePartialEvidence(t *testing.T) {
+	for formatName, format := range map[string]struct{ suffix string }{
+		"zstd": {".tar.zst"}, "gzip": {".tar.gz"}, "zip": {".zip"}, "directory": {"directory"},
+	} {
+		t.Run(formatName, func(t *testing.T) {
+			for name, tc := range map[string]struct {
+				index         string
+				missingIndex  bool
+				status        string
+				missingStatus bool
+				normalError   bool
+			}{
+				"partial":        {index: fmt.Sprintf(`{"current":%q}`, currentRun), status: "Result: partial; files withheld.\n"},
+				"invalid index":  {index: `{"current":"../outside"}`, status: "Result: partial\n", normalError: true},
+				"trailing index": {index: fmt.Sprintf(`{"current":%q} {}`, currentRun), status: "Result: partial\n", normalError: true},
+				"missing index":  {missingIndex: true, status: "Result: partial\n"},
+				"missing status": {index: fmt.Sprintf(`{"current":%q}`, currentRun), missingStatus: true},
+			} {
+				t.Run(name, func(t *testing.T) {
+					var members []testBundleMember
+					for _, member := range bundleFixture(t) {
+						if strings.HasSuffix(member.name, "runs.json") {
+							if tc.missingIndex {
+								continue
+							}
+							member.data = []byte(tc.index)
+						}
+						if member.name == bundleStatusPath {
+							if tc.missingStatus {
+								continue
+							}
+							member.data = []byte(tc.status)
+						}
+						members = append(members, member)
+					}
+					filename := writeBundle(t, format.suffix, testBundleRoot+"/", members)
+					code, out, err := runBundleCommand(t, filename, "list")
+					require.Zero(t, code, err)
+					var listing diagnosticListing
+					require.NoError(t, json.Unmarshal([]byte(out), &listing))
+					assert.Len(t, listing.Topology, 2)
+					assert.True(t, listing.Lifecycle)
+					assert.Equal(t, tc.normalError, listing.Errors["normal"] != "")
+					assert.Equal(t, tc.missingStatus, listing.Errors["collection_status"] != "")
+					if tc.missingIndex || tc.normalError {
+						assert.Empty(t, listing.Normal)
+					}
+					for _, args := range [][]string{{"validate"}, {"validate", "--lifecycle"}} {
+						code, _, err := runBundleCommand(t, filename, args...)
+						require.Zero(t, code, err)
+					}
+					if tc.normalError {
+						code, _, err := runBundleCommand(t, filename, "summary", "--normal", "--registration-id", "7")
+						require.Equal(t, 1, code)
+						assert.Contains(t, err, "normal evidence index")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestSupportBundleMemberValidation(t *testing.T) {
+	for formatName, format := range map[string]struct{ suffix string }{"zstd": {".tar.zst"}, "gzip": {".tar.gz"}, "zip": {".zip"}} {
+		t.Run(formatName, func(t *testing.T) {
+			for name, tc := range map[string]struct {
+				members []testBundleMember
+				want    string
+				success bool
+			}{
+				"duplicate":               {members: []testBundleMember{{name: bundleStatusPath}, {name: bundleStatusPath}}, want: "duplicate"},
+				"dot alias":               {members: []testBundleMember{{name: bundleStatusPath}, {name: "./" + bundleStatusPath}}, want: "duplicate"},
+				"traversal":               {members: []testBundleMember{{name: "../" + bundleStatusPath}}, want: "unsafe"},
+				"absolute":                {members: []testBundleMember{{name: "/" + bundleStatusPath}}, want: "unsafe"},
+				"backslash":               {members: []testBundleMember{{name: `06-state\snmp-diagnostics-status.txt`}}, want: "unsafe"},
+				"two roots":               {members: []testBundleMember{{name: "one/" + bundleStatusPath}, {name: "two/" + bundleStatusPath}}, want: "multiple"},
+				"file directory conflict": {members: []testBundleMember{{name: bundleDiagnosticPath}, {name: bundleDiagnosticPath + "/lifecycle.zst"}}, want: "also a directory"},
+				"symlink":                 {members: []testBundleMember{{name: bundleDiagnosticPath + "/lifecycle.zst", kind: tar.TypeSymlink}}, want: "not a regular file"},
+				"no bundle":               {members: []testBundleMember{{name: "notes.txt"}}, want: "no SNMP support-bundle root"},
+				"nested bundle":           {members: []testBundleMember{{name: "one/two/" + bundleStatusPath}}, want: "no SNMP support-bundle root"},
+				"not requested":           {members: []testBundleMember{{name: bundleStatusPath, data: []byte("Not requested. Use --include-snmp-diagnostics.")}}, success: true, want: "Not requested"},
+				"unavailable":             {members: []testBundleMember{{name: bundleStatusPath, data: []byte("Result: unavailable; complete files copied: 0.")}}, success: true, want: "unavailable"},
+			} {
+				t.Run(name, func(t *testing.T) {
+					filename := writeBundle(t, format.suffix, "", tc.members)
+					code, out, err := runBundleCommand(t, filename, "list")
+					if tc.success {
+						require.Zero(t, code, err)
+						assert.Contains(t, out, tc.want)
+					} else {
+						require.Equal(t, 1, code)
+						assert.Contains(t, err, tc.want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestSupportBundleUnselectedPayloads(t *testing.T) {
+	for name, tc := range map[string]struct{ format string }{"tar": {".tar.zst"}, "gzip": {".tar.gz"}, "zip": {".zip"}} {
+		t.Run(name, func(t *testing.T) {
+			members := bundleFixture(t)
+			// These are intentionally not diagnostic documents. Listing and selecting
+			// another member must neither decode nor retain their payloads.
+			for _, name := range []string{"logs/large.log", bundleDiagnosticPath + "/topology/checkpoint-00000000000000000009.zst"} {
+				members = append(members, testBundleMember{name: name, data: bytes.Repeat([]byte("unselected"), 1<<20)})
+			}
+			filename := writeBundle(t, tc.format, "./"+testBundleRoot+"/", members)
+			input, err := openInput(filename)
+			require.NoError(t, err)
+			defer input.Close()
+			for name, entry := range input.bundle.entries {
+				if strings.HasSuffix(name, ".zst") {
+					assert.Empty(t, entry.metadata, name)
+				}
+			}
+			code, _, message := runBundleCommand(t, filename, "list")
+			require.Zero(t, code, message)
+			code, _, message = runBundleCommand(t, filename, "validate")
+			require.Zero(t, code, message)
+			code, _, message = runBundleCommand(t, filename, "validate", "--checkpoint", "9")
+			require.Equal(t, 1, code)
+			assert.Contains(t, message, "read archive")
+		})
+	}
+}
+
+func TestSupportBundleCorruption(t *testing.T) {
+	for name, tc := range map[string]struct {
+		format  string
+		corrupt func([]byte) []byte
+	}{
+		"truncated zstd": {".tar.zst", func(b []byte) []byte { return b[:len(b)/2] }},
+		"truncated gzip": {".tar.gz", func(b []byte) []byte { return b[:len(b)/2] }},
+		"truncated zip":  {".zip", func(b []byte) []byte { return b[:len(b)/2] }},
+		"zstd trailer":   {".tar.zst", func(b []byte) []byte { b[len(b)-1] ^= 0xff; return b }},
+		"gzip trailer":   {".tar.gz", func(b []byte) []byte { b[len(b)-1] ^= 0xff; return b }},
+	} {
+		t.Run(name, func(t *testing.T) {
+			filename := writeBundle(t, tc.format, testBundleRoot+"/", bundleFixture(t))
+			data, err := os.ReadFile(filename)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filename, tc.corrupt(data), 0600))
+			code, out, message := runBundleCommand(t, filename, "validate")
+			require.Equal(t, 1, code)
+			assert.Empty(t, out)
+			assert.Contains(t, message, "open input")
+		})
+	}
+}
+
+func TestTarBundleHardLinks(t *testing.T) {
+	for name, tc := range map[string]struct{ format string }{"zstd": {".tar.zst"}, "gzip": {".tar.gz"}} {
+		t.Run(name, func(t *testing.T) {
+			filename := writeBundle(t, tc.format, "", []testBundleMember{{name: bundleDiagnosticPath + "/lifecycle.zst", kind: tar.TypeLink}})
+			code, _, message := runBundleCommand(t, filename, "list")
+			require.Equal(t, 1, code)
+			assert.Contains(t, message, "not a regular file")
+		})
+	}
+}

--- a/src/go/tools/snmp-diagnostics/input.go
+++ b/src/go/tools/snmp-diagnostics/input.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+
+	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
+)
+
+type diagnosticInput struct {
+	root   fs.FS
+	file   *os.File
+	bundle *bundleFS
+	report *bundleReport
+}
+
+type bundleReport struct {
+	Root             string  `json:"root"`
+	CollectionStatus *string `json:"collection_status"`
+}
+
+type diagnosticListing struct {
+	Bundle    *bundleReport             `json:"bundle,omitempty"`
+	Lifecycle bool                      `json:"lifecycle"`
+	Topology  []snmpdiag.CheckpointFile `json:"topology_checkpoints"`
+	Normal    []snmpdiag.NormalFile     `json:"normal_devices"`
+	Errors    map[string]string         `json:"errors,omitempty"`
+}
+
+func openInput(filename string) (*diagnosticInput, error) {
+	info, err := os.Stat(filename)
+	if err != nil {
+		return nil, err
+	}
+	input := &diagnosticInput{}
+	if info.IsDir() {
+		root := os.DirFS(filename)
+		for _, marker := range []string{"MANIFEST.json", bundleStatusPath, bundleDiagnosticPath} {
+			if _, err := fs.Stat(root, marker); err == nil {
+				input.root, err = fs.Sub(root, bundleDiagnosticPath)
+				if err != nil {
+					return nil, err
+				}
+				input.report = readBundleReport(root, ".")
+				return input, nil
+			} else if !errors.Is(err, fs.ErrNotExist) {
+				return nil, err
+			}
+		}
+		input.root = root
+		return input, nil
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("input must be a regular file or directory")
+	}
+	for _, format := range []string{".tar.zst", ".tar.gz", ".zip"} {
+		if !strings.HasSuffix(filename, format) {
+			continue
+		}
+		bundle, err := openBundle(filename, format)
+		if err != nil {
+			return nil, err
+		}
+		input.bundle = bundle
+		input.root, err = fs.Sub(bundle, path.Join(bundle.root, bundleDiagnosticPath))
+		if err != nil {
+			bundle.Close()
+			return nil, err
+		}
+		input.report = readBundleReport(bundle, bundle.root)
+		return input, nil
+	}
+	input.file, err = os.Open(filename)
+	return input, err
+}
+
+func readBundleReport(root fs.FS, prefix string) *bundleReport {
+	report := &bundleReport{Root: prefix}
+	data, err := fs.ReadFile(root, path.Join(prefix, bundleStatusPath))
+	if err == nil {
+		status := string(data)
+		report.CollectionStatus = &status
+	}
+	return report
+}
+
+func (input *diagnosticInput) Close() error {
+	if input.bundle != nil {
+		return input.bundle.Close()
+	}
+	if input.file != nil {
+		return input.file.Close()
+	}
+	return nil
+}
+
+func (input *diagnosticInput) list() diagnosticListing {
+	result := diagnosticListing{Bundle: input.report, Errors: make(map[string]string)}
+	info, err := fs.Stat(input.root, snmpdiag.LifecycleFilename)
+	switch {
+	case err == nil && info.Mode().IsRegular():
+		result.Lifecycle = true
+	case err == nil:
+		result.Errors["lifecycle"] = "lifecycle evidence is not a regular file"
+	case !errors.Is(err, fs.ErrNotExist):
+		result.Errors["lifecycle"] = err.Error()
+	}
+	result.Topology, err = snmpdiag.ListCheckpointsFS(input.root)
+	if err != nil {
+		result.Errors["topology"] = err.Error()
+	}
+	result.Normal, err = snmpdiag.ListNormalFilesFS(input.root)
+	if err != nil {
+		result.Errors["normal"] = err.Error()
+	}
+	if input.report != nil && input.report.CollectionStatus == nil {
+		result.Errors["collection_status"] = "collection status is missing or unreadable; evidence availability does not establish collection completeness"
+	}
+	return result
+}
+
+func (input *diagnosticInput) selectDocument(options commandOptions) (io.ReadCloser, error) {
+	if options.previousRun && !options.normal {
+		return nil, errors.New("--previous-run requires --normal")
+	}
+	if options.lifecycle && (options.normal || options.checkpoint != 0) {
+		return nil, errors.New("--lifecycle cannot be combined with --normal or --checkpoint")
+	}
+	if input.file != nil {
+		if options.lifecycle || options.normal || options.checkpoint != 0 {
+			return nil, errors.New("evidence selectors require a diagnostics directory or support bundle")
+		}
+		// The input owns this file; the selected reader must not close it twice.
+		return io.NopCloser(input.file), nil
+	}
+	filename, err := selectDocumentName(input.root, options)
+	if err != nil {
+		return nil, err
+	}
+	info, err := fs.Stat(input.root, filename)
+	if err != nil {
+		return nil, fmt.Errorf("selected evidence %q is unavailable: %w; use list to inspect availability and collection status", filename, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("selected evidence %q is not a regular file", filename)
+	}
+	return input.root.Open(filename)
+}
+
+func selectDocumentName(root fs.FS, options commandOptions) (string, error) {
+	if options.lifecycle {
+		return snmpdiag.LifecycleFilename, nil
+	}
+	if options.normal {
+		if options.registrationID == 0 || options.checkpoint != 0 {
+			return "", errors.New("--normal requires --registration-id and cannot select a topology checkpoint")
+		}
+		files, err := snmpdiag.ListNormalFilesFS(root)
+		if err != nil {
+			return "", fmt.Errorf("normal evidence index: %w", err)
+		}
+		for _, file := range files {
+			if file.Previous == options.previousRun && file.RegistrationID == options.registrationID {
+				return path.Join(snmpdiag.NormalDirectory, file.RunID, file.Filename), nil
+			}
+		}
+		return "", fmt.Errorf("normal device %d is not retained in the selected run; use list to inspect availability and collection status", options.registrationID)
+	}
+	entries, err := snmpdiag.ListCheckpointsFS(root)
+	if err != nil {
+		return "", err
+	}
+	if len(entries) == 0 {
+		return "", errors.New("input has no topology checkpoints; use list to inspect availability and collection status, or --lifecycle for lifecycle evidence")
+	}
+	sequence := options.checkpoint
+	if sequence == 0 {
+		sequence = entries[len(entries)-1].Sequence
+	}
+	for _, entry := range entries {
+		if entry.Sequence == sequence {
+			return path.Join(snmpdiag.TopologyDirectory, entry.Filename), nil
+		}
+	}
+	return "", fmt.Errorf("checkpoint %d is not retained", sequence)
+}

--- a/src/go/tools/snmp-diagnostics/input.go
+++ b/src/go/tools/snmp-diagnostics/input.go
@@ -15,10 +15,11 @@ import (
 )
 
 type diagnosticInput struct {
-	root   fs.FS
-	file   *os.File
-	bundle *bundleFS
-	report *bundleReport
+	root      fs.FS
+	directory *os.Root
+	file      *os.File
+	bundle    *bundleFS
+	report    *bundleReport
 }
 
 type bundleReport struct {
@@ -41,16 +42,24 @@ func openInput(filename string) (*diagnosticInput, error) {
 	}
 	input := &diagnosticInput{}
 	if info.IsDir() {
-		root := os.DirFS(filename)
+		directory, err := os.OpenRoot(filename)
+		if err != nil {
+			return nil, err
+		}
+		input.directory = directory
+		// Confine evidence and metadata through the same owned directory handle.
+		root := directory.FS()
 		for _, marker := range []string{"MANIFEST.json", bundleStatusPath, bundleDiagnosticPath} {
 			if _, err := fs.Stat(root, marker); err == nil {
 				input.root, err = fs.Sub(root, bundleDiagnosticPath)
 				if err != nil {
+					directory.Close()
 					return nil, err
 				}
 				input.report = readBundleReport(root, ".")
 				return input, nil
 			} else if !errors.Is(err, fs.ErrNotExist) {
+				directory.Close()
 				return nil, err
 			}
 		}
@@ -92,6 +101,9 @@ func readBundleReport(root fs.FS, prefix string) *bundleReport {
 }
 
 func (input *diagnosticInput) Close() error {
+	if input.directory != nil {
+		return input.directory.Close()
+	}
 	if input.bundle != nil {
 		return input.bundle.Close()
 	}

--- a/src/go/tools/snmp-diagnostics/input.go
+++ b/src/go/tools/snmp-diagnostics/input.go
@@ -127,12 +127,6 @@ func (input *diagnosticInput) list() diagnosticListing {
 }
 
 func (input *diagnosticInput) selectDocument(options commandOptions) (io.ReadCloser, error) {
-	if options.previousRun && !options.normal {
-		return nil, errors.New("--previous-run requires --normal")
-	}
-	if options.lifecycle && (options.normal || options.checkpoint != 0) {
-		return nil, errors.New("--lifecycle cannot be combined with --normal or --checkpoint")
-	}
 	if input.file != nil {
 		if options.lifecycle || options.normal || options.checkpoint != 0 {
 			return nil, errors.New("evidence selectors require a diagnostics directory or support bundle")
@@ -159,9 +153,6 @@ func selectDocumentName(root fs.FS, options commandOptions) (string, error) {
 		return snmpdiag.LifecycleFilename, nil
 	}
 	if options.normal {
-		if options.registrationID == 0 || options.checkpoint != 0 {
-			return "", errors.New("--normal requires --registration-id and cannot select a topology checkpoint")
-		}
 		files, err := snmpdiag.ListNormalFilesFS(root)
 		if err != nil {
 			return "", fmt.Errorf("normal evidence index: %w", err)

--- a/src/go/tools/snmp-diagnostics/input_test.go
+++ b/src/go/tools/snmp-diagnostics/input_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectoryInputConfinement(t *testing.T) {
+	for name, tc := range map[string]struct {
+		member   string
+		internal bool
+	}{
+		"evidence directory outside root":         {member: "evidence"},
+		"status outside root":                     {member: "status"},
+		"run index outside root":                  {member: "runs"},
+		"relative evidence directory inside root": {member: "evidence", internal: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			base := t.TempDir()
+			root := filepath.Join(base, "bundle")
+			state := filepath.Join(root, "06-state")
+			require.NoError(t, os.MkdirAll(state, 0700))
+			require.NoError(t, os.WriteFile(filepath.Join(root, "MANIFEST.json"), []byte(`{}`), 0600))
+			outside := filepath.Join(base, "outside")
+			require.NoError(t, os.Mkdir(outside, 0700))
+			link := func(target, name string) {
+				t.Helper()
+				err := os.Symlink(target, name)
+				if runtime.GOOS == "windows" && os.IsPermission(err) {
+					t.Skip("symlink creation requires Windows privileges")
+				}
+				require.NoError(t, err)
+			}
+			switch tc.member {
+			case "evidence":
+				target := outside
+				linkTarget := filepath.Join("..", "..", "outside")
+				if tc.internal {
+					target = filepath.Join(root, "captured")
+					linkTarget = filepath.Join("..", "captured")
+				}
+				require.NoError(t, os.MkdirAll(filepath.Join(target, "topology"), 0700))
+				raw, err := os.ReadFile(replayableDiagnosticArchivePath())
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(filepath.Join(target, "topology", "checkpoint-00000000000000000001.zst"), raw, 0600))
+				link(linkTarget, filepath.Join(state, "snmp-diagnostics"))
+				code, out, message := runBundleCommand(t, root, "validate")
+				if tc.internal {
+					require.Zero(t, code, message)
+					assert.Contains(t, out, `"valid": true`)
+				} else {
+					require.Equal(t, 1, code, "outside evidence must not validate")
+					assert.Empty(t, out)
+					assert.NotEmpty(t, message)
+				}
+			case "status":
+				require.NoError(t, os.WriteFile(filepath.Join(outside, "status.txt"), []byte("SYNTHETIC OUTSIDE STATUS"), 0600))
+				link(filepath.Join(outside, "status.txt"), filepath.Join(state, "snmp-diagnostics-status.txt"))
+				code, out, message := runBundleCommand(t, root, "list")
+				require.Zero(t, code, message)
+				var listing diagnosticListing
+				require.NoError(t, json.Unmarshal([]byte(out), &listing))
+				require.NotNil(t, listing.Bundle)
+				assert.Nil(t, listing.Bundle.CollectionStatus)
+				assert.NotEmpty(t, listing.Errors["collection_status"])
+				assert.NotContains(t, out, "SYNTHETIC OUTSIDE STATUS")
+			case "runs":
+				normal := filepath.Join(state, "snmp-diagnostics", "normal")
+				require.NoError(t, os.MkdirAll(filepath.Join(normal, currentRun), 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(normal, currentRun, "device-00000000000000000007.zst"), []byte("listing does not decode"), 0600))
+				require.NoError(t, os.WriteFile(filepath.Join(outside, "runs.json"), []byte(fmt.Sprintf(`{"current":%q}`, currentRun)), 0600))
+				link(filepath.Join(outside, "runs.json"), filepath.Join(normal, "runs.json"))
+				code, out, message := runBundleCommand(t, root, "list")
+				require.Zero(t, code, message)
+				var listing diagnosticListing
+				require.NoError(t, json.Unmarshal([]byte(out), &listing))
+				assert.Empty(t, listing.Normal)
+				assert.NotEmpty(t, listing.Errors["normal"])
+			}
+		})
+	}
+}

--- a/src/go/tools/snmp-diagnostics/main.go
+++ b/src/go/tools/snmp-diagnostics/main.go
@@ -95,6 +95,10 @@ func runWithOpener(arguments []string, stdout, stderr io.Writer, openArchive arc
 		return 2
 	}
 
+	if err := validateSelection(operation, options); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
 	input, err := openInput(options.inputPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: open input: %v\n", err)
@@ -102,10 +106,6 @@ func runWithOpener(arguments []string, stdout, stderr io.Writer, openArchive arc
 	}
 	defer input.Close()
 	if operation == "list" {
-		if options.normal || options.previousRun || options.registrationID != 0 || options.lifecycle || options.checkpoint != 0 {
-			fmt.Fprintln(stderr, "error: list does not support evidence selectors")
-			return 1
-		}
 		if input.root == nil {
 			fmt.Fprintln(stderr, "error: list requires a diagnostics directory or support bundle")
 			return 1
@@ -346,4 +346,20 @@ func openDiagnosticArchive(r io.Reader, limits snmpdiag.ReadLimits) (openedArchi
 	}
 	archive, err := snmptopology.InspectDiagnosticDocument(document)
 	return openedArchive{topology: archive}, err
+}
+
+func validateSelection(operation string, options commandOptions) error {
+	if operation == "list" && (options.normal || options.previousRun || options.registrationID != 0 || options.lifecycle || options.checkpoint != 0) {
+		return errors.New("list does not support evidence selectors")
+	}
+	if options.previousRun && !options.normal {
+		return errors.New("--previous-run requires --normal")
+	}
+	if options.lifecycle && (options.normal || options.checkpoint != 0) {
+		return errors.New("--lifecycle cannot be combined with --normal or --checkpoint")
+	}
+	if options.normal && (options.registrationID == 0 || options.checkpoint != 0) {
+		return errors.New("--normal requires --registration-id and cannot select a topology checkpoint")
+	}
+	return nil
 }

--- a/src/go/tools/snmp-diagnostics/main.go
+++ b/src/go/tools/snmp-diagnostics/main.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/docker/go-units"
@@ -48,6 +47,7 @@ type archiveOpener func(io.Reader, snmpdiag.ReadLimits) (openedArchive, error)
 
 type commandOptions struct {
 	inputPath         string
+	lifecycle         bool
 	normal            bool
 	previousRun       bool
 	checkpoint        uint64
@@ -95,45 +95,34 @@ func runWithOpener(arguments []string, stdout, stderr io.Writer, openArchive arc
 		return 2
 	}
 
+	input, err := openInput(options.inputPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: open input: %v\n", err)
+		return 1
+	}
+	defer input.Close()
 	if operation == "list" {
-		if options.normal || options.previousRun || options.registrationID != 0 {
-			fmt.Fprintln(stderr, "error: list does not support --normal, --previous-run, or --registration-id")
+		if options.normal || options.previousRun || options.registrationID != 0 || options.lifecycle || options.checkpoint != 0 {
+			fmt.Fprintln(stderr, "error: list does not support evidence selectors")
 			return 1
 		}
-		info, err := os.Stat(options.inputPath)
-		if err != nil || !info.IsDir() || options.checkpoint != 0 {
-			fmt.Fprintln(stderr, "error: list requires a directory and does not select a checkpoint")
+		if input.root == nil {
+			fmt.Fprintln(stderr, "error: list requires a diagnostics directory or support bundle")
 			return 1
 		}
-		entries, err := snmpdiag.ListCheckpoints(options.inputPath)
-		if err != nil {
-			fmt.Fprintf(stderr, "error: list checkpoints: %v\n", err)
-			return 1
-		}
-		normal, err := snmpdiag.ListNormalFiles(options.inputPath)
-		if err != nil {
-			fmt.Fprintf(stderr, "error: list normal devices: %v\n", err)
-			return 1
-		}
-		listing := struct {
-			Topology []snmpdiag.CheckpointFile `json:"topology_checkpoints"`
-			Normal   []snmpdiag.NormalFile     `json:"normal_devices"`
-		}{entries, normal}
-		if err := jsonv2.MarshalWrite(stdout, listing, outputJSONOptions); err != nil {
+		if err := jsonv2.MarshalWrite(stdout, input.list(), outputJSONOptions); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		fmt.Fprintln(stdout)
+		if _, err := fmt.Fprintln(stdout); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
 		return 0
 	}
-	path, err := resolveCommandInput(options)
+	file, err := input.selectDocument(options)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: select input: %v\n", err)
-		return 1
-	}
-	file, err := os.Open(path)
-	if err != nil {
-		fmt.Fprintf(stderr, "error: open archive: %v\n", err)
 		return 1
 	}
 	defer file.Close()
@@ -172,22 +161,23 @@ func parseCommandOptions(operation string, arguments []string, stderr io.Writer)
 		operationUsage(stderr, operation)
 		flags.PrintDefaults()
 	}
-	flags.StringVar(&options.inputPath, "input", "", "new-format diagnostic file or directory (latest topology checkpoint)")
-	flags.BoolVar(&options.normal, "normal", false, "select normal device evidence from a directory")
+	flags.StringVar(&options.inputPath, "input", "", "diagnostic file/directory, extracted support-bundle root, or .tar.zst/.tar.gz/.zip bundle")
+	flags.BoolVar(&options.lifecycle, "lifecycle", false, "select lifecycle evidence from a directory or bundle")
+	flags.BoolVar(&options.normal, "normal", false, "select normal device evidence from a directory or bundle")
 	flags.BoolVar(&options.previousRun, "previous-run", false, "select the previous evidence-bearing normal run")
 	flags.Uint64Var(&options.registrationID, "registration-id", 0, "device registration ID")
-	flags.Uint64Var(&options.checkpoint, "checkpoint", 0, "checkpoint sequence to select from a directory")
+	flags.Uint64Var(&options.checkpoint, "checkpoint", 0, "checkpoint sequence to select from a directory or bundle")
 	flags.StringVar(
 		&options.maxCompressedSize,
 		"max-compressed-size",
 		options.maxCompressedSize,
-		"maximum compressed archive size",
+		"maximum compressed size of the selected diagnostic document (not the bundle)",
 	)
 	flags.StringVar(
 		&options.maxDecodedSize,
 		"max-decoded-size",
 		options.maxDecodedSize,
-		"maximum decoded archive size",
+		"maximum decoded JSON size of the selected diagnostic document (not the bundle)",
 	)
 	if operation == "replay" || operation == "inspect-device" || operation == "inspect-link" {
 		addQueryFlags(flags, &options.query)
@@ -356,33 +346,4 @@ func openDiagnosticArchive(r io.Reader, limits snmpdiag.ReadLimits) (openedArchi
 	}
 	archive, err := snmptopology.InspectDiagnosticDocument(document)
 	return openedArchive{topology: archive}, err
-}
-
-func resolveInput(input string, sequence uint64) (string, error) {
-	info, err := os.Stat(input)
-	if err != nil {
-		return "", err
-	}
-	if !info.IsDir() {
-		if sequence != 0 {
-			return "", errors.New("--checkpoint requires a directory")
-		}
-		return input, nil
-	}
-	entries, err := snmpdiag.ListCheckpoints(input)
-	if err != nil {
-		return "", err
-	}
-	if len(entries) == 0 {
-		return "", errors.New("directory has no topology checkpoints; select lifecycle.zst for lifecycle inspection")
-	}
-	if sequence == 0 {
-		sequence = entries[len(entries)-1].Sequence
-	}
-	for _, entry := range entries {
-		if entry.Sequence == sequence {
-			return filepath.Join(input, snmpdiag.TopologyDirectory, entry.Filename), nil
-		}
-	}
-	return "", fmt.Errorf("checkpoint %d is not retained", sequence)
 }

--- a/src/go/tools/snmp-diagnostics/normal.go
+++ b/src/go/tools/snmp-diagnostics/normal.go
@@ -3,34 +3,10 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"path/filepath"
 
 	snmpdiag "github.com/netdata/netdata/go/plugins/plugin/go.d/collector/snmp/diagnostics"
 )
-
-func resolveCommandInput(options commandOptions) (string, error) {
-	if !options.normal {
-		if options.previousRun {
-			return "", errors.New("--previous-run requires --normal")
-		}
-		return resolveInput(options.inputPath, options.checkpoint)
-	}
-	if options.registrationID == 0 || options.checkpoint != 0 {
-		return "", errors.New("--normal requires --registration-id and cannot select a topology checkpoint")
-	}
-	files, err := snmpdiag.ListNormalFiles(options.inputPath)
-	if err != nil {
-		return "", err
-	}
-	for _, file := range files {
-		if file.Previous == options.previousRun && file.RegistrationID == options.registrationID {
-			return filepath.Join(options.inputPath, snmpdiag.NormalDirectory, file.RunID, file.Filename), nil
-		}
-	}
-	return "", fmt.Errorf("normal device %d is not retained in the selected run", options.registrationID)
-}
 
 func executeNormalOperation(operation string, archive openedArchive, options commandOptions) (any, error) {
 	device := archive.normal


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the `snmp-diagnostics` tool read evidence directly from support bundles instead of requiring a standalone diagnostics directory or single file. Bundle input supports extracted roots and `.tar.zst`, `.tar.gz`, and `.zip` archives, indexing them without extraction and rejecting unsafe or ambiguous members. Directory inputs now confine reads to the supplied tree, allowing only relative symlinks that stay within it.

**New Features**
- Archive input automatically locates `06-state/snmp-diagnostics` under one optional wrapper directory; ZIP reads relevant members directly, while compressed tar needs a full inventory pass plus at most one more to reach the selected document.
- `list` now works on bundles and reports `bundle.collection_status` and per-component `errors`, with exit code 0 on partial listings.
- Added a `--lifecycle` evidence selector; selectors are mutually exclusive and rejected for single-file input.
- Reader size limits apply only to the selected diagnostic document, not the enclosing bundle.

**Bug Fixes**
- Corrupt or missing metadata in one component (for example, the normal run index) no longer hides intact topology or lifecycle evidence.
- Directory reads are confined to the supplied root, blocking symlink escapes while allowing relative symlinks that stay inside.

<sup>Written for commit 3ee585e99ef7252529fd2d7efeef58a383b98ad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `snmp-diagnostics` now accepts diagnostic directories, extracted support-bundle roots, and `.tar.zst`, `.tar.gz`, or `.zip` archives.
  - Added evidence selection for lifecycle data, normal runs by registration ID, checkpoints, and previous runs.
  - The `list` command now reports bundle collection status and section-specific errors.
  - Archives are inspected without extracting files and validate unsafe or ambiguous evidence.
  - Directory-based inputs are confined to their selected root for safer reads.

- **Documentation**
  - Updated usage guidance, supported inputs, selectors, safety behavior, and exit-code semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->