### PR TITLE
docs(skills): add offline diagnostics triage skill

### DIFF
--- a/.agents/skills/triage-snmp-diagnostics/SKILL.md
+++ b/.agents/skills/triage-snmp-diagnostics/SKILL.md
@@ -56,7 +56,7 @@ cost owner before scanning a large tar repeatedly.
 | Missing/stale BGP peer or wrong peer state | Normal device inspection | Profile BGP rows and source operations → peer cache and refresh outcome. For a missing topology BGP edge, use the topology path too. |
 | Missing/wrong license inventory or usage | Normal device inspection | Profile license rows and source operations → normalized licensing state. |
 | Discovery, initialization, or missing device evidence | Lifecycle `summary` | Candidate/runtime state and failure → available device cuts → matching logs/configuration. |
-| Slow SNMP collection | Topology device inspection | Collection contexts and referenced operations, interpreted through the collection-cost owner; correlate normal attempt timing if relevant. |
+| Slow SNMP collection | The affected collector's device inspection | Normal attempt timestamps and referenced operation timing, or topology collection contexts and detailed accounting; use the collection-cost owner for Handler timing limits. |
 
 Topology summaries identify registrations. For normal evidence, select a run from the listing and identify the device
 from its normal summary; a lifecycle inventory can help only after its producer run matches. Do not require a topology

--- a/.agents/skills/triage-snmp-diagnostics/SKILL.md
+++ b/.agents/skills/triage-snmp-diagnostics/SKILL.md
@@ -68,10 +68,10 @@ Once inspection locates the affected stage, read only the relevant subsystem det
 
 | Question | Owner sections |
 |---|---|
-| Why this profile or value? | `src/go/plugin/go.d/collector/snmp/profile-format.md#1-selector`, `src/go/plugin/go.d/collector/snmp/profile-format.md#2-extends`, `src/go/plugin/go.d/collector/snmp/profile-format.md#value-transformation` |
-| Why a missing, combined, or derived sample? | `src/go/tools/snmp-diagnostics/README.md#acquisition-processing-and-samples`, `src/go/plugin/go.d/collector/snmp/profile-format.md#table-metrics-multiple-rows`, `src/go/plugin/go.d/collector/snmp/profile-format.md#virtual-metrics`, `src/go/plugin/go.d/collector/snmp/profile-format.md#chart-metadata` |
+| Why this profile or value? | `src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md#profile-selection`, `src/go/plugin/go.d/collector/snmp/profile-format.md#1-selector`, `src/go/plugin/go.d/collector/snmp/profile-format.md#2-extends`, `src/go/plugin/go.d/collector/snmp/profile-format.md#value-transformation` |
+| Why a missing, combined, or derived sample? | `src/go/tools/snmp-diagnostics/README.md#acquisition-processing-and-samples`, `src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md#metric-emission`, `src/go/plugin/go.d/collector/snmp/profile-format.md#virtual-metrics`, `src/go/plugin/go.d/collector/snmp/profile-format.md#chart-metadata` |
 | Were these inputs refreshed? | `src/go/tools/snmp-diagnostics/README.md#cached-inputs-and-earlier-outcomes` |
-| Why this BGP peer state or licensing result? | `src/go/plugin/go.d/collector/snmp/profile-format.md#bgp-rows`, `src/go/plugin/go.d/collector/snmp/profile-format.md#licensing-rows`, `src/go/tools/snmp-diagnostics/README.md#cached-state-versus-function-output` |
+| Why this BGP peer state or licensing result? | `src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md#bgp-collection-and-retained-rows`, `src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md#licensing-normalization-and-collection-results`, `src/go/tools/snmp-diagnostics/README.md#cached-state-versus-function-output` |
 | Why these topology observations or refresh state? | `src/go/plugin/go.d/collector/snmp/profile-format.md#41-topology`, `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#topology-profile-composition`, `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#refresh-loop` |
 | Why was a topology actor/link changed or filtered? | `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#graph-build-order` |
 

--- a/.agents/skills/triage-snmp-diagnostics/SKILL.md
+++ b/.agents/skills/triage-snmp-diagnostics/SKILL.md
@@ -92,6 +92,9 @@ These sections identify consumer source symbols where code inspection is needed.
   settle whether a chart was created or displayed; use the normal-evidence owner to bound that conclusion.
 - For a source-level explanation, check the producer version against the code being read. Treat replay through a
   different checkout as a version-qualified experiment. Do not edit captured values to make a replay succeed.
+- For discovery targets, collector enablement, polling settings, or profile overrides, inspect relevant files under
+  `04-config/` and persisted UI/API configuration under `06-state/dyncfg/`, when available. Compare them with the
+  diagnostic evidence; persisted configuration may differ from what the collector used at capture time.
 
 ## Correlate Companion Logs
 

--- a/.agents/skills/triage-snmp-diagnostics/SKILL.md
+++ b/.agents/skills/triage-snmp-diagnostics/SKILL.md
@@ -92,8 +92,21 @@ These sections identify consumer source symbols where code inspection is needed.
   settle whether a chart was created or displayed; use the normal-evidence owner to bound that conclusion.
 - For a source-level explanation, check the producer version against the code being read. Treat replay through a
   different checkout as a version-qualified experiment. Do not edit captured values to make a replay succeed.
-- Correlate only relevant companion logs/configuration after establishing the evidence timeline. Consult the bundle's
-  sanitization owner before joining identifiers: differently sanitized files may not share literal device names.
+
+## Correlate Companion Logs
+
+- After establishing the evidence timeline, use the bundle inventory to find relevant logs and configuration.
+  Prioritize available `05-logs/collector.log`, `05-logs/journal-netdata.txt`, and
+  `05-logs/journal-namespace-netdata.txt`; an empty collector log is not a reason to skip the journals.
+- Use ordinary archive/text tools for logs. Start with SNMP matches, narrow using `collector=snmp`,
+  `collector=snmp_topology`, and the affected `job` where present, then inspect nearby context. Include relevant
+  `go.d` startup, shutdown, discovery, and job messages; do not restrict the search to warnings/errors or treat
+  every SNMP match as a collector failure (alerts can also match).
+- Correlate message times, jobs, and restarts with the incident and diagnostic capture/run boundaries. Consult the
+  bundle's sanitization owner before joining identifiers: differently sanitized files may not share literal device
+  names.
+- Check log coverage and collection notes before interpreting missing matches; capped captures, missing history,
+  and rate-limited messages cannot establish that no failure occurred. Keep conclusions within the captured window.
 
 ## Report The Finding
 

--- a/.agents/skills/triage-snmp-diagnostics/SKILL.md
+++ b/.agents/skills/triage-snmp-diagnostics/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: triage-snmp-diagnostics
+description: Investigate offline SNMP support bundles or diagnostic files using src/go/tools/snmp-diagnostics; missing or wrong topology links/devices, metrics, BGP peers, licensing, slow collection, and discovery or lifecycle failures. Developer workflow for captured evidence, replay, and source tracing. Not for live Agent/Cloud queries, SNMP traps, creating profiles, or implementing collector/topology changes.
+---
+
+# Offline SNMP Diagnostics
+
+Developer workflow for investigating captured SNMP evidence with the repository's maintainer tool. Start with the
+supplied evidence and narrow the failure to acquisition, processing, or the consuming feature before proposing a fix.
+
+## Owners
+
+Read the sections needed for the current symptom; command and format details belong to these owners.
+
+| Owner section | Subject |
+|---|---|
+| `src/go/tools/snmp-diagnostics/README.md#input-selection` | Supported inputs and evidence selectors |
+| `src/go/tools/snmp-diagnostics/README.md#collection-status-and-partial-listings` | Inventory and partial collection interpretation |
+| `src/go/tools/snmp-diagnostics/README.md#normal-device-evidence` | Metrics, BGP, licensing, and source-reference interpretation |
+| `src/go/tools/snmp-diagnostics/README.md#topology-replay-and-inspection` | Device/link inspection and replay queries |
+| `src/go/tools/snmp-diagnostics/README.md#read-limits-and-container-cost` | Selected-document limits and repeated bundle reads |
+| `src/go/tools/snmp-diagnostics/README.md#collection-cost` | Acquisition timing and accounting limits |
+| `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#diagnostic-files-and-publication` | Publication cadence, retention, runs, and terminal behavior |
+| `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#offline-diagnostic-inspection` | Capture branches and stage availability |
+| `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#portable-archive-codec-and-replay-boundary` | Captured inputs and replay boundary |
+| `docs/developer-and-contributor-corner/netdata-support-bundle.md#what-it-collects` | Companion logs, configuration, and bundle inventory |
+| `docs/developer-and-contributor-corner/netdata-support-bundle.md#privacy-and-sanitization` | Sanitization boundaries |
+| `docs/developer-and-contributor-corner/netdata-support-bundle.md#include-snmp-diagnostics` | Operator capture instructions |
+
+For live API evidence, use `query-netdata-agents` or `query-netdata-cloud`. For received traps, use `query-snmp-traps`.
+When the investigation leads to implementation, route collector changes through `collectors-authoring`, profile changes
+through `collectors-snmp-profiles`, and topology producer changes through `topology-authoring`.
+
+## Establish The Evidence Window
+
+1. Identify the reported symptom, affected device/link or metric, expected behavior, and incident time. Start inventory
+   even if some incident details are missing; ask only for details that change the investigation.
+2. Keep reports under `<repo>/.local/audits/snmp-diagnostics/<case>/` with private permissions. Preserve the supplied
+   archive. Raw inspections and replay output MUST NOT enter committed fixtures, public issues, or review prompts.
+3. Use `list` for a directory or bundle and read both collection notes and component errors. With an individual file,
+   start with `validate` and `summary`. For containers, select and validate the relevant document after inventory.
+4. Record producer version, run, capture times, and selected checkpoint/device alongside the report. Check whether they
+   cover the incident before interpreting the data. Follow the publication owner for retention and freshness semantics;
+   do not assume the bundle is one synchronized sample.
+
+Run the CLI from `src/go` as shown in its README. For repeated commands, building the same tool into the private case
+folder avoids repeated compilation. Choose the evidence scope before requesting full inspections; consult the container
+cost owner before scanning a large tar repeatedly.
+
+## Choose The Investigation
+
+| Symptom | Start with | Follow the evidence |
+|---|---|---|
+| Missing/wrong topology device or link | Topology `summary`, then `inspect-device` or `inspect-link` | Captured protocol observations → graph membership → rendered actor/link; use `replay` to locate an existing link. |
+| Missing/wrong metric | Normal device `summary`, then `inspect-device` | Selected profile and acquisition results → processed metric and emission decision → sample value. |
+| Missing/stale BGP peer or wrong peer state | Normal device inspection | Profile BGP rows and source operations → peer cache and refresh outcome. For a missing topology BGP edge, use the topology path too. |
+| Missing/wrong license inventory or usage | Normal device inspection | Profile license rows and source operations → normalized licensing state. |
+| Discovery, initialization, or missing device evidence | Lifecycle `summary` | Candidate/runtime state and failure → available device cuts → matching logs/configuration. |
+| Slow SNMP collection | Topology device inspection | Collection contexts and referenced operations, interpreted through the collection-cost owner; correlate normal attempt timing if relevant. |
+
+Topology summaries identify registrations. For normal evidence, select a run from the listing and identify the device
+from its normal summary; a lifecycle inventory can help only after its producer run matches. Do not require a topology
+checkpoint to investigate normal metrics, BGP, or licensing.
+
+## Trace And Compare
+
+- Work from the affected output back to its recorded inputs. Inspect the relevant profile, row, metric, or peer before
+  expanding to all source operations. Follow source references using the normal-evidence owner; retain their context
+  with any quoted result so another maintainer can reproduce the join.
+- Separate latest attempts, retained failures/successes, and cached inputs using their own times. Resolve a stale value
+  to its recorded source before attributing it to the latest refresh. Follow the inspection owner when a stage is
+  unavailable; missing evidence is not proof that the device did not return data.
+- Compare retained topology checkpoints with identical query controls. Match device identity and producer context
+  before comparing registrations; obtain link selectors from each replay instead of carrying a row index across cuts.
+  Use previous-run normal evidence only when it helps the incident, with the run boundaries made explicit.
+- Distinguish profile/acquisition failures from processing and consumer decisions. A captured sample alone does not
+  settle whether a chart was created or displayed; use the normal-evidence owner to bound that conclusion.
+- For a source-level explanation, check the producer version against the code being read. Treat replay through a
+  different checkout as a version-qualified experiment. Do not edit captured values to make a replay succeed.
+- Correlate only relevant companion logs/configuration after establishing the evidence timeline. Consult the bundle's
+  sanitization owner before joining identifiers: differently sanitized files may not share literal device names.
+
+## Report The Finding
+
+Report the symptom and evidence coverage, then the supported failure location and its consequence. Cite the selected
+file or checkpoint, producer/run and capture time, and the relevant inspection branch or source reference. Separate
+observations from hypotheses and state what the capture cannot establish.
+
+Recommend the smallest useful next check when evidence is insufficient, explaining which uncertainty it resolves.
+Use the operator capture owner when another bundle is needed; do not silently replace offline analysis with live SNMP
+polling, configuration changes, or sharing raw reports. When a fix is justified, hand the evidence and reproduction to
+the appropriate authoring skill rather than embedding an implementation workflow here.

--- a/.agents/skills/triage-snmp-diagnostics/SKILL.md
+++ b/.agents/skills/triage-snmp-diagnostics/SKILL.md
@@ -62,6 +62,21 @@ Topology summaries identify registrations. For normal evidence, select a run fro
 from its normal summary; a lifecycle inventory can help only after its producer run matches. Do not require a topology
 checkpoint to investigate normal metrics, BGP, or licensing.
 
+## Explain The Collector Result
+
+Once inspection locates the affected stage, read only the relevant subsystem details:
+
+| Question | Owner sections |
+|---|---|
+| Why this profile or value? | `src/go/plugin/go.d/collector/snmp/profile-format.md#1-selector`, `src/go/plugin/go.d/collector/snmp/profile-format.md#2-extends`, `src/go/plugin/go.d/collector/snmp/profile-format.md#value-transformation` |
+| Why a missing, combined, or derived sample? | `src/go/tools/snmp-diagnostics/README.md#acquisition-processing-and-samples`, `src/go/plugin/go.d/collector/snmp/profile-format.md#table-metrics-multiple-rows`, `src/go/plugin/go.d/collector/snmp/profile-format.md#virtual-metrics`, `src/go/plugin/go.d/collector/snmp/profile-format.md#chart-metadata` |
+| Were these inputs refreshed? | `src/go/tools/snmp-diagnostics/README.md#cached-inputs-and-earlier-outcomes` |
+| Why this BGP peer state or licensing result? | `src/go/plugin/go.d/collector/snmp/profile-format.md#bgp-rows`, `src/go/plugin/go.d/collector/snmp/profile-format.md#licensing-rows`, `src/go/tools/snmp-diagnostics/README.md#cached-state-versus-function-output` |
+| Why these topology observations or refresh state? | `src/go/plugin/go.d/collector/snmp/profile-format.md#41-topology`, `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#topology-profile-composition`, `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#refresh-loop` |
+| Why was a topology actor/link changed or filtered? | `src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#graph-build-order` |
+
+These sections identify consumer source symbols where code inspection is needed.
+
 ## Trace And Compare
 
 - Work from the affected output back to its recorded inputs. Inspect the relevant profile, row, metric, or peer before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,6 +620,7 @@ and the rule for adding one; each skill's frontmatter description is the authori
     pack regeneration and compression, category/severity taxonomy changes
   - Also relevant: `integrations-lifecycle` (the pipeline that turns `metadata.yaml` into pages) and
     `health-alert-authoring` (alerts on a collector's contexts).
+  - Also relevant: `triage-snmp-diagnostics` (offline SNMP evidence investigations).
 - Integrations.
   - `integrations-lifecycle`: the integrations pipeline: `metadata.yaml` schemas and validation, `integrations/`
     generators, templates, generated outputs, `COLLECTORS.md`/`SECRETS.md`/`SERVICE-DISCOVERY.md`; ibm.d
@@ -649,6 +650,10 @@ and the rule for adding one; each skill's frontmatter description is the authori
     locally from a PR or docs branch; loads `docs-learn-site-structure` first
   - Also relevant: `integrations-lifecycle` (generated integration pages are published on Learn).
 - Triage.
+  - `triage-snmp-diagnostics`: offline SNMP support bundles and diagnostic files with `src/go/tools/snmp-diagnostics`;
+    topology devices/links, metrics, BGP, licensing, slow collection, discovery and lifecycle failures; `list`, `validate`,
+    `summary`, `inspect-device`, `inspect-link`, and `replay`. Not live queries, traps, or collector/profile
+    authoring
   - `triage-coverity`: Coverity Scan defect triage
   - `triage-sonarqube`: SonarCloud findings triage
   - `triage-codeql`: GitHub Code Scanning / CodeQL triage
@@ -735,6 +740,7 @@ renames:
 | `triage-codacy` | `codacy/` | local analysis output, PR issue fetches |
 | `triage-codeql` | `graphql/` | Code Scanning fetches and dismissals |
 | `triage-agent-events` | `query-agent-events/` | fetched event batches |
+| `triage-snmp-diagnostics` | `snmp-diagnostics/` | private bundle inspections, replay output, and incident reports |
 | `repo-pr-reviews` | `pr-reviews/` | per-PR comment and review caches |
 | `collectors-prometheus-profiles` | `prometheus-profiles/` | captured exposition dumps |
 | `repo-skill-authoring` | `<subject>/` | inventory, staleness, preservation map, review reports, and throwaway tooling of a skill change |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -651,9 +651,9 @@ and the rule for adding one; each skill's frontmatter description is the authori
   - Also relevant: `integrations-lifecycle` (generated integration pages are published on Learn).
 - Triage.
   - `triage-snmp-diagnostics`: offline SNMP support bundles and diagnostic files with `src/go/tools/snmp-diagnostics`;
-    topology devices/links, metrics, BGP, licensing, slow collection, discovery and lifecycle failures; `list`, `validate`,
-    `summary`, `inspect-device`, `inspect-link`, and `replay`. Not live queries, traps, or collector/profile
-    authoring
+    topology devices/links, metrics, BGP, licensing, slow collection, discovery and lifecycle failures; `list`,
+    `validate`, `summary`, `inspect-device`, `inspect-link`, and `replay`. Not live queries, traps, or
+    collector/profile authoring
   - `triage-coverity`: Coverity Scan defect triage
   - `triage-sonarqube`: SonarCloud findings triage
   - `triage-codeql`: GitHub Code Scanning / CodeQL triage

--- a/src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md
@@ -1,0 +1,97 @@
+# SNMP Collector Architecture
+
+Maintainer reference for the normal SNMP collector and the subpackage boundaries needed to investigate its results.
+Paths and symbols below are relative to this collector directory unless a link points elsewhere.
+
+**Place in the documentation set.** This document owns normal profile selection, sample emission, and BGP/licensing
+consumer behavior. The project skill `.agents/skills/triage-snmp-diagnostics/SKILL.md` cites its heading anchors; update
+those references when moving a section. The [profile guide](profile-format.md) owns user-facing profile syntax and
+rules. The [diagnostics CLI README](../../../../tools/snmp-diagnostics/README.md#normal-device-evidence) owns tool usage
+and evidence interpretation. Topology production remains in the
+[SNMP topology architecture](../snmp_topology/ARCHITECTURE.md).
+
+## Collection Boundaries
+
+| Layer | Source entry points | Responsibility |
+|---|---|---|
+| Normal collector | `collect.go`, `profile_sets.go`, `collect_snmp.go` | Runtime initialization, profile selection, and orchestration of profile results into charts and samples |
+| Profile acquisition | `ddsnmp/profile_catalog.go`, `ddsnmp/ddsnmpcollector/collector.go` | Consumer-specific profile projection, SNMP acquisition, value processing, virtual metrics, and typed BGP/licensing rows |
+| Collector consumers | `bgp_integration.go`, `licensing_integration.go` | Peer/cache updates and typed BGP samples; normalized license inventory and aggregate samples |
+| Diagnostic capture | `normal_diagnostics*.go`, `diagnostics/` | Capture adapters plus shared documents, codecs, and file publication |
+
+Acquisition success, emitted samples, stored consumer state, and a Function response are distinct stages. Use the
+[diagnostic stage interpretation](../../../../tools/snmp-diagnostics/README.md#acquisition-processing-and-samples)
+when correlating them. File cadence, retention, and publication remain documented under
+[Diagnostic Files And Publication](../snmp_topology/ARCHITECTURE.md#diagnostic-files-and-publication).
+
+## Profile Selection
+
+For normal SNMP collection, `setupProfiles` uses `manual_profiles` only when `sysObjectID` is empty. A non-empty but
+unmatched `sysObjectID` does not fall back to that list. After catalog matching, consumer projection keeps metrics,
+BGP, and licensing definitions for normal collection; topology has its own
+[composition](../snmp_topology/ARCHITECTURE.md#topology-profile-composition).
+A matched profile with no data for the requested consumer can disappear from that consumer's collection set. When
+investigating selection, compare the captured profile context's selected profiles and projection, not only profile
+names.
+
+`setupProfiles` lives in `profile_sets.go`; catalog matching and projection live in `ddsnmp/profile_catalog.go`.
+The captured selection/projection description is assembled by `ProjectedView.Context` in `ddsnmp/profile_context.go`.
+
+## Metric Emission
+
+The normal SNMP collector skips a table metric when its resolved tag map is empty. To keep rows distinct, provide
+non-empty identifying tag values; the SNMP row index is not automatically part of the emitted series identity.
+
+The collector's `tableMetricKey` combines the metric name with non-empty public tag values, ordered by tag key.
+[Underscore-prefixed tags](profile-format.md#underscore-prefixed-tags) do not distinguish chart IDs. Rows that reach
+`collectProfileTableMetrics` with the same key accumulate their ordinary numeric values into one sample; multi-value
+mapped dimensions use assignment instead. A captured row can therefore be present without having a distinct chart
+series, and a final sample can combine several rows.
+
+`collect_snmp.go` owns these emission decisions; `normal_diagnostics.go` records their relationship to captured samples.
+Profile authoring details remain in the [table metric guide](profile-format.md#table-metrics-multiple-rows).
+
+## BGP Collection And Retained Rows
+
+Profile syntax and peer identity requirements are documented in [BGP rows](profile-format.md#bgp-rows).
+
+The acquisition layer admits a typed BGP row only when it has a signal and the identity required by its row kind.
+`bgpRowHasSignals` and `bgpRowIdentityComplete` in `ddsnmp/ddsnmpcollector/collector_bgp.go` define this boundary.
+Receiving an identity OID alone does not establish a peer. Successful rows can survive errors elsewhere in the same
+profile; the profile-level BGP result can succeed while acquisition/processing reports contain failures.
+
+The normal collector's `bgpIntegration.prepareProfileMetrics` updates peer state from returned profile results. A
+returned profile with `BGPCollectError` keeps its previous source-owned peers as stale and contributes no current typed
+BGP chart metrics. Sources without that error replace their peer rows, including after partial success. Profiles omitted
+before reaching this BGP consumer do not automatically receive this retention behavior. A top-level SNMP collection
+error leaves the previous peer cache and marks collection failed instead of refreshing it.
+
+`bgpPeerCache` applies a failure-associated freshness window to retained rows: age by itself does not mark successful
+peer data stale. Function requests can suppress expired failed-source entries or report the data unavailable. Compare
+source failures and per-entry update times as well as the overall cache time; retained peer state does not imply a
+successful current measurement.
+
+## Licensing Normalization And Collection Results
+
+Profile syntax, signal definitions, and date formats are documented in [Licensing rows](profile-format.md#licensing-rows).
+
+The normal collector converts typed profile rows through `licenseRowFromTyped` in `licensing.go`. A row needs an
+identity and at least one typed signal; vendor text or perpetual/unlimited descriptors alone are insufficient.
+Remaining-duration signals become absolute expiry times at normalization. `deriveLicenseUsage` can fill missing used
+capacity from capacity minus available, when available is within that capacity, and derive a missing percentage from
+used/capacity when capacity is positive and the license is not unlimited.
+
+The normalized state bucket is not simply the raw vendor text or numeric severity. `normalizeLicenseStateBucket` in
+`licensing_state.go` gives an ignored raw classification priority; otherwise an expired applicable timer or exhausted
+finite usage is broken, and unexpired grace is degraded. An informational raw classification then takes priority over
+typed severity; other rows use typed severity when present, followed by raw-state and signal-based fallbacks.
+
+Charts aggregate the accepted normalized rows through `aggregateLicenseRows` in `licensing_aggregate.go`: state charts
+count rows by bucket, timer charts use the minimum remaining time for each timer kind, and usage uses the maximum
+rounded percentage. Ignored rows contribute only state counts; perpetual expiry and unlimited usage are excluded from
+the corresponding timer/usage aggregates. These charts do not describe one selected license from the drill-down.
+
+Whenever `licensingIntegration.collect` runs, it replaces the cached set, including with empty or partial results.
+A top-level SNMP error returns before this consumer runs and leaves the old set intact. Licensing has no BGP-style
+failure-expiry gate. The `snmp:licenses` Function uses stored state buckets but computes displayed remaining time at
+request time; its timer and bucket can therefore reflect different evaluation times until the next normalization.

--- a/src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md
@@ -5,10 +5,10 @@ Paths and symbols below are relative to this collector directory unless a link p
 
 **Place in the documentation set.** This document owns normal profile selection, sample emission, and BGP/licensing
 consumer behavior. The project skill `.agents/skills/triage-snmp-diagnostics/SKILL.md` cites its heading anchors; update
-those references when moving a section. The [profile guide](profile-format.md) owns user-facing profile syntax and
-rules. The [diagnostics CLI README](../../../../tools/snmp-diagnostics/README.md#normal-device-evidence) owns tool usage
+those references when moving a section. The [profile guide](/src/go/plugin/go.d/collector/snmp/profile-format.md) owns user-facing profile syntax and
+rules. The [diagnostics CLI README](/src/go/tools/snmp-diagnostics/README.md#normal-device-evidence) owns tool usage
 and evidence interpretation. Topology production remains in the
-[SNMP topology architecture](../snmp_topology/ARCHITECTURE.md).
+[SNMP topology architecture](/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md).
 
 ## Collection Boundaries
 
@@ -20,16 +20,16 @@ and evidence interpretation. Topology production remains in the
 | Diagnostic capture | `normal_diagnostics*.go`, `diagnostics/` | Capture adapters plus shared documents, codecs, and file publication |
 
 Acquisition success, emitted samples, stored consumer state, and a Function response are distinct stages. Use the
-[diagnostic stage interpretation](../../../../tools/snmp-diagnostics/README.md#acquisition-processing-and-samples)
+[diagnostic stage interpretation](/src/go/tools/snmp-diagnostics/README.md#acquisition-processing-and-samples)
 when correlating them. File cadence, retention, and publication remain documented under
-[Diagnostic Files And Publication](../snmp_topology/ARCHITECTURE.md#diagnostic-files-and-publication).
+[Diagnostic Files And Publication](/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#diagnostic-files-and-publication).
 
 ## Profile Selection
 
 For normal SNMP collection, `setupProfiles` uses `manual_profiles` only when `sysObjectID` is empty. A non-empty but
 unmatched `sysObjectID` does not fall back to that list. After catalog matching, consumer projection keeps metrics,
 BGP, and licensing definitions for normal collection; topology has its own
-[composition](../snmp_topology/ARCHITECTURE.md#topology-profile-composition).
+[composition](/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#topology-profile-composition).
 A matched profile with no data for the requested consumer can disappear from that consumer's collection set. When
 investigating selection, compare the captured profile context's selected profiles and projection, not only profile
 names.
@@ -43,17 +43,17 @@ The normal SNMP collector skips a table metric when its resolved tag map is empt
 non-empty identifying tag values; the SNMP row index is not automatically part of the emitted series identity.
 
 The collector's `tableMetricKey` combines the metric name with non-empty public tag values, ordered by tag key.
-[Underscore-prefixed tags](profile-format.md#underscore-prefixed-tags) do not distinguish chart IDs. Rows that reach
+[Underscore-prefixed tags](/src/go/plugin/go.d/collector/snmp/profile-format.md#underscore-prefixed-tags) do not distinguish chart IDs. Rows that reach
 `collectProfileTableMetrics` with the same key accumulate their ordinary numeric values into one sample; multi-value
 mapped dimensions use assignment instead. A captured row can therefore be present without having a distinct chart
 series, and a final sample can combine several rows.
 
 `collect_snmp.go` owns these emission decisions; `normal_diagnostics.go` records their relationship to captured samples.
-Profile authoring details remain in the [table metric guide](profile-format.md#table-metrics-multiple-rows).
+Profile authoring details remain in the [table metric guide](/src/go/plugin/go.d/collector/snmp/profile-format.md#table-metrics-multiple-rows).
 
 ## BGP Collection And Retained Rows
 
-Profile syntax and peer identity requirements are documented in [BGP rows](profile-format.md#bgp-rows).
+Profile syntax and peer identity requirements are documented in [BGP rows](/src/go/plugin/go.d/collector/snmp/profile-format.md#bgp-rows).
 
 The acquisition layer admits a typed BGP row only when it has a signal and the identity required by its row kind.
 `bgpRowHasSignals` and `bgpRowIdentityComplete` in `ddsnmp/ddsnmpcollector/collector_bgp.go` define this boundary.
@@ -73,7 +73,7 @@ successful current measurement.
 
 ## Licensing Normalization And Collection Results
 
-Profile syntax, signal definitions, and date formats are documented in [Licensing rows](profile-format.md#licensing-rows).
+Profile syntax, signal definitions, and date formats are documented in [Licensing rows](/src/go/plugin/go.d/collector/snmp/profile-format.md#licensing-rows).
 
 The normal collector converts typed profile rows through `licenseRowFromTyped` in `licensing.go`. A row needs an
 identity and at least one typed signal; vendor text or perpetual/unlimited descriptors alone are insufficient.

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -208,6 +208,14 @@ selector:
 - A profile is applied if **at least one rule** in the `selector` list matches the device.
 - If both `sysobjectid` and `sysdescr` are defined within the same rule, **both must succeed**.
 
+For normal SNMP collection, `setupProfiles` uses `manual_profiles` only when `sysObjectID` is empty. A non-empty but
+unmatched `sysObjectID` does not fall back to that list. After catalog matching, consumer projection keeps metrics,
+BGP, and licensing definitions for normal collection; topology has its own
+[composition](#stock-topology-composition).
+A matched profile with no data for the requested consumer can disappear from that consumer's collection set. When
+investigating selection, compare the captured profile context's selected profiles and projection, not only profile
+names.
+
 **Supported conditions**:
 
 | Key                   | What It Checks                       | Match Criteria (Pass)                            | Fails When...                   |
@@ -786,8 +794,14 @@ ifHCInOctets.2 = 2048
 - `.1`, `.2`, … are `row indexes` that identify the instance (e.g., interface #1, interface #2).
 - Each column (symbol) in the table has its own OID pattern but shares the same row indexes.
 
-> Table metrics **must define at least one tag** (`metric_tags`) to identify each row.
-> Without tags, only a single row can be emitted.
+The normal SNMP collector skips a table metric when its resolved tag map is empty. To keep rows distinct, provide
+non-empty identifying tag values; the SNMP row index is not automatically part of the emitted series identity.
+
+The collector's `tableMetricKey` combines the metric name with non-empty public tag values, ordered by tag key.
+[Underscore-prefixed tags](#underscore-prefixed-tags) do not distinguish chart IDs. Rows that reach
+`collectProfileTableMetrics` with the same key accumulate their ordinary numeric values into one sample; multi-value
+mapped dimensions use assignment instead. A captured row can therefore be present without having a distinct chart
+series, and a final sample can combine several rows.
 
 ```yaml
 metrics:
@@ -2433,6 +2447,24 @@ bgp:
           symbol: { OID: 1.3.6.1.4.1.99999.10.1.8, name: vendorBgpPeerOutUpdates }
 ```
 
+### BGP collection and retained rows
+
+The acquisition layer admits a typed BGP row only when it has a signal and the identity required by its row kind.
+`bgpRowHasSignals` and `bgpRowIdentityComplete` in `ddsnmp/ddsnmpcollector/collector_bgp.go` define this boundary.
+Receiving an identity OID alone does not establish a peer. Successful rows can survive errors elsewhere in the same
+profile; the profile-level BGP result can succeed while acquisition/processing reports contain failures.
+
+The normal collector's `bgpIntegration.prepareProfileMetrics` updates peer state from returned profile results. A
+returned profile with `BGPCollectError` keeps its previous source-owned peers as stale and contributes no current typed
+BGP chart metrics. Sources without that error replace their peer rows, including after partial success. Profiles omitted
+before reaching this BGP consumer do not automatically receive this retention behavior. A top-level SNMP collection
+error leaves the previous peer cache and marks collection failed instead of refreshing it.
+
+`bgpPeerCache` applies a failure-associated freshness window to retained rows: age by itself does not mark successful
+peer data stale. Function requests can suppress expired failed-source entries or report the data unavailable. Compare
+source failures and per-entry update times as well as the overall cache time; retained peer state does not imply a
+successful current measurement.
+
 ## Licensing rows
 
 The SNMP collector ships a **shared device-level licensing pipeline** that
@@ -2530,6 +2562,29 @@ licensing:
             format: snmp_dateandtime
           sentinel: [timer_pre_1971]
 ```
+
+### Licensing normalization and collection results
+
+The normal collector converts typed profile rows through `licenseRowFromTyped` in `licensing.go`. A row needs an
+identity and at least one typed signal; vendor text or perpetual/unlimited descriptors alone are insufficient.
+Remaining-duration signals become absolute expiry times at normalization. `deriveLicenseUsage` can fill missing used
+capacity from capacity minus available, when available is within that capacity, and derive a missing percentage from
+used/capacity when capacity is positive and the license is not unlimited.
+
+The normalized state bucket is not simply the raw vendor text or numeric severity. `normalizeLicenseStateBucket` in
+`licensing_state.go` gives an ignored raw classification priority; otherwise an expired applicable timer or exhausted
+finite usage is broken, and unexpired grace is degraded. An informational raw classification then takes priority over
+typed severity; other rows use typed severity when present, followed by raw-state and signal-based fallbacks.
+
+Charts aggregate the accepted normalized rows through `aggregateLicenseRows` in `licensing_aggregate.go`: state charts
+count rows by bucket, timer charts use the minimum remaining time for each timer kind, and usage uses the maximum
+rounded percentage. Ignored rows contribute only state counts; perpetual expiry and unlimited usage are excluded from
+the corresponding timer/usage aggregates. These charts do not describe one selected license from the drill-down.
+
+Whenever `licensingIntegration.collect` runs, it replaces the cached set, including with empty or partial results.
+A top-level SNMP error returns before this consumer runs and leaves the old set intact. Licensing has no BGP-style
+failure-expiry gate. The `snmp:licenses` Function uses stored state buckets but computes displayed remaining time at
+request time; its timer and bucket can therefore reflect different evaluation times until the next normalization.
 
 ### Parsing vendor expiry dates
 

--- a/src/go/plugin/go.d/collector/snmp/profile-format.md
+++ b/src/go/plugin/go.d/collector/snmp/profile-format.md
@@ -208,14 +208,6 @@ selector:
 - A profile is applied if **at least one rule** in the `selector` list matches the device.
 - If both `sysobjectid` and `sysdescr` are defined within the same rule, **both must succeed**.
 
-For normal SNMP collection, `setupProfiles` uses `manual_profiles` only when `sysObjectID` is empty. A non-empty but
-unmatched `sysObjectID` does not fall back to that list. After catalog matching, consumer projection keeps metrics,
-BGP, and licensing definitions for normal collection; topology has its own
-[composition](#stock-topology-composition).
-A matched profile with no data for the requested consumer can disappear from that consumer's collection set. When
-investigating selection, compare the captured profile context's selected profiles and projection, not only profile
-names.
-
 **Supported conditions**:
 
 | Key                   | What It Checks                       | Match Criteria (Pass)                            | Fails When...                   |
@@ -794,14 +786,9 @@ ifHCInOctets.2 = 2048
 - `.1`, `.2`, … are `row indexes` that identify the instance (e.g., interface #1, interface #2).
 - Each column (symbol) in the table has its own OID pattern but shares the same row indexes.
 
-The normal SNMP collector skips a table metric when its resolved tag map is empty. To keep rows distinct, provide
-non-empty identifying tag values; the SNMP row index is not automatically part of the emitted series identity.
-
-The collector's `tableMetricKey` combines the metric name with non-empty public tag values, ordered by tag key.
-[Underscore-prefixed tags](#underscore-prefixed-tags) do not distinguish chart IDs. Rows that reach
-`collectProfileTableMetrics` with the same key accumulate their ordinary numeric values into one sample; multi-value
-mapped dimensions use assignment instead. A captured row can therefore be present without having a distinct chart
-series, and a final sample can combine several rows.
+Table metrics need at least one resolved tag to be emitted; without tags, they are skipped. Use non-empty identifying
+tags to distinguish rows, such as an interface name or a tag derived from the row index. The SNMP row index is not
+added to the emitted series identity automatically.
 
 ```yaml
 metrics:
@@ -2447,24 +2434,6 @@ bgp:
           symbol: { OID: 1.3.6.1.4.1.99999.10.1.8, name: vendorBgpPeerOutUpdates }
 ```
 
-### BGP collection and retained rows
-
-The acquisition layer admits a typed BGP row only when it has a signal and the identity required by its row kind.
-`bgpRowHasSignals` and `bgpRowIdentityComplete` in `ddsnmp/ddsnmpcollector/collector_bgp.go` define this boundary.
-Receiving an identity OID alone does not establish a peer. Successful rows can survive errors elsewhere in the same
-profile; the profile-level BGP result can succeed while acquisition/processing reports contain failures.
-
-The normal collector's `bgpIntegration.prepareProfileMetrics` updates peer state from returned profile results. A
-returned profile with `BGPCollectError` keeps its previous source-owned peers as stale and contributes no current typed
-BGP chart metrics. Sources without that error replace their peer rows, including after partial success. Profiles omitted
-before reaching this BGP consumer do not automatically receive this retention behavior. A top-level SNMP collection
-error leaves the previous peer cache and marks collection failed instead of refreshing it.
-
-`bgpPeerCache` applies a failure-associated freshness window to retained rows: age by itself does not mark successful
-peer data stale. Function requests can suppress expired failed-source entries or report the data unavailable. Compare
-source failures and per-entry update times as well as the overall cache time; retained peer state does not imply a
-successful current measurement.
-
 ## Licensing rows
 
 The SNMP collector ships a **shared device-level licensing pipeline** that
@@ -2562,29 +2531,6 @@ licensing:
             format: snmp_dateandtime
           sentinel: [timer_pre_1971]
 ```
-
-### Licensing normalization and collection results
-
-The normal collector converts typed profile rows through `licenseRowFromTyped` in `licensing.go`. A row needs an
-identity and at least one typed signal; vendor text or perpetual/unlimited descriptors alone are insufficient.
-Remaining-duration signals become absolute expiry times at normalization. `deriveLicenseUsage` can fill missing used
-capacity from capacity minus available, when available is within that capacity, and derive a missing percentage from
-used/capacity when capacity is positive and the license is not unlimited.
-
-The normalized state bucket is not simply the raw vendor text or numeric severity. `normalizeLicenseStateBucket` in
-`licensing_state.go` gives an ignored raw classification priority; otherwise an expired applicable timer or exhausted
-finite usage is broken, and unexpired grace is degraded. An informational raw classification then takes priority over
-typed severity; other rows use typed severity when present, followed by raw-state and signal-based fallbacks.
-
-Charts aggregate the accepted normalized rows through `aggregateLicenseRows` in `licensing_aggregate.go`: state charts
-count rows by bucket, timer charts use the minimum remaining time for each timer kind, and usage uses the maximum
-rounded percentage. Ignored rows contribute only state counts; perpetual expiry and unlimited usage are excluded from
-the corresponding timer/usage aggregates. These charts do not describe one selected license from the drill-down.
-
-Whenever `licensingIntegration.collect` runs, it replaces the cached set, including with empty or partial results.
-A top-level SNMP error returns before this consumer runs and leaves the old set intact. Licensing has no BGP-style
-failure-expiry gate. The `snmp:licenses` Function uses stored state buckets but computes displayed remaining time at
-request time; its timer and bucket can therefore reflect different evaluation times until the next normalization.
 
 ### Parsing vendor expiry dates
 

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -9,8 +9,9 @@ internals: runtime order, package boundaries, the graph build, the diagnostic
 tooling, and the validation commands. What the emitted payload means is owned
 by `src/plugins.d/FUNCTION_TOPOLOGY_DEVELOPER_GUIDE.md` (its SNMP/L2 Shape
 section); the SNMP profile `topology:` rows are owned by the SNMP profile format
-and the `collectors-snmp-profiles` project skill. The project skill
-`.agents/skills/topology-authoring/SKILL.md` cites sections of this document by
+and the `collectors-snmp-profiles` project skill. The project skills
+`.agents/skills/topology-authoring/SKILL.md` and
+`.agents/skills/triage-snmp-diagnostics/SKILL.md` cite sections of this document by
 heading anchor, and `.agents/sow/audit.sh` fails when a cited heading no longer
 exists, so renaming or removing a heading here updates the skill in the same
 change.
@@ -806,19 +807,13 @@ features.
 
 ## Maintainer Diagnostic Tool
 
-`src/go/tools/snmp-diagnostics` is a source-only, read-only command run with `go run`; it is not installed with the Agent.
+`src/go/tools/snmp-diagnostics` is the source-only, read-only maintainer command; it is not installed with the Agent.
+The [tool README](../../../../tools/snmp-diagnostics/README.md#usage) owns supported inputs, selectors, operations, and
+output interpretation, including direct support-bundle access and lifecycle selection.
 
-- `list` reports retained topology checkpoints and indexed normal-device files in a directory without decoding them.
-- `validate` and `summary` read a selected topology, lifecycle, or normal document.
-- `inspect-device` exposes lifecycle/topology stages or a normal device's attempts and cache/source lineage.
-- `replay` emits the production topology-v1 payload, and `inspect-link` inspects an existing replay index or candidate
-  identity selector. Both require topology evidence.
-
-Directory input selects the newest topology checkpoint unless explicit selectors choose a checkpoint or a normal device
-in the current/previous run. Lifecycle inspection uses its file path explicitly. The command uses the shared diagnostic
-codec and the topology facade, with no second replay engine, daemon, or network service. Topology query defaults come
-from production; invalid query selectors fail. Successful operations emit one JSON document. Reports remain sensitive;
-the command does not sanitize or upload them. See the [tool README](../../../../tools/snmp-diagnostics/README.md).
+The command uses the shared diagnostic codec and topology facade, with no second replay engine, daemon, or network
+service. Topology query defaults come from production. Reports remain sensitive; the command does not sanitize or
+upload them.
 
 ## Trap Enrichment
 

--- a/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
+++ b/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md
@@ -237,7 +237,7 @@ operation table. Shared consumers do not duplicate executions. Walk timing inclu
 pagination, but ends before local PDU-map/row processing; profile phase totals remain inclusive. Preparation is finalized
 on all exits, and scalar timing includes failed and topology scalar work. Missing execution accounting means not recorded.
 A successful Handler return does not prove table completeness; terminal gosnmp response reasons are not yet available.
-See the [diagnostics tool](../../../../tools/snmp-diagnostics/README.md#collection-cost) for interpretation and exclusions.
+See the [diagnostics tool](/src/go/tools/snmp-diagnostics/README.md#collection-cost) for interpretation and exclusions.
 
 BGP evidence keeps one logical unit per configured BGP row definition. Its digest covers the main table name/root and
 every configured identity, descriptor, signal, tag source, and cross-table dependency. `Missing` counts configured scalar
@@ -781,7 +781,7 @@ no user-facing disable option. Publication failures do not stop metric collectio
 The support-bundle scripts include original files only with `--include-snmp-diagnostics` or `-IncludeSnmpDiagnostics`.
 They preserve compressed bytes and report incomplete copies. The files and decoded reports are sensitive: connection
 credentials are excluded, but device-returned values and inventory are not sanitized or pseudonymized. See
-[Collect SNMP troubleshooting data](../../../../../../docs/npm/device-metrics/collect-snmp-troubleshooting-data.md)
+[Collect SNMP troubleshooting data](/docs/npm/device-metrics/collect-snmp-troubleshooting-data.md)
 for the operator workflow.
 
 ## Portable Archive Codec And Replay Boundary
@@ -808,7 +808,7 @@ features.
 ## Maintainer Diagnostic Tool
 
 `src/go/tools/snmp-diagnostics` is the source-only, read-only maintainer command; it is not installed with the Agent.
-The [tool README](../../../../tools/snmp-diagnostics/README.md#usage) owns supported inputs, selectors, operations, and
+The [tool README](/src/go/tools/snmp-diagnostics/README.md#usage) owns supported inputs, selectors, operations, and
 output interpretation, including direct support-bundle access and lifecycle selection.
 
 The command uses the shared diagnostic codec and topology facade, with no second replay engine, daemon, or network

--- a/src/go/tools/snmp-diagnostics/README.md
+++ b/src/go/tools/snmp-diagnostics/README.md
@@ -93,6 +93,44 @@ Match a source reference's `context_id` and `operation` to a source operation's 
 keys belong to one runtime; producer run ID and runtime ID qualify cross-file comparisons. Normal inspection does not
 replay chart creation or reconstruct the Agent's time-series history.
 
+#### Acquisition, processing, and samples
+
+A normal attempt's `failed` flag includes source-operation and profile-processing failures, even when collection
+returned usable samples from other work. It is not an all-or-nothing poll result. Inspect the recorded failures and
+samples together. A `phase: check` attempt records initialization/check evidence but no sample map; absence of samples
+there is expected. These boundaries are implemented by `finishNormalAttempt` and `Check` in the SNMP collector.
+
+Acquisition `MetricValueReferences` describe values before normalization, duplicate selection, virtual-metric
+derivation,
+and hidden-metric filtering. Their ordinals are not indexes into the final `profiles[].metrics` slice. The profile
+metrics describe a later processing stage; `metric_decisions.sample_ids` links collector emission decisions to the final
+`samples` map. Several decisions can target the same sample. See the profile guide's
+[table metric rules](../../plugin/go.d/collector/snmp/profile-format.md#table-metrics-multiple-rows) for row identity
+and accumulation, and its [virtual metrics](../../plugin/go.d/collector/snmp/profile-format.md#virtual-metrics) section
+for derived values. The acquisition boundary is defined by `AcquisitionValueReference` in
+`ddsnmp/ddsnmpcollector/acquisition_report.go` under the SNMP collector.
+
+#### Cached inputs and earlier outcomes
+
+A route's cache source does not imply old metric values: cached table structure can supply the OIDs for a fresh GET.
+`Reused` instead marks an entire route outcome inherited from an earlier attempt. Cached profile tags and metadata can
+therefore coexist with newly acquired metric values. Consult operation timestamps and bindings rather than dating
+all fields from the route's source label. `AcquisitionRouteReport` defines this distinction.
+
+`DiscardedSources` records rejected acquisition candidates, such as a cached GET replaced by a WALK; those operations
+are not the accepted value source. `negative_causes` preserves original missing-OID evidence for configured sources
+whose requests are subsequently suppressed. An absent request in the latest attempt alone does not mean the OID was
+never tried. This is retained negative evidence, not a history of every disappearing table instance.
+
+#### Cached state versus Function output
+
+Normal inspection copies stored BGP and licensing state through `captureNormalBGP` and `captureNormalLicensing`; it
+does not run their Function handlers. For licensing, `normalized_at` dates the stored normalized set. Interpret that
+state using the profile guide's consumer rules:
+
+- [BGP collection and retained rows](../../plugin/go.d/collector/snmp/profile-format.md#bgp-collection-and-retained-rows)
+- [Licensing normalization and collection results](../../plugin/go.d/collector/snmp/profile-format.md#licensing-normalization-and-collection-results)
+
 ### Topology replay and inspection
 
 For topology, `summary` reports captured cuts and an ordered registration inventory. `replay` emits the production

--- a/src/go/tools/snmp-diagnostics/README.md
+++ b/src/go/tools/snmp-diagnostics/README.md
@@ -3,12 +3,17 @@
 This source-only maintainer tool reads built-in SNMP diagnostic files: topology, lifecycle, and normal per-device
 metrics/BGP/licensing evidence. Topology replay and inspection use the collector's production paths. It is run from the repository and is not installed with the Netdata Agent.
 
+**Place in the documentation set.** This README owns the maintainer CLI interface and output interpretation.
+The developer skill `.agents/skills/triage-snmp-diagnostics/SKILL.md` links to its sections for the investigation
+workflow.
+
 > Diagnostic archives can contain device addresses, hostnames, descriptions, inventory data, and topology evidence.
 > Treat an archive and the tool output as sensitive support material.
 
 ## Usage
 
-Run commands from `src/go`:
+Run commands from `src/go`. Every successful operation writes one JSON document to standard output; `validate` checks
+the selected diagnostic document and reports its identity.
 
 ```text
 go run ./tools/snmp-diagnostics validate --input /path/to/archive.zst
@@ -22,6 +27,8 @@ go run ./tools/snmp-diagnostics inspect-link --input /path/to/archive.zst \
   --family lldp \
   --direction bidirectional
 ```
+
+### Input selection
 
 The input can be a single diagnostic `.zst` file, the `snmp/diagnostics` directory, an extracted support-bundle
 root, or a support `.tar.zst`, `.tar.gz`, or `.zip` archive. Bundle inputs automatically use `06-state/snmp-diagnostics`.
@@ -43,6 +50,8 @@ go run ./tools/snmp-diagnostics inspect-device --input /path/to/support-bundle.t
 go run ./tools/snmp-diagnostics replay --input /path/to/support-bundle.tar.zst
 ```
 
+### Collection status and partial listings
+
 `list` takes a directory or bundle without selectors and reports lifecycle availability, topology checkpoints, and indexed
 normal device files without decoding evidence documents. Bundle listings also include `bundle.collection_status`: the
 producer's original collection notes, including why evidence was not requested, unavailable, or partially copied. A
@@ -54,17 +63,43 @@ an invalid normal-run index does not hide topology or lifecycle evidence. Normal
 index; it never guesses current/previous from directory names. A missing index yields no indexed normal devices.
 A selected missing or invalid document fails; the tool does not silently substitute another checkpoint or evidence kind.
 
-Normal files support `validate`, `summary`, and `inspect-device`; replay and link inspection require topology evidence.
+### Normal device evidence
+
+Normal files support `validate`, `summary`, and `inspect-device`; replay and link inspection require topology
+evidence.
 Normal `inspect-device` reports the latest attempt, retained last failure, metric samples, BGP/licensing cache state,
 profile context, and linked source operations. Cached values may originate in an earlier attempt. Compare their source
 and observation timestamps; publication time is not the time every value was collected. Device registration IDs belong to
 a process run, so do not join current lifecycle rows to previous-run normal files or historical topology by ID alone.
 
-Every successful operation writes one JSON document to standard output. `validate` verifies the complete archive and
-reports its identity. `summary` reports the captured cuts and an ordered registration inventory. `replay` emits the
-production topology-v1 payload. The inspection operations report one device or link across captured evidence, graph, and
-rendered topology stages. Link reports also include family-wide source context; that context is not causal provenance for
-the inspected link.
+A normal `summary` identifies one device and gives counts and failure indicators; use `inspect-device` for the
+underlying attempts and evidence. The inspection body is `NormalDevice` from
+`src/go/plugin/go.d/collector/snmp/diagnostics/normal.go`; its producer identity is available through `validate` or
+`summary`. Keep that identity with the inspection report when comparing runs.
+
+The attempt-level fields below live under `latest_attempt` or `last_failed_attempt`; `profile_context`,
+`initialization_sources`, and `source_operations` are device-level fields.
+
+| Evidence | Interpretation |
+|---|---|
+| `latest_attempt` / `last_failed_attempt` | Latest completed attempt and a retained failure; their timestamps qualify any comparison. |
+| `profiles` / `profile_context` | Captured profile selection, acquisition results, processed metrics, and profile rows. |
+| `metric_decisions` / `samples` | Decisions linking processed metrics to sample IDs, and the emitted sample values. |
+| `bgp_cache` / `licensing_cache` | Captured normal-collector state, its update/normalization timestamps, and source references. |
+| `cache_inputs` / `initialization_sources` | Retained inputs that may predate the latest attempt. |
+| `source_operations` | The operation table used by the source references in this device cut. |
+
+Match a source reference's `context_id` and `operation` to a source operation's `context_id` and `ordinal`. Operation
+keys belong to one runtime; producer run ID and runtime ID qualify cross-file comparisons. Normal inspection does not
+replay chart creation or reconstruct the Agent's time-series history.
+
+### Topology replay and inspection
+
+For topology, `summary` reports captured cuts and an ordered registration inventory. `replay` emits the production
+topology-v1 payload. Inspection reports one device or link across captured evidence, graph, and rendered topology
+stages. Link reports also include family-wide source context; that context is not causal provenance for the inspected
+link. Stage availability and retained-success/latest-attempt interpretation are explained in
+[Offline Diagnostic Inspection](../../plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#offline-diagnostic-inspection).
 
 Use `summary` to find a device registration ID. Use `--link-index` to inspect one existing link by its zero-based row in
 the `links` table emitted by `replay`. The index belongs to that archive and query option set; do not reuse it with a
@@ -88,6 +123,8 @@ Replay and inspection accept the production scalar query options:
 --depth all|0..10
 ```
 
+### Read limits and container cost
+
 Decode operations accept human-readable limits for the **selected diagnostic document** (128 MiB compressed and
 512 MiB decoded JSON by default). They can be overridden for a particular invocation:
 
@@ -104,6 +141,8 @@ bundle root avoids those scans.
 The tool retains member metadata and collection-status/run-index contents, not diagnostic payloads. Only the selected
 inner document is decoded. Tar inventory checks the outer compression stream; ZIP checks the members it reads. Neither
 listing nor validating one selected document is a validation of every file in the support bundle.
+
+### Exit codes
 
 Exit codes are `0` for success (including a partial listing with component errors), `1` for evidence-selection, input, or
 operation errors, and `2` for command/flag parsing and argument-validation errors. Evidence-selector conflicts such as

--- a/src/go/tools/snmp-diagnostics/README.md
+++ b/src/go/tools/snmp-diagnostics/README.md
@@ -101,12 +101,11 @@ samples together. A `phase: check` attempt records initialization/check evidence
 there is expected. These boundaries are implemented by `finishNormalAttempt` and `Check` in the SNMP collector.
 
 Acquisition `MetricValueReferences` describe values before normalization, duplicate selection, virtual-metric
-derivation,
-and hidden-metric filtering. Their ordinals are not indexes into the final `profiles[].metrics` slice. The profile
-metrics describe a later processing stage; `metric_decisions.sample_ids` links collector emission decisions to the final
-`samples` map. Several decisions can target the same sample. See the profile guide's
-[table metric rules](../../plugin/go.d/collector/snmp/profile-format.md#table-metrics-multiple-rows) for row identity
-and accumulation, and its [virtual metrics](../../plugin/go.d/collector/snmp/profile-format.md#virtual-metrics) section
+derivation, and hidden-metric filtering. Their ordinals are not indexes into the final `profiles[].metrics` slice.
+Profile metrics describe a later processing stage; `metric_decisions.sample_ids` links collector emission decisions to
+the final `samples` map. Several decisions can target the same sample. See the collector architecture's [metric
+emission](../../plugin/go.d/collector/snmp/ARCHITECTURE.md#metric-emission) section for row identity and accumulation,
+and the profile guide's [virtual metrics](../../plugin/go.d/collector/snmp/profile-format.md#virtual-metrics) section
 for derived values. The acquisition boundary is defined by `AcquisitionValueReference` in
 `ddsnmp/ddsnmpcollector/acquisition_report.go` under the SNMP collector.
 
@@ -126,10 +125,10 @@ never tried. This is retained negative evidence, not a history of every disappea
 
 Normal inspection copies stored BGP and licensing state through `captureNormalBGP` and `captureNormalLicensing`; it
 does not run their Function handlers. For licensing, `normalized_at` dates the stored normalized set. Interpret that
-state using the profile guide's consumer rules:
+state using the collector architecture's consumer rules:
 
-- [BGP collection and retained rows](../../plugin/go.d/collector/snmp/profile-format.md#bgp-collection-and-retained-rows)
-- [Licensing normalization and collection results](../../plugin/go.d/collector/snmp/profile-format.md#licensing-normalization-and-collection-results)
+- [BGP collection and retained rows](../../plugin/go.d/collector/snmp/ARCHITECTURE.md#bgp-collection-and-retained-rows)
+- [Licensing normalization and collection results](../../plugin/go.d/collector/snmp/ARCHITECTURE.md#licensing-normalization-and-collection-results)
 
 ### Topology replay and inspection
 

--- a/src/go/tools/snmp-diagnostics/README.md
+++ b/src/go/tools/snmp-diagnostics/README.md
@@ -104,8 +104,8 @@ Acquisition `MetricValueReferences` describe values before normalization, duplic
 derivation, and hidden-metric filtering. Their ordinals are not indexes into the final `profiles[].metrics` slice.
 Profile metrics describe a later processing stage; `metric_decisions.sample_ids` links collector emission decisions to
 the final `samples` map. Several decisions can target the same sample. See the collector architecture's [metric
-emission](../../plugin/go.d/collector/snmp/ARCHITECTURE.md#metric-emission) section for row identity and accumulation,
-and the profile guide's [virtual metrics](../../plugin/go.d/collector/snmp/profile-format.md#virtual-metrics) section
+emission](/src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md#metric-emission) section for row identity and accumulation,
+and the profile guide's [virtual metrics](/src/go/plugin/go.d/collector/snmp/profile-format.md#virtual-metrics) section
 for derived values. The acquisition boundary is defined by `AcquisitionValueReference` in
 `ddsnmp/ddsnmpcollector/acquisition_report.go` under the SNMP collector.
 
@@ -127,8 +127,8 @@ Normal inspection copies stored BGP and licensing state through `captureNormalBG
 does not run their Function handlers. For licensing, `normalized_at` dates the stored normalized set. Interpret that
 state using the collector architecture's consumer rules:
 
-- [BGP collection and retained rows](../../plugin/go.d/collector/snmp/ARCHITECTURE.md#bgp-collection-and-retained-rows)
-- [Licensing normalization and collection results](../../plugin/go.d/collector/snmp/ARCHITECTURE.md#licensing-normalization-and-collection-results)
+- [BGP collection and retained rows](/src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md#bgp-collection-and-retained-rows)
+- [Licensing normalization and collection results](/src/go/plugin/go.d/collector/snmp/ARCHITECTURE.md#licensing-normalization-and-collection-results)
 
 ### Topology replay and inspection
 
@@ -136,7 +136,7 @@ For topology, `summary` reports captured cuts and an ordered registration invent
 topology-v1 payload. Inspection reports one device or link across captured evidence, graph, and rendered topology
 stages. Link reports also include family-wide source context; that context is not causal provenance for the inspected
 link. Stage availability and retained-success/latest-attempt interpretation are explained in
-[Offline Diagnostic Inspection](../../plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#offline-diagnostic-inspection).
+[Offline Diagnostic Inspection](/src/go/plugin/go.d/collector/snmp_topology/ARCHITECTURE.md#offline-diagnostic-inspection).
 
 Use `summary` to find a device registration ID. Use `--link-index` to inspect one existing link by its zero-based row in
 the `links` table emitted by `replay`. The index belongs to that archive and query option set; do not reuse it with a


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `triage-snmp-diagnostics` skill for investigating offline SNMP support bundles and diagnostic files, and reorganizes the SNMP diagnostics documentation around it.

- New skill guides maintainers through evidence triage for topology devices/links, metrics, BGP, licensing, slow collection, and discovery/lifecycle failures, including correlating companion support-bundle logs and inspecting bundled configuration.
- Registers the skill in `AGENTS.md` and adds its private cache directory.
- Moves CLI usage and evidence interpretation from the topology architecture into the tool README; adds a new collector `ARCHITECTURE.md` covering profile selection, metric emission, and BGP/licensing behavior.
- Adds diagnostic evidence interpretation to `profile-format.md` and the tool README (attempt fields, acquisition/processing, cached state).
- Updates the topology architecture doc to cite the skill and removes duplicated command-level content.

<sup>Written for commit 894755ba4ce631c4ed7324d80b650101426c28c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for offline investigation of captured SNMP support bundles and diagnostic files.
  - Documented investigation paths for topology, metrics, BGP peers, licensing, discovery, lifecycle, and slow collection issues.
  - Clarified diagnostic tool inputs, outputs, validation, collection status, read limits, and exit codes.
  - Added a maintainer reference for normal SNMP collection behavior.
  - Updated topology documentation to centralize diagnostic tool details.
  - Removed detailed BGP, licensing, and selector-fallback explanations from the SNMP profile guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->