### PR TITLE
fix(go.d): unify activation outcomes and restore secret retries

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -621,6 +621,24 @@ flowchart TD
    - The `job-runtime` identity stays occupied through cleanup, so a same-job successor cannot start before those
      terminal frames complete.
 
+### Activation failure classification
+
+`joboutput/activation_error.go` owns the error classification shared by discovery, synchronous DynCfg activation,
+accepted-job activation, and SecretStore-dependent restarts. Candidate preparation returns that classification with
+the original error. Config-only validation and runtime activation fallbacks use the same classifier.
+
+The classification distinguishes invalid proposals, transient dependencies, busy physical identities, stale Store
+snapshots, superseded attempts, containment deadlines, quarantine, and other operational failures. These are failure
+facts, not a universal retry policy: synchronous UPDATE preserves its incumbent on busy/stale preparation, while an
+already-applied accepted ENABLE retains activation authority and uses timed recovery. Runtime fallback handles busy
+and quarantine only; a stale Store snapshot is rejected during candidate preparation.
+
+Each caller keeps its command-specific response, graph disposition, and recovery policy explicit. Caller cancellation
+and retained ownership take precedence over ordinary recovery. The classifier preserves the original error tree so
+those lifetime decisions remain available; a provider's own canceled operation does not by itself mean its caller
+was canceled. Managed probe failures keep their separate collector-supplied response and retry metadata. Recovery is
+armed only in `AfterApply`, after the corresponding graph mutation commits.
+
 ### Accepted-job activation
 
 An applied graph record in `accepted` is already visible to the daemon but has no installed runtime. ENABLE therefore
@@ -807,8 +825,10 @@ flowchart LR
 
 The Store change remains committed if a later job restart fails, and the graph truthfully shows that job as `Failed`.
 A retained busy/contained restart revalidates the Store dependency, source winner, desired config, resource absence,
-and run generation. A normal probe failure follows the collector's ordinary autodetection-retry policy.
-`secrets/pending.go`.
+and run generation. Transient provider/scope or other transient construction failures schedule the collector's
+ordinary autodetection retry after the Failed mutation applies, as normal probe failures do. A later disable, removal,
+replacement, or run stop revokes that retry. Invalid proposals and quarantine do not gain a timed retry.
+`joboutput/secret_restart.go`, `joboutput/autodetection_retry.go`, `secrets/pending.go`.
 
 Two rules that surprise people:
 

--- a/src/go/plugin/agent/jobmgr/composition/secret_retry_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/secret_retry_test.go
@@ -201,8 +201,8 @@ func testSecretReplacementProviderRecovery(t *testing.T, scenario secretReplacem
 		7*time.Second,
 		10*time.Millisecond,
 	)
-	wireAfterRecovery := output.String()[wireBeforeRecovery:]
 	if scenario.disable || scenario.oversized {
+		wireAfterRecovery := output.String()[wireBeforeRecovery:]
 		require.Equal(
 			t,
 			readsBeforeRecovery,
@@ -218,12 +218,17 @@ func testSecretReplacementProviderRecovery(t *testing.T, scenario secretReplacem
 		}
 		return
 	}
-	require.True(
+	// Retry dispatch is asynchronous; tick progress does not join activation.
+	require.Eventually(
 		t,
-		strings.Contains(wireAfterRecovery, "CONFIG go.d:collector:module:job status running") ||
-			strings.Contains(wireAfterRecovery, "CONFIG go.d:collector:module:job create running job"),
-		"transient provider failure did not recover after five real scheduler ticks; replacement reads: %d",
-		replacementReads.Load(),
+		func() bool {
+			wireAfterRecovery := output.String()[wireBeforeRecovery:]
+			return strings.Contains(wireAfterRecovery, "CONFIG go.d:collector:module:job status running") ||
+				strings.Contains(wireAfterRecovery, "CONFIG go.d:collector:module:job create running job")
+		},
+		3*time.Second,
+		10*time.Millisecond,
+		"transient provider failure did not publish recovery after retry became due",
 	)
 	waitSecretStart(t, starts, "replacement")
 	require.Greater(t, replacementReads.Load(), readsBeforeRecovery)

--- a/src/go/plugin/agent/jobmgr/composition/secret_retry_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/secret_retry_test.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composition
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
+	"github.com/netdata/netdata/go/plugins/pkg/metrix"
+	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/secrets/secretstore"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
+	"github.com/stretchr/testify/require"
+)
+
+// A committed Store rotation must use normal automatic activation recovery. An
+// explicit disable after the failure must cancel that desired activation.
+func TestSecretReplacementTransientProviderRecovery(t *testing.T) {
+	for version, v2 := range map[string]bool{"v1": false, "v2": true} {
+		t.Run(version, func(t *testing.T) {
+			for name, disable := range map[string]bool{"automatic retry": false, "disable cancels retry": true} {
+				t.Run(name, func(t *testing.T) {
+					testSecretReplacementProviderRecovery(t, secretReplacementScenario{
+						v2:      v2,
+						disable: disable,
+					})
+				})
+			}
+		})
+	}
+}
+
+// Result-limit validation runs in the shared resolver before either collector's
+// Init. One version exercises the permanent failure contract for this path.
+func TestSecretReplacementPermanentFailureDoesNotRetry(t *testing.T) {
+	testSecretReplacementProviderRecovery(t, secretReplacementScenario{
+		oversized: true,
+	})
+}
+
+type secretReplacementScenario struct {
+	v2        bool
+	disable   bool
+	oversized bool
+}
+
+func testSecretReplacementProviderRecovery(t *testing.T, scenario secretReplacementScenario) {
+	t.Helper()
+	var recovered atomic.Bool
+	var replacementReads atomic.Int32
+	starts := make(chan string, 4)
+	modules := collectorapi.Registry{
+		"module": {
+			Create: func() collectorapi.CollectorV1 {
+				collector := &collectorapi.MockCollectorV1{}
+				collector.InitFunc = func(ctx context.Context) error {
+					select {
+					case starts <- collector.Config.OptionStr:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+				return collector
+			},
+			Config: func() any { return &collectorapi.MockConfiguration{} },
+			AgentFunctions: func() []funcapi.FunctionConfig {
+				return []funcapi.FunctionConfig{{ID: "method"}}
+			},
+			MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+				return &runTestHandler{
+					cleanup: func() {},
+				}
+			},
+			JobConfigSchema: collectorapi.MockConfigSchema,
+		},
+	}
+	if scenario.v2 {
+		creator := modules["module"]
+		creator.Create = nil
+		creator.CreateV2 = func() collectorapi.CollectorV2 {
+			collector := &secretRetryCollectorV2{
+				store: metrix.NewCollectorStore(),
+			}
+			collector.InitFunc = func(ctx context.Context) error {
+				select {
+				case starts <- collector.Config.OptionStr:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return collector
+		}
+		modules["module"] = creator
+	}
+	jobConfig := confgroup.Config{
+		"module":              "module",
+		"name":                "job",
+		"update_every":        1,
+		"autodetection_retry": 1,
+		"function_only":       true,
+		"option_str":          "${store:vault:main:key}",
+		"option_int":          1,
+	}
+	jobConfig.SetProvider(confgroup.TypeDyncfg)
+	jobConfig.SetSourceType(confgroup.TypeDyncfg)
+	jobConfig.SetSource("test")
+	jobs := testRunJobServices(t)
+	jobs.Defaults = confgroup.Registry{
+		"module": {UpdateEvery: 1, AutoDetectionRetry: 1},
+	}
+	creators, err := secretstore.NewCreatorCatalog([]secretstore.Creator{{
+		Kind: secretstore.KindVault, Schema: `{}`,
+		Create: func() secretstore.Store {
+			return &retrySecretStore{
+				replacementReads: &replacementReads,
+				recovered:        &recovered,
+			}
+		},
+	}})
+	require.NoError(t, err)
+	jobs.StoreCreators = creators
+	reader, writer := io.Pipe()
+	output := &secretRetryTickOutput{
+		processSynchronizedBuffer: newProcessSynchronizedBuffer(),
+	}
+	process, err := newProcessCore(processCoreConfig{
+		Input:           reader,
+		Output:          output,
+		ShutdownTimeout: time.Second,
+		KeepAlive:       true,
+		Modules:         modules,
+		Jobs:            jobs,
+		Secrets: runSecretServices{
+			Initial: []secretstore.Config{{
+				"name": "main", "kind": string(secretstore.KindVault), "value": "initial",
+				"__source__": confgroup.TypeUser, "__source_type__": confgroup.TypeUser,
+			}},
+		},
+		Discovery:   testRunDiscoveryServices(t, jobConfig),
+		Diagnostics: testProcessDiagnostics(),
+	})
+	require.NoError(t, err)
+	controls := newTestProcessControls(1)
+	done := make(chan error, 1)
+	go func() { done <- process.run(context.Background(), controls) }()
+	t.Cleanup(func() {
+		controls.sendTerminate(testProcessControl())
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(3 * time.Second):
+			t.Error("test process did not terminate")
+		}
+		require.NoError(t, writer.Close())
+	})
+	waitSecretStart(t, starts, "initial")
+	output.waitContains(t, "CONFIG go.d:collector:module:job create running job")
+	replacement := "replacement"
+	if scenario.oversized {
+		replacement = "oversized"
+	}
+	_, err = fmt.Fprintf(writer,
+		"FUNCTION_PAYLOAD secret-rotation 30 \"config go.d:secretstore:vault:main update\" "+
+			"0xFFFF \"user=test\" application/json\n{\"value\":%q}\nFUNCTION_PAYLOAD_END\n", replacement)
+	require.NoError(t, err)
+	output.waitContains(t, "FUNCTION_RESULT_BEGIN secret-rotation 200 application/json")
+	output.waitContains(t, "CONFIG go.d:collector:module:job status failed")
+	require.GreaterOrEqual(t, replacementReads.Load(), int32(1))
+	require.Contains(t, output.String(), "dependent collector restarts failed for jobs: module:job")
+
+	if scenario.disable {
+		_, err = io.WriteString(writer,
+			"FUNCTION secret-disable 30 \"config go.d:collector:module:job disable\" 0xFFFF \"user=test\"\n")
+		require.NoError(t, err)
+		output.waitContains(t, "FUNCTION_RESULT_BEGIN secret-disable 200 application/json")
+		output.waitContains(t, "CONFIG go.d:collector:module:job status disabled")
+	}
+	readsBeforeRecovery := replacementReads.Load()
+	if scenario.oversized {
+		require.EqualValues(t, 1, readsBeforeRecovery, "permanent result-limit failure must not be retried")
+	}
+	wireBeforeRecovery := len(output.String())
+	recovered.Store(true)
+
+	// Keepalives follow real scheduler ticks. Five ticks exceed the one-second
+	// retry interval, including the retry clock's initial baseline tick.
+	initialTicks := output.ticks.Load()
+	require.Eventually(
+		t,
+		func() bool { return output.ticks.Load() >= initialTicks+5 },
+		7*time.Second,
+		10*time.Millisecond,
+	)
+	wireAfterRecovery := output.String()[wireBeforeRecovery:]
+	if scenario.disable || scenario.oversized {
+		require.Equal(
+			t,
+			readsBeforeRecovery,
+			replacementReads.Load(),
+			"disabled or permanently failed job must not resolve secrets again",
+		)
+		require.NotContains(t, wireAfterRecovery, "CONFIG go.d:collector:module:job status running")
+		require.NotContains(t, wireAfterRecovery, "CONFIG go.d:collector:module:job create running job")
+		select {
+		case value := <-starts:
+			t.Fatalf("disabled or permanently failed collector restarted with secret %q", value)
+		default:
+		}
+		return
+	}
+	require.True(
+		t,
+		strings.Contains(wireAfterRecovery, "CONFIG go.d:collector:module:job status running") ||
+			strings.Contains(wireAfterRecovery, "CONFIG go.d:collector:module:job create running job"),
+		"transient provider failure did not recover after five real scheduler ticks; replacement reads: %d",
+		replacementReads.Load(),
+	)
+	waitSecretStart(t, starts, "replacement")
+	require.Greater(t, replacementReads.Load(), readsBeforeRecovery)
+}
+
+type secretRetryTickOutput struct {
+	*processSynchronizedBuffer
+	ticks atomic.Int32
+}
+
+func (output *secretRetryTickOutput) Write(payload []byte) (int, error) {
+	count, err := output.processSynchronizedBuffer.Write(payload)
+	if err == nil && len(payload) == 1 && payload[0] == '\n' {
+		output.ticks.Add(1)
+	}
+	return count, err
+}
+
+type retrySecretStore struct {
+	config struct {
+		Value string `yaml:"value"`
+	}
+	replacementReads *atomic.Int32
+	recovered        *atomic.Bool
+}
+
+func (store *retrySecretStore) Configuration() any   { return &store.config }
+func (*retrySecretStore) Init(context.Context) error { return nil }
+func (store *retrySecretStore) Publish() secretstore.PublishedStore {
+	return retryPublishedSecret{
+		value:            store.config.Value,
+		replacementReads: store.replacementReads,
+		recovered:        store.recovered,
+	}
+}
+
+type retryPublishedSecret struct {
+	value            string
+	replacementReads *atomic.Int32
+	recovered        *atomic.Bool
+}
+
+func (store retryPublishedSecret) Resolve(context.Context, secretstore.ResolveRequest) (string, error) {
+	if store.value == "oversized" {
+		store.replacementReads.Add(1)
+		// A successful backend response can still violate the resolver's result
+		// bound. It must become AtomicErrorResultLimit, not a transient provider error.
+		return strings.Repeat("x", secretresolver.MaximumAtomicResolvedBytes+1), nil
+	}
+	if store.value == "replacement" {
+		store.replacementReads.Add(1)
+		if !store.recovered.Load() {
+			return "", errors.New("synthetic temporary backend outage")
+		}
+	}
+	return store.value, nil
+}
+
+// Reuse the V1 mock's configuration and lifecycle hooks while satisfying the
+// V2 runtime contract; function-only activation does not collect metrics.
+type secretRetryCollectorV2 struct {
+	collectorapi.MockCollectorV1 `yaml:",inline"`
+	store                        metrix.CollectorStore
+}
+
+func (*secretRetryCollectorV2) Collect(context.Context) error        { return nil }
+func (c *secretRetryCollectorV2) MetricStore() metrix.CollectorStore { return c.store }
+func (*secretRetryCollectorV2) ChartTemplateYAML() string            { return "" }

--- a/src/go/plugin/agent/jobmgr/joboutput/accepted_activation.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/accepted_activation.go
@@ -453,11 +453,17 @@ func (dcjc *DynCfgJobController) prepareAcceptedActivation(
 		return dcjc.noop(scope, current, permit, result)
 	}
 	if attempt.stage == nil {
-		return dcjc.prepareAcceptedActivationError(attempt, current, scope, permit, attempt.err)
+		return dcjc.prepareAcceptedActivationError(
+			attempt,
+			current,
+			scope,
+			permit,
+			classifyActivationError(attempt.err),
+		)
 	}
 	successor, probeFailure, err := dcjc.factory.prepareCandidate(scope.Successor, permit, attempt.stage)
 	if err != nil {
-		return dcjc.prepareAcceptedActivationError(attempt, current, scope, permit, err)
+		return dcjc.prepareAcceptedActivationError(attempt, current, scope, permit, classifyActivationError(err))
 	}
 	failedPostimage := graphConfig(record, dyncfg.StatusFailed)
 	if probeFailure != nil {
@@ -468,11 +474,14 @@ func (dcjc *DynCfgJobController) prepareAcceptedActivation(
 			autoDetectionRetryToken{},
 			probeFailure,
 			probeFailurePlan{
-				postimage:        failedPostimage,
-				failedCleanup:    dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
-				removedCleanup:   dcjc.configDeleteCleanup(dcjc.externalID(scope.ID)),
-				result:           func(*autoDetectionFailure) lifecycle.SealedResult { return result },
-				afterApply:       composeProbeFailureAfterApply(dcjc.scheduleRetryAfterApply(config), attempt.markApplied()),
+				postimage:      failedPostimage,
+				failedCleanup:  dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
+				removedCleanup: dcjc.configDeleteCleanup(dcjc.externalID(scope.ID)),
+				result:         func(*autoDetectionFailure) lifecycle.SealedResult { return result },
+				afterApply: composeProbeFailureAfterApply(
+					dcjc.scheduleRetryAfterApply(config),
+					attempt.markApplied(),
+				),
 				removePlainStock: config.SourceType() == confgroup.TypeStock,
 			},
 		)
@@ -490,10 +499,13 @@ func (dcjc *DynCfgJobController) prepareAcceptedActivation(
 		autoDetectionRetryToken{},
 		attempt.markApplied(),
 		activationFallbackPlan{
-			postimage:  &failedPostimage,
-			result:     result,
-			cleanup:    dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
-			afterApply: composeAfterApply(func() { dcjc.scheduleAutoDetectionRetry(config, busyFailure) }, attempt.markApplied()),
+			postimage: &failedPostimage,
+			result:    result,
+			cleanup:   dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
+			afterApply: composeAfterApply(
+				func() { dcjc.scheduleAutoDetectionRetry(config, busyFailure) },
+				attempt.markApplied(),
+			),
 		},
 		activationFallbackPlan{
 			postimage:  &failedPostimage,
@@ -509,8 +521,9 @@ func (dcjc *DynCfgJobController) prepareAcceptedActivationError(
 	current lifecycle.ReadyResource,
 	scope lifecycle.ResourceTransactionScope,
 	permit lifecycle.LongLivedPermit,
-	err error,
+	activation activationFailure,
 ) (lifecycle.PreparedResourceTransaction, error) {
+	err := activation.err
 	if err == nil {
 		return nil, errors.New("job output: accepted activation has no candidate outcome")
 	}
@@ -526,7 +539,8 @@ func (dcjc *DynCfgJobController) prepareAcceptedActivationError(
 	}
 	failedPostimage := graphConfig(record, dyncfg.StatusFailed)
 	config := attempt.spec.config
-	if errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+	switch activation.kind {
+	case activationFailureQuarantined, activationFailureProposal:
 		return dcjc.prepareMutationWithRetryAfterApply(
 			scope,
 			current,
@@ -540,12 +554,8 @@ func (dcjc *DynCfgJobController) prepareAcceptedActivationError(
 			attempt.markApplied(),
 			jobConfigFailure(err, "activation"),
 		)
-	}
-	if errors.Is(err, jobmgr.ErrProcessAttemptBusy) ||
-		errors.Is(err, jobmgr.ErrProcessAttemptSuperseded) ||
-		errors.Is(err, jobmgr.ErrProcessAttemptDeadline) ||
-		errors.Is(err, ErrStaleStoreGeneration) ||
-		classifyConstructionError(err) == constructionErrorTransient {
+	case activationFailureBusy, activationFailureStaleStore, activationFailureSuperseded,
+		activationFailureDeadline, activationFailureTransient:
 		failure := transientActivationFailure(config, err)
 		return dcjc.prepareMutationWithRetryAfterApply(
 			scope,
@@ -560,23 +570,9 @@ func (dcjc *DynCfgJobController) prepareAcceptedActivationError(
 			composeAfterApply(func() { dcjc.scheduleAutoDetectionRetry(config, failure) }, attempt.markApplied()),
 			jobConfigFailure(err, "activation"),
 		)
+	default:
+		return nil, err
 	}
-	if classifyConstructionError(err) == constructionErrorProposal {
-		return dcjc.prepareMutationWithRetryAfterApply(
-			scope,
-			current,
-			nil,
-			permit,
-			resourceRemovalDisposition(current),
-			&failedPostimage,
-			result,
-			dcjc.configStatusCleanup(scope.ID, dyncfg.StatusFailed),
-			autoDetectionRetryToken{},
-			attempt.markApplied(),
-			jobConfigFailure(err, "activation"),
-		)
-	}
-	return nil, err
 }
 
 func composeProbeFailureAfterApply(

--- a/src/go/plugin/agent/jobmgr/joboutput/activation_error.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/activation_error.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package joboutput
+
+import (
+	"errors"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+)
+
+type activationFailureKind uint8
+
+const (
+	activationFailureOperational activationFailureKind = iota
+	activationFailureProposal
+	activationFailureTransient
+	activationFailureBusy
+	activationFailureStaleStore
+	activationFailureSuperseded
+	activationFailureDeadline
+	activationFailureQuarantined
+)
+
+// activationFailure preserves the cause while giving every activation path the
+// same failure facts. Callers own cancellation, graph disposition and recovery.
+type activationFailure struct {
+	err  error
+	kind activationFailureKind
+}
+
+func classifyActivationError(err error) activationFailure {
+	if err == nil {
+		return activationFailure{}
+	}
+	failure := activationFailure{
+		err: err,
+	}
+	var transient *transientJobConstructionError
+	var resolveErr *secretresolver.AtomicResolveError
+	var invalid *invalidJobConfigurationError
+	switch {
+	case errors.Is(err, jobmgr.ErrProcessAttemptQuarantined):
+		failure.kind = activationFailureQuarantined
+	case errors.Is(err, jobmgr.ErrProcessAttemptBusy):
+		failure.kind = activationFailureBusy
+	case errors.Is(err, ErrStaleStoreGeneration):
+		failure.kind = activationFailureStaleStore
+	case errors.Is(err, jobmgr.ErrProcessAttemptSuperseded):
+		failure.kind = activationFailureSuperseded
+	case errors.Is(err, jobmgr.ErrProcessAttemptDeadline):
+		failure.kind = activationFailureDeadline
+	case errors.As(err, &transient):
+		failure.kind = activationFailureTransient
+	case errors.As(err, &resolveErr):
+		switch resolveErr.Kind {
+		case secretresolver.AtomicErrorProvider, secretresolver.AtomicErrorScope:
+			failure.kind = activationFailureTransient
+		default:
+			failure.kind = activationFailureProposal
+		}
+	case errors.As(err, &invalid):
+		failure.kind = activationFailureProposal
+	}
+	return failure
+}

--- a/src/go/plugin/agent/jobmgr/joboutput/activation_error.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/activation_error.go
@@ -49,6 +49,8 @@ func classifyActivationError(err error) activationFailure {
 	case errors.Is(err, jobmgr.ErrProcessAttemptSuperseded):
 		failure.kind = activationFailureSuperseded
 	case errors.Is(err, jobmgr.ErrProcessAttemptDeadline):
+		// The containment fuse has its own recovery policy. Callers handle context
+		// expiry; provider/scope deadlines keep their transient classification below.
 		failure.kind = activationFailureDeadline
 	case errors.As(err, &transient):
 		failure.kind = activationFailureTransient

--- a/src/go/plugin/agent/jobmgr/joboutput/activation_error_test.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/activation_error_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package joboutput
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActivationFailureClassificationPreservesRecoveryDistinctions(t *testing.T) {
+	// Contention waits for physical release; provider failures retry on a timer;
+	// invalid proposals and quarantined identities must not gain such retries.
+	tests := []struct {
+		name string
+		err  error
+		kind activationFailureKind
+	}{
+		{name: "success", kind: activationFailureOperational},
+		{name: "operational", err: errors.New("construction failed"), kind: activationFailureOperational},
+		{
+			name: "invalid config",
+			err:  invalidJobConfiguration(errors.New("invalid shape")),
+			kind: activationFailureProposal,
+		},
+		{
+			name: "transient construction",
+			err:  transientJobConstruction(errors.New("dependency unavailable")),
+			kind: activationFailureTransient,
+		},
+		{
+			name: "provider",
+			err: &secretresolver.AtomicResolveError{
+				Kind: secretresolver.AtomicErrorProvider,
+			},
+			kind: activationFailureTransient,
+		},
+		{
+			name: "scope",
+			err: &secretresolver.AtomicResolveError{
+				Kind: secretresolver.AtomicErrorScope,
+			},
+			kind: activationFailureTransient,
+		},
+		{
+			name: "invalid reference",
+			err: &secretresolver.AtomicResolveError{
+				Kind: secretresolver.AtomicErrorReference,
+			},
+			kind: activationFailureProposal,
+		},
+		{
+			name: "resolution limit",
+			err: &secretresolver.AtomicResolveError{
+				Kind: secretresolver.AtomicErrorResultLimit,
+			},
+			kind: activationFailureProposal,
+		},
+		{name: "busy", err: jobmgr.ErrProcessAttemptBusy, kind: activationFailureBusy},
+		{name: "stale Store", err: ErrStaleStoreGeneration, kind: activationFailureStaleStore},
+		{name: "superseded", err: jobmgr.ErrProcessAttemptSuperseded, kind: activationFailureSuperseded},
+		{name: "deadline", err: jobmgr.ErrProcessAttemptDeadline, kind: activationFailureDeadline},
+		{name: "quarantined", err: jobmgr.ErrProcessAttemptQuarantined, kind: activationFailureQuarantined},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.err
+			if err != nil {
+				err = fmt.Errorf("candidate: %w", err)
+			}
+			failure := classifyActivationError(err)
+			require.Equal(t, test.kind, failure.kind)
+			require.Equal(t, err, failure.err)
+		})
+	}
+}
+
+func TestActivationFailureKeepsContainmentAndOwnershipAuthoritative(t *testing.T) {
+	err := lifecycle.RetainOwnership(errors.Join(
+		jobmgr.ErrProcessAttemptQuarantined,
+		transientJobConstruction(jobmgr.ErrProcessAttemptBusy),
+	))
+	failure := classifyActivationError(err)
+	require.Equal(t, activationFailureQuarantined, failure.kind)
+	require.True(t, lifecycle.OwnershipRetained(failure.err))
+	require.ErrorIs(t, failure.err, jobmgr.ErrProcessAttemptBusy)
+
+	// A provider may cancel its own work while the command remains live. Keep
+	// that transient fact; only the caller can decide its lifetime disposition.
+	err = &secretresolver.AtomicResolveError{
+		Kind:  secretresolver.AtomicErrorProvider,
+		Cause: context.Canceled,
+	}
+	failure = classifyActivationError(err)
+	require.Equal(t, activationFailureTransient, failure.kind)
+	require.ErrorIs(t, failure.err, context.Canceled)
+}

--- a/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/candidate_stage.go
@@ -1042,27 +1042,23 @@ func validateStoreSnapshot(snapshot secretresolver.AtomicScopeSnapshot) (err err
 	return nil
 }
 
-func candidatePreparationBusy(err error) bool {
-	return errors.Is(err, jobmgr.ErrProcessAttemptBusy) ||
-		errors.Is(err, ErrStaleStoreGeneration)
-}
-
 func (dcjc *DynCfgJobController) prepareContainedJob(
 	ctx context.Context,
 	config confgroup.Config,
 	identity lifecycle.ResourceIdentity,
 	permit lifecycle.LongLivedPermit,
-) (PreparedJob, *autoDetectionFailure, error) {
+) (PreparedJob, *autoDetectionFailure, activationFailure) {
 	if dcjc == nil || dcjc.factory == nil {
-		return PreparedJob{}, nil, errors.New("job output: invalid contained job preparation")
+		return PreparedJob{}, nil, classifyActivationError(errors.New("job output: invalid contained job preparation"))
 	}
 	stage, err := dcjc.factory.newCandidate(config)
 	if err != nil {
-		return PreparedJob{}, nil, err
+		return PreparedJob{}, nil, classifyActivationError(err)
 	}
 	defer stage.Release()
 	if err := dcjc.factory.awaitCandidate(ctx, stage); err != nil {
-		return PreparedJob{}, nil, err
+		return PreparedJob{}, nil, classifyActivationError(err)
 	}
-	return dcjc.factory.prepareCandidate(identity, permit, stage)
+	prepared, probeFailure, err := dcjc.factory.prepareCandidate(identity, permit, stage)
+	return prepared, probeFailure, classifyActivationError(err)
 }

--- a/src/go/plugin/agent/jobmgr/joboutput/construction_error.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/construction_error.go
@@ -2,20 +2,7 @@
 
 package joboutput
 
-import (
-	"errors"
-
-	secretresolver "github.com/netdata/netdata/go/plugins/plugin/agent/secrets/resolver"
-	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
-)
-
-type constructionErrorClass uint8
-
-const (
-	constructionErrorOperational constructionErrorClass = iota
-	constructionErrorProposal
-	constructionErrorTransient
-)
+import "github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
 
 type invalidJobConfigurationError struct {
 	cause error
@@ -45,37 +32,18 @@ func invalidJobConfiguration(err error) error {
 	if err == nil {
 		return nil
 	}
-	return &invalidJobConfigurationError{cause: err}
+	return &invalidJobConfigurationError{
+		cause: err,
+	}
 }
 
 func transientJobConstruction(err error) error {
 	if err == nil {
 		return nil
 	}
-	return &transientJobConstructionError{cause: err}
-}
-
-func classifyConstructionError(err error) constructionErrorClass {
-	var transient *transientJobConstructionError
-	if errors.As(err, &transient) {
-		return constructionErrorTransient
+	return &transientJobConstructionError{
+		cause: err,
 	}
-
-	var resolveErr *secretresolver.AtomicResolveError
-	if errors.As(err, &resolveErr) {
-		switch resolveErr.Kind {
-		case secretresolver.AtomicErrorProvider, secretresolver.AtomicErrorScope:
-			return constructionErrorTransient
-		default:
-			return constructionErrorProposal
-		}
-	}
-
-	var invalid *invalidJobConfigurationError
-	if errors.As(err, &invalid) {
-		return constructionErrorProposal
-	}
-	return constructionErrorOperational
 }
 
 func transientActivationFailure(config confgroup.Config, err error) *autoDetectionFailure {

--- a/src/go/plugin/agent/jobmgr/joboutput/discovery.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/discovery.go
@@ -292,17 +292,18 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 			cleanup,
 		)
 	}
-	successor, probeFailure, err := dcjc.prepareContainedJob(
+	successor, probeFailure, activation := dcjc.prepareContainedJob(
 		ctx,
 		change.Config,
 		scope.Successor,
 		permit,
 	)
-	if err != nil {
+	if err := activation.err; err != nil {
 		if ctx.Err() != nil || lifecycle.OwnershipRetained(err) {
 			return nil, err
 		}
-		if errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+		switch activation.kind {
+		case activationFailureQuarantined:
 			failedPostimage := postimage
 			failedPostimage.Status = dyncfg.StatusFailed.String()
 			return dcjc.prepareMutationWithRetryAfterApply(
@@ -323,8 +324,7 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 				pendingSettlement,
 				jobConfigFailure(err, "activation"),
 			)
-		}
-		if candidatePreparationBusy(err) {
+		case activationFailureBusy, activationFailureStaleStore:
 			baselineUID := ""
 			if exists {
 				baselineUID = incumbent.UID()
@@ -343,11 +343,9 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 					),
 				),
 			)
-		}
-		if errors.Is(err, jobmgr.ErrProcessAttemptSuperseded) {
+		case activationFailureSuperseded:
 			return dcjc.noopWithAfterApply(scope, current, permit, result, settlement)
-		}
-		if errors.Is(err, jobmgr.ErrProcessAttemptDeadline) {
+		case activationFailureDeadline:
 			failedPostimage := postimage
 			failedPostimage.Status = dyncfg.StatusFailed.String()
 			return dcjc.prepareMutationWithRetryAfterApply(
@@ -375,9 +373,7 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 				),
 				jobConfigFailure(err, "activation"),
 			)
-		}
-		switch classifyConstructionError(err) {
-		case constructionErrorTransient:
+		case activationFailureTransient:
 			failedPostimage := postimage
 			failedPostimage.Status = dyncfg.StatusFailed.String()
 			failure := transientActivationFailure(change.Config, err)
@@ -404,7 +400,7 @@ func (dcjc *DynCfgJobController) prepareDiscovered(
 				),
 				jobConfigFailure(err, "activation"),
 			)
-		case constructionErrorProposal:
+		case activationFailureProposal:
 			return nil, jobmgr.RejectProposal(err)
 		default:
 			return nil, err

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_jobs.go
@@ -166,9 +166,8 @@ func (dcjc *DynCfgJobController) Handle(
 				return lifecycle.SealedResult{}, err
 			}
 			code := 422
-			if errors.Is(err, jobmgr.ErrProcessAttemptBusy) ||
-				errors.Is(err, jobmgr.ErrProcessAttemptDeadline) ||
-				errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+			switch classifyActivationError(err).kind {
+			case activationFailureBusy, activationFailureDeadline, activationFailureQuarantined:
 				code = 503
 			}
 			return dynCfgMessage(code, err.Error())
@@ -192,9 +191,8 @@ func (dcjc *DynCfgJobController) Handle(
 				return lifecycle.SealedResult{}, err
 			}
 			code := 500
-			if errors.Is(err, jobmgr.ErrProcessAttemptBusy) ||
-				errors.Is(err, jobmgr.ErrProcessAttemptDeadline) ||
-				errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+			switch classifyActivationError(err).kind {
+			case activationFailureBusy, activationFailureDeadline, activationFailureQuarantined:
 				code = 503
 			}
 			return dynCfgMessage(code, err.Error())

--- a/src/go/plugin/agent/jobmgr/joboutput/dyncfg_prepare.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/dyncfg_prepare.go
@@ -4,10 +4,8 @@ package joboutput
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
 	"github.com/netdata/netdata/go/plugins/plugin/framework/confgroup"
@@ -37,9 +35,8 @@ func (dcjc *DynCfgJobController) prepareAdd(
 	if _, err := dcjc.runConfigOperation(ctx, config, configOperationValidate, true); err != nil {
 		// The resource lane stays active while validation yields the graph
 		// claim, so same-resource DynCfg work cannot supersede this attempt.
-		if errors.Is(err, jobmgr.ErrProcessAttemptBusy) ||
-			errors.Is(err, jobmgr.ErrProcessAttemptDeadline) ||
-			errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+		switch classifyActivationError(err).kind {
+		case activationFailureBusy, activationFailureDeadline, activationFailureQuarantined:
 			return dcjc.noop(
 				scope,
 				current,
@@ -152,9 +149,9 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 			}
 			// The resource lane stays active while validation yields the graph
 			// claim, so same-resource DynCfg work cannot supersede this attempt.
-			if errors.Is(err, jobmgr.ErrProcessAttemptBusy) ||
-				errors.Is(err, jobmgr.ErrProcessAttemptDeadline) ||
-				errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+			code := 400
+			switch classifyActivationError(err).kind {
+			case activationFailureBusy, activationFailureDeadline, activationFailureQuarantined:
 				return dcjc.noop(
 					scope,
 					current,
@@ -162,13 +159,12 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 					mustDynCfgMessage(503, "config validation is busy; retry the command."),
 					dcjc.configStatusCleanup(target.resourceID, dyncfg.StatusDisabled),
 				)
-			}
-			if classifyConstructionError(err) == constructionErrorOperational {
-				return nil, err
-			}
-			code := 400
-			if classifyConstructionError(err) == constructionErrorTransient {
+			case activationFailureTransient:
 				code = 503
+			case activationFailureProposal:
+				// Invalid disabled proposals preserve the existing configuration.
+			default:
+				return nil, err
 			}
 			return dcjc.noop(
 				scope,
@@ -190,17 +186,18 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 			cleanup,
 		)
 	}
-	successor, probeFailure, err := dcjc.prepareContainedJob(
+	successor, probeFailure, activation := dcjc.prepareContainedJob(
 		ctx,
 		config,
 		scope.Successor,
 		permit,
 	)
-	if err != nil {
+	if err := activation.err; err != nil {
 		if ctx.Err() != nil || lifecycle.OwnershipRetained(err) {
 			return nil, err
 		}
-		if errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+		switch activation.kind {
+		case activationFailureQuarantined:
 			failedPostimage := postimage
 			failedPostimage.Status = dyncfg.StatusFailed.String()
 			return dcjc.prepareMutationWithRetryAfterApply(
@@ -225,9 +222,7 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 				nil,
 				jobConfigFailure(err, "activation"),
 			)
-		}
-		if candidatePreparationBusy(err) ||
-			errors.Is(err, jobmgr.ErrProcessAttemptSuperseded) {
+		case activationFailureBusy, activationFailureStaleStore, activationFailureSuperseded:
 			return dcjc.noop(
 				scope,
 				current,
@@ -235,8 +230,7 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 				mustDynCfgMessage(503, "config update is busy; retry the command."),
 				dcjc.configStatusCleanup(target.resourceID, dyncfg.Status(record.Status)),
 			)
-		}
-		if errors.Is(err, jobmgr.ErrProcessAttemptDeadline) {
+		case activationFailureDeadline:
 			failedPostimage := postimage
 			failedPostimage.Status = dyncfg.StatusFailed.String()
 			return dcjc.prepareTransientConstructionFailure(
@@ -250,9 +244,7 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 				config,
 				err,
 			)
-		}
-		switch classifyConstructionError(err) {
-		case constructionErrorTransient:
+		case activationFailureTransient:
 			failedPostimage := postimage
 			failedPostimage.Status = dyncfg.StatusFailed.String()
 			return dcjc.prepareTransientConstructionFailure(
@@ -266,7 +258,7 @@ func (dcjc *DynCfgJobController) prepareUpdate(
 				config,
 				err,
 			)
-		case constructionErrorProposal:
+		case activationFailureProposal:
 			return dcjc.noop(
 				scope,
 				current,
@@ -454,17 +446,18 @@ func (dcjc *DynCfgJobController) prepareRunningTransition(
 	if err != nil {
 		return nil, err
 	}
-	successor, probeFailure, err := dcjc.prepareContainedJob(
+	successor, probeFailure, activation := dcjc.prepareContainedJob(
 		ctx,
 		config,
 		scope.Successor,
 		permit,
 	)
-	if err != nil {
+	if err := activation.err; err != nil {
 		if ctx.Err() != nil || lifecycle.OwnershipRetained(err) {
 			return nil, err
 		}
-		if errors.Is(err, jobmgr.ErrProcessAttemptQuarantined) {
+		switch activation.kind {
+		case activationFailureQuarantined:
 			failedPostimage := graphConfig(record, dyncfg.StatusFailed)
 			return dcjc.prepareMutationWithRetryAfterApply(
 				scope,
@@ -482,9 +475,7 @@ func (dcjc *DynCfgJobController) prepareRunningTransition(
 				nil,
 				jobConfigFailure(err, "activation"),
 			)
-		}
-		if candidatePreparationBusy(err) ||
-			errors.Is(err, jobmgr.ErrProcessAttemptSuperseded) {
+		case activationFailureBusy, activationFailureStaleStore, activationFailureSuperseded:
 			return dcjc.noop(
 				scope,
 				current,
@@ -492,8 +483,7 @@ func (dcjc *DynCfgJobController) prepareRunningTransition(
 				mustDynCfgMessage(503, "job activation is busy; retry the command."),
 				dcjc.configStatusCleanup(target.resourceID, dyncfg.Status(record.Status)),
 			)
-		}
-		if errors.Is(err, jobmgr.ErrProcessAttemptDeadline) {
+		case activationFailureDeadline:
 			failedPostimage := graphConfig(record, dyncfg.StatusFailed)
 			return dcjc.prepareTransientConstructionFailure(
 				scope,
@@ -506,9 +496,7 @@ func (dcjc *DynCfgJobController) prepareRunningTransition(
 				config,
 				err,
 			)
-		}
-		switch classifyConstructionError(err) {
-		case constructionErrorTransient:
+		case activationFailureTransient:
 			failedPostimage := graphConfig(record, dyncfg.StatusFailed)
 			failure := transientActivationFailure(config, err)
 			return dcjc.prepareTransientConstructionFailure(
@@ -522,7 +510,7 @@ func (dcjc *DynCfgJobController) prepareRunningTransition(
 				config,
 				err,
 			)
-		case constructionErrorProposal:
+		case activationFailureProposal:
 			return onPrepareFailure(err)
 		default:
 			return nil, err

--- a/src/go/plugin/agent/jobmgr/joboutput/secret_restart.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/secret_restart.go
@@ -143,7 +143,11 @@ func (dcjc *DynCfgJobController) PlanSecretDependentStop(id string) (jobmgr.Work
 					dcjc.configStatusCleanup(id, dyncfg.StatusFailed),
 					autoDetectionRetryToken{},
 					state.markStopped,
-					collectorapi.JobConfigFailure{Stage: "secret_restart", Reason: "dependent_stopped", CompletedAt: time.Now()},
+					collectorapi.JobConfigFailure{
+						Stage:       "secret_restart",
+						Reason:      "dependent_stopped",
+						CompletedAt: time.Now(),
+					},
 				)
 			},
 		},
@@ -209,21 +213,25 @@ func (dcjc *DynCfgJobController) PlanSecretDependentStart(
 				if cloned.FullName() != id {
 					return nil, errors.New("job output: dependent start identity differs")
 				}
-				successor, probeFailure, prepareErr := dcjc.prepareContainedJob(
+				successor, probeFailure, activation := dcjc.prepareContainedJob(
 					ctx,
 					cloned,
 					scope.Successor,
 					permit,
 				)
-				if prepareErr != nil {
+				if prepareErr := activation.err; prepareErr != nil {
 					if ctx.Err() != nil || lifecycle.OwnershipRetained(prepareErr) {
 						return nil, prepareErr
 					}
 					postimage := graphConfig(record, dyncfg.StatusFailed)
 					var pending func()
-					if candidatePreparationBusy(prepareErr) ||
-						errors.Is(prepareErr, jobmgr.ErrProcessAttemptDeadline) {
+					switch activation.kind {
+					case activationFailureBusy, activationFailureStaleStore, activationFailureDeadline:
 						pending = state.RetainPending
+					case activationFailureTransient:
+						pending = func() {
+							dcjc.scheduleAutoDetectionRetry(cloned, transientActivationFailure(cloned, prepareErr))
+						}
 					}
 					return dcjc.prepareMutationWithRetryAfterApply(
 						scope,

--- a/src/go/plugin/agent/jobmgr/joboutput/transaction.go
+++ b/src/go/plugin/agent/jobmgr/joboutput/transaction.go
@@ -442,10 +442,10 @@ func (prt *PreparedResourceTransaction) Apply(ctx context.Context) (
 }
 
 func activationFallback(spec ResourceTransactionSpec, err error) *ResourceActivationFallback {
-	switch {
-	case errors.Is(err, jobmgr.ErrProcessAttemptQuarantined):
+	switch classifyActivationError(err).kind {
+	case activationFailureQuarantined:
 		return spec.ActivationQuarantinedFallback
-	case errors.Is(err, jobmgr.ErrProcessAttemptBusy):
+	case activationFailureBusy:
 		return spec.ActivationBusyFallback
 	default:
 		return nil


### PR DESCRIPTION
##### Summary

Centralize activation failure classification across entry paths. Restore automatic retries after transient secret-resolution failures during dependent-job restart, preserving command-specific behavior.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies activation failure classification across discovery, DynCfg, and secret-dependent job restart paths, and restores automatic retries after transient secret-resolution failures.

**Behavior**
- All entry paths now share one classifier; each caller keeps its command-specific response and recovery policy.
- Transient provider/scope or construction failures during secret-dependent restart schedule the ordinary autodetection retry after the Failed mutation applies.
- A later disable, removal, replacement, or run stop revokes that retry; invalid proposals, quarantine, and permanent result-limit failures never gain a timed retry.
- Synchronous UPDATE still preserves its incumbent on busy or stale-store preparation, while accepted ENABLE keeps timed recovery.
- Adds process-level tests covering V1/V2 recovery, disable cancellation, and permanent result-limit failure, and documents the recovery rules in `ARCHITECTURE.md`.

<sup>Written for commit e979b9c6d5013dbc9d51443f75307e2bab5599ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic recovery after temporary failures during secret rotation and dependent job restarts.
  - Explicitly disabling a secret now cancels pending recovery attempts.
  - Permanent failures, including oversized replacements, are no longer retried.
  - Activation failures now receive consistent handling across job discovery, configuration changes, accepted jobs, and restarts.
  - Busy, deadline, quarantined, and invalid requests retain consistent response behavior.

- **Documentation**
  - Documented activation failure categories, retry behavior, and recovery timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->