### PR TITLE
docs(agents): clarify workflow and knowledge capture policies

### DIFF
--- a/.agents/skill-verification/query-netdata-agents/questions.md
+++ b/.agents/skill-verification/query-netdata-agents/questions.md
@@ -7,9 +7,8 @@ a Sonnet-class assistant with `../SKILL.md` + `../how-tos/INDEX.md`
 below, captures the transcript, and grades it against the
 verification harness rubric.
 
-When the assistant cannot answer or has to perform analysis not
-already documented under `../how-tos/`, the assistant must author
-a new how-to and add it to the index before completing.
+Verification questions do not authorize guide edits. Record unanswered questions and reusable discoveries as
+sanitized local evidence under `AGENTS.md#knowledge-capture`; documentation implementation is separately authorized.
 
 ## Anchor: target nodes
 

--- a/.agents/skill-verification/query-netdata-cloud/questions.md
+++ b/.agents/skill-verification/query-netdata-cloud/questions.md
@@ -6,9 +6,8 @@ with `../SKILL.md` + `../how-tos/INDEX.md` + the canonical
 reference docs as context, asks each question below, captures the
 transcript, and grades it against the verification harness rubric.
 
-When the assistant cannot answer or has to perform analysis not
-already documented under `../how-tos/`, the assistant must author
-a new how-to and add it to the index before completing.
+Verification questions do not authorize guide edits. Record unanswered questions and reusable discoveries as
+sanitized local evidence under `AGENTS.md#knowledge-capture`; documentation implementation is separately authorized.
 
 ## Anchor: target node
 

--- a/.agents/skills/integrations-lifecycle/SKILL.md
+++ b/.agents/skills/integrations-lifecycle/SKILL.md
@@ -50,10 +50,8 @@ Citations in this skill name files and symbols, never line numbers; open the fil
 
 ## Live how-to rule
 
-When a concrete question about the pipeline needs non-trivial analysis (reading several scripts, running the pipeline,
-cross-referencing schemas) and no file above answers it, the assistant MUST write `how-tos/<slug>.md` and add its row to
-`how-tos/INDEX.md` before completing the task, so the next assistant does not repeat the analysis. When an existing
-guide almost answers it, update that guide instead.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Pipeline recipes live in `how-tos/` and are
+listed in `./how-tos/INDEX.md`; prefer updating an existing guide when it already covers most of the question.
 
 ## Path discipline
 

--- a/.agents/skills/integrations-lifecycle/how-tos/INDEX.md
+++ b/.agents/skills/integrations-lifecycle/how-tos/INDEX.md
@@ -1,7 +1,7 @@
 # How-tos
 
-Analysis-derived answers to concrete pipeline questions. The rule that keeps this catalog live is in `../SKILL.md`
-("Live how-to rule").
+Analysis-derived answers to concrete pipeline questions. Capture timing and authorization are in
+`AGENTS.md#knowledge-capture`.
 
 | Question | How-to | Audience |
 |---|---|---|
@@ -17,7 +17,7 @@ Analysis-derived answers to concrete pipeline questions. The rule that keeps thi
 1. Create `how-tos/<slug>.md`: the question in one line, the answer citing files and symbols (never line numbers), and,
    when the work read other repositories, a "How I figured this out" footer naming files and commands so the next reader
    can verify.
-2. Add a row above and commit it with the work that prompted the analysis.
+2. Add a row above with the authorized documentation change. Git operations follow `AGENTS.md#git-and-pr-workflow`.
 
 Do not add one when an existing guide already covers the question (update that guide), when the answer is a lookup that
 needs no analysis, or when it is speculative or tied to a release that will change.

--- a/.agents/skills/packaging-static-installer/SKILL.md
+++ b/.agents/skills/packaging-static-installer/SKILL.md
@@ -240,7 +240,9 @@ sh artifacts/netdata-x86_64-latest.gz.run --target /tmp/nd-extract --noexec --ke
 
 ## How to extend this skill
 
-When you discover a new failure mode, an arch-specific quirk, or a workflow that's worth preserving, add a how-to under `how-tos/` and link it from `how-tos/INDEX.md`. Keep `SKILL.md` tight; push detail into how-tos. The catalog is live — every assistant who solves a non-trivial build problem must commit the recipe before moving on.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Authorized recipes for build failures,
+architecture-specific quirks, and reusable workflows belong in `how-tos/`, with an entry in `./how-tos/INDEX.md`.
+Keep `SKILL.md` focused on the workflow and route detailed recipes through the catalog.
 
 ## Source-of-truth pointers
 

--- a/.agents/skills/packaging-static-installer/how-tos/INDEX.md
+++ b/.agents/skills/packaging-static-installer/how-tos/INDEX.md
@@ -1,6 +1,7 @@
 # How-tos catalog: packaging-static-installer
 
-Live catalog. When you solve a static-build problem that takes more than a couple of wrapper calls or that future-you would not reconstruct in 30 seconds from `SKILL.md`, write a how-to here and link it below before closing the task.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Add authorized static-build recipes here and
+keep the catalog consistent with them.
 
 ## Conventions
 

--- a/.agents/skills/repo-mirror-sources/how-tos/INDEX.md
+++ b/.agents/skills/repo-mirror-sources/how-tos/INDEX.md
@@ -3,16 +3,8 @@
 Live catalog of analysis-derived how-tos for the
 repo-mirror-sources skill.
 
-**Live-catalog rule** (also stated in `../SKILL.md`): if an
-assistant is asked a concrete question about the mirror that
-required non-trivial analysis (multiple file reads, running
-the script with custom flags, debugging a failed sync) AND
-the answer is not already documented in `../SKILL.md`, the
-assistant MUST author a new `how-tos/<slug>.md` and add a row
-to this INDEX BEFORE completing the task.
-
-This is durable. Skipping it means the next assistant repeats
-the same analysis from scratch.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Add authorized mirror recipes here when
+`../SKILL.md` does not already cover the question.
 
 ## Catalog
 
@@ -32,7 +24,7 @@ not-yet-documented questions)
    - A "How I figured this out" footer naming the files read
      and the commands run.
 2. Add a row to the table above with topic, slug, short notes.
-3. Commit alongside the work that prompted the analysis.
+3. Git operations follow `AGENTS.md#git-and-pr-workflow`.
 
 ## When NOT to add a how-to
 

--- a/.agents/skills/repo-pr-reviews/SKILL.md
+++ b/.agents/skills/repo-pr-reviews/SKILL.md
@@ -550,9 +550,7 @@ If a new AI reviewer appears in the project, classify it by adding to
 
 ## MANDATORY -- keep this skill alive
 
-If you (the agent) discover a new pattern, gotcha, working flow, correction,
-or any piece of knowledge while running this skill -- update this `SKILL.md`
-AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.
+Capture timing and authorization for operational discoveries follow `AGENTS.md#knowledge-capture`.
 
 Examples of things to capture:
 - A new AI reviewer bot that appears in the project (add to the directory + `PR_AI_BOT_RE`)

--- a/.agents/skills/repo-pr-reviews/SKILL.md
+++ b/.agents/skills/repo-pr-reviews/SKILL.md
@@ -1,22 +1,26 @@
 ---
 name: repo-pr-reviews
-description: Address pull-request comments and reviews iteratively until the PR is clean — fetch all comments with paranoid pagination, classify by author (AI bot vs human), verify each finding, address it, find similar patterns, reply per-thread, resolve threads, pull SonarCloud findings, check CI before pushing, retrigger AI reviewers (cubic-dev-ai, coderabbitai), and wait for new feedback. Use when the user says "address PR comments", "look at the reviews on PR N", "deal with the bot comments", "there is a coderabbit review", "another review", "iterate on PR N until clean", or anything mentioning PR comments / reviews / cubic / cubic-dev-ai / coderabbit / coderabbitai / copilot / sonar findings on a PR.
+description: Inspect pull-request comments and reviews, or address them when authorized under the repository review policy — fetch all comments with paranoid pagination, classify by author (AI bot vs human), verify each finding, address it, find similar patterns, reply per-thread, resolve threads, pull SonarCloud findings, check CI before pushing, retrigger AI reviewers (cubic-dev-ai, coderabbitai), and wait for new feedback. Use when the user says "address PR comments", "look at the reviews on PR N", "deal with the bot comments", "there is a coderabbit review", "another review", "iterate on PR N until clean", or anything mentioning PR comments / reviews / cubic / cubic-dev-ai / coderabbit / coderabbitai / copilot / sonar findings on a PR.
 ---
 
 # PR review handler skill
 
-This skill iterates a PR through review/comment cycles until there is nothing
-left to address.
+This skill gathers and verifies PR findings, then applies the authorized handling path below.
 
 ## Your role on a PR
 
-When this skill is in use, the agent's job is to **bring the PR into
-merge-ready shape**: solve the original problem the PR was opened for,
-**and** address every legitimate finding the PR has accumulated, from
-every source. Reviewers, linters, and CI all matter. Comments are the
-loudest source but they are not the only source -- you must proactively
-pull findings from every channel that reports on the PR, not wait for
-something to surface as a chat message.
+Authorization and read-only scope are owned by `AGENTS.md#when-a-sow-is-required`; Git operations by
+`AGENTS.md#git-and-pr-workflow`; finding classification, review repetition and stopping by `AGENTS.md#review`.
+
+- **Inspect/report:** requests such as "look at the reviews" gather and verify findings using steps 1-2, then report
+  them under step 8. Do not fix source, post replies, resolve threads, mark Sonar findings, or trigger reviewers.
+- **Address:** when fixes are authorized, solve the original PR problem and handle verified findings within approved
+  scope. Posting replies, resolving threads, changing remote triage state and triggering bots require user
+  authorization for those actions; permission to fix code alone does not grant it. Preserve already-granted approval.
+  Prepare proposed replies or triage decisions for the user when remote actions are not authorized.
+- Fetch all configured finding sources for either path, not just the comments mentioned in the request. The mutation
+  steps below apply only to authorized actions. Human-comment handling retains the separate direction requirement
+  under "Author classes".
 
 Sources of findings, in priority order:
 
@@ -49,40 +53,34 @@ These are non-negotiable. Skipping any of them will cost the user time.
    pagination defaults to 100, and round-multiples almost always mean there
    is a next page that the previous client missed. Always re-probe with an
    explicit `page=N+1` request. `fetch-all.sh` does this automatically.
-2. **Accept all comments and address them all.** No exceptions. No "this is
-   minor, skip it." The bar is: Netdata's performance, stability, and
-   long-term maintainability.
+2. **Triage every comment.** Verify it and classify it under `AGENTS.md#review`. Handle non-blocking findings under
+   `AGENTS.md#scope-discipline-at-every-step` and `AGENTS.md#followup-discipline`; do not silently discard them or
+   promote them to shipping blockers merely because a reviewer requested them.
 3. **Verify every comment properly.** No shortcuts. Read the code, follow
    the trace, confirm the claim. AI bots produce false positives -- judge
    each one on its merits.
-4. **Reply per-thread, one by one.** No bulk replies. No mechanical "fixed"
+4. **When replies are authorized, reply per-thread, one by one.** No bulk replies. No mechanical "fixed"
    answers. Each thread gets a substantive reply that explains what you
    did or why the comment doesn't apply.
-5. **Don't dismiss comments because they look minor.** Even style nits
-   compound. The goal is for the project to thrive.
-6. **Help bots when they're confused.** AI reviewers sometimes flag false
-   positives because the surrounding code is ambiguous. Add a short
-   comment in the source that clarifies the intent -- it helps the next
-   reviewer (human or bot).
+5. **Assess materiality, not phrasing.** Optional improvements receive an explicit disposition; they do not
+   independently extend the review cycle (`AGENTS.md#review`).
+6. **Explain false positives with evidence.** During authorized fixes, add a source comment only when it clarifies
+   otherwise ambiguous intent. Bot confusion alone does not justify changing correct code.
 7. **Check CI BEFORE every push, but never WAIT for CI between iterations.**
    Waiting for CI between bot-review cycles destroys throughput -- a CI
    run can take 30+ minutes, and during that time the AI reviewers are
    idle. The right cadence is:
-   - Before each push: run `ci-status.sh`. If there are FAILURES, fix
+   - Before each push: run `ci-status.sh`. If there are PR-caused failures, fix
      them and bundle into the same push. If checks are still running,
      that's fine -- ignore them and push anyway. The next push triggers
      fresh CI on the new code, which is what we actually care about.
-   - After each push: re-trigger the bots, then `wait-for-activity.sh`
-     for new comments (NOT for CI).
+   - After a push: if another round is warranted under `AGENTS.md#review` and trigger comments are authorized,
+     re-trigger the selected bots, then use `wait-for-activity.sh` for their feedback.
    - If `wait-for-activity.sh` times out (30 min, no new comments):
      re-check `ci-status.sh`. If checks are still running, that's normal,
-     surface to the user. If there are failures, fix and iterate.
-8. **Re-trigger AI reviewers explicitly.** They do NOT react to thread
-   replies or pushed commits the way humans do. Re-trigger every reviewer the
-   exit condition waits on -- if such a reviewer is never re-triggered it can
-   never post its "no new findings" pass, so the loop cannot end. A reviewer
-   that is deliberately excluded from the loop (see Copilot below) must also
-   be excluded from the exit condition, so the two lists always match.
+     surface to the user. Treat PR-caused failures as blockers; report unrelated failures without fixing them.
+8. **Re-trigger selected reviewers when another round is warranted.** Use `AGENTS.md#review` to decide whether to
+   repeat a round; do not re-trigger solely to obtain an approval phrase. Trigger comments require authorization.
    - cubic-dev-ai: post a new top-level comment mentioning it
      (`trigger-cubic.sh`).
    - coderabbitai: post a new top-level comment with a command
@@ -112,26 +110,17 @@ These are non-negotiable. Skipping any of them will cost the user time.
     affected script (or the smallest invocation that exercises the
     change) and verify the output looks right. "Linter green" is not
     the same as "still works."
-12. **Before every push, spawn a subagent for a holistic PR review.**
-    See Step 4a in the workflow. The orchestrator's context is biased
-    toward the fixes it just made; a clean-context subagent re-reviewing
-    the WHOLE diff is what catches the issues the orchestrator and the
-    AI reviewers missed. Skipping this turns each iteration into a
-    30-minute round-trip to discover issues that could have been found
-    in 2 minutes locally.
-13. **Before every push, re-fetch all finding sources one last time.**
-    See Step 4-pre. Reviewers post in parallel; if findings arrive
-    while you're addressing the current batch, they belong in THIS
-    push, not the next one. Without this sync barrier, you and the
-    reviewers stay one round out of sync forever -- the next iteration
-    is always "fixing" issues that no longer apply.
+12. **Check full-scope review coverage before pushing.** Step 4a applies `AGENTS.md#review`; a push alone does not
+    require another review when the current change already has adequate coverage.
+13. **Before every authorized push, re-fetch finding sources.** Step 4-pre verifies and dispositions newly arrived
+    feedback against the current HEAD; do not leave findings unassessed or assume the fetch prevents later arrivals.
 
 ## Author classes -- different handling per class
 
 - **AI bots** (`cubic-dev-ai[bot]`, `coderabbitai[bot]`, `copilot[bot]` and
   variants): handle
-  autonomously. Verify the finding, fix or push back with reasoning, reply
-  in-thread, resolve thread.
+  within the authorized path above. Verify every finding; fix, reply and resolve only when those actions are
+  authorized. Inspection alone ends with a report.
 - **Informational bots** (`sonarqubecloud[bot]`, `github-actions[bot]`,
   `netdata-bot[bot]`): read for signal (e.g. quality
   gate status). They don't usually require a reply.
@@ -161,8 +150,8 @@ State for each PR is cached under `<repo-root>/.local/audits/pr-reviews/pr-<N>/`
 
 ## Workflow
 
-The order is: **gather all findings -> address them per-thread / per-finding
--> check CI for failures the PR caused -> push -> retrigger -> wait -> loop.**
+For inspection, gather and verify findings in steps 1-2, then report under step 8. For authorized addressing, apply
+steps 3-4, perform only authorized remote actions, and use `AGENTS.md#review` to decide whether steps 5-7 are needed.
 
 ### 1a. Fetch all comments (paranoid)
 
@@ -230,9 +219,9 @@ For thread N:
    on the first thread of a class -- subsequent threads in the same
    class share the same fix.)
 4. **Decide**:
-   - If valid -> fix it AND every similar instance you found.
-   - If invalid -> understand why the bot got confused. Often a small
-     source comment clarifying the intent will help the next reviewer.
+   - If valid -> classify under `AGENTS.md#review`; fix blockers and approved improvements, including similar
+     in-scope instances. Record dispositions for non-blocking items under the root scope and follow-up rules.
+   - If invalid -> record the evidence; clarify source intent only when warranted under rule 6.
 5. **Reply in the thread.**
    ```
    bash .agents/skills/repo-pr-reviews/scripts/reply-thread.sh <PR> <comment-id> "<reply>"
@@ -272,19 +261,18 @@ For each issue in `sonar-issues.json` and each hotspot in
    instance of S131 (case without default), sweep all case statements.
    If Sonar flagged S2245 (insecure RNG), sweep all `random()` callsites.
 4. **Decide**:
-   - If valid -> fix it AND every similar instance you found in the
-     project where the same reasoning applies (within the diff, plus
-     nearby code in files this PR already touches).
-   - If invalid -> the corresponding `triage-sonarqube` skill provides
-     `sonar-mark.sh fp <KEY> "<reason>"` to mark it False Positive
-     directly in SonarCloud. Comments are ASCII-only (Cloudflare).
-5. **Repeat until `sonar-issues.json` has zero issues that we caused.**
+   - If valid -> classify under `AGENTS.md#review`; fix blockers and approved improvements, including similar
+     in-scope instances. Disposition other findings under the root scope and follow-up rules.
+   - If invalid -> record the evidence. When remote triage is authorized, `triage-sonarqube` provides
+     `sonar-mark.sh fp <KEY> "<reason>"` to mark it False Positive in SonarCloud. Comments are ASCII-only (Cloudflare).
+5. Account for every finding. An open issue count alone is not the stopping condition; use `AGENTS.md#review` and
+   report unmet required quality gates explicitly.
 
 For Sonar there is no "thread reply" -- you address the issue with
 either a code fix or a `sonar-mark.sh` action. There's nothing to
 resolve in GitHub for Sonar findings.
 
-### 4-pre. Before pushing -- MANDATORY final-fetch sync barrier
+### 4-pre. Before pushing -- refresh and triage findings
 
 Reviewers run in parallel. Multiple bots and humans can be appending
 findings WHILE you're addressing the current batch. If you push the
@@ -295,12 +283,9 @@ longer apply because you addressed them implicitly with the next push.
 The result: chronic desync, where your commit and the reviewers'
 findings are always one round apart.
 
-The fix: a sync barrier immediately before push. Re-fetch ALL sources
-(comments, Sonar, CI) one more time. If ANY new finding has arrived
-since you last looked, loop back to step 2 -- address those new
-findings in the SAME upcoming push -- then re-fetch again. Only push
-when a fresh fetch comes back with no new findings against the current
-HEAD. This guarantees you and the reviewers are synchronized.
+Before an authorized push, re-fetch all sources (comments, Sonar, CI) and triage new findings against the current
+HEAD. Resolve verified blockers before pushing; handle non-blocking items under the root scope/follow-up rules.
+This reduces stale work but is not an atomic barrier: new feedback can arrive after the fetch.
 
 ```
 bash .agents/skills/repo-pr-reviews/scripts/fetch-all.sh <PR_NUMBER>
@@ -314,68 +299,25 @@ shellcheck, broke a YAML parse, etc.) is in scope and must be folded
 in. CI failures unrelated to this PR are noted, surfaced to the user
 at the end, but not fixed here.
 
-If `summary.txt` shows any new open thread or `sonar-issues.json` shows
-any new issue you haven't addressed yet, **do NOT push**. Loop back to
-step 2 and address them first. Then re-run the fetch. Only push when
-the fetch is clean.
+If the fresh snapshot contains an unassessed finding, verify and disposition it before pushing. Additional fixes
+require relevant validation; repeat review only under `AGENTS.md#review`, not merely because another comment arrived.
 
-The same loop applies during the iteration: if you re-fetched while
-addressing the previous batch and saw new findings drop in, fold them
-into the same push rather than dispatching a half-done batch.
+### 4a. Before pushing -- verify full-scope review coverage
 
-### 4a. Before pushing -- MANDATORY holistic PR review via subagent
+Ensure the complete current PR diff has independent review coverage under `AGENTS.md#review`. Reuse a completed
+review when no condition requiring another round applies; do not launch a reviewer merely because a push is next.
+The coordinator owns delegation, validates findings and decides whether a repeat is warranted under the root rule.
 
-This is the most important pre-push step. Skipping it is what makes
-review cycles last for hours.
+A full-scope prompt template:
 
-After you have made all the fixes for the current iteration's findings
-but BEFORE running `git push`, spawn a subagent to re-review the WHOLE
-PR diff (not the small change you just made). The orchestrator's
-context is already loaded with the recent fixes; the subagent's clean
-context is what gives an honest second look.
+> Review PR <N> end-to-end on branch <X>, against base <base>. Read AGENTS.md and the active SOW <filename, if any>.
+> Check correctness, tests, side effects, security, operations, and similar defects throughout the complete diff.
+> For performance-sensitive code, also audit hot-path complexity, allocations, contention and unbounded growth.
+> Classify each finding under AGENTS.md Review, with file/line evidence, trigger, consequence and a suggested fix.
+> This is read-only: do not edit files, mutate remote or Git state, stop processes, or launch other agents.
 
-Why this is non-negotiable:
-
-- AI reviewers (cubic-dev-ai, coderabbitai, sonarqube) only surface their
-  top 3-7 findings. The full set of similar issues remains hidden.
-- Each fix can introduce its own new problems (a printf format-string
-  fix that breaks color rendering, a portability fix that drops a
-  feature, an input-validation fix that rejects valid inputs).
-- Without a holistic pre-push review, every iteration takes ~30 min of
-  bot review latency just to discover problems the orchestrator could
-  have spotted in 2 minutes by re-reading the diff.
-
-How to invoke:
-
-Use the orchestrator's Agent / subagent tool (whatever the harness
-provides). Pass the subagent the PR diff (or the list of touched files)
-and ask it to:
-
-- Verify each fix in this iteration solves the original finding without
-  side effects.
-- Sweep the touched files for similar patterns the original findings
-  did not point at, but which the same reasoning would flag.
-- Sweep the touched files for NEW issues the fixes themselves may have
-  introduced (broken behavior, lost features, regressions).
-- Report findings as a flat list -- file:line + class + suggested fix.
-
-Then the orchestrator addresses every finding the subagent returns
-BEFORE push. Loop the subagent if necessary until it returns a clean
-review. Only then proceed to step 4b.
-
-A good subagent prompt template:
-
-> Re-review PR <N> end-to-end. The current diff is on branch <X>; the
-> base is <master|...>. Recent fixes addressed: <list>. For the WHOLE
-> diff (not just the recent fixes), find:
-> 1. Similar patterns to the ones recently fixed that were NOT pointed
->    at by reviewers but where the same reasoning applies.
-> 2. Issues the recent fixes may have introduced (regressions, broken
->    behavior, dropped features).
-> 3. Anything in the diff that does not match the project's
->    conventions (AGENTS.md, sibling files, the rest of the repo).
-> Report a flat list of file:line + class + suggested fix. Be
-> exhaustive; do not stop at 3-7 findings.
+Verify reviewer findings before acting. Handle blockers and optional improvements under the root review, scope and
+follow-up rules. A reviewer returning no suggestions is not required before proceeding.
 
 ### 4b. Before pushing -- check CI for FAILURES (don't wait)
 
@@ -396,7 +338,8 @@ user, move on. Do not make drive-by fixes here.
 
 ### 5. Push, then re-trigger reviewers
 
-After pushing the fix commit(s):
+When a further review round is warranted under `AGENTS.md#review`, and posting trigger comments is authorized,
+run the selected reviewers after the fix commits have been pushed:
 
 ```
 bash .agents/skills/repo-pr-reviews/scripts/trigger-cubic.sh      <PR_NUMBER>
@@ -404,9 +347,8 @@ bash .agents/skills/repo-pr-reviews/scripts/trigger-coderabbit.sh <PR_NUMBER>
 ```
 
 cubic and coderabbit re-review when mentioned in a new top-level PR comment.
-Copilot is deliberately absent: see rule 8. If you add a reviewer to
-`PR_AI_BOT_RE`, add its re-trigger here in the same change -- a classified
-reviewer with no re-trigger is silently skipped every iteration.
+Copilot is deliberately absent: see rule 8. If a new reviewer is selected for repeated review, document its
+re-trigger mechanism here; recognizing its comments does not by itself require repeatedly invoking it.
 
 ### 6. Wait for new activity
 
@@ -414,9 +356,8 @@ reviewer with no re-trigger is silently skipped every iteration.
 bash .agents/skills/repo-pr-reviews/scripts/wait-for-activity.sh <PR_NUMBER>
 ```
 
-Default timeout 30 min, poll every 30 s. Returns 0 on new activity, 124 on
-timeout. Both bots typically post a "no new findings" comment when they
-have nothing left, so the loop ends naturally on a clean PR.
+Default timeout 30 min, poll every 30 s. Returns 0 on new activity, 124 on timeout. Use it when awaiting a warranted
+review round; a bot's "no new findings" comment is evidence to assess, not a required exit phrase.
 
 What counts as "new activity":
 - New issue comment / review comment / review on the PR.
@@ -427,24 +368,15 @@ What counts as "new activity":
 
 ### 7. Loop
 
-Go back to step 1. Continue until ALL of these are true:
+Iteration and completion follow `AGENTS.md#review`. Re-fetch and assess new findings when another round is warranted;
+do not repeat merely to reach zero open threads, zero optional suggestions, or a particular bot verdict.
 
-- `fetch-all.sh` reports all review threads resolved.
-- `fetch-sonar-findings.sh` reports zero open issues / hotspots that
-  this PR introduced (or the remaining ones are explicitly marked FP /
-  WontFix).
-- The re-triggered AI bots (cubic-dev-ai, coderabbitai) have posted a
-  "no new findings" or equivalent comment after their most recent
-  re-trigger. Copilot is not re-triggered and never gates this.
-- `ci-status.sh` reports no failures caused by this PR (failures
-  unrelated to the PR are noted, surfaced to the user, but not fixed).
-
-When `wait-for-activity.sh` times out (30 min):
-- Re-run `ci-status.sh`. If checks are still running, surface to the
-  user and stop -- the PR is in a clean intermediate state.
-- If there are CI failures attributable to the PR, treat them as a new
-  finding and iterate (commit -> ci-check -> push -> retrigger -> wait).
-- If the failures are unrelated, note them in the final report.
+- Before concluding, account for findings from every source and report their verified disposition. Required CI,
+  quality gates, human decisions and actual merge requirements remain prerequisites for claiming merge readiness.
+- A silent reviewer or a wait timeout is not approval. Re-check CI and available feedback, then report any remaining
+  coverage or validation limitation; do not loop solely to make the bot respond.
+- If required checks are running or human input is pending, report that waiting state without claiming readiness.
+  If a required check fails because of this PR, treat it as a blocker. Unrelated failures are reported, not fixed here.
 
 ### 8. Final report
 
@@ -452,7 +384,9 @@ When the loop ends, summarize for the user:
 - Findings addressed (count by source: review threads, Sonar, CI).
 - Any unrelated CI failures observed but not fixed (with check name + URL).
 - Any human comments that need their attention.
-- Current PR state (mergeable / blocked, decision, head SHA).
+- Current PR state (mergeable / blocked / awaiting validation or input, decision, head SHA).
+- Proposed but unperformed replies or remote actions, remaining optional findings and their dispositions, and any
+  review/validation coverage limits.
 
 ## Commit message hygiene
 
@@ -543,10 +477,10 @@ If a new AI reviewer appears in the project, classify it by adding to
 | `resolve-thread.sh` -> "thread not found"              | Used REST id instead of GraphQL node id.                              |
 | `trigger-copilot.sh` succeeds but no new review        | Expected. The org has no Copilot review credits, which is why it is not in the loop. Do not wait on it. |
 | `trigger-cubic.sh` succeeds but no new review          | cubic ignores comments without an explicit `@cubic-dev-ai` mention. The script always prepends it. |
-| `ci-status.sh` exits 3 (failing)                       | At least one check failed or a commit status is in FAILURE/ERROR. Fix before pushing; 3 wins over 2 when checks are also running. |
+| `ci-status.sh` exits 3 (failing)                       | Fix PR-caused failures before pushing; report unrelated failures. Exit 3 wins over 2 when checks are also running. |
 | `ci-status.sh` exits 2 (running)                       | CI hasn't finished. Push anyway -- waiting on CI between iterations destroys throughput. The next push triggers a fresh CI run on the new code, which is what matters. (See Step 4b.) |
 | Bot keeps re-flagging the same line after a fix push   | The bot didn't see the new commit because it wasn't re-triggered.    |
-| `wait-for-activity.sh` 124 timeout                     | Bots are silent -- could be done, could be quota-limited. Check `summary.txt`; if all threads resolved, you're done. |
+| `wait-for-activity.sh` 124 timeout                     | Check available feedback and CI; use `AGENTS.md#review` and report coverage gaps. Silence or resolved threads alone do not establish readiness. |
 
 ## MANDATORY -- keep this skill alive
 

--- a/.agents/skills/repo-skill-authoring/SKILL.md
+++ b/.agents/skills/repo-skill-authoring/SKILL.md
@@ -34,7 +34,8 @@ names.
 | `AGENTS.md#local-only-working-directory` | where skill-change evidence goes, and how this skill's `<dir>` (the `<subject>` in `./change-method.md#changing-a-skill`) is named |
 | `AGENTS.md#clean-end-state-over-less-churn` | the target is recorded before options are generated; the disclosure of what is removed and what is excluded; the reference search when a path is replaced; how coupled cleanup is handled |
 | `AGENTS.md#working-with-the-user` | the user-decision format and when a decision is recorded |
-| `AGENTS.md#review` | the blocker bar, what to do with a finding before acting, red test first, checkpoint commits, when a round repeats, the recurrence guard |
+| `AGENTS.md#review` | review scope, reproduction evidence, authorized checkpoints, repeat and stop conditions |
+| `AGENTS.md#knowledge-capture` | discovery notes, documentation authorization, and coupled skill maintenance |
 | `AGENTS.md#when-a-sow-is-required`, `AGENTS.md#followup-discipline`, `AGENTS.md#validation-gate`, `AGENTS.md#artifact-maintenance-gate` | a skill change is non-trivial work with a SOW; how deferred items are tracked; what Validation must hold and what every close records |
 | `AGENTS.md#git-and-pr-workflow` | staging, and which git actions need explicit approval (deleting a file among them) |
 | `AGENTS.md#open-source-reference-evidence` | the citation form for an owner outside this repository |
@@ -110,9 +111,10 @@ Structure and routing:
 - When a skill serves more than one audience, `SKILL.md` routes by audience and a topic file SHOULD serve one. Split
   into two skills only when the audiences differ and the seam cuts no shared step and no facts that change together;
   otherwise one skill with a router.
-- The live how-tos catalog requirement (`AGENTS.md#project-skills`) binds public skills only. In a runtime skill an
-  index file in any subdirectory (`how-tos/INDEX.md`, `recipes/INDEX.md`) is optional: keep it when `SKILL.md` routes
-  it and every listed file exists, otherwise list the files in `SKILL.md`.
+- The required public catalog shape is owned by `AGENTS.md#project-skills`; capture timing and authorization by
+  `AGENTS.md#knowledge-capture`. In a runtime skill an index file in any subdirectory (`how-tos/INDEX.md`,
+  `recipes/INDEX.md`) is optional: keep it when `SKILL.md` routes it and every listed file exists, otherwise list the
+  files in `SKILL.md`.
 - A peer skill gets one routing sentence. A one-way prerequisite MAY be declared (an entry-point skill, a
   read-this-first skill).
 - Two skills MUST NOT require each other. When two skills claim one directory, each carries one boundary line.

--- a/.agents/skills/topology-authoring/SKILL.md
+++ b/.agents/skills/topology-authoring/SKILL.md
@@ -161,6 +161,5 @@ Each step names the owner section that holds the rules; read it before designing
 - `how-tos/verify-network-connections-layout-tokens.md`: check a live local Agent's link layout tokens and
   correlation wiring without exposing identifiers.
 
-Whenever you answer a developer question that needed analysis across more than one owner document and no how-to
-covers it, write the how-to here and list it above before finishing. Developer recipes stay in this skill; operator
-recipes belong under `docs/netdata-ai/skills/`.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Authorized developer recipes stay in this
+skill and are listed above; operator recipes belong under `docs/netdata-ai/skills/`.

--- a/.agents/skills/triage-agent-events/SKILL.md
+++ b/.agents/skills/triage-agent-events/SKILL.md
@@ -114,17 +114,12 @@ index-friendly, what each enum value means for triage).
 | `finding-crashes.md` | Recipe: signal crashes (SIGSEGV / SIGBUS / SIGFPE / SIGABRT) on stable. |
 | `finding-fatals.md` | Recipe: deliberate fatals (OOM, disk full, asserts). |
 | `recipes/INDEX.md` | Live catalog of recipes (find-by-function, find-by-version, find-related-to-work). |
-| `how-tos/INDEX.md` | Live catalog: every analysis question becomes a how-to entry. |
+| `how-tos/INDEX.md` | Catalog of reusable investigation how-tos. |
 
 ## Live how-to rule (mandatory)
 
-If asked a concrete question about agent-events that requires
-non-trivial analysis (multiple file reads, running queries,
-cross-referencing with producer source) AND the answer is not
-already documented in the per-domain guides above or in
-`recipes/`, the assistant MUST author a new how-to under
-`how-tos/<slug>.md` and add a one-line entry to
-`how-tos/INDEX.md` BEFORE completing the task.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Investigation recipes live in `how-tos/` and
+are listed in `./how-tos/INDEX.md`; check the per-domain guides and `recipes/` before adding another recipe.
 
 ## Scripts (in scripts/)
 

--- a/.agents/skills/triage-agent-events/SKILL.md
+++ b/.agents/skills/triage-agent-events/SKILL.md
@@ -116,7 +116,7 @@ index-friendly, what each enum value means for triage).
 | `recipes/INDEX.md` | Live catalog of recipes (find-by-function, find-by-version, find-related-to-work). |
 | `how-tos/INDEX.md` | Catalog of reusable investigation how-tos. |
 
-## Live how-to rule (mandatory)
+## Knowledge Capture
 
 Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Investigation recipes live in `how-tos/` and
 are listed in `./how-tos/INDEX.md`; check the per-domain guides and `recipes/` before adding another recipe.

--- a/.agents/skills/triage-agent-events/how-tos/INDEX.md
+++ b/.agents/skills/triage-agent-events/how-tos/INDEX.md
@@ -3,19 +3,8 @@
 Live catalog of analysis-derived how-tos for the
 triage-agent-events skill.
 
-**Live-catalog rule** (also stated in `../SKILL.md`): if an
-assistant is asked a concrete question about agent-events
-that requires non-trivial analysis (multiple file reads,
-multiple queries, cross-referencing producer source) AND the
-answer is not already documented in the per-domain guides
-(`../AE_FIELDS.md`, `../transports.md`, `../update-cadence.md`,
-`../query-discipline.md`, `../finding-crashes.md`,
-`../finding-fatals.md`) or the recipes (`../recipes/`), the
-assistant MUST author a new `how-tos/<slug>.md` and add a
-one-line entry to this INDEX BEFORE completing the task.
-
-This is durable. Skipping it means the next assistant repeats
-the same analysis from scratch.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Check the guides and recipes routed from
+`../SKILL.md` before adding an authorized how-to.
 
 ## Catalog
 
@@ -32,7 +21,7 @@ the same analysis from scratch.
    - A "How I figured this out" footer naming the files read,
      the queries run (with payloads), and the helpers used.
 2. Add a row to the table above with topic, slug, short notes.
-3. Commit alongside the work that prompted the analysis.
+3. Git operations follow `AGENTS.md#git-and-pr-workflow`.
 
 ## When NOT to add a how-to
 

--- a/.agents/skills/triage-agent-events/recipes/INDEX.md
+++ b/.agents/skills/triage-agent-events/recipes/INDEX.md
@@ -22,8 +22,5 @@ agentevents_load_env
 
 ## Live how-to rule
 
-If you investigate a question that isn't covered by the
-existing per-domain guides or these recipes AND your work
-involved non-trivial analysis, AUTHOR a how-to under
-`../how-tos/<slug>.md` and add a row to `../how-tos/INDEX.md`.
-See SKILL.md for the rule.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Additional authorized how-tos belong under
+`../how-tos/` and are listed in `../how-tos/INDEX.md`.

--- a/.agents/skills/triage-codacy/SKILL.md
+++ b/.agents/skills/triage-codacy/SKILL.md
@@ -16,7 +16,7 @@ each keeps its own `.local/audits/<dir>/` (root `AGENTS.md`, Local-Only Working 
 
 ## MANDATORY -- keep this skill alive
 
-If you (the assistant) discover a new pattern, gotcha, working flow, correction, or any operational knowledge while running this skill -- update this `SKILL.md` AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.
+Capture timing and authorization for operational discoveries follow `AGENTS.md#knowledge-capture`.
 
 Examples worth capturing:
 - New v3 API endpoint or response-shape detail learned the hard way
@@ -27,7 +27,8 @@ Examples worth capturing:
 
 ## MANDATORY -- live how-tos catalog
 
-Each concrete question that requires non-trivial analysis (multiple wrapper calls, jq pipelines, cross-referencing other skills) MUST become a how-to under `how-tos/<slug>.md` AND get an entry in `how-tos/INDEX.md` BEFORE the task is reported complete. Skipping this means the next assistant repeats the analysis from scratch.
+`AGENTS.md#knowledge-capture` governs this catalog. Authorized Codacy recipes live under `how-tos/` and are listed in
+`./how-tos/INDEX.md`.
 
 ## Scope
 

--- a/.agents/skills/triage-codacy/how-tos/INDEX.md
+++ b/.agents/skills/triage-codacy/how-tos/INDEX.md
@@ -1,8 +1,7 @@
 # triage-codacy how-tos catalog
 
-This catalog is **live**. When an assistant performs concrete analysis on a Codacy question that requires more than one wrapper call OR more than one jq pipeline OR cross-referencing another skill, AND the answer is not already documented here or in the per-domain SKILL.md, the assistant MUST author a new entry under `how-tos/<slug>.md` AND add it here BEFORE marking the task complete.
-
-Skipping this rule means the next assistant repeats the analysis from scratch -- that is an explicit framework violation.
+Capture timing and authorization follow `AGENTS.md#knowledge-capture`. Add authorized recipes under `how-tos/` and
+keep this catalog consistent with those changes.
 
 ## Entries
 

--- a/.agents/skills/triage-codeql/SKILL.md
+++ b/.agents/skills/triage-codeql/SKILL.md
@@ -15,9 +15,7 @@ The skill operates on whatever repo this checkout points at — it derives the
 
 ## MANDATORY — keep this skill alive
 
-**If you (the agent) discover a new pattern, gotcha, working flow, correction,
-or any piece of knowledge while running this skill — update this `SKILL.md`
-AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.**
+Capture timing and authorization for operational discoveries follow `AGENTS.md#knowledge-capture`.
 
 Examples of things to capture:
 - A CodeQL rule with a known FP pattern + the canonical comment to use

--- a/.agents/skills/triage-coverity/SKILL.md
+++ b/.agents/skills/triage-coverity/SKILL.md
@@ -17,9 +17,7 @@ adhoc; agree the approach with the user up front.
 
 ## MANDATORY — keep this skill alive
 
-If you (the agent) discover a new pattern, gotcha, working flow, correction,
-or any piece of knowledge while running this skill — update this `SKILL.md`
-AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.
+Capture timing and authorization for operational discoveries follow `AGENTS.md#knowledge-capture`.
 
 Examples of things to capture:
 - New view IDs encountered (and what each represents)

--- a/.agents/skills/triage-sonarqube/SKILL.md
+++ b/.agents/skills/triage-sonarqube/SKILL.md
@@ -16,9 +16,7 @@ auto-detect the repo root and write all artifacts under `<repo-root>/.local/`.
 
 ## MANDATORY — keep this skill alive
 
-**If you (the agent) discover a new pattern, gotcha, working flow, correction,
-or any piece of knowledge while running this skill — update this `SKILL.md`
-AND commit it BEFORE proceeding. Knowledge that isn't committed is lost.**
+Capture timing and authorization for operational discoveries follow `AGENTS.md#knowledge-capture`.
 
 Examples of things to capture:
 - New rule with a known FP pattern (and the exact comment to use)

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -198,7 +198,8 @@ Deferred clean-end-state remainder:
 Tests or equivalent validation:
 
 - <command/output summary; for reviewer-reported bugs, the failing regression test or the reason automation is
-  impractical plus observable before/after reproduction evidence and any remaining gap.>
+  impractical plus observable reproduction evidence; record the post-fix passing result or non-reproduction evidence
+  from rerunning the same test/reproducer, and explicitly state any remaining validation gap.>
 
 Real-use evidence:
 

--- a/.agents/sow/SOW.template.md
+++ b/.agents/sow/SOW.template.md
@@ -16,7 +16,7 @@ One value only: `planning`, `ready`, `in-progress`, `paused`, or `completed`.
 `planning` means analysis or decisions are incomplete. `ready` means the
 Pre-Implementation Gate is complete and, where the goal-approval round ("Plan
 Before Non-Trivial Work") applies, the user has approved the goal and plan.
-`completed` means work is validated and durable memory transferred. SOW files
+`completed` means work is validated and required memory transfer under `AGENTS.md#sow-lifecycle` is complete. SOW files
 are local-only working memory under `.agents/sow/q/` (gitignored) and are never
 committed.
 
@@ -94,10 +94,12 @@ Affected contracts and surfaces:
 Clean-end-state target:
 
 - <The structure the codebase should have once the approved scope is fully delivered.>
-- Removed as redundant (i): <code/config/docs/tests this change makes redundant.>
-- Excluded coupled items (ii): <coupled items NOT part of this clean end state, each with reason + scope source.>
-- Reference search (when a path/contract is replaced): <command(s) run + result; every surviving reference mapped to
-  (i)/(ii), or the target is incomplete.>
+- Removed or migrated (i): <redundant code/config/docs/tests and replacement where applicable.>
+- Intentionally retained (ii): <valid retained items and references, with rationale; not unfinished migration work.>
+- Deferred or excluded (iii): <coupled items omitted from delivery, each with reason, scope source, required user
+  approval, and follow-up tracking under AGENTS.md#followup-discipline.>
+- Reference search (when a path/contract is replaced): <command(s) run + result; every relevant hit mapped to
+  (i)/(ii)/(iii), and unrelated matches explained, or the target is incomplete.>
 
 Existing patterns to reuse:
 
@@ -184,8 +186,9 @@ Acceptance criteria evidence:
 
 Clean-end-state evidence:
 
-- <Delivered state vs the recorded target: (i) removed as redundant, (ii) excluded coupled items, and the recorded
-  reference search where a path or contract was replaced; or a link to the user approval for a non-clean state.>
+- <Delivered state vs the recorded target: (i) removed/migrated, (ii) intentionally retained, (iii) deferred/excluded,
+  and the recorded reference search where a path or contract was replaced; include required user approval for any
+  non-clean state.>
 
 Deferred clean-end-state remainder:
 
@@ -194,7 +197,8 @@ Deferred clean-end-state remainder:
 
 Tests or equivalent validation:
 
-- <command/output summary>
+- <command/output summary; for reviewer-reported bugs, the failing regression test or the reason automation is
+  impractical plus observable before/after reproduction evidence and any remaining gap.>
 
 Real-use evidence:
 
@@ -202,7 +206,8 @@ Real-use evidence:
 
 Reviewer findings:
 
-- <reviewer; each finding and how it was handled: verified and fixed, rejected with evidence, or tracked>
+- <reviewer; scope and reviewed checkpoint commit or working-tree state; each finding and how it was handled:
+  verified and fixed, rejected with evidence, or tracked; note Git operations not performed because unauthorized.>
 
 Same-failure scan:
 
@@ -225,9 +230,10 @@ Sensitive data gate:
 - Specs: <updated .agents/sow/specs/ path or evidence-backed reason no update was needed>
 - End-user/operator docs: <updated docs/runbooks/help paths or evidence-backed reason none were affected>
 - End-user/operator skills: <updated output/reference skill paths or evidence-backed reason none were affected>
-- SOW lifecycle: <durable knowledge transferred to skills/docs/code/tests; follow-ups moved to GitHub issues or
-  rejected; `Status: completed` set; SOW working file is local-only under .agents/sow/q/ and never committed;
-  regression-as-new-SOW handling recorded>
+- SOW lifecycle: <deliverable knowledge transferred to skills/docs/code/tests under AGENTS.md#sow-lifecycle; other
+  discoveries captured under AGENTS.md#knowledge-capture; follow-ups implemented, rejected, or tracked under
+  AGENTS.md#followup-discipline; `Status: completed` set; SOW working file is local-only under .agents/sow/q/ and never
+  committed; regression-as-new-SOW handling recorded>
 - Workflow friction triaged: <each `Workflow Friction & Rule Gaps` entry resolved to a rule update (file + change), an
   evidence-backed rejection, or a tracked follow-up; "no workflow friction arose" if the section is empty>
 
@@ -237,7 +243,9 @@ Lessons:
 
 Follow-up mapping:
 
-- <implemented/rejected/GitHub issue link>
+- <implemented/rejected/GitHub issue link; for eligible independent personal work, the parked SOW path and explicit
+  user acceptance of private tracking under AGENTS.md#followup-discipline. Local discovery notes alone are not
+  accepted deferrals.>
 
 ## Outcome <!-- sow:optional -->
 

--- a/.github/scripts/test-ci-workflow-file-selection.py
+++ b/.github/scripts/test-ci-workflow-file-selection.py
@@ -2,6 +2,9 @@
 
 import fnmatch
 import re
+import shlex
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path, PurePosixPath
 
@@ -9,6 +12,7 @@ from pathlib import Path, PurePosixPath
 ROOT = Path(__file__).resolve().parents[2]
 REVIEW_WORKFLOW = ROOT / ".github/workflows/review.yml"
 GO_TESTS_WORKFLOW = ROOT / ".github/workflows/go-tests.yml"
+SOW_WORKFLOW = ROOT / ".github/workflows/sow.yml"
 BUILD_WORKFLOW_STEPS = (
     (ROOT / ".github/workflows/build.yml", "Check build files"),
     (ROOT / ".github/workflows/docker.yml", "Check build system files"),
@@ -75,6 +79,52 @@ def literal_block(step: list[str], key: str) -> set[str]:
 
 
 class WorkflowFileSelectionTest(unittest.TestCase):
+    def test_public_skill_changes_trigger_sow_workflow(self) -> None:
+        workflow = SOW_WORKFLOW.read_text(encoding="utf-8")
+        paths_block = workflow.split("    paths:\n", 1)[1].split("\n\n", 1)[0]
+        patterns = [line.strip()[2:].strip('"\'') for line in paths_block.splitlines()]
+        # Require recursive directory coverage; a single '*' does not cross '/' in GitHub path filters.
+        recursive_prefixes = [pattern[:-2] for pattern in patterns if pattern.endswith("/**")]
+
+        for path in (
+            "docs/netdata-ai/skills/query-netdata-agents/SKILL.md",
+            "docs/netdata-ai/skills/query-netdata-cloud/how-tos/INDEX.md",
+            "docs/netdata-ai/skills/query-snmp-traps/scripts/helper.sh",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(any(path.startswith(prefix) for prefix in recursive_prefixes))
+
+    def test_sow_scanner_selects_canonical_public_skills(self) -> None:
+        workflow = SOW_WORKFLOW.read_text(encoding="utf-8")
+        step = "\n".join(workflow_step(workflow, "Scan changed durable artifacts for sensitive data"))
+        selection = re.search(r'git diff --name-only --diff-filter=ACMR "\$base\.\.\.\$head" -- (.*?)\|',
+                              step, re.DOTALL)
+        self.assertIsNotNone(selection)
+        pathspecs = shlex.split(selection.group(1).replace("\\\n", " "))
+        expected = {
+            "AGENTS.md",
+            ".agents/skills/repo-pr-reviews/SKILL.md",
+            ".agents/sow/SOW.template.md",
+            "docs/netdata-ai/skills/query-netdata-agents/SKILL.md",
+            "docs/netdata-ai/skills/query-netdata-cloud/how-tos/INDEX.md",
+            "docs/netdata-ai/skills/query-snmp-traps/scripts/helper.sh",
+        }
+        unrelated = {"docs/operator-guide.md", "src/example.c"}
+
+        with tempfile.TemporaryDirectory(prefix="sow-file-selection-") as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "--quiet", directory], check=True, capture_output=True)
+            for path in expected | unrelated:
+                file = root / path
+                file.parent.mkdir(parents=True, exist_ok=True)
+                file.write_text("Benign routing fixture.\n", encoding="utf-8")
+            subprocess.run(["git", "add", "--", *sorted(expected | unrelated)], cwd=root, check=True)
+            selected = subprocess.check_output(
+                ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR", "--", *pathspecs],
+                cwd=root, text=True,
+            )
+            self.assertEqual(set(selected.splitlines()), expected)
+
     def test_literal_block_ignores_indentation_and_blank_lines(self) -> None:
         workflow = """
   - name: Example

--- a/.github/workflows/sow.yml
+++ b/.github/workflows/sow.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".agents/sow/**"
       - ".agents/skills/**"
+      - "docs/netdata-ai/skills/**"
       - ".agents/skill-verification/**"
       - ".agents/ENV.md"
       - "AGENTS.md"
@@ -61,7 +62,7 @@ jobs:
           mapfile -t files < <(
             git diff --name-only --diff-filter=ACMR "$base...$head" -- \
               .agents/sow .agents/skills .agents/skill-verification .agents/ENV.md \
-              AGENTS.md CLAUDE.md GEMINI.md \
+              docs/netdata-ai/skills AGENTS.md CLAUDE.md GEMINI.md \
               | while IFS= read -r file; do
                   [ -f "$file" ] && printf '%s\n' "$file"
                 done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,9 @@ removes debt beats a smaller one that preserves it.
 
 ### Definitions
 
-- **Trivial vs non-trivial work**: defined under "When A SOW Is Required". Trivial work has no SOW and is exempt from
-  the record-the-target, disclosure, and reference-search rules below; the clean-end-state preference still applies.
+- **Work categories**: defined under "When A SOW Is Required". Trivial changes and read-only work are exempt from
+  the implementation record-the-target, disclosure, and reference-search rules below; the clean-end-state preference
+  still applies to changes. Read-only work may use local tracking when the user requests it.
 - **Approved scope**: the union of (a) the issue or user request, (b) the SOW Purpose and Acceptance Criteria as
   recorded in the SOW, and (c) the migration/contract surface they imply.
 - **Coupled item**: code, config, docs, or tests the current change makes redundant or leaves inconsistent (a
@@ -80,8 +81,10 @@ removes debt beats a smaller one that preserves it.
   proceeding, before requesting non-draft review, and before marking the work complete. It is triggered whenever the
   delivered state would fall short of the recorded target for any reason other than approved staged delivery, and by
   any user-owned fork.
-- **Default on doubt**: if unsure whether something is in scope, trivial, coupled, or a user-owned fork, treat it as
-  in-scope, non-trivial, coupled, user-owned, and ask.
+- **Default on doubt**: investigate uncertainty before classifying work. Suspected low-risk coupling follows the
+  explicit include-and-disclose rule under "Clean End State Over Less Churn". Ask when a material scope, contract,
+  or risk fork remains unresolved. If an intended change's risk remains unclear, treat the change as non-trivial;
+  read-only investigation follows "When A SOW Is Required".
 
 ### Clean End State Over Less Churn
 
@@ -93,10 +96,13 @@ removes debt beats a smaller one that preserves it.
   the recorded target is a non-clean state and triggers the Mandatory pause.
 - Open design decision: when the clean end state is itself the user's design decision, do not invent a fixed
   target. Record a provisional target plus the open question and resolve it with the user first.
-- Disclose exclusions: the recorded target MUST list (i) what you remove as redundant and (ii) every coupled item
-  you treat as NOT part of this clean end state, each with its reason and the scope source it rests on. Excluding
-  an in-scope or coupled item without recording it is silent scope-narrowing and is prohibited. The list lets a
-  reviewer or the next agent check your exclusions against their sources.
+- The recorded target MUST account for affected items:
+  - (i) removed or migrated: redundant code, config, docs, tests, and their replacement when applicable;
+  - (ii) intentionally retained: items and references that remain valid in the delivered state, with their rationale;
+  - (iii) deferred or excluded: every coupled item omitted from the delivered state, with its reason, scope source,
+    and required user approval and follow-up tracking.
+  Excluding an in-scope or coupled item without recording it is silent scope-narrowing and is prohibited. Retention
+  under (ii) MUST NOT disguise unfinished migration work; such work belongs under (iii) and the Mandatory pause.
 - You are not the scope authority:
   - Coupled cleanup is in scope. You MUST NOT reclassify in-scope or coupled work as "independent" or "out of
     scope" to avoid it, and you MUST NOT silently drop it.
@@ -107,13 +113,14 @@ removes debt beats a smaller one that preserves it.
 - Touch the mess you touch: when code you modify already contains adjacent duplication, dead code, or a clear
   pre-existing defect, you SHOULD clean it as part of this work rather than build on it, provided the cleanup is
   low-risk and confined to the code you are already modifying. Cleanup reaching into unrelated code is independent
-  work (see "Scope Discipline At Every Step"). If you leave adjacent mess in place, record why under disclosure (ii).
+  work (see "Scope Discipline At Every Step"). If you leave adjacent mess in place, record why under disclosure (iii).
 - Reference search (when replacing a path or altering a contract):
   - You MUST run and record in the SOW (command and result) a search for remaining references to the replaced path
     or contract. Search construction sites and prefixes too, not only literal final names; identifiers here are often
     built dynamically (for example via `fmt.Sprintf`).
-  - Every surviving reference MUST appear in (i) or (ii) with its scope source, or the target is incomplete. An
-    item you did not search for counts as silent scope-narrowing.
+  - Every relevant search hit MUST have a disposition under (i), (ii), or (iii), or the target is incomplete.
+    Legitimate retained references, such as negative regression tests mentioning a retired identifier, belong under
+    (ii). Record and explain unrelated search matches. An item you did not search for counts as silent scope-narrowing.
   - A repository-wide search cannot prove safety for consumers outside this repo (Netdata Cloud, exporters,
     streaming, ML, the docs pipeline). Renaming a shipped public contract is a user-owned breaking decision routed
     through the Mandatory pause, not something the search clears.
@@ -126,8 +133,9 @@ removes debt beats a smaller one that preserves it.
 - Exception evidence: for (a)/(b) you MUST cite specific evidence (file/line, failure class, or test) and route
   through the Mandatory pause; you do not self-certify "unsafe". For (d) track the remainder per Followup Discipline
   with why deferral is acceptable and when it lands; repeatedly shipping partials is debt accumulation, not delivery.
-- Never valid: risk reduction, review convenience, smaller diff, and issue staging are NEVER valid reasons for a
-  non-clean route and MUST NOT be relabeled "unsafe" or "independent".
+- Never valid: unsupported claims of risk reduction, review convenience, smaller diff, and issue staging do not
+  justify a non-clean route and MUST NOT be relabeled "unsafe" or "independent". The evidenced-hazard exception
+  above remains available with the required evidence and user approval.
 - Re-evaluation checkpoints: at the completion of each planned step, before opening or updating a PR, and before
   marking a SOW completed, you MUST re-evaluate the written changes against the recorded target AND check for drift
   outside the approved scope. You SHOULD also re-evaluate whenever you pause to report progress. Do not keep a
@@ -185,8 +193,8 @@ removes debt beats a smaller one that preserves it.
 
 - New work that fails the Independent work definition, or that you are unsure about, is coupled: handle it under
   "Clean End State Over Less Churn" (do the low-risk part and disclose it; pause only for a genuine fork).
-- Genuinely independent work: do NOT silently bundle it. Submit it as a separate PR first and rebase after it
-  merges, or track it as a GitHub issue per Followup Discipline. Do NOT fold it into this SOW's steps.
+- Genuinely independent work: do NOT silently bundle it. Submit it as a separately authorized PR first and rebase
+  after it merges, or track it per Followup Discipline. Do NOT fold it into this SOW's steps.
 
 ## SOW System
 
@@ -205,8 +213,8 @@ SOWs and specs are local-only working memory, never committed:
   git later, reorganized, as a deliberate decision; until then treat them as local memory.
 - Committed framework files: `.agents/sow/SOW.template.md`, `.agents/sow/audit.sh`, `.agents/sow/scan-sensitive.sh`,
   `.agents/sow/worktree-link.sh`.
-- Durable knowledge that must survive a SOW belongs in project skills, docs, code, and tests (and specs once
-  re-introduced), not in the SOW body.
+- Durable knowledge needed for the approved deliverable belongs in project skills, docs, code, and tests (and specs
+  once re-introduced), not solely in the SOW body. Other discoveries follow Knowledge Capture.
 - Queues under `.agents/sow/q/`. Move the file as its state changes; a queue move is normal lifecycle, not deletion.
 
   | Queue | Meaning | Status values inside |
@@ -230,23 +238,29 @@ SOWs and specs are local-only working memory, never committed:
     already has its own real `.env` keeps it);
   - it is idempotent, never loses data on a name collision, re-points a symlink whose origin moved, and refuses to run
     in a worktree whose origin checkout is not yet on this model (it prints how to update it).
-- Because nothing is committed there is no commit-for-handoff, no remove-before-merge step, and no CI merge guard
-  to clear.
+- Legitimate local SOW files require no commit-for-handoff or remove-before-merge step. The CI guard described under
+  Enforcement rejects working files that were accidentally committed; it does not require deleting local memory.
 
 ### When A SOW Is Required
 
-Create or reuse a SOW for non-trivial work:
+Read-only investigation, explanation, and review require no implementation SOW or branch unless the user requests
+tracking. They MAY save local evidence and sanitized notes under "Knowledge Capture". They MUST NOT change source,
+tracked documentation, Git state, or remote state without separate authorization. When changes are authorized,
+classify those changes below before implementation; a request for review alone does not authorize fixes.
+
+Create or reuse a SOW for non-trivial changes:
 
 - feature work; bug fixes with behavioral impact; refactors; migrations; regressions;
 - documentation or content changes with product/business impact; spec hygiene; project skill changes;
 - process changes; collector changes; packaging, install, or deployment changes;
 - PR review iteration; static analysis triage that changes source, docs, or project policy;
-- any work with unclear risk.
+- any intended change with unclear risk.
 
 Trivial work needs no SOW: typo fixes; formatting-only changes; mechanical renames with no behavior change; simple
 low-risk search/replace (still grep the old token to confirm no call site is missed).
 
-Default on doubt applies: unsure means non-trivial.
+Default on doubt applies to intended changes: unresolved risk means non-trivial, not that read-only analysis itself
+requires an implementation gate.
 
 ### Required First Checks
 
@@ -294,10 +308,13 @@ Before non-trivial work:
 - Progress reports and Re-evaluation checkpoints are not stop points. Once a SOW is in progress with its approval
   recorded, continue until it is delivered, failed with evidence, blocked on a real user decision or approval, or
   superseded by newer user instructions.
-- Completion of a standalone or step SOW, when the work is ready to merge (umbrellas: see "Umbrella And Step SOWs"):
-  1. Finish implementation, docs, skills, validation, and follow-up mapping.
-  2. Transfer all durable knowledge into project skills, docs, code, and tests (and specs once re-introduced). The
-     SOW body MUST then hold nothing durable that is not captured elsewhere.
+- Completion of a standalone or step SOW, when the authorized deliverable is complete and any changes are ready to
+  merge (umbrellas: see "Umbrella And Step SOWs"):
+  1. Finish authorized implementation, coupled docs and skills, validation, and follow-up mapping.
+  2. Transfer durable knowledge needed for the approved deliverable into project skills, docs, code, and tests (and
+     specs once re-introduced). Other discoveries, including those from tracked answer-only work, follow Knowledge
+     Capture and MAY remain sanitized local notes. Closure does not authorize documentation outside the approved
+     scope. The SOW MUST NOT be the sole record of a delivered project contract.
   3. Set `Status: completed` and move the file to `.agents/sow/q/done/` (unless the user asks to discard it).
 
 ### Umbrella And Step SOWs
@@ -327,12 +344,13 @@ Staged delivery uses one umbrella SOW plus one SOW per step (each step a mergeab
 
 ### Pre-Implementation Gate
 
-Implementation MUST NOT begin until the SOW's `## Pre-Implementation Gate` section records `Gate status: ready` and the
-SOW's top-level `Status:` is `ready` or `in-progress`. The `Gate status:` line takes only `blocked` (gate incomplete),
+For non-trivial work, implementation MUST NOT begin until the SOW's `## Pre-Implementation Gate` section records
+`Gate status: ready` and the SOW's top-level `Status:` is `ready` or `in-progress`.
+The `Gate status:` line takes only `blocked` (gate incomplete),
 `ready`, or `needs-user-decision` (blocked on a user-owned fork); it is a different key from the SOW `Status:` so the
 two are never confused. Before changing implementation files, or before continuing an existing SOW that lacks the
 section, fill the gate. Gate `ready` additionally requires the goal/plan approval of "Plan Before Non-Trivial Work"
-where that round applies.
+where that round applies. Trivial changes and read-only work retain the exemptions under "When A SOW Is Required".
 
 The gate MUST fill every field of the template's `## Pre-Implementation Gate` section (the template is the SOW schema,
 see "SOW Lifecycle"; field semantics live in its placeholders). Placeholders such as `TBD`, `N/A`, or "to be checked
@@ -351,8 +369,9 @@ approves it, then run `.agents/sow/worktree-link.sh` (see Storage Model).
   NOT be committed.
 - Never `git checkout <file>`, `git reset`, delete files, or rewrite history without explicit user approval. Undo a
   change by editing it out, not by checking the file out.
-- Commit and push only when the user asks or the approved plan says so. Checkpoint commits before review rounds
-  and squashing at PR time are described under "Review".
+- Commit and push only when the user asks or explicitly approves those operations in the plan. Approval to implement
+  a fixed goal is not implicit approval of Git operations subsequently added to the plan. Checkpoint commits and
+  squashing under "Review" remain subject to these authorization rules.
 - Commit messages and PR bodies describe the change. A PR body links the follow-up issues tracked from its SOW.
 
 ### Local SOW Parking
@@ -362,14 +381,16 @@ approves it, then run `.agents/sow/worktree-link.sh` (see Storage Model).
   team-visible GitHub issue yet.
 - Parked SOWs are private memory only: not durable project memory, not visible to other contributors, and not
   acceptable as the only tracking for work that must coordinate a team, block a merge, or survive across machines.
-- Deferred work has two tracking paths: public or team-visible follow-up is a GitHub issue; private or local
-  follow-up is `<repo-root>/.local/sow/`.
+- Eligibility for private deferred-work tracking and the required user acceptance are defined under Followup
+  Discipline. Local discovery notes follow Knowledge Capture and are not approval to defer in-scope work.
 - Active implementation work still MUST use the `.agents/sow/q/` queues.
 
 ### Review
 
 Review findings are leads until verified against the shipped code and its contracts.
 
+- A review request alone is read-only, as defined under "When A SOW Is Required". The fix requirements below apply
+  only when implementation is authorized.
 - A shipping blocker MUST identify a production-reachable trigger, the violated contract or invariant, the
   concrete consequence, and supporting code or test evidence.
 - Failing required validation or an unmet explicit acceptance criterion is also a shipping blocker, regardless of
@@ -378,15 +399,20 @@ Review findings are leads until verified against the shipped code and its contra
   promoted to a blocker. Reject it with evidence, or track it separately when it has independent value.
 - Optional test expansion, documentation polish, and maintainability suggestions without a concrete current defect
   MUST NOT extend the review cycle by themselves.
-- Reproduce a reviewer-reported bug as a FAILING test first, then fix to green. The red test proves the finding,
-  pins the contract, and catches wrong assumptions in your own tests.
-- Multi-round review: checkpoint-commit each validated change (specific files only) before its review and squash at
-  PR time.
+- Reproduce a reviewer-reported bug as a FAILING automated regression test before fixing it when feasible. If
+  automation is impractical, record why and use concrete observable evidence, such as an executable reproducer,
+  build failure, hardware observation, or incorrect documented behavior. Verify the same failure after the fix;
+  record any remaining validation gap rather than claiming it was tested. Speculation alone is not reproduction.
+- Multi-round review: when Git operations are authorized under "Git And PR Workflow", checkpoint-commit each
+  validated change (specific files only) before its review and squash at PR time only if history rewriting is
+  explicitly approved. Otherwise review the working-tree diff, preserve a record of the reviewed state, and report
+  that no checkpoint commit or squash was performed. A review requirement never grants Git authorization.
 - Recurrence: if findings keep clustering in one subsystem for ~2-3 rounds, stop patching individual cases, name the
   missing invariant, and propose one class-level fix as a user decision.
 - Obtaining a review: spawn independent, full-scope reviewers with clean context, or run the external assistants
   the user names. For performance-sensitive code at least one reviewer MUST carry an explicit hot-path performance
-  lens. Record each reviewer and its findings under Validation in the SOW.
+  lens. Record each reviewer and its findings under Validation in the SOW when one exists; otherwise report the
+  findings and review scope directly to the user.
 - One complete review round is the default. Repeat the same full scope only when a verified shipping blocker
   required a material change to shipped implementation or behavior, or when the prior review could not assess the
   complete change.
@@ -395,9 +421,17 @@ Review findings are leads until verified against the shipped code and its contra
 
 ### Followup Discipline
 
-"Deferred" is not a terminal outcome. Before a SOW can close, every valid deferred item MUST be implemented in the
-current SOW, explicitly rejected as not worth doing with evidence, or represented by a GitHub issue linked from the
-SOW or PR.
+"Deferred" is not a terminal outcome. Before a SOW can close, every valid deferred item MUST be implemented,
+explicitly rejected as not worth doing with evidence, or tracked as follows:
+
+- Use a GitHub issue linked from the SOW or PR unless the private-tracking exception below applies.
+- In-scope remainders, merge dependencies, and work needed for team coordination MUST have a GitHub issue linked
+  from the SOW or PR. Tracking does not replace the user approval required to deliver a partial clean end state.
+- Genuinely independent personal/local work MAY use a parked SOW under `<repo-root>/.local/sow/` only when the user
+  explicitly accepts private tracking and the item does not block merge, require team coordination, or need to
+  survive across machines. Record that acceptance, the reason, and the path in the active SOW.
+- A local discovery note from Knowledge Capture preserves an observation; it is not an accepted implementation
+  commitment or permission to defer a coupled item. Triage it under these rules if it becomes a deferred work item.
 
 Pre-close, search the SOW for `defer|later|follow-up|future|TODO|pending` and map every hit to implemented,
 rejected, or tracked.
@@ -436,7 +470,7 @@ and each step's Artifact Maintenance Gate records the actual updates):
 - End-user/operator docs: README, docs site, runbooks, published guides, help text, other human-facing docs.
 - End-user/operator skills: output/reference skills copied or consumed outside normal repo work.
 - SOW lifecycle: local-only SOW under `.agents/sow/q/`, durable memory transferred, deferred work tracked as GitHub
-  issues, regressions handled as new linked SOWs.
+  issues or explicitly accepted private tracking per Followup Discipline, regressions handled as new linked SOWs.
 
 This is an assistant responsibility. If a SOW changes behavior, docs, specs, commands, schemas, defaults, workflows,
 examples, or operating procedure, the assistant MUST update every affected artifact in the same SOW or record the
@@ -465,8 +499,8 @@ evidence-backed reason it is unaffected.
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and
   framework files for raw sensitive data.
-- These checks are guards, not substitutes for the Validation Gate. The assistant still owns transferring durable
-  knowledge out of the SOW before merge.
+- These checks are guards, not substitutes for the Validation Gate. The assistant still owns the scoped knowledge
+  transfer required by SOW Lifecycle before merge.
 
 ## Durable Artifacts
 
@@ -540,6 +574,25 @@ docs, code, and tests, not in specs.
 - Specs describe current reality, not aspiration. If specs and code disagree, record the discrepancy in the active
   SOW and resolve or track it.
 
+### Knowledge Capture
+
+- Reusable findings supported by evidence and not already documented MUST be captured. Prefer improving an existing
+  guide over creating a duplicate. Routine lookups, speculation, and one-off incident details do not require a recipe.
+- For answer-only investigation or review, deliver the requested answer without starting documentation work. Record
+  a reusable discovery in a sanitized local note under `<repo-root>/.local/audits/<subject>/followups.md`, using the
+  existing skill audit directory when one applies. Include the finding, supporting evidence, and proposed owning
+  guide. If no writable local workspace is available, include that sanitized follow-up in the response instead.
+- Documentation implementation requires separate authorization unless it is coupled to already-authorized
+  implementation work. In that case, keep affected guides and catalogs consistent before completing the work.
+  Unrelated discoveries remain independent work under Scope Discipline At Every Step.
+- Local notes are private evidence, not shared project contracts or automatic follow-up commitments. Accepted
+  deferred work follows Followup Discipline. Commit, push, and publication requirements never grant authorization
+  to perform those actions.
+- Developer skills that give capture instructions MUST point to this section for timing and authorization.
+  Public/operator skills MUST carry a self-contained operator-facing version because they can be used outside this
+  checkout; their catalogs
+  SHOULD point to that skill-local rule rather than repeat it. Preserve operator/developer audience boundaries.
+
 ### Project Skills
 
 Project skills are memory of HOW to work here.
@@ -550,7 +603,8 @@ Project skills are memory of HOW to work here.
 - Output/reference skills may also exist under product documentation or generated skill directories. Do not rename,
   shorten, or change their descriptions only to satisfy runtime discovery. Update them when their related
   public/operator workflow changes.
-- Skill updates that close gaps or fix outdated pointers MUST ship in the same PR that exposed the issue.
+- Skill updates coupled to an authorized implementation change MUST ship in the same PR. Capture of discoveries
+  from answer-only tasks and unrelated findings follows Knowledge Capture and Scope Discipline At Every Step.
 - Every change to a skill MUST end with a slimming pass over the touched files: remove restatements, merged-in
   duplicates, and rules that now live elsewhere, keeping every rule (a removed directive is moved or superseded by a
   recorded decision, never dropped). Skills accrete bloat with each update; report line counts before and after.
@@ -585,12 +639,9 @@ Public skill convention (`docs/netdata-ai/skills/`):
   `.env` internally and emit ONLY the response body. Each token-handling lib MUST ship a
   `<prefix>_selftest_no_token_leak` that drives every public wrapper with a sentinel token and asserts it never
   reaches captured stdout.
-- How-tos catalog: each public skill ships `how-tos/INDEX.md`, and the catalog is live. Whenever an assistant
-  answers a concrete operator/end-user question that needs analysis (multiple wrapper calls, jq pipelines, or
-  cross-referencing more than one per-domain guide) and the answer is not yet under `how-tos/`, it MUST author the
-  how-to and add it to `INDEX.md` BEFORE completing the task. Each `SKILL.md` repeats this rule. Skipping it is a
-  framework violation: the next assistant repeats the analysis from scratch. Audience boundaries still apply: a
-  developer validation recipe goes into the matching `.agents/skills/` project skill and its index instead.
+- How-tos catalog: each public skill ships `how-tos/INDEX.md`. Capture timing and authorization follow Knowledge
+  Capture. When an authorized change adds or updates a how-to, keep its catalog consistent. Operator recipes stay
+  in public skills; developer recipes belong in the matching `.agents/skills/` project skill and its index, if any.
 - Skills without an operator audience (for example `triage-coverity`, `triage-sonarqube`, `triage-codeql`,
   `repo-pr-reviews`) stay under `.agents/skills/<name>/` with no public counterpart.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -599,9 +599,10 @@ docs, code, and tests, not in specs.
   deferred work follows Followup Discipline. Commit, push, and publication requirements never grant authorization
   to perform those actions.
 - Developer skills that give capture instructions MUST point to this section for timing and authorization.
-  Public/operator skills MUST carry a self-contained operator-facing version because they can be used outside this
-  checkout; their catalogs
-  SHOULD point to that skill-local rule rather than repeat it. Preserve operator/developer audience boundaries.
+- Public/operator skills MUST carry a self-contained operator-facing version because they can be used outside this
+  checkout.
+- Public/operator skill catalogs SHOULD point to their skill-local rule rather than repeat it.
+- Preserve operator/developer audience boundaries.
 
 ### Project Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,7 @@ Create or reuse a SOW for non-trivial changes:
 - feature work; bug fixes with behavioral impact; refactors; migrations; regressions;
 - documentation or content changes with product/business impact; spec hygiene; project skill changes;
 - process changes; collector changes; packaging, install, or deployment changes;
-- PR review iteration; static analysis triage that changes source, docs, or project policy;
+- PR review iteration or static analysis triage that changes source, docs, or project policy;
 - any intended change with unclear risk.
 
 Trivial work needs no SOW: typo fixes; formatting-only changes; mechanical renames with no behavior change; simple
@@ -404,8 +404,10 @@ Review findings are leads until verified against the shipped code and its contra
   MUST NOT extend the review cycle by themselves.
 - Reproduce a reviewer-reported bug as a FAILING automated regression test before fixing it when feasible. If
   automation is impractical, record why and use concrete observable evidence, such as an executable reproducer,
-  build failure, hardware observation, or incorrect documented behavior. Verify the same failure after the fix;
-  record any remaining validation gap rather than claiming it was tested. Speculation alone is not reproduction.
+  build failure, hardware observation, or incorrect documented behavior. After the fix, rerun the same test or
+  reproducer and confirm the failure no longer occurs. Record the passing result or non-reproduction evidence;
+  if verification is unavailable or incomplete, record the gap instead of claiming success. Speculation alone is
+  not reproduction.
 - Multi-round review: when Git operations are authorized under "Git And PR Workflow", checkpoint-commit each
   validated change (specific files only) before its review and squash at PR time only if history rewriting is
   explicitly approved. Otherwise review the working-tree diff, preserve a record of the reviewed state, and report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,9 @@ removes debt beats a smaller one that preserves it.
 
 ### Scope Discipline At Every Step
 
+- Documentation capture during authorized implementation is part of that task under Knowledge Capture, even when
+  the discovered gap is not required to complete the code change. This does not authorize additional implementation
+  or changes to product behavior or contracts.
 - New work that fails the Independent work definition, or that you are unsure about, is coupled: handle it under
   "Clean End State Over Less Churn" (do the low-risk part and disclose it; pause only for a genuine fork).
 - Genuinely independent work: do NOT silently bundle it. Submit it as a separately authorized PR first and rebase
@@ -310,11 +313,11 @@ Before non-trivial work:
   superseded by newer user instructions.
 - Completion of a standalone or step SOW, when the authorized deliverable is complete and any changes are ready to
   merge (umbrellas: see "Umbrella And Step SOWs"):
-  1. Finish authorized implementation, coupled docs and skills, validation, and follow-up mapping.
+  1. Finish authorized implementation, documentation capture under Knowledge Capture, validation, and follow-up mapping.
   2. Transfer durable knowledge needed for the approved deliverable into project skills, docs, code, and tests (and
-     specs once re-introduced). Other discoveries, including those from tracked answer-only work, follow Knowledge
-     Capture and MAY remain sanitized local notes. Closure does not authorize documentation outside the approved
-     scope. The SOW MUST NOT be the sole record of a delivered project contract.
+     specs once re-introduced). Document reusable discoveries from implementation under Knowledge Capture. Discoveries
+     from tracked answer-only work MAY remain sanitized local notes without authorizing guide edits. The SOW MUST NOT
+     be the sole record of a delivered project contract.
   3. Set `Status: completed` and move the file to `.agents/sow/q/done/` (unless the user asks to discard it).
 
 ### Umbrella And Step SOWs
@@ -582,9 +585,12 @@ docs, code, and tests, not in specs.
   a reusable discovery in a sanitized local note under `<repo-root>/.local/audits/<subject>/followups.md`, using the
   existing skill audit directory when one applies. Include the finding, supporting evidence, and proposed owning
   guide. If no writable local workspace is available, include that sanitized follow-up in the response instead.
-- Documentation implementation requires separate authorization unless it is coupled to already-authorized
-  implementation work. In that case, keep affected guides and catalogs consistent before completing the work.
-  Unrelated discoveries remain independent work under Scope Discipline At Every Step.
+- During authorized implementation, assistants MUST update missing or outdated documentation for reusable,
+  evidence-backed discoveries made while doing the work, even when the documentation is not required for the code
+  change. This capture is part of the task and needs no separate authorization. Keep affected guides, skills, and
+  catalogs consistent before completing the work; describe the updates in the final report.
+- Documentation work arising from answer-only questions requires separate authorization. Documentation capture
+  records observed behavior; it does not authorize additional implementation or new product contracts.
 - Local notes are private evidence, not shared project contracts or automatic follow-up commitments. Accepted
   deferred work follows Followup Discipline. Commit, push, and publication requirements never grant authorization
   to perform those actions.
@@ -603,8 +609,8 @@ Project skills are memory of HOW to work here.
 - Output/reference skills may also exist under product documentation or generated skill directories. Do not rename,
   shorten, or change their descriptions only to satisfy runtime discovery. Update them when their related
   public/operator workflow changes.
-- Skill updates coupled to an authorized implementation change MUST ship in the same PR. Capture of discoveries
-  from answer-only tasks and unrelated findings follows Knowledge Capture and Scope Discipline At Every Step.
+- Skill updates required by Knowledge Capture during authorized implementation MUST ship in the same PR. Discoveries
+  from answer-only tasks follow its local-note and authorization rules.
 - Every change to a skill MUST end with a slimming pass over the touched files: remove restatements, merged-in
   duplicates, and rules that now live elsewhere, keeping every rule (a removed directive is moved or superseded by a
   recorded decision, never dropped). Skills accrete bloat with each update; report line counts before and after.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,10 +412,11 @@ Review findings are leads until verified against the shipped code and its contra
   that no checkpoint commit or squash was performed. A review requirement never grants Git authorization.
 - Recurrence: if findings keep clustering in one subsystem for ~2-3 rounds, stop patching individual cases, name the
   missing invariant, and propose one class-level fix as a user decision.
-- Obtaining a review: spawn independent, full-scope reviewers with clean context, or run the external assistants
-  the user names. For performance-sensitive code at least one reviewer MUST carry an explicit hot-path performance
-  lens. Record each reviewer and its findings under Validation in the SOW when one exists; otherwise report the
-  findings and review scope directly to the user.
+- Obtaining a review: the coordinating assistant spawns independent, full-scope reviewers with clean context, or runs
+  the external assistants the user names. Delegated reviewers MUST NOT launch other agents; include this restriction
+  in each review assignment. For performance-sensitive code at least one reviewer MUST carry an explicit hot-path
+  performance lens. Record each reviewer and its findings under Validation in the SOW when one exists; otherwise
+  report the findings and review scope directly to the user.
 - One complete review round is the default. Repeat the same full scope only when a verified shipping blocker
   required a material change to shipped implementation or behavior, or when the prior review could not assess the
   complete change.
@@ -501,7 +502,7 @@ evidence-backed reason it is unaffected.
 - `.github/workflows/sow.yml` rejects pull requests that commit SOW working files or specs: anything tracked under
   `.agents/sow/q/**`, `.agents/sow/specs/**`, or a legacy top-level `.agents/sow/{active,pending,current,done}/`.
   A hit means a file was force-added and MUST be removed before merge. It also scans changed instruction, skill, and
-  framework files for raw sensitive data.
+  framework files, including canonical public skills under `docs/netdata-ai/skills/**`, for raw sensitive data.
 - These checks are guards, not substitutes for the Validation Gate. The assistant still owns the scoped knowledge
   transfer required by SOW Lifecycle before merge.
 
@@ -585,6 +586,9 @@ docs, code, and tests, not in specs.
   a reusable discovery in a sanitized local note under `<repo-root>/.local/audits/<subject>/followups.md`, using the
   existing skill audit directory when one applies. Include the finding, supporting evidence, and proposed owning
   guide. If no writable local workspace is available, include that sanitized follow-up in the response instead.
+- Report reusable documentation discoveries briefly in the answer-only final response, with the proposed update.
+  Obtain authorization before implementing those documentation changes; do not delay the requested answer while
+  awaiting it. A local note does not replace notifying the user.
 - During authorized implementation, assistants MUST update missing or outdated documentation for reusable,
   evidence-backed discoveries made while doing the work, even when the documentation is not required for the code
   change. This capture is part of the task and needs no separate authorization. Keep affected guides, skills, and
@@ -633,8 +637,10 @@ Public skill convention (`docs/netdata-ai/skills/`):
 - Skill verification harness inputs (seed questions, grader rubrics, runner scripts, transcript-generation prompts)
   live under `.agents/skill-verification/<skill>/`, never under `docs/netdata-ai/skills/<skill>/`.
 - Each public skill is reachable from `.agents/skills/<skill-name>` via a relative symlink
-  (`.agents/skills/<name>` -> `../../docs/netdata-ai/skills/<name>`), created with `ln -srfn` and verified with
-  `readlink -f .agents/skills/<name>`.
+  (`.agents/skills/<name>` -> `../../docs/netdata-ai/skills/<name>`). From the repository root, create a new link with
+  `ln -s ../../docs/netdata-ai/skills/<name> .agents/skills/<name>`. Inspect an existing path instead of overwriting it;
+  replacement follows Git And PR Workflow. Verify the target with `readlink .agents/skills/<name>` and verify that
+  `.agents/skills/<name>/SKILL.md` resolves to a file.
 - Scripts MUST follow the existing `_lib.sh` shape: `set -euo pipefail`; ANSI colors as real ESC bytes via
   `$'\033[...]'`; `<prefix>_repo_root` via `git rev-parse --show-toplevel`; `<prefix>_load_env` sourcing `<repo>/.env`
   with `: "${VAR:?}"` validation; `<prefix>_audit_dir` creating the skill's `<repo>/.local/audits/<dir>/` (Local-Only
@@ -720,7 +726,7 @@ and the rule for adding one; each skill's frontmatter description is the authori
     `AE_*` fields; 23h dedup; journal multi-value `selections` filters. Bug-investigation tool, not generic logs
   - Also relevant: `repo-pr-reviews` (pulls SonarCloud findings for a PR).
 - Repo.
-  - `repo-pr-reviews`: PR comment and review iteration
+  - `repo-pr-reviews`: inspecting or addressing PR comments and reviews
   - `repo-mirror-sources`: setting up or syncing the local mirror of Netdata-org repos at `${NETDATA_REPOS_DIR}`;
     reset-to-default safety; `--repo` scoping
   - `repo-skill-authoring`: creating, editing, slimming, splitting, or reviewing a skill; the authoring rules (point

--- a/docs/netdata-ai/skills/query-netdata-agents/SKILL.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/SKILL.md
@@ -49,8 +49,10 @@ implementation.
 ## Knowledge Capture
 
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
-  not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
-  documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+  not already documented, you MUST preserve a sanitized note with the finding, supporting evidence, and proposed
+  owning guide. In a repository checkout, use `<repo-root>/.local/audits/<subject>/followups.md`, reusing this skill's
+  audit directory when available. Outside a checkout, use an appropriate local workspace. If no writable workspace
+  is available, include the sanitized follow-up in the response instead.
 - Briefly report reusable documentation discoveries and proposed updates in the answer-only final response, even
   when recorded locally. Obtain authorization before those guide edits; do not delay the answer while awaiting it.
 - During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed

--- a/docs/netdata-ai/skills/query-netdata-agents/SKILL.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/SKILL.md
@@ -46,19 +46,21 @@ implementation.
 
 ---
 
+## Knowledge Capture
+
+- For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
+  not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
+  documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+- Editing this skill or its guides requires authorization; discovering a missing recipe does not grant it.
+  Documentation coupled to already-authorized implementation MUST be updated within that work, including
+  [`how-tos/INDEX.md`](./how-tos/INDEX.md) when a recipe changes. Commit and publication require authorization too.
+- Prefer updating an existing guide over duplicating it. Keep recipes operator-facing: fetching or using Agent
+  data. Developer contract validation for topology producers, schemas, fixtures, UI adapters, or aggregator
+  handoffs belongs in the relevant project developer skill, not in this public skill.
+
 ## Mandatory Requirements (READ FIRST)
 
-1. **If you analyze, you author a how-to.** When asked a concrete
-   question about an agent that isn't already covered by an
-   existing how-to under [`how-tos/`](./how-tos/), you MUST author
-   a new how-to and add it to
-   [`how-tos/INDEX.md`](./how-tos/INDEX.md) BEFORE completing the
-   task. The catalog is **live** -- the next assistant should not
-   redo the same analysis. Keep this catalog operator-facing:
-   recipes here should explain how to fetch or use Agent data.
-   Developer contract validation for topology producers, schemas,
-   fixtures, UI adapters, or aggregator handoffs belongs in the
-   relevant project developer skill, not in this public skill.
+1. **Preserve reusable discoveries** under [Knowledge Capture](#knowledge-capture).
 2. **Use the token-safe wrappers.** `agents_query_cloud`,
    `agents_query_agent`, `agents_call_function` from
    [`scripts/_lib.sh`](./scripts/_lib.sh) handle auth internally

--- a/docs/netdata-ai/skills/query-netdata-agents/SKILL.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/SKILL.md
@@ -51,6 +51,8 @@ implementation.
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
   not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
   documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+- Briefly report reusable documentation discoveries and proposed updates in the answer-only final response, even
+  when recorded locally. Obtain authorization before those guide edits; do not delay the answer while awaiting it.
 - During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed
   discoveries made while doing the work, even when the documentation is not required for the code change. This
   needs no separate authorization. Keep [`how-tos/INDEX.md`](./how-tos/INDEX.md) consistent and report the updates.

--- a/docs/netdata-ai/skills/query-netdata-agents/SKILL.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/SKILL.md
@@ -51,9 +51,12 @@ implementation.
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
   not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
   documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
-- Editing this skill or its guides requires authorization; discovering a missing recipe does not grant it.
-  Documentation coupled to already-authorized implementation MUST be updated within that work, including
-  [`how-tos/INDEX.md`](./how-tos/INDEX.md) when a recipe changes. Commit and publication require authorization too.
+- During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed
+  discoveries made while doing the work, even when the documentation is not required for the code change. This
+  needs no separate authorization. Keep [`how-tos/INDEX.md`](./how-tos/INDEX.md) consistent and report the updates.
+- Guide edits arising from answer-only questions require separate authorization. Documentation capture records
+  observed behavior; it does not authorize additional implementation or new product contracts. Commit and
+  publication require authorization too.
 - Prefer updating an existing guide over duplicating it. Keep recipes operator-facing: fetching or using Agent
   data. Developer contract validation for topology producers, schemas, fixtures, UI adapters, or aggregator
   handoffs belongs in the relevant project developer skill, not in this public skill.

--- a/docs/netdata-ai/skills/query-netdata-agents/how-tos/INDEX.md
+++ b/docs/netdata-ai/skills/query-netdata-agents/how-tos/INDEX.md
@@ -6,21 +6,10 @@ into answers for specific questions. Each how-to documents the
 question, the steps taken, the wrappers used, and the expected
 output shape.
 
-## The "if you analyze, you author a how-to" rule
+## Knowledge Capture
 
-The how-tos catalog is meant to be **live**. Every time an AI
-assistant (or human) is asked a question that:
-
-1. The user expects a concrete answer to, AND
-2. Is not already documented in this index, AND
-3. Forces analysis (multiple wrapper calls, jq pipelines, or
-   cross-referencing more than one per-domain guide)
-
-the assistant MUST author a new how-to in this directory and add
-it to the index BELOW before completing the task.
-
-This is mandatory. Skipping it means the next assistant repeats
-the same analysis from scratch.
+Capture timing, authorization, and audience boundaries follow
+[the skill's Knowledge Capture section](../SKILL.md#knowledge-capture).
 
 ## How-to authoring template
 

--- a/docs/netdata-ai/skills/query-netdata-cloud/SKILL.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/SKILL.md
@@ -52,6 +52,8 @@ skill [`query-netdata-agents`](../query-netdata-agents/SKILL.md).
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
   not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
   documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+- Briefly report reusable documentation discoveries and proposed updates in the answer-only final response, even
+  when recorded locally. Obtain authorization before those guide edits; do not delay the answer while awaiting it.
 - During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed
   discoveries made while doing the work, even when the documentation is not required for the code change. This
   needs no separate authorization. Keep [`how-tos/INDEX.md`](./how-tos/INDEX.md) consistent and report the updates.

--- a/docs/netdata-ai/skills/query-netdata-cloud/SKILL.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/SKILL.md
@@ -50,8 +50,10 @@ skill [`query-netdata-agents`](../query-netdata-agents/SKILL.md).
 ## Knowledge Capture
 
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
-  not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
-  documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+  not already documented, you MUST preserve a sanitized note with the finding, supporting evidence, and proposed
+  owning guide. In a repository checkout, use `<repo-root>/.local/audits/<subject>/followups.md`, reusing this skill's
+  audit directory when available. Outside a checkout, use an appropriate local workspace. If no writable workspace
+  is available, include the sanitized follow-up in the response instead.
 - Briefly report reusable documentation discoveries and proposed updates in the answer-only final response, even
   when recorded locally. Obtain authorization before those guide edits; do not delay the answer while awaiting it.
 - During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed

--- a/docs/netdata-ai/skills/query-netdata-cloud/SKILL.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/SKILL.md
@@ -47,20 +47,21 @@ skill [`query-netdata-agents`](../query-netdata-agents/SKILL.md).
 
 ---
 
+## Knowledge Capture
+
+- For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
+  not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
+  documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+- Editing this skill or its guides requires authorization; discovering a missing recipe does not grant it.
+  Documentation coupled to already-authorized implementation MUST be updated within that work, including
+  [`how-tos/INDEX.md`](./how-tos/INDEX.md) when a recipe changes. Commit and publication require authorization too.
+- Prefer updating an existing guide over duplicating it. Keep recipes operator-facing: fetching or using Cloud
+  data. Developer contract validation for collectors, topology producers, schemas, fixtures, UI adapters, or
+  aggregator handoffs belongs in the relevant project developer skill, not in this public skill.
+
 ## Mandatory Requirements (READ FIRST)
 
-1. **If you analyze, you author a how-to.** When asked a concrete
-   question about a Netdata environment that isn't already covered
-   by an existing how-to under [`how-tos/`](./how-tos/), you MUST
-   author a new how-to in this directory and add it to
-   [`how-tos/INDEX.md`](./how-tos/INDEX.md) BEFORE completing the
-   task. The catalog is meant to be **live** -- the next assistant
-   should not redo the same analysis from scratch. Keep this
-   catalog operator-facing: recipes here should explain how to fetch
-   or use Cloud data. Developer contract validation for collectors,
-   topology producers, schemas, fixtures, UI adapters, or aggregator
-   handoffs belongs in the relevant project developer skill, not in
-   this public skill.
+1. **Preserve reusable discoveries** under [Knowledge Capture](#knowledge-capture).
 2. **Use the token-safe wrappers.** Every example in this skill
    uses `agents_query_cloud` (and friends) from
    `../query-netdata-agents/scripts/_lib.sh`. Never paste raw

--- a/docs/netdata-ai/skills/query-netdata-cloud/SKILL.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/SKILL.md
@@ -52,9 +52,12 @@ skill [`query-netdata-agents`](../query-netdata-agents/SKILL.md).
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
   not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
   documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
-- Editing this skill or its guides requires authorization; discovering a missing recipe does not grant it.
-  Documentation coupled to already-authorized implementation MUST be updated within that work, including
-  [`how-tos/INDEX.md`](./how-tos/INDEX.md) when a recipe changes. Commit and publication require authorization too.
+- During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed
+  discoveries made while doing the work, even when the documentation is not required for the code change. This
+  needs no separate authorization. Keep [`how-tos/INDEX.md`](./how-tos/INDEX.md) consistent and report the updates.
+- Guide edits arising from answer-only questions require separate authorization. Documentation capture records
+  observed behavior; it does not authorize additional implementation or new product contracts. Commit and
+  publication require authorization too.
 - Prefer updating an existing guide over duplicating it. Keep recipes operator-facing: fetching or using Cloud
   data. Developer contract validation for collectors, topology producers, schemas, fixtures, UI adapters, or
   aggregator handoffs belongs in the relevant project developer skill, not in this public skill.

--- a/docs/netdata-ai/skills/query-netdata-cloud/how-tos/INDEX.md
+++ b/docs/netdata-ai/skills/query-netdata-cloud/how-tos/INDEX.md
@@ -5,21 +5,10 @@ recipes that combine the per-domain guides into answers for
 specific questions. Each how-to documents the question, the steps
 taken, the wrappers used, and the expected output shape.
 
-## The "if you analyze, you author a how-to" rule
+## Knowledge Capture
 
-The how-tos catalog is meant to be **live**. Every time an AI
-assistant (or human) is asked a question that:
-
-1. The user expects a concrete answer to, AND
-2. Is not already documented in this index, AND
-3. Forces analysis (multiple wrapper calls, jq pipelines, or
-   cross-referencing more than one per-domain guide)
-
-the assistant MUST author a new how-to in this directory and add
-it to the index BELOW before completing the task.
-
-This is mandatory. Skipping it means the next assistant repeats
-the same analysis from scratch.
+Capture timing, authorization, and audience boundaries follow
+[the skill's Knowledge Capture section](../SKILL.md#knowledge-capture).
 
 ## How-to authoring template
 

--- a/docs/netdata-ai/skills/query-snmp-traps/SKILL.md
+++ b/docs/netdata-ai/skills/query-snmp-traps/SKILL.md
@@ -29,13 +29,21 @@ Log Function request shape from
 | Convert custom MIBs into trap profiles | [how-tos/convert-custom-mibs-to-trap-profiles.md](./how-tos/convert-custom-mibs-to-trap-profiles.md) |
 | Operational how-tos catalog | [how-tos/INDEX.md](./how-tos/INDEX.md) |
 
+## Knowledge Capture
+
+- For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
+  not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
+  documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+- Editing this skill or its guides requires authorization; discovering a missing recipe does not grant it.
+  Documentation coupled to already-authorized implementation MUST be updated within that work, including
+  [`how-tos/INDEX.md`](./how-tos/INDEX.md) when a recipe changes. Commit and publication require authorization too.
+- Prefer updating an existing guide over duplicating it. Keep recipes operator-facing: querying and interpreting
+  SNMP traps. Developer validation, schema work, collector implementation, fixtures, and project handoff notes
+  belong in project developer documentation, not in this public skill.
+
 ## Mandatory Requirements
 
-1. **If you analyze, you author a how-to.** When asked a concrete
-   SNMP trap query question that is not already covered under
-   [`how-tos/`](./how-tos/), author a new how-to and add it to
-   [`how-tos/INDEX.md`](./how-tos/INDEX.md) before completing the
-   task.
+1. **Preserve reusable discoveries** under [Knowledge Capture](#knowledge-capture).
 2. **Use token-safe wrappers.** Source
    `docs/netdata-ai/skills/query-netdata-agents/scripts/_lib.sh`,
    call `agents_load_env`, then use `agents_call_function`,

--- a/docs/netdata-ai/skills/query-snmp-traps/SKILL.md
+++ b/docs/netdata-ai/skills/query-snmp-traps/SKILL.md
@@ -34,6 +34,8 @@ Log Function request shape from
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
   not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
   documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+- Briefly report reusable documentation discoveries and proposed updates in the answer-only final response, even
+  when recorded locally. Obtain authorization before those guide edits; do not delay the answer while awaiting it.
 - During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed
   discoveries made while doing the work, even when the documentation is not required for the code change. This
   needs no separate authorization. Keep [`how-tos/INDEX.md`](./how-tos/INDEX.md) consistent and report the updates.

--- a/docs/netdata-ai/skills/query-snmp-traps/SKILL.md
+++ b/docs/netdata-ai/skills/query-snmp-traps/SKILL.md
@@ -34,9 +34,12 @@ Log Function request shape from
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
   not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
   documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
-- Editing this skill or its guides requires authorization; discovering a missing recipe does not grant it.
-  Documentation coupled to already-authorized implementation MUST be updated within that work, including
-  [`how-tos/INDEX.md`](./how-tos/INDEX.md) when a recipe changes. Commit and publication require authorization too.
+- During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed
+  discoveries made while doing the work, even when the documentation is not required for the code change. This
+  needs no separate authorization. Keep [`how-tos/INDEX.md`](./how-tos/INDEX.md) consistent and report the updates.
+- Guide edits arising from answer-only questions require separate authorization. Documentation capture records
+  observed behavior; it does not authorize additional implementation or new product contracts. Commit and
+  publication require authorization too.
 - Prefer updating an existing guide over duplicating it. Keep recipes operator-facing: querying and interpreting
   SNMP traps. Developer validation, schema work, collector implementation, fixtures, and project handoff notes
   belong in project developer documentation, not in this public skill.

--- a/docs/netdata-ai/skills/query-snmp-traps/SKILL.md
+++ b/docs/netdata-ai/skills/query-snmp-traps/SKILL.md
@@ -32,8 +32,10 @@ Log Function request shape from
 ## Knowledge Capture
 
 - For answer-only questions, deliver the requested answer. If the work reveals a reusable, evidence-backed recipe
-  not already documented, you MUST preserve it in a sanitized local follow-up note for separately authorized
-  documentation work. If no writable workspace is available, include the sanitized follow-up in the response.
+  not already documented, you MUST preserve a sanitized note with the finding, supporting evidence, and proposed
+  owning guide. In a repository checkout, use `<repo-root>/.local/audits/<subject>/followups.md`, reusing this skill's
+  audit directory when available. Outside a checkout, use an appropriate local workspace. If no writable workspace
+  is available, include the sanitized follow-up in the response instead.
 - Briefly report reusable documentation discoveries and proposed updates in the answer-only final response, even
   when recorded locally. Obtain authorization before those guide edits; do not delay the answer while awaiting it.
 - During authorized implementation, you MUST update this skill or its guides for reusable, evidence-backed

--- a/docs/netdata-ai/skills/query-snmp-traps/how-tos/INDEX.md
+++ b/docs/netdata-ai/skills/query-snmp-traps/how-tos/INDEX.md
@@ -6,16 +6,10 @@ how-to uses the token-safe wrappers from
 the `snmp:traps` Function with optional `__logs_sources`
 selection.
 
-## The "if you analyze, you author a how-to" rule
+## Knowledge Capture
 
-The catalog is live. Every time an AI assistant or operator answers a
-new concrete SNMP trap query that needs multiple wrapper calls, jq
-pipelines, or cross-referencing more than one guide, add the recipe
-here before completing the task.
-
-Keep these how-tos operator-facing. Developer validation, schema
-work, collector implementation, test fixtures, or SOW handoff notes
-belong in `.agents/skills/` and SOW files, not in this public skill.
+Capture timing, authorization, and audience boundaries follow
+[the skill's Knowledge Capture section](../SKILL.md#knowledge-capture).
 
 ## How-to authoring template
 


### PR DESCRIPTION
##### Summary

Resolve conflicting rules around scope, SOW gates, Git authorization, review validation, and follow-up tracking. Align the SOW template and affected skills while keeping repository guidance model-neutral.

Answer-only tasks now preserve reusable discoveries in sanitized local notes. Documentation requires authorization unless coupled to approved implementation.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the conflicting per-skill "author a how-to before completing" mandates with one consistent Knowledge Capture policy in `AGENTS.md`, so documentation timing and authorization are uniform across project skills, the SOW template, and public operator skills.

Answer-only investigation and review are now read-only: deliver the answer, keep reusable discoveries as sanitized notes under `.local/audits/`, and get separate authorization before guide edits or Git operations. During authorized implementation, updating guides for reusable evidence-backed discoveries is part of the task.

**Other clarifications**
- Approval to implement does not grant Git authorization; commits and squashing need explicit approval.
- A review request alone does not authorize fixes; `repo-pr-reviews` separates read-only inspection from authorized addressing.
- SOW clean-end-state tracking separates removed/migrated, intentionally retained, and deferred/excluded items.
- Public operator skills carry a self-contained Knowledge Capture section since they work outside this checkout.
- The SOW workflow now triggers on and scans canonical public skills under `docs/netdata-ai/skills/**` for sensitive data; new tests cover file-selection behavior.

<sup>Written for commit 1ae6d6c6fc19cb321856d224e3ae84f9f238bc74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated knowledge-capture, documentation authorization, review, SOW lifecycle, and follow-up guidance.
  - How-to and recipe catalogs now reference centralized capture and workflow policies.
  - Clarified inspection versus authorized PR-comment handling, review triage, validation evidence, and unresolved coverage reporting.
  - Updated public skill guidance to preserve reusable discoveries with supporting evidence and proposed ownership.

- **CI & Validation**
  - SOW workflows now monitor public skill documentation changes and include them in sensitive-data scans.
  - Added automated checks for workflow triggers and canonical skill-file selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->