### PR TITLE
fix(go.d): report Function failures and honor finalizer context

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -1040,6 +1040,19 @@ agent-level module) stages one stable process-owned handler bundle outside contr
 `functions/bundle.go`, `functions/module_stage.go`, `functions/controller.go`, `containment/authority.go`,
 `process_attempt.go`.
 
+Availability callback, contained-attempt, and asynchronous reconciliation failures emit separate fixed diagnostic
+categories through the process observer. Events contain the run generation, sanitized bundle identity, and a safe
+failure/panic classification; callback error text and recovered values are omitted. The production logger limits
+each category to one message per hour across all bundles and run generations. Pure cancellation, retirement,
+supersession, and process-stop results remain quiet; mixed failures remain observable. Existing containment events
+and synchronous reconciliation error propagation keep their separate roles.
+
+Run finalization passes its caller's context through `FunctionAssembly.FinalizeRun` and `Controller.Stop` to any
+remaining bundle cleanup waits. Wait expiry does not complete physical cleanup or reopen publication. Agent-module
+owners are released without waiting in the run finalizer; their process attempts keep ownership until the handler
+actually returns. Physical handler cleanup retains its process-owned context. Normal kernel shutdown detaches job
+handles before finalization; the cancelable waits also cover retained job bundles at the assembly boundary.
+
 ### DynCfg is not a published Function
 
 - DynCfg `config` prefix routes are **private catalog routes**, not Function publications. Netdata owns the global

--- a/src/go/plugin/agent/jobmgr/composition/diagnostics.go
+++ b/src/go/plugin/agent/jobmgr/composition/diagnostics.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"log/slog"
 	"sync/atomic"
+	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
 	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	functionadapter "github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/functions"
 )
 
 type diagnosticLogger struct {
@@ -69,6 +71,21 @@ func (dl *diagnosticLogger) ObserveDiagnostic(event jobmgr.DiagnosticEvent) {
 		attributes = append(attributes, slog.String("error", event.Err.Error()))
 	}
 	log := dl.logger.With(attributes...)
+	switch event.Name {
+	case functionadapter.DiagnosticAvailabilityCallbackFailed,
+		functionadapter.DiagnosticAvailabilityAttemptFailed,
+		functionadapter.DiagnosticAvailabilityReconciliationFailed:
+		// Poll failures can recur every scheduler tick across many bundles. Use
+		// fixed category keys shared across jobs and run generations.
+		limited := log.Limit(event.Name, 1, time.Hour)
+		switch event.Level {
+		case jobmgr.DiagnosticWarning:
+			limited.Warning(event.Name)
+		case jobmgr.DiagnosticError:
+			limited.Error(event.Name)
+		}
+		return
+	}
 	// The jobmgr.ObserveDiagnostic production gateway rejects invalid levels before dispatch.
 	switch event.Level {
 	case jobmgr.DiagnosticInfo:

--- a/src/go/plugin/agent/jobmgr/composition/function_availability_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/function_availability_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composition
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/containment"
+	functionadapter "github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/functions"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunFunctionAvailabilityDiagnosticsAreSafeAndBounded(t *testing.T) {
+	const eventName = "Function availability callback failed"
+	const secret = "synthetic-backend-password"
+	output := newProcessSynchronizedBuffer()
+	logs := newProcessSynchronizedBuffer()
+	diagnostics := &availabilityTestDiagnostics{
+		sink:   newDiagnosticLogger(logs),
+		events: make(chan jobmgr.DiagnosticEvent, 16),
+	}
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	uids := lifecycle.NewUIDLedger()
+	var mode atomic.Int32
+	generation, err := newTestRunGeneration(t, runGenerationConfig{
+		Generation:      7,
+		ShutdownTimeout: time.Second,
+		Diagnostics:     diagnostics,
+		UIDs:            uids,
+		Frames:          frames,
+		Modules: collectorapi.Registry{
+			"module": {
+				AgentFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{
+						ID: "method",
+						Available: func() bool {
+							if mode.Load() == 1 {
+								panic(secret)
+							}
+							return mode.Load() == 2
+						},
+					}}
+				},
+				MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+					return &assemblyTestHandler{}
+				},
+			},
+		},
+		Jobs:      testRunJobServices(t),
+		Discovery: testRunDiscoveryServices(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		generation.Stop()
+		require.NoError(t, generation.Wait(context.Background()))
+		closeRunTestUIDs(t, uids)
+	})
+	require.NoError(t, generation.start(context.Background()))
+	require.NotContains(t, output.String(), `FUNCTION GLOBAL "module:method"`)
+
+	mode.Store(1)
+	for range 3 {
+		require.NoError(t, generation.functions.ReconcileModule(t.Context(), "module"))
+		select {
+		case event := <-diagnostics.events:
+			require.Equal(t, eventName, event.Name)
+			require.Equal(t, "panic", event.State)
+			require.EqualValues(t, 7, event.Generation)
+			require.Nil(t, event.Err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "availability callback failure was not diagnosed")
+		}
+	}
+	require.Equal(t, 1, strings.Count(logs.String(), eventName))
+	require.NotContains(t, logs.String(), secret)
+	require.NotContains(t, output.String(), secret)
+	require.NotContains(t, output.String(), `FUNCTION GLOBAL "module:method"`)
+	require.NoError(t, generation.run.DirtyCause())
+
+	// Recovery must still flow through the poll, kernel mutation and normal
+	// Function publication; diagnostic suppression must not suppress work.
+	mode.Store(2)
+	require.NoError(t, generation.functions.ReconcileModule(t.Context(), "module"))
+	require.Eventually(t, func() bool {
+		return strings.Contains(output.String(), `FUNCTION GLOBAL "module:method"`)
+	}, time.Second, time.Millisecond)
+	select {
+	case event := <-diagnostics.events:
+		require.FailNow(t, "successful availability poll emitted a failure", "%+v", event)
+	default:
+	}
+}
+
+func TestFunctionAvailabilityReconciliationCollisionIsDiagnosed(t *testing.T) {
+	output := newProcessSynchronizedBuffer()
+	logs := newProcessSynchronizedBuffer()
+	diagnostics := &availabilityTestDiagnostics{
+		sink:   newDiagnosticLogger(logs),
+		events: make(chan jobmgr.DiagnosticEvent, 16),
+	}
+	attempts, err := containment.NewAuthority(diagnostics)
+	require.NoError(t, err)
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	var available atomic.Bool
+	var initialCalls atomic.Int32
+	assembly, err := NewContainedFunctionAssembly(
+		context.Background(), 7, attempts, diagnostics,
+		collectorapi.Registry{
+			"module": {
+				AgentFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{ID: "method", Available: available.Load}}
+				},
+				MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler {
+					return &assemblyTestHandler{}
+				},
+			},
+		},
+		frames,
+		functionadapter.InitialRoute{
+			Declaration: functionadapter.Declaration{
+				ID:         "initial",
+				PublicName: "module:method",
+				Generation: &functionadapter.HandlerGenerationDeclaration{
+					ID: "initial",
+					Handler: func(context.Context, functionadapter.HandlerInput) (lifecycle.SealedResult, error) {
+						initialCalls.Add(1)
+						return lifecycle.NewSealedResult(200, "text/plain", nil)
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, stopFunctionAssembly(assembly, 7))
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, attempts.Shutdown(ctx))
+	})
+	catalog := assembly.Catalog().(*functionadapter.Catalog)
+	require.NoError(t, assembly.Bind(&assemblyMutationPort{
+		catalog: catalog,
+	}))
+	require.NoError(t, assembly.Activate())
+	available.Store(true)
+	require.NoError(t, assembly.ReconcileModule(t.Context(), "module"))
+	select {
+	case event := <-diagnostics.events:
+		require.Equal(t, "Function availability reconciliation failed", event.Name)
+		require.Equal(t, "failed", event.State)
+		require.EqualValues(t, 7, event.Generation)
+		require.Nil(t, event.Err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "availability route collision was not diagnosed")
+	}
+	require.Empty(t, output.String(), "colliding route must not be externally published")
+	decision, err := catalog.ResolveAndAcquire(jobmgr.FunctionLookup{
+		UID:   "retained-initial",
+		Route: "module:method",
+	})
+	require.NoError(t, err)
+	require.Zero(t, decision.Rejected)
+	_, err = decision.Plan.Work(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, initialCalls.Load())
+	_, err = catalog.ReleaseInvocation(decision.Lease)
+	require.NoError(t, err)
+}
+
+type availabilityTestDiagnostics struct {
+	sink   jobmgr.DiagnosticObserver
+	events chan jobmgr.DiagnosticEvent
+}
+
+func (d *availabilityTestDiagnostics) ObserveDiagnostic(event jobmgr.DiagnosticEvent) {
+	d.sink.ObserveDiagnostic(event)
+	if strings.HasPrefix(event.Name, "Function availability ") {
+		d.events <- event
+	}
+}

--- a/src/go/plugin/agent/jobmgr/composition/function_finalization_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/function_finalization_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package composition
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/containment"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFunctionFinalizerHonorsRetainedBundleWaitContext(t *testing.T) {
+	for _, deadline := range []bool{false, true} {
+		name := "cancellation"
+		if deadline {
+			name = "deadline"
+		}
+		t.Run(name, func(t *testing.T) {
+			frames, err := lifecycle.NewFrameOwner(io.Discard)
+			require.NoError(t, err)
+			release := make(chan struct{})
+			var releaseOnce sync.Once
+			releaseCleanup := func() { releaseOnce.Do(func() { close(release) }) }
+			handlers := map[string]*finalizerTestHandler{
+				"first":  newFinalizerTestHandler(release),
+				"second": newFinalizerTestHandler(release),
+			}
+			assembly, err := newTestFunctionAssembly(t, 1, collectorapi.Registry{
+				"module": {
+					SharedFunctions: func() []funcapi.FunctionConfig {
+						return []funcapi.FunctionConfig{{ID: "method"}}
+					},
+					MethodHandler: func(job collectorapi.RuntimeJob) funcapi.MethodHandler {
+						return handlers[job.Name()]
+					},
+				},
+			}, frames)
+			require.NoError(t, err)
+			// Release blocked callbacks before the assembly helper's cleanup, including
+			// when the baseline ignores cancellation and this regression fails.
+			t.Cleanup(releaseCleanup)
+			require.NoError(t, assembly.Bind(&assemblyMutationPort{
+				catalog: assembly.catalog,
+			}))
+			require.NoError(t, assembly.Activate())
+			for name := range handlers {
+				job := &finalizerTestJob{
+					name: name,
+				}
+				staged, err := assembly.jobLifecycle().Stage(job)
+				require.NoError(t, err)
+				handle, err := assembly.jobLifecycle().Attach(lifecycle.ResourceIdentity{
+					ID:         job.FullName(),
+					Generation: 1,
+				}, staged)
+				require.NoError(t, err)
+				require.NoError(t, handle.Publish())
+			}
+			// Exercise the retained-bundle fallback through real attachment and catalog
+			// transitions. Normal kernel shutdown detaches these job handles first.
+			require.NoError(t, closeFunctionAssemblyCatalog(assembly, 1))
+			ctx, cancel := context.WithCancel(context.Background())
+			if deadline {
+				cancel()
+				ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+			}
+			defer cancel()
+			finished := make(chan error, 1)
+			go func() { finished <- assembly.FinalizeRun(ctx, 1) }()
+			require.Eventually(t, func() bool {
+				return handlers["first"].calls.Load()+handlers["second"].calls.Load() > 0
+			}, time.Second, time.Millisecond)
+			if !deadline {
+				cancel()
+			}
+			select {
+			case err := <-finished:
+				require.ErrorIs(t, err, ctx.Err())
+			case <-time.After(time.Second):
+				t.Fatal("Function finalization ignored its caller's wait context")
+			}
+			for _, handler := range handlers {
+				select {
+				case cleanupCtx := <-handler.entered:
+					require.NoError(t, cleanupCtx.Err(), "wait cancellation must not cancel physical cleanup")
+				case <-time.After(time.Second):
+					t.Fatal("expired wait prevented another bundle from retiring")
+				}
+				select {
+				case <-handler.done:
+					t.Fatal("caller wait reported physical cleanup completion before callback returned")
+				default:
+				}
+				require.EqualValues(t, 1, handler.calls.Load())
+			}
+			require.Error(t, assembly.Activate(), "finalization must not reopen publication")
+			releaseCleanup()
+			for _, handler := range handlers {
+				waitShutdownFunctionGate(t, handler.done, "retained handler cleanup")
+				require.EqualValues(t, 1, handler.calls.Load())
+			}
+		})
+	}
+}
+
+func TestFunctionFinalizerRejectsNilContextWithoutStopping(t *testing.T) {
+	frames, err := lifecycle.NewFrameOwner(io.Discard)
+	require.NoError(t, err)
+	assembly, err := newTestFunctionAssembly(t, 1, collectorapi.Registry{}, frames)
+	require.NoError(t, err)
+	require.NoError(t, assembly.Bind(&assemblyMutationPort{
+		catalog: assembly.catalog,
+	}))
+	require.NoError(t, assembly.Activate())
+	require.NoError(t, closeFunctionAssemblyCatalog(assembly, 1))
+	require.Error(t, assembly.FinalizeRun(nil, 1))
+	require.NoError(t, assembly.FinalizeRun(context.Background(), 1))
+}
+
+func TestFunctionRunFinalizationRetainsPhysicalModuleCleanup(t *testing.T) {
+	output := newProcessSynchronizedBuffer()
+	frames, err := lifecycle.NewFrameOwner(output)
+	require.NoError(t, err)
+	attempts, err := containment.NewAuthority(nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, attempts.Shutdown(ctx))
+	})
+	release := make(chan struct{})
+	var once sync.Once
+	releaseCleanup := func() { once.Do(func() { close(release) }) }
+	handler := newFinalizerTestHandler(release)
+	uids := lifecycle.NewUIDLedger()
+	generation, err := newTestRunGeneration(t, runGenerationConfig{
+		Generation:      1,
+		Attempts:        attempts,
+		ShutdownTimeout: time.Second,
+		UIDs:            uids,
+		Frames:          frames,
+		Modules: collectorapi.Registry{
+			"module": {
+				AgentFunctions: func() []funcapi.FunctionConfig {
+					return []funcapi.FunctionConfig{{ID: "method"}}
+				},
+				MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler { return handler },
+			},
+		},
+		Jobs:      testRunJobServices(t),
+		Discovery: testRunDiscoveryServices(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		releaseCleanup()
+		generation.Stop()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, generation.Wait(ctx))
+		closeRunTestUIDs(t, uids)
+	})
+	require.NoError(t, generation.start(context.Background()))
+	generation.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, generation.Wait(ctx), "run finalization must not wait for process-owned handler cleanup")
+	select {
+	case cleanupCtx := <-handler.entered:
+		require.NoError(t, cleanupCtx.Err())
+	case <-ctx.Done():
+		t.Fatal("module handler cleanup did not start")
+	}
+	require.Equal(t, containment.Census{
+		Active:   1,
+		Admitted: 1,
+	}, attempts.Census())
+	require.Contains(t, output.String(), `FUNCTION_DEL GLOBAL "module:method"`)
+	require.NoError(t, generation.run.DirtyCause())
+	releaseCleanup()
+	waitShutdownFunctionGate(t, handler.done, "process-owned module cleanup")
+	require.Eventually(t, func() bool {
+		return attempts.Census() == (containment.Census{})
+	}, time.Second, time.Millisecond)
+	require.EqualValues(t, 1, handler.calls.Load())
+}
+
+type finalizerTestHandler struct {
+	assemblyTestHandler
+	release <-chan struct{}
+	entered chan context.Context
+	done    chan struct{}
+	calls   atomic.Int32
+}
+
+func newFinalizerTestHandler(release <-chan struct{}) *finalizerTestHandler {
+	return &finalizerTestHandler{
+		release: release,
+		entered: make(chan context.Context, 1),
+		done:    make(chan struct{}),
+	}
+}
+
+func (h *finalizerTestHandler) Cleanup(ctx context.Context) {
+	h.calls.Add(1)
+	h.entered <- ctx
+	<-h.release
+	close(h.done)
+}
+
+type finalizerTestJob struct {
+	assemblyTestJob
+	name string
+}
+
+func (job *finalizerTestJob) FullName() string { return "module_" + job.name }
+func (job *finalizerTestJob) Name() string     { return job.name }

--- a/src/go/plugin/agent/jobmgr/composition/functions.go
+++ b/src/go/plugin/agent/jobmgr/composition/functions.go
@@ -27,6 +27,7 @@ func NewContainedFunctionAssembly(
 	ctx context.Context,
 	epoch uint64,
 	attempts jobmgr.ProcessAttemptAuthority,
+	diagnostics jobmgr.DiagnosticObserver,
 	modules collectorapi.Registry,
 	frames *lifecycle.FrameOwner,
 	initial ...functionadapter.InitialRoute,
@@ -38,6 +39,7 @@ func NewContainedFunctionAssembly(
 		ctx,
 		epoch,
 		attempts,
+		diagnostics,
 		modules,
 		initial...,
 	)
@@ -139,11 +141,11 @@ func (fa *FunctionAssembly) BeforeFunctionCatalogClose(_ context.Context, genera
 
 // FinalizeRun terminalizes controller-owned Function state after the kernel has
 // drained the catalog and every job handle.
-func (fa *FunctionAssembly) FinalizeRun(_ context.Context, generation uint64) error {
+func (fa *FunctionAssembly) FinalizeRun(ctx context.Context, generation uint64) error {
 	if fa == nil {
 		return nil
 	}
-	return fa.controller.Stop(generation)
+	return fa.controller.Stop(ctx, generation)
 }
 
 type functionJobLifecycle struct {

--- a/src/go/plugin/agent/jobmgr/composition/functions_test.go
+++ b/src/go/plugin/agent/jobmgr/composition/functions_test.go
@@ -22,6 +22,13 @@ import (
 // stopFunctionAssembly runs the same shutdown sequence the kernel drives in
 // production: shutdown barrier, catalog drain, then run finalization.
 func stopFunctionAssembly(fa *FunctionAssembly, epoch uint64) error {
+	if err := closeFunctionAssemblyCatalog(fa, epoch); err != nil {
+		return err
+	}
+	return fa.FinalizeRun(context.Background(), epoch)
+}
+
+func closeFunctionAssemblyCatalog(fa *FunctionAssembly, epoch uint64) error {
 	if fa == nil {
 		return nil
 	}
@@ -56,7 +63,7 @@ func stopFunctionAssembly(fa *FunctionAssembly, epoch uint64) error {
 	if !catalog.LifecycleDrained() {
 		return errors.New("Function catalog did not drain")
 	}
-	return fa.FinalizeRun(context.Background(), epoch)
+	return nil
 }
 
 func newTestFunctionAssembly(
@@ -73,6 +80,7 @@ func newTestFunctionAssembly(
 		t.Context(),
 		epoch,
 		attempts,
+		nil,
 		modules,
 		frames,
 		initial...,

--- a/src/go/plugin/agent/jobmgr/composition/run.go
+++ b/src/go/plugin/agent/jobmgr/composition/run.go
@@ -217,6 +217,7 @@ func newRunGeneration(
 		ctx,
 		config.Generation,
 		config.Attempts,
+		config.Diagnostics,
 		config.Modules,
 		config.Frames,
 		initialRoutes...,

--- a/src/go/plugin/agent/jobmgr/functions/bundle_containment_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/bundle_containment_test.go
@@ -820,6 +820,7 @@ func TestContainedFunctionControllerPublishesSuccessfulAvailabilityTransition(t 
 		context.Background(),
 		1,
 		attempts,
+		nil,
 		collectorapi.Registry{
 			"module": {
 				AgentFunctions: func() []funcapi.FunctionConfig {
@@ -865,7 +866,7 @@ func TestContainedFunctionControllerPublishesSuccessfulAvailabilityTransition(t 
 			break
 		}
 	}
-	require.NoError(t, controller.Stop(1))
+	require.NoError(t, controller.Stop(context.Background(), 1))
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	require.NoError(t, attempts.Shutdown(shutdownCtx))

--- a/src/go/plugin/agent/jobmgr/functions/controller.go
+++ b/src/go/plugin/agent/jobmgr/functions/controller.go
@@ -22,10 +22,11 @@ import (
 )
 
 type Controller struct {
-	mu sync.Mutex // guards all fields
+	mu sync.Mutex // guards mutable fields
 
 	epoch       uint64 // run generation this controller belongs to
 	attempts    jobmgr.ProcessAttemptAuthority
+	diagnostics jobmgr.DiagnosticObserver   // immutable operational log sink
 	modules     collectorapi.Registry       // collector module registry
 	catalog     *Catalog                    // the route catalog it mutates
 	mutations   jobmgr.FunctionMutationPort // kernel Function-mutation port
@@ -294,6 +295,7 @@ func NewContainedController(
 	ctx context.Context,
 	epoch uint64,
 	attempts jobmgr.ProcessAttemptAuthority,
+	diagnostics jobmgr.DiagnosticObserver,
 	modules collectorapi.Registry,
 	initial ...InitialRoute,
 ) (*Controller, *Catalog, error) {
@@ -301,7 +303,7 @@ func NewContainedController(
 	if err != nil {
 		return nil, nil, err
 	}
-	controller, catalog, err := newControllerWithPlans(epoch, attempts, modules, plans, initial...)
+	controller, catalog, err := newControllerWithPlans(epoch, attempts, diagnostics, modules, plans, initial...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -311,6 +313,7 @@ func NewContainedController(
 func newControllerWithPlans(
 	epoch uint64,
 	attempts jobmgr.ProcessAttemptAuthority,
+	diagnostics jobmgr.DiagnosticObserver,
 	modules collectorapi.Registry,
 	plans map[string]controllerModulePlan,
 	initial ...InitialRoute,
@@ -324,6 +327,7 @@ func newControllerWithPlans(
 	controller := &Controller{
 		epoch:        epoch,
 		attempts:     attempts,
+		diagnostics:  diagnostics,
 		modules:      make(collectorapi.Registry, len(modules)),
 		plans:        plans,
 		jobs:         make(map[string]map[string]controllerJob),
@@ -669,26 +673,41 @@ func (c *Controller) finishAvailabilityPoll(
 	poll functionAvailabilityPoll,
 ) {
 	if err := poll.attempt.Await(context.Background()); err != nil {
+		if !jobmgr.ContainsOnlyErrorLeaves(err,
+			context.Canceled,
+			jobmgr.ErrProcessAttemptRetired,
+			jobmgr.ErrProcessAttemptStopped,
+			jobmgr.ErrProcessAttemptSuperseded,
+		) {
+			c.observeAvailabilityFailure(DiagnosticAvailabilityAttemptFailed, poll.bundle, err)
+		}
 		return
 	}
 	result := <-poll.workerResult
 	if result.err != nil {
+		c.observeAvailabilityFailure(DiagnosticAvailabilityCallbackFailed, poll.bundle, result.err)
 		return
 	}
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.usableLocked() != nil {
+		c.mu.Unlock()
 		return
 	}
 	if !poll.bundle.commitAvailability(result.availability) {
+		c.mu.Unlock()
 		return
 	}
-	_, _ = c.reconcileModuleLocked(context.Background(), module, creator)
+	_, err := c.reconcileModuleLocked(context.Background(), module, creator)
+	c.mu.Unlock()
+	c.observeAvailabilityFailure(DiagnosticAvailabilityReconciliationFailed, poll.bundle, err)
 }
 
-func (c *Controller) Stop(epoch uint64) error {
+func (c *Controller) Stop(ctx context.Context, epoch uint64) error {
 	if c == nil {
 		return nil
+	}
+	if ctx == nil {
+		return errors.New("jobmgr Function controller: nil stop context")
 	}
 	c.mu.Lock()
 	if epoch != c.epoch || !c.draining || c.terminated {
@@ -698,7 +717,7 @@ func (c *Controller) Stop(epoch uint64) error {
 	c.terminated = true
 	dirty := c.dirty
 	c.mu.Unlock()
-	return errors.Join(dirty, c.cleanupModuleBundles(context.Background()))
+	return errors.Join(dirty, c.cleanupModuleBundles(ctx))
 }
 
 // BeginShutdown withdraws external routes before CommandKernel closes the

--- a/src/go/plugin/agent/jobmgr/functions/controller_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/controller_test.go
@@ -391,7 +391,7 @@ func TestFunctionControllerWithdrawalFailureCleansUnpublishedSuccessor(t *testin
 			break
 		}
 	}
-	require.ErrorIs(t, controller.Stop(1), withdrawErr)
+	require.ErrorIs(t, controller.Stop(context.Background(), 1), withdrawErr)
 	require.Eventually(t, func() bool {
 		return predecessor.cleanupCount() == 1
 	}, time.Second, time.Millisecond)
@@ -846,6 +846,7 @@ func newContainedControllerTest(
 		t.Context(),
 		epoch,
 		attempts,
+		nil,
 		modules,
 		initial...,
 	)
@@ -870,7 +871,7 @@ func newContainedControllerTest(
 						}
 					}
 				}
-				_ = controller.Stop(epoch)
+				_ = controller.Stop(context.Background(), epoch)
 			}
 		}
 		attempts.BeginShutdown()

--- a/src/go/plugin/agent/jobmgr/functions/diagnostics.go
+++ b/src/go/plugin/agent/jobmgr/functions/diagnostics.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package functions
+
+import (
+	"errors"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+)
+
+// Stable categories let the production sink bound repeated poll diagnostics
+// without keeping per-job or per-error logging state.
+const (
+	DiagnosticAvailabilityCallbackFailed       = "Function availability callback failed"
+	DiagnosticAvailabilityAttemptFailed        = "Function availability attempt failed"
+	DiagnosticAvailabilityReconciliationFailed = "Function availability reconciliation failed"
+)
+
+func (c *Controller) observeAvailabilityFailure(name string, bundle *functionBundle, err error) {
+	if c == nil || c.diagnostics == nil || err == nil {
+		return
+	}
+	level := jobmgr.DiagnosticWarning
+	if name == DiagnosticAvailabilityReconciliationFailed {
+		level = jobmgr.DiagnosticError
+	}
+	state := "failed"
+	if errors.Is(err, lifecycle.ErrTaskPanic) {
+		state = "panic"
+	}
+	// Callback errors can contain recovered values or credentials. Keep only
+	// a fixed classification and the bundle's already-sanitized identity.
+	jobmgr.ObserveDiagnostic(c.diagnostics, jobmgr.DiagnosticEvent{
+		Name:       name,
+		Resource:   bundle.resource,
+		Generation: c.epoch,
+		State:      state,
+		Level:      level,
+	})
+}

--- a/src/go/plugin/agent/jobmgr/functions/diagnostics_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/diagnostics_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package functions
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/pkg/funcapi"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr"
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/containment"
+	"github.com/netdata/netdata/go/plugins/plugin/framework/collectorapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAvailabilityAttemptDiagnosticsDistinguishControlAndMixedFailures(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		cause  error
+		report bool
+	}{
+		{name: "canceled", cause: context.Canceled},
+		{name: "retired", cause: jobmgr.ErrProcessAttemptRetired},
+		{name: "stopped", cause: jobmgr.ErrProcessAttemptStopped},
+		{name: "superseded", cause: jobmgr.ErrProcessAttemptSuperseded},
+		{name: "joined control", cause: errors.Join(context.Canceled, jobmgr.ErrProcessAttemptRetired)},
+		{name: "mixed failure", cause: errors.Join(context.Canceled, errors.New("synthetic-password")), report: true},
+		{name: "deadline", cause: jobmgr.ErrProcessAttemptDeadline, report: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			attempts, err := containment.NewAuthority(nil)
+			require.NoError(t, err)
+			diagnostics := &availabilityDiagnosticRecorder{}
+			controller, _, err := NewContainedController(
+				context.Background(), 1, attempts, diagnostics, collectorapi.Registry{},
+			)
+			require.NoError(t, err)
+			var blocking atomic.Bool
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			bundle, err := newAgentFunctionBundle("module", collectorapi.Creator{
+				MethodHandler: func(collectorapi.RuntimeJob) funcapi.MethodHandler { return &controllerTestHandler{} },
+			}, []funcapi.FunctionConfig{{
+				ID: "method",
+				Available: func() bool {
+					if blocking.Load() {
+						close(entered)
+						<-release
+					}
+					return true
+				},
+			}})
+			require.NoError(t, err)
+			require.NoError(t, bundle.bindContainment(attempts, 1, "module-poll", "module"))
+			t.Cleanup(func() {
+				close(release)
+				bundle.retire()
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				require.NoError(t, bundle.wait(ctx))
+				require.NoError(t, controller.AbortConstruction(ctx))
+				require.NoError(t, attempts.Shutdown(ctx))
+			})
+			blocking.Store(true)
+			poll, err := bundle.startAvailabilityPoll()
+			require.NoError(t, err)
+			waitBundleContainmentTestValue(t, entered, "availability callback")
+			require.True(t, poll.attempt.Cut(test.cause))
+			finished := make(chan struct{})
+			go func() {
+				controller.finishAvailabilityPoll("module", collectorapi.Creator{}, poll)
+				close(finished)
+			}()
+			waitBundleContainmentTestValue(t, finished, "availability failure diagnostic")
+			if !test.report {
+				require.Empty(t, diagnostics.events)
+				return
+			}
+			require.Equal(t, []jobmgr.DiagnosticEvent{{
+				Name:       DiagnosticAvailabilityAttemptFailed,
+				Resource:   "module",
+				Generation: 1,
+				State:      "failed",
+				Level:      jobmgr.DiagnosticWarning,
+			}}, diagnostics.events)
+		})
+	}
+}
+
+type availabilityDiagnosticRecorder struct {
+	events []jobmgr.DiagnosticEvent
+}
+
+func (r *availabilityDiagnosticRecorder) ObserveDiagnostic(event jobmgr.DiagnosticEvent) {
+	r.events = append(r.events, event)
+}

--- a/src/go/plugin/agent/jobmgr/functions/module_stage_test.go
+++ b/src/go/plugin/agent/jobmgr/functions/module_stage_test.go
@@ -38,6 +38,7 @@ func TestContainedControllerAcceptsInvalidUTF8ModuleIdentity(t *testing.T) {
 		context.Background(),
 		1,
 		attempts,
+		nil,
 		collectorapi.Registry{module: {}},
 	)
 	require.NoError(t, err)
@@ -57,6 +58,7 @@ func TestContainedControllerAcceptsLongModuleIdentity(t *testing.T) {
 		context.Background(),
 		1,
 		attempts,
+		nil,
 		collectorapi.Registry{module: {}},
 	)
 	require.NoError(t, err)
@@ -76,6 +78,7 @@ func TestContainedControllerConsumesPlanPublishedBeforeSuccessfulSettlement(t *t
 				context.Background(),
 				1,
 				attempts,
+				nil,
 				collectorapi.Registry{"module": {}},
 			)
 			require.NoError(t, err)
@@ -96,6 +99,7 @@ func TestContainedControllerConstructionSettlesWhileModuleCallbackRemainsOwned(t
 			ctx,
 			1,
 			attempts,
+			nil,
 			collectorapi.Registry{
 				"module": {
 					AgentFunctions: func() []funcapi.FunctionConfig {
@@ -139,6 +143,7 @@ func TestContainedControllerAbortDoesNotWaitForHandlerCleanup(t *testing.T) {
 		context.Background(),
 		1,
 		attempts,
+		nil,
 		collectorapi.Registry{
 			"module": {
 				AgentFunctions: func() []funcapi.FunctionConfig {
@@ -188,7 +193,7 @@ func TestContainedControllerWaitsForPriorEpochModuleRelease(t *testing.T) {
 			},
 		},
 	}
-	first, _, err := NewContainedController(context.Background(), 1, attempts, modules)
+	first, _, err := NewContainedController(context.Background(), 1, attempts, nil, modules)
 	require.NoError(t, err)
 	require.NoError(t, first.AbortConstruction(context.Background()))
 	<-handler.cleanupEntered
@@ -201,7 +206,7 @@ func TestContainedControllerWaitsForPriorEpochModuleRelease(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	go func() {
-		controller, _, buildErr := NewContainedController(ctx, 2, attempts, modules)
+		controller, _, buildErr := NewContainedController(ctx, 2, attempts, nil, modules)
 		secondResult <- controllerResult{controller: controller, err: buildErr}
 	}()
 	select {
@@ -238,14 +243,14 @@ func TestContainedControllerRejectsPriorEpochModuleQuarantine(t *testing.T) {
 			},
 		},
 	}
-	first, _, err := NewContainedController(context.Background(), 1, attempts, modules)
+	first, _, err := NewContainedController(context.Background(), 1, attempts, nil, modules)
 	require.NoError(t, err)
 	require.NoError(t, first.AbortConstruction(context.Background()))
 	require.Eventually(t, func() bool {
 		return attempts.Census() == (containment.Census{Quarantined: 1})
 	}, time.Second, time.Millisecond)
 
-	second, _, err := NewContainedController(context.Background(), 2, attempts, modules)
+	second, _, err := NewContainedController(context.Background(), 2, attempts, nil, modules)
 	require.Nil(t, second)
 	require.ErrorIs(t, err, jobmgr.ErrProcessAttemptQuarantined)
 	require.Equal(t, containment.Census{Quarantined: 1}, attempts.Census())
@@ -264,6 +269,7 @@ func TestContainedControllerCanceledAfterModuleAdmissionCleansAbandonedPlan(t *t
 			ctx,
 			1,
 			attempts,
+			nil,
 			collectorapi.Registry{
 				"module": {
 					AgentFunctions: func() []funcapi.FunctionConfig {


### PR DESCRIPTION
##### Summary

Add sanitized, rate-limited diagnostics for Function availability failures. Propagate the finalizer context to cleanup waits while preserving physical cleanup ownership.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports Function availability failures with sanitized, rate-limited diagnostics, and propagates the run finalizer's context into retained bundle cleanup waits.

**Behavior**
- Availability callback panics/errors, contained-attempt failures, and reconciliation collisions now emit fixed diagnostic categories with run generation, sanitized bundle identity, and a safe failed/panic classification.
- Callback error text and recovered values are omitted; pure cancellation, retirement, supersession, and process-stop failures stay quiet, while mixed failures are still reported.
- The production logger limits each category to one message per hour, shared across all bundles and run generations.

**Finalization**
- `FunctionAssembly.FinalizeRun` and `Controller.Stop` now accept a caller context and pass it to remaining bundle cleanup waits.
- Wait expiry does not complete physical cleanup or reopen publication; agent-module owners are released without waiting, while physical handler cleanup keeps its process-owned context.
- `Controller.Stop` rejects a nil context; `NewContainedController` and `NewContainedFunctionAssembly` now require a diagnostics observer.

<sup>Written for commit bc777b18ba91f7dd884081501ccee4c95aca279a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer diagnostics for function availability failures, including callback, attempt, and reconciliation issues.
  - Diagnostic details are sanitized to protect sensitive error information.
  - Repeated availability warnings are rate-limited to reduce log noise.

- **Bug Fixes**
  - Improved handling of unavailable or conflicting functions so invalid routes are not published.
  - Shutdown and finalization now honor cancellation and deadline contexts while allowing cleanup to complete safely.

- **Documentation**
  - Updated architecture documentation to describe availability diagnostics, logging behavior, and cleanup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->