### PR TITLE
test(ml): cover anomaly detector decisions

### DIFF
--- a/src/ml/ml-unittest.cc
+++ b/src/ml/ml-unittest.cc
@@ -839,6 +839,58 @@ static void test_constant_input()
     }
 }
 
+// Test: prediction applies the anomaly threshold to a real model decision.
+static void test_dimension_predict_decision()
+{
+    fprintf(stderr, "  test_dimension_predict_decision...\n");
+
+    const unsigned old_diff_n = Cfg.diff_n;
+    const unsigned old_lag_n = Cfg.lag_n;
+    const double old_threshold = Cfg.dimension_anomaly_score_threshold;
+    const size_t old_suppression_window = Cfg.suppression_window;
+    const size_t old_suppression_threshold = Cfg.suppression_threshold;
+
+    Cfg.diff_n = 0;
+    Cfg.lag_n = 5;
+    Cfg.dimension_anomaly_score_threshold = 0.4;
+    Cfg.suppression_window = 100;
+    Cfg.suppression_threshold = 100;
+
+    ml_dimension_t dim = {};
+    dim.mls = MACHINE_LEARNING_STATUS_ENABLED;
+    dim.ts = TRAINING_STATUS_TRAINED;
+    spinlock_init(&dim.slock);
+
+    ml_kmeans_inlined_t model;
+    for (int i = 0; i < 6; i++) {
+        model.cluster_centers[0](i) = 10.0;
+        model.cluster_centers[1](i) = 10.0;
+    }
+    model.min_dist = 0.0;
+    model.max_dist = 180.0;
+    dim.km_contexts.push_back(model);
+
+    // Warm the prediction ring, then verify a normal sample is not anomalous.
+    for (size_t i = 0; i < Cfg.lag_n + 1; i++)
+        ML_TEST_ASSERT(!ml_dimension_predict(&dim, 10.0, true), "normal warmup/sample should not be anomalous");
+
+    ML_TEST_ASSERT(ml_dimension_predict(&dim, 100.0, true), "anomalous sample should cross the configured threshold");
+
+    // The same score must change classification when only the threshold changes.
+    dim.cns.clear();
+    dim.cns_head = 0;
+    Cfg.dimension_anomaly_score_threshold = 0.6;
+    for (size_t i = 0; i < Cfg.lag_n + 1; i++)
+        ML_TEST_ASSERT(!ml_dimension_predict(&dim, 10.0, true), "threshold test warmup should not be anomalous");
+    ML_TEST_ASSERT(!ml_dimension_predict(&dim, 100.0, true), "raising threshold should classify the same score as normal");
+
+    Cfg.diff_n = old_diff_n;
+    Cfg.lag_n = old_lag_n;
+    Cfg.dimension_anomaly_score_threshold = old_threshold;
+    Cfg.suppression_window = old_suppression_window;
+    Cfg.suppression_threshold = old_suppression_threshold;
+}
+
 // Test: various parameter combinations produce correctly sized outputs
 static void test_parameter_combinations()
 {
@@ -1142,6 +1194,7 @@ extern "C" int ml_unittest()
     test_same_value_uses_newest_sample();
     test_preprocess_predict_equivalence();
     test_constant_input();
+    test_dimension_predict_decision();
     test_parameter_combinations();
     test_kmeans_timestamp_roundtrip();
     test_kmeans_timestamp_rejection();


### PR DESCRIPTION
##### Summary

Add direct ML prediction coverage for the anomaly decision threshold and link the change to issue #23630 with `Fixes #23630`. The deterministic fixture checks normal and anomalous classifications and verifies that changing the configured threshold changes the same score's classification.

##### Test Plan

`git diff --check` passed. `netdata -W mltest` was not run locally because CMake is unavailable; an ML-enabled native run remains required.

##### Additional Information

This is a test-only change with no production behavior, API, configuration, documentation, or release-note changes.

<details> <summary>For users: How does this change affect me?</summary>

This change does not affect users; it strengthens the ML test suite.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds direct ML prediction coverage for the anomaly decision threshold, verifying that normal and anomalous samples are classified correctly and that changing the configured threshold flips the same score's classification. Fixes #23630.

This is a test-only change with no production behavior, API, configuration, documentation, or release-note impact.

<sup>Written for commit 805be7c0e6541aa11900e3622d7e3f65c0eb8c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for dimension-based anomaly prediction using a k-means model.
  - Validated classification of normal and anomalous samples against configurable anomaly thresholds.
  - Confirmed that adjusting the threshold correctly changes sample classification.
  - Added checks for prediction behavior after warming the model’s data window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->