### PR TITLE
Fix SQLite lifetime races during agent shutdown

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -15,9 +15,20 @@ char cmd_prefix_by_status[] = {
 };
 
 // Accessed from the command loop thread, the libuv workers, the signal thread and the shutdown
-// thread, so every read and write goes through __atomic_* - see commands_exit().
+// thread, so every read and write of THIS variable goes through __atomic_* - see commands_exit().
+// The two below have their own rules; do not read this comment as covering them.
 static cmd_init_status_t command_server_initialized = CMD_INIT_STATUS_OFF;
+
+// Written by the command loop thread before it marks the init completion, read by commands_init()
+// after completion_wait_for() returns. The completion supplies the ordering, so plain accesses
+// are correct here and atomics would add nothing.
 static int command_thread_error;
+
+// Written by commands_exit() from ANOTHER thread and read by the command loop's own condition, so
+// it must be atomic: a missed store means the loop calls uv_run() again, never exits, and
+// uv_thread_join() blocks until the shutdown watchdog aborts the process - the exact failure this
+// change exists to remove. (The loop also zeroes it during setup, which is why commands_exit()
+// waits for the init handshake before it may be touched.)
 static int command_thread_shutdown;
 static unsigned clients = 0;
 
@@ -987,11 +998,11 @@ static void command_thread(void *arg) {
     }
 
     command_thread_error = 0;
-    command_thread_shutdown = 0;
+    __atomic_store_n(&command_thread_shutdown, 0, __ATOMIC_RELEASE);
     /* wake up initialization thread */
     completion_mark_complete(&completion);
 
-    while (command_thread_shutdown == 0) {
+    while (__atomic_load_n(&command_thread_shutdown, __ATOMIC_ACQUIRE) == 0) {
         uv_run(loop, UV_RUN_DEFAULT);
     }
     /* cleanup operations of the event loop */
@@ -1191,7 +1202,7 @@ void commands_exit(void)
         return;
     }
 
-    command_thread_shutdown = 1;
+    __atomic_store_n(&command_thread_shutdown, 1, __ATOMIC_RELEASE);
     netdata_log_info("Shutting down command server.");
     /* wake up event loop */
     fatal_assert(0 == uv_async_send(&async));

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -14,6 +14,8 @@ char cmd_prefix_by_status[] = {
         CMD_PREFIX_ERROR
 };
 
+// Accessed from the command loop thread, the libuv workers, the signal thread and the shutdown
+// thread, so every read and write goes through __atomic_* - see commands_exit().
 static cmd_init_status_t command_server_initialized = CMD_INIT_STATUS_OFF;
 static int command_thread_error;
 static int command_thread_shutdown;
@@ -22,6 +24,24 @@ static unsigned clients = 0;
 struct command_context {
     /* embedded client pipe structure at address 0 */
     uv_pipe_t client;
+
+    // Will a libuv callback close this handle?
+    //
+    // The shutdown teardown closes IDLE clients - ones sitting on an open connection with nothing
+    // outstanding - so that the final uv_run() can drain. It must NOT close a handle that a
+    // callback chain is going to close, because closing frees the whole context (the pipe is
+    // embedded at offset 0 and pipe_close_cb() frees it) and the later callback would then
+    // double-close it and touch freed memory.
+    //
+    // Set at BOTH points where a callback chain takes ownership, and NEVER cleared:
+    //   - when a command is queued (uv_queue_work): schedule_command() and
+    //     after_schedule_command() use the context, and the latter starts the reply write;
+    //   - when any reply write is started (send_command_reply): pipe_write_cb() closes the
+    //     handle once that write completes. This covers the invalid-command reply, which is sent
+    //     directly from parse_commands() with no work item at all.
+    // If the uv_write fails to start, send_command_reply() closes the handle itself there and
+    // then, so the flag staying set costs nothing - uv_is_closing() covers that case.
+    bool close_by_callback;
 
     uv_work_t work;
     uv_write_t write_req;
@@ -644,6 +664,11 @@ static void send_command_reply(struct command_context *cmd_ctx, cmd_status_t sta
     int ret;
     BUFFER *reply_string = buffer_create(128, NULL);
 
+    // From here on pipe_write_cb() owns closing this handle - see close_by_callback. This must be
+    // set for EVERY reply, not just those that came from a queued command: the invalid-command
+    // reply is sent straight from parse_commands() with no work item.
+    cmd_ctx->close_by_callback = true;
+
     char exit_status_string[MAX_EXIT_STATUS_LENGTH + 1] = {'\0', };
     unsigned reply_string_size = 0;
     uv_buf_t write_buf;
@@ -678,7 +703,7 @@ cmd_status_t execute_command(cmd_t idx, char *args, char **message)
     cmd_type_t type = command_info_array[idx].type;
 
     cmd_lock_by_type[type](idx);
-    if (command_server_initialized >= command_info_array[idx].init_status)
+    if (__atomic_load_n(&command_server_initialized, __ATOMIC_ACQUIRE) >= command_info_array[idx].init_status)
         status = command_info_array[idx].func(args, message);
     else {
         if (message)
@@ -690,6 +715,32 @@ cmd_status_t execute_command(cmd_t idx, char *args, char **message)
     return status;
 }
 
+// Command handlers dispatched to the libuv threadpool, and whether THIS thread is inside one.
+//
+// SCOPE, so the count is not over-trusted: this covers the QUEUED commands only. The signal
+// path calls execute_command(CMD_RELOAD_HEALTH / CMD_REOPEN_LOGS) directly on its own thread
+// (signal-handler.c), and CMD_EXIT is executed inline by parse_commands(); neither is counted.
+// CMD_RELOAD_HEALTH does reach SQLite (health_plugin_reload() -> ... -> sql_alert_store_config()),
+// so "no commands in flight" means no netdatacli WORK ITEM is in flight - it is not a statement
+// about every SQLite user.
+//
+// commands_exit() needs both. A handler can terminate the process from where it runs -
+// cmd_fatal_execute() calls fatal(), which runs the whole shutdown sequence on the threadpool
+// worker - and shutdown then reaches commands_exit(). Joining the command loop from there
+// deadlocks: the loop's own teardown runs uv_run(loop, UV_RUN_DEFAULT) to flush, and the work
+// request it is waiting to flush is the one this thread is still inside.
+static uint32_t commands_in_flight = 0;
+static __thread bool this_thread_runs_a_command = false;
+
+// commands_exit() has TWO callers now - the signal path and the shutdown sequence - and they
+// can run on different threads at the same time (a systemd PrepareForShutdown, an API quit, or
+// a fatal() on any thread can be inside netdata_cleanup_and_exit() when SIGTERM arrives).
+// command_server_initialized only becomes CMD_INIT_STATUS_OFF after the join completes, so it
+// cannot by itself keep two callers apart: both would pass it and both would reach
+// uv_thread_join() on the same thread, which is undefined behaviour, and then destroy the same
+// mutexes twice.
+static bool commands_exit_in_progress = false;
+
 static void after_schedule_command(uv_work_t *req, int status)
 {
     struct command_context *cmd_ctx = req->data;
@@ -699,6 +750,8 @@ static void after_schedule_command(uv_work_t *req, int status)
     send_command_reply(cmd_ctx, cmd_ctx->status, cmd_ctx->message);
     if (cmd_ctx->message)
         freez(cmd_ctx->message);
+
+    __atomic_sub_fetch(&commands_in_flight, 1, __ATOMIC_ACQ_REL);
 }
 
 static void schedule_command(uv_work_t *req)
@@ -707,7 +760,9 @@ static void schedule_command(uv_work_t *req)
     worker_is_busy(UV_EVENT_SCHEDULE_CMD);
 
     struct command_context *cmd_ctx = req->data;
+    this_thread_runs_a_command = true;
     cmd_ctx->status = execute_command(cmd_ctx->idx, cmd_ctx->args, &cmd_ctx->message);
+    this_thread_runs_a_command = false;
 
     worker_is_idle();
 }
@@ -738,6 +793,8 @@ static void parse_commands(struct command_context *cmd_ctx)
             cmd_ctx->args = lstrip;
             cmd_ctx->message = NULL;
 
+            cmd_ctx->close_by_callback = true;
+            __atomic_add_fetch(&commands_in_flight, 1, __ATOMIC_ACQ_REL);
             fatal_assert(0 == uv_queue_work(loop, &cmd_ctx->work, schedule_command, after_schedule_command));
             break;
         }
@@ -801,6 +858,7 @@ static void connection_cb(uv_stream_t *server, int status)
     /* combined allocation of client pipe and command context */
     cmd_ctx = mallocz(sizeof(*cmd_ctx));
     cmd_ctx->idx = CMD_HELP;
+    cmd_ctx->close_by_callback = false;
     client = (uv_pipe_t *)cmd_ctx;
     ret = uv_pipe_init(server->loop, client, 1);
     if (ret) {
@@ -834,6 +892,36 @@ static void connection_cb(uv_stream_t *server, int status)
 static void async_cb(uv_async_t *handle)
 {
     uv_stop(handle->loop);
+}
+
+// Close the client connections that are merely sitting there.
+//
+// The teardown below closes the listener and the async handle, then flushes with
+// uv_run(loop, UV_RUN_DEFAULT). That flush does not return while ANY handle is still active -
+// including an accepted client that connected and then sent nothing, which keeps its read
+// handle open indefinitely. Since commands_exit() joins this thread, such a client would stall
+// the whole shutdown until the 135 s watchdog SIGABRTs it - and it would also trip the
+// fatal_assert(0 == uv_loop_close(loop)) below.
+//
+// Only IDLE clients are closed here - those that never had a command dispatched. A client the
+// loop is working for is left alone: its context is freed by pipe_close_cb(), so closing it now
+// would pull the memory out from under schedule_command(), after_schedule_command(), or the
+// uv_write they start. Each closes itself in pipe_write_cb() once its reply is written, and this
+// same flush collects it.
+static void close_idle_clients_cb(uv_handle_t *handle, void *arg __maybe_unused)
+{
+    if (handle->type != UV_NAMED_PIPE || handle == (uv_handle_t *)&server_pipe)
+        return;
+
+    if (uv_is_closing(handle))
+        return;
+
+    struct command_context *cmd_ctx = (struct command_context *)handle;
+    if (cmd_ctx->close_by_callback)
+        return;
+
+    uv_close(handle, pipe_close_cb);
+    --clients;
 }
 
 static void command_thread(void *arg) {
@@ -901,7 +989,11 @@ static void command_thread(void *arg) {
     /* cleanup operations of the event loop */
     netdata_log_info("Shutting down command event loop.");
     uv_close((uv_handle_t *)&async, NULL);
+
+    /* stop accepting new connections first, then drop the idle ones, then flush */
     uv_close((uv_handle_t*)&server_pipe, NULL);
+    uv_walk(loop, close_idle_clients_cb, NULL);
+
     uv_run(loop, UV_RUN_DEFAULT); /* flush all libuv handles */
 
     netdata_log_info("Shutting down command loop complete.");
@@ -937,16 +1029,19 @@ void commands_init(void)
     int error;
 
     sanity_check();
-    if (command_server_initialized == CMD_INIT_STATUS_FULL)
+    if (__atomic_load_n(&command_server_initialized, __ATOMIC_ACQUIRE) == CMD_INIT_STATUS_FULL)
         return;
 
-    if (command_server_initialized == CMD_INIT_STATUS_OFF) {
+    if (__atomic_load_n(&command_server_initialized, __ATOMIC_ACQUIRE) == CMD_INIT_STATUS_OFF) {
         netdata_log_info("Initializing command server for liveness CHECK");
-        command_server_initialized = CMD_INIT_STATUS_INIT;
+        // Re-arm, so a second init/exit cycle in one process does not latch instead of
+        // joining. sqlite_library_init() does the same for its own flags.
+        __atomic_store_n(&commands_exit_in_progress, false, __ATOMIC_RELEASE);
+        __atomic_store_n(&command_server_initialized, CMD_INIT_STATUS_INIT, __ATOMIC_RELEASE);
     }
     else {
         netdata_log_info("Initializing full command server.");
-        command_server_initialized = CMD_INIT_STATUS_FULL;
+        __atomic_store_n(&command_server_initialized, CMD_INIT_STATUS_FULL, __ATOMIC_RELEASE);
         return;
     }
 
@@ -977,15 +1072,73 @@ void commands_init(void)
 
 after_error:
     netdata_log_error("Failed to initialize command server. The netdata cli tool will be unable to send commands.");
-    command_server_initialized = CMD_INIT_STATUS_OFF;
+    __atomic_store_n(&command_server_initialized, CMD_INIT_STATUS_OFF, __ATOMIC_RELEASE);
 }
 
 void commands_exit(void)
 {
-    cmd_t i;
-
-    if (command_server_initialized == CMD_INIT_STATUS_OFF)
+    // Already stopped, by whichever caller got here first. Nothing to drain and nothing to
+    // suppress: that caller completed the join before setting this.
+    if (__atomic_load_n(&command_server_initialized, __ATOMIC_ACQUIRE) == CMD_INIT_STATUS_OFF)
         return;
+
+    // Two shutdown paths originate INSIDE this subsystem, and neither can join the loop:
+    //
+    //  - `netdatacli shutdown-agent`: parse_commands() executes CMD_EXIT inline rather than
+    //    through the workqueue (musl does not tolerate a libuv worker calling exit()), and
+    //    cmd_exit_execute() -> netdata_exit_gracefully() -> netdata_cleanup_and_exit() runs
+    //    the whole shutdown ON THE LOOP THREAD. Joining ourselves trips the fatal_assert below.
+    //  - `netdatacli fatal-agent` (and any handler that calls fatal()): those DO go through the
+    //    workqueue, so shutdown runs on a threadpool WORKER. That worker is not the loop
+    //    thread, so a naive thread comparison lets it through to the join - and then it
+    //    deadlocks, because the loop's teardown flushes with uv_run(loop, UV_RUN_DEFAULT) and
+    //    the request it waits on is the one this worker is still inside. Shutdown then hangs
+    //    until the watchdog SIGABRTs it.
+    //
+    // So: skip the join whenever we are the loop thread OR we are inside a command handler.
+    //
+    // Whether to suppress the SQLite teardown as well is a SEPARATE question, and must not be
+    // answered by the shape of the path. `netdatacli shutdown-agent` is the stop command used
+    // by the installer and the documented manual stop, and CMD_EXIT itself touches no SQLite;
+    // latching there unconditionally would skip the database close, PRAGMA optimize and WAL
+    // checkpoint on ordinary restarts. Latch only when a command handler is actually in flight
+    // and may be holding SQLite state - which for the fatal-agent path includes ourselves.
+    // Do not touch `thread` until commands_init() has actually created it: it sets
+    // CMD_INIT_STATUS_INIT before uv_thread_create(), so a fatal() in that window would reach
+    // uv_thread_equal()/uv_thread_join() on an uninitialised uv_thread_t.
+    if (__atomic_load_n(&command_server_initialized, __ATOMIC_ACQUIRE) != CMD_INIT_STATUS_FULL) {
+        netdata_log_info("Command server is not fully initialized; nothing to stop.");
+        return;
+    }
+
+    uv_thread_t self = uv_thread_self();
+    if (uv_thread_equal(&thread, &self) || this_thread_runs_a_command) {
+        uint32_t in_flight = __atomic_load_n(&commands_in_flight, __ATOMIC_ACQUIRE);
+
+        if (in_flight) {
+            sqlite_mark_teardown_unsafe(
+                "shutdown started inside the netdatacli command subsystem while a command was still "
+                "running, so the command loop cannot be drained");
+            netdata_log_info(
+                "Command server cannot be joined from this thread; %u command(s) still in flight.", in_flight);
+        }
+        else
+            netdata_log_info(
+                "Command server cannot be joined from this thread; no netdatacli command is in flight.");
+
+        return;
+    }
+
+    // Someone else is inside this function right now (see commands_exit_in_progress). We must
+    // not join a thread they are already joining, and we cannot wait for them without risking a
+    // deadlock of our own - so we fall back to the other half of the contract and suppress the
+    // teardown, because we cannot establish that the command loop was drained.
+    if (__atomic_exchange_n(&commands_exit_in_progress, true, __ATOMIC_ACQ_REL)) {
+        sqlite_mark_teardown_unsafe(
+            "another thread is already stopping the netdatacli command loop, so this one cannot "
+            "confirm it was drained");
+        return;
+    }
 
     command_thread_shutdown = 1;
     netdata_log_info("Shutting down command server.");
@@ -993,10 +1146,17 @@ void commands_exit(void)
     fatal_assert(0 == uv_async_send(&async));
     fatal_assert(0 == uv_thread_join(&thread));
 
-    for (i = 0 ; i < CMD_TOTAL_COMMANDS ; ++i) {
-        netdata_mutex_destroy(&command_lock_array[i]);
-    }
-    netdata_rwlock_destroy(&exclusive_rwlock);
+    // Deliberately NOT destroying command_lock_array[] / exclusive_rwlock.
+    //
+    // This function used to have a single caller on the signal thread - the same thread that
+    // runs the signal path's direct execute_command() calls - so a destroy could never race a
+    // held lock. It now also runs from the shutdown sequence, which can be on a different
+    // thread (systemd PrepareForShutdown, an API quit, or any fatal()), so destroying here
+    // could tear down a mutex that the signal thread is holding inside execute_command().
+    // POSIX says that is undefined; glibc happens to return EBUSY.
+    //
+    // There is nothing to gain by destroying them: the process exits immediately after, and
+    // the OS reclaims everything. Leaking them is the safe half of the trade.
     netdata_log_info("Command server has stopped.");
-    command_server_initialized = CMD_INIT_STATUS_OFF;
+    __atomic_store_n(&command_server_initialized, CMD_INIT_STATUS_OFF, __ATOMIC_RELEASE);
 }

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -741,6 +741,14 @@ static __thread bool this_thread_runs_a_command = false;
 // mutexes twice.
 static bool commands_exit_in_progress = false;
 
+// Has uv_thread_create() actually produced `thread`?
+//
+// This is NOT the same question as the init status. commands_init() sets CMD_INIT_STATUS_INIT
+// BEFORE it creates the thread, so the status cannot tell us whether `thread` is safe to touch,
+// and CMD_INIT_STATUS_FULL is too strict in the other direction: at INIT the loop is already
+// running and serving commands, so a shutdown there still has to drain it.
+static bool command_thread_created = false;
+
 static void after_schedule_command(uv_work_t *req, int status)
 {
     struct command_context *cmd_ctx = req->data;
@@ -1029,6 +1037,16 @@ void commands_init(void)
     int error;
 
     sanity_check();
+
+    // Never (re)start the command server once shutdown has begun. Without this, a SIGTERM during
+    // startup could have commands_exit() stop the loop while main() is still initializing, and
+    // the next commands_init() would bring a fresh loop up - dispatching commands that touch
+    // db_meta while the shutdown sequence is closing it.
+    if (exit_initiated_get()) {
+        netdata_log_info("Not initializing the command server: shutdown has already begun.");
+        return;
+    }
+
     if (__atomic_load_n(&command_server_initialized, __ATOMIC_ACQUIRE) == CMD_INIT_STATUS_FULL)
         return;
 
@@ -1045,10 +1063,23 @@ void commands_init(void)
         return;
     }
 
-    for (i = 0 ; i < CMD_TOTAL_COMMANDS ; ++i) {
-        fatal_assert(0 == netdata_mutex_init(&command_lock_array[i]));
+    // Initialize the command locks ONCE per process.
+    //
+    // commands_exit() deliberately does not destroy them (another thread may hold one; see the
+    // note there), so re-running netdata_mutex_init() on an already-initialized mutex would be
+    // undefined behaviour on a second init/exit cycle. Guarding here keeps both halves safe:
+    // nothing is destroyed while it may be held, and nothing is re-initialized while it is live.
+    //
+    // Only ever reached from commands_init(), which main() calls during single-threaded startup,
+    // so a plain flag is sufficient.
+    static bool command_locks_initialized = false;
+    if (!command_locks_initialized) {
+        for (i = 0 ; i < CMD_TOTAL_COMMANDS ; ++i) {
+            fatal_assert(0 == netdata_mutex_init(&command_lock_array[i]));
+        }
+        fatal_assert(0 == netdata_rwlock_init(&exclusive_rwlock));
+        command_locks_initialized = true;
     }
-    fatal_assert(0 == netdata_rwlock_init(&exclusive_rwlock));
 
     completion_init(&completion);
     error = uv_thread_create(&thread, command_thread, NULL);
@@ -1066,6 +1097,25 @@ void commands_init(void)
             netdata_log_error("uv_thread_create(): %s", uv_strerror(error));
         }
         goto after_error;
+    }
+
+    // Publish ONLY here - after the initialization handshake, never right after
+    // uv_thread_create(). Between those two points the worker has not yet initialized `async`
+    // and `server_pipe`, and it ends its setup with `command_thread_shutdown = 0`. A
+    // commands_exit() that passed the gate in that window would (a) uv_async_send() an
+    // uninitialized handle and (b) have its `command_thread_shutdown = 1` overwritten by the
+    // worker, so the loop would never exit and uv_thread_join() would block until the shutdown
+    // watchdog aborted. Publishing after the handshake makes the gate mean "the loop is up and
+    // can be told to stop", which is what commands_exit() actually needs.
+    __atomic_store_n(&command_thread_created, true, __ATOMIC_RELEASE);
+
+    // Shutdown may have begun while we were completing that handshake (on Windows the service
+    // reports itself running before netdata_main(), so a stop can arrive during startup). The
+    // commands_exit() that ran then saw no thread and returned without stopping anything, so
+    // stop it now rather than leaving a live loop dispatching commands into a teardown.
+    if (exit_initiated_get()) {
+        netdata_log_info("Command server came up during shutdown; stopping it again.");
+        commands_exit();
     }
 
     return;
@@ -1103,11 +1153,12 @@ void commands_exit(void)
     // latching there unconditionally would skip the database close, PRAGMA optimize and WAL
     // checkpoint on ordinary restarts. Latch only when a command handler is actually in flight
     // and may be holding SQLite state - which for the fatal-agent path includes ourselves.
-    // Do not touch `thread` until commands_init() has actually created it: it sets
-    // CMD_INIT_STATUS_INIT before uv_thread_create(), so a fatal() in that window would reach
-    // uv_thread_equal()/uv_thread_join() on an uninitialised uv_thread_t.
-    if (__atomic_load_n(&command_server_initialized, __ATOMIC_ACQUIRE) != CMD_INIT_STATUS_FULL) {
-        netdata_log_info("Command server is not fully initialized; nothing to stop.");
+    // Do not touch `thread` until it exists - but do not demand CMD_INIT_STATUS_FULL either.
+    // At CMD_INIT_STATUS_INIT the loop is already running (only help/ping/version are
+    // dispatchable, none of which touch SQLite, but the loop must still be stopped), so gating
+    // on FULL would leave it running straight through the SQLite teardown.
+    if (!__atomic_load_n(&command_thread_created, __ATOMIC_ACQUIRE)) {
+        netdata_log_info("Command server thread was never created; nothing to stop.");
         return;
     }
 
@@ -1158,5 +1209,6 @@ void commands_exit(void)
     // There is nothing to gain by destroying them: the process exits immediately after, and
     // the OS reclaims everything. Leaking them is the safe half of the trade.
     netdata_log_info("Command server has stopped.");
+    __atomic_store_n(&command_thread_created, false, __ATOMIC_RELEASE);
     __atomic_store_n(&command_server_initialized, CMD_INIT_STATUS_OFF, __ATOMIC_RELEASE);
 }

--- a/src/daemon/daemon-service.c
+++ b/src/daemon/daemon-service.c
@@ -82,7 +82,7 @@ bool service_is_running(SERVICE_TYPE service) {
     bool first = true;
     while((PValue = JudyLFirstThenNext(service_globals.pid_judy, &tid, &first))) {
         SERVICE_THREAD *sth = *PValue;
-        if((sth->services & service) && sth->tid != gettid_cached()) {
+        if((__atomic_load_n(&sth->services, __ATOMIC_ACQUIRE) & service) && sth->tid != gettid_cached()) {
             running = true;
             break;
         }
@@ -99,7 +99,14 @@ bool service_running(SERVICE_TYPE service) {
     if(unlikely(!sth))
         sth = service_register(NULL, NULL, NULL);
 
-    sth->services |= service;
+    // Publish the bit atomically, but only the first time this thread claims a service.
+    // service_running() is called constantly from the collector and health loops, so the common
+    // case stays a plain relaxed read plus a branch; the atomic OR runs once per thread per
+    // service. Readers (service_is_running(), service_signal_exit(), service_wait_exit()) load
+    // this with ACQUIRE, so a plain non-atomic RMW here would be a genuine data race - and
+    // service_is_running() now makes a shutdown DECISION on the result.
+    if(!(__atomic_load_n(&sth->services, __ATOMIC_RELAXED) & service))
+        __atomic_or_fetch(&sth->services, service, __ATOMIC_RELEASE);
 
     return !nd_thread_signaled_to_cancel() && !exit_initiated_get();
 }
@@ -113,7 +120,7 @@ void service_signal_exit(SERVICE_TYPE service) {
     while((PValue = JudyLFirstThenNext(service_globals.pid_judy, &tid, &first))) {
         SERVICE_THREAD *sth = *PValue;
 
-        if((sth->services & service)) {
+        if((__atomic_load_n(&sth->services, __ATOMIC_ACQUIRE) & service)) {
             nd_thread_signal_cancel(sth->netdata_thread);
             nd_log_daemon(NDLP_DEBUG, "SERVICE: Signal to stop : %s", sth->name);
             request_quit_t request_quit_callback = sth->request_quit_callback;
@@ -175,7 +182,7 @@ bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
         bool first = true;
         while((PValue = JudyLFirstThenNext(service_globals.pid_judy, &tid, &first))) {
             SERVICE_THREAD *sth = *PValue;
-            if(sth->services & service && sth->tid != gettid_cached() && !sth->cancelled) {
+            if((__atomic_load_n(&sth->services, __ATOMIC_ACQUIRE) & service) && sth->tid != gettid_cached() && !sth->cancelled) {
                 sth->cancelled = true;
                 nd_thread_signal_cancel(sth->netdata_thread);
                 if(running)
@@ -184,7 +191,7 @@ bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
                 buffer_sprintf(thread_list, "'%s' (%d)", sth->name, sth->tid);
 
                 running++;
-                running_services |= sth->services & service;
+                running_services |= __atomic_load_n(&sth->services, __ATOMIC_ACQUIRE) & service;
 
                 force_quit_t force_quit_callback = sth->force_quit_callback;
                 void *force_quit_data = sth->data;
@@ -219,13 +226,13 @@ bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
         bool first = true;
         while((PValue = JudyLFirstThenNext(service_globals.pid_judy, &tid, &first))) {
             SERVICE_THREAD *sth = *PValue;
-            if(sth->services & service && sth->tid != gettid_cached()) {
+            if((__atomic_load_n(&sth->services, __ATOMIC_ACQUIRE) & service) && sth->tid != gettid_cached()) {
                 if(running)
                     buffer_strcat(thread_list, ", ");
 
                 buffer_sprintf(thread_list, "'%s' (%d)", sth->name, sth->tid);
 
-                running_services |= sth->services & service;
+                running_services |= __atomic_load_n(&sth->services, __ATOMIC_ACQUIRE) & service;
                 running++;
             }
         }

--- a/src/daemon/daemon-service.c
+++ b/src/daemon/daemon-service.c
@@ -62,6 +62,37 @@ void service_exits(void) {
     spinlock_unlock(&service_globals.lock);
 }
 
+// Is any thread other than the caller still registered for any of these services?
+//
+// A pure query: unlike service_wait_exit() it neither signals cancellation nor waits, and it
+// answers for exactly the services asked about. service_wait_exit() returns one bool for its
+// whole mask, so it cannot be used to ask about one service when it was called with several.
+//
+// Threads are removed from this registry by service_exits(), which runs from the per-thread
+// cleanup callbacks registered in main() - after the thread function has returned and
+// therefore after its own cleanup handlers have run. So a "no" here means the thread finished
+// its cleanup, not merely that it was asked to stop.
+bool service_is_running(SERVICE_TYPE service) {
+    bool running = false;
+
+    spinlock_lock(&service_globals.lock);
+
+    Pvoid_t *PValue;
+    Word_t tid = 0;
+    bool first = true;
+    while((PValue = JudyLFirstThenNext(service_globals.pid_judy, &tid, &first))) {
+        SERVICE_THREAD *sth = *PValue;
+        if((sth->services & service) && sth->tid != gettid_cached()) {
+            running = true;
+            break;
+        }
+    }
+
+    spinlock_unlock(&service_globals.lock);
+
+    return running;
+}
+
 bool service_running(SERVICE_TYPE service) {
     static __thread SERVICE_THREAD *sth = NULL;
 

--- a/src/daemon/daemon-service.h
+++ b/src/daemon/daemon-service.h
@@ -26,6 +26,7 @@ typedef void (*force_quit_t)(void *data);
 typedef void (*request_quit_t)(void *data);
 
 void service_exits(void);
+bool service_is_running(SERVICE_TYPE service);
 bool service_running(SERVICE_TYPE service);
 struct service_thread *service_register(request_quit_t request_quit_callback, force_quit_t force_quit_callback, void *data);
 

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -400,10 +400,16 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
     // unlink the pipe
     // commands_exit() above (or the earlier signal-handler call) has normally stopped the
     // command loop by now, and libuv unlinks the pipe when it closes. Two exceptions, where the
-    // loop is still live and we unlink from under it: the `netdatacli shutdown-agent` path,
-    // where shutdown runs ON the command event-loop thread so it cannot be joined, and any
-    // abnormal exit, where commands_exit() is skipped entirely. Both are safe - the SQLite
-    // teardown is suppressed on both - but the pipe does go away under a live listener.
+    // loop is still live and we unlink from under it:
+    //
+    //  - `netdatacli shutdown-agent`: shutdown runs ON the command event-loop thread, so it
+    //    cannot be joined. The SQLite teardown is NOT suppressed here, and does not need to be:
+    //    CMD_EXIT runs inline in parse_commands() and touches no SQLite, and that thread is
+    //    executing the teardown rather than serving the loop. It is suppressed only if some
+    //    OTHER command is in flight at the time.
+    //  - an abnormal exit, where commands_exit() is skipped entirely. The teardown IS suppressed
+    //    there, by the abnormal latch above.
+    //
     // ENOENT just means libuv beat us to it.
     const char *pipe = daemon_pipename();
     if(pipe && *pipe && unlink(pipe) != 0 && errno != ENOENT)

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -268,6 +268,33 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
     watcher_step_complete(WATCHER_STEP_ID_STOP_ALL_REMAINING_WORKER_THREADS);
 
     cancel_main_threads();
+
+    // Stop the netdatacli command loop. Its handlers use db_meta directly, and commands_exit()
+    // is otherwise reached only from the signal path - on every other exit path the command
+    // thread just keeps running, straight through the SQLite teardown below.
+    //
+    // Drain it HERE, alongside the other thread cancellations, rather than just before the
+    // SQLite teardown. By that later point rrdhosts, dbengine and the metadata loop are already
+    // gone, so waiting there for a handler like remove-stale-node would be waiting for it to
+    // finish operating on subsystems that no longer exist. Draining here also matches what the
+    // signal path already does, so the two orders agree.
+    //
+    // commands_exit() is idempotent and re-entry safe; where it cannot drain (it is called from
+    // the command thread itself, or another thread is already draining) it marks the SQLite
+    // teardown unsafe instead, which is the other half of the same contract.
+    //
+    // Skipped entirely on an abnormal exit: there the teardown is suppressed anyway (see the
+    // abnormal latch below), so the join would buy nothing - while a handler blocked on a lock
+    // held by the thread that is currently fatal()ing would turn that fatal into a 135 s
+    // watchdog SIGABRT, destroying the evidence of what actually went wrong.
+    if (!abnormal)
+        commands_exit();
+
+    // Billed to CANCEL_MAIN_THREADS deliberately: commands_exit() joins the command loop, so its
+    // duration belongs to a thread-stopping step. Completing the step before it would charge the
+    // join to whatever step ran next, which did nothing - and this join is the one thing here
+    // that can plausibly stall a shutdown, so it must not be misattributed in the timings the
+    // status file records.
     watcher_step_complete(WATCHER_STEP_ID_CANCEL_MAIN_THREADS);
 
     if (abnormal) {
@@ -326,6 +353,42 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
     nd_thread_join_threads();
     watcher_step_complete(WATCHER_STEP_ID_JOIN_STATIC_THREADS);
 
+    // Everything below destroys SQLite state. Before any of it, establish that nobody can
+    // still be using it - and where we cannot establish that, say so and let the teardown
+    // suppress itself rather than free memory out from under a running thread.
+    //
+    // HEALTH is the thread that matters here. It caches prepared statements (the
+    // is_health_thread branches in sqlite_health.c / sqlite_aclk_alert.c) and nothing above
+    // joins it: service_wait_exit() at the top of this function is bounded and proceeds
+    // regardless, and nd_thread_join_threads() only drains threads that have ALREADY exited.
+    // Ask the service registry directly - a thread leaves it from its per-thread cleanup,
+    // which runs after its own cleanup handlers, so "gone" means health finished finalizing
+    // its statements.
+    //
+    // Do NOT try to infer this from the service_wait_exit() call above: it was given a mask of
+    // four services and returns a single bool for all of them, so a slow HTTPD would look
+    // exactly like a live HEALTH and we would suppress teardown on every ordinary shutdown.
+    if (service_is_running(SERVICE_HEALTH))
+        sqlite_mark_teardown_unsafe(
+            "the health thread is still running and may be using its cached SQL statements");
+
+    // An abnormal exit skipped the whole block above: metadata_sync_shutdown() and ml_fini()
+    // never ran, so the metadata thread and its libuv workers were never asked to stop and are
+    // still binding and stepping statements against db_meta, db_context_meta and - through
+    // metadata_scan_host() -> ml_dimension_load_models() - ml_db. None of the latch setters in
+    // those functions can have fired, because neither function was called.
+    //
+    // Zombie detection alone does not cover this: it samples sqlite3_next_stmt() at one instant,
+    // so a worker that is between statements, about to call sqlite3_prepare_v2(), leaves nothing
+    // attached and the teardown would proceed underneath it.
+    //
+    // This is also the path where tearing SQLite down does the most damage: a second crash
+    // inside the teardown masks the fatal that caused the abnormal exit in the first place,
+    // which is exactly the evidence we need to diagnose it.
+    if (abnormal)
+        sqlite_mark_teardown_unsafe(
+            "the shutdown is abnormal, so the metadata and ML subsystems were never stopped");
+
     sqlite_close_databases();
     sqlite_library_shutdown();
     watcher_step_complete(WATCHER_STEP_ID_CLOSE_SQL_DATABASES);
@@ -335,10 +398,13 @@ static void netdata_cleanup_and_exit(EXIT_REASON reason, bool abnormal, bool exi
         netdata_log_error("EXIT: cannot unlink pidfile '%s'.", pidfile);
 
     // unlink the pipe
-    // During the commands_exit() signal-handler path, libuv may already
-    // have unlinked the pipe on close. For other exit paths the command
-    // thread keeps running and we must clean it up here. ENOENT just means
-    // libuv beat us to removing it.
+    // commands_exit() above (or the earlier signal-handler call) has normally stopped the
+    // command loop by now, and libuv unlinks the pipe when it closes. Two exceptions, where the
+    // loop is still live and we unlink from under it: the `netdatacli shutdown-agent` path,
+    // where shutdown runs ON the command event-loop thread so it cannot be joined, and any
+    // abnormal exit, where commands_exit() is skipped entirely. Both are safe - the SQLite
+    // teardown is suppressed on both - but the pipe does go away under a live listener.
+    // ENOENT just means libuv beat us to it.
     const char *pipe = daemon_pipename();
     if(pipe && *pipe && unlink(pipe) != 0 && errno != ENOENT)
         netdata_log_error("EXIT: cannot unlink netdatacli socket file '%s'.", pipe);

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -981,6 +981,12 @@ static void aclk_synchronization_event_loop(void *arg)
                 config->aclk_queries_running,
                 config->alert_push_running,
                 config->aclk_batch_job_is_running);
+
+            // Same reasoning as the metadata loop: these jobs run on libuv threadpool
+            // threads that nothing joins, and they use db_meta. Suppress the SQLite
+            // teardown so their handles and statements outlive this shutdown.
+            sqlite_mark_teardown_unsafe(
+                "an ACLK libuv job outlived the shutdown watchdog and may still be using the databases");
             break;
         }
 
@@ -1238,13 +1244,21 @@ void aclk_synchronization_shutdown(void)
     // on init and still valid
     aclk_mqtt_client_reset();
 
+    // Same two give-up paths as metadata_sync_shutdown(), and the same consequence: if we never
+    // asked the loop to stop, or could not join it, it and its libuv workers may still be using
+    // db_meta when the caller tears SQLite down.
     if (queue_aclk_sync_cmd(ACLK_SYNC_SHUTDOWN, NULL, NULL))
         completion_wait_for(&aclk_sync_config.start_stop_complete);
+    else
+        sqlite_mark_teardown_unsafe(
+            "the ACLK shutdown command could not be queued, so its sync thread is still running");
 
     completion_destroy(&aclk_sync_config.start_stop_complete);
     int rc = nd_thread_join(aclk_sync_config.thread);
-    if (rc)
+    if (rc) {
         nd_log_daemon(NDLP_ERR, "ACLK: Failed to join synchronization thread");
+        sqlite_mark_teardown_unsafe("the ACLK synchronization thread could not be joined");
+    }
     else
         nd_log_daemon(NDLP_INFO, "ACLK: synchronization thread shutdown completed");
 }

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -1244,14 +1244,15 @@ void aclk_synchronization_shutdown(void)
     // on init and still valid
     aclk_mqtt_client_reset();
 
-    // Same two give-up paths as metadata_sync_shutdown(), and the same consequence: if we never
-    // asked the loop to stop, or could not join it, it and its libuv workers may still be using
-    // db_meta when the caller tears SQLite down.
+    // NOTE the asymmetry with metadata_sync_shutdown(), which DOES latch when its command cannot
+    // be queued: that function returns immediately without joining, so nothing else establishes
+    // that its thread is gone. Here we fall through to nd_thread_join() regardless, and a
+    // successful join is proof the thread finished. Latching on the enqueue failure as well
+    // would leave the one-way latch set on a shutdown where no ACLK worker remains, leaking the
+    // metadata and context handles and skipping sqlite3_shutdown() for nothing. The failed-join
+    // branch below is the one that matters.
     if (queue_aclk_sync_cmd(ACLK_SYNC_SHUTDOWN, NULL, NULL))
         completion_wait_for(&aclk_sync_config.start_stop_complete);
-    else
-        sqlite_mark_teardown_unsafe(
-            "the ACLK shutdown command could not be queued, so its sync thread is still running");
 
     completion_destroy(&aclk_sync_config.start_stop_complete);
     int rc = nd_thread_join(aclk_sync_config.thread);

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -769,11 +769,17 @@ int sqlite_library_init(void)
             NDLP_INFO, "SQLITE: heap memory hard limit %s, soft limit %s", sqlite_hard_limit_mb, sqlite_soft_limit_mb);
     }
     __atomic_store_n(&sqlite_databases_closed, false, __ATOMIC_RELEASE);
-    // Re-arm the suppression flags too. Only the -W unittest drivers re-initialize the library
-    // in one process; without this, one test that trips either flag would silently turn every
-    // later sqlite_library_shutdown() into a no-op.
+    // Re-arm the LIVENESS latch only. It is about threads that were still running during a
+    // previous shutdown, and those are gone by the time we re-initialize, so carrying it forward
+    // would silently turn every later sqlite_library_shutdown() into a no-op (only the -W
+    // unittest drivers re-initialize the library in one process).
     __atomic_store_n(&sqlite_teardown_unsafe, false, __ATOMIC_RELEASE);
-    __atomic_store_n(&sqlite_zombie_connection_created, false, __ATOMIC_RELEASE);
+
+    // The ZOMBIE flag is deliberately NOT cleared. It records that a connection was closed with
+    // statements still attached, so its real close is deferred - that is a property of the
+    // process, not of a library lifetime. The connection survives re-initialization, and calling
+    // sqlite3_shutdown() with it outstanding is exactly the pcache1 teardown crash this flag
+    // exists to prevent.
     sqlite_library_initialized = true;
     spinlock_unlock(&sqlite_spinlock);
 
@@ -794,6 +800,8 @@ void sqlite_library_shutdown(void)
     // Suppressing the handle close without suppressing this would not fix anything: it would
     // move the fault out of a Vdbe and into pcache1 one line later in the shutdown sequence.
     if (sqlite_teardown_is_unsafe() || __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE)) {
+        // Fast path only - the authoritative re-check happens under sqlite_spinlock below,
+        // because a thread can close a handle (creating a zombie) after this point.
         nd_log_daemon(
             NDLP_WARNING,
             "SQL: skipping sqlite3_shutdown() (%s%s%s). The library stays initialized until the "
@@ -817,6 +825,26 @@ void sqlite_library_shutdown(void)
         spinlock_unlock(&sqlite_spinlock);
         return;
     }
+
+    // Re-check under the lock, and immediately before sqlite3_shutdown(). The check above is
+    // unlocked, so between it and here another thread could have closed a handle with statements
+    // attached, and tearing the library down over a fresh zombie is the crash we are avoiding.
+    //
+    // SCOPE, so this is not read as a stronger guarantee than it is: holding the lock makes this
+    // authoritative against sql_close_thread_db_safe(), which takes this same lock around its
+    // note-and-close. It is NOT authoritative against ml_fini(), whose close runs with no lock
+    // held at all (see sqlite_note_zombie_connection). That is sufficient only because ml_fini()
+    // and this function are strictly ordered on the one shutdown thread - not because the lock
+    // excludes it.
+    if (sqlite_teardown_is_unsafe() || __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE)) {
+        spinlock_unlock(&sqlite_spinlock);
+        nd_log_daemon(
+            NDLP_WARNING,
+            "SQL: skipping sqlite3_shutdown() - a SQLite user or a zombie connection appeared while "
+            "we were tearing down. The library stays initialized until the process exits.");
+        return;
+    }
+
     sqlite_library_initialized = false;
     (void) sqlite3_shutdown();
     spinlock_unlock(&sqlite_spinlock);

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -95,6 +95,20 @@ static bool sqlite_teardown_unsafe = false;
 // life of the process, with a single warning to show for it.
 static bool sqlite_zombie_connection_created = false;
 
+// When, and for which database, the first zombie was noted. Recorded ONLY so the eventual
+// "skipping sqlite3_shutdown()" line can say whether the suppression came from this shutdown or
+// from something that happened hours earlier at startup.
+//
+// KNOWN LIMITATION, deliberate: this latch is sticky for the life of the process even if the
+// deferred close later completes (the owning thread finalizes its statements and the connection
+// really does go away). It cannot be cleared safely - once sqlite3_close_v2() has been called,
+// touching that handle to re-test it is undefined - and the trade is one-sided: skipping
+// sqlite3_shutdown() costs a teardown the exiting process does not need, while clearing it
+// wrongly reinstates the pcache1 crash it exists to prevent. The log line below is how you tell
+// a stale suppression from a live one.
+static usec_t sqlite_zombie_noted_ut = 0;
+static const char *sqlite_zombie_noted_db = NULL;
+
 // Every distinct reason is logged, not just the first: when several conditions fire, the list
 // is what tells a triage pass which one actually drove the decision.
 void sqlite_mark_teardown_unsafe(const char *reason)
@@ -623,7 +637,10 @@ static void sqlite_note_zombie_connection(sqlite3 *database, const char *databas
         // Record WHICH database and WHEN, because this flag can be set at startup (the
         // context-load path closes thread-local handles) and is then reported hours later at
         // exit. Without provenance the exit message looks like a shutdown problem.
-        __atomic_store_n(&sqlite_zombie_connection_created, true, __ATOMIC_RELEASE);
+        if (!__atomic_exchange_n(&sqlite_zombie_connection_created, true, __ATOMIC_RELEASE)) {
+            sqlite_zombie_noted_ut = now_monotonic_usec();
+            sqlite_zombie_noted_db = database_name;
+        }
         nd_log_daemon(
             NDLP_WARNING,
             "SQL: the %s database still has prepared statements attached; closing it leaves a zombie "
@@ -799,6 +816,20 @@ void sqlite_library_shutdown(void)
     //
     // Suppressing the handle close without suppressing this would not fix anything: it would
     // move the fault out of a Vdbe and into pcache1 one line later in the shutdown sequence.
+
+    // Say WHERE the zombie came from. A suppression traced to a close that happened long before
+    // shutdown is a different problem from one caused by this teardown, and without this the two
+    // are indistinguishable in the log.
+    char zombie_note[160];
+    if (__atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE))
+        snprintfz(
+            zombie_note, sizeof(zombie_note) - 1,
+            "a zombie %s connection was noted %llu s ago and cannot be proven closed",
+            sqlite_zombie_noted_db ? sqlite_zombie_noted_db : "sqlite",
+            sqlite_zombie_noted_ut ? (unsigned long long)((now_monotonic_usec() - sqlite_zombie_noted_ut) / USEC_PER_SEC) : 0ULL);
+    else
+        zombie_note[0] = '\0';
+
     if (sqlite_teardown_is_unsafe() || __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE)) {
         // Fast path only - the authoritative re-check happens under sqlite_spinlock below,
         // because a thread can close a handle (creating a zombie) after this point.
@@ -809,7 +840,7 @@ void sqlite_library_shutdown(void)
             sqlite_teardown_is_unsafe() ? "a SQLite user may still be running" : "",
             (sqlite_teardown_is_unsafe() && __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE))
                 ? " and " : "",
-            __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE) ? "a zombie connection exists" : "");
+            __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE) ? zombie_note : "");
         return;
     }
 

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -99,6 +99,13 @@ static bool sqlite_zombie_connection_created = false;
 // "skipping sqlite3_shutdown()" line can say whether the suppression came from this shutdown or
 // from something that happened hours earlier at startup.
 //
+// Both are ATOMIC, and the ORDER matters: they are written BEFORE the flag is published, and
+// read AFTER it is observed. sqlite_note_zombie_connection() cannot take sqlite_spinlock (it
+// runs both with that lock held and without it), and the reader in sqlite_library_shutdown()
+// formats this message outside the lock - so a thread-local close noting the first zombie can
+// run concurrently with that formatting. Publishing the flag first would let the reader see
+// "a zombie exists" and then read an unwritten name and timestamp.
+//
 // KNOWN LIMITATION, deliberate: this latch is sticky for the life of the process even if the
 // deferred close later completes (the owning thread finalizes its statements and the connection
 // really does go away). It cannot be cleared safely - once sqlite3_close_v2() has been called,
@@ -637,10 +644,15 @@ static void sqlite_note_zombie_connection(sqlite3 *database, const char *databas
         // Record WHICH database and WHEN, because this flag can be set at startup (the
         // context-load path closes thread-local handles) and is then reported hours later at
         // exit. Without provenance the exit message looks like a shutdown problem.
-        if (!__atomic_exchange_n(&sqlite_zombie_connection_created, true, __ATOMIC_RELEASE)) {
-            sqlite_zombie_noted_ut = now_monotonic_usec();
-            sqlite_zombie_noted_db = database_name;
+        // Populate BEFORE publishing, and publish with RELEASE - see the note at the
+        // declarations. Two threads racing to record the first zombie may overwrite each
+        // other's values, which is harmless for a diagnostic; what must not happen is the flag
+        // becoming visible ahead of the data.
+        if (!__atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE)) {
+            __atomic_store_n(&sqlite_zombie_noted_db, database_name, __ATOMIC_RELAXED);
+            __atomic_store_n(&sqlite_zombie_noted_ut, now_monotonic_usec(), __ATOMIC_RELAXED);
         }
+        __atomic_store_n(&sqlite_zombie_connection_created, true, __ATOMIC_RELEASE);
         nd_log_daemon(
             NDLP_WARNING,
             "SQL: the %s database still has prepared statements attached; closing it leaves a zombie "
@@ -821,12 +833,17 @@ void sqlite_library_shutdown(void)
     // shutdown is a different problem from one caused by this teardown, and without this the two
     // are indistinguishable in the log.
     char zombie_note[160];
-    if (__atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE))
+    if (__atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE)) {
+        // The ACQUIRE above pairs with the RELEASE publish in sqlite_note_zombie_connection(),
+        // so these two are guaranteed written by the time we get here.
+        const char *noted_db = __atomic_load_n(&sqlite_zombie_noted_db, __ATOMIC_RELAXED);
+        usec_t noted_ut = __atomic_load_n(&sqlite_zombie_noted_ut, __ATOMIC_RELAXED);
         snprintfz(
             zombie_note, sizeof(zombie_note) - 1,
             "a zombie %s connection was noted %llu s ago and cannot be proven closed",
-            sqlite_zombie_noted_db ? sqlite_zombie_noted_db : "sqlite",
-            sqlite_zombie_noted_ut ? (unsigned long long)((now_monotonic_usec() - sqlite_zombie_noted_ut) / USEC_PER_SEC) : 0ULL);
+            noted_db ? noted_db : "sqlite",
+            noted_ut ? (unsigned long long)((now_monotonic_usec() - noted_ut) / USEC_PER_SEC) : 0ULL);
+    }
     else
         zombie_note[0] = '\0';
 

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -7,13 +7,60 @@
 static SPINLOCK JudyL_thread_stmt_lock = SPINLOCK_INITIALIZER;
 static Pvoid_t JudyL_thread_stmt_pool = NULL;
 
+// Per-thread cache of prepared statements, and the contract that governs its lifetime.
+//
+// THE RULES (all four are load-bearing; breaking any one reintroduces a shutdown crash):
+//
+//  1. NO DECISION ABOUT POOL OWNERSHIP is made on an unlocked read of
+//     sqlite_databases_closed. An unlocked pre-check in
+//     finalize_self_prepared_sql_statements() was the double-free: the reader could be told
+//     "not closed", block on the lock, and free a pool that the teardown thread had already
+//     freed. (#20731 added such a pre-check after #20536 had removed the sibling one from that
+//     same function. Do not add it back.)
+//     Note this rule is about POOL OWNERSHIP only. The flag is deliberately read unlocked
+//     elsewhere, where a stale answer is harmless: REQUIRE_HEALTH_DB_OPEN() uses it as a hint,
+//     and sqlite_close_databases() stores it before taking the lock so that new work is
+//     refused as early as possible.
+//  2. Every find, mutate and free of a JudyL_thread_stmt_pool entry happens under
+//     JudyL_thread_stmt_lock.
+//  3. THE JUDYL ARRAY IS THE AUTHORITY for pool lifetime, not thread_stmt_pool. Self cleanup
+//     frees only the entry the array maps for gettid_cached() and deletes that key. Nothing
+//     else frees a pool at all: finalize_all_prepared_sql_statements() only REPORTS the pools
+//     it finds and suppresses the teardown (see rule 4), so a pool is only ever released by
+//     its own owner. thread_stmt_pool is a same-thread cache for prepare_statement(); the
+//     lookup, not the cache, decides what exists.
+//  4. NO TEARDOWN PATH WRITES ANOTHER THREAD'S THREAD-LOCAL STORAGE - not the pool
+//     pointer, not the caller's cached sqlite3_stmt * slot. It is tempting to have the
+//     finalizer NULL the owner's slots so they cannot be reused after finalization, but
+//     finalize_all_prepared_sql_statements() exists precisely for pools whose owner did
+//     NOT clean up, and such an owner's TLS block may no longer have a valid lifetime.
+//     Holding the locks does not prolong it.
+//
+// WHAT PROTECTS A STATEMENT THAT IS STILL IN USE is not this struct - it is
+// sqlite_teardown_unsafe (see below). When any pooled-statement owner might still be
+// running, teardown is suppressed entirely and nothing is finalized out from under it.
+//
+// THE OWNER SET IS AN ENUMERATED INVARIANT, NOT ONE THIS CODE ENFORCES. Today the only threads
+// that register here are HEALTH (the PREPARE_COMPILED_STATEMENT sites in sqlite_health.c and
+// sqlite_aclk_alert.c are all gated on is_health_thread) and the ML threads - both the TRAIN[N]
+// workers and the detection thread reach the direct prepare_statement() sites in ml.cc, which
+// is why both call finalize_self_prepared_sql_statements() at the end of their loops. Every ML
+// thread is joined by ml_stop_threads() before teardown; health cleans up from a
+// CLEANUP_FUNCTION handler.
+// So in a correct shutdown finalize_all_prepared_sql_statements() finds NOTHING and is a
+// pure diagnostic. IF YOU ADD A PREPARE_COMPILED_STATEMENT CALLER ON A THREAD THAT IS
+// NEITHER JOINED BEFORE TEARDOWN NOR GUARANTEED TO RUN
+// finalize_self_prepared_sql_statements(), you MUST extend the liveness check that sets
+// sqlite_teardown_unsafe, or you reintroduce the use-after-free.
 struct stmt_pool_s {
     int count;
+    bool overflow_reported;
     pid_t thread_id;
     char *name;
     void *stmt[MAX_PREPARED_THREAD_STATEMENTS];
 };
 
+// Same-thread cache only. Rule 3: the JudyL array, not this pointer, decides what exists.
 __thread struct stmt_pool_s *thread_stmt_pool = NULL;
 
 long long def_journal_size_limit = 16777216;
@@ -22,6 +69,50 @@ SPINLOCK sqlite_spinlock = SPINLOCK_INITIALIZER;
 
 bool sqlite_library_initialized;
 bool sqlite_databases_closed;
+
+// One-way latch: "someone may still be using SQLite, so tearing it down would be a
+// use-after-free". Set on every shutdown path that gives up waiting for a SQLite user
+// instead of proving it finished, and checked by every teardown entry point -
+// ml_fini(), sqlite_close_databases() and sqlite_library_shutdown().
+//
+// When it is set we deliberately leak: the METADATA, CONTEXT and ML handles stay open,
+// statements stay unfinalized and the library stays initialized until the process exits and the
+// OS reclaims everything. (Thread-local handles are the exception: sql_close_thread_db_safe()
+// still closes those, which is safe because they are private to a single thread.)
+// That is strictly safer than crashing inside pcache1 - the same reasoning that already
+// governs sql_close_thread_db_safe() below. sqlite_databases_closed is still set in that
+// case, so no NEW work is admitted; only the destruction is skipped.
+static bool sqlite_teardown_unsafe = false;
+
+// A SEPARATE, narrower signal: a connection was closed with statements still attached, so it
+// became a zombie. That makes sqlite3_shutdown() unsafe - it would dismantle pcache1 while the
+// zombie still references pages - but it says nothing about whether anyone is still USING
+// db_meta, so it must not suppress the database closes.
+//
+// Keeping the two apart matters because this one is reachable at STARTUP:
+// sql_close_thread_db_safe() runs on the context-load path during boot. Folding it into the
+// liveness latch would let one leaked statement there suppress every teardown for the entire
+// life of the process, with a single warning to show for it.
+static bool sqlite_zombie_connection_created = false;
+
+// Every distinct reason is logged, not just the first: when several conditions fire, the list
+// is what tells a triage pass which one actually drove the decision.
+void sqlite_mark_teardown_unsafe(const char *reason)
+{
+    bool was_set = __atomic_exchange_n(&sqlite_teardown_unsafe, true, __ATOMIC_RELEASE);
+
+    nd_log_daemon(
+        NDLP_WARNING,
+        "SQL: %s SQLite teardown: %s. Databases, statements and library state are leaked "
+        "deliberately; the process is exiting.",
+        was_set ? "also suppressing" : "suppressing",
+        reason ? reason : "a SQLite user may still be running");
+}
+
+bool sqlite_teardown_is_unsafe(void)
+{
+    return __atomic_load_n(&sqlite_teardown_unsafe, __ATOMIC_ACQUIRE);
+}
 
 SQLITE_API int sqlite3_exec_monitored(
     sqlite3 *db,                               /* An open database */
@@ -174,8 +265,9 @@ static void finalize_and_free_stmt_list(struct stmt_pool_s *stmt_list)
     if (!stmt_list)
         return;
 
-    int max_keys = MIN(stmt_list->count, MAX_PREPARED_THREAD_STATEMENTS);
-    for (int i = 0; i < max_keys; i++) {
+    // count is bounded by prepare_statement(), which refuses to register past
+    // MAX_PREPARED_THREAD_STATEMENTS instead of incrementing and dropping silently.
+    for (int i = 0; i < stmt_list->count; i++) {
         if (!stmt_list->stmt[i])
             continue;
         int rc = sqlite3_finalize((sqlite3_stmt *)stmt_list->stmt[i]);
@@ -187,26 +279,53 @@ static void finalize_and_free_stmt_list(struct stmt_pool_s *stmt_list)
     freez(stmt_list);
 }
 
-// This must be called when the thread terminates
+// This must be called when the thread terminates.
+//
+// There is deliberately NO sqlite_databases_closed check here, neither before the lock nor under
+// it - see rule 1 at the top of this file. The unlocked one used to be at the head of this
+// function and was the double free: this thread read "not closed", waited for the lock, and then
+// freed a pool that the teardown thread had already freed and removed.
+//
+// That teardown-side free no longer exists - finalize_all_prepared_sql_statements() now only
+// reports and latches - so today nothing else frees a pool and the double free is structurally
+// impossible. The lookup below is still the guard, and it is what keeps that true regardless of
+// who might free one in future: the JudyL mapping, never the TLS pointer, decides what exists.
 void finalize_self_prepared_sql_statements()
 {
-    if (__atomic_load_n(&sqlite_databases_closed, __ATOMIC_ACQUIRE))
-        return;
-
     spinlock_lock(&sqlite_spinlock);
-
     spinlock_lock(&JudyL_thread_stmt_lock);
-    if (thread_stmt_pool) {
-        Word_t thread_id = thread_stmt_pool->thread_id;
-        finalize_and_free_stmt_list(thread_stmt_pool);
-        thread_stmt_pool = NULL;
+
+    // Ask the authority, not our TLS cache: our cached pointer may name a pool that
+    // finalize_all_prepared_sql_statements() has already freed.
+    Word_t thread_id = (Word_t)gettid_cached();
+    Pvoid_t *Pvalue = JudyLGet(JudyL_thread_stmt_pool, thread_id, PJE0);
+    if (Pvalue && *Pvalue) {
+        finalize_and_free_stmt_list((struct stmt_pool_s *)*Pvalue);
         (void)JudyLDel(&JudyL_thread_stmt_pool, thread_id, PJE0);
     }
-    spinlock_unlock(&JudyL_thread_stmt_lock);
+    thread_stmt_pool = NULL;
 
+    spinlock_unlock(&JudyL_thread_stmt_lock);
     spinlock_unlock(&sqlite_spinlock);
 }
 
+// Report any statement pool whose owner did not clean up, and suppress the teardown if there
+// is one.
+//
+// In a correct shutdown this finds NOTHING: every pool owner either was joined before we got
+// here (the ML TRAIN workers, via ml_stop_threads()) or ran
+// finalize_self_prepared_sql_statements() from its own cleanup handler (HEALTH, and the main
+// thread just above). So the normal path walks an empty array and changes nothing.
+//
+// If it DOES find a pool, we cannot safely finalize it. We would be finalizing statements
+// that a thread may still hold cached, and rule 4 forbids clearing that thread's slot, so
+// there would be no way to stop it reusing freed memory. We cannot tell from here whether
+// that owner is alive or merely sloppy, so we take the safe reading: warn, latch, and leak.
+//
+// That check is deliberately structural rather than a list of known owners. The liveness test
+// in daemon-shutdown.c knows about HEALTH specifically; this one catches ANY future pool owner
+// that is neither joined before teardown nor runs its own cleanup, without needing to be told
+// about it.
 void finalize_all_prepared_sql_statements()
 {
     spinlock_lock(&JudyL_thread_stmt_lock);
@@ -223,9 +342,12 @@ void finalize_all_prepared_sql_statements()
                 "SQL: Pending SQL statements for thread %lu (%s), make sure thread does a proper cleanup",
                 thread_id,
                 local_stmt_pool->name);
-            finalize_and_free_stmt_list(local_stmt_pool);
+
+            // Do NOT finalize or free it: see the note above. The pool and its statements are
+            // leaked on purpose and the whole teardown is suppressed.
+            sqlite_mark_teardown_unsafe(
+                "a thread left cached SQL statements registered, so it may still be using them");
         }
-        (void)JudyLFreeArray(&JudyL_thread_stmt_pool, PJE0);
     }
     spinlock_unlock(&JudyL_thread_stmt_lock);
 }
@@ -236,6 +358,7 @@ static void init_thread_stmt_pool(void) {
         fatal("Failed to allocate memory for statement pool");
 
     thread_stmt_pool->count = 0;
+    thread_stmt_pool->overflow_reported = false;
     thread_stmt_pool->thread_id = gettid_cached();
     thread_stmt_pool->name = strdupz(nd_thread_tag());
     memset(thread_stmt_pool->stmt, 0, sizeof(void *) * MAX_PREPARED_THREAD_STATEMENTS);
@@ -276,9 +399,28 @@ int prepare_statement(sqlite3 *database, const char *query, sqlite3_stmt **state
     if (rc == SQLITE_OK) {
         if (!thread_stmt_pool)
             init_thread_stmt_pool();
-        int stmt_key = __atomic_fetch_add(&thread_stmt_pool->count, 1, __ATOMIC_RELAXED);
-        if (stmt_key < MAX_PREPARED_THREAD_STATEMENTS)
-            thread_stmt_pool->stmt[stmt_key] = *statement;
+
+        // Register the statement so shutdown can account for it. count is only ever
+        // touched under sqlite_spinlock, so no atomic is needed.
+        //
+        // Do NOT increment past the limit: the old code incremented unconditionally and
+        // dropped the statement silently once the array was full, so those statements were
+        // never finalized and were exactly what left a zombie connection behind at
+        // sqlite3_close_v2(). Refuse loudly instead - it is a real limit being hit, and the
+        // caller keeps a usable statement either way.
+        if (thread_stmt_pool->count < MAX_PREPARED_THREAD_STATEMENTS)
+            thread_stmt_pool->stmt[thread_stmt_pool->count++] = *statement;
+        else if (!thread_stmt_pool->overflow_reported) {
+            // Report ONCE per thread, not per call: this runs under sqlite_spinlock, which also
+            // serializes simple_prepare_statement() for every web, API and metadata thread, so an
+            // unconditional log here would turn a full pool into a global throughput problem.
+            thread_stmt_pool->overflow_reported = true;
+            error_report(
+                "SQL: thread %s exhausted its %d cached statement slots; further statements on this "
+                "thread will not be finalized at shutdown",
+                thread_stmt_pool->name,
+                MAX_PREPARED_THREAD_STATEMENTS);
+        }
     }
     spinlock_unlock(&sqlite_spinlock);
     return rc;
@@ -424,6 +566,73 @@ uint64_t sqlite_get_db_space(sqlite3 *db)
  * Close the sqlite database
  */
 
+// Called immediately before every sqlite3_close_v2() in this file.
+//
+// sqlite3_close_v2() does not fail when statements are still attached: it marks the
+// connection a ZOMBIE and defers the real close until whatever later finalize or close makes
+// it non-busy. If sqlite3_shutdown() runs in between it dismantles pcache1 while the zombie
+// still references pages, and the deferred close then faults inside pcache1RemoveFromHash -
+// after main() has returned, which is why these crashes have no netdata frames.
+//
+// sqlite3_next_stmt() measures the condition directly rather than inferring it from whether
+// some thread failed to clean up: it sees untracked statements (PREPARE_STATEMENT /
+// simple_prepare_statement) as well as the pooled ones, and untracked statements are the ones
+// most likely to still be attached here.
+//
+// NOTE, because this reads like a contradiction otherwise: we detect the zombie and then close
+// ANYWAY. That is deliberate, and it is safe for reasons that are worth spelling out, because
+// the obvious justification is WRONG. It is NOT true that everyone is provably finished by the
+// time we get here: the pooled-statement owners are (that is what the liveness latch
+// establishes), but UNTRACKED users - the PREPARE_STATEMENT / simple_prepare_statement callers
+// on web and API threads - are only bounded by service_wait_exit(~0, 20s), which proceeds
+// whether or not they finished, and they set no latch.
+//
+// Closing over such a user is nevertheless safe, and this is the actual argument:
+//  - sqlite3_close_v2() on a BUSY connection frees nothing. It marks the connection a zombie
+//    and defers the real close until the last statement is finalized, so a thread mid-step
+//    keeps operating on live memory.
+//  - The handles reaching this function from sqlite_close_databases() and ml_fini() come from
+//    plain sqlite3_open(), and nothing in this tree overrides SQLITE_THREADSAFE or calls
+//    sqlite3_config(), so they are fully serialized - the deferred close cannot race a step.
+//  - Nobody can START new work afterwards: prepare_statement() and simple_prepare_statement()
+//    both re-check sqlite_databases_closed under sqlite_spinlock and return SQLITE_MISUSE.
+//  - The caller NULLs db_meta / db_context_meta after this returns, so a late user gets
+//    SQLITE_MISUSE from a NULL handle rather than a dangling one.
+//  - What genuinely is unsafe afterwards is sqlite3_shutdown(), which would dismantle pcache1
+//    while that deferred connection still references pages. That single thing is what this flag
+//    suppresses.
+// Known gap, pre-existing and not introduced here: db_execute() / sqlite3_exec_monitored() do
+// not check the closed flag, so they are not covered by the third bullet.
+//
+// MUST NOT take sqlite_spinlock: it is non-recursive and this runs both WITH the lock held
+// (from sqlite_close_databases() via sql_close_database(), and from sql_close_thread_db_safe(),
+// which takes it itself) and WITHOUT it (from ml_fini(), which holds nothing).
+//
+// Thread-safety of sqlite3_next_stmt() here rests on the same assumption the sqlite3_close_v2()
+// one line later already makes: the caller is the sole owner of this handle at this point. That
+// matters because the handles passed from sql_close_thread_db_safe() are opened
+// SQLITE_OPEN_NOMUTEX, so the call is not internally serialized for them.
+static void sqlite_note_zombie_connection(sqlite3 *database, const char *database_name)
+{
+    if (unlikely(!database))
+        return;
+
+    if (sqlite3_next_stmt(database, NULL)) {
+        // Only sqlite3_shutdown() is unsafe from here - see sqlite_zombie_connection_created.
+        // Do NOT set the liveness latch: this runs at startup too.
+        // Record WHICH database and WHEN, because this flag can be set at startup (the
+        // context-load path closes thread-local handles) and is then reported hours later at
+        // exit. Without provenance the exit message looks like a shutdown problem.
+        __atomic_store_n(&sqlite_zombie_connection_created, true, __ATOMIC_RELEASE);
+        nd_log_daemon(
+            NDLP_WARNING,
+            "SQL: the %s database still has prepared statements attached; closing it leaves a zombie "
+            "connection, so sqlite3_shutdown() will be skipped at exit (recorded %s)",
+            database_name ? database_name : "sqlite",
+            __atomic_load_n(&sqlite_databases_closed, __ATOMIC_ACQUIRE) ? "during shutdown" : "before shutdown began");
+    }
+}
+
 void sql_close_database(sqlite3 *database, const char *database_name)
 {
     int rc;
@@ -447,10 +656,15 @@ void sql_close_database(sqlite3 *database, const char *database_name)
     (void) sqlite3_db_release_memory(database);
 #endif
 
+    sqlite_note_zombie_connection(database, database_name);
+
     rc = sqlite3_close_v2(database);
     if (unlikely(rc != SQLITE_OK))
         error_report("%s: Error while closing the sqlite database: rc %d, error \"%s\"", database_name, rc, sqlite3_errstr(rc));
-    database = NULL;
+
+    // NOTE: the caller's handle is NOT cleared here - this parameter is by value. Callers
+    // that keep a global (db_meta, db_context_meta, ml_db) must NULL it themselves, and they
+    // do; see sqlite_close_databases() and ml_fini().
 }
 
 extern sqlite3 *db_context_meta;
@@ -464,8 +678,10 @@ void sql_close_thread_db_safe(sqlite3 **database)
         return;
 
     spinlock_lock(&sqlite_spinlock);
-    if (sqlite_library_initialized)
+    if (sqlite_library_initialized) {
+        sqlite_note_zombie_connection(*database, "thread-local");
         (void) sqlite3_close_v2(*database);
+    }
     spinlock_unlock(&sqlite_spinlock);
 
     *database = NULL;
@@ -473,19 +689,41 @@ void sql_close_thread_db_safe(sqlite3 **database)
 
 void sqlite_close_databases(void)
 {
-    // In case we have statements in the main thread (we should not)
+    // In case we have statements in the main thread (we should not).
+    // This is the main thread's own pool, so it is safe regardless of the latch below.
     finalize_self_prepared_sql_statements();
 
+    // Refuse new work from this point, whether or not we go on to destroy anything.
     __atomic_store_n(&sqlite_databases_closed, true, __ATOMIC_RELEASE);
 
     spinlock_lock(&sqlite_spinlock);
 
-    // Finalize pending statements and report any thread that failed
-    // to do it properly
+    // Always run the diagnostic walk, even when teardown is already suppressed. It is the only
+    // thing that NAMES the thread that failed to clean up, and it is precisely when the
+    // teardown is being suppressed that a triage pass needs that name. It frees nothing, so it
+    // is safe to run on any path; it latches if it finds a pool.
     finalize_all_prepared_sql_statements();
 
+    if (sqlite_teardown_is_unsafe()) {
+        spinlock_unlock(&sqlite_spinlock);
+
+        // Someone may still be inside SQLite with these handles. Finalizing their statements or
+        // closing the connections underneath them is a use-after-free; leaking is not.
+        //
+        // The databases keep an un-checkpointed WAL, which SQLite replays on the next open. The
+        // process is exiting, so nothing in it observes the difference. PRAGMA optimize is also
+        // skipped, since it lives in sql_close_database().
+        nd_log_daemon(
+            NDLP_WARNING,
+            "SQL: skipping statement finalization and the METADATA/CONTEXT database closes - "
+            "SQLite teardown is not safe on this shutdown path");
+        return;
+    }
+
     sql_close_database(db_context_meta, "CONTEXT");
+    db_context_meta = NULL;
     sql_close_database(db_meta, "METADATA");
+    db_meta = NULL;
     spinlock_unlock(&sqlite_spinlock);
 }
 
@@ -531,6 +769,11 @@ int sqlite_library_init(void)
             NDLP_INFO, "SQLITE: heap memory hard limit %s, soft limit %s", sqlite_hard_limit_mb, sqlite_soft_limit_mb);
     }
     __atomic_store_n(&sqlite_databases_closed, false, __ATOMIC_RELEASE);
+    // Re-arm the suppression flags too. Only the -W unittest drivers re-initialize the library
+    // in one process; without this, one test that trips either flag would silently turn every
+    // later sqlite_library_shutdown() into a no-op.
+    __atomic_store_n(&sqlite_teardown_unsafe, false, __ATOMIC_RELEASE);
+    __atomic_store_n(&sqlite_zombie_connection_created, false, __ATOMIC_RELEASE);
     sqlite_library_initialized = true;
     spinlock_unlock(&sqlite_spinlock);
 
@@ -544,6 +787,24 @@ int sqlite_release_memory(int bytes)
 
 void sqlite_library_shutdown(void)
 {
+    // The check lives here rather than at the call sites so that every caller is covered by
+    // construction, and it comes BEFORE the release-memory drain below - that drain mutates
+    // the same global allocator state sqlite3_shutdown() tears down.
+    //
+    // Suppressing the handle close without suppressing this would not fix anything: it would
+    // move the fault out of a Vdbe and into pcache1 one line later in the shutdown sequence.
+    if (sqlite_teardown_is_unsafe() || __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE)) {
+        nd_log_daemon(
+            NDLP_WARNING,
+            "SQL: skipping sqlite3_shutdown() (%s%s%s). The library stays initialized until the "
+            "process exits.",
+            sqlite_teardown_is_unsafe() ? "a SQLite user may still be running" : "",
+            (sqlite_teardown_is_unsafe() && __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE))
+                ? " and " : "",
+            __atomic_load_n(&sqlite_zombie_connection_created, __ATOMIC_ACQUIRE) ? "a zombie connection exists" : "");
+        return;
+    }
+
 #ifdef NETDATA_INTERNAL_CHECKS
     int bytes;
     do {

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -316,8 +316,9 @@ void finalize_self_prepared_sql_statements()
     spinlock_lock(&sqlite_spinlock);
     spinlock_lock(&JudyL_thread_stmt_lock);
 
-    // Ask the authority, not our TLS cache: our cached pointer may name a pool that
-    // finalize_all_prepared_sql_statements() has already freed.
+    // Ask the authority, not our TLS cache. The JudyL mapping is what decides a pool exists;
+    // the TLS pointer is only a same-thread cache and may be stale. (It is not that someone else
+    // freed the pool - nothing else frees one any more - it is that the cache is not the record.)
     Word_t thread_id = (Word_t)gettid_cached();
     Pvoid_t *Pvalue = JudyLGet(JudyL_thread_stmt_pool, thread_id, PJE0);
     if (Pvalue && *Pvalue) {
@@ -839,7 +840,7 @@ void sqlite_library_shutdown(void)
         const char *noted_db = __atomic_load_n(&sqlite_zombie_noted_db, __ATOMIC_RELAXED);
         usec_t noted_ut = __atomic_load_n(&sqlite_zombie_noted_ut, __ATOMIC_RELAXED);
         snprintfz(
-            zombie_note, sizeof(zombie_note) - 1,
+            zombie_note, sizeof(zombie_note),
             "a zombie %s connection was noted %llu s ago and cannot be proven closed",
             noted_db ? noted_db : "sqlite",
             noted_ut ? (unsigned long long)((now_monotonic_usec() - noted_ut) / USEC_PER_SEC) : 0ULL);

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -109,6 +109,16 @@ int simple_prepare_statement(sqlite3 *database, const char *query, sqlite3_stmt 
 void finalize_self_prepared_sql_statements();
 void finalize_all_prepared_sql_statements();
 
+// The SQLite teardown latch. Set it from any shutdown path that stops waiting for a SQLite
+// user instead of proving it finished; every teardown entry point (ml_fini(),
+// sqlite_close_databases(), sqlite_library_shutdown()) then skips its destruction and leaks
+// deliberately. One-way within a library lifetime: nothing clears it during a shutdown, and
+// only sqlite_library_init() re-arms it (which in practice means the -W unittest drivers, the
+// sole place the library is re-initialized in one process). See the contract at the top of
+// sqlite_functions.c.
+void sqlite_mark_teardown_unsafe(const char *reason);
+bool sqlite_teardown_is_unsafe(void);
+
 int execute_insert(sqlite3_stmt *res);
 int db_execute(sqlite3 *database, const char *cmd, int *sqlite_rc);
 char *get_database_extented_error(sqlite3 *database, int i, const char *description);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -3027,6 +3027,19 @@ static void metadata_event_loop(void *arg)
 
     (void)uv_loop_close(loop);
 
+    // Did we give up on outstanding libuv work? Key this on the flags themselves rather than
+    // on loop_count: the loop above also exits when uv_run() reports no pending callbacks,
+    // and what matters is not "did we time out" but "is a worker still using the databases".
+    //
+    // Such a worker runs on a libuv threadpool thread, which nd_thread_join_threads() does not
+    // know about and cannot wait for. It is still binding and stepping statements against
+    // db_meta - and, via metadata_scan_host() -> ml_dimension_load_models(), against ml_db.
+    // Suppress the whole SQLite teardown so its handles and statements stay valid until the
+    // process exits.
+    if (config->metadata_running || config->ctx_load_running)
+        sqlite_mark_teardown_unsafe(
+            "a metadata worker outlived the shutdown wait and may still be using the databases");
+
     store_alert_transitions(pending_alert_list, false, true);
     store_sql_statements(pending_sql_statement, false, true);
 
@@ -3061,6 +3074,13 @@ void metadata_sync_shutdown(void)
     // and shutdown will timeout
     if (!metadata_enq_cmd(&cmd, true)) {
         nd_log_daemon(NDLP_WARNING, "METADATA: Failed to send a shutdown command");
+
+        // We never asked the metadata thread to stop, so we are returning with it - and its
+        // libuv workers - still running against db_meta and ml_db. This is a worse position
+        // than the watchdog timeout below: there we at least drained for 15s first. Suppress
+        // the SQLite teardown, including ml_fini()'s close, before the caller walks into it.
+        sqlite_mark_teardown_unsafe(
+            "the metadata shutdown command could not be queued, so the metadata thread is still running");
         return;
     }
     nd_log_daemon(NDLP_INFO, "METADATA: Submitted shutdown command, waiting for ACK");
@@ -3069,8 +3089,13 @@ void metadata_sync_shutdown(void)
     completion_destroy(&meta_config.start_stop_complete);
 
     int rc = nd_thread_join(meta_config.thread);
-    if (rc)
+    if (rc) {
         nd_log_daemon(NDLP_ERR, "METADATA: Failed to join synchronization thread");
+
+        // Same reasoning as the enqueue failure above: an unjoined metadata thread may still
+        // be inside SQLite when the caller tears it down.
+        sqlite_mark_teardown_unsafe("the metadata synchronization thread could not be joined");
+    }
     else
         nd_log_daemon(NDLP_INFO, "METADATA: synchronization thread shutdown completed");
 }

--- a/src/ml/ml_public.cc
+++ b/src/ml/ml_public.cc
@@ -710,6 +710,21 @@ void ml_fini() {
     if (!Cfg.enable_anomaly_detection || !ml_db)
         return;
 
+    // ml_db is the third database exposed to the shutdown lifetime problem, and the least
+    // obvious: an abandoned metadata worker reaches ml_dimension_load_models() through
+    // metadata_scan_host(), so it is still preparing statements against this handle.
+    //
+    // Deferring this call until after metadata_sync_shutdown() (see daemon-shutdown.c) is
+    // necessary but NOT sufficient: that drain is bounded and can abandon its workers, and
+    // then the ordering guarantees nothing. Honour the same latch as every other teardown
+    // entry point and leak the handle instead.
+    if (sqlite_teardown_is_unsafe()) {
+        nd_log_daemon(
+            NDLP_WARNING,
+            "SQL: skipping the ML database close - SQLite teardown is not safe on this shutdown path");
+        return;
+    }
+
     sql_close_database(ml_db, "ML");
     ml_db = NULL;
 }


### PR DESCRIPTION
##### Summary
- Drain command handlers before database teardown, close idle command connections, and preserve SQLite state when workers may still be using it or outstanding statements prevent a complete close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability by coordinating command processing and service termination.
  * Prevented database cleanup while background work or active connections may remain, reducing crash and corruption risks.
  * Added safer handling for incomplete, concurrent, or abnormal shutdowns.
  * Improved detection of running services and unfinished background tasks.
  * Protected metadata and machine-learning data when shutdown cannot safely complete database cleanup.
  * Improved shutdown diagnostics when database cleanup is deferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->