### PR TITLE
refactor(go.d): centralize one-shot task handshakes

### DIFF
--- a/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
+++ b/src/go/plugin/agent/jobmgr/ARCHITECTURE.md
@@ -264,6 +264,18 @@ Which mechanism each command surface uses:
 - **Process-owned off-loop** — contained attempts own their physical worker, per-identity exclusion, and final cleanup
   across run rotation.
 
+Shutdown barrier, run finalizer, and Function cleanup work share the kernel-local `oneShotTask` handshake
+(`kernel_one_shot.go`). It validates request-to-task starts, the sequence-1 no-value completion, and the expected
+sequence-2 terminate/abandon acknowledgment. A terminal action is recorded only after the supervisor accepts it;
+replayed completion dirties the run without replacing that accepted action. Invalid acknowledgments and failed
+release retain ownership. Task references clear only after `TaskSupervisor.Release` succeeds.
+
+Each caller keeps its domain policy: barrier/finalizer errors dirty the run immediately, and their readiness gates
+preserve shutdown ordering. Function cleanup stores ordinary work errors until physical release, then acknowledges
+the exact catalog cleanup generation and reports errors. Resource stop/finalize and prepare/apply/dispose
+transactions retain their separate multi-phase protocols. The shared record is a value in the existing owner or map;
+it adds no scheduler, worker, per-task heap object, or population scan.
+
 ### Fairness and timeout rules
 
 - **`TaskSupervisor` runs two independent classes** — framework-control work (lifecycle/DynCfg commands) and generic

--- a/src/go/plugin/agent/jobmgr/architecture_test.go
+++ b/src/go/plugin/agent/jobmgr/architecture_test.go
@@ -95,14 +95,11 @@ func TestCommandKernelRoutesOperationActionsThroughOwnershipGate(t *testing.T) {
 		}
 	}
 
-	// These are the ownership boundary itself and the four lifecycle-event
-	// adapters that are allowed to enter it.
+	// Operation, resource-shutdown and one-shot work each have one action owner.
 	require.Equal(t, map[string]int{
-		"jobmgr.completeRunFinalizer":    1,
-		"jobmgr.completeShutdownBarrier": 1,
-		"jobmgr.completeTask":            1,
-		"jobmgr.sendOperationAction":     1,
-		"jobmgr.sendShutdownAction":      1,
+		"jobmgr.completeOneShotTask": 1,
+		"jobmgr.sendOperationAction": 1,
+		"jobmgr.sendShutdownAction":  1,
 	}, directSenders)
 }
 

--- a/src/go/plugin/agent/jobmgr/kernel.go
+++ b/src/go/plugin/agent/jobmgr/kernel.go
@@ -251,17 +251,9 @@ type CommandKernel struct {
 	shutdownRequests         map[lifecycle.TaskRequestRef]*commandLane       // lanes awaiting a shutdown stop, by request ref
 	shutdownTasks            map[lifecycle.TaskRef]*commandLane              // lanes with an in-flight shutdown stop, by task ref
 	shutdownBarrier          RunShutdownBarrier                              // run shutdown barrier (withdraw publications, close catalog)
-	shutdownBarrierRequest   lifecycle.TaskRequestRef                        // shutdown barrier task-request ref
-	shutdownBarrierTask      lifecycle.TaskRef                               // shutdown barrier task ref
-	shutdownBarrierAction    lifecycle.TaskActionKind                        // shutdown barrier task action kind
-	shutdownBarrierDone      bool                                            // barrier completed (or was a noop)
-	shutdownBarrierFailed    bool                                            // barrier failed
+	barrierWork              oneShotTask                                     // shutdown barrier handshake
 	finalizer                RunFinalizer                                    // run finalizer callback
-	finalizerRequest         lifecycle.TaskRequestRef                        // finalizer task-request ref
-	finalizerTask            lifecycle.TaskRef                               // finalizer task ref
-	finalizerAction          lifecycle.TaskActionKind                        // finalizer task action kind
-	finalizerDone            bool                                            // finalizer completed (or was a noop)
-	finalizerFailed          bool                                            // finalizer failed
+	finalizerWork            oneShotTask                                     // run finalizer handshake
 	lanes                    map[commandLaneKey]*commandLane                 // active lanes by key
 	freeLane                 *commandLane                                    // head of the recycled-lane freelist
 	ready                    [2]readyQueue                                   // per-source ready-lane queues
@@ -472,33 +464,15 @@ func (ck *CommandKernel) completeTask(completion lifecycle.TaskCompletion) {
 		})
 	}
 	if cleanup, ok := ck.functionCleanupTasks[completion.Ref]; ok {
-		if completion.Sequence != 1 || completion.Kind != lifecycle.TaskOutcomeNone {
-			completion.Err = errors.Join(
-				completion.Err,
-				errors.New("jobmgr kernel: invalid Function cleanup completion"),
-			)
-			cleanup.err = completion.Err
-			ck.functionCleanupTasks[completion.Ref] = cleanup
-			ck.abandonTask(completion.Ref, completion.Sequence+1, completion.Err)
-			return
-		}
-		cleanup.err = completion.Err
-		ck.functionCleanupTasks[completion.Ref] = cleanup
-		if err := ck.tasks.SendAction(lifecycle.TaskAction{
-			Ref:      completion.Ref,
-			Sequence: 2,
-			Kind:     lifecycle.TaskActionTerminate,
-		}); err != nil {
-			ck.abandonTask(completion.Ref, 2, err)
-		}
+		ck.completeFunctionCleanup(cleanup, completion)
 		return
 	}
-	if ck.finalizerTask.Valid() && completion.Ref == ck.finalizerTask {
-		ck.completeRunFinalizer(completion)
+	if ck.finalizerWork.ref.Valid() && completion.Ref == ck.finalizerWork.ref {
+		ck.completeShutdownWork(&ck.finalizerWork, completion, "run finalizer")
 		return
 	}
-	if ck.shutdownBarrierTask.Valid() && completion.Ref == ck.shutdownBarrierTask {
-		ck.completeShutdownBarrier(completion)
+	if ck.barrierWork.ref.Valid() && completion.Ref == ck.barrierWork.ref {
+		ck.completeShutdownWork(&ck.barrierWork, completion, "shutdown barrier")
 		return
 	}
 	operation := ck.tasksByRef[completion.Ref]
@@ -1096,32 +1070,15 @@ func (ck *CommandKernel) sendEncodeAction(operation *commandOperation) error {
 
 func (ck *CommandKernel) acknowledgeTask(ack lifecycle.TaskAcknowledgement) {
 	if cleanup, ok := ck.functionCleanupTasks[ack.Ref]; ok {
-		if (ack.Kind != lifecycle.TaskActionTerminate && ack.Kind != lifecycle.TaskActionAbandon) ||
-			ack.Sequence != 2 {
-			ck.run.Dirty(errors.New("jobmgr kernel: invalid Function cleanup acknowledgement"))
-			return
-		}
-		if ack.Kind == lifecycle.TaskActionAbandon {
-			ck.recordAbandonment("function-cleanup", ack.Ref, ack.Abandoned)
-		}
-		if err := ck.tasks.Release(ack.Ref); err != nil {
-			ck.run.Dirty(err)
-			return
-		}
-		delete(ck.functionCleanupTasks, ack.Ref)
-		completeErr := errors.Join(cleanup.err, ack.Err)
-		catalogErr := ck.functionCatalog.CompleteCleanup(cleanup.ref)
-		if completeErr != nil || catalogErr != nil {
-			ck.run.Dirty(errors.Join(completeErr, catalogErr))
-		}
+		ck.acknowledgeFunctionCleanup(cleanup, ack)
 		return
 	}
-	if ck.finalizerTask.Valid() && ack.Ref == ck.finalizerTask {
-		ck.acknowledgeRunFinalizer(ack)
+	if ck.finalizerWork.ref.Valid() && ack.Ref == ck.finalizerWork.ref {
+		ck.acknowledgeShutdownWork(&ck.finalizerWork, ack, "run finalizer", "run-finalizer")
 		return
 	}
-	if ck.shutdownBarrierTask.Valid() && ack.Ref == ck.shutdownBarrierTask {
-		ck.acknowledgeShutdownBarrier(ack)
+	if ck.barrierWork.ref.Valid() && ack.Ref == ck.barrierWork.ref {
+		ck.acknowledgeShutdownWork(&ck.barrierWork, ack, "shutdown barrier", "shutdown-barrier")
 		return
 	}
 	operation := ck.tasksByRef[ack.Ref]
@@ -1461,7 +1418,7 @@ func (ck *CommandKernel) abortFunctionMutationForShutdown() error {
 }
 
 func (ck *CommandKernel) serviceShutdownStops(quantum int) (bool, error) {
-	if ck.shutdownPhase != commandShutdownCleanupDrain || !ck.shutdownBarrierDone || quantum <= 0 {
+	if ck.shutdownPhase != commandShutdownCleanupDrain || !ck.barrierWork.done || quantum <= 0 {
 		return false, errors.New("jobmgr kernel: invalid shutdown lane service")
 	}
 	for visited := 0; visited < quantum && ck.shutdownLaneCursor != nil; visited++ {
@@ -1548,10 +1505,7 @@ func (ck *CommandKernel) enqueueShutdownStop(lane *commandLane) error {
 func (ck *CommandKernel) advanceShutdownBarrier() error {
 	if ck.shutdownPhase != commandShutdownCleanupDrain ||
 		ck.shutdownBarrier == nil ||
-		ck.shutdownBarrierDone ||
-		ck.shutdownBarrierFailed ||
-		ck.shutdownBarrierRequest.Valid() ||
-		ck.shutdownBarrierTask.Valid() {
+		!ck.barrierWork.ready() {
 		return nil
 	}
 	if ck.shutdownCancelCursor != nil || ck.tasks.InheritedCancellationPending() {
@@ -1576,76 +1530,12 @@ func (ck *CommandKernel) advanceShutdownBarrier() error {
 	if err != nil {
 		return err
 	}
-	ck.shutdownBarrierRequest = request
+	ck.barrierWork.request = request
 	return nil
 }
 
-func (ck *CommandKernel) completeShutdownBarrier(completion lifecycle.TaskCompletion) {
-	if completion.Sequence != 1 ||
-		completion.Kind != lifecycle.TaskOutcomeNone ||
-		ck.shutdownBarrierAction != 0 ||
-		ck.shutdownBarrierDone ||
-		ck.shutdownBarrierFailed {
-		cause := errors.New("jobmgr kernel: invalid shutdown barrier completion")
-		ck.shutdownBarrierFailed = true
-		ck.shutdownBarrierAction = lifecycle.TaskActionAbandon
-		ck.abandonTask(completion.Ref, completion.Sequence+1, cause)
-		return
-	}
-	if completion.Err != nil {
-		ck.shutdownBarrierFailed = true
-		ck.run.Dirty(completion.Err)
-	}
-	ck.shutdownBarrierAction = lifecycle.TaskActionTerminate
-	if err := ck.tasks.SendAction(lifecycle.TaskAction{
-		Ref:      completion.Ref,
-		Sequence: 2,
-		Kind:     lifecycle.TaskActionTerminate,
-	}); err != nil {
-		ck.shutdownBarrierFailed = true
-		ck.shutdownBarrierAction = lifecycle.TaskActionAbandon
-		ck.abandonTask(completion.Ref, 2, err)
-	}
-}
-
-func (ck *CommandKernel) acknowledgeShutdownBarrier(ack lifecycle.TaskAcknowledgement) {
-	if ack.Sequence != 2 ||
-		(ack.Kind != lifecycle.TaskActionTerminate && ack.Kind != lifecycle.TaskActionAbandon) ||
-		ck.shutdownBarrierAction != ack.Kind ||
-		ck.shutdownBarrierDone {
-		ck.run.Dirty(errors.New("jobmgr kernel: invalid shutdown barrier acknowledgement"))
-		return
-	}
-	if ack.Err != nil {
-		ck.shutdownBarrierFailed = true
-		ck.run.Dirty(ack.Err)
-	}
-	if ack.Kind == lifecycle.TaskActionAbandon {
-		ck.shutdownBarrierFailed = true
-		ck.recordAbandonment("shutdown-barrier", ack.Ref, ack.Abandoned)
-	}
-	if err := ck.tasks.Release(ack.Ref); err != nil {
-		ck.shutdownBarrierFailed = true
-		ck.run.Dirty(err)
-		return
-	}
-	ck.shutdownBarrierTask = lifecycle.TaskRef{}
-	ck.shutdownBarrierAction = 0
-	if !ck.shutdownBarrierFailed {
-		ck.shutdownBarrierDone = true
-	}
-}
-
-func (ck *CommandKernel) runShutdownBarrierFailedTerminal() bool {
-	return ck.shutdownBarrierFailed &&
-		!ck.shutdownBarrierRequest.Valid() &&
-		!ck.shutdownBarrierTask.Valid() &&
-		ck.shutdownBarrierAction == 0
-}
-
 func (ck *CommandKernel) advanceRunFinalizer() error {
-	if ck.finalizer == nil || ck.finalizerDone || ck.finalizerFailed || ck.finalizerRequest.Valid() ||
-		ck.finalizerTask.Valid() {
+	if ck.finalizer == nil || !ck.finalizerWork.ready() {
 		return nil
 	}
 	if !ck.shutdownReadyForFinalizer() {
@@ -1668,7 +1558,7 @@ func (ck *CommandKernel) advanceRunFinalizer() error {
 	if err != nil {
 		return err
 	}
-	ck.finalizerRequest = request
+	ck.finalizerWork.request = request
 	return nil
 }
 
@@ -1678,10 +1568,7 @@ func (ck *CommandKernel) advanceRunFinalizer() error {
 func (ck *CommandKernel) shutdownBarrierSettled() bool {
 	return ck.shutdownPhase == commandShutdownCleanupDrain &&
 		ck.ownershipChains == 0 &&
-		ck.shutdownBarrierDone && !ck.shutdownBarrierFailed &&
-		!ck.shutdownBarrierRequest.Valid() &&
-		!ck.shutdownBarrierTask.Valid() &&
-		ck.shutdownBarrierAction == 0
+		ck.barrierWork.settled()
 }
 
 func (ck *CommandKernel) shutdownReadyForFinalizer() bool {
@@ -1693,66 +1580,6 @@ func (ck *CommandKernel) shutdownReadyForFinalizer() bool {
 		return false
 	}
 	return true
-}
-
-func (ck *CommandKernel) completeRunFinalizer(completion lifecycle.TaskCompletion) {
-	if completion.Sequence != 1 || completion.Kind != lifecycle.TaskOutcomeNone || ck.finalizerAction != 0 ||
-		ck.finalizerDone ||
-		ck.finalizerFailed {
-		cause := errors.New("jobmgr kernel: invalid run finalizer completion")
-		ck.finalizerFailed = true
-		ck.finalizerAction = lifecycle.TaskActionAbandon
-		ck.abandonTask(completion.Ref, completion.Sequence+1, cause)
-		return
-	}
-	if completion.Err != nil {
-		ck.finalizerFailed = true
-		ck.run.Dirty(completion.Err)
-	}
-	ck.finalizerAction = lifecycle.TaskActionTerminate
-	if err := ck.tasks.SendAction(
-		lifecycle.TaskAction{
-			Ref:      completion.Ref,
-			Sequence: 2,
-			Kind:     lifecycle.TaskActionTerminate,
-		},
-	); err != nil {
-		ck.finalizerFailed = true
-		ck.finalizerAction = lifecycle.TaskActionAbandon
-		ck.abandonTask(completion.Ref, 2, err)
-	}
-}
-
-func (ck *CommandKernel) acknowledgeRunFinalizer(ack lifecycle.TaskAcknowledgement) {
-	if ack.Sequence != 2 ||
-		(ack.Kind != lifecycle.TaskActionTerminate && ack.Kind != lifecycle.TaskActionAbandon) ||
-		ck.finalizerAction != ack.Kind ||
-		ck.finalizerDone {
-		ck.run.Dirty(errors.New("jobmgr kernel: invalid run finalizer acknowledgement"))
-		return
-	}
-	if ack.Err != nil {
-		ck.finalizerFailed = true
-		ck.run.Dirty(ack.Err)
-	}
-	if ack.Kind == lifecycle.TaskActionAbandon {
-		ck.finalizerFailed = true
-		ck.recordAbandonment("run-finalizer", ack.Ref, ack.Abandoned)
-	}
-	if err := ck.tasks.Release(ack.Ref); err != nil {
-		ck.finalizerFailed = true
-		ck.run.Dirty(err)
-		return
-	}
-	ck.finalizerTask = lifecycle.TaskRef{}
-	ck.finalizerAction = 0
-	if !ck.finalizerFailed {
-		ck.finalizerDone = true
-	}
-}
-
-func (ck *CommandKernel) runFinalizerFailedTerminal() bool {
-	return ck.finalizerFailed && !ck.finalizerRequest.Valid() && !ck.finalizerTask.Valid() && ck.finalizerAction == 0
 }
 
 func (ck *CommandKernel) kernelOwnershipDrained() bool {
@@ -1812,7 +1639,7 @@ func (ck *CommandKernel) runCensus() lifecycle.RunCensus {
 		LongLived:              ck.tasks.LongLivedCensus(),
 		Frame:                  ck.frames.Census(),
 		Abandoned:              ck.abandoned,
-		RunFinalizerComplete:   ck.finalizerDone && !ck.finalizerFailed,
+		RunFinalizerComplete:   ck.finalizerWork.done && !ck.finalizerWork.failed,
 	}
 }
 

--- a/src/go/plugin/agent/jobmgr/kernel_dispatch.go
+++ b/src/go/plugin/agent/jobmgr/kernel_dispatch.go
@@ -190,28 +190,32 @@ func (ck *CommandKernel) serviceTaskStarts(quantum int) bool {
 				ck.run.Dirty(errors.New("jobmgr kernel: duplicate Function cleanup task slot"))
 				return more
 			}
-			delete(ck.functionCleanupRequests, start.Request)
-			ck.functionCleanupTasks[start.Task] = functionCleanupTask{
+			cleanup := functionCleanupTask{
 				ref: cleanupRef,
+				task: oneShotTask{
+					request: start.Request,
+				},
+			}
+			if err := cleanup.task.start(start, "Function cleanup"); err != nil {
+				ck.run.Dirty(err)
+				return more
+			}
+			delete(ck.functionCleanupRequests, start.Request)
+			ck.functionCleanupTasks[start.Task] = cleanup
+			continue
+		}
+		if ck.barrierWork.request.Valid() && start.Request == ck.barrierWork.request {
+			if err := ck.barrierWork.start(start, "shutdown barrier"); err != nil {
+				ck.run.Dirty(err)
+				return more
 			}
 			continue
 		}
-		if ck.shutdownBarrierRequest.Valid() && start.Request == ck.shutdownBarrierRequest {
-			if ck.shutdownBarrierTask.Valid() || ck.shutdownBarrierDone || ck.shutdownBarrierFailed {
-				ck.run.Dirty(errors.New("jobmgr kernel: invalid shutdown barrier start acknowledgement"))
+		if ck.finalizerWork.request.Valid() && start.Request == ck.finalizerWork.request {
+			if err := ck.finalizerWork.start(start, "run finalizer"); err != nil {
+				ck.run.Dirty(err)
 				return more
 			}
-			ck.shutdownBarrierRequest = lifecycle.TaskRequestRef{}
-			ck.shutdownBarrierTask = start.Task
-			continue
-		}
-		if ck.finalizerRequest.Valid() && start.Request == ck.finalizerRequest {
-			if ck.finalizerTask.Valid() || ck.finalizerDone || ck.finalizerFailed {
-				ck.run.Dirty(errors.New("jobmgr kernel: invalid run finalizer start acknowledgement"))
-				return more
-			}
-			ck.finalizerRequest = lifecycle.TaskRequestRef{}
-			ck.finalizerTask = start.Task
 			continue
 		}
 		operation := ck.tasksByRequest[start.Request]

--- a/src/go/plugin/agent/jobmgr/kernel_disposal.go
+++ b/src/go/plugin/agent/jobmgr/kernel_disposal.go
@@ -308,7 +308,7 @@ func (ck *CommandKernel) tryDispose(operation *commandOperation) {
 		ck.run.Dirty(errors.New("jobmgr kernel: negative lane ownership"))
 		return
 	}
-	if ck.shutdownPhase != commandShutdownRunning && ck.shutdownBarrierDone &&
+	if ck.shutdownPhase != commandShutdownRunning && ck.barrierWork.done &&
 		lane.shutdownVisited && lane.owners == 0 {
 		if err := ck.enqueueShutdownStop(lane); err != nil {
 			ck.run.Dirty(err)

--- a/src/go/plugin/agent/jobmgr/kernel_function_catalog.go
+++ b/src/go/plugin/agent/jobmgr/kernel_function_catalog.go
@@ -27,6 +27,30 @@ func (ck *CommandKernel) abortFunctionMutation(mutation FunctionCatalogMutation)
 	return ck.functionCatalog.AbortMutation(mutation)
 }
 
+func (ck *CommandKernel) completeFunctionCleanup(cleanup functionCleanupTask, completion lifecycle.TaskCompletion) {
+	cleanup.err = ck.completeOneShotTask(&cleanup.task, completion, "Function cleanup")
+	ck.functionCleanupTasks[completion.Ref] = cleanup
+}
+
+func (ck *CommandKernel) acknowledgeFunctionCleanup(cleanup functionCleanupTask, ack lifecycle.TaskAcknowledgement) {
+	if err := cleanup.task.validateAcknowledgement(ack, "Function cleanup"); err != nil {
+		ck.run.Dirty(err)
+		return
+	}
+	if !ck.releaseOneShotTask(&cleanup.task, ack, "function-cleanup") {
+		ck.functionCleanupTasks[ack.Ref] = cleanup
+		return
+	}
+	delete(ck.functionCleanupTasks, ack.Ref)
+	// Ordinary cleanup errors become terminal only after the physical task and
+	// its exact catalog generation have both been acknowledged.
+	completeErr := errors.Join(cleanup.err, ack.Err)
+	catalogErr := ck.functionCatalog.CompleteCleanup(cleanup.ref)
+	if completeErr != nil || catalogErr != nil {
+		ck.run.Dirty(errors.Join(completeErr, catalogErr))
+	}
+}
+
 func (ck *CommandKernel) serviceFunctionCleanupBacklog(quantum int) bool {
 	if quantum <= 0 {
 		return ck.functionCleanupBacklog.count != 0
@@ -182,7 +206,7 @@ func (ck *CommandKernel) serviceFunctionMutation(quantum int) bool {
 }
 
 func (ck *CommandKernel) serviceFunctionCatalogClose(quantum int) bool {
-	if !ck.shutdownBarrierDone || ck.shutdownBarrierFailed {
+	if !ck.barrierWork.done || ck.barrierWork.failed {
 		return false
 	}
 	if !ck.functionCatalogClosing {

--- a/src/go/plugin/agent/jobmgr/kernel_lifecycle_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_lifecycle_test.go
@@ -3188,7 +3188,7 @@ func completeNoopShutdownBarrier(t *testing.T, kernel *testCommandKernel) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "shutdown barrier termination was not acknowledged")
 	}
-	require.True(t, kernel.shutdownBarrierDone)
+	require.True(t, kernel.barrierWork.done)
 }
 
 func TestKernelCancelsQueuedOperationWithoutStartingWork(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/kernel_one_shot.go
+++ b/src/go/plugin/agent/jobmgr/kernel_one_shot.go
@@ -57,7 +57,7 @@ func (ck *CommandKernel) completeOneShotTask(
 		cause := errors.Join(completion.Err, fmt.Errorf("jobmgr kernel: invalid %s completion", name))
 		task.failed = true
 		if task.action == 0 && task.ref.Valid() && completion.Ref == task.ref {
-			ck.abandonOneShotTask(task, completion.Sequence+1, cause)
+			ck.abandonOneShotTask(task, cause)
 		} else {
 			// A replay cannot replace an action already accepted by the child.
 			ck.run.Dirty(cause)
@@ -72,17 +72,18 @@ func (ck *CommandKernel) completeOneShotTask(
 		Sequence: 2,
 		Kind:     lifecycle.TaskActionTerminate,
 	}); err != nil {
-		ck.abandonOneShotTask(task, 2, err)
+		ck.abandonOneShotTask(task, err)
 	} else {
 		task.action = lifecycle.TaskActionTerminate
 	}
 	return completion.Err
 }
 
-func (ck *CommandKernel) abandonOneShotTask(task *oneShotTask, sequence uint8, cause error) {
+func (ck *CommandKernel) abandonOneShotTask(task *oneShotTask, cause error) {
 	task.failed = true
 	ck.run.Dirty(cause)
-	if err := ck.tasks.Abandon(task.ref, sequence); err != nil {
+	// The child awaits action 2 even when the reported completion is malformed.
+	if err := ck.tasks.Abandon(task.ref, 2); err != nil {
 		ck.run.Dirty(errors.Join(cause, err))
 		return
 	}

--- a/src/go/plugin/agent/jobmgr/kernel_one_shot.go
+++ b/src/go/plugin/agent/jobmgr/kernel_one_shot.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+)
+
+// oneShotTask is kernel-owned bookkeeping for work with no returned resource.
+// The accepted terminal action remains owned until its acknowledged task releases.
+type oneShotTask struct {
+	request lifecycle.TaskRequestRef
+	ref     lifecycle.TaskRef
+	action  lifecycle.TaskActionKind
+	done    bool
+	failed  bool
+}
+
+func (task *oneShotTask) idle() bool {
+	return !task.request.Valid() && !task.ref.Valid() && task.action == 0
+}
+
+func (task *oneShotTask) ready() bool {
+	return !task.done && !task.failed && task.idle()
+}
+
+func (task *oneShotTask) settled() bool {
+	return task.done && !task.failed && task.idle()
+}
+
+func (task *oneShotTask) failedTerminal() bool {
+	return task.failed && task.idle()
+}
+
+func (task *oneShotTask) start(start lifecycle.TaskStart, name string) error {
+	if !task.request.Valid() || start.Request != task.request || !start.Task.Valid() ||
+		task.ref.Valid() || task.action != 0 || task.done || task.failed {
+		return fmt.Errorf("jobmgr kernel: invalid %s start acknowledgement", name)
+	}
+	task.request = lifecycle.TaskRequestRef{}
+	task.ref = start.Task
+	return nil
+}
+
+// The caller decides when ordinary work errors dirty the run. Protocol failures
+// dirty it immediately because abandonment requires a dirty run.
+func (ck *CommandKernel) completeOneShotTask(
+	task *oneShotTask,
+	completion lifecycle.TaskCompletion,
+	name string,
+) error {
+	if !task.ref.Valid() || completion.Ref != task.ref || completion.Sequence != 1 ||
+		completion.Kind != lifecycle.TaskOutcomeNone || task.action != 0 || task.done || task.failed {
+		cause := errors.Join(completion.Err, fmt.Errorf("jobmgr kernel: invalid %s completion", name))
+		task.failed = true
+		if task.action == 0 && task.ref.Valid() && completion.Ref == task.ref {
+			ck.abandonOneShotTask(task, completion.Sequence+1, cause)
+		} else {
+			// A replay cannot replace an action already accepted by the child.
+			ck.run.Dirty(cause)
+		}
+		return cause
+	}
+	if completion.Err != nil {
+		task.failed = true
+	}
+	if err := ck.tasks.SendAction(lifecycle.TaskAction{
+		Ref:      task.ref,
+		Sequence: 2,
+		Kind:     lifecycle.TaskActionTerminate,
+	}); err != nil {
+		ck.abandonOneShotTask(task, 2, err)
+	} else {
+		task.action = lifecycle.TaskActionTerminate
+	}
+	return completion.Err
+}
+
+func (ck *CommandKernel) abandonOneShotTask(task *oneShotTask, sequence uint8, cause error) {
+	task.failed = true
+	ck.run.Dirty(cause)
+	if err := ck.tasks.Abandon(task.ref, sequence); err != nil {
+		ck.run.Dirty(errors.Join(cause, err))
+		return
+	}
+	task.action = lifecycle.TaskActionAbandon
+}
+
+func (task *oneShotTask) validateAcknowledgement(ack lifecycle.TaskAcknowledgement, name string) error {
+	if !task.ref.Valid() || ack.Ref != task.ref || ack.Sequence != 2 ||
+		(ack.Kind != lifecycle.TaskActionTerminate && ack.Kind != lifecycle.TaskActionAbandon) ||
+		task.action != ack.Kind || task.done {
+		return fmt.Errorf("jobmgr kernel: invalid %s acknowledgement", name)
+	}
+	return nil
+}
+
+// Call only after validating the acknowledgment. Domain acknowledgments, such
+// as catalog cleanup, remain the caller's responsibility after successful release.
+func (ck *CommandKernel) releaseOneShotTask(
+	task *oneShotTask,
+	ack lifecycle.TaskAcknowledgement,
+	resource string,
+) bool {
+	if ack.Err != nil {
+		task.failed = true
+	}
+	if ack.Kind == lifecycle.TaskActionAbandon {
+		task.failed = true
+		ck.recordAbandonment(resource, ack.Ref, ack.Abandoned)
+	}
+	if err := ck.tasks.Release(ack.Ref); err != nil {
+		task.failed = true
+		ck.run.Dirty(err)
+		return false
+	}
+	task.ref = lifecycle.TaskRef{}
+	task.action = 0
+	task.done = !task.failed
+	return true
+}
+
+func (ck *CommandKernel) completeShutdownWork(task *oneShotTask, completion lifecycle.TaskCompletion, name string) {
+	if completion.Err != nil {
+		ck.run.Dirty(completion.Err)
+	}
+	ck.completeOneShotTask(task, completion, name)
+}
+
+func (ck *CommandKernel) acknowledgeShutdownWork(
+	task *oneShotTask, ack lifecycle.TaskAcknowledgement, name, resource string,
+) {
+	if err := task.validateAcknowledgement(ack, name); err != nil {
+		ck.run.Dirty(err)
+		return
+	}
+	if ack.Err != nil {
+		ck.run.Dirty(ack.Err)
+	}
+	ck.releaseOneShotTask(task, ack, resource)
+}

--- a/src/go/plugin/agent/jobmgr/kernel_one_shot_bench_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_one_shot_bench_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/stretchr/testify/require"
+)
+
+// Measures the real cleanup task launch, completion, termination and release.
+// Bookkeeping is O(1) per task; timing is a local trend, not a CI threshold.
+func BenchmarkBKernelFunctionCleanupLifecycle(b *testing.B) {
+	run, err := lifecycle.NewRunSupervisor(1, lifecycle.RealClock{}, time.Second)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = run.FinishShutdown() })
+	frames, err := lifecycle.NewFrameOwner(io.Discard)
+	require.NoError(b, err)
+	tasks, err := lifecycle.NewTaskSupervisor(frames)
+	require.NoError(b, err)
+	var released, completed uint64
+	work := func(context.Context) (lifecycle.TaskOutcome, error) {
+		return lifecycle.NoValueOutcome(), nil
+	}
+	catalog := functionCatalogPortStub{
+		release: func(FunctionInvocationRef) (FunctionCleanupPlan, error) {
+			released++
+			return NewFunctionCleanupPlan(FunctionCleanupRef(released), work)
+		},
+		complete: func(ref FunctionCleanupRef) error {
+			completed++
+			if uint64(ref) != completed || tasks.Active() != 0 {
+				b.Fatal("cleanup acknowledged out of order or before task release")
+			}
+			return nil
+		},
+	}
+	kernel, err := NewCommandKernel(run, lifecycle.NewUIDLedger(), tasks, frames, lifecycle.RealClock{},
+		newNoopRunShutdownBarrier(), newNoopRunFinalizer(), catalog)
+	require.NoError(b, err)
+	require.NoError(b, run.OpenAdmission())
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := kernel.releaseFunctionInvocation(FunctionInvocationRef{
+			Slot:       1,
+			Generation: 1,
+		}); err != nil {
+			b.Fatal(err)
+		}
+		kernel.serviceFunctionCleanupBacklog(1)
+		kernel.serviceTaskStarts(1)
+		kernel.completeTask(<-tasks.CompletionCh())
+		kernel.acknowledgeTask(<-tasks.AcknowledgementCh())
+	}
+	require.Equal(b, released, completed)
+	require.NoError(b, run.DirtyCause())
+}

--- a/src/go/plugin/agent/jobmgr/kernel_one_shot_protocol_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_one_shot_protocol_test.go
@@ -13,6 +13,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestKernelOneShotInvalidCompletionSequenceAbandons(t *testing.T) {
+	for _, kind := range []string{"barrier", "finalizer", "function-cleanup"} {
+		t.Run(kind, func(t *testing.T) {
+			for name, sequence := range map[string]uint8{"zero": 0, "unexpected phase": 2, "overflow": 255} {
+				t.Run(name, func(t *testing.T) {
+					fixture := startOneShotProtocolFixture(t, kind)
+					t.Cleanup(func() {
+						// Join the child if the regression prevents abandonment, before
+						// the fixture's cleanup releases its supervisor slot.
+						if !fixture.ackReceived {
+							require.NoError(t, fixture.kernel.tasks.Abandon(fixture.completion.Ref, 2))
+							fixture.receiveAcknowledgment(t)
+						}
+					})
+					malformed := fixture.completion
+					malformed.Sequence = sequence
+					fixture.kernel.completeTask(malformed)
+					require.Error(t, fixture.kernel.run.DirtyCause())
+					require.Equal(t, 1, fixture.kernel.tasks.Active())
+					fixture.assertCatalogCompletions(t, 0)
+
+					ack := fixture.receiveAcknowledgment(t)
+					require.Equal(t, lifecycle.TaskAcknowledgement{
+						Ref:      fixture.completion.Ref,
+						Sequence: 2,
+						Kind:     lifecycle.TaskActionAbandon,
+						Abandoned: lifecycle.TaskAbandonment{
+							Outcome: lifecycle.TaskOutcomeNone,
+						},
+					}, ack)
+					fixture.kernel.acknowledgeTask(ack)
+					require.Zero(t, fixture.kernel.tasks.Active())
+					fixture.assertCatalogCompletions(t, 1)
+				})
+			}
+		})
+	}
+}
+
 func TestKernelOneShotRejectsWrongAcknowledgmentAction(t *testing.T) {
 	for _, kind := range []string{"barrier", "finalizer", "function-cleanup"} {
 		t.Run(kind, func(t *testing.T) {

--- a/src/go/plugin/agent/jobmgr/kernel_one_shot_protocol_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_one_shot_protocol_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKernelOneShotRejectsWrongAcknowledgmentAction(t *testing.T) {
+	for _, kind := range []string{"barrier", "finalizer", "function-cleanup"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := startOneShotProtocolFixture(t, kind)
+			fixture.kernel.completeTask(fixture.completion)
+			ack := fixture.receiveAcknowledgment(t)
+			require.Equal(t, lifecycle.TaskActionTerminate, ack.Kind)
+
+			wrong := ack
+			wrong.Kind = lifecycle.TaskActionAbandon
+			fixture.kernel.acknowledgeTask(wrong)
+			assert.Equal(t, 1, fixture.kernel.tasks.Active(), "wrong action must not release a joined task")
+			assert.Zero(t, fixture.catalogCompletions, "wrong action must not acknowledge catalog cleanup")
+			assert.Error(t, fixture.kernel.run.DirtyCause())
+
+			fixture.kernel.acknowledgeTask(ack)
+			assert.Zero(t, fixture.kernel.tasks.Active(), "the genuine acknowledgment must remain usable")
+			fixture.assertCatalogCompletions(t, 1)
+		})
+	}
+}
+
+func TestKernelOneShotDuplicateCompletionPreservesAcceptedAction(t *testing.T) {
+	for _, kind := range []string{"barrier", "finalizer", "function-cleanup"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := startOneShotProtocolFixture(t, kind)
+			fixture.kernel.completeTask(fixture.completion)
+			ack := fixture.receiveAcknowledgment(t)
+
+			// Hold the real acknowledgment while replaying completion. The child is
+			// joined, but the kernel still owns its accepted termination handshake.
+			fixture.kernel.completeTask(fixture.completion)
+			assert.Error(t, fixture.kernel.run.DirtyCause())
+			assert.Equal(t, 1, fixture.kernel.tasks.Active())
+			fixture.kernel.acknowledgeTask(ack)
+			assert.Zero(t, fixture.kernel.tasks.Active(), "replay must not replace the accepted terminal action")
+			fixture.assertCatalogCompletions(t, 1)
+			if kind == "barrier" {
+				assert.False(t, fixture.kernel.shutdownBarrierSettled())
+			}
+			if kind == "finalizer" {
+				assert.False(t, fixture.kernel.runCensus().RunFinalizerComplete)
+			}
+		})
+	}
+}
+
+func TestKernelOneShotDuplicateAcknowledgmentDoesNotReleaseTwice(t *testing.T) {
+	for _, kind := range []string{"barrier", "finalizer", "function-cleanup"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := startOneShotProtocolFixture(t, kind)
+			fixture.kernel.completeTask(fixture.completion)
+			ack := fixture.receiveAcknowledgment(t)
+			fixture.kernel.acknowledgeTask(ack)
+			require.Zero(t, fixture.kernel.tasks.Active())
+			fixture.assertCatalogCompletions(t, 1)
+
+			fixture.kernel.acknowledgeTask(ack)
+			assert.Zero(t, fixture.kernel.tasks.Active())
+			fixture.assertCatalogCompletions(t, 1)
+			assert.Error(t, fixture.kernel.run.DirtyCause())
+		})
+	}
+}
+
+func TestKernelOneShotReleaseFailureRetainsOwnership(t *testing.T) {
+	for _, kind := range []string{"barrier", "finalizer", "function-cleanup"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := startOneShotProtocolFixture(t, kind)
+			fixture.kernel.completeTask(fixture.completion)
+			ack := fixture.receiveAcknowledgment(t)
+
+			// Inject a real supervisor release guard after the child joins. One-shot
+			// work does not normally retain timeouts; this tests failure ownership.
+			_, err := fixture.kernel.tasks.MarkRetainedTimeout(ack.Ref)
+			require.NoError(t, err)
+			fixture.kernel.acknowledgeTask(ack)
+			assert.Equal(t, 1, fixture.kernel.tasks.Active())
+			assert.Zero(t, fixture.catalogCompletions)
+			assert.Error(t, fixture.kernel.run.DirtyCause())
+
+			_, err = fixture.kernel.tasks.ClearRetainedTimeout(ack.Ref)
+			require.NoError(t, err)
+			fixture.kernel.acknowledgeTask(ack)
+			assert.Zero(t, fixture.kernel.tasks.Active(), "failed release must preserve the acknowledgment owner")
+			fixture.assertCatalogCompletions(t, 1)
+			if kind == "barrier" {
+				assert.False(t, fixture.kernel.shutdownBarrierSettled())
+			}
+			if kind == "finalizer" {
+				assert.False(t, fixture.kernel.runCensus().RunFinalizerComplete)
+			}
+		})
+	}
+}
+
+type oneShotProtocolFixture struct {
+	kernel             *testCommandKernel
+	kind               string
+	completion         lifecycle.TaskCompletion
+	ackReceived        bool
+	catalogCompletions int
+}
+
+func startOneShotProtocolFixture(t *testing.T, kind string) *oneShotProtocolFixture {
+	t.Helper()
+	fixture := &oneShotProtocolFixture{
+		kind: kind,
+	}
+	const cleanupRef = FunctionCleanupRef(73)
+	catalog := functionCatalogPortStub{
+		release: func(FunctionInvocationRef) (FunctionCleanupPlan, error) {
+			return NewFunctionCleanupPlan(cleanupRef, func(context.Context) (lifecycle.TaskOutcome, error) {
+				return lifecycle.NoValueOutcome(), nil
+			})
+		},
+		complete: func(ref FunctionCleanupRef) error {
+			assert.Equal(t, cleanupRef, ref, "catalog acknowledgment must preserve exact cleanup identity")
+			fixture.catalogCompletions++
+			return nil
+		},
+	}
+	kernel, run, uids, tasks := newKernelWithClockFinalizerCatalogAndTimeout(
+		t, stoppedKernelPlanner{}, catalog, io.Discard, lifecycle.RealClock{}, newNoopRunFinalizer(), time.Second,
+	)
+	fixture.kernel = kernel
+	t.Cleanup(func() {
+		// On a red assertion the child is still joined; release its supervisor
+		// slot directly so an expected protocol failure cannot leak task state.
+		if fixture.ackReceived && tasks.Active() != 0 {
+			_, err := tasks.ClearRetainedTimeout(fixture.completion.Ref)
+			assert.NoError(t, err)
+			assert.NoError(t, tasks.Release(fixture.completion.Ref))
+		}
+		closeUIDLedger(t, uids)
+	})
+	require.NoError(t, run.OpenAdmission())
+	if kind == "function-cleanup" {
+		require.NoError(t, kernel.releaseFunctionInvocation(FunctionInvocationRef{
+			Slot:       1,
+			Generation: 1,
+		}))
+		kernel.serviceFunctionCleanupBacklog(1)
+	} else {
+		require.NoError(t, kernel.beginShutdown(time.Now().Add(time.Second)))
+		require.NoError(t, kernel.advanceShutdownAuthority())
+		if kind == "finalizer" {
+			completeNoopShutdownBarrier(t, kernel)
+			kernel.serviceFunctionCatalogClose(MaximumFunctionCloseQuantum)
+			require.NoError(t, kernel.advanceRunFinalizer())
+		} else {
+			require.NoError(t, kernel.advanceShutdownBarrier())
+		}
+	}
+	kernel.serviceTaskStarts(1)
+	require.Equal(t, 1, tasks.Active())
+	select {
+	case fixture.completion = <-tasks.CompletionCh():
+	case <-time.After(time.Second):
+		require.FailNow(t, "one-shot work did not complete")
+	}
+	return fixture
+}
+
+func (fixture *oneShotProtocolFixture) receiveAcknowledgment(t *testing.T) lifecycle.TaskAcknowledgement {
+	t.Helper()
+	select {
+	case ack := <-fixture.kernel.tasks.AcknowledgementCh():
+		fixture.ackReceived = true
+		return ack
+	case <-time.After(time.Second):
+		require.FailNow(t, "one-shot terminal action was not acknowledged")
+		return lifecycle.TaskAcknowledgement{}
+	}
+}
+
+func (fixture *oneShotProtocolFixture) assertCatalogCompletions(t *testing.T, want int) {
+	t.Helper()
+	if fixture.kind != "function-cleanup" {
+		want = 0
+	}
+	assert.Equal(t, want, fixture.catalogCompletions)
+}

--- a/src/go/plugin/agent/jobmgr/kernel_one_shot_test.go
+++ b/src/go/plugin/agent/jobmgr/kernel_one_shot_test.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package jobmgr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/netdata/netdata/go/plugins/plugin/agent/jobmgr/lifecycle"
+	"github.com/stretchr/testify/require"
+)
+
+func newOneShotKernel(
+	t *testing.T,
+	barrier RunShutdownBarrier,
+	finalizer RunFinalizer,
+	catalog FunctionCatalogPort,
+) (*CommandKernel, *lifecycle.RunSupervisor, *lifecycle.TaskSupervisor) {
+	t.Helper()
+	run, err := lifecycle.NewRunSupervisor(1, lifecycle.RealClock{}, time.Second)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = run.FinishShutdown() })
+	frames, err := lifecycle.NewFrameOwner(io.Discard)
+	require.NoError(t, err)
+	tasks, err := lifecycle.NewTaskSupervisor(frames)
+	require.NoError(t, err)
+	kernel, err := NewCommandKernel(
+		run,
+		lifecycle.NewUIDLedger(),
+		tasks,
+		frames,
+		lifecycle.RealClock{},
+		barrier,
+		finalizer,
+		catalog,
+	)
+	require.NoError(t, err)
+	require.NoError(t, run.OpenAdmission())
+	return kernel, run, tasks
+}
+
+func TestKernelOneShotBarrierFailure(t *testing.T) {
+	want := errors.New("barrier failed")
+	for name, test := range map[string]struct {
+		work func(context.Context, uint64) error
+		want error
+	}{
+		"error": {work: func(context.Context, uint64) error { return want }, want: want},
+		"panic": {work: func(context.Context, uint64) error { panic("barrier panic") }, want: lifecycle.ErrTaskPanic},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var barrierCalls, finalizerCalls int
+			catalog := &oneShotClosingCatalog{}
+			kernel, run, tasks := newOneShotKernel(t,
+				runShutdownBarrierFunc(func(ctx context.Context, generation uint64) error {
+					barrierCalls++
+					return test.work(ctx, generation)
+				}),
+				runFinalizerFunc(func(context.Context, uint64) error { finalizerCalls++; return nil }), catalog)
+			require.NoError(t, kernel.Start(context.Background()))
+			kernel.Stop()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			require.ErrorIs(t, kernel.Wait(ctx), test.want)
+			require.Equal(t, 1, barrierCalls)
+			require.Zero(t, finalizerCalls)
+			require.False(t, catalog.closed)
+			require.Zero(t, tasks.Active())
+			require.Zero(t, tasks.Pending())
+			require.False(t, run.TerminalState().Quiescent)
+		})
+	}
+}
+
+type oneShotClosingCatalog struct {
+	functionCatalogPortStub
+	closed bool
+	close  func()
+}
+
+func (catalog *oneShotClosingCatalog) BeginClose() error {
+	catalog.closed = true
+	if catalog.close != nil {
+		catalog.close()
+	}
+	return nil
+}
+
+func (catalog *oneShotClosingCatalog) LifecycleDrained() bool { return catalog.closed }
+
+func TestKernelOneShotShutdownOrdering(t *testing.T) {
+	barrierEntered := make(chan struct{})
+	barrierRelease := make(chan struct{})
+	events := make(chan string, 4)
+	catalog := &oneShotClosingCatalog{
+		close: func() { events <- "catalog" },
+	}
+	kernel, run, tasks := newOneShotKernel(t,
+		runShutdownBarrierFunc(func(ctx context.Context, _ uint64) error {
+			close(barrierEntered)
+			select {
+			case <-barrierRelease:
+				events <- "barrier"
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}),
+		runFinalizerFunc(func(context.Context, uint64) error { events <- "finalizer"; return nil }), catalog)
+	require.NoError(t, kernel.Start(context.Background()))
+	kernel.Stop()
+	select {
+	case <-barrierEntered:
+	case <-time.After(time.Second):
+		t.Fatal("barrier did not start")
+	}
+	select {
+	case event := <-events:
+		t.Fatalf("shutdown advanced while barrier owned its work: %s", event)
+	default:
+	}
+	close(barrierRelease)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, kernel.Wait(ctx))
+	require.Equal(t, "barrier", <-events)
+	require.Equal(t, "catalog", <-events)
+	require.Equal(t, "finalizer", <-events)
+	require.Empty(t, events)
+	require.Zero(t, tasks.Active())
+	require.True(t, run.TerminalState().Quiescent)
+}
+
+func receiveOneShotCompletion(t *testing.T, tasks *lifecycle.TaskSupervisor) lifecycle.TaskCompletion {
+	t.Helper()
+	select {
+	case completion := <-tasks.CompletionCh():
+		return completion
+	case <-time.After(time.Second):
+		t.Fatal("one-shot work did not complete")
+		return lifecycle.TaskCompletion{}
+	}
+}
+
+func receiveOneShotAcknowledgement(t *testing.T, tasks *lifecycle.TaskSupervisor) lifecycle.TaskAcknowledgement {
+	t.Helper()
+	select {
+	case ack := <-tasks.AcknowledgementCh():
+		return ack
+	case <-time.After(time.Second):
+		t.Fatal("one-shot action was not acknowledged")
+		return lifecycle.TaskAcknowledgement{}
+	}
+}
+
+func TestKernelOneShotFunctionCleanupDisposition(t *testing.T) {
+	workErr := errors.New("cleanup work failed")
+	catalogErr := errors.New("catalog acknowledgement failed")
+	for name, test := range map[string]struct {
+		work       lifecycle.TaskWork
+		catalogErr error
+		abandon    bool
+	}{
+		"work error":    {work: func(context.Context) (lifecycle.TaskOutcome, error) { return lifecycle.NoValueOutcome(), workErr }},
+		"catalog error": {work: func(context.Context) (lifecycle.TaskOutcome, error) { return lifecycle.NoValueOutcome(), nil }, catalogErr: catalogErr},
+		"unexpected outcome": {work: func(context.Context) (lifecycle.TaskOutcome, error) {
+			result, err := lifecycle.NewControlResult(lifecycle.ControlInternal)
+			if err != nil {
+				return lifecycle.TaskOutcome{}, err
+			}
+			return lifecycle.NewFrameOutcome(result)
+		}, abandon: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			const cleanupRef FunctionCleanupRef = 37
+			var tasks *lifecycle.TaskSupervisor
+			var completed []FunctionCleanupRef
+			catalog := functionCatalogPortStub{
+				release: func(FunctionInvocationRef) (FunctionCleanupPlan, error) {
+					return NewFunctionCleanupPlan(cleanupRef, test.work)
+				},
+				complete: func(ref FunctionCleanupRef) error {
+					require.Zero(t, tasks.Active(), "catalog acknowledgement must follow physical task release")
+					completed = append(completed, ref)
+					return test.catalogErr
+				},
+			}
+			kernel, run, supervisor := newOneShotKernel(t, newNoopRunShutdownBarrier(), newNoopRunFinalizer(), catalog)
+			tasks = supervisor
+			require.NoError(t, kernel.releaseFunctionInvocation(FunctionInvocationRef{
+				Slot:       1,
+				Generation: 1,
+			}))
+			kernel.serviceFunctionCleanupBacklog(1)
+			kernel.serviceTaskStarts(1)
+			completion := receiveOneShotCompletion(t, tasks)
+			kernel.completeTask(completion)
+			require.Empty(t, completed)
+			if !test.abandon {
+				require.NoError(t, run.DirtyCause(), "ordinary cleanup errors are reported after acknowledgment")
+			}
+			ack := receiveOneShotAcknowledgement(t, tasks)
+			if test.abandon {
+				require.Equal(t, lifecycle.TaskActionAbandon, ack.Kind)
+			}
+			kernel.acknowledgeTask(ack)
+			require.Equal(t, []FunctionCleanupRef{cleanupRef}, completed)
+			require.Empty(t, kernel.functionCleanupTasks)
+			require.Zero(t, tasks.Active())
+			require.Error(t, run.DirtyCause())
+			if completion.Err != nil {
+				require.ErrorIs(t, run.DirtyCause(), workErr)
+			}
+			if test.catalogErr != nil {
+				require.ErrorIs(t, run.DirtyCause(), catalogErr)
+			}
+		})
+	}
+}

--- a/src/go/plugin/agent/jobmgr/kernel_runloop.go
+++ b/src/go/plugin/agent/jobmgr/kernel_runloop.go
@@ -121,7 +121,7 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 		moreFunctionClose := false
 		if ck.shutdownPhase != commandShutdownCleanupDrain {
 			moreFunctionMutation = ck.serviceFunctionMutation(16)
-		} else if ck.shutdownBarrierDone {
+		} else if ck.barrierWork.done {
 			moreFunctionClose = ck.serviceFunctionCatalogClose(MaximumFunctionCloseQuantum)
 		}
 		if !shuttingDown {
@@ -175,7 +175,7 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 				if err := ck.advanceShutdownBarrier(); err != nil {
 					ck.run.Dirty(err)
 				}
-				if ck.shutdownBarrierDone {
+				if ck.barrierWork.done {
 					moreShutdownLanes, shutdownErr = ck.serviceShutdownStops(4)
 					if shutdownErr != nil {
 						ck.run.Dirty(shutdownErr)
@@ -193,7 +193,7 @@ func (ck *CommandKernel) runLoop(ctx context.Context) {
 				return
 			}
 			census := ck.runCensus()
-			if census.Drained() || ck.runShutdownBarrierFailedTerminal() || ck.runFinalizerFailedTerminal() {
+			if census.Drained() || ck.barrierWork.failedTerminal() || ck.finalizerWork.failedTerminal() {
 				terminal = errors.Join(terminal, ck.run.Terminal(census))
 				return
 			}

--- a/src/go/plugin/agent/jobmgr/kernel_structures.go
+++ b/src/go/plugin/agent/jobmgr/kernel_structures.go
@@ -7,8 +7,9 @@ import (
 )
 
 type functionCleanupTask struct {
-	ref FunctionCleanupRef
-	err error
+	ref  FunctionCleanupRef
+	err  error
+	task oneShotTask
 }
 
 // Fixed chunks keep every kernel-loop queue operation worst-case O(1). The


### PR DESCRIPTION
##### Summary

Share task bookkeeping across shutdown barriers, finalizers, and Function cleanup. Validate acknowledgments consistently and preserve accepted actions until task release, keeping shutdown ordering and domain-specific error handling intact.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes one-shot task handshakes for the shutdown barrier, run finalizer, and Function cleanup into a shared `oneShotTask` value, removing duplicated bookkeeping and making protocol validation consistent.

- The single `oneShotTask` value tracks request, task ref, accepted action, and done/failed flags without adding per-task heap objects or scheduler work.
- Invalid completions abandon at the expected sequence 2; invalid acknowledgments, replayed completions, and release failures keep ownership so the genuine acknowledgment stays usable and the accepted action is never replaced.
- Function cleanup reports ordinary work errors only after physical release and catalog acknowledgment, keeping its domain-specific error handling intact.
- Adds protocol tests covering malformed completions, wrong ack actions, duplicate completions, duplicate acks, and release failures across all three callers.

<sup>Written for commit 1db3a813ca6c91748252c0db5ddb043a403346ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/netdata/pull/23859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability during shutdown, finalization, and function cleanup by validating task completion and acknowledgments.
  - Safely handle invalid, duplicate, or failed lifecycle operations without incorrectly releasing task ownership.
  - Preserved shutdown ordering and surfaced cleanup failures consistently.

- **Documentation**
  - Expanded documentation for one-shot task lifecycle handling.

- **Tests**
  - Added coverage and benchmarking for shutdown, finalization, cleanup, error, and acknowledgment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->